### PR TITLE
cmd/snap-confine: fix nvidia support under lxd

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -282,7 +282,7 @@ static void sc_mkdir_and_mount_and_glob_files(const char *rootfs_dir,
 	}
 	// Remount $tgt_dir (i.e. .../lib/gl) read only
 	debug("remounting tmpfs as read-only %s", libgl_dir);
-	if (mount(NULL, buf, NULL, MS_REMOUNT | MS_RDONLY, NULL) != 0) {
+	if (mount(NULL, buf, NULL, MS_REMOUNT | MS_BIND | MS_RDONLY, NULL) != 0) {
 		die("cannot remount %s as read-only", buf);
 	}
 }

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -264,17 +264,17 @@
     mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
     /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/{,*} w,
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
-    mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
 
     # Vulkan support
     /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/{,*} w,
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
-    mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
 
     # GLVND EGL vendor
     /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/{,*} w,
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
-    mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
 
     # create gl dirs as needed
     /tmp/snap.rootfs_*/ r,


### PR DESCRIPTION
From mount(2), we can learn that MS_REMOUNT has a special meaning when
coupled with MS_BIND:

   Since Linux 2.6.26, this flag can be used with MS_BIND to modify only the
   per-mount-point flags.  This is particularly useful for setting or clearing the
   "read-only"  flag  on  a  mount  point  without changing the underlying
   filesystem.  Specifying mountflags as:

       MS_REMOUNT | MS_BIND | MS_RDONLY

   will make access through this mountpoint read-only, without affecting other
   mount points.

Under LXD snap-confine runs under stacked apparmor profile where the effective
profile is an intersection of the LXD profile and the snap-confine profile. LXD
has a very carefully crafted profile that limits unsafe operations. One of
those is a filesystem remount operation, which could potentially affect the
host. Since this is disallowed by LXD, snap-confine cannot perform the remount
and application startup fails with the following denial.

    [61955.378584] audit: type=1400 audit(1530126985.909:482):
    apparmor="DENIED" operation="mount" info="failed flags match" error=-13
    profile="lxd-brave-drum_</var/snap/lxd/common/lxd>"
    name="/tmp/snap.rootfs_o6dcBz/var/lib/snapd/lib/vulkan/" pid=12945
    comm="snap-confine" flags="ro, remount"

Since this issue is only evident when using nvidia hardware it went under the
radar.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>