### PR TITLE
data: add systemd environment configuration

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -1,5 +1,6 @@
 all install clean:
 	$(MAKE) -C systemd $@
+	$(MAKE) -C systemd-env $@
 	$(MAKE) -C dbus $@
 	$(MAKE) -C env $@
 	$(MAKE) -C desktop $@

--- a/data/systemd-env/990-snapd.conf.in
+++ b/data/systemd-env/990-snapd.conf.in
@@ -1,0 +1,1 @@
+PATH=$PATH:@SNAP_MOUNT_DIR@/bin

--- a/data/systemd-env/Makefile
+++ b/data/systemd-env/Makefile
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+SNAP_MOUNT_DIR := /snap
+ENVD := /usr/lib/environment.d/
+
+%.conf: %.conf.in
+	sed   < $< > $@ \
+		s:@SNAP_MOUNT_DIR@:${SNAP_MOUNT_DIR}:g
+
+GENERATED = 990-snapd.conf
+
+
+all: ${GENERATED}
+.PHONY: all
+
+install: ${GENERATED}
+	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
+	install -d -m 0755 ${DESTDIR}/${ENVD}
+	install -m 0644 -t ${DESTDIR}/${ENVD} $^
+.PHONY: install
+
+clean:
+	$(RM) ${GENERATED}
+.PHONY: clean

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -649,6 +649,7 @@ popd
 %dir %{_localstatedir}/snap
 %ghost %{_sharedstatedir}/snapd/state.json
 %ghost %{_sharedstatedir}/snapd/snap/README
+%{_environmentdir}/990-snapd.conf
 
 %files -n snap-confine
 %doc cmd/snap-confine/PORTING
@@ -667,7 +668,6 @@ popd
 %{_mandir}/man1/snap-confine.1*
 %{_mandir}/man5/snap-discard-ns.5*
 %attr(0000,root,root) %{_sharedstatedir}/snapd/void
-
 
 %files selinux
 %license data/selinux/COPYING

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -6,6 +6,9 @@
 %bcond_without vendorized
 %endif
 
+# Compat macros
+%{?!_environmentdir: %global _environmentdir %{_prefix}/lib/environment.d}
+
 # A switch to allow building the package with support for testkeys which
 # are used for the spread test suite of snapd.
 %bcond_with testkeys

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -25,6 +25,7 @@
 
 # Compat macros
 %{!?make_build: %global make_build %{__make} %{?_smp_mflags}}
+%{?!_environmentdir: %global _environmentdir %{_prefix}/lib/environment.d}
 
 # This is fixed in SUSE Linux 15
 # Cf. https://build.opensuse.org/package/rdiff/Base:System/rpm?linkrev=base&rev=396

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -374,6 +374,7 @@ fi
 %if %{with apparmor}
 %{_sysconfdir}/apparmor.d/usr.lib.snapd.snap-confine
 %endif
+%{_environmentdir}/990-snapd.conf
 
 %changelog
 


### PR DESCRIPTION
This addresses LP: 1771858 and ensures that /snap/bin is available in
the PATH everywhere. This superseeds #5226 which was using a full
generator but we really just need the simpler environment conf file.
