### PR TITLE
tests: do not mask errors in interfaces-timezone-control

### DIFF
--- a/tests/main/interfaces-timezone-control/task.yaml
+++ b/tests/main/interfaces-timezone-control/task.yaml
@@ -13,7 +13,7 @@ prepare: |
 restore: |
     # Restore the initial timezone
     if [ -f timezone.txt ]; then
-        timedatectl set-timezone "$(cat timezone.txt)"
+        timedatectl set-timezone "$(cat timezone.txt)" || true
         rm -f timezone.txt
     fi
     rm -f call.error
@@ -38,13 +38,11 @@ execute: |
     fi
 
     # Set the timezone1 as timezone and check the status
-    # The set-timezone command works but fails in some images (lp: #1650688)
-    test-snapd-timedate-control-consumer.timedatectl-timezone set-timezone $timezone1 || true
+    test-snapd-timedate-control-consumer.timedatectl-timezone set-timezone $timezone1
     [ "$(test-snapd-timedate-control-consumer.timedatectl-timezone status | grep -oP 'Time zone: \K(.*)(?= \()')" = "$timezone1" ]
 
     # Set the timezone2 as timezone and check the status
-    # The set-timezone command works but fails in some images (lp: #1650688)
-    test-snapd-timedate-control-consumer.timedatectl-timezone set-timezone $timezone2 || true
+    test-snapd-timedate-control-consumer.timedatectl-timezone set-timezone $timezone2
     [ "$(test-snapd-timedate-control-consumer.timedatectl-timezone status | grep -oP 'Time zone: \K(.*)(?= \()')" = "$timezone2" ]
 
     if [ "$(snap debug confinement)" = partial ] ; then


### PR DESCRIPTION
We currently mask errors from `timedatectl set-timezone`. This
is bad because:
a) The bug is supposed to be fixed (LP: 1650688)
b) We run `timedatectl set-timezone` in restore and if it fails
   there the entire suite aborts

This PR changes this so that we don't mask the error in the
execution but do not fail in restore anymore (to not block the
entire suite).
