### PR TITLE
interfaces/hotplug: add hotplug Specification and HotplugDeviceInfo

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -106,6 +106,7 @@ var (
 	SnapshotsDir     string
 
 	ErrtrackerDbDir string
+	SysDir          string
 )
 
 const (
@@ -265,4 +266,5 @@ func SetRootDir(rootdir string) {
 	SnapshotsDir = filepath.Join(rootdir, snappyDir, "snapshots")
 
 	ErrtrackerDbDir = filepath.Join(rootdir, snappyDir, "errtracker.db")
+	SysDir = filepath.Join(rootdir, "/sys")
 }

--- a/interfaces/hotplug/deviceinfo.go
+++ b/interfaces/hotplug/deviceinfo.go
@@ -1,0 +1,113 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hotplug
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+type HotplugDeviceInfo struct {
+	object       string
+	Data         map[string]string
+	idVendor     string
+	idProduct    string
+	product      string
+	manufacturer string
+	serial       string
+}
+
+func NewHotplugDeviceInfo(obj string, env map[string]string) *HotplugDeviceInfo {
+	return &HotplugDeviceInfo{
+		object: obj,
+		Data:   env,
+	}
+}
+
+func (h *HotplugDeviceInfo) Object() string {
+	return h.object
+}
+
+func (h *HotplugDeviceInfo) Path() string {
+	return filepath.Join(dirs.SysDir, h.Data["DEVPATH"])
+}
+
+func (h *HotplugDeviceInfo) Subsystem() string {
+	return h.Data["SUBSYSTEM"]
+}
+
+func (h *HotplugDeviceInfo) Minor() string {
+	return h.Data["MINOR"]
+}
+
+func (h *HotplugDeviceInfo) Major() string {
+	return h.Data["MAJOR"]
+}
+
+func (h *HotplugDeviceInfo) DeviceName() string {
+	return h.Data["DEVNAME"]
+}
+
+func (h *HotplugDeviceInfo) DeviceType() string {
+	return h.Data["DEVTYPE"]
+}
+
+func (h *HotplugDeviceInfo) IdVendor() string {
+	return h.readOnceMaybe("idVendor", &h.idVendor)
+}
+
+func (h *HotplugDeviceInfo) IdProduct() string {
+	return h.readOnceMaybe("idProduct", &h.idProduct)
+}
+
+func (h *HotplugDeviceInfo) Product() string {
+	return h.readOnceMaybe("product", &h.product)
+}
+
+func (h *HotplugDeviceInfo) Manufacturer() string {
+	return h.readOnceMaybe("manufacturer", &h.manufacturer)
+}
+
+func (h *HotplugDeviceInfo) Serial() string {
+	return h.readOnceMaybe("serial", &h.serial)
+}
+
+func (h *HotplugDeviceInfo) readOnceMaybe(fileName string, out *string) string {
+	if *out == "" {
+		data, err := ioutil.ReadFile(filepath.Join(h.Path(), fileName))
+		if err != nil {
+			return ""
+		}
+		*out = string(data)
+	}
+	return *out
+}
+
+// HotplugDeviceHandler can be implemented by interfaces that need to create slots in response to hotplug events
+type HotplugDeviceHandler interface {
+	HotplugDeviceDetected(di *HotplugDeviceInfo, spec *Specification) error
+}
+
+// HotplugDeviceInfo can be implemented by interfaces that need to provide a non-standard device key for hotplug devices
+type HotplugDeviceKeyHandler interface {
+	HotplugDeviceKey(di *HotplugDeviceInfo) (string, error)
+}

--- a/interfaces/hotplug/deviceinfo_test.go
+++ b/interfaces/hotplug/deviceinfo_test.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hotplug
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type hotplugSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&hotplugSuite{})
+
+func (s *hotplugSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *hotplugSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+	dirs.SetRootDir("")
+}
+
+func (s *hotplugSuite) TestBasicProperties(c *C) {
+	env := map[string]string{
+		"DEVPATH": "/devices/pci0000:00/0000:00:14.0/usb2/2-3", "DEVNAME": "bus/usb/002/003",
+		"DEVTYPE": "usb_device",
+		"PRODUCT": "1d50/6108/0", "DEVNUM": "003",
+		"SEQNUM": "4053",
+		"ACTION": "add", "SUBSYSTEM": "usb",
+		"MAJOR": "189", "MINOR": "130",
+		"TYPE": "0/0/0", "BUSNUM": "002",
+	}
+
+	di := NewHotplugDeviceInfo("/devices/pci0000:00/0000:00:14.0/usb2/2-3", env)
+
+	c.Assert(di.Data, DeepEquals, env)
+	c.Assert(di.Object(), Equals, "/devices/pci0000:00/0000:00:14.0/usb2/2-3")
+	c.Assert(di.DeviceName(), Equals, "bus/usb/002/003")
+	c.Assert(di.DeviceType(), Equals, "usb_device")
+	c.Assert(di.Path(), Equals, filepath.Join(dirs.SysDir, "/devices/pci0000:00/0000:00:14.0/usb2/2-3"))
+	c.Assert(di.Subsystem(), Equals, "usb")
+	c.Assert(di.Major(), Equals, "189")
+	c.Assert(di.Minor(), Equals, "130")
+}
+
+func (s *hotplugSuite) TestPropertiesFromFiles(c *C) {
+	devpath := "/devices/foo"
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SysDir, devpath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "idProduct"), ([]byte)("1234"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "idVendor"), ([]byte)("5678"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "product"), ([]byte)("ghijk"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "manufacturer"), ([]byte)("abcd"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "serial"), ([]byte)("deadbeef"), 0644), IsNil)
+
+	di := NewHotplugDeviceInfo("", map[string]string{"DEVPATH": devpath})
+	c.Assert(di.IdProduct(), Equals, "1234")
+	c.Assert(di.IdVendor(), Equals, "5678")
+	c.Assert(di.Product(), Equals, "ghijk")
+	c.Assert(di.Manufacturer(), Equals, "abcd")
+	c.Assert(di.Serial(), Equals, "deadbeef")
+}
+
+func (s *hotplugSuite) TestFileIsOptional(c *C) {
+	devpath := "/devices/bar"
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SysDir, devpath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "idProduct"), ([]byte)("1234"), 0644), IsNil)
+
+	di := NewHotplugDeviceInfo("", map[string]string{"DEVPATH": devpath})
+	c.Assert(di.IdProduct(), Equals, "1234")
+	c.Assert(di.IdVendor(), Equals, "")
+	c.Assert(di.Product(), Equals, "")
+	c.Assert(di.Manufacturer(), Equals, "")
+	c.Assert(di.Serial(), Equals, "")
+}
+
+func (s *hotplugSuite) TestFileIsReadOnce(c *C) {
+	devpath := "/devices/bar"
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SysDir, devpath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SysDir, devpath, "idProduct"), ([]byte)("1234"), 0644), IsNil)
+
+	di := NewHotplugDeviceInfo("", map[string]string{"DEVPATH": devpath})
+	c.Assert(di.IdProduct(), Equals, "1234")
+
+	c.Assert(os.Remove(filepath.Join(dirs.SysDir, devpath, "idProduct")), IsNil)
+	c.Assert(di.IdProduct(), Equals, "1234")
+}

--- a/interfaces/hotplug/spec.go
+++ b/interfaces/hotplug/spec.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hotplug
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces/utils"
+)
+
+type SlotSpec struct {
+	Name  string
+	Label string
+	Attrs map[string]interface{}
+}
+
+type Specification struct {
+	slots map[string]SlotSpec
+}
+
+func NewSpecification() *Specification {
+	return &Specification{
+		slots: make(map[string]SlotSpec),
+	}
+}
+
+func (h *Specification) AddSlot(name, label string, attrs map[string]interface{}) error {
+	if _, ok := h.slots[name]; ok {
+		return fmt.Errorf("slot %q already exists", name)
+	}
+	// TODO: use ValidateName here (after moving to utils)
+	if attrs == nil {
+		attrs = make(map[string]interface{})
+	}
+	h.slots[name] = SlotSpec{
+		Name:  name,
+		Label: label,
+		Attrs: utils.NormalizeInterfaceAttributes(attrs).(map[string]interface{}),
+	}
+	return nil
+}
+
+func (h *Specification) Slots() []SlotSpec {
+	slots := make([]SlotSpec, len(h.slots))
+	for _, s := range h.slots {
+		slots = append(slots, SlotSpec{
+			Name:  s.Name,
+			Label: s.Label,
+			Attrs: s.Attrs,
+		})
+	}
+	return slots
+}

--- a/interfaces/hotplug/spec_test.go
+++ b/interfaces/hotplug/spec_test.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hotplug
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type hotplugSpecSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&hotplugSpecSuite{})
+
+func (s *hotplugSpecSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *hotplugSpecSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+	dirs.SetRootDir("")
+}
+
+func (s *hotplugSpecSuite) TestAddSlot(c *C) {
+	spec := NewSpecification()
+	c.Assert(spec.AddSlot("slot1", "A slot", map[string]interface{}{"foo": "bar"}), IsNil)
+	c.Assert(spec.AddSlot("slot2", "A slot", map[string]interface{}{"baz": "booze"}), IsNil)
+
+	c.Assert(spec.slots, DeepEquals, []SlotSpec{
+		SlotSpec{Name: "slot1", Label: "A slot", Attrs: map[string]interface{}{"foo": "bar"}},
+		SlotSpec{Name: "slot2", Label: "A slot", Attrs: map[string]interface{}{"baz": "booze"}},
+	})
+}
+
+func (s *hotplugSpecSuite) TestAddSlotDuplicate(c *C) {
+	spec := NewSpecification()
+	c.Assert(spec.AddSlot("slot1", "A slot", map[string]interface{}{"foo": "bar"}), IsNil)
+	err := spec.AddSlot("slot1", "A slot", map[string]interface{}{"baz": "booze"})
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `slot "slot1" already exists`)
+
+	c.Assert(spec.slots, DeepEquals, []SlotSpec{
+		SlotSpec{Name: "slot1", Label: "A slot", Attrs: map[string]interface{}{"foo": "bar"}},
+	})
+}


### PR DESCRIPTION
Introduce two structures related to hotplug: `Specification` will be passed to interfaces that implement `HotplugDeviceDetected(..)` method, it's a way for interfaces to add slot definitions on hot plug add event. `HotplugDeviceInfo` wraps some uevent data, it will be passed from udev monitor to interface manager callback on hotplug add/remove events.