### PR TITLE
snapstate: allow setting "refresh.timer=managed"

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -442,9 +442,7 @@ func refreshScheduleManaged(st *state.State) (managed bool, legacy bool) {
 	}
 	// if not set, fallback to refresh.schedule
 	if confStr == "" {
-		tr := config.NewTransaction(st)
-		err := tr.Get("core", "refresh.schedule", &confStr)
-		if err != nil {
+		if err := tr.Get("core", "refresh.schedule", &confStr); err != nil {
 			return false, legacy
 		}
 		legacy = true

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -64,7 +64,7 @@ func (r *refreshHints) needsUpdate() (bool, error) {
 
 func (r *refreshHints) refresh() error {
 	var refreshManaged bool
-	refreshManaged = refreshScheduleManaged(r.state)
+	refreshManaged, _ = refreshScheduleManaged(r.state)
 
 	_, _, _, err := refreshCandidates(auth.EnsureContextTODO(), r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
 	// TODO: we currently set last-refresh-hints even when there was an

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6597,7 +6597,7 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesWithUpdateStoreError(c *C) {
 	c.Check(autoRefreshAssertionsCalled, Equals, 1)
 }
 
-func (s *snapmgrTestSuite) TestEnsureRefreshesDisabledViaSnapdControl(c *C) {
+func (s *snapmgrTestSuite) testEnsureRefreshesDisabledViaSnapdControl(c *C, confSet func(*config.Transaction)) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -6628,8 +6628,9 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesDisabledViaSnapdControl(c *C) {
 		return true
 	}
 	defer func() { snapstate.CanManageRefreshes = oldCanManageRefreshes }()
+
 	tr := config.NewTransaction(st)
-	tr.Set("core", "refresh.schedule", "managed")
+	confSet(tr)
 	tr.Commit()
 
 	// Ensure() also runs ensureRefreshes()
@@ -6649,6 +6650,30 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesDisabledViaSnapdControl(c *C) {
 	var lastRefreshHints time.Time
 	st.Get("last-refresh-hints", &lastRefreshHints)
 	c.Check(lastRefreshHints.Year(), Equals, time.Now().Year())
+}
+
+func (s *snapmgrTestSuite) TestEnsureRefreshDisableLegacy(c *C) {
+	f := func(tr *config.Transaction) {
+		tr.Set("core", "refresh.timer", "")
+		tr.Set("core", "refresh.schedule", "managed")
+	}
+	s.testEnsureRefreshesDisabledViaSnapdControl(c, f)
+}
+
+func (s *snapmgrTestSuite) TestEnsureRefreshDisableNew(c *C) {
+	f := func(tr *config.Transaction) {
+		tr.Set("core", "refresh.timer", "managed")
+		tr.Set("core", "refresh.schedule", "")
+	}
+	s.testEnsureRefreshesDisabledViaSnapdControl(c, f)
+}
+
+func (s *snapmgrTestSuite) TestEnsureRefreshDisableNewTrumpsOld(c *C) {
+	f := func(tr *config.Transaction) {
+		tr.Set("core", "refresh.timer", "managed")
+		tr.Set("core", "refresh.schedule", "00:00-12:00")
+	}
+	s.testEnsureRefreshesDisabledViaSnapdControl(c, f)
 }
 
 func (s *snapmgrTestSuite) TestDefaultRefreshScheduleParsing(c *C) {


### PR DESCRIPTION
Current only refresh.schedule can be set to "managed". However
this is a legacy option and the new default to set the refresh
configuration is "refresh.timer". This PR allows setting the
new option to "managed".

Note that this PR as it is makes refresh.timer take precedence over refresh.schedule for the managed setting. This means that if you have "refresh.schedule=managed" but "refresh.timer=00:00-12:00" the later takes precedence and the schedule is *not* managed. This is consistent with the behaviour we have for the regular settings but we might make any managed "managed" override any non-managed setting to ensure maximum compatibility. Right now if a system was set to "refresh.schedule=managed" and "refresh.timer=something-else" the system is in "managed" mode but with this PR (as is) it would go into "something-else" mode. This is trivial to change here though (if we want).