### PR TITLE
dirs: improve identification of Arch Linux like systems

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -178,7 +178,7 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	if release.DistroLike("fedora", "arch", "manjaro") {
+	if release.DistroLike("fedora", "archlinux", "manjaro") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
Arch Linux derivatives correctly set `ID_LIKE=archlinux` but we use 'arch' in our
detection (which is only set by Arch as `ID=arch`).

