### PR TITLE
snap: introduce a struct Channel to represent store channels, and helpers to work with it

### DIFF
--- a/snap/channel.go
+++ b/snap/channel.go
@@ -1,0 +1,154 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/strutil"
+)
+
+var channelRisks = []string{"stable", "candidate", "beta", "edge"}
+
+// StoreChannel identifies and describes completely a store channel.
+type StoreChannel struct {
+	Architecture string `json:"architecture"`
+	Name         string `json:"name"`
+	Track        string `json:"track"`
+	Risk         string `json:"risk"`
+	Branch       string `json:"branch,omitempty"`
+}
+
+// ParseStoreChannel parses a string representing a store channel and includes the given architecture, if architecture is "" the system architecture is included.
+func ParseStoreChannel(s string, architecture string) (StoreChannel, error) {
+	if s == "" {
+		return StoreChannel{}, fmt.Errorf("channel name cannot be empty")
+	}
+	p := strings.Split(s, "/")
+	var risk, track, branch string
+	switch len(p) {
+	default:
+		return StoreChannel{}, fmt.Errorf("channel name has too many components: %s", s)
+	case 3:
+		track, risk, branch = p[0], p[1], p[2]
+	case 2:
+		if strutil.ListContains(channelRisks, p[0]) {
+			risk, branch = p[0], p[1]
+		} else {
+			track, risk = p[0], p[1]
+		}
+	case 1:
+		if strutil.ListContains(channelRisks, p[0]) {
+			risk = p[0]
+		} else {
+			track = p[0]
+			risk = "stable"
+		}
+	}
+
+	if !strutil.ListContains(channelRisks, risk) {
+		return StoreChannel{}, fmt.Errorf("invalid risk in channel name: %s", s)
+	}
+
+	if architecture == "" {
+		architecture = arch.UbuntuArchitecture()
+	}
+
+	return StoreChannel{
+		Architecture: architecture,
+		Track:        track,
+		Risk:         risk,
+		Branch:       branch,
+	}.Clean(), nil
+}
+
+// Clean returns a StoreChannel with a normalized track and name.
+func (c StoreChannel) Clean() StoreChannel {
+	track := c.Track
+
+	if track == "latest" {
+		track = ""
+	}
+
+	// normalized name
+	name := c.Risk
+	if track != "" {
+		name = track + "/" + name
+	}
+	if c.Branch != "" {
+		name = name + "/" + c.Branch
+	}
+
+	return StoreChannel{
+		Architecture: c.Architecture,
+		Name:         name,
+		Track:        track,
+		Risk:         c.Risk,
+		Branch:       c.Branch,
+	}
+}
+
+func (c *StoreChannel) String() string {
+	return c.Name
+}
+
+// Full returns the full name of the channel, inclusive the default track "latest".
+func (c *StoreChannel) Full() string {
+	if c.Track == "" {
+		return "latest/" + c.Name
+	}
+	return c.String()
+}
+
+func riskLevel(risk string) int {
+	for i, r := range channelRisks {
+		if r == risk {
+			return i
+		}
+	}
+	return -1
+}
+
+// Match returns a representation of which fields among architecture,track,risk match between c and c1 store channels, risk is matched taking channel inheritance into account and considering c requested. Results can be:
+//  "architecture:track:risk"
+//  "architecture:track"
+//  "architecture:risk"
+//  "track:risk"
+//  "architecture"
+//  "track"
+//  "risk"
+//  ""
+func (c *StoreChannel) Match(c1 *StoreChannel) string {
+	matching := []string{}
+	if c.Architecture == c1.Architecture {
+		matching = append(matching, "architecture")
+	}
+	if c.Track == c1.Track {
+		matching = append(matching, "track")
+	}
+	requestedRiskLevel := riskLevel(c.Risk)
+	rl1 := riskLevel(c1.Risk)
+	if requestedRiskLevel >= rl1 {
+		matching = append(matching, "risk")
+	}
+	return strings.Join(matching, ":")
+}

--- a/snap/channel.go
+++ b/snap/channel.go
@@ -29,8 +29,8 @@ import (
 
 var channelRisks = []string{"stable", "candidate", "beta", "edge"}
 
-// StoreChannel identifies and describes completely a store channel.
-type StoreChannel struct {
+// Channel identifies and describes completely a store channel.
+type Channel struct {
 	Architecture string `json:"architecture"`
 	Name         string `json:"name"`
 	Track        string `json:"track"`
@@ -38,16 +38,16 @@ type StoreChannel struct {
 	Branch       string `json:"branch,omitempty"`
 }
 
-// ParseStoreChannel parses a string representing a store channel and includes the given architecture, if architecture is "" the system architecture is included.
-func ParseStoreChannel(s string, architecture string) (StoreChannel, error) {
+// ParseChannel parses a string representing a store channel and includes the given architecture, if architecture is "" the system architecture is included.
+func ParseChannel(s string, architecture string) (Channel, error) {
 	if s == "" {
-		return StoreChannel{}, fmt.Errorf("channel name cannot be empty")
+		return Channel{}, fmt.Errorf("channel name cannot be empty")
 	}
 	p := strings.Split(s, "/")
 	var risk, track, branch string
 	switch len(p) {
 	default:
-		return StoreChannel{}, fmt.Errorf("channel name has too many components: %s", s)
+		return Channel{}, fmt.Errorf("channel name has too many components: %s", s)
 	case 3:
 		track, risk, branch = p[0], p[1], p[2]
 	case 2:
@@ -66,14 +66,14 @@ func ParseStoreChannel(s string, architecture string) (StoreChannel, error) {
 	}
 
 	if !strutil.ListContains(channelRisks, risk) {
-		return StoreChannel{}, fmt.Errorf("invalid risk in channel name: %s", s)
+		return Channel{}, fmt.Errorf("invalid risk in channel name: %s", s)
 	}
 
 	if architecture == "" {
 		architecture = arch.UbuntuArchitecture()
 	}
 
-	return StoreChannel{
+	return Channel{
 		Architecture: architecture,
 		Track:        track,
 		Risk:         risk,
@@ -81,8 +81,8 @@ func ParseStoreChannel(s string, architecture string) (StoreChannel, error) {
 	}.Clean(), nil
 }
 
-// Clean returns a StoreChannel with a normalized track and name.
-func (c StoreChannel) Clean() StoreChannel {
+// Clean returns a Channel with a normalized track and name.
+func (c Channel) Clean() Channel {
 	track := c.Track
 
 	if track == "latest" {
@@ -98,7 +98,7 @@ func (c StoreChannel) Clean() StoreChannel {
 		name = name + "/" + c.Branch
 	}
 
-	return StoreChannel{
+	return Channel{
 		Architecture: c.Architecture,
 		Name:         name,
 		Track:        track,
@@ -107,12 +107,12 @@ func (c StoreChannel) Clean() StoreChannel {
 	}
 }
 
-func (c *StoreChannel) String() string {
+func (c *Channel) String() string {
 	return c.Name
 }
 
 // Full returns the full name of the channel, inclusive the default track "latest".
-func (c *StoreChannel) Full() string {
+func (c *Channel) Full() string {
 	if c.Track == "" {
 		return "latest/" + c.Name
 	}
@@ -128,8 +128,8 @@ func riskLevel(risk string) int {
 	return -1
 }
 
-// StoreChannelMatch represents on which fields two channels are matching.
-type StoreChannelMatch struct {
+// ChannelMatch represents on which fields two channels are matching.
+type ChannelMatch struct {
 	Architecture bool
 	Track        bool
 	Risk         bool
@@ -144,7 +144,7 @@ type StoreChannelMatch struct {
 //  "track"
 //  "risk"
 //  ""
-func (cm StoreChannelMatch) String() string {
+func (cm ChannelMatch) String() string {
 	matching := []string{}
 	if cm.Architecture {
 		matching = append(matching, "architecture")
@@ -159,11 +159,11 @@ func (cm StoreChannelMatch) String() string {
 
 }
 
-// Match returns a StoreChannelMatch of which fields among architecture,track,risk match between c and c1 store channels, risk is matched taking channel inheritance into account and considering c the requested channel.
-func (c *StoreChannel) Match(c1 *StoreChannel) StoreChannelMatch {
+// Match returns a ChannelMatch of which fields among architecture,track,risk match between c and c1 store channels, risk is matched taking channel inheritance into account and considering c the requested channel.
+func (c *Channel) Match(c1 *Channel) ChannelMatch {
 	requestedRiskLevel := riskLevel(c.Risk)
 	rl1 := riskLevel(c1.Risk)
-	return StoreChannelMatch{
+	return ChannelMatch{
 		Architecture: c.Architecture == c1.Architecture,
 		Track:        c.Track == c1.Track,
 		Risk:         requestedRiskLevel >= rl1,

--- a/snap/channel.go
+++ b/snap/channel.go
@@ -107,7 +107,7 @@ func (c Channel) Clean() Channel {
 	}
 }
 
-func (c *Channel) String() string {
+func (c Channel) String() string {
 	return c.Name
 }
 

--- a/snap/channel.go
+++ b/snap/channel.go
@@ -128,7 +128,14 @@ func riskLevel(risk string) int {
 	return -1
 }
 
-// Match returns a representation of which fields among architecture,track,risk match between c and c1 store channels, risk is matched taking channel inheritance into account and considering c requested. Results can be:
+// StoreChannelMatch represents on which fields two channels are matching.
+type StoreChannelMatch struct {
+	Architecture bool
+	Track        bool
+	Risk         bool
+}
+
+// String returns the string represantion of the match, results can be:
 //  "architecture:track:risk"
 //  "architecture:track"
 //  "architecture:risk"
@@ -137,18 +144,28 @@ func riskLevel(risk string) int {
 //  "track"
 //  "risk"
 //  ""
-func (c *StoreChannel) Match(c1 *StoreChannel) string {
+func (cm StoreChannelMatch) String() string {
 	matching := []string{}
-	if c.Architecture == c1.Architecture {
+	if cm.Architecture {
 		matching = append(matching, "architecture")
 	}
-	if c.Track == c1.Track {
+	if cm.Track {
 		matching = append(matching, "track")
 	}
-	requestedRiskLevel := riskLevel(c.Risk)
-	rl1 := riskLevel(c1.Risk)
-	if requestedRiskLevel >= rl1 {
+	if cm.Risk {
 		matching = append(matching, "risk")
 	}
 	return strings.Join(matching, ":")
+
+}
+
+// Match returns a StoreChannelMatch of which fields among architecture,track,risk match between c and c1 store channels, risk is matched taking channel inheritance into account and considering c the requested channel.
+func (c *StoreChannel) Match(c1 *StoreChannel) StoreChannelMatch {
+	requestedRiskLevel := riskLevel(c.Risk)
+	rl1 := riskLevel(c1.Risk)
+	return StoreChannelMatch{
+		Architecture: c.Architecture == c1.Architecture,
+		Track:        c.Track == c1.Track,
+		Risk:         requestedRiskLevel >= rl1,
+	}
 }

--- a/snap/channel_test.go
+++ b/snap/channel_test.go
@@ -1,0 +1,209 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/snap"
+)
+
+type storeChannelSuite struct{}
+
+var _ = Suite(&storeChannelSuite{})
+
+func (s storeChannelSuite) TestParseStoreChannel(c *C) {
+	ch, err := snap.ParseStoreChannel("stable", "")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: arch.UbuntuArchitecture(),
+		Name:         "stable",
+		Track:        "",
+		Risk:         "stable",
+		Branch:       "",
+	})
+
+	ch, err = snap.ParseStoreChannel("latest/stable", "")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: arch.UbuntuArchitecture(),
+		Name:         "stable",
+		Track:        "",
+		Risk:         "stable",
+		Branch:       "",
+	})
+
+	ch, err = snap.ParseStoreChannel("1.0/edge", "")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: arch.UbuntuArchitecture(),
+		Name:         "1.0/edge",
+		Track:        "1.0",
+		Risk:         "edge",
+		Branch:       "",
+	})
+
+	ch, err = snap.ParseStoreChannel("1.0", "")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: arch.UbuntuArchitecture(),
+		Name:         "1.0/stable",
+		Track:        "1.0",
+		Risk:         "stable",
+		Branch:       "",
+	})
+
+	ch, err = snap.ParseStoreChannel("1.0/beta/foo", "")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: arch.UbuntuArchitecture(),
+		Name:         "1.0/beta/foo",
+		Track:        "1.0",
+		Risk:         "beta",
+		Branch:       "foo",
+	})
+
+	ch, err = snap.ParseStoreChannel("candidate/foo", "")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: arch.UbuntuArchitecture(),
+		Name:         "candidate/foo",
+		Track:        "",
+		Risk:         "candidate",
+		Branch:       "foo",
+	})
+
+	ch, err = snap.ParseStoreChannel("candidate/foo", "other-arch")
+	c.Assert(err, IsNil)
+	c.Check(ch, DeepEquals, snap.StoreChannel{
+		Architecture: "other-arch",
+		Name:         "candidate/foo",
+		Track:        "",
+		Risk:         "candidate",
+		Branch:       "foo",
+	})
+}
+
+func (s storeChannelSuite) TestClean(c *C) {
+	ch := snap.StoreChannel{
+		Architecture: "arm64",
+		Track:        "latest",
+		Name:         "latest/stable",
+		Risk:         "stable",
+	}
+
+	cleanedCh := ch.Clean()
+	c.Check(cleanedCh, Not(DeepEquals), c)
+	c.Check(cleanedCh, DeepEquals, snap.StoreChannel{
+		Architecture: "arm64",
+		Track:        "",
+		Name:         "stable",
+		Risk:         "stable",
+	})
+}
+
+func (s storeChannelSuite) TestParseStoreChannelErrors(c *C) {
+	_, err := snap.ParseStoreChannel("", "")
+	c.Check(err, ErrorMatches, "channel name cannot be empty")
+
+	_, err = snap.ParseStoreChannel("1.0////", "")
+	c.Check(err, ErrorMatches, "channel name has too many components: 1.0////")
+
+	_, err = snap.ParseStoreChannel("1.0/cand", "invalid risk in channel name: 1.0/cand")
+	c.Check(err, ErrorMatches, "invalid risk in channel name: 1.0/cand")
+}
+
+func (s *storeChannelSuite) TestString(c *C) {
+	tests := []struct {
+		channel string
+		str     string
+	}{
+		{"stable", "stable"},
+		{"latest/stable", "stable"},
+		{"1.0/edge", "1.0/edge"},
+		{"1.0/beta/foo", "1.0/beta/foo"},
+		{"candidate/foo", "candidate/foo"},
+	}
+
+	for _, t := range tests {
+		ch, err := snap.ParseStoreChannel(t.channel, "")
+		c.Assert(err, IsNil)
+
+		c.Check(ch.String(), Equals, t.str)
+	}
+}
+
+func (s *storeChannelSuite) TestFull(c *C) {
+	tests := []struct {
+		channel string
+		str     string
+	}{
+		{"stable", "latest/stable"},
+		{"latest/stable", "latest/stable"},
+		{"1.0/edge", "1.0/edge"},
+		{"1.0/beta/foo", "1.0/beta/foo"},
+		{"candidate/foo", "latest/candidate/foo"},
+	}
+
+	for _, t := range tests {
+		ch, err := snap.ParseStoreChannel(t.channel, "")
+		c.Assert(err, IsNil)
+
+		c.Check(ch.Full(), Equals, t.str)
+	}
+}
+
+func (s *storeChannelSuite) TestMatch(c *C) {
+	tests := []struct {
+		req      string
+		c1       string
+		sameArch bool
+		res      string
+	}{
+		{"stable", "stable", true, "architecture:track:risk"},
+		{"stable", "beta", true, "architecture:track"},
+		{"beta", "stable", true, "architecture:track:risk"},
+		{"stable", "edge", false, "track"},
+		{"edge", "stable", false, "track:risk"},
+		{"1.0/stable", "1.0/edge", true, "architecture:track"},
+		{"1.0/edge", "stable", true, "architecture:risk"},
+		{"1.0/edge", "stable", false, "risk"},
+		{"1.0/stable", "stable", false, "risk"},
+		{"1.0/stable", "beta", false, ""},
+		{"1.0/stable", "2.0/beta", false, ""},
+		{"2.0/stable", "2.0/beta", false, "track"},
+		{"1.0/stable", "2.0/beta", true, "architecture"},
+	}
+
+	for _, t := range tests {
+		reqArch := "amd64"
+		c1Arch := "amd64"
+		if !t.sameArch {
+			c1Arch = "arm64"
+		}
+		req, err := snap.ParseStoreChannel(t.req, reqArch)
+		c.Assert(err, IsNil)
+		c1, err := snap.ParseStoreChannel(t.c1, c1Arch)
+		c.Assert(err, IsNil)
+
+		c.Check(req.Match(&c1), Equals, t.res)
+	}
+}

--- a/snap/channel_test.go
+++ b/snap/channel_test.go
@@ -30,10 +30,10 @@ type storeChannelSuite struct{}
 
 var _ = Suite(&storeChannelSuite{})
 
-func (s storeChannelSuite) TestParseStoreChannel(c *C) {
-	ch, err := snap.ParseStoreChannel("stable", "")
+func (s storeChannelSuite) TestParseChannel(c *C) {
+	ch, err := snap.ParseChannel("stable", "")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: arch.UbuntuArchitecture(),
 		Name:         "stable",
 		Track:        "",
@@ -41,9 +41,9 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 		Branch:       "",
 	})
 
-	ch, err = snap.ParseStoreChannel("latest/stable", "")
+	ch, err = snap.ParseChannel("latest/stable", "")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: arch.UbuntuArchitecture(),
 		Name:         "stable",
 		Track:        "",
@@ -51,9 +51,9 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 		Branch:       "",
 	})
 
-	ch, err = snap.ParseStoreChannel("1.0/edge", "")
+	ch, err = snap.ParseChannel("1.0/edge", "")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: arch.UbuntuArchitecture(),
 		Name:         "1.0/edge",
 		Track:        "1.0",
@@ -61,9 +61,9 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 		Branch:       "",
 	})
 
-	ch, err = snap.ParseStoreChannel("1.0", "")
+	ch, err = snap.ParseChannel("1.0", "")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: arch.UbuntuArchitecture(),
 		Name:         "1.0/stable",
 		Track:        "1.0",
@@ -71,9 +71,9 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 		Branch:       "",
 	})
 
-	ch, err = snap.ParseStoreChannel("1.0/beta/foo", "")
+	ch, err = snap.ParseChannel("1.0/beta/foo", "")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: arch.UbuntuArchitecture(),
 		Name:         "1.0/beta/foo",
 		Track:        "1.0",
@@ -81,9 +81,9 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 		Branch:       "foo",
 	})
 
-	ch, err = snap.ParseStoreChannel("candidate/foo", "")
+	ch, err = snap.ParseChannel("candidate/foo", "")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: arch.UbuntuArchitecture(),
 		Name:         "candidate/foo",
 		Track:        "",
@@ -91,9 +91,9 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 		Branch:       "foo",
 	})
 
-	ch, err = snap.ParseStoreChannel("candidate/foo", "other-arch")
+	ch, err = snap.ParseChannel("candidate/foo", "other-arch")
 	c.Assert(err, IsNil)
-	c.Check(ch, DeepEquals, snap.StoreChannel{
+	c.Check(ch, DeepEquals, snap.Channel{
 		Architecture: "other-arch",
 		Name:         "candidate/foo",
 		Track:        "",
@@ -103,7 +103,7 @@ func (s storeChannelSuite) TestParseStoreChannel(c *C) {
 }
 
 func (s storeChannelSuite) TestClean(c *C) {
-	ch := snap.StoreChannel{
+	ch := snap.Channel{
 		Architecture: "arm64",
 		Track:        "latest",
 		Name:         "latest/stable",
@@ -112,7 +112,7 @@ func (s storeChannelSuite) TestClean(c *C) {
 
 	cleanedCh := ch.Clean()
 	c.Check(cleanedCh, Not(DeepEquals), c)
-	c.Check(cleanedCh, DeepEquals, snap.StoreChannel{
+	c.Check(cleanedCh, DeepEquals, snap.Channel{
 		Architecture: "arm64",
 		Track:        "",
 		Name:         "stable",
@@ -120,14 +120,14 @@ func (s storeChannelSuite) TestClean(c *C) {
 	})
 }
 
-func (s storeChannelSuite) TestParseStoreChannelErrors(c *C) {
-	_, err := snap.ParseStoreChannel("", "")
+func (s storeChannelSuite) TestParseChannelErrors(c *C) {
+	_, err := snap.ParseChannel("", "")
 	c.Check(err, ErrorMatches, "channel name cannot be empty")
 
-	_, err = snap.ParseStoreChannel("1.0////", "")
+	_, err = snap.ParseChannel("1.0////", "")
 	c.Check(err, ErrorMatches, "channel name has too many components: 1.0////")
 
-	_, err = snap.ParseStoreChannel("1.0/cand", "invalid risk in channel name: 1.0/cand")
+	_, err = snap.ParseChannel("1.0/cand", "invalid risk in channel name: 1.0/cand")
 	c.Check(err, ErrorMatches, "invalid risk in channel name: 1.0/cand")
 }
 
@@ -140,11 +140,12 @@ func (s *storeChannelSuite) TestString(c *C) {
 		{"latest/stable", "stable"},
 		{"1.0/edge", "1.0/edge"},
 		{"1.0/beta/foo", "1.0/beta/foo"},
+		{"1.0", "1.0/stable"},
 		{"candidate/foo", "candidate/foo"},
 	}
 
 	for _, t := range tests {
-		ch, err := snap.ParseStoreChannel(t.channel, "")
+		ch, err := snap.ParseChannel(t.channel, "")
 		c.Assert(err, IsNil)
 
 		c.Check(ch.String(), Equals, t.str)
@@ -160,11 +161,12 @@ func (s *storeChannelSuite) TestFull(c *C) {
 		{"latest/stable", "latest/stable"},
 		{"1.0/edge", "1.0/edge"},
 		{"1.0/beta/foo", "1.0/beta/foo"},
+		{"1.0", "1.0/stable"},
 		{"candidate/foo", "latest/candidate/foo"},
 	}
 
 	for _, t := range tests {
-		ch, err := snap.ParseStoreChannel(t.channel, "")
+		ch, err := snap.ParseChannel(t.channel, "")
 		c.Assert(err, IsNil)
 
 		c.Check(ch.Full(), Equals, t.str)
@@ -199,9 +201,9 @@ func (s *storeChannelSuite) TestMatch(c *C) {
 		if !t.sameArch {
 			c1Arch = "arm64"
 		}
-		req, err := snap.ParseStoreChannel(t.req, reqArch)
+		req, err := snap.ParseChannel(t.req, reqArch)
 		c.Assert(err, IsNil)
-		c1, err := snap.ParseStoreChannel(t.c1, c1Arch)
+		c1, err := snap.ParseChannel(t.c1, c1Arch)
 		c.Assert(err, IsNil)
 
 		c.Check(req.Match(&c1).String(), Equals, t.res)

--- a/snap/channel_test.go
+++ b/snap/channel_test.go
@@ -204,6 +204,6 @@ func (s *storeChannelSuite) TestMatch(c *C) {
 		c1, err := snap.ParseStoreChannel(t.c1, c1Arch)
 		c.Assert(err, IsNil)
 
-		c.Check(req.Match(&c1), Equals, t.res)
+		c.Check(req.Match(&c1).String(), Equals, t.res)
 	}
 }


### PR DESCRIPTION
This introduces snap.Channel to represent store channels, with ParseChannel for parsing it, and helpers to turn it back into strings and to check whether two channels match.