### PR TITLE
tests: use grep to avoid non-matching messages from MATCH

### DIFF
--- a/tests/main/interfaces-many/task.yaml
+++ b/tests/main/interfaces-many/task.yaml
@@ -101,13 +101,13 @@ execute: |
         fi
 
         # Skip any interfaces that core doesn't ship
-        if ! snap interfaces | MATCH "$slot_iface +" ; then
+        if ! snap interfaces | grep -E -q "$slot_iface +"; then
             echo "$slot_iface not present, skipping"
             continue
         fi
 
         echo "When slot $slot_iface is connected"
-        if snap interfaces | MATCH "$DISCONNECTED_PATTERN" ; then
+        if snap interfaces | grep -E -q "$DISCONNECTED_PATTERN"; then
             if [ "$slot_iface" = ":broadcom-asic-control" ] || [ "$slot_iface" = ":firewall-control" ] || [ "$slot_iface" = ":kubernetes-support" ] || [ "$slot_iface" = ":openvswitch-support" ] || [ "$slot_iface" = ":ppp" ]; then
                 # TODO: when the kmod backend no longer fails on missing
                 # modules, we can remove this


### PR DESCRIPTION
Code such as:
```
if foo | MATCH bar; then
   ... # something that is not a fatal error
fi
```
Logs potentially long output from "foo" for no good reason. Using grep
here has the same semantics at a much less verbose output.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
