### PR TITLE
tests: start using the new opensuse image with test dependencies

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -86,7 +86,6 @@ backends:
                 workers: 4
 
             - opensuse-42.3-64:
-                image: opensuse-cloud/opensuse-leap-42-3-v20180116
                 workers: 4
             - arch-linux-64:
                 workers: 4


### PR DESCRIPTION
By removing this images we will start using the image opensuse-leap-42-3-64-v* which  is created under the computeengine project, this image includes test dependencies.