### PR TITLE
tests: enable new fedora image with test dependencies installed

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -82,7 +82,6 @@ backends:
                 workers: 4
                 manual: true
             - fedora-28-64:
-                image: fedora-28-64-selinux-permissive
                 workers: 4
 
             - opensuse-42.3-64:


### PR DESCRIPTION
This change will enable the new fedora image which already has the snapd
test dependencies installed.
