### PR TITLE
packaging/opensuse: snap-confine should be 06755

### DIFF
--- a/packaging/opensuse/permissions
+++ b/packaging/opensuse/permissions
@@ -1,1 +1,1 @@
-/usr/lib/snapd/snap-confine                             root:root         4755
+/usr/lib/snapd/snap-confine                             root:root         6755

--- a/packaging/opensuse/permissions.easy
+++ b/packaging/opensuse/permissions.easy
@@ -1,1 +1,1 @@
-/usr/lib/snapd/snap-confine                             root:root         4755
+/usr/lib/snapd/snap-confine                             root:root         6755

--- a/packaging/opensuse/permissions.secure
+++ b/packaging/opensuse/permissions.secure
@@ -1,1 +1,1 @@
-/usr/lib/snapd/snap-confine                             root:root         4755
+/usr/lib/snapd/snap-confine                             root:root         6755


### PR DESCRIPTION
For many months now, snap-confine needs to be setgid to work correctly.
This was not captured in the opensuse permissions override. This patch
fixes it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
