### PR TITLE
many: rename snap.Info.StoreName() to snap.Info.SnapName()

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -109,7 +109,7 @@ func SetNextBoot(s *snap.Info) error {
 	}
 
 	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel && s.Type != snap.TypeBase {
-		return fmt.Errorf("cannot set next boot to snap %q with type %q", s.StoreName(), s.Type)
+		return fmt.Errorf("cannot set next boot to snap %q with type %q", s.SnapName(), s.Type)
 	}
 
 	bootloader, err := partition.FindBootloader()

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -45,7 +45,7 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 		Active: true,
 		Sequence: []*snap.SideInfo{
 			{
-				RealName: snapInfo.StoreName(),
+				RealName: snapInfo.SnapName(),
 				Revision: snapInfo.Revision,
 				SnapID:   "ididid",
 			},

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2134,7 +2134,7 @@ func makeMockRepoWithConnectedSnaps(c *C, st *state.State, info11, core11 *snap.
 func (s *deviceMgrSuite) makeSnapDeclaration(c *C, st *state.State, info *snap.Info) {
 	decl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
 		"series":       "16",
-		"snap-name":    info.StoreName(),
+		"snap-name":    info.SnapName(),
 		"snap-id":      info.SideInfo.SnapID,
 		"publisher-id": "canonical",
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -144,7 +144,7 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 		Active: true,
 		Sequence: []*snap.SideInfo{
 			{
-				RealName: info1.StoreName(),
+				RealName: info1.SnapName(),
 				Revision: info1.Revision,
 				SnapID:   "test-snap-id",
 			},
@@ -155,7 +155,7 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 		Active: true,
 		Sequence: []*snap.SideInfo{
 			{
-				RealName: info2.StoreName(),
+				RealName: info2.SnapName(),
 				Revision: info2.Revision,
 				SnapID:   "other-snap-id",
 			},

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -865,7 +865,7 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 		Revision: snap.R(1),
 	}
 	snapInfo := snaptest.MockSnap(c, yamlText, sideInfo)
-	sideInfo.RealName = snapInfo.StoreName()
+	sideInfo.RealName = snapInfo.SnapName()
 
 	a, err := s.db.FindMany(asserts.SnapDeclarationType, map[string]string{
 		"snap-name": sideInfo.RealName,
@@ -895,7 +895,7 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision int) *snap.Info {
 	sideInfo := &snap.SideInfo{Revision: snap.R(revision)}
 	snapInfo := snaptest.MockSnap(c, yamlText, sideInfo)
-	sideInfo.RealName = snapInfo.StoreName()
+	sideInfo.RealName = snapInfo.SnapName()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1063,7 +1063,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsUndesiredFlag(c *C)
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1107,7 +1107,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsPlugs(c *C) {
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1155,7 +1155,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1208,7 +1208,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiple
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1270,7 +1270,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1341,7 +1341,7 @@ slots:
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
 			Revision: snapInfo.Revision,
 		},
@@ -1388,7 +1388,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionSt
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1434,7 +1434,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyIgnoresStrayConnection(c 
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1463,7 +1463,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 	// Run the setup-profiles task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -1562,7 +1562,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	// Note that the task will see SnapSetup.Flags equal to DeveloperMode.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 		Flags: snapstate.Flags{DevMode: true},
@@ -1613,7 +1613,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	// Run the setup-profiles task for the new revision and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: newSnapInfo.StoreName(),
+			RealName: newSnapInfo.SnapName(),
 			Revision: newSnapInfo.Revision,
 		},
 	})
@@ -1651,7 +1651,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityForConnectedSlots(c 
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -2119,7 +2119,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: siC.StoreName(),
+			RealName: siC.SnapName(),
 			Revision: siC.Revision,
 		},
 		Flags: snapstate.Flags{DevMode: true},
@@ -2233,7 +2233,7 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnInstall(c *C) {
 	// Add a change that undoes "setup-snap-security"
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -2273,7 +2273,7 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	// Add a change that undoes "setup-snap-security"
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})
@@ -2463,7 +2463,7 @@ func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
 	// Run the setup-snap-security task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
-			RealName: snapInfo.StoreName(),
+			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
 	})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -449,7 +449,7 @@ func (ms *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (pat
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
-		"snap-id":       fakeSnapID(info.StoreName()),
+		"snap-id":       fakeSnapID(info.SnapName()),
 		"snap-sha3-384": snapDigest,
 		"snap-size":     fmt.Sprintf("%d", size),
 		"snap-revision": revno,
@@ -642,7 +642,7 @@ func (ms *mgrsSuite) serveSnap(snapPath, revno string) {
 	if err != nil {
 		panic(err)
 	}
-	name := info.StoreName()
+	name := info.SnapName()
 	ms.serveIDtoName[fakeSnapID(name)] = name
 	ms.serveSnapPath[name] = snapPath
 	ms.serveRevision[name] = revno

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -860,10 +860,10 @@ var kindRevOrder = map[snap.Type]int{
 func (bk byKind) Less(i, j int) bool {
 	// snapd sorts first to ensure that on all refrehses it is the first
 	// snap package that gets refreshed.
-	if bk[i].StoreName() == "snapd" {
+	if bk[i].SnapName() == "snapd" {
 		return true
 	}
-	if bk[j].StoreName() == "snapd" {
+	if bk[j].SnapName() == "snapd" {
 		return false
 	}
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -264,11 +264,11 @@ type ChannelSnapInfo struct {
 // InstanceName returns the blessed name of the snap decorated with instance
 // key, if any.
 func (s *Info) InstanceName() string {
-	return InstanceName(s.StoreName(), s.InstanceKey)
+	return InstanceName(s.SnapName(), s.InstanceKey)
 }
 
-// StoreName returns the global blessed name of the snap.
-func (s *Info) StoreName() string {
+// SnapName returns the global blessed name of the snap.
+func (s *Info) SnapName() string {
 	if s.RealName != "" {
 		return s.RealName
 	}
@@ -1005,28 +1005,28 @@ func DropNick(nick string) string {
 	return nick
 }
 
-// StoreName splits the instance name and returns the store name of the snap.
-func StoreName(instanceName string) string {
-	storeName, _ := SplitInstanceName(instanceName)
-	return storeName
+// SnapName splits the instance name and returns the name of the snap.
+func SnapName(instanceName string) string {
+	snapName, _ := SplitInstanceName(instanceName)
+	return snapName
 }
 
-// SplitInstanceName splits the instance name and returns the store name and the
+// SplitInstanceName splits the instance name and returns the snap name and the
 // instance key.
-func SplitInstanceName(instanceName string) (storeName, instanceKey string) {
+func SplitInstanceName(instanceName string) (snapName, instanceKey string) {
 	split := strings.SplitN(instanceName, "_", 2)
-	storeName = split[0]
+	snapName = split[0]
 	if len(split) > 1 {
 		instanceKey = split[1]
 	}
-	return storeName, instanceKey
+	return snapName, instanceKey
 }
 
-// InstanceName takes the store name and the instance key and returns an instance
+// InstanceName takes the snap name and the instance key and returns an instance
 // name of the snap.
-func InstanceName(storeName, instanceKey string) string {
+func InstanceName(snapName, instanceKey string) string {
 	if instanceKey != "" {
-		return fmt.Sprintf("%s_%s", storeName, instanceKey)
+		return fmt.Sprintf("%s_%s", snapName, instanceKey)
 	}
-	return storeName
+	return snapName
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -1005,8 +1005,8 @@ func DropNick(nick string) string {
 	return nick
 }
 
-// SnapName splits the instance name and returns the name of the snap.
-func SnapName(instanceName string) string {
+// InstanceSnap splits the instance name and returns the name of the snap.
+func InstanceSnap(instanceName string) string {
 	snapName, _ := SplitInstanceName(instanceName)
 	return snapName
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1100,8 +1100,8 @@ func (s *infoSuite) TestSplitInstanceName(c *C) {
 }
 
 func (s *infoSuite) TestInstanceSnapName(c *C) {
-	c.Check(snap.SnapName("foo_bar"), Equals, "foo")
-	c.Check(snap.SnapName("foo"), Equals, "foo")
+	c.Check(snap.InstanceSnap("foo_bar"), Equals, "foo")
+	c.Check(snap.InstanceSnap("foo"), Equals, "foo")
 
 	c.Check(snap.InstanceName("foo", "bar"), Equals, "foo_bar")
 	c.Check(snap.InstanceName("foo", ""), Equals, "foo")

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1076,32 +1076,32 @@ func (s *infoSuite) TestNickname(c *C) {
 }
 
 func (s *infoSuite) TestSplitInstanceName(c *C) {
-	store, key := snap.SplitInstanceName("foo_bar")
-	c.Check(store, Equals, "foo")
-	c.Check(key, Equals, "bar")
+	snapName, instanceKey := snap.SplitInstanceName("foo_bar")
+	c.Check(snapName, Equals, "foo")
+	c.Check(instanceKey, Equals, "bar")
 
-	store, key = snap.SplitInstanceName("foo")
-	c.Check(store, Equals, "foo")
-	c.Check(key, Equals, "")
+	snapName, instanceKey = snap.SplitInstanceName("foo")
+	c.Check(snapName, Equals, "foo")
+	c.Check(instanceKey, Equals, "")
 
 	// all following instance names are invalid
 
-	store, key = snap.SplitInstanceName("_bar")
-	c.Check(store, Equals, "")
-	c.Check(key, Equals, "bar")
+	snapName, instanceKey = snap.SplitInstanceName("_bar")
+	c.Check(snapName, Equals, "")
+	c.Check(instanceKey, Equals, "bar")
 
-	store, key = snap.SplitInstanceName("foo___bar_bar")
-	c.Check(store, Equals, "foo")
-	c.Check(key, Equals, "__bar_bar")
+	snapName, instanceKey = snap.SplitInstanceName("foo___bar_bar")
+	c.Check(snapName, Equals, "foo")
+	c.Check(instanceKey, Equals, "__bar_bar")
 
-	store, key = snap.SplitInstanceName("")
-	c.Check(store, Equals, "")
-	c.Check(key, Equals, "")
+	snapName, instanceKey = snap.SplitInstanceName("")
+	c.Check(snapName, Equals, "")
+	c.Check(instanceKey, Equals, "")
 }
 
-func (s *infoSuite) TestInstanceStoreName(c *C) {
-	c.Check(snap.StoreName("foo_bar"), Equals, "foo")
-	c.Check(snap.StoreName("foo"), Equals, "foo")
+func (s *infoSuite) TestInstanceSnapName(c *C) {
+	c.Check(snap.SnapName("foo_bar"), Equals, "foo")
+	c.Check(snap.SnapName("foo"), Equals, "foo")
 
 	c.Check(snap.InstanceName("foo", "bar"), Equals, "foo_bar")
 	c.Check(snap.InstanceName("foo", ""), Equals, "foo")
@@ -1114,9 +1114,9 @@ func (s *infoSuite) TestInstanceNameInSnapInfo(c *C) {
 	}
 
 	c.Check(info.InstanceName(), Equals, "snap-name_foo")
-	c.Check(info.StoreName(), Equals, "snap-name")
+	c.Check(info.SnapName(), Equals, "snap-name")
 
 	info.InstanceKey = ""
 	c.Check(info.InstanceName(), Equals, "snap-name")
-	c.Check(info.StoreName(), Equals, "snap-name")
+	c.Check(info.SnapName(), Equals, "snap-name")
 }

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -218,7 +218,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 	}
 
 	return &essentialInfo{
-		Name:        info.StoreName(),
+		Name:        info.SnapName(),
 		SnapID:      snapID,
 		DeveloperID: develID,
 		DevelName:   devel,
@@ -329,7 +329,7 @@ func (s *Store) collectSnaps() (map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		snaps[info.StoreName()] = fn
+		snaps[info.SnapName()] = fn
 	}
 
 	return snaps, err


### PR DESCRIPTION
As suggested in https://github.com/snapcore/snapd/pull/5370#discussion_r197469547 we're renaming `StoreName()` to something more fitting, such as `SnapName()`
