### PR TITLE
snap: account for parallel installs in wrappers, place info and tests

### DIFF
--- a/snap/broken.go
+++ b/snap/broken.go
@@ -46,7 +46,7 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 				// be available under '<snap>' name, if the snap
 				// was installed with instance key, the app will
 				// be named `<snap>_<instance>'
-				appname = StoreName(l[0])
+				appname = InstanceSnap(l[0])
 			} else {
 				appname = l[1]
 			}

--- a/snap/broken.go
+++ b/snap/broken.go
@@ -35,14 +35,18 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 	out := make(map[string]*AppInfo)
 
 	// guess binaries first
-	name := info.SuggestedName
+	name := info.InstanceName()
 	for _, p := range []string{name, fmt.Sprintf("%s.*", name)} {
 		matches, _ := filepath.Glob(filepath.Join(dirs.SnapBinariesDir, p))
 		for _, m := range matches {
 			l := strings.SplitN(filepath.Base(m), ".", 2)
 			var appname string
 			if len(l) == 1 {
-				appname = l[0]
+				// when app is named the same as snap, it will
+				// be available under '<snap>' name, if the snap
+				// was installed with instance key, the app will
+				// be named `<snap>_<instance>'
+				appname = StoreName(l[0])
 			} else {
 				appname = l[1]
 			}

--- a/snap/broken_test.go
+++ b/snap/broken_test.go
@@ -53,23 +53,39 @@ func touch(c *C, path string) {
 func (s *brokenSuite) TestGuessAppsForBrokenBinaries(c *C) {
 	touch(c, filepath.Join(dirs.SnapBinariesDir, "foo"))
 	touch(c, filepath.Join(dirs.SnapBinariesDir, "foo.bar"))
+	touch(c, filepath.Join(dirs.SnapBinariesDir, "foo_instance"))
+	touch(c, filepath.Join(dirs.SnapBinariesDir, "foo_instance.baz"))
 
 	info := &snap.Info{SuggestedName: "foo"}
 	apps := snap.GuessAppsForBroken(info)
 	c.Check(apps, HasLen, 2)
 	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo"})
 	c.Check(apps["bar"], DeepEquals, &snap.AppInfo{Snap: info, Name: "bar"})
+
+	info = &snap.Info{SuggestedName: "foo", InstanceKey: "instance"}
+	apps = snap.GuessAppsForBroken(info)
+	c.Check(apps, HasLen, 2)
+	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo"})
+	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz"})
 }
 
 func (s *brokenSuite) TestGuessAppsForBrokenServices(c *C) {
 	touch(c, filepath.Join(dirs.SnapServicesDir, "snap.foo.foo.service"))
 	touch(c, filepath.Join(dirs.SnapServicesDir, "snap.foo.bar.service"))
+	touch(c, filepath.Join(dirs.SnapServicesDir, "snap.foo_instance.foo.service"))
+	touch(c, filepath.Join(dirs.SnapServicesDir, "snap.foo_instance.baz.service"))
 
 	info := &snap.Info{SuggestedName: "foo"}
 	apps := snap.GuessAppsForBroken(info)
 	c.Check(apps, HasLen, 2)
 	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple"})
 	c.Check(apps["bar"], DeepEquals, &snap.AppInfo{Snap: info, Name: "bar", Daemon: "simple"})
+
+	info = &snap.Info{SuggestedName: "foo", InstanceKey: "instance"}
+	apps = snap.GuessAppsForBroken(info)
+	c.Check(apps, HasLen, 2)
+	c.Check(apps["foo"], DeepEquals, &snap.AppInfo{Snap: info, Name: "foo", Daemon: "simple"})
+	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz", Daemon: "simple"})
 }
 
 func (s *brokenSuite) TestRenamePlug(c *C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -731,7 +731,7 @@ func (app *AppInfo) launcherCommand(command string) string {
 	if command != "" {
 		command = " " + command
 	}
-	if app.Name == app.Snap.StoreName() {
+	if app.Name == app.Snap.SnapName() {
 		return fmt.Sprintf("/usr/bin/snap run%s %s", command, app.Snap.InstanceName())
 	}
 	return fmt.Sprintf("/usr/bin/snap run%s %s.%s", command, app.Snap.InstanceName(), app.Name)
@@ -972,7 +972,7 @@ func InstallDate(name string) time.Time {
 func SplitSnapApp(snapApp string) (snap, app string) {
 	l := strings.SplitN(snapApp, ".", 2)
 	if len(l) < 2 {
-		return l[0], StoreName(l[0])
+		return l[0], InstanceSnap(l[0])
 	}
 	return l[0], l[1]
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -731,9 +731,8 @@ func (app *AppInfo) launcherCommand(command string) string {
 	if command != "" {
 		command = " " + command
 	}
-	// TODO parallel-install: use of proper instance/store name
-	if app.Name == app.Snap.InstanceName() {
-		return fmt.Sprintf("/usr/bin/snap run%s %s", command, app.Name)
+	if app.Name == app.Snap.StoreName() {
+		return fmt.Sprintf("/usr/bin/snap run%s %s", command, app.Snap.InstanceName())
 	}
 	return fmt.Sprintf("/usr/bin/snap run%s %s.%s", command, app.Snap.InstanceName(), app.Name)
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -972,7 +972,7 @@ func InstallDate(name string) time.Time {
 func SplitSnapApp(snapApp string) (snap, app string) {
 	l := strings.SplitN(snapApp, ".", 2)
 	if len(l) < 2 {
-		return l[0], l[0]
+		return l[0], StoreName(l[0])
 	}
 	return l[0], l[1]
 }
@@ -981,8 +981,9 @@ func SplitSnapApp(snapApp string) (snap, app string) {
 // `snap` and the `app` part. It also deals with the special
 // case of snapName == appName.
 func JoinSnapApp(snap, app string) string {
-	if snap == app {
-		return app
+	storeName, instanceKey := SplitInstanceName(snap)
+	if storeName == app {
+		return InstanceName(app, instanceKey)
 	}
 	return fmt.Sprintf("%s.%s", snap, app)
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -77,7 +77,8 @@ type PlaceInfo interface {
 
 // MinimalPlaceInfo returns a PlaceInfo with just the location information for a snap of the given name and revision.
 func MinimalPlaceInfo(name string, revision Revision) PlaceInfo {
-	return &Info{SideInfo: SideInfo{RealName: name, Revision: revision}}
+	storeName, instanceKey := SplitInstanceName(name)
+	return &Info{SideInfo: SideInfo{RealName: storeName, Revision: revision}, InstanceKey: instanceKey}
 }
 
 // MountDir returns the base directory where it gets mounted of the snap with the given name and revision.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -507,6 +507,10 @@ func (s *infoSuite) TestSplitSnapApp(c *C) {
 		{"foo.bar.baz", []string{"foo", "bar.baz"}},
 		// special case, snapName == appName
 		{"foo", []string{"foo", "foo"}},
+		// snap instance names
+		{"foo_instance.bar", []string{"foo_instance", "bar"}},
+		{"foo_instance.bar.baz", []string{"foo_instance", "bar.baz"}},
+		{"foo_instance", []string{"foo_instance", "foo"}},
 	} {
 		snap, app := snap.SplitSnapApp(t.in)
 		c.Check([]string{snap, app}, DeepEquals, t.out)
@@ -523,6 +527,10 @@ func (s *infoSuite) TestJoinSnapApp(c *C) {
 		{[]string{"foo", "bar-baz"}, "foo.bar-baz"},
 		// special case, snapName == appName
 		{[]string{"foo", "foo"}, "foo"},
+		// snap instance names
+		{[]string{"foo_instance", "bar"}, "foo_instance.bar"},
+		{[]string{"foo_instance", "bar-baz"}, "foo_instance.bar-baz"},
+		{[]string{"foo_instance", "foo"}, "foo_instance"},
 	} {
 		snapApp := snap.JoinSnapApp(t.in[0], t.in[1])
 		c.Check(snapApp, Equals, t.out)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -742,6 +742,13 @@ func (s *infoSuite) TestAppDesktopFile(c *C) {
 	c.Check(snapInfo.InstanceName(), Equals, "sample")
 	c.Check(snapInfo.Apps["app"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_app.desktop`)
 	c.Check(snapInfo.Apps["sample"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_sample.desktop`)
+
+	// snap with instance key
+	snapInfo.InstanceKey = "instance"
+	c.Check(snapInfo.InstanceName(), Equals, "sample_instance")
+	c.Check(snapInfo.Apps["app"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_instance_app.desktop`)
+	c.Check(snapInfo.Apps["sample"].DesktopFile(), Matches, `.*/var/lib/snapd/desktop/applications/sample_instance_sample.desktop`)
+
 }
 
 const coreSnapYaml = `name: core
@@ -810,6 +817,18 @@ apps:
 		"snap.pans.svc1.service",
 		"snap.pans.svc2.service",
 	})
+
+	// snap with instance
+	info.InstanceKey = "instance"
+	svcNames = []string{}
+	for i := range info.Services() {
+		svcNames = append(svcNames, svcs[i].ServiceName())
+	}
+	sort.Strings(svcNames)
+	c.Check(svcNames, DeepEquals, []string{
+		"snap.pans_instance.svc1.service",
+		"snap.pans_instance.svc2.service",
+	})
 }
 
 func (s *infoSuite) TestAppInfoIsService(c *C) {
@@ -832,6 +851,11 @@ apps:
 	c.Check(info.Apps["svc2"].IsService(), Equals, true)
 	c.Check(info.Apps["app1"].IsService(), Equals, false)
 	c.Check(info.Apps["app1"].IsService(), Equals, false)
+
+	// snap with instance key
+	info.InstanceKey = "instance"
+	c.Check(svc.ServiceName(), Equals, "snap.pans_instance.svc1.service")
+	c.Check(svc.ServiceFile(), Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans_instance.svc1.service")
 }
 
 func (s *infoSuite) TestAppInfoStringer(c *C) {
@@ -859,6 +883,10 @@ apps:
 	app := info.Apps["app1"]
 	socket := app.Sockets["sock1"]
 	c.Check(socket.File(), Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans.app1.sock1.socket")
+
+	// snap with instance key
+	info.InstanceKey = "instance"
+	c.Check(socket.File(), Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans_instance.app1.sock1.socket")
 }
 
 func (s *infoSuite) TestTimerFile(c *C) {
@@ -875,6 +903,10 @@ apps:
 	timerFile := app.Timer.File()
 	c.Check(timerFile, Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans.app1.timer")
 	c.Check(strings.TrimSuffix(app.ServiceFile(), ".service")+".timer", Equals, timerFile)
+
+	// snap with instance key
+	info.InstanceKey = "instance"
+	c.Check(app.Timer.File(), Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans_instance.app1.timer")
 }
 
 func (s *infoSuite) TestLayoutParsing(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -164,6 +164,15 @@ apps:
 	c.Check(info.Apps["bar"].LauncherPostStopCommand(), Equals, "/usr/bin/snap run --command=post-stop foo.bar")
 	c.Check(info.Apps["foo"].LauncherCommand(), Equals, "/usr/bin/snap run foo")
 	c.Check(info.Apps["baz"].LauncherCommand(), Equals, `/usr/bin/snap run --timer="10:00-12:00,,mon,12:00~14:00" foo.baz`)
+
+	// snap with instance key
+	info.InstanceKey = "instance"
+	c.Check(info.Apps["bar"].LauncherCommand(), Equals, "/usr/bin/snap run foo_instance.bar")
+	c.Check(info.Apps["bar"].LauncherStopCommand(), Equals, "/usr/bin/snap run --command=stop foo_instance.bar")
+	c.Check(info.Apps["bar"].LauncherReloadCommand(), Equals, "/usr/bin/snap run --command=reload foo_instance.bar")
+	c.Check(info.Apps["bar"].LauncherPostStopCommand(), Equals, "/usr/bin/snap run --command=post-stop foo_instance.bar")
+	c.Check(info.Apps["foo"].LauncherCommand(), Equals, "/usr/bin/snap run foo_instance")
+	c.Check(info.Apps["baz"].LauncherCommand(), Equals, `/usr/bin/snap run --timer="10:00-12:00,,mon,12:00~14:00" foo_instance.baz`)
 }
 
 const sampleYaml = `


### PR DESCRIPTION
Make sure that we pick up the right app names when handling apps from parallel
installations of the same snap.
