### PR TITLE
interfaces: make findSnapdPath smarter

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -369,7 +369,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 				 scratch_dir);
 
 		// bind mount the current $ROOT/usr/lib/snapd path,
-		// where $ROOT is either "/" or the "/snap/core/current"
+		// where $ROOT is either "/" or the "/snap/{core,snapd}/current"
 		// that we are re-execing from
 		char *src = NULL;
 		char self[PATH_MAX + 1] = { 0 };

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -193,6 +193,8 @@
 
     # allow making re-execed host snap-exec available inside base snaps
     mount options=(ro bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    # allow making snapd snap tools available inside base snaps
+    mount options=(ro bind) @SNAP_MOUNT_DIR@/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -73,7 +73,10 @@ func (c BySlotInfo) Len() int           { return bySlotInfo(c).Len() }
 func (c BySlotInfo) Swap(i, j int)      { bySlotInfo(c).Swap(i, j) }
 func (c BySlotInfo) Less(i, j int) bool { return bySlotInfo(c).Less(i, j) }
 
-var CopyAttributes = copyAttributes
+var (
+	CopyAttributes = copyAttributes
+	FindSnapdPath  = findSnapdPath
+)
 
 // MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS
 func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
@@ -81,5 +84,14 @@ func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
 	isHomeUsingNFS = new
 	return func() {
 		isHomeUsingNFS = old
+	}
+}
+
+// MockOsReadlink mocks the real implementation of os.Readlink
+func MockOsReadlink(new func(string) (string, error)) (restore func()) {
+	old := osReadlink
+	osReadlink = new
+	return func() {
+		osReadlink = old
 	}
 }

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -86,6 +86,10 @@ func findSnapdPath() (string, error) {
 	}
 
 	if strings.HasPrefix(exe, dirs.SnapMountDir) {
+		// reexecd' snapd may be coming from either 'core' or 'snapd'
+		// snaps, find the local prefix to the snap:
+		// /snap/snapd/123/usr/bin/snap       -> /snap/snapd/123
+		// /snap/core/234/usr/lib/snapd/snapd -> /snap/core/234
 		prefix := strings.Split(exe, "/usr/")[0]
 		return filepath.Join(prefix, "/usr/lib/snapd/snapd"), nil
 	}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -73,19 +73,21 @@ type systemKey struct {
 var (
 	isHomeUsingNFS  = osutil.IsHomeUsingNFS
 	mockedSystemKey *systemKey
+	osReadlink      = os.Readlink
 )
 
 func findSnapdPath() (string, error) {
 	snapdPath := filepath.Join(dirs.DistroLibExecDir, "snapd")
 
 	// find the right snapdPath by looking if we are re-execing or not
-	exe, err := os.Readlink("/proc/self/exe")
+	exe, err := osReadlink("/proc/self/exe")
 	if err != nil {
 		return "", err
 	}
 
 	if strings.HasPrefix(exe, dirs.SnapMountDir) {
-		return filepath.Join(dirs.SnapMountDir, "core/current/usr/lib/snapd/snapd"), nil
+		prefix := strings.Split(exe, "/usr/")[0]
+		return filepath.Join(prefix, "/usr/lib/snapd/snapd"), nil
 	}
 	return snapdPath, nil
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -147,3 +147,27 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
 	_, err = interfaces.SystemKeyMismatch()
 	c.Assert(err, Equals, interfaces.ErrSystemKeyVersion)
 }
+
+func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathNormal(c *C) {
+	p, err := interfaces.FindSnapdPath()
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, filepath.Join(dirs.DistroLibExecDir, "snapd"))
+}
+
+func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathReexec(c *C) {
+	s.AddCleanup(interfaces.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+	}))
+	p, err := interfaces.FindSnapdPath()
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, filepath.Join(dirs.SnapMountDir, "/core/111/usr/lib/snapd/snapd"))
+}
+
+func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathSnapdSnap(c *C) {
+	s.AddCleanup(interfaces.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.SnapMountDir, "snapd/22/usr/bin/snap"), nil
+	}))
+	p, err := interfaces.FindSnapdPath()
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, filepath.Join(dirs.SnapMountDir, "/snapd/22/usr/lib/snapd/snapd"))
+}

--- a/tests/core18/basic/task.yaml
+++ b/tests/core18/basic/task.yaml
@@ -17,6 +17,6 @@ execute: |
     test-snapd-tools-core18.echo hello | MATCH hello
 
     if python3 -m json.tool < /var/lib/snapd/system-key | grep '"build-id": ""'; then
-        echo "No the build-id of snapd is should not be empty."
+        echo "The build-id of snapd must not be empty."
         exit 1
     fi

--- a/tests/core18/basic/task.yaml
+++ b/tests/core18/basic/task.yaml
@@ -15,3 +15,8 @@ execute: |
     echo "Check that snapd tools for core18 works"
     snap install test-snapd-tools-core18
     test-snapd-tools-core18.echo hello | MATCH hello
+
+    if python3 -m json.tool < /var/lib/snapd/system-key | grep '"build-id": ""'; then
+        echo "No the build-id of snapd is should not be empty."
+        exit 1
+    fi


### PR DESCRIPTION
The current code that finds the snapd binary to read the build-id
for the system-key generation is not very smart and hardcodes
"core". This PR makes it smarter and it will now also find the
snapd snap which means the build-id is valid.