### PR TITLE
tests: fix for the download of the big snap

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that ECONNRESET is handled
 restore: |
     echo "Stop the snap download command"
-    kill -9 "$(ps aux | grep '[s]nap download' | awk '{print $2}')"
+    kill -9 "$(pgrep -f 'snap download')" || true
 
     echo "Remove the firewall rule again"
     iptables -D OUTPUT -m owner --uid-owner "$(id -u test)" -j REJECT -p tcp --reject-with tcp-reset || true
@@ -35,7 +35,7 @@ execute: |
 
     if [ ! -f "$partial" ] || [ "$(stat -c%s "$partial")" -eq 0 ]; then
         echo "Partial file $partial did not start downloading, test broken"
-        kill -9 "$(ps aux | grep '[s]nap download' | awk '{print $2}')"
+        kill -9 "$(pgrep -f 'snap download')" || true
         exit 1
     fi
 
@@ -43,7 +43,7 @@ execute: |
         echo "File fully downloaded before the test could act"
         echo "Test broken"
         echo "end: $(date)"
-        kill -9 "$(ps aux | grep '[s]nap download' | awk '{print $2}')"
+        kill -9 "$(pgrep -f 'snap download')" || true
         exit 1
     fi
 

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that ECONNRESET is handled
 restore: |
+    echo "Stop the snap download command"
+    kill -9 "$(ps aux | grep '[s]nap download' | awk '{print $2}')"
+
     echo "Remove the firewall rule again"
     iptables -D OUTPUT -m owner --uid-owner "$(id -u test)" -j REJECT -p tcp --reject-with tcp-reset || true
 
@@ -22,17 +25,17 @@ execute: |
 
     echo "Wait until the download started and downloaded more than 1 MB"
     echo "starting: $(date)"
-    for _ in $(seq 400); do
+    for _ in $(seq 120); do
         partial=$(find . -name 'test-snapd-huge_*.snap.partial' | head -1)
         if [ -n "$partial" ] && [ "$(stat -c%s "$partial")" -gt "$(( 1024 * 1024 ))" ]; then
             break
         fi
-        sleep 0.1
+        sleep 0.5
     done
 
     if [ ! -f "$partial" ] || [ "$(stat -c%s "$partial")" -eq 0 ]; then
         echo "Partial file $partial did not start downloading, test broken"
-        kill -9 "$(pidof snap)"
+        kill -9 "$(ps aux | grep '[s]nap download' | awk '{print $2}')"
         exit 1
     fi
 
@@ -40,6 +43,7 @@ execute: |
         echo "File fully downloaded before the test could act"
         echo "Test broken"
         echo "end: $(date)"
+        kill -9 "$(ps aux | grep '[s]nap download' | awk '{print $2}')"
         exit 1
     fi
 


### PR DESCRIPTION
After a research it was determined that the download is taking
somethimes more than 20 seconds to start (the GET does not finishes).

See this log: https://paste.ubuntu.com/p/9C5FHbx23d/

Also we can see that the "kill $(pidof snap)" does not work when for
example the process snap userd is alive. This produces a problem because
the snap download will be still alive and the snap is downloaded after
the test fails.

See PR #5329 for more information about the debug lines introduced.

In the following log we can see that the GET done through the line
"s.doRequest(ctx, httputil.NewHTTPClient(nil), reqOptions, user)" in the
file store/store.go does not finishes during the 20 seconds which we are
checking the partial file size.

log: https://paste.ubuntu.com/p/tbdcGfBshS/

So, this change is adding more time to the retry checking the partial
file size, and changes the kill command used to finish the snap
download.
