### PR TITLE
overlord/ifacestate: translate "core" <=> "snapd" as appropriate

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1908,6 +1908,9 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 		repo := c.d.overlord.InterfaceManager().Repository()
 		connRef, err = repo.ResolveConnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		if err == nil {
+			ifacestate.RemapIncomingConnRef(st, connRef)
+			// NOTE: now we don't talk about "core" but about "snapd" snap, where applicable.
+			// This persists in the state through tasks but not in the connection state.
 			var ts *state.TaskSet
 			summary = fmt.Sprintf("Connect %s:%s to %s:%s", connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
 			ts, err = ifacestate.Connect(st, connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
@@ -1924,6 +1927,9 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 				return InterfacesUnchanged("nothing to do")
 			}
 			for _, connRef := range conns {
+				ifacestate.RemapIncomingConnRef(st, connRef)
+				// NOTE: now we don't talk about "core" but about "snapd" snap, where applicable.
+				// This persists in the state through tasks but not in the connection state.
 				var ts *state.TaskSet
 				ts, err = ifacestate.Disconnect(st, connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
 				if err != nil {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1902,36 +1902,53 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 		a.Slots[i].Snap = snap.DropNick(a.Slots[i].Snap)
 	}
 
+	repo := c.d.overlord.InterfaceManager().Repository()
+
 	switch a.Action {
 	case "connect":
-		var connRef *interfaces.ConnRef
-		repo := c.d.overlord.InterfaceManager().Repository()
-		connRef, err = repo.ResolveConnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
+		// Pack the connection arguments into a connection reference for a
+		// moment. We need this for the re-mapping API.
+		cref := &interfaces.ConnRef{
+			PlugRef: interfaces.PlugRef{Snap: a.Plugs[0].Snap, Name: a.Plugs[0].Name},
+			SlotRef: interfaces.SlotRef{Snap: a.Slots[0].Snap, Name: a.Slots[0].Name},
+		}
+
+		// Re-map the connection (e.g. core => snapd). Now we don't talk about
+		// "core" but about "snapd" snap, where applicable. This re-mapping
+		// doesn't persist in the system state but does persist in per-task
+		// state.
+		ifacestate.RemapIncomingConnRef(st, cref)
+
+		// Resolve the connection, yeah some API skew here.
+		cref, err = repo.ResolveConnect(cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
 		if err == nil {
-			ifacestate.RemapIncomingConnRef(st, connRef)
-			// NOTE: now we don't talk about "core" but about "snapd" snap, where applicable.
-			// This persists in the state through tasks but not in the connection state.
 			var ts *state.TaskSet
-			summary = fmt.Sprintf("Connect %s:%s to %s:%s", connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
-			ts, err = ifacestate.Connect(st, connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
+			summary = fmt.Sprintf("Connect %s:%s to %s:%s", cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
+			ts, err = ifacestate.Connect(st, cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
 			tasksets = append(tasksets, ts)
-			affected = snapNamesFromConns([]*interfaces.ConnRef{connRef})
+			affected = snapNamesFromConns([]*interfaces.ConnRef{cref})
 		}
 	case "disconnect":
+		// Pack the connection arguments into a connection reference for a
+		// moment. We need this for the re-mapping API.
+		cref := &interfaces.ConnRef{
+			PlugRef: interfaces.PlugRef{Snap: a.Plugs[0].Snap, Name: a.Plugs[0].Name},
+			SlotRef: interfaces.SlotRef{Snap: a.Slots[0].Snap, Name: a.Slots[0].Name},
+		}
+
+		// Re-map the connection (e.g. core => snapd), same as above.
+		ifacestate.RemapIncomingConnRef(st, cref)
+
 		var conns []*interfaces.ConnRef
-		repo := c.d.overlord.InterfaceManager().Repository()
-		summary = fmt.Sprintf("Disconnect %s:%s from %s:%s", a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
-		conns, err = repo.ResolveDisconnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
+		summary = fmt.Sprintf("Disconnect %s:%s from %s:%s", cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
+		conns, err = repo.ResolveDisconnect(cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
 		if err == nil {
 			if len(conns) == 0 {
 				return InterfacesUnchanged("nothing to do")
 			}
-			for _, connRef := range conns {
-				ifacestate.RemapIncomingConnRef(st, connRef)
-				// NOTE: now we don't talk about "core" but about "snapd" snap, where applicable.
-				// This persists in the state through tasks but not in the connection state.
+			for _, cref := range conns {
 				var ts *state.TaskSet
-				ts, err = ifacestate.Disconnect(st, connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
+				ts, err = ifacestate.Disconnect(st, cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
 				if err != nil {
 					break
 				}

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -32,6 +32,10 @@ var (
 	CheckConnectConflicts     = checkConnectConflicts
 	FindSymmetricAutoconnect  = findSymmetricAutoconnect
 	ConnectPriv               = connect
+	HasSnapdSnap              = hasSnapdSnap
+	RemapIncomingConnRef      = remapIncomingConnRef
+	RemapIncomingConnStrings  = remapIncomingConnStrings
+	RemapOutgoingConnRef      = remapOutgoingConnRef
 )
 
 // AddForeignTaskHandlers registers handlers for tasks handled outside of the

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -33,9 +33,6 @@ var (
 	FindSymmetricAutoconnect  = findSymmetricAutoconnect
 	ConnectPriv               = connect
 	HasSnapdSnap              = hasSnapdSnap
-	RemapIncomingConnRef      = remapIncomingConnRef
-	RemapIncomingConnStrings  = remapIncomingConnStrings
-	RemapOutgoingConnRef      = remapOutgoingConnRef
 )
 
 // AddForeignTaskHandlers registers handlers for tasks handled outside of the

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -426,6 +426,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		task.Set("old-conn", oldconn)
 	}
 
+	remapOutgoingConnRef(st, connRef)
 	conns[connRef.ID()] = connState{
 		Interface:        conn.Interface(),
 		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
@@ -452,14 +453,16 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
+	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
 
+	remapIncomingConnRef(st, cref)
 	conns, err := getConns(st)
 	if err != nil {
 		return err
 	}
 
 	var snapStates []snapstate.SnapState
-	for _, snapName := range []string{plugRef.Snap, slotRef.Snap} {
+	for _, snapName := range []string{cref.PlugRef.Snap, cref.SlotRef.Snap} {
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, snapName, &snapst); err != nil {
 			if err == state.ErrNoState {
@@ -472,7 +475,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	err = m.repo.Disconnect(plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name)
+	err = m.repo.Disconnect(cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name)
 	if err != nil {
 		return fmt.Errorf("snapd changed, please retry the operation: %v", err)
 	}
@@ -487,7 +490,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	cref := interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
+	remapOutgoingConnRef(st, cref)
 	if conn, ok := conns[cref.ID()]; ok && conn.Auto {
 		conn.Undesired = true
 		conn.DynamicPlugAttrs = nil
@@ -770,7 +773,7 @@ func (m *InterfaceManager) transitionConnectionsCoreMigration(st *state.State, o
 
 	// The reloadConnections() just modifies the repository object, it
 	// has no effect on the running system, i.e. no security profiles
-	// on disk are rewriten. This is ok because core/ubuntu-core have
+	// on disk are rewritten. This is ok because core/ubuntu-core have
 	// exactly the same profiles and nothing in the generated policies
 	// has the slot-name encoded.
 	if _, err := m.reloadConnections(oldName); err != nil {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -426,7 +426,6 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		task.Set("old-conn", oldconn)
 	}
 
-	remapOutgoingConnRef(st, connRef)
 	conns[connRef.ID()] = connState{
 		Interface:        conn.Interface(),
 		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
@@ -455,7 +454,6 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	}
 	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
 
-	remapIncomingConnRef(st, cref)
 	conns, err := getConns(st)
 	if err != nil {
 		return err
@@ -490,7 +488,6 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	remapOutgoingConnRef(st, cref)
 	if conn, ok := conns[cref.ID()]; ok && conn.Auto {
 		conn.Undesired = true
 		conn.DynamicPlugAttrs = nil

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -253,16 +253,17 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 		if conn.Undesired {
 			continue
 		}
-		connRef, err := interfaces.ParseConnRef(id)
+		cref, err := interfaces.ParseConnRef(id)
 		if err != nil {
 			return nil, err
 		}
-		if snapName != "" && connRef.PlugRef.Snap != snapName && connRef.SlotRef.Snap != snapName {
+		if snapName != "" && cref.PlugRef.Snap != snapName && cref.SlotRef.Snap != snapName {
 			continue
 		}
+		remapIncomingConnRef(m.state, cref)
 
 		// Note: reloaded connections are not checked against policy again, and also we don't call BeforeConnect* methods on them.
-		if _, err := m.repo.Connect(connRef, conn.DynamicPlugAttrs, conn.DynamicSlotAttrs, nil); err != nil {
+		if _, err := m.repo.Connect(cref, conn.DynamicPlugAttrs, conn.DynamicSlotAttrs, nil); err != nil {
 			if _, ok := err.(*interfaces.UnknownPlugSlotError); ok {
 				// Some versions of snapd may have left stray connections that
 				// don't have the corresponding plug or slot anymore. Before we
@@ -272,8 +273,8 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 			}
 			logger.Noticef("%s", err)
 		} else {
-			affected[connRef.PlugRef.Snap] = true
-			affected[connRef.SlotRef.Snap] = true
+			affected[cref.PlugRef.Snap] = true
+			affected[cref.SlotRef.Snap] = true
 		}
 	}
 	result := make([]string, 0, len(affected))
@@ -539,4 +540,43 @@ func resolveSnapIDToName(st *state.State, snapID string) (name string, err error
 		return "", err
 	}
 	return decl.SnapName(), nil
+}
+
+// remapIncomingConnRef potentially re-maps connection reference from an API request or being loaded from store.
+//
+// The operation done by remapIncomingConnRef must be symmetric with remapIncomingConnRef.
+// In practice the pair of functions are used to make "snapd" snap the host of implicit
+// interfaces and connections without altering the state in a backwards incompatible way.
+//
+// Data coming from the state and from API requests is changed so that slots on "core"
+// become slots on "snapd" (but only when "snapd" snap itself is being used). When
+// data is about to hit the state again it is re-mapped back.
+func remapIncomingConnRef(st *state.State, cref *interfaces.ConnRef) {
+	if cref.SlotRef.Snap == "core" && hasSnapdSnap(st) {
+		cref.SlotRef.Snap = "snapd"
+	}
+}
+
+// remapIncomingConnRef potentially re-maps connection reference being saved to store.
+func remapOutgoingConnRef(st *state.State, cref *interfaces.ConnRef) {
+	if cref.SlotRef.Snap == "snapd" && hasSnapdSnap(st) {
+		cref.SlotRef.Snap = "core"
+	}
+}
+
+// hasSnapdSnap returns true if there snapd snap is represented in the state.
+func hasSnapdSnap(st *state.State) bool {
+	var snapst snapstate.SnapState
+	err := snapstate.Get(st, "snapd", &snapst)
+	return err == nil
+}
+
+// remapIncomingConnStrings is like remapIncomingConnRef but with different argument and return types.
+func remapIncomingConnStrings(st *state.State, plugSnap, plugName, slotSnap, slotName string) (outPlugSnap, outPlugName, outSlotSnap, outSlotName string) {
+	cref := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: plugSnap, Name: plugName},
+		SlotRef: interfaces.SlotRef{Snap: slotSnap, Name: slotName},
+	}
+	remapIncomingConnRef(st, cref)
+	return cref.PlugRef.Snap, cref.PlugRef.Name, cref.SlotRef.Snap, cref.SlotRef.Name
 }

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -134,33 +134,6 @@ func (s *helpersSuite) TestRemapIncomingConnRef(c *C) {
 	})
 }
 
-func (s *helpersSuite) TestRemapIncomingConnStrings(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	// When "snapd" snap is present, incoming requests re-map "core" snap
-	// to "snapd" snap for interface connections.
-	restore := MockSnapdPresence(c, s.st, true)
-	defer restore()
-
-	plugSnap, plugName, slotSnap, slotName := "example", "network", "core", "network"
-	plugSnapX, plugNameX, slotSnapX, slotNameX := ifacestate.RemapIncomingConnStrings(s.st, plugSnap, plugName, slotSnap, slotName)
-	c.Assert(plugSnapX, Equals, "example")
-	c.Assert(plugNameX, Equals, "network")
-	c.Assert(slotSnapX, Equals, "snapd")
-	c.Assert(slotNameX, Equals, "network")
-
-	// When "snapd" snap is absent, requests are not changed in any way.
-	restore = MockSnapdPresence(c, s.st, false)
-	defer restore()
-
-	plugSnapX, plugNameX, slotSnapX, slotNameX = ifacestate.RemapIncomingConnStrings(s.st, plugSnap, plugName, slotSnap, slotName)
-	c.Assert(plugSnapX, Equals, "example")
-	c.Assert(plugNameX, Equals, "network")
-	c.Assert(slotSnapX, Equals, "core")
-	c.Assert(slotNameX, Equals, "network")
-}
-
 func (s *helpersSuite) TestRemapOutgoingConnRef(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -1,0 +1,182 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type helpersSuite struct {
+	st *state.State
+}
+
+var _ = Suite(&helpersSuite{})
+
+func (s *helpersSuite) SetUpTest(c *C) {
+	s.st = state.New(nil)
+}
+
+func (s *helpersSuite) TearDownTest(c *C) {
+}
+
+// MockSnapdPresence arranges for state to have the required presence of "snapd" snap.
+func MockSnapdPresence(c *C, st *state.State, isPresent bool) (restore func()) {
+	var origState snapstate.SnapState
+
+	err := snapstate.Get(st, "snapd", &origState)
+	if err != state.ErrNoState {
+		c.Assert(err, IsNil)
+	}
+
+	if isPresent {
+		snapstate.Set(st, "snapd", &snapstate.SnapState{
+			SnapType: string(snap.TypeApp),
+			Sequence: []*snap.SideInfo{{
+				Revision: snap.R(1),
+			}},
+			Active:  true,
+			Current: snap.R(1),
+		})
+	} else {
+		snapstate.Set(st, "snapd", nil)
+	}
+
+	return func() {
+		// Restoring a snap state with empty sequence is just like removing it
+		// so we don't need to special-case or remember if ErrNoState happened.
+		snapstate.Set(st, "snapd", &origState)
+	}
+}
+
+func (s *helpersSuite) TestHasSnapdSnap(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// Not having any state means we don't "have" snapd snap
+	c.Assert(ifacestate.HasSnapdSnap(s.st), Equals, false)
+
+	// Having an active "snapd" snap means we have it.
+	snapstate.Set(s.st, "snapd", &snapstate.SnapState{
+		SnapType: string(snap.TypeApp),
+		Sequence: []*snap.SideInfo{{
+			Revision: snap.R(1),
+		}},
+		Active:  true,
+		Current: snap.R(1),
+	})
+	c.Assert(ifacestate.HasSnapdSnap(s.st), Equals, true)
+
+	// Having an inactive "snapd" snap also means we have it.
+	snapstate.Set(s.st, "snapd", &snapstate.SnapState{
+		SnapType: string(snap.TypeApp),
+		Sequence: []*snap.SideInfo{{
+			Revision: snap.R(1),
+		}},
+		Current: snap.R(1),
+	})
+	c.Assert(ifacestate.HasSnapdSnap(s.st), Equals, true)
+}
+
+func (s *helpersSuite) TestRemapIncomingConnRef(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// When "snapd" snap is present, incoming requests re-map "core" snap
+	// to "snapd" snap for interface connections.
+	restore := MockSnapdPresence(c, s.st, true)
+	defer restore()
+
+	cref := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "example", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "network"},
+	}
+	ifacestate.RemapIncomingConnRef(s.st, cref)
+	c.Assert(cref, DeepEquals, &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "example", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "snapd", Name: "network"},
+	})
+
+	// When "snapd" snap is absent, requests are not changed in any way.
+	restore = MockSnapdPresence(c, s.st, false)
+	defer restore()
+
+	cref = &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "example", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "network"},
+	}
+	ifacestate.RemapIncomingConnRef(s.st, cref)
+	c.Assert(cref, DeepEquals, &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "example", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "network"},
+	})
+}
+
+func (s *helpersSuite) TestRemapIncomingConnStrings(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// When "snapd" snap is present, incoming requests re-map "core" snap
+	// to "snapd" snap for interface connections.
+	restore := MockSnapdPresence(c, s.st, true)
+	defer restore()
+
+	plugSnap, plugName, slotSnap, slotName := "example", "network", "core", "network"
+	plugSnapX, plugNameX, slotSnapX, slotNameX := ifacestate.RemapIncomingConnStrings(s.st, plugSnap, plugName, slotSnap, slotName)
+	c.Assert(plugSnapX, Equals, "example")
+	c.Assert(plugNameX, Equals, "network")
+	c.Assert(slotSnapX, Equals, "snapd")
+	c.Assert(slotNameX, Equals, "network")
+
+	// When "snapd" snap is absent, requests are not changed in any way.
+	restore = MockSnapdPresence(c, s.st, false)
+	defer restore()
+
+	plugSnapX, plugNameX, slotSnapX, slotNameX = ifacestate.RemapIncomingConnStrings(s.st, plugSnap, plugName, slotSnap, slotName)
+	c.Assert(plugSnapX, Equals, "example")
+	c.Assert(plugNameX, Equals, "network")
+	c.Assert(slotSnapX, Equals, "core")
+	c.Assert(slotNameX, Equals, "network")
+}
+
+func (s *helpersSuite) TestRemapOutgoingConnRef(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// When "snapd" snap is present, outgoing requests re-map "snapd" snap
+	// to "core" snap for on-disk data.
+	restore := MockSnapdPresence(c, s.st, true)
+	defer restore()
+
+	cref := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "example", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "snapd", Name: "network"},
+	}
+	ifacestate.RemapOutgoingConnRef(s.st, cref)
+	c.Assert(cref, DeepEquals, &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "example", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "network"},
+	})
+}

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -135,8 +135,6 @@ func checkConnectConflicts(st *state.State, plugSnap, slotSnap string, auto bool
 
 // Connect returns a set of tasks for connecting an interface.
 func Connect(st *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
-	plugSnap, plugName, slotSnap, slotName = remapIncomingConnStrings(st, plugSnap, plugName, slotSnap, slotName)
-
 	const auto = false
 	if err := checkConnectConflicts(st, plugSnap, slotSnap, auto); err != nil {
 		return nil, err
@@ -267,8 +265,6 @@ func initialConnectAttributes(st *state.State, plugSnap string, plugName string,
 
 // Disconnect returns a set of tasks for  disconnecting an interface.
 func Disconnect(st *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
-	plugSnap, plugName, slotSnap, slotName = remapIncomingConnStrings(st, plugSnap, plugName, slotSnap, slotName)
-
 	if err := snapstate.CheckChangeConflict(st, plugSnap, noConflictOnConnectTasks, nil); err != nil {
 		return nil, err
 	}

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -134,8 +134,9 @@ func checkConnectConflicts(st *state.State, plugSnap, slotSnap string, auto bool
 }
 
 // Connect returns a set of tasks for connecting an interface.
-//
 func Connect(st *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
+	plugSnap, plugName, slotSnap, slotName = remapIncomingConnStrings(st, plugSnap, plugName, slotSnap, slotName)
+
 	const auto = false
 	if err := checkConnectConflicts(st, plugSnap, slotSnap, auto); err != nil {
 		return nil, err
@@ -266,6 +267,8 @@ func initialConnectAttributes(st *state.State, plugSnap string, plugName string,
 
 // Disconnect returns a set of tasks for  disconnecting an interface.
 func Disconnect(st *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
+	plugSnap, plugName, slotSnap, slotName = remapIncomingConnStrings(st, plugSnap, plugName, slotSnap, slotName)
+
 	if err := snapstate.CheckChangeConflict(st, plugSnap, noConflictOnConnectTasks, nil); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch adds a mechanism for transparently re-mapping interface
connection peers for both incoming (API) requests and outgoing (state)
requests.

The mechanism is then applied to make it so that every time a connection
request for "snapd" comes in, it is re-mapped to "core" in the state, so
it seems that the connection is to core if one inspects the state alone.
At the same time explicit requests to "core" are re-mapped to to
"snapd", so that it seems that one can connect interfaces to implicit
slots on core, as before.

In both cases this mechanism is only applied if "snapd" is the host of
implicit interfaces.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
