### PR TITLE
firstboot: mark essential snaps as "Required" in the state

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -111,10 +111,9 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 		return nil, err
 	}
 
-	var required map[string]bool
+	required := map[string]bool{}
 	reqSnaps := model.RequiredSnaps()
 	if len(reqSnaps) > 0 {
-		required = make(map[string]bool, len(reqSnaps))
 		for _, snap := range reqSnaps {
 			required[snap] = true
 		}
@@ -139,7 +138,7 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 		if seedSnap == nil {
 			return fmt.Errorf("cannot proceed without seeding %q", snapName)
 		}
-		ts, err := installSeedSnap(st, seedSnap, snapstate.Flags{SkipConfigure: true})
+		ts, err := installSeedSnap(st, seedSnap, snapstate.Flags{SkipConfigure: true, Required: true})
 		if err != nil {
 			return err
 		}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -111,8 +111,9 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 		return nil, err
 	}
 
-	required := map[string]bool{}
 	reqSnaps := model.RequiredSnaps()
+	// +4 for (snapd, base, gadget, kernel)
+	required := make(map[string]bool, len(reqSnaps)+4)
 	if len(reqSnaps) > 0 {
 		for _, snap := range reqSnaps {
 			required[snap] = true

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -510,6 +510,14 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
 	_, err = snapstate.CurrentInfo(state, "pc")
 	c.Assert(err, IsNil)
 
+	// ensure requied flag is set on all essential snaps
+	var snapst snapstate.SnapState
+	for _, reqName := range []string{"core", "pc-kernel", "pc"} {
+		err = snapstate.Get(state, reqName, &snapst)
+		c.Assert(err, IsNil)
+		c.Assert(snapst.Required, Equals, true, Commentf("required not set for %v", reqName))
+	}
+
 	// check foo
 	info, err := snapstate.CurrentInfo(state, "foo")
 	c.Assert(err, IsNil)
@@ -520,7 +528,6 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(pubAcct.AccountID(), Equals, "developerid")
 
-	var snapst snapstate.SnapState
 	err = snapstate.Get(state, "foo", &snapst)
 	c.Assert(err, IsNil)
 	c.Assert(snapst.DevMode, Equals, true)
@@ -1191,6 +1198,14 @@ snaps:
 	c.Check(err, IsNil)
 	_, err = snapstate.CurrentInfo(state, "pc")
 	c.Check(err, IsNil)
+
+	// ensure requied flag is set on all essential snaps
+	var snapst snapstate.SnapState
+	for _, reqName := range []string{"snapd", "core18", "pc-kernel", "pc"} {
+		err = snapstate.Get(state, reqName, &snapst)
+		c.Assert(err, IsNil)
+		c.Assert(snapst.Required, Equals, true, Commentf("required not set for %v", reqName))
+	}
 
 	// and ensure state is now considered seeded
 	var seeded bool


### PR DESCRIPTION
This ensures that we cannot remove the "snapd" or "core18" snaps
on a core18 system. As a side-effect it also sets the kernel and
gadget as Required which is something we want to do anyway.
