### PR TITLE
snap,interfaces: move interface name validation to snap

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -69,7 +68,7 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 			continue
 		}
 		// Reject plug with invalid name
-		if err := utils.ValidateName(plugName); err != nil {
+		if err := snap.ValidatePlugName(plugName); err != nil {
 			snapInfo.BadInterfaces[plugName] = err.Error()
 			badPlugs = append(badPlugs, plugName)
 			continue
@@ -89,7 +88,7 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 			continue
 		}
 		// Reject slot with invalid name
-		if err := utils.ValidateName(slotName); err != nil {
+		if err := snap.ValidateSlotName(slotName); err != nil {
 			snapInfo.BadInterfaces[slotName] = err.Error()
 			badSlots = append(badSlots, slotName)
 			continue

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -308,7 +308,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
 	snapInfo := snaptest.MockInfo(c, testConsumerInvalidSlotNameYaml, nil)
 	snap.SanitizePlugsSlots(snapInfo)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
-	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS5 \(invalid interface name: "ttyS5"\)`)
+	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS5 \(invalid slot name: "ttyS5"\)`)
 }
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
@@ -320,7 +320,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 	snapInfo := snaptest.MockInfo(c, testConsumerInvalidPlugNameYaml, nil)
 	snap.SanitizePlugsSlots(snapInfo)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
-	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS3 \(invalid interface name: "ttyS3"\)`)
+	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS3 \(invalid plug name: "ttyS3"\)`)
 }
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotInterface(c *C) {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -72,7 +71,7 @@ func (r *Repository) AddInterface(i Interface) error {
 	defer r.m.Unlock()
 
 	interfaceName := i.Name()
-	if err := utils.ValidateName(interfaceName); err != nil {
+	if err := snap.ValidateInterfaceName(interfaceName); err != nil {
 		return err
 	}
 	if _, ok := r.ifaces[interfaceName]; ok {
@@ -269,8 +268,8 @@ func (r *Repository) AddPlug(plug *snap.PlugInfo) error {
 	if err := snap.ValidateName(snapName); err != nil {
 		return err
 	}
-	// Reject plug with invalid names
-	if err := utils.ValidateName(plug.Name); err != nil {
+	// Reject plugs with invalid names
+	if err := snap.ValidatePlugName(plug.Name); err != nil {
 		return err
 	}
 	i := r.ifaces[plug.Interface]
@@ -364,8 +363,8 @@ func (r *Repository) AddSlot(slot *snap.SlotInfo) error {
 	if err := snap.ValidateName(snapName); err != nil {
 		return err
 	}
-	// Reject plug with invalid names
-	if err := utils.ValidateName(slot.Name); err != nil {
+	// Reject slots with invalid names
+	if err := snap.ValidateSlotName(slot.Name); err != nil {
 		return err
 	}
 	// TODO: ensure that apps are correct

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -267,7 +267,7 @@ func (s *RepositorySuite) TestAddPlugFailsWithInvalidPlugName(c *C) {
 		Interface: "interface",
 	}
 	err := s.testRepo.AddPlug(plug)
-	c.Assert(err, ErrorMatches, `invalid interface name: "bad-name-"`)
+	c.Assert(err, ErrorMatches, `invalid plug name: "bad-name-"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
 }
 
@@ -500,7 +500,7 @@ func (s *RepositorySuite) TestAddSlotFailsWhenSlotNameIsInvalid(c *C) {
 		Interface: "interface",
 	}
 	err := s.emptyRepo.AddSlot(slot)
-	c.Assert(err, ErrorMatches, `invalid interface name: "bad-name-"`)
+	c.Assert(err, ErrorMatches, `invalid slot name: "bad-name-"`)
 	c.Assert(s.emptyRepo.AllSlots(""), HasLen, 0)
 }
 

--- a/interfaces/utils/utils.go
+++ b/interfaces/utils/utils.go
@@ -19,11 +19,6 @@
 
 package utils
 
-import (
-	"fmt"
-	"regexp"
-)
-
 // NormalizeInterfaceAttributes normalises types of an attribute values.
 // The following transformations are applied: int -> int64, float32 -> float64.
 // The normalisation proceeds recursively through maps and slices.
@@ -44,16 +39,4 @@ func NormalizeInterfaceAttributes(value interface{}) interface{} {
 		}
 	}
 	return value
-}
-
-// Regular expression describing correct identifiers.
-var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
-
-// ValidateName checks if a string can be used as a plug or slot name.
-func ValidateName(name string) error {
-	valid := validName.MatchString(name)
-	if !valid {
-		return fmt.Errorf("invalid interface name: %q", name)
-	}
-	return nil
 }

--- a/interfaces/utils/utils_test.go
+++ b/interfaces/utils/utils_test.go
@@ -23,56 +23,12 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-
-	"github.com/snapcore/snapd/testutil"
 )
 
 func Test(t *testing.T) {
 	TestingT(t)
 }
 
-type utilsSuite struct {
-	testutil.BaseTest
-}
+type utilsSuite struct{}
 
 var _ = Suite(&utilsSuite{})
-
-func (s *utilsSuite) SetUpTest(c *C) {
-	s.BaseTest.SetUpTest(c)
-}
-
-func (s *utilsSuite) TearDownTest(c *C) {
-	s.BaseTest.TearDownTest(c)
-}
-
-func (s *utilsSuite) TestValidateName(c *C) {
-	validNames := []string{
-		"a", "aa", "aaa", "aaaa",
-		"a-a", "aa-a", "a-aa", "a-b-c",
-		"a0", "a-0", "a-0a",
-	}
-	for _, name := range validNames {
-		err := ValidateName(name)
-		c.Assert(err, IsNil)
-	}
-	invalidNames := []string{
-		// name cannot be empty
-		"",
-		// dashes alone are not a name
-		"-", "--",
-		// double dashes in a name are not allowed
-		"a--a",
-		// name should not end with a dash
-		"a-",
-		// name cannot have any spaces in it
-		"a ", " a", "a a",
-		// a number alone is not a name
-		"0", "123",
-		// identifier must be plain ASCII
-		"日本語", "한글", "ру́сский язы́к",
-	}
-	for _, name := range invalidNames {
-		err := ValidateName(name)
-		c.Assert(err, ErrorMatches, `invalid interface name: ".*"`)
-	}
-}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -101,6 +101,41 @@ func ValidateName(name string) error {
 	return nil
 }
 
+// Regular expression describing correct plug, slot and interface names.
+var validPlugSlotIfaceName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+
+// ValidatePlugName checks if a string can be used as a slot name.
+//
+// Slot names and plug names within one snap must have unique names.
+// This is not enforced by this function but is enforced by snap-level
+// validation.
+func ValidatePlugName(name string) error {
+	if !validPlugSlotIfaceName.MatchString(name) {
+		return fmt.Errorf("invalid plug name: %q", name)
+	}
+	return nil
+}
+
+// ValidateSlotName checks if a string can be used as a slot name.
+//
+// Slot names and plug names within one snap must have unique names.
+// This is not enforced by this function but is enforced by snap-level
+// validation.
+func ValidateSlotName(name string) error {
+	if !validPlugSlotIfaceName.MatchString(name) {
+		return fmt.Errorf("invalid slot name: %q", name)
+	}
+	return nil
+}
+
+// ValidateInterfaceName checks if a string can be used as an interface name.
+func ValidateInterfaceName(name string) error {
+	if !validPlugSlotIfaceName.MatchString(name) {
+		return fmt.Errorf("invalid interface name: %q", name)
+	}
+	return nil
+}
+
 // NB keep this in sync with snapcraft and the review tools :-)
 var isValidVersion = regexp.MustCompile("^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~-]{0,30}[a-zA-Z0-9+~])?$").MatchString
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1365,3 +1365,37 @@ apps:
 		}
 	}
 }
+
+func (s *validateSuite) TestValidatePlugSlotName(c *C) {
+	validNames := []string{
+		"a", "aa", "aaa", "aaaa",
+		"a-a", "aa-a", "a-aa", "a-b-c",
+		"a0", "a-0", "a-0a",
+	}
+	for _, name := range validNames {
+		c.Assert(ValidatePlugName(name), IsNil)
+		c.Assert(ValidateSlotName(name), IsNil)
+		c.Assert(ValidateInterfaceName(name), IsNil)
+	}
+	invalidNames := []string{
+		// name cannot be empty
+		"",
+		// dashes alone are not a name
+		"-", "--",
+		// double dashes in a name are not allowed
+		"a--a",
+		// name should not end with a dash
+		"a-",
+		// name cannot have any spaces in it
+		"a ", " a", "a a",
+		// a number alone is not a name
+		"0", "123",
+		// identifier must be plain ASCII
+		"日本語", "한글", "ру́сский язы́к",
+	}
+	for _, name := range invalidNames {
+		c.Assert(ValidatePlugName(name), ErrorMatches, `invalid plug name: ".*"`)
+		c.Assert(ValidateSlotName(name), ErrorMatches, `invalid slot name: ".*"`)
+		c.Assert(ValidateInterfaceName(name), ErrorMatches, `invalid interface name: ".*"`)
+	}
+}


### PR DESCRIPTION
This patch moves the helper that validates plug, slot and interface
names to the snap package (alongside other validation helpers).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
