### PR TITLE
interfaces: move assertions around for better failure line number

### DIFF
--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -179,6 +179,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 			"# Layout path: /var/tmp\n/var/tmp{,/**} mrwklix,",
 		},
 	})
+	updateNS := s.spec.UpdateNS()
 
 	profile0 := `  # Layout /etc/foo.conf: bind-file $SNAP/foo.conf
   mount options=(bind, rw) /snap/vanguard/42/foo.conf -> /etc/foo.conf,
@@ -210,6 +211,8 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
 `
+	c.Assert(updateNS[0], Equals, profile0)
+
 	profile1 := `  # Layout /usr/foo: bind $SNAP/usr/foo
   mount options=(rbind, rw) /snap/vanguard/42/usr/foo/ -> /usr/foo/,
   umount /usr/foo/,
@@ -242,6 +245,8 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
 `
+	c.Assert(updateNS[1], Equals, profile1)
+
 	profile2 := `  # Layout /var/cache/mylink: symlink $SNAP_DATA/link/target
   /var/cache/mylink rw,
   # Writable mimic /var/cache
@@ -258,6 +263,8 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /tmp/.snap/var/ rw,
   /tmp/.snap/ rw,
 `
+	c.Assert(updateNS[2], Equals, profile2)
+
 	profile3 := `  # Layout /var/tmp: type tmpfs, mode: 01777
   mount fstype=tmpfs tmpfs -> /var/tmp/,
   umount /var/tmp/,
@@ -273,10 +280,6 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /tmp/.snap/var/ rw,
   /tmp/.snap/ rw,
 `
-	updateNS := s.spec.UpdateNS()
-	c.Assert(updateNS[0], Equals, profile0)
-	c.Assert(updateNS[1], Equals, profile1)
-	c.Assert(updateNS[2], Equals, profile2)
 	c.Assert(updateNS[3], Equals, profile3)
 	c.Assert(updateNS, DeepEquals, []string{profile0, profile1, profile2, profile3})
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -569,6 +569,8 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
+	c.Assert(updateNS[0], Equals, profile0)
+
 	profile1 := `  # Read-write content sharing consumer:content -> producer:content (w#1)
   mount options=(bind, rw) /var/snap/producer/2/write-data/ -> /var/snap/consumer/common/import/write-data/,
   umount /var/snap/consumer/common/import/write-data/,
@@ -582,6 +584,8 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
+	c.Assert(updateNS[1], Equals, profile1)
+
 	profile2 := `  # Read-only content sharing consumer:content -> producer:content (r#0)
   mount options=(bind) /var/snap/producer/common/read-common/ -> /var/snap/consumer/common/import/read-common/,
   remount options=(bind, ro) /var/snap/consumer/common/import/read-common/,
@@ -596,6 +600,8 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
+	c.Assert(updateNS[2], Equals, profile2)
+
 	profile3 := `  # Read-only content sharing consumer:content -> producer:content (r#1)
   mount options=(bind) /var/snap/producer/2/read-data/ -> /var/snap/consumer/common/import/read-data/,
   remount options=(bind, ro) /var/snap/consumer/common/import/read-data/,
@@ -610,6 +616,8 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
+	c.Assert(updateNS[3], Equals, profile3)
+
 	profile4 := `  # Read-only content sharing consumer:content -> producer:content (r#2)
   mount options=(bind) /snap/producer/2/read-snap/ -> /var/snap/consumer/common/import/read-snap/,
   remount options=(bind, ro) /var/snap/consumer/common/import/read-snap/,
@@ -635,10 +643,6 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
-	c.Assert(updateNS[0], Equals, profile0)
-	c.Assert(updateNS[1], Equals, profile1)
-	c.Assert(updateNS[2], Equals, profile2)
-	c.Assert(updateNS[3], Equals, profile3)
 	c.Assert(updateNS[4], Equals, profile4)
 	c.Assert(updateNS, DeepEquals, []string{profile0, profile1, profile2, profile3, profile4})
 }


### PR DESCRIPTION
The code that had something like this:

 expected0 := `...`
 expected1 := `...`
 // more expectedN
 actual0 := compute(...)
 actual1 := compute(...)
 // more computations
 c.Assert(actual0, Equals, expected0)
 c.Assert(actual1, Equals, expected1)
 // .. more assertions

Was converted to this for better error location while debugging:

 expected0 := `...`
 actual0 := compute(...)
 c.Assert(actual0, Equals, expected0)
 expected1 := `...`
 actual1 := compute(...)
 c.Assert(actual1, Equals, expected1)
 // .. more of the same

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
