### PR TITLE
interfaces: treat "snapd" snap as type:os

### DIFF
--- a/interfaces/policy/export_test.go
+++ b/interfaces/policy/export_test.go
@@ -22,4 +22,5 @@ package policy
 var (
 	NestedGet              = nestedGet
 	ComposeBaseDeclaration = composeBaseDeclaration
+	CheckSnapType          = checkSnapType
 )

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -38,8 +38,6 @@ func snapIDSnapd(snapID string) bool {
 		// TODO: when snapd snap is uploaded to staging, replace this with
 		// the real snap-id.
 		"todo-staging-snapd-id",
-		// tests
-		"snapd-snap-id",
 	}
 	return strutil.ListContains(snapIDsSnapd, snapID)
 }

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -26,16 +26,33 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // check helpers
 
-func checkSnapType(snapType snap.Type, types []string) error {
+func snapIDSnapd(snapID string) bool {
+	var snapIDsSnapd = []string{
+		// production
+		"PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+		// TODO: when snapd snap is uploaded to staging, replace this with
+		// the real snap-id.
+		"todo-staging-snapd-id",
+		// tests
+		"snapd-snap-id",
+	}
+	return strutil.ListContains(snapIDsSnapd, snapID)
+}
+
+func checkSnapType(snap *snap.Info, types []string) error {
 	if len(types) == 0 {
 		return nil
 	}
-	s := string(snapType)
-	if s == "os" { // we use "core" in the assertions
+	snapID := snap.SnapID
+	s := string(snap.Type)
+	if s == "os" || snapIDSnapd(snapID) {
+		// we use "core" in the assertions and we need also to
+		// allow for the "snapd" snap
 		s = "core"
 	}
 	for _, t := range types {
@@ -87,7 +104,7 @@ func checkPlugConnectionConstraints1(connc *ConnectCandidate, cstrs *asserts.Plu
 	if err := cstrs.SlotAttributes.Check(connc.Slot, connc); err != nil {
 		return err
 	}
-	if err := checkSnapType(connc.slotSnapType(), cstrs.SlotSnapTypes); err != nil {
+	if err := checkSnapType(connc.Slot.Snap(), cstrs.SlotSnapTypes); err != nil {
 		return err
 	}
 	if err := checkID("snap id", connc.slotSnapID(), cstrs.SlotSnapIDs, nil); err != nil {
@@ -127,7 +144,7 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, cstrs *asserts.Slo
 	if err := cstrs.SlotAttributes.Check(connc.Slot, connc); err != nil {
 		return err
 	}
-	if err := checkSnapType(connc.plugSnapType(), cstrs.PlugSnapTypes); err != nil {
+	if err := checkSnapType(connc.Plug.Snap(), cstrs.PlugSnapTypes); err != nil {
 		return err
 	}
 	if err := checkID("snap id", connc.plugSnapID(), cstrs.PlugSnapIDs, nil); err != nil {
@@ -165,7 +182,7 @@ func checkSlotInstallationConstraints1(slot *snap.SlotInfo, cstrs *asserts.SlotI
 	if err := cstrs.SlotAttributes.Check(slot, nil); err != nil {
 		return err
 	}
-	if err := checkSnapType(slot.Snap.Type, cstrs.SlotSnapTypes); err != nil {
+	if err := checkSnapType(slot.Snap, cstrs.SlotSnapTypes); err != nil {
 		return err
 	}
 	if err := checkOnClassic(cstrs.OnClassic); err != nil {
@@ -194,7 +211,7 @@ func checkPlugInstallationConstraints1(plug *snap.PlugInfo, cstrs *asserts.PlugI
 	if err := cstrs.PlugAttributes.Check(plug, nil); err != nil {
 		return err
 	}
-	if err := checkSnapType(plug.Snap.Type, cstrs.PlugSnapTypes); err != nil {
+	if err := checkSnapType(plug.Snap, cstrs.PlugSnapTypes); err != nil {
 		return err
 	}
 	if err := checkOnClassic(cstrs.OnClassic); err != nil {

--- a/interfaces/policy/helpers_test.go
+++ b/interfaces/policy/helpers_test.go
@@ -86,7 +86,7 @@ func (s *helpersSuite) TestSnapdTypeCheck(c *C) {
 	// Type checking the snapd snap is done in a special way.
 	// It appears to be of type "core" while in reality it is of type "app".
 	sideInfo := &snap.SideInfo{
-		SnapID: "snapd-snap-id",
+		SnapID: "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
 	}
 	snapInfo := snaptest.MockInfo(c, `
 name: snapd

--- a/interfaces/policy/helpers_test.go
+++ b/interfaces/policy/helpers_test.go
@@ -22,6 +22,7 @@ package policy_test
 import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/policy"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 
 	. "gopkg.in/check.v1"
@@ -79,4 +80,21 @@ slots:
 	v, err = policy.NestedGet("slot", slot, "a.b")
 	c.Check(err, IsNil)
 	c.Check(v, DeepEquals, []interface{}{"1", "2", "3"})
+}
+
+func (s *helpersSuite) TestSnapdTypeCheck(c *C) {
+	// Type checking the snapd snap is done in a special way.
+	// It appears to be of type "core" while in reality it is of type "app".
+	sideInfo := &snap.SideInfo{
+		SnapID: "snapd-snap-id",
+	}
+	snapInfo := snaptest.MockInfo(c, `
+name: snapd
+version: 1
+type: app
+slots:
+    network:
+`, sideInfo)
+	err := policy.CheckSnapType(snapInfo, []string{"core"})
+	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
This patch changes the policy checker to internally detect the snap with
IDs of the "snapd" (in either staging or production) and translate its
type to "core". This allows the base policy to remain unchanged while
implicit interfaces are moved to "snapd" snap.

This also includes snap-id checking improvements from mvo (thanks)

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
