### PR TITLE
i18n: handle write errors in xgettext-go

### DIFF
--- a/i18n/xgettext-go/main.go
+++ b/i18n/xgettext-go/main.go
@@ -192,12 +192,13 @@ var formatTime = func() string {
 	return time.Now().Format("2006-01-02 15:04-0700")
 }
 
-func mustFprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
-	n, err = fmt.Fprintf(w, format, a...)
+// mustFprintf will write the given format string to the given
+// writer. Any error will make it panic.
+func mustFprintf(w io.Writer, format string, a ...interface{}) {
+	_, err := fmt.Fprintf(w, format, a...)
 	if err != nil {
 		panic(fmt.Sprintf("cannot write output: %v", err))
 	}
-	return n, err
 }
 
 func writePotFile(out io.Writer) {


### PR DESCRIPTION
The old code was too naive and would ignore write errors in
writePotFile silently. This PR fixes this and makes it fail
explicitly if anything with the write goes wrong.

This may help with LP#1758684 in which the snappy.pot file
is truncated.
