### PR TITLE
tests: check catalog refresh before and after restart snapd

### DIFF
--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -5,13 +5,13 @@ execute: |
     . "$TESTSLIB/journalctl.sh"
 
     echo "We count how many catalog refreshes are logged before starting snapd"
-    refreshes_before="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh')"
+    refreshes_before="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh' || true)"
 
     systemctl restart snapd.{socket,service}
 
     echo "Ensure that catalog refresh happens on startup"
     for _ in $(seq 60); do
-        refreshes_after="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh')"
+        refreshes_after="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh' || true)"
         if [ "$refreshes_after" -gt "$refreshes_before" ]; then
             break
         fi

--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -4,14 +4,21 @@ execute: |
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
+    echo "We count how many catalog refreshes are logged before starting snapd"
+    refreshes_before="$(get_journalctl_log -u snapd | grep 'Catalog refresh' | wc -l)"
+
+    systemctl restart snapd.{socket,service}
+
     echo "Ensure that catalog refresh happens on startup"
     for _ in $(seq 60); do
-        if get_journalctl_log -u snapd | MATCH "Catalog refresh"; then
+        refreshes_after="$(get_journalctl_log -u snapd | grep 'Catalog refresh' | wc -l)"
+        if [ "$refreshes_after" -gt "$refreshes_before" ]; then
             break
         fi
         sleep 1
     done
-    get_journalctl_log -u snapd | MATCH "Catalog refresh"
+    echo "Ensure the current number of refreshes is greater than before restarting snapd"
+    [ "$refreshes_after" -gt "$refreshes_before" ]
 
     echo "Ensure that we don't log all catalog body data"
     if get_journalctl_log -u snapd | MATCH "Tools for testing the snapd application"; then

--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -5,13 +5,13 @@ execute: |
     . "$TESTSLIB/journalctl.sh"
 
     echo "We count how many catalog refreshes are logged before starting snapd"
-    refreshes_before="$(get_journalctl_log -u snapd | grep 'Catalog refresh' | wc -l)"
+    refreshes_before="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh')"
 
     systemctl restart snapd.{socket,service}
 
     echo "Ensure that catalog refresh happens on startup"
     for _ in $(seq 60); do
-        refreshes_after="$(get_journalctl_log -u snapd | grep 'Catalog refresh' | wc -l)"
+        refreshes_after="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh')"
         if [ "$refreshes_after" -gt "$refreshes_before" ]; then
             break
         fi


### PR DESCRIPTION
As during the prepare we are starting snapd service just before set the
cursor to prevent the log of snaps of previous test is included in the
current journal, it is possible that the "Catalog refresh" is logged
before the cursor is set.

It is easy to reproduce on boards such as pi2 or pi3.

The change is simple an checks the catalog is refreshed after the
restart which is done as part of the test.

Error on pi3: 
https://paste.ubuntu.com/p/yxdfxGNc85/
