### PR TITLE
userd: fix running unit tests on KDE

### DIFF
--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -95,12 +95,11 @@ func (s *launcherSuite) TestOpenURLWithFailingXdgOpen(c *C) {
 }
 
 func mockUICommands(c *C, script string) (restore func()) {
-	mockZenity := testutil.MockCommand(c, "zenity", script)
-	mockKdialog := testutil.MockCommand(c, "kdialog", script)
+	mock := testutil.MockCommand(c, "zenity", script)
+	mock.Also("kdialog", script)
 
 	return func() {
-		mockZenity.Restore()
-		mockKdialog.Restore()
+		mock.Restore()
 	}
 }
 

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -94,9 +94,19 @@ func (s *launcherSuite) TestOpenURLWithFailingXdgOpen(c *C) {
 	c.Assert(err, ErrorMatches, "cannot open supplied URL")
 }
 
+func mockUICommands(c *C, script string) (restore func()) {
+	mockZenity := testutil.MockCommand(c, "zenity", script)
+	mockKdialog := testutil.MockCommand(c, "kdialog", script)
+
+	return func() {
+		mockZenity.Restore()
+		mockKdialog.Restore()
+	}
+}
+
 func (s *launcherSuite) TestOpenFileUserAccepts(c *C) {
-	mockZenity := testutil.MockCommand(c, "zenity", "true")
-	defer mockZenity.Restore()
+	restore := mockUICommands(c, "true")
+	defer restore()
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
@@ -116,8 +126,8 @@ func (s *launcherSuite) TestOpenFileUserAccepts(c *C) {
 }
 
 func (s *launcherSuite) TestOpenFileUserDeclines(c *C) {
-	mockZenity := testutil.MockCommand(c, "zenity", "false")
-	defer mockZenity.Restore()
+	restore := mockUICommands(c, "false")
+	defer restore()
 
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
@@ -136,8 +146,8 @@ func (s *launcherSuite) TestOpenFileUserDeclines(c *C) {
 }
 
 func (s *launcherSuite) TestOpenFileSucceedsWithDirectory(c *C) {
-	mockZenity := testutil.MockCommand(c, "zenity", "true")
-	defer mockZenity.Restore()
+	restore := mockUICommands(c, "true")
+	defer restore()
 
 	dir := c.MkDir()
 	fd, err := syscall.Open(dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0755)
@@ -155,8 +165,8 @@ func (s *launcherSuite) TestOpenFileSucceedsWithDirectory(c *C) {
 }
 
 func (s *launcherSuite) TestOpenFileFailsWithDeviceFile(c *C) {
-	mockZenity := testutil.MockCommand(c, "zenity", "true")
-	defer mockZenity.Restore()
+	restore := mockUICommands(c, "true")
+	defer restore()
 
 	file, err := os.Open("/dev/null")
 	c.Assert(err, IsNil)
@@ -172,8 +182,8 @@ func (s *launcherSuite) TestOpenFileFailsWithDeviceFile(c *C) {
 }
 
 func (s *launcherSuite) TestOpenFileFailsWithPathDescriptor(c *C) {
-	mockZenity := testutil.MockCommand(c, "zenity", "true")
-	defer mockZenity.Restore()
+	restore := mockUICommands(c, "true")
+	defer restore()
 
 	dir := c.MkDir()
 	fd, err := syscall.Open(dir, sys.O_PATH, 0755)


### PR DESCRIPTION
Unit tests will launch kdialog when run under KDE. This is caused by us
preferring kdialog over zenity when the deskop is KDE but only zenity is mocked
in the tests.