### PR TITLE
tests: add halt-timeout to google backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -50,6 +50,7 @@ backends:
     google:
         key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
         location: computeengine/us-east1-b
+        halt-timeout: 2h
         systems:
             - ubuntu-14.04-64:
                 workers: 6


### PR DESCRIPTION
This is going to be used to kill machines after halt time 