### PR TITLE
tests: add basic integration test for spread hold

### DIFF
--- a/tests/main/refresh-hold/task.yaml
+++ b/tests/main/refresh-hold/task.yaml
@@ -1,0 +1,7 @@
+summary: Check that the refresh hold works
+
+execute: |
+    echo "Ensure snap set core refresh.hold works"
+    when="$(date --iso-8601=seconds -d tomorrow)"
+    snap set core refresh.hold="$when"
+    snap snap refresh --time | MATCH "^hold: $when"

--- a/tests/main/refresh-hold/task.yaml
+++ b/tests/main/refresh-hold/task.yaml
@@ -2,6 +2,7 @@ summary: Check that the refresh hold works
 
 execute: |
     echo "Ensure snap set core refresh.hold works"
-    when="$(date --iso-8601=seconds -d tomorrow)"
+    when="$(date --iso-8601=seconds -d 'tomorrow 8:05 UTC')"
+    when_nice="$(date -d "$when" +'tomorrow at %H:%M %Z')"
     snap set core refresh.hold="$when"
-    snap snap refresh --time | MATCH "^hold: $when"
+    snap refresh --time | MATCH "^hold: $when_nice"

--- a/tests/main/refresh-hold/task.yaml
+++ b/tests/main/refresh-hold/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that the refresh hold works
 
+# ubuntu-14.04 date prints differently and cannto be parsed by golang
+systems: [-ubuntu-14.04-*]
+
 execute: |
     echo "Ensure snap set core refresh.hold works"
     when="$(date --iso-8601=seconds -d 'tomorrow 8:05 UTC')"


### PR DESCRIPTION
I noticed we had no explicit integration test for "snap refresh hold".