### PR TITLE
many: use extra "releases" information on store "revision-not-found" errors to produce better errors (2.34)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -387,7 +387,10 @@ const (
 	ErrorKindSnapNeedsClassic       = "snap-needs-classic"
 	ErrorKindSnapNeedsClassicSystem = "snap-needs-classic-system"
 	ErrorKindNoUpdateAvailable      = "snap-no-update-available"
-	ErrorKindRevisionNotAvailable   = "snap-revision-not-available"
+
+	ErrorKindRevisionNotAvailable     = "snap-revision-not-available"
+	ErrorKindChannelNotAvailable      = "snap-channel-not-available"
+	ErrorKindArchitectureNotAvailable = "snap-architecture-not-available"
 
 	ErrorKindNotSnap = "snap-not-a-snap"
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -300,6 +300,314 @@ func (s *SnapOpSuite) TestInstallUnaliased(c *check.C) {
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
+func (s *SnapOpSuite) TestInstallSnapNotFound(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "snap not found", "value": "foo", "kind": "snap-not-found"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("error: %v\n", err), check.Equals, `error: snap "foo" not found
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailable(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision available as specified", "value": "foo", "kind": "snap-revision-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" not available as specified (see 'snap info foo')
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableOnChannel(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision available as specified", "value": "foo", "kind": "snap-revision-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=mytrack", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" not available on channel "mytrack/stable" (see 'snap info
+       foo')
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableAtRevision(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision available as specified", "value": "foo", "kind": "snap-revision-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--revision=2", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" revision 2 not available (see 'snap info foo')
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackOK(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "stable",
+  "releases": [{"architecture": "amd64", "channel": "beta"},
+               {"architecture": "amd64", "channel": "edge"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on stable but is available to install on the
+       following channels:
+
+       beta       snap install --beta foo
+       edge       snap install --edge foo
+
+       Please be mindful pre-release channels may include features not
+       completely tested or implemented. Get more information with 'snap info
+       foo'.
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackOKPrerelOK(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "candidate",
+  "releases": [{"architecture": "amd64", "channel": "beta"},
+               {"architecture": "amd64", "channel": "edge"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--candidate", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on candidate but is available to install on
+       the following channels:
+
+       beta       snap install --beta foo
+       edge       snap install --edge foo
+
+       Get more information with 'snap info foo'.
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackOther(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "stable",
+  "releases": [{"architecture": "amd64", "channel": "1.0/stable"},
+               {"architecture": "amd64", "channel": "2.0/stable"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on latest/stable but is available to install
+       on the following tracks:
+
+       1.0/stable  snap install --channel=1.0 foo
+       2.0/stable  snap install --channel=2.0 foo
+
+       Please be mindful that different tracks may include different features.
+       Get more information with 'snap info foo'.
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackLatestStable(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "2.0/stable",
+  "releases": [{"architecture": "amd64", "channel": "stable"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=2.0/stable", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on 2.0/stable but is available to install on
+       the following tracks:
+
+       latest/stable  snap install --stable foo
+
+       Please be mindful that different tracks may include different features.
+       Get more information with 'snap info foo'.
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackAndRiskOther(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "2.0/stable",
+  "releases": [{"architecture": "amd64", "channel": "1.0/edge"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=2.0/stable", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on 2.0/stable but other tracks exist.
+
+       Please be mindful that different tracks may include different features.
+       Get more information with 'snap info foo'.
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForArchitectureTrackAndRiskOK(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified architecture", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "arm64",
+  "channel": "stable",
+  "releases": [{"architecture": "amd64", "channel": "stable"},
+               {"architecture": "s390x", "channel": "stable"}]
+}, "kind": "snap-architecture-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on stable for this architecture (arm64) but
+       exists on other architectures (amd64, s390x).
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForArchitectureTrackAndRiskOther(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified architecture", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "arm64",
+  "channel": "1.0/stable",
+  "releases": [{"architecture": "amd64", "channel": "stable"},
+               {"architecture": "s390x", "channel": "stable"}]
+}, "kind": "snap-architecture-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=1.0/stable", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: snap "foo" is not available on this architecture (arm64) but exists on
+       other architectures (amd64, s390x).
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableInvalidChannel(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "a/b/c/d",
+  "releases": [{"architecture": "amd64", "channel": "stable"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=a/b/c/d", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: requested channel "a/b/c/d" is not valid (see 'snap info foo' for valid
+       ones)
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelNonExistingBranchOnMainChannel(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "stable/baz",
+  "releases": [{"architecture": "amd64", "channel": "stable"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=stable/baz", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: requested a non-existing branch on latest/stable for snap "foo": baz
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelNonExistingBranch(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision on specified channel", "value": {
+  "snap-name": "foo",
+  "action": "install",
+  "architecture": "amd64",
+  "channel": "stable/baz",
+  "releases": [{"architecture": "amd64", "channel": "edge"}]
+}, "kind": "snap-channel-not-available"}, "status-code": 404}`)
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=stable/baz", "foo"})
+	c.Assert(err, check.NotNil)
+	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
+error: requested a non-existing branch for snap "foo": latest/stable/baz
+`)
+
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
 }
 
 func testForm(r *http.Request, c *check.C) *multipart.Form {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1216,17 +1216,6 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 		default:
 			return InternalError("store.SnapNotFound with %d snaps", len(inst.Snaps))
 		}
-	case store.ErrRevisionNotAvailable:
-		// store.ErrRevisionNotAvailable should only be returned for
-		// individual snap queries; in all other cases something's wrong
-		switch len(inst.Snaps) {
-		case 1:
-			return SnapRevisionNotAvailable(inst.Snaps[0], err)
-		case 0:
-			return InternalError("store.RevisionNotAvailable with no snap given")
-		default:
-			return InternalError("store.RevisionNotAvailable with %d snaps", len(inst.Snaps))
-		}
 	case store.ErrNoUpdateAvailable:
 		kind = errorKindSnapNoUpdateAvailable
 	case store.ErrLocalSnap:
@@ -1234,6 +1223,17 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 	default:
 		handled := true
 		switch err := err.(type) {
+		case *store.RevisionNotAvailableError:
+			// store.ErrRevisionNotAvailable should only be returned for
+			// individual snap queries; in all other cases something's wrong
+			switch len(inst.Snaps) {
+			case 1:
+				return SnapRevisionNotAvailable(inst.Snaps[0], err)
+			case 0:
+				return InternalError("store.RevisionNotAvailable with no snap given")
+			default:
+				return InternalError("store.RevisionNotAvailable with %d snaps", len(inst.Snaps))
+			}
 		case *snap.AlreadyInstalledError:
 			kind = errorKindSnapAlreadyInstalled
 			snapName = err.Snap

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -47,6 +47,7 @@ import (
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
@@ -6825,7 +6826,7 @@ func (s *appSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
 	si := &snapInstruction{Action: "frobble"}
 	errors := []error{
 		store.ErrSnapNotFound,
-		store.ErrRevisionNotAvailable,
+		&store.RevisionNotAvailableError{},
 		store.ErrNoUpdateAvailable,
 		store.ErrLocalSnap,
 		&snap.AlreadyInstalledError{Snap: "foo"},
@@ -6846,4 +6847,74 @@ func (s *appSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
 		status := rsp.(*resp).Status
 		c.Check(status/100 == 4 || status/100 == 5, check.Equals, true, com)
 	}
+}
+
+func (s *apiSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
+	si := &snapInstruction{Action: "frobble", Snaps: []string{"foo"}}
+
+	thisArch := arch.UbuntuArchitecture()
+
+	err := &store.RevisionNotAvailableError{
+		Action:  "install",
+		Channel: "stable",
+		Releases: []snap.Channel{
+			snaptest.MustParseChannel("beta", thisArch),
+		},
+	}
+	rsp := si.errToResponse(err).(*resp)
+	c.Check(rsp, check.DeepEquals, &resp{
+		Status: 404,
+		Type:   ResponseTypeError,
+		Result: &errorResult{
+			Message: "no snap revision on specified channel",
+			Kind:    errorKindSnapChannelNotAvailable,
+			Value: map[string]interface{}{
+				"snap-name":    "foo",
+				"action":       "install",
+				"channel":      "stable",
+				"architecture": thisArch,
+				"releases": []map[string]interface{}{
+					{"architecture": thisArch, "channel": "beta"},
+				},
+			},
+		},
+	})
+
+	err = &store.RevisionNotAvailableError{
+		Action:  "install",
+		Channel: "stable",
+		Releases: []snap.Channel{
+			snaptest.MustParseChannel("beta", "other-arch"),
+		},
+	}
+	rsp = si.errToResponse(err).(*resp)
+	c.Check(rsp, check.DeepEquals, &resp{
+		Status: 404,
+		Type:   ResponseTypeError,
+		Result: &errorResult{
+			Message: "no snap revision on specified architecture",
+			Kind:    errorKindSnapArchitectureNotAvailable,
+			Value: map[string]interface{}{
+				"snap-name":    "foo",
+				"action":       "install",
+				"channel":      "stable",
+				"architecture": thisArch,
+				"releases": []map[string]interface{}{
+					{"architecture": "other-arch", "channel": "beta"},
+				},
+			},
+		},
+	})
+
+	err = &store.RevisionNotAvailableError{}
+	rsp = si.errToResponse(err).(*resp)
+	c.Check(rsp, check.DeepEquals, &resp{
+		Status: 404,
+		Type:   ResponseTypeError,
+		Result: &errorResult{
+			Message: "no snap revision available as specified",
+			Kind:    errorKindSnapRevisionNotAvailable,
+			Value:   "foo",
+		},
+	})
 }

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -29,9 +29,11 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -141,7 +143,9 @@ const (
 	errorKindSnapLocal             = errorKind("snap-local")
 	errorKindSnapNoUpdateAvailable = errorKind("snap-no-update-available")
 
-	errorKindSnapRevisionNotAvailable = errorKind("snap-revision-not-available")
+	errorKindSnapRevisionNotAvailable     = errorKind("snap-revision-not-available")
+	errorKindSnapChannelNotAvailable      = errorKind("snap-channel-not-available")
+	errorKindSnapArchitectureNotAvailable = errorKind("snap-architecture-not-available")
 
 	errorKindNotSnap = errorKind("snap-not-a-snap")
 
@@ -365,13 +369,49 @@ func SnapNotFound(snapName string, err error) Response {
 // operation is requested for which no revivision can be found
 // in the given context (e.g. request an install from a stable
 // channel when this channel is empty).
-func SnapRevisionNotAvailable(snapName string, err error) Response {
+func SnapRevisionNotAvailable(snapName string, rnaErr *store.RevisionNotAvailableError) Response {
+	var value interface{} = snapName
+	kind := errorKindSnapRevisionNotAvailable
+	msg := rnaErr.Error()
+	if len(rnaErr.Releases) != 0 && rnaErr.Channel != "" {
+		thisArch := arch.UbuntuArchitecture()
+		values := map[string]interface{}{
+			"snap-name":    snapName,
+			"action":       rnaErr.Action,
+			"channel":      rnaErr.Channel,
+			"architecture": thisArch,
+		}
+		archOK := false
+		releases := make([]map[string]interface{}, 0, len(rnaErr.Releases))
+		for _, c := range rnaErr.Releases {
+			if c.Architecture == thisArch {
+				archOK = true
+			}
+			releases = append(releases, map[string]interface{}{
+				"architecture": c.Architecture,
+				"channel":      c.Name,
+			})
+		}
+		// we return all available releases (arch x channel)
+		// as reported in the store error, but we hint with
+		// the error kind whether there was anything at all
+		// available for this architecture
+		if archOK {
+			kind = errorKindSnapChannelNotAvailable
+			msg = "no snap revision on specified channel"
+		} else {
+			kind = errorKindSnapArchitectureNotAvailable
+			msg = "no snap revision on specified architecture"
+		}
+		values["releases"] = releases
+		value = values
+	}
 	return &resp{
 		Type: ResponseTypeError,
 		Result: &errorResult{
-			Message: err.Error(),
-			Kind:    errorKindSnapRevisionNotAvailable,
-			Value:   snapName,
+			Message: msg,
+			Kind:    kind,
+			Value:   value,
 		},
 		Status: 404,
 	}

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -102,24 +102,7 @@ func installInfo(st *state.State, name, channel string, revision snap.Revision, 
 	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, nil)
 	st.Lock()
 
-	si, err := singleActionResult(name, action.Action, res, err)
-	// TODO: Ideally the store would provide better error reporting
-	//       right now it sends store.ErrRevisionNotAvailable when
-	//       a snap is in a different channel and also when it is
-	//       not available for the given architecture. Once the
-	//       store differentiates between those we can just do
-	//       `return singleActionResult(name, action.Action, res, err)`
-	//       here.
-	if channel != "" && err == store.ErrRevisionNotAvailable {
-		st.Unlock()
-		_, err1 := theStore.SnapInfo(store.SnapSpec{Name: name}, user)
-		st.Lock()
-		if err1 != nil {
-			return nil, store.ErrSnapNotFound
-		}
-	}
-	return si, err
-
+	return singleActionResult(name, action.Action, res, err)
 }
 
 func updateInfo(st *state.State, snapst *SnapState, opts *updateInfoOpts, userID int) (*snap.Info, error) {

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -203,3 +203,14 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 	}
 	return filepath.Join(snapSource, snapFilePath)
 }
+
+// MustParseChannel parses a string representing a store channel and
+// includes the given architecture, if architecture is "" the system
+// architecture is included. It panics on error.
+func MustParseChannel(s string, architecture string) snap.Channel {
+	c, err := snap.ParseChannel(s, architecture)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -5650,7 +5651,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 		err = json.Unmarshal(jsonReq, &req)
 		c.Assert(err, IsNil)
 
-		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context, HasLen, 2)
 		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
 			"snap-id":          helloWorldSnapID,
 			"instance-key":     helloWorldSnapID,
@@ -5658,20 +5659,32 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
 		})
-		c.Assert(req.Actions, HasLen, 3)
+		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
+			"snap-id":          "snap2-id",
+			"instance-key":     "snap2-id",
+			"revision":         float64(2),
+			"tracking-channel": "edge",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 4)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
 			"action":       "refresh",
 			"instance-key": helloWorldSnapID,
 			"snap-id":      helloWorldSnapID,
-			"channel":      "stable",
 		})
 		c.Assert(req.Actions[1], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": "snap2-id",
+			"snap-id":      "snap2-id",
+			"channel":      "candidate",
+		})
+		c.Assert(req.Actions[2], DeepEquals, map[string]interface{}{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "foo",
 			"channel":      "stable",
 		})
-		c.Assert(req.Actions[2], DeepEquals, map[string]interface{}{
+		c.Assert(req.Actions[3], DeepEquals, map[string]interface{}{
 			"action":       "download",
 			"instance-key": "download-1",
 			"name":         "bar",
@@ -5687,6 +5700,19 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
      "error": {
        "code": "revision-not-found",
        "message": "msg1"
+     }
+  }, {
+     "result": "error",
+     "instance-key": "snap2-id",
+     "snap-id": "snap2-id",
+     "name": "snap2",
+     "error": {
+       "code": "revision-not-found",
+       "message": "msg1",
+       "extra": {
+         "releases": [{"architecture": "amd64", "channel": "beta"},
+                      {"architecture": "arm64", "channel": "beta"}]
+       }
      }
   }, {
      "result": "error",
@@ -5728,11 +5754,21 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			Revision:        snap.R(26),
 			RefreshedDate:   helloRefreshedDate,
 		},
+		{
+			Name:            "snap2",
+			SnapID:          "snap2-id",
+			TrackingChannel: "edge",
+			Revision:        snap.R(2),
+			RefreshedDate:   helloRefreshedDate,
+		},
 	}, []*SnapAction{
 		{
+			Action: "refresh",
+			SnapID: helloWorldSnapID,
+		}, {
 			Action:  "refresh",
-			SnapID:  helloWorldSnapID,
-			Channel: "stable",
+			SnapID:  "snap2-id",
+			Channel: "candidate",
 		}, {
 			Action:  "install",
 			Name:    "foo",
@@ -5746,13 +5782,30 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &SnapActionError{
 		Refresh: map[string]error{
-			"hello-world": ErrRevisionNotAvailable,
+			"hello-world": &RevisionNotAvailableError{
+				Action:  "refresh",
+				Channel: "stable",
+			},
+			"snap2": &RevisionNotAvailableError{
+				Action:  "refresh",
+				Channel: "candidate",
+				Releases: []snap.Channel{
+					snaptest.MustParseChannel("beta", "amd64"),
+					snaptest.MustParseChannel("beta", "arm64"),
+				},
+			},
 		},
 		Install: map[string]error{
-			"foo": ErrRevisionNotAvailable,
+			"foo": &RevisionNotAvailableError{
+				Action:  "install",
+				Channel: "stable",
+			},
 		},
 		Download: map[string]error{
-			"bar": ErrRevisionNotAvailable,
+			"bar": &RevisionNotAvailableError{
+				Action:  "download",
+				Channel: "",
+			},
 		},
 	})
 }

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -70,14 +70,14 @@ execute: |
         echo "Installing test-snapd-only-in-edge should fail but did not"
         exit 1
     fi
-    MATCH 'error: snap "test-snapd-only-in-edge" not found in the given context.' < stderr.out
-    MATCH "use 'snap info test-snapd-only-in-edge' to list" < stderr.out
+    MATCH 'error: snap "test-snapd-only-in-edge" is not available on stable but' < stderr.out
+    MATCH "snap install --edge test-snapd-only-in-edge" < stderr.out
 
     echo "Install a snap not available for the given architecture"
     if [ "$(uname -m)" = "x86_64" ]; then
-        if snap install pi3-kernel 2>stderr.out; then
-            echo "Installing pi3-kernel should fail on amd64 systems but did not"
+        if snap install pi2-kernel 2>stderr.out; then
+            echo "Installing pi2-kernel should fail on amd64 systems but did not"
             exit 1
         fi
-        MATCH 'error: snap "pi3-kernel" not found' < stderr.out
+        MATCH 'error: snap "pi2-kernel" is not available on stable for this architecture' < stderr.out
     fi

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -30,7 +30,7 @@ execute: |
     ( snap install --channel beta "$DEVMODE_SNAP" 2>&1 && exit 1 || true ) | MATCH -z "${expected// /[[:space:]]+}"
 
     echo "Install devmode snap from stable"
-    expected='error: snap "'"$DEVMODE_SNAP"'" not found in the given context.'
+    expected='error: snap "'"$DEVMODE_SNAP"'" is not available on stable but'
     #shellcheck disable=SC2015
     actual=$(snap install --devmode "$DEVMODE_SNAP" 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"

--- a/tests/regression/lp-1693042/task.yaml
+++ b/tests/regression/lp-1693042/task.yaml
@@ -10,5 +10,5 @@ execute: |
   if [[ "$revno" =~ x[0-9]+ ]]; then
       MATCH 'error: local snap "core" is unknown to the store' <<< "$out"
   else
-      MATCH not.found <<< "$out"
+      MATCH not.available <<< "$out"
   fi


### PR DESCRIPTION
This uses the new extra "releases" information on store "revision-not-found" errors to produce better errors when a revision is not available for the given channel or architecture.

The extra information when available is passed back over the snapd API using two new error kinds:

* snap-channel-not-available
* snap-architecture-not-available