### PR TITLE
overlord/ifacestate: get/set connection state only via helpers

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -558,13 +558,9 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	var conns map[string]connState
-	err := st.Get("conns", &conns)
-	if err != nil && err != state.ErrNoState {
+	conns, err := getConns(st)
+	if err != nil {
 		return err
-	}
-	if conns == nil {
-		conns = make(map[string]connState)
 	}
 
 	snapsup, err := snapstate.TaskSnapSetup(task)
@@ -818,13 +814,9 @@ func (m *InterfaceManager) doGadgetConnect(task *state.Task, _ *tomb.Tomb) error
 	st.Lock()
 	defer st.Unlock()
 
-	var conns map[string]connState
-	err := st.Get("conns", &conns)
-	if err != nil && err != state.ErrNoState {
+	conns, err := getConns(st)
+	if err != nil {
 		return err
-	}
-	if conns == nil {
-		conns = make(map[string]connState)
 	}
 
 	gconns, err := snapstate.GadgetConnections(st)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -457,10 +457,9 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 	return plugRef, slotRef, nil
 }
 
-func getConns(st *state.State) (map[string]connState, error) {
-	// Get information about connections from the state
-	var conns map[string]connState
-	err := st.Get("conns", &conns)
+// Get information about connections from the state
+func getConns(st *state.State) (conns map[string]connState, err error) {
+	err = st.Get("conns", &conns)
 	if err != nil && err != state.ErrNoState {
 		return nil, fmt.Errorf("cannot obtain data about existing connections: %s", err)
 	}


### PR DESCRIPTION
This patch ensures that interface connections are only loaded and stored
with the help of a pair of helpers (getConns, setConns). This is a step
towards those helpers doing data mapping for snapd.snap

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
