### PR TITLE
tests: show executed tests on current system when a test fails

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -300,6 +300,8 @@ debug-each: |
         dmesg --ctime | grep type=1326 || true
         echo '# snap interfaces'
         snap interfaces || true
+        echo '# tasks executed on system'
+        cat "$SPREAD_PATH/tests/runs" || true
     fi
 
 rename:

--- a/spread.yaml
+++ b/spread.yaml
@@ -291,6 +291,8 @@ debug-each: |
     if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
         # shellcheck source=tests/lib/journalctl.sh
         . "$TESTSLIB/journalctl.sh"
+        #shellcheck source=tests/lib/state.sh
+        . "$TESTSLIB/state.sh"
 
         echo '# journal messages for snapd'
         get_journalctl_log -u snapd
@@ -301,7 +303,7 @@ debug-each: |
         echo '# snap interfaces'
         snap interfaces || true
         echo '# tasks executed on system'
-        cat "$SPREAD_PATH/tests/runs" || true
+        cat "$RUNTIME_STATE_PATH/runs" || true
     fi
 
 rename:

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -411,7 +411,9 @@ prepare_suite_each() {
     if is_classic_system; then
         prepare_each_classic
     fi
-    echo -n "$SPREAD_JOB " >> "$SPREAD_PATH/tests/runs"
+    #shellcheck source=tests/lib/state.sh
+    . "$TESTSLIB"/state.sh
+    echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
 }
 
 restore_suite_each() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -411,6 +411,7 @@ prepare_suite_each() {
     if is_classic_system; then
         prepare_each_classic
     fi
+    echo -n "$SPREAD_JOB " >> "$SPREAD_PATH/tests/runs"
 }
 
 restore_suite_each() {

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 SNAPD_STATE_PATH="$SPREAD_PATH/tests/snapd-state"
-SNAPD_STATE_FILE="$SPREAD_PATH/tests/snapd-state.tar"
+SNAPD_STATE_FILE="$SPREAD_PATH/tests/snapd-state/snapd-state.tar"
+RUNTIME_STATE_PATH="$SPREAD_PATH/tests/runtime-state"
 
 # shellcheck source=tests/lib/dirs.sh
 . "$TESTSLIB/dirs.sh"
@@ -13,19 +14,16 @@ SNAPD_STATE_FILE="$SPREAD_PATH/tests/snapd-state.tar"
 . "$TESTSLIB/systems.sh"
 
 delete_snapd_state() {
-    if is_core_system; then
-        rm -rf "$SNAPD_STATE_PATH"
-    else
-        rm -f "$SNAPD_STATE_FILE"
-    fi
+    rm -rf "$SNAPD_STATE_PATH"
 }
 
 save_snapd_state() {
+    mkdir -p "$SNAPD_STATE_PATH" "RUNTIME_STATE_PATH"
     if is_core_system; then
         boot_path="$(get_boot_path)"
         test -n "$boot_path" || return 1
 
-        mkdir -p "$SNAPD_STATE_PATH" "$SNAPD_STATE_PATH"/system-units
+        mkdir -p "$SNAPD_STATE_PATH"/system-units
 
         # Copy the state preserving the timestamps
         cp -a /var/lib/snapd "$SNAPD_STATE_PATH"/snapd-lib

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -18,7 +18,7 @@ delete_snapd_state() {
 }
 
 save_snapd_state() {
-    mkdir -p "$SNAPD_STATE_PATH" "RUNTIME_STATE_PATH"
+    mkdir -p "$SNAPD_STATE_PATH" "$RUNTIME_STATE_PATH"
     if is_core_system; then
         boot_path="$(get_boot_path)"
         test -n "$boot_path" || return 1


### PR DESCRIPTION
The idea of this change is to have information about which tests were
executed before a failed test and in which order. This will help to
reproduce errors much easier when the test failes because another does
not clean the environment as it should. This is usefull on when many
workers are used and it is not clear which tests were executed before.
