### PR TITLE
overlord/{config,snap}state: introduce parallel-installs feature flag

### DIFF
--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -57,17 +57,28 @@ var supportedConfigurations = map[string]bool{
 	"core.experimental.layouts": true,
 }
 
-func validateExperimentalSettings(tr Conf) error {
-	layoutsEnabled, err := coreCfg(tr, "experimental.layouts")
+func validateBoolFlag(tr Conf, flag string) error {
+	value, err := coreCfg(tr, flag)
 	if err != nil {
 		return err
 	}
-	switch layoutsEnabled {
+	switch value {
 	case "", "true", "false":
-		return nil
+		// noop
 	default:
-		return fmt.Errorf("experimental.layouts can only be set to 'true' or 'false'")
+		return fmt.Errorf("%s can only be set to 'true' or 'false'", flag)
 	}
+	return nil
+}
+
+func validateExperimentalSettings(tr Conf) error {
+	if err := validateBoolFlag(tr, "experimental.layouts"); err != nil {
+		return err
+	}
+	if err := validateBoolFlag(tr, "experimental.parallel-installs"); err != nil {
+		return err
+	}
+	return nil
 }
 
 func Run(tr Conf) error {

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -109,28 +109,35 @@ type runCfgSuite struct {
 var _ = Suite(&runCfgSuite{})
 
 func (r *runCfgSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
-	conf := &mockConf{
-		state: r.state,
-		conf: map[string]interface{}{
-			"experimental.layouts": "foo",
-		},
-	}
-
-	err := configcore.Run(conf)
-	c.Check(err, ErrorMatches, `experimental.layouts can only be set to 'true' or 'false'`)
-}
-
-func (r *runCfgSuite) TestConfigureExperimentalSettingsHappy(c *C) {
-	for _, t := range []string{"true", "false"} {
+	for setting, value := range map[string]interface{}{
+		"experimental.layouts":           "foo",
+		"experimental.parallel-installs": "foo",
+	} {
 		conf := &mockConf{
 			state: r.state,
 			conf: map[string]interface{}{
-				"experimental.layouts": t,
+				setting: value,
 			},
 		}
 
 		err := configcore.Run(conf)
-		c.Check(err, IsNil)
+		c.Check(err, ErrorMatches, fmt.Sprintf(`%s can only be set to 'true' or 'false'`, setting))
+	}
+}
+
+func (r *runCfgSuite) TestConfigureExperimentalSettingsHappy(c *C) {
+	for _, setting := range []string{"experimental.layouts", "experimental.parallel-installs"} {
+		for _, t := range []string{"true", "false"} {
+			conf := &mockConf{
+				state: r.state,
+				conf: map[string]interface{}{
+					setting: t,
+				},
+			}
+
+			err := configcore.Run(conf)
+			c.Check(err, IsNil)
+		}
 	}
 }
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -134,6 +134,7 @@ var (
 	NameAndRevnoFromSnap   = nameAndRevnoFromSnap
 	DoInstall              = doInstall
 	UserFromUserID         = userFromUserID
+	ValidateFeatureFlags   = validateFeatureFlags
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -511,20 +511,29 @@ func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
 // validateFeatureFlags validates the given snap only uses experimental
 // features that are enabled by the user.
 func validateFeatureFlags(st *state.State, info *snap.Info) error {
-	if len(info.Layout) == 0 {
-		return nil
-	}
-
 	tr := config.NewTransaction(st)
-	var featureFlagLayouts bool
-	if err := tr.GetMaybe("core", "experimental.layouts", &featureFlagLayouts); err != nil {
-		return err
-	}
-	if featureFlagLayouts {
-		return nil
+
+	if len(info.Layout) > 0 {
+		var featureFlagLayouts bool
+		if err := tr.GetMaybe("core", "experimental.layouts", &featureFlagLayouts); err != nil {
+			return err
+		}
+		if !featureFlagLayouts {
+			return fmt.Errorf("cannot use experimental 'layouts' feature, set option 'experimental.layouts' to true and try again")
+		}
 	}
 
-	return fmt.Errorf("cannot use experimental 'layouts' feature, set option 'experimental.layouts' to true and try again")
+	if info.InstanceKey != "" {
+		var featureFlagParallelInstall bool
+		if err := tr.GetMaybe("core", "experimental.parallel-installs", &featureFlagParallelInstall); err != nil {
+			return err
+		}
+		if !featureFlagParallelInstall {
+			return fmt.Errorf("cannot use experimental 'parallel-installs' feature, set option 'experimental.parallel-installs' to true and try again")
+		}
+	}
+
+	return nil
 }
 
 // InstallPath returns a set of tasks for installing snap from a file path.

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9779,6 +9779,26 @@ func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
 	c.Assert(refreshes, DeepEquals, []string{"some-snap"})
 }
 
+func (s *snapmgrTestSuite) TestParallelInstallValidateFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	info := &snap.Info{
+		InstanceKey: "foo",
+	}
+
+	err := snapstate.ValidateFeatureFlags(s.state, info)
+	c.Assert(err, ErrorMatches, `cannot use experimental 'parallel-installs' feature, set option 'experimental.parallel-installs' to true and try again`)
+
+	// enable parallel installs
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.parallel-installs", true)
+	tr.Commit()
+
+	err = snapstate.ValidateFeatureFlags(s.state, info)
+	c.Assert(err, IsNil)
+}
+
 func (s *snapmgrTestSuite) TestInjectTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/snap/info.go
+++ b/snap/info.go
@@ -144,6 +144,7 @@ type SideInfo struct {
 // Info provides information about snaps.
 type Info struct {
 	SuggestedName string
+	InstanceKey   string
 	Version       string
 	Type          Type
 	Architectures []string
@@ -256,8 +257,7 @@ type ChannelSnapInfo struct {
 // InstanceName returns the blessed name of the snap decorated with instance
 // key, if any.
 func (s *Info) InstanceName() string {
-	// TODO parallel-install: include instance key
-	return s.StoreName()
+	return InstanceName(s.StoreName(), s.InstanceKey)
 }
 
 // StoreName returns the global blessed name of the snap.
@@ -996,4 +996,29 @@ func DropNick(nick string) string {
 		return "core"
 	}
 	return nick
+}
+
+// StoreName splits the instance name and returns the store name of the snap.
+func StoreName(name string) string {
+	return strings.SplitN(name, "_", 2)[0]
+}
+
+// SplitInstanceName splits the instance name and returns the store name and the
+// instance key.
+func SplitInstanceName(name string) (store string, instanceKey string) {
+	split := strings.SplitN(name, "_", 2)
+	store = split[0]
+	if len(split) > 1 {
+		instanceKey = split[1]
+	}
+	return store, instanceKey
+}
+
+// InstanceName takes the store name and the instance key and returns an instance
+// name of the snap.
+func InstanceName(storeName string, instanceKey string) string {
+	if instanceKey != "" {
+		return fmt.Sprintf("%s_%s", storeName, instanceKey)
+	}
+	return storeName
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1074,3 +1074,45 @@ func (s *infoSuite) TestNickname(c *C) {
 	c.Check(snap.DropNick("system"), Equals, "core")
 	c.Check(snap.DropNick("foo"), Equals, "foo")
 }
+
+func (s *infoSuite) TestInstanceStoreName(c *C) {
+	store, key := snap.SplitInstanceName("foo_bar")
+	c.Check(store, Equals, "foo")
+	c.Check(key, Equals, "bar")
+
+	store, key = snap.SplitInstanceName("foo")
+	c.Check(store, Equals, "foo")
+	c.Check(key, Equals, "")
+
+	store, key = snap.SplitInstanceName("_bar")
+	c.Check(store, Equals, "")
+	c.Check(key, Equals, "bar")
+
+	store, key = snap.SplitInstanceName("foo___bar_bar")
+	c.Check(store, Equals, "foo")
+	c.Check(key, Equals, "__bar_bar")
+
+	store, key = snap.SplitInstanceName("")
+	c.Check(store, Equals, "")
+	c.Check(key, Equals, "")
+
+	c.Check(snap.StoreName("foo_bar"), Equals, "foo")
+	c.Check(snap.StoreName("foo"), Equals, "foo")
+
+	c.Check(snap.InstanceName("foo", "bar"), Equals, "foo_bar")
+	c.Check(snap.InstanceName("foo", ""), Equals, "foo")
+}
+
+func (s *infoSuite) TestInstanceNameInSnapInfo(c *C) {
+	info := &snap.Info{
+		SuggestedName: "snap-name",
+		InstanceKey:   "foo",
+	}
+
+	c.Check(info.InstanceName(), Equals, "snap-name_foo")
+	c.Check(info.StoreName(), Equals, "snap-name")
+
+	info.InstanceKey = ""
+	c.Check(info.InstanceName(), Equals, "snap-name")
+	c.Check(info.StoreName(), Equals, "snap-name")
+}

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -268,6 +268,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	// check that up to few exceptions info is filled
 	expectedZeroFields := []string{
 		"SuggestedName",
+		"InstanceKey",
 		"Assumes",
 		"OriginalTitle",
 		"OriginalSummary",


### PR DESCRIPTION
Introduce a feature flag that will be gating parallel installation of snaps. The proposed name for the flag is `experimenta.parallel-installs`. 

The PR includes bits from #5363 but does not include changes to `snapstate.Install()/InstallPath()` API, thus the feature validation helper is exported for the tests.
