### PR TITLE
strutil: add PathIterator.Rewind

### DIFF
--- a/strutil/pathiter.go
+++ b/strutil/pathiter.go
@@ -129,3 +129,10 @@ func (iter *PathIterator) Next() bool {
 	iter.depth++
 	return true
 }
+
+// Rewind returns the iterator the the initial state, allowing the path to be traversed again.
+func (iter *PathIterator) Rewind() {
+	iter.left = 0
+	iter.right = 0
+	iter.depth = 0
+}

--- a/strutil/pathiter_test.go
+++ b/strutil/pathiter_test.go
@@ -174,6 +174,20 @@ func (s *pathIterSuite) TestPathIteratorUnicode(c *C) {
 	c.Assert(iter.Depth(), Equals, 4)
 }
 
+func (s *pathIterSuite) TestPathIteratorRewind(c *C) {
+	iter, err := strutil.NewPathIterator("/foo/bar")
+	c.Assert(err, IsNil)
+	for i := 0; i < 2; i++ {
+		c.Assert(iter.Next(), Equals, true)
+		c.Assert(iter.Depth(), Equals, 1)
+		c.Assert(iter.CurrentPath(), Equals, "/")
+		c.Assert(iter.Next(), Equals, true)
+		c.Assert(iter.Depth(), Equals, 2)
+		c.Assert(iter.CurrentPath(), Equals, "/foo/")
+		iter.Rewind()
+	}
+}
+
 func (s *pathIterSuite) TestPathIteratorExample(c *C) {
 	iter, err := strutil.NewPathIterator("/some/path/there")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The rewind method is useful to cut the number of error paths since it
allows to rewind an already constructed path iterator without having to
handle errors.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
