### PR TITLE
packaging/opensuse: don't use %-macros in comments

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -197,7 +197,7 @@ sed -e "s/-Bstatic -lseccomp/-Bstatic/g" -i %{_builddir}/go/src/%{provider_prefi
 %goinstall
 # TODO: instead of removing it move this to a dedicated golang package
 rm -rf %{buildroot}%{_libdir}/go
-# Move snapd, snap-exec, snap-seccomp and snap-update-ns into %{_libexecdir}/snapd
+# Move snapd, snap-exec, snap-seccomp and snap-update-ns into {_libexecdir}/snapd
 install -m 755 -d %{buildroot}%{_libexecdir}/snapd
 mv %{buildroot}%{_bindir}/snapd %{buildroot}%{_libexecdir}/snapd/snapd
 mv %{buildroot}%{_bindir}/snap-exec %{buildroot}%{_libexecdir}/snapd/snap-exec


### PR DESCRIPTION
Commenting out an RPM macro is almost always a bug since the expansion
ignores the comment and if the macro is multi-line it can have
unexpected consequences.

This fixes the following rpmlint warning

[  108s] snapd.src:197: W: macro-in-comment %{_libexecdir}
[  108s] There is a unescaped macro after a shell style comment in the specfile. Macros
[  108s] are expanded everywhere, so check if it can cause a problem in this case and
[  108s] escape the macro with another leading % if appropriate.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
