### PR TITLE
tests: blacklist more main tests for core18

### DIFF
--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure that the firewall-control interface works.
 
-systems: [-fedora-*, -opensuse-*, -arch-*]
+# core18 has no "nc"
+systems: [-fedora-*, -opensuse-*, -arch-*, -ubuntu-core-18-*]
 
 details: |
     The firewall-control interface allows a snap to configure the firewall.

--- a/tests/main/interfaces-gpg-keys/task.yaml
+++ b/tests/main/interfaces-gpg-keys/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that the gpg-keys interface works.
 
+# core18 has no gpg
+systems: [-ubuntu-core-18-*]
+
 details: |
     The gpg-keys interface allows to access gpg binary and keys.
 

--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure network interface works.
 
-systems: [-fedora-*, -opensuse-*]
+# core18 has no "nc"
+systems: [-fedora-*, -opensuse-*, -ubuntu-core-18-*]
 
 details: |
     The network interface allows a snap to access the network as a client.

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snap info works
 
+# core18 has no python3-yaml
+systems: [-ubuntu-core-18-*]
+
 prepare: |
     . $TESTSLIB/pkgdb.sh
     distro_install_package python3-yaml


### PR DESCRIPTION
Next round of tests we need to blacklist on core18 (at least for now).