### PR TITLE
tests: replace MATCH by grep to check users created for ubuntu core

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -481,9 +481,8 @@ EOF
         # append ubuntu, test user for the testing
         grep "^test:" /etc/$f >> /mnt/system-data/var/lib/extrausers/"$f"
         grep "^ubuntu:" /etc/$f >> /mnt/system-data/var/lib/extrausers/"$f"
-        # check test was copied
-        MATCH "^test:" </mnt/system-data/var/lib/extrausers/"$f"
-        MATCH "^ubuntu:" </mnt/system-data/var/lib/extrausers/"$f"
+        # check users were copied
+        cat /mnt/system-data/var/lib/extrausers/"$f" | grep -e '^test:' -e '^ubuntu:'
     done
 
     # ensure spread -reuse works in the core image as well


### PR DESCRIPTION
This replace is done because MATCH for some reason is failing to check
something that should be found.

See the following log, in this case test user is in the file but it
fails to be found by using MATCH.
https://paste.ubuntu.com/p/QsftThrmyj/

It is failing consistently on travis:
https://travis-ci.org/snapcore/snapd/builds/397395023
