### PR TITLE
tests/lib: sync the file before checking its contents.

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -481,6 +481,7 @@ EOF
         # append ubuntu, test user for the testing
         grep "^test:" /etc/$f >> /mnt/system-data/var/lib/extrausers/"$f"
         grep "^ubuntu:" /etc/$f >> /mnt/system-data/var/lib/extrausers/"$f"
+        sync /mnt/system-data/var/lib/extrausers/"$f"
         # check test was copied
         MATCH "^test:" </mnt/system-data/var/lib/extrausers/"$f"
         MATCH "^ubuntu:" </mnt/system-data/var/lib/extrausers/"$f"


### PR DESCRIPTION
This should not work. POSIX demands that it not work. There is a basic
"if you write something to the file, and then read it, you should read
what you just wrote" expectation that would be being broken, so if
this worked a _lot_ of things out there would come into weird issues
and hard-to-debug crazy stuff would be going on all the time.

And yet...
