### PR TITLE
tests: disable core tests on all core systems (16 and 18)

### DIFF
--- a/tests/main/ack/task.yaml
+++ b/tests/main/ack/task.yaml
@@ -1,5 +1,5 @@
 summary: Check snap ack
-systems: [-ubuntu-core-16-arm-*]
+systems: [-ubuntu-core-*-arm-*]
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/main/auth-errors/task.yaml
+++ b/tests/main/auth-errors/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that the authentication errors are properly reported.
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     mkdir -p /home/test/.snap

--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that auto-refresh works with private snaps.
 
 # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 details: |
     These tests rely on the existence of a snap in the remote store set to private.

--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -1,7 +1,7 @@
 summary: test chattr
 # ubuntu-core doesn't have go :-)
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2503
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 prepare: |
   go build -o toggle ./toggle.go
 execute: |

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -1,7 +1,7 @@
 summary: |
    Test gadget customized device initialisation and registration also on classic
 systems:
-    - -ubuntu-core-16-*
+    - -ubuntu-core-*
     # The test fails on Arch right now, disable it temporarily
     - -arch-*
 environment:

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that firstboot assertions are imported and snaps installed also on classic
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 environment:
     SEED_DIR: /var/lib/snapd/seed
 prepare: |

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -4,7 +4,7 @@ summary: Ensure that the ubuntu-core -> core transition works with auth.json
 # we disable on ppc64el because the downloads are very slow there
 # Fedora, openSUSE and Arch are disabled at the moment as there is something
 # fishy going on and the snapd service gets terminated during the process.
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -arch-*]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -arch-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the ubuntu-core -> core transition works with two cores
 
 # we never test on core because the transition can only happen on "classic"
 # we disable on ppc64el because the downloads are very slow there
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -4,7 +4,7 @@ summary: Ensure that the ubuntu-core -> core transition works
 # we disable on ppc64el because the downloads are very slow there
 # Fedora, openSUSE and Arch are disabled at the moment as there is something
 # fishy going on and the snapd service gets terminated during the process.
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386, -arch-*]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386, -arch-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,7 +1,7 @@
 summary: Check different completions
 
 systems:
-    - -ubuntu-core-16-*
+    - -ubuntu-core-*
     # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
     - -ubuntu-*-ppc64el
 

--- a/tests/main/config-versions/task.yaml
+++ b/tests/main/config-versions/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that snap configuration is maintained on per-revision basis.
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 details: |
     This test ensures that snap configuration is mainted per snap revision

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -1,6 +1,6 @@
 summary: trivial snap with classic confinement runs correctly
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 details: |
     This test checks that a very much trivial "hello-world"-like snap using

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for snap create-key
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
 prepare: |
     #shellcheck source=tests/lib/mkpinentry.sh

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure create-user functionality
 
 # Disabled for Fedora, openSUSE and Arch as none have all options for add user
 # the `snap create-user` command requires. Needs code rework.
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 
 environment:
     USER_EMAIL: mvo@ubuntu.com

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -7,7 +7,7 @@ details: |
   consistent behaviour across various distributions.
 systems:
     # This test only applies to classic systems
-    - -ubuntu-core-16-*
+    - -ubuntu-core-*
 prepare: |
     echo "Having installed the test snap"
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/disable-autoconnect/task.yaml
+++ b/tests/main/disable-autoconnect/task.yaml
@@ -4,7 +4,7 @@ details: |
     This test ensures that auto-connections are not restored if manually disconnected
     by the user.
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     snap pack "$TESTSLIB"/snaps/config-versions

--- a/tests/main/generic-classic-reg/task.yaml
+++ b/tests/main/generic-classic-reg/task.yaml
@@ -2,7 +2,7 @@ summary: |
     Ensure device initialisation registration works with the fallback
     generic/generi-classic model and we have a serial and can acquire
     a session macaroon
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 execute: |
     echo "Wait for device initialisation to have been done"
     # this was in fact triggered around when core was installed

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for cli errors installing snaps
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 environment:
     SNAP_NAME: test-snapd-tools

--- a/tests/main/install-refresh-private/task.yaml
+++ b/tests/main/install-refresh-private/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that install and refresh work with private snaps.
 
 # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 details: |
     These tests rely on the existence of a snap in the remote store set to private.

--- a/tests/main/interfaces-autopilot-introspection/task.yaml
+++ b/tests/main/interfaces-autopilot-introspection/task.yaml
@@ -7,7 +7,7 @@ details: |
     The test uses an snap that declares a plug on autopilot-intrsopection, it
     needs to request a dbus name on start so that its state can be queried.
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/interfaces-content-default-provider/task.yaml
+++ b/tests/main/interfaces-content-default-provider/task.yaml
@@ -4,7 +4,7 @@ summary: Ensure that the content default-provider download works
 # with (potentially) a different core snap. Running this on core will
 # also trigger a reboot in the middle of the tests because the new
 # core will be applied. So skip the test on core devices.
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 execute: |
     echo "A snap with no default-provider is installed"

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -4,7 +4,7 @@ summary: Ensure that the content sharing interface works.
 # with (potentially) a different core snap. Running this on core will
 # also trigger a reboot in the middle of the tests because the new
 # core will be applied. So skip the test on core devices.
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 details: |
     The content-sharing interface interface allows a snap to access contents from

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the cups interface works.
 
 # Default cups/cups-pdf configuration on these distributions isn't
 # working yet without further tweaks.
-systems: [-ubuntu-core-16-*, -opensuse-*, -fedora-*, -arch-*]
+systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*]
 
 details: |
     The cups-control interface allows a snap to access the locale configuration.

--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -11,7 +11,7 @@ details: |
 environment:
     DISPLAY: :0
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     . "$TESTSLIB/dirs.sh"

--- a/tests/main/interfaces-location-control/task.yaml
+++ b/tests/main/interfaces-location-control/task.yaml
@@ -10,7 +10,7 @@ details: |
 
 # dbus-launch not supported in ubuntu-core
 # s390x does not support locationd
-systems: [-ubuntu-core-16-*, -ubuntu-*-s390x]
+systems: [-ubuntu-core-*, -ubuntu-*-s390x]
 
 prepare: |
     . "$TESTSLIB/dbus.sh"

--- a/tests/main/interfaces-network-status/task.yaml
+++ b/tests/main/interfaces-network-status/task.yaml
@@ -9,7 +9,7 @@ details: |
     The snap is also declaring a plug on this interface must be able to ask for its status.
 
 # dbus-launch not supported in ubuntu-core
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     . "$TESTSLIB/dbus.sh"

--- a/tests/main/interfaces-openvswitch-support/task.yaml
+++ b/tests/main/interfaces-openvswitch-support/task.yaml
@@ -6,7 +6,7 @@ details: |
 # ubuntu-core, ubuntu-14 and fedora are skipped due to /run/uuidd/request file does not
 # exist. On those systems different files are being used instead.
 # arch: uses /run/run/uuidd/request, filed a bug report https://bugs.archlinux.org/task/58122
-systems: [-ubuntu-14.04-*,-ubuntu-core-16-*,-fedora-*, -arch-*]
+systems: [-ubuntu-14.04-*,-ubuntu-core-*,-fedora-*, -arch-*]
 
 prepare: |
     snap install test-snapd-openvswitch-support

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -8,6 +8,9 @@ prepare: |
 # with the distro
 backends: [-autopkgtest]
 
+# TODO: update test for core18 but its already pretty confusing as is
+systems: [-ubuntu-core-18-*]
+
 execute: |
     echo "List prints core snap version"
     # most core versions should be like "16-2", so [0-9]{2}-[0-9.]+

--- a/tests/main/local-install-w-metadata/task.yaml
+++ b/tests/main/local-install-w-metadata/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for local install with metadata from assertions
 # XXX we would need to bother with curl there atm
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 restore: |
     rm -f test-snapd-tools_*.{snap,assert}
 execute: |

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for snap login
 
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
 restore: |
     snap logout || true

--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -1,7 +1,7 @@
 summary: the essential manual pages are installed by the native package
 
 # core systems don't ship man or manual pages
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 execute: |
 

--- a/tests/main/op-install-failed-undone/task.yaml
+++ b/tests/main/op-install-failed-undone/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that all tasks of a failed installtion are undone
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 restore: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that postrm purge works
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 execute: |
     echo "When some snaps are installed"

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that prepare-image works for grub-systems
 
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that undo for snap refresh works
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that more than one snap is refreshed.
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 details: |
     We use only the fake store for this test because we currently

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the security rules for private tmp are in place.
 
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
 environment:
     SNAP_INSTALL_DIR: $(pwd)/snap-install-dir

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that the setting proxy.store config works
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 environment:
     SNAP_NAME: test-snapd-tools
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -1,7 +1,7 @@
 summary: Test that snap-confine is run from core on re-exec
 
 # Disable for Fedora, openSUSE and Arch as re-exec is not support there yet
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 
 prepare: |
     echo "Installing test-snapd-tools"

--- a/tests/main/snap-confine-privs/task.yaml
+++ b/tests/main/snap-confine-privs/task.yaml
@@ -8,7 +8,7 @@ details: |
 # This test is not executed on a core system simply because of the hassle of
 # building the support C program. In the future it might be improved with the
 # use of the classic snap where we just use classic to build the helper.
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 environment:
     # This is used to abbreviate some of the paths below.
     P: /var/snap/test-snapd-sh/common

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -2,7 +2,7 @@ summary: Test that snap-confine errors in the right way
 
 # the error message can only happen on classic systems
 # our debian image does not have fully working apprmor
-systems: [-ubuntu-core-16-*, -debian-*]
+systems: [-ubuntu-core-*, -debian-*]
 
 prepare: |
     echo "Install test snap"

--- a/tests/main/snap-run-alias/task.yaml
+++ b/tests/main/snap-run-alias/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that alias symlinks work correctly
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     echo Ensure we have a os snap with snap run

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that symlinks to /usr/bin/snap trigger `snap run`
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     echo Ensure we have a os snap with snap run

--- a/tests/main/snap-run-userdata-current/task.yaml
+++ b/tests/main/snap-run-userdata-current/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that 'current' symlink is created with 'snap run'
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh

--- a/tests/main/snap-set-core-w-no-core/task.yaml
+++ b/tests/main/snap-set-core-w-no-core/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure core can be configure before being installed
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 warn-timeout: 1m
 kill-timeout: 5m

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -1,7 +1,7 @@
 summary: Run snap sign to sign a model assertion
 
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
 
 prepare: |
     . "$TESTSLIB"/mkpinentry.sh

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -1,7 +1,7 @@
 summary: Test that snapd reexecs itself into core
 
 # Disable for Fedora, openSUSE and Arch as re-exec is not support there yet
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 
 restore: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/static/task.yaml
+++ b/tests/main/static/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that snapd can be built without cgo
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 execute: |
     CGO_ENABLED=0 go build -o snapd.static github.com/snapcore/snapd/cmd/snapd
     ldd snapd.static && exit 1 || true

--- a/tests/main/try-non-fatal/task.yaml
+++ b/tests/main/try-non-fatal/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks that removing the base directory of a tried snap works.
 
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 execute: |
     echo "Given a tried snap"

--- a/tests/main/try-snap-is-optional/task.yaml
+++ b/tests/main/try-snap-is-optional/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that try command works when snap dir is omitted
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 execute: |
     echo "When try is executed inside a snap directory"
     cd $TESTSLIB/snaps/test-snapd-tools

--- a/tests/main/try-twice-with-daemon/task.yaml
+++ b/tests/main/try-twice-with-daemon/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that try command works when daemon line is added to snap.yaml
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-*]
 
 environment:
   SERVICE: snap.test-snapd-service-try.service.service

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that try command works
 
 # s390x does not have /dev/kmsg
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*, -ubuntu-*-s390x]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -ubuntu-*-s390x]
 
 environment:
     PORT: 8081

--- a/tests/main/whoami/task.yaml
+++ b/tests/main/whoami/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for snap whoami
 
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
+systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
 restore: |
     snap logout || true

--- a/tests/regression/lp-1595444/task.yaml
+++ b/tests/regression/lp-1595444/task.yaml
@@ -6,7 +6,7 @@ details: |
 
 systems:
     # This test only applies to classic systems
-    - -ubuntu-core-16-*
+    - -ubuntu-core-*
     # No confinement (AppArmor, Seccomp) available on these systems
     - -debian-*
     - -fedora-*

--- a/tests/regression/lp-1597839/task.yaml
+++ b/tests/regression/lp-1597839/task.yaml
@@ -1,6 +1,6 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1597839
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-*, -fedora-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -arch-*]
 details: |
     The snappy execution environment should contain the /lib/modules directory
     from the host filesystem when running on a classic distribution

--- a/tests/regression/lp-1597842/task.yaml
+++ b/tests/regression/lp-1597842/task.yaml
@@ -4,7 +4,7 @@ details: |
     directory from the classic distribution. Certain snaps may use that to
     access kernel sources.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-*, -fedora-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -arch-*]
 prepare: |
     echo "Having installed the test snap"
     . "$TESTSLIB/snaps.sh"

--- a/tests/regression/lp-1613845/task.yaml
+++ b/tests/regression/lp-1613845/task.yaml
@@ -5,7 +5,7 @@ details: |
     the host filesystem. While this would never work in an all-snap image it is
     still important to ensure that it works in classic devmode environment.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-*, -fedora-*, -arch-*]
+systems: [-ubuntu-core-*, -fedora-*, -arch-*]
 prepare: |
     echo "Having installed the test snap in devmode"
     . "$TESTSLIB/snaps.sh"


### PR DESCRIPTION
Pretty mechanical, prepare for running the tests on core18 devices.