### PR TITLE
client, cmd/snap: pass snap instance name when installing from file

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -39,6 +39,7 @@ type SnapOptions struct {
 	Dangerous        bool   `json:"dangerous,omitempty"`
 	IgnoreValidation bool   `json:"ignore-validation,omitempty"`
 	Unaliased        bool   `json:"unaliased,omitempty"`
+	Instance         string `json:"instance,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
@@ -204,8 +205,13 @@ func (client *Client) InstallPath(path string, options *SnapOptions) (changeID s
 		return "", fmt.Errorf("cannot open: %q", path)
 	}
 
+	instanceName := ""
+	if options != nil {
+		instanceName = options.Instance
+	}
 	action := actionData{
 		Action:      "install",
+		Name:        instanceName,
 		SnapPath:    path,
 		SnapOptions: options,
 	}

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -196,7 +196,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 	return client.doAsyncFull("POST", "/v2/snaps", nil, headers, bytes.NewBuffer(data))
 }
 
-// InstallPath sideloads the snap with the given path under provided name,
+// InstallPath sideloads the snap with the given path under optional provided name,
 // returning the UUID of the background operation upon success.
 func (client *Client) InstallPath(path, name string, options *SnapOptions) (changeID string, err error) {
 	f, err := os.Open(path)

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -39,7 +39,6 @@ type SnapOptions struct {
 	Dangerous        bool   `json:"dangerous,omitempty"`
 	IgnoreValidation bool   `json:"ignore-validation,omitempty"`
 	Unaliased        bool   `json:"unaliased,omitempty"`
-	Instance         string `json:"instance,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
@@ -197,21 +196,17 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 	return client.doAsyncFull("POST", "/v2/snaps", nil, headers, bytes.NewBuffer(data))
 }
 
-// InstallPath sideloads the snap with the given path, returning the UUID
-// of the background operation upon success.
-func (client *Client) InstallPath(path string, options *SnapOptions) (changeID string, err error) {
+// InstallPath sideloads the snap with the given path under provided name,
+// returning the UUID of the background operation upon success.
+func (client *Client) InstallPath(path, name string, options *SnapOptions) (changeID string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("cannot open: %q", path)
 	}
 
-	instanceName := ""
-	if options != nil {
-		instanceName = options.Instance
-	}
 	action := actionData{
 		Action:      "install",
-		Name:        instanceName,
+		Name:        name,
 		SnapPath:    path,
 		SnapOptions: options,
 	}

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -229,6 +229,36 @@ func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
 	c.Check(id, check.Equals, "66b3")
 }
 
+func (cs *clientSuite) TestClientOpInstallPathInstance(c *check.C) {
+	cs.rsp = `{
+		"change": "66b3",
+		"status-code": 202,
+		"type": "async"
+	}`
+	bodyData := []byte("snap-data")
+
+	snap := filepath.Join(c.MkDir(), "foo.snap")
+	err := ioutil.WriteFile(snap, bodyData, 0644)
+	c.Assert(err, check.IsNil)
+
+	id, err := cs.cli.InstallPath(snap, &client.SnapOptions{
+		Instance: "foo_bar",
+	})
+	c.Assert(err, check.IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(body), check.Matches, "(?s).*\r\nsnap-data\r\n.*")
+	c.Assert(string(body), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n.*")
+	c.Assert(string(body), check.Matches, "(?s).*Content-Disposition: form-data; name=\"name\"\r\n\r\nfoo_bar\r\n.*")
+
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, fmt.Sprintf("/v2/snaps"))
+	c.Assert(cs.req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+	c.Check(id, check.Equals, "66b3")
+}
+
 func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 	cs.rsp = `{
 		"change": "66b3",

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -214,7 +214,7 @@ func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
 	err := ioutil.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
-	id, err := cs.cli.InstallPath(snap, nil)
+	id, err := cs.cli.InstallPath(snap, "", nil)
 	c.Assert(err, check.IsNil)
 
 	body, err := ioutil.ReadAll(cs.req.Body)
@@ -241,9 +241,7 @@ func (cs *clientSuite) TestClientOpInstallPathInstance(c *check.C) {
 	err := ioutil.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
-	id, err := cs.cli.InstallPath(snap, &client.SnapOptions{
-		Instance: "foo_bar",
-	})
+	id, err := cs.cli.InstallPath(snap, "foo_bar", nil)
 	c.Assert(err, check.IsNil)
 
 	body, err := ioutil.ReadAll(cs.req.Body)
@@ -276,7 +274,7 @@ func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 	}
 
 	// InstallPath takes Dangerous
-	_, err = cs.cli.InstallPath(snap, &opts)
+	_, err = cs.cli.InstallPath(snap, "", &opts)
 	c.Assert(err, check.IsNil)
 
 	body, err := ioutil.ReadAll(cs.req.Body)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -338,6 +338,8 @@ type cmdInstall struct {
 
 	Unaliased bool `long:"unaliased"`
 
+	Instance string `long:"instance" hidden:"yes"`
+
 	Positional struct {
 		Snaps []remoteSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -353,6 +355,9 @@ func (x *cmdInstall) installOne(name string, opts *client.SnapOptions) error {
 		installFromFile = true
 		changeID, err = cli.InstallPath(name, opts)
 	} else {
+		if opts.Instance != "" {
+			return errors.New(i18n.G("cannot use instance name when installing from store"))
+		}
 		changeID, err = cli.Install(name, opts)
 	}
 	if err != nil {
@@ -457,6 +462,7 @@ func (x *cmdInstall) Execute([]string) error {
 		Revision:  x.Revision,
 		Dangerous: dangerous,
 		Unaliased: x.Unaliased,
+		Instance:  x.Instance,
 	}
 	x.setModes(opts)
 
@@ -469,6 +475,9 @@ func (x *cmdInstall) Execute([]string) error {
 		return errors.New(i18n.G("a single snap name is needed to specify mode or channel flags"))
 	}
 
+	if x.Instance != "" {
+		return errors.New(i18n.G("cannot use instance name when installing multiple snaps"))
+	}
 	return x.installMany(names, nil)
 }
 
@@ -897,6 +906,7 @@ func init() {
 			"dangerous":       i18n.G("Install the given snap file even if there are no pre-acknowledged signatures for it, meaning it was not verified and could be dangerous (--devmode implies this)"),
 			"force-dangerous": i18n.G("Alias for --dangerous (DEPRECATED)"),
 			"unaliased":       i18n.G("Install the given snap without enabling its automatic aliases"),
+			"instance":        i18n.G("Install the snap file as given snap instance"),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
 		waitDescs.also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -486,7 +486,7 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 	err := ioutil.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath, "--instance", "foo_bar"})
+	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath, "--name", "foo_bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo_bar 1.0 from 'bar' installed`)
@@ -496,12 +496,12 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 }
 
 func (s *SnapSuite) TestInstallWithInstanceNoPath(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"install", "--instance", "foo_bar", "some-snap"})
-	c.Assert(err, check.ErrorMatches, "cannot use instance name when installing from store")
+	_, err := snap.Parser().ParseArgs([]string{"install", "--name", "foo_bar", "some-snap"})
+	c.Assert(err, check.ErrorMatches, "cannot use explicit name when installing from store")
 }
 
 func (s *SnapSuite) TestInstallManyWithInstance(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"install", "--instance", "foo_bar", "some-snap-1", "some-snap-2"})
+	_, err := snap.Parser().ParseArgs([]string{"install", "--name", "foo_bar", "some-snap-1", "some-snap-2"})
 	c.Assert(err, check.ErrorMatches, "cannot use instance name when installing multiple snaps")
 }
 


### PR DESCRIPTION
Allow passing a desired snap instance name when installing from snap. The client uses `name` field in `multipart/form-data` passed to the daemon. The field is currently unused by the daemon.

The PR proposes to add an `--instance` parameter to `snap install` command. The parameter can only be passed when installing a snap from file. The resulting invocation will look like this:
```
snap install --dangerous --instance foo_instance foo.snap
```