### PR TITLE
packaging/opensuse: build position-independent binaries

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -134,13 +134,13 @@ the system:snappy repository.
 # Generate autotools build system files
 cd cmd && autoreconf -i -f
 
-# Enable hardening; We can't use -pie here as this conflicts with
-# our build of static binaries for snap-confine. Also see
-# https://bugzilla.redhat.com/show_bug.cgi?id=1343892
-CFLAGS="$RPM_OPT_FLAGS -fPIC -Wl,-z,relro -Wl,-z,now"
+# Enable hardening; Also see https://bugzilla.redhat.com/show_bug.cgi?id=1343892
+CFLAGS="$RPM_OPT_FLAGS -fPIC -Wl,-z,relro -Wl,-z,now -fPIE -pie"
 CXXFLAGS="$RPM_OPT_FLAGS -fPIC -Wl,-z,relro -Wl,-z,now"
+LDFLAGS="-pie"
 export CFLAGS
 export CXXFLAGS
+export LDFLAGS
 
 # N.B.: Prior to openSUSE Tumbleweed in May 2018, the AppArmor userspace in SUSE
 # did not support what we needed to be able to turn on basic integration.

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -141,9 +141,9 @@ LDFLAGS=""
 # On openSUSE Leap 15 or more recent build position independent executables.
 # For a helpful guide about the versions and macros used below, please see:
 # https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto
-%if (0%{?sle_version} >= 150000 && 0%{?is_opensuse}) || %if 0%{?suse_version} > 1500
-CFLAGS="$CFLAGS -fPIE -fpie"
-CXXFLAGS"$CXXFLAGS -fPIE -pie"
+%if 0%{?suse_version} >= 1500
+CFLAGS="$CFLAGS -fPIE"
+CXXFLAGS"$CXXFLAGS -fPIE"
 LDFLAGS="$LDFLAGS -pie"
 %endif
 

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -135,9 +135,18 @@ the system:snappy repository.
 cd cmd && autoreconf -i -f
 
 # Enable hardening; Also see https://bugzilla.redhat.com/show_bug.cgi?id=1343892
-CFLAGS="$RPM_OPT_FLAGS -fPIC -Wl,-z,relro -Wl,-z,now -fPIE -pie"
+CFLAGS="$RPM_OPT_FLAGS -fPIC -Wl,-z,relro -Wl,-z,now"
 CXXFLAGS="$RPM_OPT_FLAGS -fPIC -Wl,-z,relro -Wl,-z,now"
-LDFLAGS="-pie"
+LDFLAGS=""
+# On openSUSE Leap 15 or more recent build position independent executables.
+# For a helpful guide about the versions and macros used below, please see:
+# https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto
+%if (0%{?sle_version} >= 150000 && 0%{?is_opensuse}) || %if 0%{?suse_version} > 1500
+CFLAGS="$CFLAGS -fPIE -fpie"
+CXXFLAGS"$CXXFLAGS -fPIE -pie"
+LDFLAGS="$LDFLAGS -pie"
+%endif
+
 export CFLAGS
 export CXXFLAGS
 export LDFLAGS


### PR DESCRIPTION
This patch adds appropriate flags to build position independent
C-binaries. This fixes the following rpmlint warnings:

[  108s] snapd.x86_64: W: position-independent-executable-suggested /usr/lib/snapd/snap-discard-ns
[  108s] snapd.x86_64: W: position-independent-executable-suggested /usr/lib/snapd/snap-gdb-shim
[  108s] snapd.x86_64: W: position-independent-executable-suggested /usr/lib/systemd/system-generators/snapd-generator
[  108s] This executable should be position independent (all binaries should).  Check
[  108s] that it is built with -fPIE/-fpie in compiler flags and -pie in linker flags.

In addition, since our build system correctly filters out those flags
from statically linked binaries, simplify the code and reword the
comment that sets those flags.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
