### PR TITLE
many: assorted shellcheck fixes

### DIFF
--- a/get-deps.sh
+++ b/get-deps.sh
@@ -3,18 +3,20 @@
 set -e
 
 if [ "$GOPATH" = "" ]; then
-    export GOPATH=$(mktemp -d)
+    GOPATH=$(mktemp -d)
+    export GOPATH
+    # shellcheck disable=SC2064
     trap "rm -rf $GOPATH" EXIT
 
-    mkdir -p $GOPATH/src/github.com/snapcore/
-    ln -s $(pwd) $GOPATH/src/github.com/snapcore/snapd
-    cd $GOPATH/src/github.com/snapcore/snapd
+    mkdir -p "$GOPATH/src/github.com/snapcore/"
+    ln -s "$(pwd)" "$GOPATH/src/github.com/snapcore/snapd"
+    cd "$GOPATH/src/github.com/snapcore/snapd"
 fi
 
-if ! which govendor >/dev/null;then
+if ! command -v govendor >/dev/null;then
     export PATH="$PATH:${GOPATH%%:*}/bin"
 
-    if ! which govendor >/dev/null;then
+    if ! command -v govendor >/dev/null;then
 	    echo Installing govendor
 	    go get -u github.com/kardianos/govendor
     fi

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -34,7 +34,7 @@ fi
 
 if [ -z "$v" ]; then
     # Let's try to derive the version from git..
-    if which git >/dev/null; then
+    if command -v git >/dev/null; then
         v="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./' )"
         o=git
     fi

--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -18,7 +18,7 @@ fi
 systemctl daemon-reload
 
 # ensure we are not get killed too easily
-printf "%s\n" "-950" > /proc/$$/oom_score_adj
+printf '%s\n' "-950" > /proc/$$/oom_score_adj
 
 # see what mem we have (for debugging)
 cat /proc/meminfo

--- a/run-checks
+++ b/run-checks
@@ -10,7 +10,7 @@ export LANG=C.UTF-8
 export LANGUAGE=en
 set -eu
 
-if which goctest >/dev/null; then
+if command -v goctest >/dev/null; then
     goctest="goctest"
 else
     goctest="go test"
@@ -99,7 +99,7 @@ missing_interface_spread_test() {
     core_snap_yaml="tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml"
     classic_snap_yaml="tests/lib/snaps/test-snapd-policy-app-provider-classic/meta/snap.yaml"
     for iface in $(go run ./tests/lib/list-interfaces.go) ; do
-        search="plugs: \[ $iface \]"
+        search="plugs: \\[ $iface \\]"
         case "$iface" in
             bool-file|gpio|hidraw|i2c|iio|serial-port|spi)
                 # skip gadget provided interfaces for now
@@ -109,7 +109,7 @@ missing_interface_spread_test() {
                 search="interface: $iface"
                 ;;
             autopilot)
-                search="plugs: \[ autopilot-introspection \]"
+                search='plugs: \[ autopilot-introspection \]'
                 ;;
         esac
         if ! grep -q "$search" "$snap_yaml" ; then
@@ -135,7 +135,7 @@ if [ "$STATIC" = 1 ]; then
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
         s="$(gofmt -s -l "$dir")"
         if [ -n "$s" ]; then
-            fmt="$s\n$fmt"
+            fmt="$s\\n$fmt"
         fi
     done
 
@@ -154,7 +154,7 @@ if [ "$STATIC" = 1 ]; then
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
         s="$(grep -nP 'http\.Status(?!Text)' "$dir"/*.go || true)"
         if [ -n "$s" ]; then
-            got="$s\n$got"
+            got="$s\\n$got"
         fi
     done
 
@@ -164,7 +164,7 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    if which shellcheck >/dev/null; then
+    if command -v shellcheck >/dev/null; then
         echo Checking shell scripts...
         ( git ls-files -z 2>/dev/null ||
                 find . \( -name .git -o -name vendor \) -prune -o -print0 ) |
@@ -181,7 +181,7 @@ if [ "$STATIC" = 1 ]; then
     fi
 
     echo Checking spelling errors
-    if ! which misspell >/dev/null; then
+    if ! command -v misspell >/dev/null; then
         go get -u github.com/client9/misspell/cmd/misspell
     fi
     for file in *; do
@@ -192,14 +192,14 @@ if [ "$STATIC" = 1 ]; then
     done
 
     echo Checking for ineffective assignments
-    if ! which ineffassign >/dev/null; then
+    if ! command -v ineffassign >/dev/null; then
         go get -u github.com/gordonklaus/ineffassign
     fi
     # ineffassign knows about ignoring vendor/ \o/
     ineffassign .
 
     echo Checking for naked returns
-    if ! which nakedret >/dev/null; then
+    if ! command -v nakedret >/dev/null; then
         go get -u github.com/alexkohler/nakedret
     fi
     got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)

--- a/tests/lib/changes.sh
+++ b/tests/lib/changes.sh
@@ -4,5 +4,5 @@ change_id() {
     # takes <summary pattern> [<status>]
     local SUMMARY_PAT=$1
     local STATUS=${2:-}
-    snap changes|grep -o -P "^\d+(?= *${STATUS}.*${SUMMARY_PAT}.*)"
+    snap changes|grep -o -P "^\\d+(?= *${STATUS}.*${SUMMARY_PAT}.*)"
 }

--- a/tests/lib/mkpinentry.sh
+++ b/tests/lib/mkpinentry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if gpg --version | MATCH "gpg \(GnuPG\) 1."; then
+if gpg --version | MATCH 'gpg \(GnuPG\) 1.'; then
     echo "fake gpg pinentry not used for gpg v1"
 else
     echo "setup fake gpg pinentry environment for gpg v2 or higher"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # shellcheck source=tests/lib/systemd.sh
-. $TESTSLIB/systemd.sh
+. "$TESTSLIB"/systemd.sh
 
 wait_for_ssh(){
     retry=300
@@ -34,10 +34,10 @@ create_nested_core_vm(){
     # determine arch related vars
     case "$NESTED_ARCH" in
     amd64)
-        QEMU="$(which qemu-system-x86_64)"
+        QEMU="$(command -v qemu-system-x86_64)"
         ;;
     i386)
-        QEMU="$(which qemu-system-i386)"
+        QEMU="$(command -v qemu-system-i386)"
         ;;
     *)
         echo "unsupported architecture"

--- a/tests/lib/network.sh
+++ b/tests/lib/network.sh
@@ -8,7 +8,7 @@ wait_listen_port(){
     PORT="$1"
 
     for _ in $(seq 120); do
-        if ss -lnt | grep -Pq "LISTEN.*?:$PORT +.*?\n*"; then
+        if ss -lnt | grep -Pq "LISTEN.*?:$PORT +.*?\\n*"; then
             break
         fi
         sleep 0.5
@@ -16,5 +16,5 @@ wait_listen_port(){
 
     # Ensure we really have the listen port, this will fail with an
     # exit code if the port is not available.
-    ss -lnt | grep -Pq "LISTEN.*?:$PORT +.*?\n*"
+    ss -lnt | grep -Pq "LISTEN.*?:$PORT +.*?\\n*"
 }

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -202,6 +202,7 @@ distro_install_package() {
         ;;
     esac
 
+    # shellcheck disable=SC2207
     pkg_names=($(
         for pkg in "$@" ; do
             package_name=$(distro_name_package "$pkg")

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -99,8 +99,7 @@ build_rpm() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*)
-            # shellcheck disable=SC2089
-            extra_tar_args="$extra_tar_args --exclude='vendor/*'"
+            extra_tar_args="$extra_tar_args --exclude=vendor/*"
             ;;
         opensuse-*)
             archive_name=snapd_$version.vendor.tar.xz
@@ -118,7 +117,7 @@ build_rpm() {
     cp -ra -- * "/tmp/pkg/snapd-$version/"
     mkdir -p "$rpm_dir/SOURCES"
     # shellcheck disable=SC2086
-    (cd /tmp/pkg && tar "-c${archive_compression}f" "$rpm_dir/SOURCES/$archive_name" "${extra_tar_args[@]}" "snapd-$version")
+    (cd /tmp/pkg && tar "-c${archive_compression}f" "$rpm_dir/SOURCES/$archive_name" $extra_tar_args "snapd-$version")
     cp "$packaging_path"/* "$rpm_dir/SOURCES/"
 
     # Cleanup all artifacts from previous builds

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -99,6 +99,7 @@ build_rpm() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*)
+            # shellcheck disable=SC2089
             extra_tar_args="$extra_tar_args --exclude='vendor/*'"
             ;;
         opensuse-*)
@@ -117,7 +118,7 @@ build_rpm() {
     cp -ra -- * "/tmp/pkg/snapd-$version/"
     mkdir -p "$rpm_dir/SOURCES"
     # shellcheck disable=SC2086
-    (cd /tmp/pkg && tar "-c${archive_compression}f" "$rpm_dir/SOURCES/$archive_name" $extra_tar_args "snapd-$version")
+    (cd /tmp/pkg && tar "-c${archive_compression}f" "$rpm_dir/SOURCES/$archive_name" "${extra_tar_args[@]}" "snapd-$version")
     cp "$packaging_path"/* "$rpm_dir/SOURCES/"
 
     # Cleanup all artifacts from previous builds
@@ -328,7 +329,7 @@ prepare_project() {
     esac
 
     # update vendoring
-    if [ -z "$(which govendor)" ]; then
+    if [ -z "$(command -v govendor)" ]; then
         rm -rf "$GOPATH/src/github.com/kardianos/govendor"
         go get -u github.com/kardianos/govendor
     fi
@@ -426,7 +427,7 @@ restore_suite() {
     "$TESTSLIB"/reset.sh --store
     if is_classic_system; then
         # shellcheck source=tests/lib/pkgdb.sh
-        . $TESTSLIB/pkgdb.sh
+        . "$TESTSLIB"/pkgdb.sh
         distro_purge_package snapd
         if [[ "$SPREAD_SYSTEM" != opensuse-* && "$SPREAD_SYSTEM" != arch-* ]]; then
             # A snap-confine package never existed on openSUSE or Arch

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -388,12 +388,11 @@ EOF
         extra_snap=("$IMAGE_HOME"/core_*.snap)
     fi
 
-    # shellcheck disable=SC2128
     # extra_snap should contain only ONE snap
     /snap/bin/ubuntu-image -w "$IMAGE_HOME" "$IMAGE_HOME/pc.model" \
                            --channel "$IMAGE_CHANNEL" \
                            "$EXTRA_FUNDAMENTAL" \
-                           --extra-snaps "$extra_snap" \
+                           --extra-snaps "${extra_snap[0]}" \
                            --output "$IMAGE_HOME/$IMAGE"
     rm -f ./pc-kernel_*.{snap,assert} ./pc_*.{snap,assert}
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -28,7 +28,7 @@ disable_kernel_rate_limiting() {
 }
 
 ensure_jq() {
-    if which jq; then
+    if command -v jq; then
         return
     fi
 
@@ -318,14 +318,18 @@ setup_reflash_magic() {
         # We can do this once https://forum.snapcraft.io/t/5947 is
         # answered.
         echo "Added needed assertions so that core-amd64-18.model works"
+        # shellcheck source=tests/lib/store.sh
         . "$TESTSLIB/store.sh"
-        export STORE_DIR="$(pwd)/fake-store-blobdir"
-        export STORE_ADDR="localhost:11028"
+        STORE_DIR="$(pwd)/fake-store-blobdir"
+        export STORE_DIR
+        STORE_ADDR="localhost:11028"
+        export STORE_ADDR
         setup_fake_store "$STORE_DIR"
         cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR"/asserts
         cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR"/asserts
         # have snap use the fakestore for assertions (but nothing else)
-        export SNAPPY_FORCE_SAS_URL="http://$STORE_ADDR"
+        SNAPPY_FORCE_SAS_URL="http://$STORE_ADDR"
+        export SNAPPY_FORCE_SAS_URL
         # -----------------------8<----------------------------
     else
         # modify the core snap so that the current root-pw works there
@@ -379,11 +383,13 @@ EOF
     # on core18 we need to use the modified snapd snap and on core16
     # it is the modified core that contains our freshly build snapd
     if is_core18_system; then
-        extra_snap="$IMAGE_HOME"/snapd_*.snap
+        extra_snap=("$IMAGE_HOME"/snapd_*.snap)
     else
-        extra_snap="$IMAGE_HOME"/core_*.snap
+        extra_snap=("$IMAGE_HOME"/core_*.snap)
     fi
 
+    # shellcheck disable=SC2128
+    # extra_snap should contain only ONE snap
     /snap/bin/ubuntu-image -w "$IMAGE_HOME" "$IMAGE_HOME/pc.model" \
                            --channel "$IMAGE_CHANNEL" \
                            "$EXTRA_FUNDAMENTAL" \
@@ -580,7 +586,7 @@ prepare_ubuntu_core() {
     fi
 
     echo "Ensure rsync is available"
-    if ! which rsync; then
+    if ! command -v rsync; then
         rsync_snap="test-snapd-rsync"
         if is_core18_system; then
             rsync_snap="test-snapd-rsync-core18"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -389,6 +389,11 @@ EOF
     fi
 
     # extra_snap should contain only ONE snap
+    if "${#extra_snap[@]}" -ne 1; then
+        echo "unexpected number of globbed snaps: ${extra_snap[*]}"
+        exit 1
+    fi
+
     /snap/bin/ubuntu-image -w "$IMAGE_HOME" "$IMAGE_HOME/pc.model" \
                            --channel "$IMAGE_CHANNEL" \
                            "$EXTRA_FUNDAMENTAL" \

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -71,8 +71,8 @@ reset_classic() {
         # Restore snapd state and start systemd service units
         restore_snapd_state
         escaped_snap_mount_dir="$(systemd-escape --path "$SNAP_MOUNT_DIR")"
-        mounts="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.mount" | cut -f1 -d ' ')"
-        services="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.service" | cut -f1 -d ' ')"
+        mounts="$(systemctl list-unit-files --full | grep "^${escaped_snap_mount_dir}[-.].*\\.mount" | cut -f1 -d ' ')"
+        services="$(systemctl list-unit-files --full | grep "^${escaped_snap_mount_dir}[-.].*\\.service" | cut -f1 -d ' ')"
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         for unit in $mounts $services; do
             systemctl start "$unit"
@@ -90,7 +90,7 @@ reset_classic() {
         if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
             EXTRA_NC_ARGS=""
         fi
-        while ! printf "GET / HTTP/1.0\r\n\r\n" | nc -U $EXTRA_NC_ARGS /run/snapd.socket; do sleep 0.5; done
+        while ! printf 'GET / HTTP/1.0\r\n\r\n' | nc -U $EXTRA_NC_ARGS /run/snapd.socket; do sleep 0.5; done
     fi
 }
 
@@ -132,6 +132,6 @@ fi
 
 if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then
     # shellcheck source=tests/lib/store.sh
-    . $TESTSLIB/store.sh
+    . "$TESTSLIB"/store.sh
     teardown_staging_store
 fi

--- a/tests/lib/snaps/basic-iface-hooks-consumer/meta/hooks/prepare-plug-consumer
+++ b/tests/lib/snaps/basic-iface-hooks-consumer/meta/hooks/prepare-plug-consumer
@@ -34,8 +34,8 @@ fi
 
 # Count executions of the hook using snap config; store exec-count in the config and in the dynamic attribute of the interface
 count=$(snapctl get exec-count)
-count=$(expr $count + 1)
-snapctl set exec-count=$count
-snapctl set :consumer exec-count=$count
+count=$((count + 1))
+snapctl set "exec-count=$count"
+snapctl set :consumer "exec-count=$count"
 
 touch "$SNAP_COMMON/prepare-plug-consumer-done"

--- a/tests/lib/snaps/test-snapd-complexion/bin/test-snapd-complexion
+++ b/tests/lib/snaps/test-snapd-complexion/bin/test-snapd-complexion
@@ -2,6 +2,6 @@
 echo "Greetings from inside ${SNAP:?}."
 if [ "$#" -gt "0" ]; then
     echo "Arguments given:"
-    printf "> %q\n" "$@"
+    printf '> %q\n' "$@"
 fi
 echo "That is all. Have a nice day."

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -66,14 +66,14 @@ setup_fake_store(){
 
     echo "Create fakestore at the given port"
     PORT="11028"
-    systemd_create_and_start_unit fakestore "$(which fakestore) run --dir $top_dir --addr localhost:$PORT --https-proxy=${https_proxy} --http-proxy=${http_proxy} --assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
+    systemd_create_and_start_unit fakestore "$(command -v fakestore) run --dir $top_dir --addr localhost:$PORT --https-proxy=${https_proxy} --http-proxy=${http_proxy} --assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 
     echo "And snapd is configured to use the controlled store"
     _configure_store_backends "SNAPPY_FORCE_API_URL=http://localhost:$PORT" "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 
     echo "Wait until fake store is ready"
     # shellcheck source=tests/lib/network.sh
-    . $TESTSLIB/network.sh
+    . "$TESTSLIB"/network.sh
     if wait_listen_port "$PORT"; then
         return 0
     fi

--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -2,7 +2,7 @@
 
 # Use like systemd_create_and_start_unit(fakestore, "$(which fakestore) -start -dir $top_dir -addr localhost:11028 $@")
 systemd_create_and_start_unit() {
-    printf "[Unit]\nDescription=For testing purposes\n[Service]\nType=simple\nExecStart=%s\n" "$2" > "/run/systemd/system/$1.service"
+    printf '[Unit]\nDescription=For testing purposes\n[Service]\nType=simple\nExecStart=%s\n' "$2" > "/run/systemd/system/$1.service"
     if [ -n "${3:-}" ]; then
         echo "Environment=$3" >> "/run/systemd/system/$1.service"
     fi

--- a/update-pot
+++ b/update-pot
@@ -22,7 +22,7 @@ check_canaries() {
     done
 }
 
-HERE="$(readlink -f $(dirname "$0"))"
+HERE="$(readlink -f "$(dirname "$0")")"
 
 OUTPUT="$HERE/po/snappy.pot"
 if [ -n "$1" ]; then
@@ -34,7 +34,8 @@ go install github.com/snapcore/snapd/i18n/xgettext-go
 
 # exclude vendor and _build subdir
 I18N_FILES="$(mktemp -d)/i18n.files"
-find "$HERE" -type d \( -name "vendor" -o -name "_build" \) -prune -o -name "*.go" -type f -print > $I18N_FILES
+find "$HERE" -type d \( -name "vendor" -o -name "_build" \) -prune -o -name "*.go" -type f -print > "$I18N_FILES"
+# shellcheck disable=SC2064
 trap "rm -rf $(dirname "$I18N_FILES")" EXIT
 
 "${GOPATH%%:*}/bin/xgettext-go" \
@@ -66,7 +67,7 @@ xgettext "$HERE"/data/polkit/*.policy \
 check_canaries
 
 # language packs
-for p in ${HERE}/po/*.po; do
+for p in "${HERE}"/po/*.po; do
 	lang=$(basename "$p" .po)
 	mkdir -p "$HERE/share/locale/$lang/LC_MESSAGES"
 	msgfmt -v -o "$HERE/share/locale/$lang/LC_MESSAGES/snappy.mo" "$p"


### PR DESCRIPTION
run-checks --static will run shellcheck only if one is installed in the system,
which is not the case when it's called in spread tests. As a result quite a lot
of issues got their way into the code unnoticed.
