### PR TITLE
spread: increase the number of auto retries for package downloads in opensuse

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -367,6 +367,14 @@ prepare: |
         sed -i -s -E -e 's@^#?baseurl=http://download.fedoraproject.org/@baseurl=http://dl.fedoraproject.org/@g' -e 's@^metalink=@#metalink@g' /etc/yum.repos.d/fedora*.repo
         dnf --refresh -y makecache
     fi
+    if [[ "$SPREAD_SYSTEM" == opensuse-* ]]; then
+        # We seem to be hitting a flaky openSUSE mirror from time to time,
+        # increase the number of download attempts libzypp will try to
+        # workaround that.
+        echo >> /etc/zypp/zypp.conf
+        echo '# added by spread tests' >> /etc/zypp/zypp.conf
+        echo 'download.max_silent_tries = 20' >> /etc/zypp/zypp.conf
+    fi
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
     if [ -f current.delta ]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -371,9 +371,12 @@ prepare: |
         # We seem to be hitting a flaky openSUSE mirror from time to time,
         # increase the number of download attempts libzypp will try to
         # workaround that.
-        echo >> /etc/zypp/zypp.conf
-        echo '# added by spread tests' >> /etc/zypp/zypp.conf
-        echo 'download.max_silent_tries = 20' >> /etc/zypp/zypp.conf
+        cat <<-EOF >> /etc/zypp/zypp.conf
+
+    # added by spread tests
+    download.max_silent_tries = 20
+    EOF
+
     fi
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)


### PR DESCRIPTION
We seem to be hitting a flaky openSUSE mirror from time to time. Try to
workaround this by letting libzypp retry the download a couple of times.
