### PR TITLE
strutil: support iteration over almost clean paths

### DIFF
--- a/strutil/pathiter.go
+++ b/strutil/pathiter.go
@@ -50,10 +50,10 @@ type PathIterator struct {
 // The path is passed through filepath.Clean automatically.
 func NewPathIterator(path string) (*PathIterator, error) {
 	cleanPath := filepath.Clean(path)
-	if path != cleanPath {
+	if cleanPath != path && cleanPath+"/" != path {
 		return nil, fmt.Errorf("cannot iterate over unclean path %q", path)
 	}
-	return &PathIterator{path: cleanPath}, nil
+	return &PathIterator{path: path}, nil
 }
 
 // Path returns the path being traversed.

--- a/strutil/pathiter_test.go
+++ b/strutil/pathiter_test.go
@@ -76,6 +76,37 @@ func (s *pathIterSuite) TestPathIteratorRelative(c *C) {
 	c.Assert(iter.Depth(), Equals, 2)
 }
 
+func (s *pathIterSuite) TestPathIteratorAbsoluteAlmostClean(c *C) {
+	iter, err := strutil.NewPathIterator("/foo/bar/")
+	c.Assert(err, IsNil)
+	c.Assert(iter.Path(), Equals, "/foo/bar/")
+	c.Assert(iter.Depth(), Equals, 0)
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "/")
+	c.Assert(iter.CurrentName(), Equals, "/")
+	c.Assert(iter.CurrentCleanName(), Equals, "")
+	c.Assert(iter.Depth(), Equals, 1)
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/")
+	c.Assert(iter.CurrentPath(), Equals, "/foo/")
+	c.Assert(iter.CurrentName(), Equals, "foo/")
+	c.Assert(iter.CurrentCleanName(), Equals, "foo")
+	c.Assert(iter.Depth(), Equals, 2)
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/foo/")
+	c.Assert(iter.CurrentPath(), Equals, "/foo/bar/")
+	c.Assert(iter.CurrentName(), Equals, "bar/")
+	c.Assert(iter.CurrentCleanName(), Equals, "bar")
+	c.Assert(iter.Depth(), Equals, 3)
+
+	c.Assert(iter.Next(), Equals, false)
+	c.Assert(iter.Depth(), Equals, 3)
+}
+
 func (s *pathIterSuite) TestPathIteratorAbsoluteClean(c *C) {
 	iter, err := strutil.NewPathIterator("/foo/bar")
 	c.Assert(err, IsNil)
@@ -105,12 +136,6 @@ func (s *pathIterSuite) TestPathIteratorAbsoluteClean(c *C) {
 
 	c.Assert(iter.Next(), Equals, false)
 	c.Assert(iter.Depth(), Equals, 3)
-}
-
-func (s *pathIterSuite) TestPathIteratorAbsoluteUnclean(c *C) {
-	iter, err := strutil.NewPathIterator("/foo/bar/")
-	c.Assert(err, ErrorMatches, `cannot iterate over unclean path "/foo/bar/"`)
-	c.Assert(iter, IsNil)
 }
 
 func (s *pathIterSuite) TestPathIteratorRootDir(c *C) {


### PR DESCRIPTION
This patch changes the path iterator to support otherwise clean (as in
filepath.Clean-wise) that end with a trailing slash. Such paths are
common in apparmor world and supporting them without errors is
convenient.

The path that the iterator uses is always the input path, that is, clean
is only used as a validator. This allows us to keep the assumptions that
the path is not transformed.

The patch also removes a duplicate test for unclean paths.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>?
