### PR TITLE
data: remove /bin/sh from snapd.sh

### DIFF
--- a/data/env/Makefile
+++ b/data/env/Makefile
@@ -20,6 +20,14 @@ ENVD := /etc/profile.d
 	sed   < $< > $@ \
 		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g
 
+# When processing snapd.sh.in remove the /bin/sh shebang as this file is meant
+# to be sourced, not executed, and the presence of that line causes rpmlint
+# validation warnings.
+snapd.sh: snapd.sh.in
+	sed   < $< \
+		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g | \
+		tail -n +3 > $@
+
 GENERATED = snapd.sh
 
 

--- a/data/env/Makefile
+++ b/data/env/Makefile
@@ -20,14 +20,6 @@ ENVD := /etc/profile.d
 	sed   < $< > $@ \
 		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g
 
-# When processing snapd.sh.in remove the /bin/sh shebang as this file is meant
-# to be sourced, not executed, and the presence of that line causes rpmlint
-# validation warnings.
-snapd.sh: snapd.sh.in
-	sed   < $< \
-		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g | \
-		tail -n +3 > $@
-
 GENERATED = snapd.sh
 
 

--- a/data/env/snapd.sh.in
+++ b/data/env/snapd.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh --this-shebang-is-just-here-to-inform-shellcheck--
+# shellcheck shell=sh
 
 # Expand $PATH to include the directory where snappy applications go.
 snap_bin_path="@SNAP_MOUNT_DIR@/bin"


### PR DESCRIPTION
The snapd.sh file is meant to be sourced so the shebang line is just
some meta-data that shellcheck is using. This meta-data is, however,
also picked up by rpmlint, resulting in the following warning:

[   73s] snapd.x86_64: W: sourced-script-with-shebang /etc/profile.d/snapd.sh /bin/sh --this-shebang-is-just-here-to-inform-shellcheck--
[   73s] This text file contains a shebang, but is meant to be sourced, not executed.

This patch keeps the shebang for validation but drops it for
installation.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
