### PR TITLE
snap{/snaptest}: set instance key based on snap name

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -904,6 +904,9 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 		return nil, &invalidMetaError{Snap: name, Revision: si.Revision, Msg: err.Error()}
 	}
 
+	_, instanceKey := SplitInstanceName(name)
+	info.InstanceKey = instanceKey
+
 	return info, nil
 }
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -195,6 +195,24 @@ func (s *infoSuite) TestReadInfo(c *C) {
 	c.Check(snapInfo2, DeepEquals, snapInfo1)
 }
 
+func (s *infoSuite) TestReadInfoWithInstance(c *C) {
+	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "instance summary"}
+
+	snapInfo1 := snaptest.MockSnapInstance(c, "sample_instance", sampleYaml, si)
+
+	snapInfo2, err := snap.ReadInfo("sample_instance", si)
+	c.Assert(err, IsNil)
+
+	c.Check(snapInfo2.InstanceName(), Equals, "sample_instance")
+	c.Check(snapInfo2.StoreName(), Equals, "sample")
+	c.Check(snapInfo2.Revision, Equals, snap.R(42))
+	c.Check(snapInfo2.Summary(), Equals, "instance summary")
+
+	c.Check(snapInfo2.Apps["app"].Command, Equals, "foo")
+
+	c.Check(snapInfo2, DeepEquals, snapInfo1)
+}
+
 func (s *infoSuite) TestReadCurrentInfo(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42)}
 
@@ -210,6 +228,24 @@ func (s *infoSuite) TestReadCurrentInfo(c *C) {
 	snapInfo3, err := snap.ReadCurrentInfo("not-sample")
 	c.Check(snapInfo3, IsNil)
 	c.Assert(err, ErrorMatches, `cannot find current revision for snap not-sample:.*`)
+}
+
+func (s *infoSuite) TestReadCurrentInfoWithInstance(c *C) {
+	si := &snap.SideInfo{Revision: snap.R(42)}
+
+	snapInfo1 := snaptest.MockSnapInstanceCurrent(c, "sample_instance", sampleYaml, si)
+
+	snapInfo2, err := snap.ReadCurrentInfo("sample_instance")
+	c.Assert(err, IsNil)
+
+	c.Check(snapInfo2.InstanceName(), Equals, "sample_instance")
+	c.Check(snapInfo2.StoreName(), Equals, "sample")
+	c.Check(snapInfo2.Revision, Equals, snap.R(42))
+	c.Check(snapInfo2, DeepEquals, snapInfo1)
+
+	snapInfo3, err := snap.ReadCurrentInfo("sample_other")
+	c.Check(snapInfo3, IsNil)
+	c.Assert(err, ErrorMatches, `cannot find current revision for snap sample_other:.*`)
 }
 
 func (s *infoSuite) TestInstallDate(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -204,7 +204,7 @@ func (s *infoSuite) TestReadInfoWithInstance(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapInfo2.InstanceName(), Equals, "sample_instance")
-	c.Check(snapInfo2.StoreName(), Equals, "sample")
+	c.Check(snapInfo2.SnapName(), Equals, "sample")
 	c.Check(snapInfo2.Revision, Equals, snap.R(42))
 	c.Check(snapInfo2.Summary(), Equals, "instance summary")
 
@@ -239,7 +239,7 @@ func (s *infoSuite) TestReadCurrentInfoWithInstance(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapInfo2.InstanceName(), Equals, "sample_instance")
-	c.Check(snapInfo2.StoreName(), Equals, "sample")
+	c.Check(snapInfo2.SnapName(), Equals, "sample")
 	c.Check(snapInfo2.Revision, Equals, snap.R(42))
 	c.Check(snapInfo2, DeepEquals, snapInfo1)
 

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -46,9 +46,15 @@ func mockSnap(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo
 	// Set SideInfo so that we can use MountDir below
 	snapInfo.SideInfo = *sideInfo
 
-	// Set the snap instance name
-	_, instanceKey := snap.SplitInstanceName(instanceName)
-	snapInfo.InstanceKey = instanceKey
+	if instanceName != "" {
+		// Set the snap instance name
+		snapName, instanceKey := snap.SplitInstanceName(instanceName)
+		snapInfo.InstanceKey = instanceKey
+
+		// Make sure snap name/instance name checks out
+		c.Assert(snapInfo.InstanceName(), check.Equals, instanceName)
+		c.Assert(snapInfo.SnapName(), check.Equals, snapName)
+	}
 
 	// Put the YAML on disk, in the right spot.
 	metaDir := filepath.Join(snapInfo.MountDir(), "meta")

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -33,11 +33,7 @@ import (
 	"github.com/snapcore/snapd/snap/pack"
 )
 
-// MockSnap puts a snap.yaml file on disk so to mock an installed snap, based on the provided arguments.
-//
-// The caller is responsible for mocking root directory with dirs.SetRootDir()
-// and for altering the overlord state if required.
-func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+func mockSnap(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	c.Assert(sideInfo, check.Not(check.IsNil))
 
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
@@ -49,6 +45,10 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 
 	// Set SideInfo so that we can use MountDir below
 	snapInfo.SideInfo = *sideInfo
+
+	// Set the snap instance name
+	_, instanceKey := snap.SplitInstanceName(instanceName)
+	snapInfo.InstanceKey = instanceKey
 
 	// Put the YAML on disk, in the right spot.
 	metaDir := filepath.Join(snapInfo.MountDir(), "meta")
@@ -68,6 +68,23 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return snapInfo
 }
 
+// MockSnap puts a snap.yaml file on disk so to mock an installed snap, based on the provided arguments.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	return mockSnap(c, "", yamlText, sideInfo)
+}
+
+// MockSnapInstance puts a snap.yaml file on disk so to mock an installed snap
+// instance, based on the provided arguments.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockSnapInstance(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	return mockSnap(c, instanceName, yamlText, sideInfo)
+}
+
 // MockSnapCurrent does the same as MockSnap but additionally creates the
 // 'current' symlink.
 //
@@ -75,6 +92,18 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 // and for altering the overlord state if required.
 func MockSnapCurrent(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	si := MockSnap(c, yamlText, sideInfo)
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, check.IsNil)
+	return si
+}
+
+// MockSnapInstanceCurrent does the same as MockSnapInstance but additionally
+// creates the 'current' symlink.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockSnapInstanceCurrent(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	si := MockSnapInstance(c, instanceName, yamlText, sideInfo)
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
 	c.Assert(err, check.IsNil)
 	return si

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -76,7 +76,7 @@ func (s *snapTestSuite) TestMockSnapInstance(c *C) {
 	snapInfo := snaptest.MockSnapInstance(c, "sample_instance", sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
 	// Data from YAML and parameters is used
 	c.Check(snapInfo.InstanceName(), Equals, "sample_instance")
-	c.Check(snapInfo.StoreName(), Equals, "sample")
+	c.Check(snapInfo.SnapName(), Equals, "sample")
 	c.Check(snapInfo.InstanceKey, Equals, "instance")
 
 	// Data from SideInfo is used
@@ -108,7 +108,7 @@ func (s *snapTestSuite) TestMockSnapInstanceCurrent(c *C) {
 	snapInfo := snaptest.MockSnapInstanceCurrent(c, "sample_instance", sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
 	// Data from YAML and parameters is used
 	c.Check(snapInfo.InstanceName(), Equals, "sample_instance")
-	c.Check(snapInfo.StoreName(), Equals, "sample")
+	c.Check(snapInfo.SnapName(), Equals, "sample")
 	c.Check(snapInfo.InstanceKey, Equals, "instance")
 	// Data from SideInfo is used
 	c.Check(snapInfo.Revision, Equals, snap.R(42))

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -72,6 +72,24 @@ func (s *snapTestSuite) TestMockSnap(c *C) {
 	c.Check(snapInfo.Plugs["network"].Interface, Equals, "network")
 }
 
+func (s *snapTestSuite) TestMockSnapInstance(c *C) {
+	snapInfo := snaptest.MockSnapInstance(c, "sample_instance", sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
+	// Data from YAML and parameters is used
+	c.Check(snapInfo.InstanceName(), Equals, "sample_instance")
+	c.Check(snapInfo.StoreName(), Equals, "sample")
+	c.Check(snapInfo.InstanceKey, Equals, "instance")
+
+	// Data from SideInfo is used
+	c.Check(snapInfo.Revision, Equals, snap.R(42))
+	// The YAML is placed on disk
+	c.Check(filepath.Join(dirs.SnapMountDir, "sample_instance", "42", "meta", "snap.yaml"),
+		testutil.FileEquals, sampleYaml)
+
+	// More
+	c.Check(snapInfo.Apps["app"].Command, Equals, "foo")
+	c.Check(snapInfo.Plugs["network"].Interface, Equals, "network")
+}
+
 func (s *snapTestSuite) TestMockSnapCurrent(c *C) {
 	snapInfo := snaptest.MockSnapCurrent(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
 	// Data from YAML is used
@@ -84,6 +102,22 @@ func (s *snapTestSuite) TestMockSnapCurrent(c *C) {
 	link, err := os.Readlink(filepath.Join(dirs.SnapMountDir, "sample", "current"))
 	c.Check(err, IsNil)
 	c.Check(link, Equals, filepath.Join(dirs.SnapMountDir, "sample", "42"))
+}
+
+func (s *snapTestSuite) TestMockSnapInstanceCurrent(c *C) {
+	snapInfo := snaptest.MockSnapInstanceCurrent(c, "sample_instance", sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
+	// Data from YAML and parameters is used
+	c.Check(snapInfo.InstanceName(), Equals, "sample_instance")
+	c.Check(snapInfo.StoreName(), Equals, "sample")
+	c.Check(snapInfo.InstanceKey, Equals, "instance")
+	// Data from SideInfo is used
+	c.Check(snapInfo.Revision, Equals, snap.R(42))
+	// The YAML is placed on disk
+	c.Check(filepath.Join(dirs.SnapMountDir, "sample_instance", "42", "meta", "snap.yaml"),
+		testutil.FileEquals, sampleYaml)
+	link, err := os.Readlink(filepath.Join(dirs.SnapMountDir, "sample_instance", "current"))
+	c.Check(err, IsNil)
+	c.Check(link, Equals, filepath.Join(dirs.SnapMountDir, "sample_instance", "42"))
 }
 
 func (s *snapTestSuite) TestMockInfo(c *C) {


### PR DESCRIPTION
This is a prerequisite for opening PR with `SnapState` changes.
