### PR TITLE
configcore: fix incorrect handling of keys with nubmers (like gpu_mem_512)

### DIFF
--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -49,7 +49,7 @@ var mockConfigTxt = `
 # and your display can output without overscan
 #disable_overscan=1
 unrelated_options=are-kept
-gpu_mem_512=true
+#gpu_mem_512=true
 `
 
 func (s *piCfgSuite) SetUpTest(c *C) {
@@ -167,5 +167,6 @@ func (s *piCfgSuite) TestConfigurePiConfigRegression(c *C) {
 		},
 	})
 	c.Assert(err, IsNil)
-	s.checkMockConfig(c, mockConfigTxt)
+	expected := strings.Replace(mockConfigTxt, "#gpu_mem_512=true", "gpu_mem_512=true", -1)
+	s.checkMockConfig(c, expected)
 }

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -49,6 +49,7 @@ var mockConfigTxt = `
 # and your display can output without overscan
 #disable_overscan=1
 unrelated_options=are-kept
+gpu_mem_512=true
 `
 
 func (s *piCfgSuite) SetUpTest(c *C) {
@@ -153,5 +154,18 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 	c.Assert(err, IsNil)
 
 	s.checkMockConfig(c, mockConfigTxt)
+}
 
+func (s *piCfgSuite) TestConfigurePiConfigRegression(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"pi-config.gpu-mem-512": true,
+		},
+	})
+	c.Assert(err, IsNil)
+	s.checkMockConfig(c, mockConfigTxt)
 }

--- a/overlord/configstate/configcore/utils.go
+++ b/overlord/configstate/configcore/utils.go
@@ -27,7 +27,7 @@ import (
 )
 
 // first match is if it is comment, second is key, third value
-var rx = regexp.MustCompile(`^[ \t]*(#?)[ \t#]*([a-zA-Z0-9_]+)=(.*)$`)
+var rx = regexp.MustCompile(`^[ \t]*(#?)[ \t#]*([a-z0-9_]+)=(.*)$`)
 
 // updateKeyValueStream updates simple key=value files with comments.
 // Example for such formats are: /etc/environment or /boot/uboot/config.txt

--- a/overlord/configstate/configcore/utils.go
+++ b/overlord/configstate/configcore/utils.go
@@ -27,7 +27,7 @@ import (
 )
 
 // first match is if it is comment, second is key, third value
-var rx = regexp.MustCompile(`^[ \t]*(#?)[ \t#]*([a-z_]+)=(.*)$`)
+var rx = regexp.MustCompile(`^[ \t]*(#?)[ \t#]*([a-zA-Z0-9_]+)=(.*)$`)
 
 // updateKeyValueStream updates simple key=value files with comments.
 // Example for such formats are: /etc/environment or /boot/uboot/config.txt


### PR DESCRIPTION
The configcore code scans a key/value file using a regexp. Unfortunately
this regexp is a bit too narrow and does not include valid chars
like 0-9 or A-Z. This caused a bug on the pi2/pi3 config.txt handling
for keys like  gpu_mem_512=true.
