### PR TITLE
coreconfig: add support for `snap set system network.disable-ipv6`

### DIFF
--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -145,7 +145,7 @@ func Run(tr Conf) error {
 	if err := handleWatchdogConfiguration(tr); err != nil {
 		return err
 	}
-	// network.disable-{ipv4,ipv6}
+	// network.disable-ipv6
 	if err := handleNetworkConfiguration(tr); err != nil {
 		return err
 	}

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -106,6 +106,9 @@ func Run(tr Conf) error {
 	if err := validateWatchdogOptions(tr); err != nil {
 		return err
 	}
+	if err := validateNetworkSettings(tr); err != nil {
+		return err
+	}
 	// FIXME: ensure the user cannot set "core seed.loaded"
 
 	// capture cloud information
@@ -140,6 +143,10 @@ func Run(tr Conf) error {
 	}
 	// watchdog.{runtime-timeout,shutdown-timeout}
 	if err := handleWatchdogConfiguration(tr); err != nil {
+		return err
+	}
+	// network.disable-{ipv4,ipv6}
+	if err := handleNetworkConfiguration(tr); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -54,6 +54,8 @@ func handleNetworkConfiguration(tr Conf) error {
 		sysctl = "net.ipv6.conf.all.disable_ipv6=1"
 		content.WriteString(sysctl + "\n")
 	case "false", "":
+		// Store the sysctl for the code below but don't write it to
+		// content so that the file setting this option gets removed.
 		sysctl = "net.ipv6.conf.all.disable_ipv6=0"
 	default:
 		return fmt.Errorf("unsupported disable-ipv6 option: %q", output)

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations["core.network.disable-ipv6"] = true
+}
+
+func validateNetworkSettings(tr Conf) error {
+	return validateBoolFlag(tr, "network.disable-ipv6")
+}
+
+func handleNetworkConfiguration(tr Conf) error {
+	dir := filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d")
+	name := "10-snapd-network.conf"
+	content := bytes.NewBuffer(nil)
+
+	if !osutil.FileExists(dir) {
+		return nil
+	}
+
+	var sysctl string
+	output, err := coreCfg(tr, "network.disable-ipv6")
+	if err != nil {
+		return nil
+	}
+	switch output {
+	case "true":
+		sysctl = "net.ipv6.conf.all.disable_ipv6=1"
+		content.WriteString(sysctl + "\n")
+	case "false":
+		sysctl = "net.ipv6.conf.all.disable_ipv6=0"
+		content.WriteString(sysctl + "\n")
+	case "":
+		if err := os.Remove(filepath.Join(dir, name)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported disable-ipv6 option: %q", output)
+	}
+
+	if sysctl != "" {
+		// write the new config
+		dirContent := map[string]*osutil.FileState{
+			name: &osutil.FileState{
+				Content: content.Bytes(),
+				Mode:    0644,
+			},
+		}
+		glob := name
+		if _, _, err = osutil.EnsureDirState(dir, glob, dirContent); err != nil {
+			return err
+		}
+
+		// load the new config into the kernel
+		output, err := exec.Command("sysctl", "-p", filepath.Join(dir, name)).CombinedOutput()
+		if err != nil {
+			return osutil.OutputErr(output, err)
+		}
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -44,10 +44,6 @@ func handleNetworkConfiguration(tr Conf) error {
 	name := "10-snapd-network.conf"
 	content := bytes.NewBuffer(nil)
 
-	if !osutil.FileExists(dir) {
-		return nil
-	}
-
 	var sysctl string
 	output, err := coreCfg(tr, "network.disable-ipv6")
 	if err != nil {
@@ -71,7 +67,7 @@ func handleNetworkConfiguration(tr Conf) error {
 	if sysctl != "" {
 		// write the new config
 		dirContent := map[string]*osutil.FileState{
-			name: &osutil.FileState{
+			name: {
 				Content: content.Bytes(),
 				Mode:    0644,
 			},

--- a/overlord/configstate/configcore/network_test.go
+++ b/overlord/configstate/configcore/network_test.go
@@ -1,0 +1,102 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type networkSuite struct {
+	configcoreSuite
+
+	mockNetworkSysctlPath string
+	restores              []func()
+	mockSysctl            *testutil.MockCmd
+}
+
+var _ = Suite(&networkSuite{})
+
+func (s *networkSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.restores = append(s.restores, release.MockOnClassic(false))
+
+	s.mockSysctl = testutil.MockCommand(c, "sysctl", "")
+	s.restores = append(s.restores, func() { s.mockSysctl.Restore() })
+
+	s.mockNetworkSysctlPath = filepath.Join(dirs.GlobalRootDir, "/etc/sysctl.d/10-snapd-network.conf")
+	c.Assert(os.MkdirAll(filepath.Dir(s.mockNetworkSysctlPath), 0755), IsNil)
+}
+
+func (s *networkSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+	for _, f := range s.restores {
+		f()
+	}
+}
+
+func (s *networkSuite) TestConfigureNetworkIntegrationIPv6True(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"network.disable-ipv6": true,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.mockNetworkSysctlPath, testutil.FileEquals, "net.ipv6.conf.all.disable_ipv6=1\n")
+	c.Check(s.mockSysctl.Calls(), DeepEquals, [][]string{
+		{"sysctl", "-p", s.mockNetworkSysctlPath},
+	})
+}
+
+func (s *networkSuite) TestConfigureNetworkIntegrationIPv6False(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"network.disable-ipv6": false,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(s.mockNetworkSysctlPath, testutil.FileEquals, "net.ipv6.conf.all.disable_ipv6=0\n")
+	c.Check(s.mockSysctl.Calls(), DeepEquals, [][]string{
+		{"sysctl", "-p", s.mockNetworkSysctlPath},
+	})
+}
+
+func (s *networkSuite) TestConfigureNetworkIntegrationNone(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf:  map[string]interface{}{},
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(osutil.FileExists(s.mockNetworkSysctlPath), Equals, false)
+}

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -17,7 +17,8 @@ execute: |
 
     echo "Enable ipv6"
     snap set core network.disable-ipv6=false
-    MATCH "net.ipv6.conf.all.disable_ipv6=0" < /etc/sysctl.d/10-snapd-network.conf
+    ! test -f /etc/sysctl.d/10-snapd-network.conf
+    sysctl net.ipv6.conf.all.disable_ipv6 | MATCH "net.ipv6.conf.all.disable_ipv6=0"
 
     echo "Reset ipv6"
     snap set core network.disable-ipv6=""

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -1,0 +1,24 @@
+summary: Check that `snap set core network.disable-ipv6` works
+
+systems: [ubuntu-core-*]
+
+execute: |
+    echo "Ensure we have inet6"
+    ip addr | MATCH inet6
+    
+    echo "Disable ipv6"
+    snap set core network.disable-ipv6=true
+    MATCH "net.ipv6.conf.all.disable_ipv6=1" < /etc/sysctl.d/10-snapd-network.conf
+    if ip addr | grep -q inet6; then
+        echo "Disable of ipv6 did not work"
+        ip addr
+        exit 1
+    fi
+
+    echo "Enable ipv6"
+    snap set core network.disable-ipv6=false
+    MATCH "net.ipv6.conf.all.disable_ipv6=0" < /etc/sysctl.d/10-snapd-network.conf
+
+    echo "Reset ipv6"
+    snap set core network.disable-ipv6=""
+    ! test -f /etc/sysctl.d/10-snapd-network.conf 

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -1,13 +1,17 @@
-summary: Check that `snap set core network.disable-ipv6` works
+summary: Check that `snap set {system,core} network.disable-ipv6` works
 
 systems: [ubuntu-core-*]
+
+environment:
+    snap_nick/system: system
+    snap_nick/core: core
 
 execute: |
     echo "Ensure we have inet6"
     ip addr | MATCH inet6
     
     echo "Disable ipv6"
-    snap set core network.disable-ipv6=true
+    snap set "$snap_nick" network.disable-ipv6=true
     MATCH "net.ipv6.conf.all.disable_ipv6=1" < /etc/sysctl.d/10-snapd-network.conf
     if ip addr | grep -q inet6; then
         echo "Disable of ipv6 did not work"
@@ -16,10 +20,10 @@ execute: |
     fi
 
     echo "Enable ipv6"
-    snap set core network.disable-ipv6=false
+    snap set "$snap_nick" network.disable-ipv6=false
     ! test -f /etc/sysctl.d/10-snapd-network.conf
     sysctl net.ipv6.conf.all.disable_ipv6 | MATCH "net.ipv6.conf.all.disable_ipv6 = 0"
 
     echo "Reset ipv6"
-    snap set core network.disable-ipv6=""
+    snap set "$snap_nick" network.disable-ipv6=""
     ! test -f /etc/sysctl.d/10-snapd-network.conf 

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -11,6 +11,7 @@ execute: |
     ip addr | MATCH inet6
     
     echo "Disable ipv6"
+    # shellcheck disable=SC2154
     snap set "$snap_nick" network.disable-ipv6=true
     MATCH "net.ipv6.conf.all.disable_ipv6=1" < /etc/sysctl.d/10-snapd-network.conf
     if ip addr | grep -q inet6; then

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -18,7 +18,7 @@ execute: |
     echo "Enable ipv6"
     snap set core network.disable-ipv6=false
     ! test -f /etc/sysctl.d/10-snapd-network.conf
-    sysctl net.ipv6.conf.all.disable_ipv6 | MATCH "net.ipv6.conf.all.disable_ipv6=0"
+    sysctl net.ipv6.conf.all.disable_ipv6 | MATCH "net.ipv6.conf.all.disable_ipv6 = 0"
 
     echo "Reset ipv6"
     snap set core network.disable-ipv6=""


### PR DESCRIPTION
This allows disabling the ipv6 supprt on core devices.
