### PR TITLE
tests: fix shellcheck 0.5.0 warnings

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -477,7 +477,7 @@ suites:
                 exit 0
             fi
             #shellcheck source=tests/lib/pkgdb.sh
-            . $TESTSLIB/pkgdb.sh
+            . "$TESTSLIB"/pkgdb.sh
             distro_purge_package snapd
             distro_purge_package snapd-xdg-open || true
 
@@ -502,17 +502,17 @@ suites:
             COVERMODE: "$(HOST: echo $COVERMODE)"
         prepare: |
             #shellcheck source=tests/lib/prepare.sh
-            . $TESTSLIB/prepare.sh
+            . "$TESTSLIB"/prepare.sh
             prepare_classic
         prepare-each: |
             "$TESTSLIB"/reset.sh --reuse-core
             #shellcheck source=tests/lib/prepare.sh
-            . $TESTSLIB/prepare.sh
+            . "$TESTSLIB"/prepare.sh
             prepare_each_classic
         restore: |
             "$TESTSLIB"/reset.sh --store
             #shellcheck source=tests/lib/pkgdb.sh
-            . $TESTSLIB/pkgdb.sh
+            . "$TESTSLIB"/pkgdb.sh
 
             distro_purge_package snapd
             case "$SPREAD_SYSTEM" in

--- a/tests/main/base-snaps/task.yaml
+++ b/tests/main/base-snaps/task.yaml
@@ -3,7 +3,7 @@ systems: [-opensuse-*]
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
 
     echo "Ensure a snap that requires a unavailable base snap can not be installed"
     if install_local test-snapd-requires-base; then

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -4,7 +4,7 @@ details: |
     placed into the appropriate hierarchy under the freezer cgroup.
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-sh
 execute: |
     # Start a "sleep" process in the background

--- a/tests/main/classic-confinement-not-supported/task.yaml
+++ b/tests/main/classic-confinement-not-supported/task.yaml
@@ -7,12 +7,12 @@ systems: [ubuntu-core-*, fedora-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     snap pack "$TESTSLIB/snaps/$CLASSIC_SNAP/"
 
 execute: |
     #shellcheck source=tests/lib/strings.sh
-    . $TESTSLIB/strings.sh
+    . "$TESTSLIB"/strings.sh
 
     echo "Check that classic snaps work only with --classic"
     if snap install --dangerous "${CLASSIC_SNAP}_1.0_all.snap"; then

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -8,9 +8,9 @@ systems: [-ubuntu-core-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
     snap pack "$TESTSLIB/snaps/$CLASSIC_SNAP/"
 
     if [[ "$SPREAD_SYSTEM" == fedora-* || "$SPREAD_SYSTEM" == arch-* ]]; then

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -13,7 +13,7 @@ kill-timeout: 5m
 debug: |
     snap changes
     #shellcheck source=tests/lib/changes.sh
-    . $TESTSLIB/changes.sh
+    . "$TESTSLIB"/changes.sh
     snap change "$(change_id 'Transition ubuntu-core to core')" || true
 execute: |
     echo "install a snap"

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -28,7 +28,7 @@ execute: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
     #shellcheck source=tests/lib/systemd.sh
-    . $TESTSLIB/systemd.sh
+    . "$TESTSLIB"/systemd.sh
     curl() {
         local url="$1"
         # sadly systemd active means not that its really ready so we wait

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -10,7 +10,7 @@ details: |
 
 prepare: |
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
     if [[ "$SPREAD_SYSTEM" == fedora-* || "$SPREAD_SYSTEM" == arch-* ]]; then
         # although classic snaps do not work out of the box on fedora,
         # we still want to verify if the basics do work if the user
@@ -20,7 +20,7 @@ prepare: |
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
 
     snap install --classic test-snapd-hello-classic
     $SNAP_MOUNT_DIR/bin/test-snapd-hello-classic | MATCH 'Hello Classic!'

--- a/tests/main/core-snap-refresh-on-core/task.yaml
+++ b/tests/main/core-snap-refresh-on-core/task.yaml
@@ -44,7 +44,7 @@ execute: |
     fi
   
     #shellcheck source=tests/lib/boot.sh
-    . $TESTSLIB/boot.sh
+    . "$TESTSLIB"/boot.sh
     if [ "$SPREAD_REBOOT" = 0 ]; then
         # ensure we have a good starting place
     

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -11,7 +11,7 @@ systems:
 prepare: |
     echo "Having installed the test snap"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
     # Arch does not use /etc/alternatives
     if [[ "$SPREAD_SYSTEM" == arch-* ]]; then

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -22,7 +22,7 @@ prepare: |
     fi
     echo "Given a snap declaring a plug on gpio is installed"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local gpio-consumer
 
     echo "And a mocked gpio device is in place"

--- a/tests/main/enable-disable/task.yaml
+++ b/tests/main/enable-disable/task.yaml
@@ -2,10 +2,10 @@ summary: Check that enable/disable works
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
     echo "Install test-snapd-tools and ensure it runs"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
     test-snapd-tools.echo Hello|MATCH Hello
     echo "Disable test-snapd-tools and ensure it is listed as disabled"
@@ -41,7 +41,7 @@ execute: |
 
     echo "Ensure the important snaps can not be disabled"
     #shellcheck source=tests/lib/names.sh
-    . $TESTSLIB/names.sh
+    . "$TESTSLIB"/names.sh
     for sn in core $kernel_name $gadget_name; do
         if snap disable "$sn"; then
             echo "It should not be possible to disable $sn"

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -35,13 +35,13 @@ restore: |
 
     # FIXME: remove the unset when we reset properly snap_try_{core,kernel} on rollback
     #shellcheck source=tests/lib/boot.sh
-    . $TESTSLIB/boot.sh
+    . "$TESTSLIB"/boot.sh
     bootenv_unset snap_try_core
     bootenv_unset snap_try_kernel
 
 debug: |
     #shellcheck source=tests/lib/boot.sh
-    . $TESTSLIB/boot.sh
+    . "$TESTSLIB"/boot.sh
     #shellcheck disable=SC2119
     bootenv
     snap list
@@ -65,9 +65,9 @@ execute: |
     }
 
     #shellcheck source=tests/lib/names.sh
-    . $TESTSLIB/names.sh
+    . "$TESTSLIB"/names.sh
     #shellcheck source=tests/lib/boot.sh
-    . $TESTSLIB/boot.sh
+    . "$TESTSLIB"/boot.sh
     if [ "$TARGET_SNAP" = kernel ]; then
         TARGET_SNAP_NAME=$kernel_name
     else

--- a/tests/main/fakestore-install/task.yaml
+++ b/tests/main/fakestore-install/task.yaml
@@ -9,7 +9,7 @@ restore: |
         exit
     fi
     #shellcheck source=tests/lib/store.sh
-    . $TESTSLIB/store.sh
+    . "$TESTSLIB"/store.sh
     teardown_fake_store "$BLOB_DIR"
   
 execute: |
@@ -21,11 +21,11 @@ execute: |
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
 
     #shellcheck source=tests/lib/store.sh
-    . $TESTSLIB/store.sh
+    . "$TESTSLIB"/store.sh
     setup_fake_store "$BLOB_DIR"
 
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     snap_path=$(make_snap basic)
     make_snap_installable "$BLOB_DIR" "${snap_path}"
 

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -12,7 +12,7 @@ environment:
 prepare: |
     echo "Given a snap with a failing command is installed"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local "$SNAP_NAME"
 
 execute: |

--- a/tests/main/install-refresh-remove-hooks/task.yaml
+++ b/tests/main/install-refresh-remove-hooks/task.yaml
@@ -8,7 +8,7 @@ restore: |
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local snap-hooks
 
     echo "Verify configuration value with snap get"

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -33,7 +33,7 @@ execute: |
     [ "$(test-snapd-tools.echo Hello World)" = "Hello World" ]
 
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
 
     echo "Sideload desktop snap"
     snap install --dangerous ./basic-desktop_1.0_all.snap

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -9,7 +9,7 @@ systems: [ubuntu-core-16-64]
 prepare: |
     echo "Given a snap declaring a plug on account-control is installed"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local account-control-consumer
 
     echo "And the account-control plug is connected"
@@ -23,7 +23,7 @@ restore: |
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
 
     "$SNAP_MOUNT_DIR"/bin/account-control-consumer.useradd --extrausers alice
     echo alice:password | "$SNAP_MOUNT_DIR"/bin/account-control-consumer.chpasswd

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -12,7 +12,7 @@ environment:
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
-    . $TESTSLIB/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
     echo "Ensure we have a working goa-daemon"
     distro_install_package gnome-online-accounts
     snap install --edge test-snapd-accounts-service
@@ -20,7 +20,7 @@ prepare: |
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
-    . $TESTSLIB/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
     rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"

--- a/tests/main/interfaces-alsa/task.yaml
+++ b/tests/main/interfaces-alsa/task.yaml
@@ -19,7 +19,7 @@ details: |
 prepare: |
     echo "Given a snap declaring a plug on the alsa interface is installed"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_generic_consumer alsa
 
 restore: |

--- a/tests/main/interfaces-avahi-observe/task.yaml
+++ b/tests/main/interfaces-avahi-observe/task.yaml
@@ -5,12 +5,12 @@ systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 prepare: |
     echo "Given a snap with an avahi-observe interface plug is installed"
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_generic_consumer avahi-observe,unity7
 
     echo "And avahi-daemon is installed and configured"
     #shellcheck source=tests/lib/pkgdb.sh
-    . $TESTSLIB/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
     distro_install_package avahi-daemon
     sed -i 's/^#enable-dbus=yes/enable-dbus=yes/' /etc/avahi/avahi-daemon.conf
     if [[ "$SPREAD_SYSTEM" = ubuntu-14.04-* ]]; then
@@ -24,7 +24,7 @@ prepare: |
 restore: |
     rm -f ./*.error
     #shellcheck source=tests/lib/pkgdb.sh
-    . $TESTSLIB/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
     distro_purge_package avahi-daemon
     distro_auto_remove_packages
 

--- a/tests/main/interfaces-broadcom-asic-control/task.yaml
+++ b/tests/main/interfaces-broadcom-asic-control/task.yaml
@@ -12,11 +12,11 @@ details: |
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-broadcom-asic-control
 
     #shellcheck source=tests/lib/files.sh
-    . $TESTSLIB/files.sh
+    . "$TESTSLIB"/files.sh
     ensure_file_exists_backup_real /dev/linux-user-bde
     ensure_file_exists_backup_real /dev/linux-kernel-bde
     ensure_file_exists_backup_real /dev/linux-bcm-knet
@@ -27,7 +27,7 @@ restore: |
     rm -f call.error
 
     #shellcheck source=tests/lib/files.sh
-    . $TESTSLIB/files.sh
+    . "$TESTSLIB"/files.sh
     clean_file /dev/linux-user-bde
     clean_file /dev/linux-kernel-bde
     clean_file /dev/linux-bcm-knet

--- a/tests/main/interfaces-content-mimic/task.yaml
+++ b/tests/main/interfaces-content-mimic/task.yaml
@@ -8,7 +8,7 @@ details: |
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-content-mimic-plug
     install_local test-snapd-content-mimic-slot
 

--- a/tests/main/interfaces-content-mkdir-writable/task.yaml
+++ b/tests/main/interfaces-content-mkdir-writable/task.yaml
@@ -24,14 +24,14 @@ prepare: |
     # Install a pair of snaps that both have two content interfaces as
     # sub-directories of $SNAP_DATA and $SNAP_COMMON.
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
     install_local test-snapd-content-advanced-plug
     install_local test-snapd-content-advanced-slot
 
 execute: |
     # Put our internal tools on PATH so that we can call snap-discard-ns easily.
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
     PATH=$LIBEXECDIR/snapd:$PATH
 
     # Test that initially there are no mount points on the plug side (because

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -55,9 +55,9 @@ prepare: |
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB"/dirs.sh
     #shellcheck source=tests/lib/snaps.sh
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB"/snaps.sh
 
     install_local test-snapd-policy-app-consumer
 


### PR DESCRIPTION
ShellCheck 0.5.0 picks up more issues than the 0.4.6 version we currently use in
the tests.
