### PR TITLE
tests/main/xdg-open: restore or clean up xdg-open

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -13,6 +13,10 @@ restore: |
     . "$TESTSLIB/pkgdb.sh"
     rm -f dbus.env
     umount -f /usr/bin/xdg-open || true
+    rm /usr/bin/xdg-open
+    if [ -e /usr/bin/xdg-open.orig ]; then
+        mv /usr/bin/xdg-open.orig /usr/bin/xdg-open
+    fi
 
 execute: |
     . "$TESTSLIB/pkgdb.sh"
@@ -41,6 +45,9 @@ execute: |
     echo "$@" > /tmp/xdg-open-output
     EOF
     chmod +x /tmp/xdg-open
+    if [ -e /usr/bin/xdg-open ]; then
+        mv /usr/bin/xdg-open /usr/bin/xdg-open.orig
+    fi
     touch /usr/bin/xdg-open
     mount --bind /tmp/xdg-open /usr/bin/xdg-open
 


### PR DESCRIPTION
Clean up temporary files created by the test.
