### PR TITLE
interfaces: move ValidateName helper to utils

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -68,7 +69,7 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 			continue
 		}
 		// Reject plug with invalid name
-		if err := interfaces.ValidateName(plugName); err != nil {
+		if err := utils.ValidateName(plugName); err != nil {
 			snapInfo.BadInterfaces[plugName] = err.Error()
 			badPlugs = append(badPlugs, plugName)
 			continue
@@ -88,7 +89,7 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 			continue
 		}
 		// Reject slot with invalid name
-		if err := interfaces.ValidateName(slotName); err != nil {
+		if err := utils.ValidateName(slotName); err != nil {
 			snapInfo.BadInterfaces[slotName] = err.Error()
 			badSlots = append(badSlots, slotName)
 			continue

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -216,18 +216,6 @@ const (
 	SecuritySystemd SecuritySystem = "systemd"
 )
 
-// Regular expression describing correct identifiers.
-var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
-
-// ValidateName checks if a string can be used as a plug or slot name.
-func ValidateName(name string) error {
-	valid := validName.MatchString(name)
-	if !valid {
-		return fmt.Errorf("invalid interface name: %q", name)
-	}
-	return nil
-}
-
 // ValidateDBusBusName checks if a string conforms to
 // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
 func ValidateDBusBusName(busName string) error {

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -58,7 +59,7 @@ func (s *CoreSuite) TestValidateName(c *C) {
 		"a0", "a-0", "a-0a",
 	}
 	for _, name := range validNames {
-		err := ValidateName(name)
+		err := utils.ValidateName(name)
 		c.Assert(err, IsNil)
 	}
 	invalidNames := []string{
@@ -78,7 +79,7 @@ func (s *CoreSuite) TestValidateName(c *C) {
 		"日本語", "한글", "ру́сский язы́к",
 	}
 	for _, name := range invalidNames {
-		err := ValidateName(name)
+		err := utils.ValidateName(name)
 		c.Assert(err, ErrorMatches, `invalid interface name: ".*"`)
 	}
 }

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -27,7 +27,6 @@ import (
 
 	. "github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
-	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -50,38 +49,6 @@ func (s *CoreSuite) SetUpTest(c *C) {
 
 func (s *CoreSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
-}
-
-func (s *CoreSuite) TestValidateName(c *C) {
-	validNames := []string{
-		"a", "aa", "aaa", "aaaa",
-		"a-a", "aa-a", "a-aa", "a-b-c",
-		"a0", "a-0", "a-0a",
-	}
-	for _, name := range validNames {
-		err := utils.ValidateName(name)
-		c.Assert(err, IsNil)
-	}
-	invalidNames := []string{
-		// name cannot be empty
-		"",
-		// dashes alone are not a name
-		"-", "--",
-		// double dashes in a name are not allowed
-		"a--a",
-		// name should not end with a dash
-		"a-",
-		// name cannot have any spaces in it
-		"a ", " a", "a a",
-		// a number alone is not a name
-		"0", "123",
-		// identifier must be plain ASCII
-		"日本語", "한글", "ру́сский язы́к",
-	}
-	for _, name := range invalidNames {
-		err := utils.ValidateName(name)
-		c.Assert(err, ErrorMatches, `invalid interface name: ".*"`)
-	}
 }
 
 func (s *CoreSuite) TestValidateDBusBusName(c *C) {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -71,7 +72,7 @@ func (r *Repository) AddInterface(i Interface) error {
 	defer r.m.Unlock()
 
 	interfaceName := i.Name()
-	if err := ValidateName(interfaceName); err != nil {
+	if err := utils.ValidateName(interfaceName); err != nil {
 		return err
 	}
 	if _, ok := r.ifaces[interfaceName]; ok {
@@ -269,7 +270,7 @@ func (r *Repository) AddPlug(plug *snap.PlugInfo) error {
 		return err
 	}
 	// Reject plug with invalid names
-	if err := ValidateName(plug.Name); err != nil {
+	if err := utils.ValidateName(plug.Name); err != nil {
 		return err
 	}
 	i := r.ifaces[plug.Interface]
@@ -364,7 +365,7 @@ func (r *Repository) AddSlot(slot *snap.SlotInfo) error {
 		return err
 	}
 	// Reject plug with invalid names
-	if err := ValidateName(slot.Name); err != nil {
+	if err := utils.ValidateName(slot.Name); err != nil {
 		return err
 	}
 	// TODO: ensure that apps are correct

--- a/interfaces/utils/utils.go
+++ b/interfaces/utils/utils.go
@@ -19,6 +19,11 @@
 
 package utils
 
+import (
+	"fmt"
+	"regexp"
+)
+
 // NormalizeInterfaceAttributes normalises types of an attribute values.
 // The following transformations are applied: int -> int64, float32 -> float64.
 // The normalisation proceeds recursively through maps and slices.
@@ -39,4 +44,16 @@ func NormalizeInterfaceAttributes(value interface{}) interface{} {
 		}
 	}
 	return value
+}
+
+// Regular expression describing correct identifiers.
+var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+
+// ValidateName checks if a string can be used as a plug or slot name.
+func ValidateName(name string) error {
+	valid := validName.MatchString(name)
+	if !valid {
+		return fmt.Errorf("invalid interface name: %q", name)
+	}
+	return nil
 }

--- a/interfaces/utils/utils_test.go
+++ b/interfaces/utils/utils_test.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package utils
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type utilsSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&utilsSuite{})
+
+func (s *utilsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+}
+
+func (s *utilsSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *utilsSuite) TestValidateName(c *C) {
+	validNames := []string{
+		"a", "aa", "aaa", "aaaa",
+		"a-a", "aa-a", "a-aa", "a-b-c",
+		"a0", "a-0", "a-0a",
+	}
+	for _, name := range validNames {
+		err := ValidateName(name)
+		c.Assert(err, IsNil)
+	}
+	invalidNames := []string{
+		// name cannot be empty
+		"",
+		// dashes alone are not a name
+		"-", "--",
+		// double dashes in a name are not allowed
+		"a--a",
+		// name should not end with a dash
+		"a-",
+		// name cannot have any spaces in it
+		"a ", " a", "a a",
+		// a number alone is not a name
+		"0", "123",
+		// identifier must be plain ASCII
+		"日本語", "한글", "ру́сский язы́к",
+	}
+	for _, name := range invalidNames {
+		err := ValidateName(name)
+		c.Assert(err, ErrorMatches, `invalid interface name: ".*"`)
+	}
+}


### PR DESCRIPTION
Move ValidateName helper to utils to make it available to interfaces/hotplug package (as having it interfaces results in cyclic dependency). This is `interfaces/utils` to avoid cyclic dependency with import from `interfaces/hotplug`.
