### PR TITLE
spread.yaml: enable main and regression suite on core18 systems

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -66,7 +66,7 @@ backends:
                 workers: 6
             - ubuntu-core-18-64:
                 image: ubuntu-16.04-64
-                workers: 1
+                workers: 6
 
             - debian-9-64:
                 workers: 6
@@ -420,8 +420,6 @@ restore-each: |
 suites:
     tests/main/:
         summary: Full-system tests for snapd
-        # TODO: cleanup tests and enable ubuntu-core-18 everywhere
-        systems: [-ubuntu-core-18-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -470,8 +468,6 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
-        # TODO: cleanup tests and enable ubuntu-core-18 everywhere
-        systems: [-ubuntu-core-18-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |


### PR DESCRIPTION
This PR will fail right now. But as better core18 support gets merged into master we will see progress here and it also allows to focus on the areas that are failing currently.