### PR TITLE
tests: remove double debug: | entry in tests and add more checks

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -14,6 +14,8 @@ debug: |
     ls -lh test-snapd-huge_* || true
     echo "other dir content"
     ls -lh
+    echo "download log:"
+    cat snap-download.log
 
 execute: |
     echo "Downloading a large snap in the background"
@@ -53,10 +55,16 @@ execute: |
         fi
         sleep .5
     done
+
+    if [ -n "$(find . -name 'test-snapd-huge_*.snap')" ]; then
+        echo "File fully downloaded even after iptables was applied"
+        echo "Test broken"
+        echo "end: $(date)"
+        exit 1
+    fi
+
     MATCH 'Retrying.*\.snap, attempt 2' < snap-download.log
 
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will
     # end up with a "connection refused" error, something we do not retry
-debug: |
-    cat snap-download.log


### PR DESCRIPTION
This also adds another check after iptables if the file was fully downloaded. If iptables is really slow we may loose another race here and the test breaks.