### PR TITLE
image: block installation of parallel snap instances

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -125,15 +125,14 @@ func validateNoParallelSnapInstances(snaps []string) error {
 	for _, snapName := range snaps {
 		_, instanceKey := snap.SplitInstanceName(snapName)
 		if instanceKey != "" {
-			return fmt.Errorf("cannot use snap %q, parallel snap instances are unsupported",
-				snapName)
+			return fmt.Errorf("cannot use snap %q, parallel snap instances are unsupported", snapName)
 		}
 	}
 	return nil
 }
 
 func validateNonLocalSnaps(snaps []string) error {
-	nonLocalSnaps := make([]string, len(snaps))
+	nonLocalSnaps := make([]string, 0, len(snaps))
 	for _, snapName := range snaps {
 		if !strings.HasSuffix(snapName, ".snap") {
 			nonLocalSnaps = append(nonLocalSnaps, snapName)
@@ -206,7 +205,9 @@ func decodeModelAssertion(opts *Options) (*asserts.Model, error) {
 		}
 	}
 
-	if err := validateNoParallelSnapInstances(modela.RequiredSnaps()); err != nil {
+	modelSnaps := modela.RequiredSnaps()
+	modelSnaps = append(modelSnaps, modela.Kernel(), modela.Gadget(), modela.Base())
+	if err := validateNoParallelSnapInstances(modelSnaps); err != nil {
 		return nil, err
 	}
 

--- a/image/image.go
+++ b/image/image.go
@@ -131,6 +131,8 @@ func validateNoParallelSnapInstances(snaps []string) error {
 	return nil
 }
 
+// validateNonLocalSnaps raises an error when snaps that would be pulled from
+// the store use an instance key in their names
 func validateNonLocalSnaps(snaps []string) error {
 	nonLocalSnaps := make([]string, 0, len(snaps))
 	for _, snapName := range snaps {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -316,7 +316,7 @@ AXNpZw==
 	}
 }
 
-func (s *imageSuite) TestModelAssertionNoParallelInstances(c *C) {
+func (s *imageSuite) TestModelAssertionNoParallelInstancesOfSnaps(c *C) {
 	const mod = `type: model
 authority-id: brand
 series: 16
@@ -340,6 +340,79 @@ AXNpZw==
 		ModelFile: fn,
 	})
 	c.Check(err, ErrorMatches, `cannot use snap "foo_instance", parallel snap instances are unsupported`)
+}
+
+func (s *imageSuite) TestModelAssertionNoParallelInstancesOfKernel(c *C) {
+	const mod = `type: model
+authority-id: brand
+series: 16
+brand-id: brand
+model: baz-3000
+architecture: armhf
+gadget: brand-gadget
+kernel: kernel_instance
+timestamp: 2016-01-02T10:00:00-05:00
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==
+`
+
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	c.Assert(err, IsNil)
+	_, err = image.DecodeModelAssertion(&image.Options{
+		ModelFile: fn,
+	})
+	c.Check(err, ErrorMatches, `cannot use snap "kernel_instance", parallel snap instances are unsupported`)
+}
+
+func (s *imageSuite) TestModelAssertionNoParallelInstancesOfGadget(c *C) {
+	const mod = `type: model
+authority-id: brand
+series: 16
+brand-id: brand
+model: baz-3000
+architecture: armhf
+gadget: brand-gadget_instance
+kernel: kernel
+timestamp: 2016-01-02T10:00:00-05:00
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==
+`
+
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	c.Assert(err, IsNil)
+	_, err = image.DecodeModelAssertion(&image.Options{
+		ModelFile: fn,
+	})
+	c.Check(err, ErrorMatches, `cannot use snap "brand-gadget_instance", parallel snap instances are unsupported`)
+}
+
+func (s *imageSuite) TestModelAssertionNoParallelInstancesOfBase(c *C) {
+	const mod = `type: model
+authority-id: brand
+series: 16
+brand-id: brand
+model: baz-3000
+architecture: armhf
+gadget: brand-gadget
+kernel: kernel
+base: core18_instance
+timestamp: 2016-01-02T10:00:00-05:00
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==
+`
+
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	c.Assert(err, IsNil)
+	_, err = image.DecodeModelAssertion(&image.Options{
+		ModelFile: fn,
+	})
+	c.Check(err, ErrorMatches, `cannot use snap "core18_instance", parallel snap instances are unsupported`)
 }
 
 func (s *imageSuite) TestHappyDecodeModelAssertion(c *C) {


### PR DESCRIPTION
Block installation of parallel snap instances either coming from the model
assertion or directly form the command line.
