### PR TITLE
asserts: add (optional) kernel-track to model assertion

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -190,6 +190,9 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if _, ok := assert.headers["kernel"]; ok {
 			return nil, fmt.Errorf("cannot specify a kernel with a classic model")
 		}
+		if _, ok := assert.headers["kernel-track"]; ok {
+			return nil, fmt.Errorf("cannot specify kernel-track with a classic model")
+		}
 		if _, ok := assert.headers["base"]; ok {
 			return nil, fmt.Errorf("cannot specify a base with a classic model")
 		}
@@ -206,6 +209,12 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if _, err := checker(assert.headers, h); err != nil {
 			return nil, err
 		}
+	}
+
+	// kernel-track is optional but must be a string.
+	_, err = checkOptionalString(assert.headers, "kernel-track")
+	if err != nil {
+		return nil, err
 	}
 
 	// store is optional but must be a string, defaults to the ubuntu store

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -81,6 +81,11 @@ func (mod *Model) Kernel() string {
 	return mod.HeaderString("kernel")
 }
 
+// KernelTrack returns the kernel track the model uses.
+func (mod *Model) KernelTrack() string {
+	return mod.HeaderString("kernel-track")
+}
+
 // Base returns the base snap the model uses.
 func (mod *Model) Base() string {
 	return mod.HeaderString("base")

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -60,6 +60,7 @@ const (
 		"gadget: brand-gadget\n" +
 		"base: core18\n" +
 		"kernel: baz-linux\n" +
+		"kernel-track: 4.15\n" +
 		"store: brand-store\n" +
 		sysUserAuths +
 		reqSnaps +
@@ -102,6 +103,7 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	c.Check(model.Architecture(), Equals, "amd64")
 	c.Check(model.Gadget(), Equals, "brand-gadget")
 	c.Check(model.Kernel(), Equals, "baz-linux")
+	c.Check(model.KernelTrack(), Equals, "4.15")
 	c.Check(model.Base(), Equals, "core18")
 	c.Check(model.Store(), Equals, "brand-store")
 	c.Check(model.RequiredSnaps(), DeepEquals, []string{"foo", "bar"})
@@ -121,6 +123,21 @@ func (mods *modelSuite) TestDecodeStoreIsOptional(c *C) {
 	c.Assert(err, IsNil)
 	model = a.(*asserts.Model)
 	c.Check(model.Store(), Equals, "")
+}
+
+func (mods *modelSuite) TestDecodeKernelTrackIsOptional(c *C) {
+	withTimestamp := strings.Replace(modelExample, "TSLINE", mods.tsLine, 1)
+	encoded := strings.Replace(withTimestamp, "kernel-track: 4.15\n", "kernel-track: \n", 1)
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	model := a.(*asserts.Model)
+	c.Check(model.KernelTrack(), Equals, "")
+
+	encoded = strings.Replace(withTimestamp, "kernel-track: 4.15\n", "", 1)
+	a, err = asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	model = a.(*asserts.Model)
+	c.Check(model.KernelTrack(), Equals, "")
 }
 
 func (mods *modelSuite) TestDecodeBaseIsOptional(c *C) {

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -222,6 +222,7 @@ func (mods *modelSuite) TestDecodeInvalid(c *C) {
 		{"gadget: brand-gadget\n", "gadget: \n", `"gadget" header should not be empty`},
 		{"kernel: baz-linux\n", "", `"kernel" header is mandatory`},
 		{"kernel: baz-linux\n", "kernel: \n", `"kernel" header should not be empty`},
+		{"kernel-track: 4.15\n", "kernel-track:\n  - 123\n", `"kernel-track" header must be a string`},
 		{"store: brand-store\n", "store:\n  - xyz\n", `"store" header must be a string`},
 		{mods.tsLine, "", `"timestamp" header is mandatory`},
 		{mods.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
@@ -301,6 +302,7 @@ func (mods *modelSuite) TestClassicDecodeInvalid(c *C) {
 		{"architecture: amd64\n", "architecture:\n  - foo\n", `"architecture" header must be a string`},
 		{"gadget: brand-gadget\n", "gadget:\n  - foo\n", `"gadget" header must be a string`},
 		{"gadget: brand-gadget\n", "kernel: brand-kernel\n", `cannot specify a kernel with a classic model`},
+		{"gadget: brand-gadget\n", "kernel-track: edge\n", `cannot specify kernel-track with a classic model`},
 		{"gadget: brand-gadget\n", "base: some-base\n", `cannot specify a base with a classic model`},
 	}
 


### PR DESCRIPTION
This allows specifying the kernel track in the model assertion
so that e.g. core18 can pull in a 4.15 kernel when building a
core18 system.

If this gets accepted we need to add code to `snap prepare-image`
to pull the kernel from the right track and also code to snapstate
to ensure the track of the kernel cannot be changed.

If it gets accepted we can also create official core18 model assertions
which means the code in https://github.com/snapcore/snapd/pull/5398
can be reverted :)

This is also discussed in https://forum.snapcraft.io/t/5947
