### PR TITLE
packaging: put snapctl into /usr/lib/snapd and symlink in usr/bin

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -254,6 +254,7 @@ var defaultTemplate = `
 
   # snapctl and its requirements
   /usr/bin/snapctl ixr,
+  /usr/lib/snapd/snapctl ixr,
   @{PROC}/sys/net/core/somaxconn r,
   /run/snapd-snap.socket rw,
 

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -1,5 +1,5 @@
 usr/bin/snap
-usr/bin/snapctl
+usr/bin/snapctl /usr/lib/snapd/
 usr/lib/snapd/system-shutdown
 usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-repair /usr/lib/snapd/

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,1 +1,2 @@
 ../../usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
+usr/lib/snapd/snapctl usr/bin/snapctl


### PR DESCRIPTION
This will allow bases to use snapctl. Bases mount /usr/lib/snapd
into the snap namespace and with a symlink in the base from
/usr/bin/snapctl to /usr/lib/snapd/snapctl it will be available.
