### PR TITLE
snap: add helper for renaming slots

### DIFF
--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -397,7 +397,7 @@ func (s *AllSuite) TestUnexpectedSpecSignatures(c *C) {
 		for _, sig := range sigs {
 			meth, ok := ifaceType.MethodByName(sig.name)
 			if !ok {
-				// all specificiation methods are optional.
+				// all specification methods are optional.
 				continue
 			}
 			methType := meth.Type

--- a/snap/broken.go
+++ b/snap/broken.go
@@ -80,13 +80,13 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 func (info *Info) renameClashingCorePlugs() {
 	if info.InstanceName() == "core" && info.Type == TypeOS {
 		for _, plugName := range []string{"network-bind", "core-support"} {
-			info.renamePlug(plugName, plugName+"-plug")
+			info.forceRenamePlug(plugName, plugName+"-plug")
 		}
 	}
 }
 
-// renamePlug renames the plug from oldName to newName, if present.
-func (info *Info) renamePlug(oldName, newName string) {
+// forceRenamePlug renames the plug from oldName to newName, if present.
+func (info *Info) forceRenamePlug(oldName, newName string) {
 	if plugInfo, ok := info.Plugs[oldName]; ok {
 		delete(info.Plugs, oldName)
 		info.Plugs[newName] = plugInfo

--- a/snap/broken_test.go
+++ b/snap/broken_test.go
@@ -88,7 +88,7 @@ func (s *brokenSuite) TestGuessAppsForBrokenServices(c *C) {
 	c.Check(apps["baz"], DeepEquals, &snap.AppInfo{Snap: info, Name: "baz", Daemon: "simple"})
 }
 
-func (s *brokenSuite) TestRenamePlug(c *C) {
+func (s *brokenSuite) TestForceRenamePlug(c *C) {
 	snapInfo := snaptest.MockInvalidInfo(c, `name: core
 version: 0
 plugs:
@@ -111,7 +111,7 @@ hooks:
 	c.Assert(snapInfo.Hooks["configure"].Plugs["old"], DeepEquals, snapInfo.Plugs["old"])
 
 	// Rename the plug now.
-	snapInfo.RenamePlug("old", "new")
+	snapInfo.ForceRenamePlug("old", "new")
 
 	// Check that there's no trace of the old plug name.
 	c.Assert(snapInfo.Plugs["old"], IsNil)

--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -24,6 +24,6 @@ var (
 	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
 )
 
-func (info *Info) RenamePlug(oldName, newName string) {
-	info.renamePlug(oldName, newName)
+func (info *Info) ForceRenamePlug(oldName, newName string) {
+	info.forceRenamePlug(oldName, newName)
 }

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -203,3 +203,47 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 	}
 	return filepath.Join(snapSource, snapFilePath)
 }
+
+// RenameSlot renames gives an existing slot a new name.
+//
+// The new slot name cannot clash with an existing plug or slot and must
+// be a valid slot name.
+func RenameSlot(snapInfo *snap.Info, oldName, newName string) error {
+	if snapInfo.Slots[oldName] == nil {
+		return fmt.Errorf("cannot rename slot %q to %q: no such slot", oldName, newName)
+	}
+	if err := snap.ValidateSlotName(newName); err != nil {
+		return fmt.Errorf("cannot rename slot %q to %q: %s", oldName, newName, err)
+	}
+	if oldName == newName {
+		return nil
+	}
+	if snapInfo.Slots[newName] != nil {
+		return fmt.Errorf("cannot rename slot %q to %q: existing slot with that name", oldName, newName)
+	}
+	if snapInfo.Plugs[newName] != nil {
+		return fmt.Errorf("cannot rename slot %q to %q: existing plug with that name", oldName, newName)
+	}
+
+	// Rename the slot.
+	slotInfo := snapInfo.Slots[oldName]
+	snapInfo.Slots[newName] = slotInfo
+	delete(snapInfo.Slots, oldName)
+	slotInfo.Name = newName
+
+	// Update references to the slot in all applications and hooks.
+	for _, appInfo := range snapInfo.Apps {
+		if _, ok := appInfo.Slots[oldName]; ok {
+			delete(appInfo.Slots, oldName)
+			appInfo.Slots[newName] = slotInfo
+		}
+	}
+	for _, hookInfo := range snapInfo.Hooks {
+		if _, ok := hookInfo.Slots[oldName]; ok {
+			delete(hookInfo.Slots, oldName)
+			hookInfo.Slots[newName] = slotInfo
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This patch adds a helper for renaming slots in snap.Info objects.  This
helper is only intended for testing. It will be used to rename slots
between tests to reuse and share one common definition of a helper snap.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
