### PR TITLE
tests: disable auto-refresh test on core18

### DIFF
--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -1,5 +1,12 @@
 summary: Check that auto-refresh works
 
+# FIXME: core18 right now does not have a canonical model. This means
+# that it will not get a serial. We code in devicestate.go that will only
+# try to auto-refresh after the systems has tried at least 3 times to get
+# a serial. But this means this test will timeout because the first retry
+# for the serial happens after 5min, then 10min, then 20min.
+systems: [-ubuntu-core-18-*]
+
 prepare: |
     snap install --devmode jq
 


### PR DESCRIPTION
Disable auto-refresh on core18 until we have a Canonical model
assertion here.

core18 right now does not have a canonical model. This means
that it will not get a serial. We code in devicestate.go that will only
try to auto-refresh after the systems has tried at least 3 times to get
a serial. But this means this test will timeout because the first retry
for the serial happens after 5min, then 10min, then 20min.
