### PR TITLE
devicestate: fix race when refreshing a snap with snapd-control

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -245,11 +245,13 @@ func CanManageRefreshes(st *state.State) bool {
 		return false
 	}
 	for _, snapst := range snapStates {
-		if !snapst.Active {
-			continue
-		}
+		// Always get the current info even if the snap is currently
+		// being operated on or if its disabled.
 		info, err := snapst.CurrentInfo()
 		if err != nil {
+			continue
+		}
+		if info.Broken != "" {
 			continue
 		}
 		// The snap must have a snap declaration (implies that

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -239,6 +239,13 @@ func interfaceConnected(st *state.State, snapName, ifName string) bool {
 
 // CanManageRefreshes returns true if the device can be
 // switched to the "core.refresh.schedule=managed" mode.
+//
+// TODO:
+// - Move the CanManageRefreshes code into the ifstate
+// - Look at the connections and find the connection for snapd-control
+//   with the managed attribute
+// - Take the snap from this connection and look at the snapstate to see
+//   if that snap has a snap declaration (to ensure it comes from the store)
 func CanManageRefreshes(st *state.State) bool {
 	snapStates, err := snapstate.All(st)
 	if err != nil {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2169,6 +2169,15 @@ func (s *deviceMgrSuite) TestCanManageRefreshes(c *C) {
 	// manage schedules
 	s.makeSnapDeclaration(c, st, info11)
 	c.Check(devicestate.CanManageRefreshes(st), Equals, true)
+
+	// works if the snap is not active as well (to fix race when a
+	// snap is refreshed)
+	var sideInfo11 snapstate.SnapState
+	err := snapstate.Get(st, "snap-with-snapd-control", &sideInfo11)
+	c.Assert(err, IsNil)
+	sideInfo11.Active = false
+	snapstate.Set(st, "snap-with-snapd-control", &sideInfo11)
+	c.Check(devicestate.CanManageRefreshes(st), Equals, true)
 }
 
 func (s *deviceMgrSuite) TestCanManageRefreshesNoRefreshScheduleManaged(c *C) {


### PR DESCRIPTION
When a snap that has the snapd-control interface is refreshed the code in CanManageRefreshes() may return incorrect data. This is a first (naive) attempt at a fix. It lacks a proper test.