### PR TITLE
tests: add fedora to distro_clean_package_cache function

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -301,6 +301,7 @@ distro_clean_package_cache() {
             quiet apt-get clean
             ;;
         fedora-*)
+            dnf clean all
             ;;
         opensuse-*)
             zypper -q clean --all

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -300,6 +300,8 @@ distro_clean_package_cache() {
         ubuntu-*|debian-*)
             quiet apt-get clean
             ;;
+        fedora-*)
+            ;;
         opensuse-*)
             zypper -q clean --all
             ;;
@@ -345,6 +347,10 @@ distro_query_package_info() {
             ;;
         arch-*)
             pacman -Si "$1"
+            ;;
+        *)
+            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            exit 1
             ;;
     esac
 }


### PR DESCRIPTION
We need this to update the packages from the spread-images project.

In this project there is a task which we use to install/update the
packages for the images, but is it failing for fedora currently.

error:

+ case "$SPREAD_SYSTEM" in
+ quiet dnf -y --refresh install curl dbus-x11 expect git golang jq
iptables-services man mock net-tools redhat-lsb-core rpm-build xdg-user-
dirs
+ rm -rf snapd-master
+ distro_clean_package_cache
+ case "$SPREAD_SYSTEM" in
+ echo 'ERROR: Unsupported distribution fedora-28-64'
ERROR: Unsupported distribution fedora-28-64
+ exit 1
