### PR TITLE
cmd/snap-confine: fix snaps running on core18

### DIFF
--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -29,19 +29,43 @@ static void test_is_on_classic(void)
 	g_file_set_contents("os-release.classic", os_release_classic,
 			    strlen(os_release_classic), NULL);
 	os_release = "os-release.classic";
-	g_assert_true(is_running_on_classic_distribution());
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
 	unlink("os-release.classic");
 }
 
-const char *os_release_core = ""
-    "NAME=\"Ubuntu Core\"\n" "VERSION=\"16\"\n" "ID=ubuntu-core\n";
+const char *os_release_core16 = ""
+    "NAME=\"Ubuntu Core\"\n" "VERSION_ID=\"16\"\n" "ID=ubuntu-core\n";
 
-static void test_is_on_core(void)
+static void test_is_on_core_on16(void)
 {
-	g_file_set_contents("os-release.core", os_release_core,
-			    strlen(os_release_core), NULL);
+	g_file_set_contents("os-release.core", os_release_core16,
+			    strlen(os_release_core16), NULL);
 	os_release = "os-release.core";
-	g_assert_false(is_running_on_classic_distribution());
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE16);
+	unlink("os-release.core");
+}
+
+const char *os_release_core18 = ""
+    "NAME=\"Ubuntu Core\"\n" "VERSION_ID=\"18\"\n" "ID=ubuntu-core\n";
+
+static void test_is_on_core_on18(void)
+{
+	g_file_set_contents("os-release.core", os_release_core18,
+			    strlen(os_release_core18), NULL);
+	os_release = "os-release.core";
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
+	unlink("os-release.core");
+}
+
+const char *os_release_core20 = ""
+    "NAME=\"Ubuntu Core\"\n" "VERSION_ID=\"20\"\n" "ID=ubuntu-core\n";
+
+static void test_is_on_core_on20(void)
+{
+	g_file_set_contents("os-release.core", os_release_core20,
+			    strlen(os_release_core20), NULL);
+	os_release = "os-release.core";
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
 	unlink("os-release.core");
 }
 
@@ -58,8 +82,20 @@ static void test_is_on_classic_with_long_line(void)
 			    os_release_classic, strlen(os_release_classic),
 			    NULL);
 	os_release = "os-release.classic-with-long-line";
-	g_assert_true(is_running_on_classic_distribution());
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
 	unlink("os-release.classic-with-long-line");
+}
+
+static void test_should_use_normal_mode(void)
+{
+	g_assert_false(sc_should_use_normal_mode(SC_DISTRO_CORE16, "core"));
+	g_assert_true(sc_should_use_normal_mode(SC_DISTRO_CORE_OTHER, "core"));
+	g_assert_true(sc_should_use_normal_mode(SC_DISTRO_CLASSIC, "core"));
+
+	g_assert_true(sc_should_use_normal_mode(SC_DISTRO_CORE16, "core18"));
+	g_assert_true(sc_should_use_normal_mode
+		      (SC_DISTRO_CORE_OTHER, "core18"));
+	g_assert_true(sc_should_use_normal_mode(SC_DISTRO_CLASSIC, "core18"));
 }
 
 static void __attribute__ ((constructor)) init(void)
@@ -67,5 +103,9 @@ static void __attribute__ ((constructor)) init(void)
 	g_test_add_func("/classic/on-classic", test_is_on_classic);
 	g_test_add_func("/classic/on-classic-with-long-line",
 			test_is_on_classic_with_long_line);
-	g_test_add_func("/classic/on-core", test_is_on_core);
+	g_test_add_func("/classic/on-core-on16", test_is_on_core_on16);
+	g_test_add_func("/classic/on-core-on18", test_is_on_core_on18);
+	g_test_add_func("/classic/on-core-on20", test_is_on_core_on20);
+	g_test_add_func("/classic/should-use-normal-mode",
+			test_should_use_normal_mode);
 }

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -1,25 +1,51 @@
 #include "config.h"
 #include "classic.h"
 #include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/string-utils.h"
 
-#include <string.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 
 char *os_release = "/etc/os-release";
 
-bool is_running_on_classic_distribution()
+sc_distro sc_classify_distro(void)
 {
 	FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
 	if (f == NULL) {
-		return true;
+		return SC_DISTRO_CLASSIC;
 	}
 
+	bool is_core = false;
+	int core_version = 0;
 	char buf[255] = { 0 };
+
 	while (fgets(buf, sizeof buf, f) != NULL) {
-		if (strcmp(buf, "ID=ubuntu-core\n") == 0) {
-			return false;
+		size_t len = strlen(buf);
+		if (len > 0 && buf[len - 1] == '\n') {
+			buf[len - 1] = '\0';
+		}
+		if (sc_streq(buf, "ID=\"ubuntu-core\"")
+		    || sc_streq(buf, "ID=ubuntu-core")) {
+			is_core = true;
+		} else if (sc_streq(buf, "VERSION_ID=\"16\"")
+			   || sc_streq(buf, "VERSION_ID=16")) {
+			core_version = 16;
 		}
 	}
-	return true;
+
+	if (is_core) {
+		if (core_version == 16) {
+			return SC_DISTRO_CORE16;
+		}
+		return SC_DISTRO_CORE_OTHER;
+	} else {
+		return SC_DISTRO_CLASSIC;
+	}
+}
+
+bool sc_should_use_normal_mode(sc_distro distro, const char *base_snap_name)
+{
+	return distro != SC_DISTRO_CORE16 || !sc_streq(base_snap_name, "core");
 }

--- a/cmd/libsnap-confine-private/classic.h
+++ b/cmd/libsnap-confine-private/classic.h
@@ -22,6 +22,14 @@
 // Location of the host filesystem directory in the core snap.
 #define SC_HOSTFS_DIR "/var/lib/snapd/hostfs"
 
-bool is_running_on_classic_distribution(void);
+typedef enum sc_distro {
+	SC_DISTRO_CORE16,	// As present in both "core" and later on in "core16"
+	SC_DISTRO_CORE_OTHER,	// Any core distribution.
+	SC_DISTRO_CLASSIC,	// Any classic distribution.
+} sc_distro;
+
+sc_distro sc_classify_distro(void);
+
+bool sc_should_use_normal_mode(sc_distro distro, const char *base_snap_name);
 
 #endif

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -208,8 +208,9 @@ struct sc_mount_config {
 	const char *rootfs_dir;
 	// The struct is terminated with an entry with NULL path.
 	const struct sc_mount *mounts;
-	bool on_classic_distro;
-	bool uses_base_snap;
+	sc_distro distro;
+	bool normal_mode;
+	const char *base_snap_name;
 };
 
 /**
@@ -326,7 +327,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
 		}
 	}
-	if (config->on_classic_distro) {
+	if (config->normal_mode) {
 		// Since we mounted /etc from the host filesystem to the scratch directory,
 		// we may need to put certain directories from the desired root filesystem
 		// (e.g. the core snap) back. This way the behavior of running snaps is not
@@ -357,7 +358,11 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			}
 		}
 	}
-	if (config->uses_base_snap) {
+	// The "core" base snap is special as it contains snapd and friends.
+	// Other base snaps do not, so whenever a base snap other than core is
+	// in use we need extra provisions for setting up internal tooling to
+	// be available.
+	if (!sc_streq(config->base_snap_name, "core")) {
 		// when bases are used we need to bind-mount the libexecdir
 		// (that contains snap-exec) into /usr/lib/snapd of the
 		// base snap so that snap-exec is available for the snaps
@@ -445,7 +450,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// uniform way after pivot_root but this is good enough and requires less
 	// code changes the nvidia code assumes it has access to the existing
 	// pre-pivot filesystem.
-	if (config->on_classic_distro) {
+	if (config->distro == SC_DISTRO_CLASSIC) {
 		sc_mount_nvidia_driver(scratch_dir);
 	}
 	// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -603,11 +608,11 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	if (vanilla_cwd == NULL) {
 		die("cannot get the current working directory");
 	}
-
-	bool on_classic_distro = is_running_on_classic_distribution();
-	// on classic or with alternative base snaps we need to setup
-	// a different confinement
-	if (on_classic_distro || !sc_streq(base_snap_name, "core")) {
+	// Classify the current distribution, as claimed by /etc/os-release.
+	sc_distro distro = sc_classify_distro();
+	// Check which mode we should run in, normal or legacy.
+	if (sc_should_use_normal_mode(distro, base_snap_name)) {
+		// In normal mode we use the base snap as / and set up several bind mounts.
 		const struct sc_mount mounts[] = {
 			{"/dev"},	// because it contains devices on host OS
 			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
@@ -652,30 +657,30 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			}
 			die("cannot locate the base snap: %s", base_snap_name);
 		}
-		struct sc_mount_config classic_config = {
+		struct sc_mount_config normal_config = {
 			.rootfs_dir = rootfs_dir,
 			.mounts = mounts,
-			.on_classic_distro = true,
-			.uses_base_snap = !sc_streq(base_snap_name, "core"),
+			.distro = distro,
+			.normal_mode = true,
+			.base_snap_name = base_snap_name,
 		};
-		sc_bootstrap_mount_namespace(&classic_config);
+		sc_bootstrap_mount_namespace(&normal_config);
 	} else {
-		// This is what happens on an all-snap system. The rootfs we start with
-		// is the real outer rootfs.  There are no unidirectional bind mounts
-		// needed because everything is already OK. We still keep the
-		// bidirectional /media mount point so that snaps designed for mounting
-		// filesystems can use that space for whatever they need.
+		// In legacy mode we don't pivot and instead just arrange bi-
+		// directional mount propagation for two directories.
 		const struct sc_mount mounts[] = {
 			{"/media", true},
 			{"/run/netns", true},
 			{},
 		};
-		struct sc_mount_config all_snap_config = {
+		struct sc_mount_config legacy_config = {
 			.rootfs_dir = "/",
 			.mounts = mounts,
-			.uses_base_snap = !sc_streq(base_snap_name, "core"),
+			.distro = distro,
+			.normal_mode = false,
+			.base_snap_name = base_snap_name,
 		};
-		sc_bootstrap_mount_namespace(&all_snap_config);
+		sc_bootstrap_mount_namespace(&legacy_config);
 	}
 
 	// set up private mounts
@@ -687,7 +692,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	setup_private_pts();
 
 	// setup quirks for specific snaps
-	if (on_classic_distro) {
+	if (distro == SC_DISTRO_CLASSIC) {
 		sc_setup_quirks();
 	}
 	// setup the security backend bind mounts

--- a/tests/core18/compat/task.yaml
+++ b/tests/core18/compat/task.yaml
@@ -1,0 +1,11 @@
+summary: Ensure that core(16) compatibility is there
+
+execute: |
+    echo "Install test-snapd-tools (which uses the core snap)"
+    snap install test-snapd-tools
+
+    echo "Ensure that this pulled in core"
+    snap list | MATCH "^core +"
+
+    echo "Check test-snapd-tools see the core16 environment"
+    test-snapd-tools.cat /etc/os-release | MATCH "Ubuntu Core 16"


### PR DESCRIPTION
This patch changes the logic that selects mount namespace construction
behavior so that it is correct on machines booting with core18 wishing
to run core16/core snaps.

In the past core devices never used pivot_root and always used a minimal
set of changes on top of the initial mount namespace. Once bases were
introduced that logic was extended to use a full pivot_root approach
(which is always used on classic) when the invoked snap uses base other
than "core" (since the boot base was fixed at the time).

With the introduction of bootable core18 base, snaps need to use
pivot_root and the regular set of bind mounts to see their expected
"core" root filesystem when running on core18.

The code is tweaked to introduce "normal mode" and "legacy mode". Normal
mode uses pivot root and a predictable set of bind mounts. It is always
used on classic, it is also used on core devices _except_ for one
exception that limits any chances of backwards incompatible changes to
existing core devices.

A core device using "core" as boot base running snaps that demand "core"
base snap will use the "legacy mode" which doesn't pivot root. This is
exactly what used to happen on core devices before.

Core devices are identified with os-release(2) ID=ubuntu-core string.
A "core16" or "core" device is identified with an additional
VERSION_ID=16 string. All devices without ID=ubuntu-core are considered
classic. This logic will likely need to be extended as the Fedora 29
base work advances but no decision on how to identify such devices has
been made yet.

Existing classification between core and classic is extended to
differentiate core16 from other core systems. Classic classification is
retained as-is. There is a new helper function for checking if normal
mode should be used, given distribution and base snap name. Existing
call sites that used classic distinction are changed to use it instead.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
