### PR TITLE
tests: "snap connect" is idempotent so just connect

### DIFF
--- a/tests/main/interfaces-many/task.yaml
+++ b/tests/main/interfaces-many/task.yaml
@@ -64,11 +64,7 @@ execute: |
         DISCONNECTED_PATTERN="$slot_iface +-"
 
         echo "When slot $slot_iface is connected"
-        if snap interfaces | MATCH "$DISCONNECTED_PATTERN" ; then
-            snap connect "$plug_iface" "$slot_iface"
-        else
-            echo "$plug_iface already connected"
-        fi
+        snap connect "$plug_iface" "$slot_iface"
         snap interfaces | MATCH "$CONNECTED_PATTERN"
 
         echo "Then $slotcmd_bn should succeed"


### PR DESCRIPTION
This patch changes the interfaces-many test so that it avoids a check
if a specific interface is connected. First of all using MATCH there
just adds noisy output that looks like a problem while not being one.
Second of all connect is idempotent so this is not something we need
to check for.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
