### PR TITLE
Optimize snap install time 1

### DIFF
--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -37,46 +37,69 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-// LoadProfile loads an apparmor profile from the given file.
+// LoadProfile loads apparmor profiles from the given files.
 //
 // If no such profile was previously loaded then it is simply added to the kernel.
 // If there was a profile with the same name before, that profile is replaced.
-func LoadProfile(fname string) error {
-	return loadProfile(fname, dirs.AppArmorCacheDir)
+func LoadProfiles(fnames []string) error {
+	return loadProfiles(fnames, dirs.AppArmorCacheDir)
 }
 
 // UnloadProfile removes the named profile from the running kernel.
 //
 // The operation is done with: apparmor_parser --remove $name
 // The binary cache file is removed from /var/cache/apparmor
-func UnloadProfile(name string) error {
-	return unloadProfile(name, dirs.AppArmorCacheDir)
+func UnloadProfiles(names []string) error {
+	return unloadProfiles(names, dirs.AppArmorCacheDir)
 }
 
-func loadProfile(fname, cacheDir string) error {
+func loadProfiles(fnames []string, cacheDir string) error {
+	if len(fnames) == 0 {
+		return nil
+	}
+
 	// Use no-expr-simplify since expr-simplify is actually slower on armhf (LP: #1383858)
-	args := []string{"--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s", cacheDir)}
+	args := []string{"--replace", "--write-cache", "-O", "no-expr-simplify",
+		fmt.Sprintf("--cache-loc=%s", cacheDir)}
+
 	if !osutil.GetenvBool("SNAPD_DEBUG") {
 		args = append(args, "--quiet")
 	}
-	args = append(args, fname)
+	args = append(args, fnames...)
 
 	output, err := exec.Command("apparmor_parser", args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("cannot load apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))
+		if len(fnames) > 1 {
+			// Revert possibly applied profiles. Note that this will always return
+			// an error as at least one of the profiles could not be loaded. We do
+			// not log it as this is anyway a paliative solution.
+			args := []string{"--remove"}
+			args = append(args, fnames...)
+			exec.Command("apparmor_parser", args...).Run()
+		}
+		return fmt.Errorf("cannot load apparmor profile: %s\napparmor_parser output:\n%s",
+			err, string(output))
 	}
 	return nil
 }
 
-func unloadProfile(name, cacheDir string) error {
-	output, err := exec.Command("apparmor_parser", "--remove", name).CombinedOutput()
+func unloadProfiles(names []string, cacheDir string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	args := []string{"--remove"}
+	args = append(args, names...)
+	output, err := exec.Command("apparmor_parser", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot unload apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))
 	}
-	err = os.Remove(filepath.Join(cacheDir, name))
-	// It is not an error if the cache file wasn't there to remove.
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("cannot remove apparmor profile cache: %s", err)
+	for _, name := range names {
+		err = os.Remove(filepath.Join(cacheDir, name))
+		// It is not an error if the cache file wasn't there to remove.
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("cannot remove apparmor profile cache: %s", err)
+		}
 	}
 	return nil
 }

--- a/interfaces/apparmor/apparmor_test.go
+++ b/interfaces/apparmor/apparmor_test.go
@@ -56,7 +56,7 @@ func (s *appArmorSuite) SetUpTest(c *C) {
 func (s *appArmorSuite) TestLoadProfileRunsAppArmorParserReplace(c *C) {
 	cmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer cmd.Restore()
-	err := apparmor.LoadProfile("/path/to/snap.samba.smbd")
+	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"})
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
@@ -66,7 +66,7 @@ func (s *appArmorSuite) TestLoadProfileRunsAppArmorParserReplace(c *C) {
 func (s *appArmorSuite) TestLoadProfileReportsErrors(c *C) {
 	cmd := testutil.MockCommand(c, "apparmor_parser", "exit 42")
 	defer cmd.Restore()
-	err := apparmor.LoadProfile("/path/to/snap.samba.smbd")
+	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"})
 	c.Assert(err.Error(), Equals, `cannot load apparmor profile: exit status 42
 apparmor_parser output:
 `)
@@ -80,7 +80,7 @@ func (s *appArmorSuite) TestLoadProfileRunsAppArmorParserReplaceWithSnapdDebug(c
 	defer os.Unsetenv("SNAPD_DEBUG")
 	cmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer cmd.Restore()
-	err := apparmor.LoadProfile("/path/to/snap.samba.smbd")
+	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"})
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
@@ -94,7 +94,7 @@ func (s *appArmorSuite) TestUnloadProfileRunsAppArmorParserRemove(c *C) {
 	defer dirs.SetRootDir("")
 	cmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer cmd.Restore()
-	err := apparmor.UnloadProfile("snap.samba.smbd")
+	err := apparmor.UnloadProfiles([]string{"snap.samba.smbd"})
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{"apparmor_parser", "--remove", "snap.samba.smbd"},
@@ -104,7 +104,7 @@ func (s *appArmorSuite) TestUnloadProfileRunsAppArmorParserRemove(c *C) {
 func (s *appArmorSuite) TestUnloadProfileReportsErrors(c *C) {
 	cmd := testutil.MockCommand(c, "apparmor_parser", "exit 42")
 	defer cmd.Restore()
-	err := apparmor.UnloadProfile("snap.samba.smbd")
+	err := apparmor.UnloadProfiles([]string{"snap.samba.smbd"})
 	c.Assert(err.Error(), Equals, `cannot unload apparmor profile: exit status 42
 apparmor_parser output:
 `)
@@ -121,7 +121,7 @@ func (s *appArmorSuite) TestUnloadRemovesCachedProfile(c *C) {
 
 	fname := filepath.Join(dirs.AppArmorCacheDir, "profile")
 	ioutil.WriteFile(fname, []byte("blob"), 0600)
-	err = apparmor.UnloadProfile("profile")
+	err = apparmor.UnloadProfiles([]string{"profile"})
 	c.Assert(err, IsNil)
 	_, err = os.Stat(fname)
 	c.Check(os.IsNotExist(err), Equals, true)

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -165,8 +165,8 @@ func (b *Backend) Initialize() error {
 		return fmt.Errorf("cannot find system apparmor profile for snap-confine")
 	}
 
-	// We are not using apparmor.LoadProfile() because it uses other cache.
-	if err := loadProfile(profilePath, dirs.SystemApparmorCacheDir); err != nil {
+	// We are not using apparmor.LoadProfiles() because it uses other cache.
+	if err := loadProfiles([]string{profilePath}, dirs.SystemApparmorCacheDir); err != nil {
 		// When we cannot reload the profile then let's remove the generated
 		// policy. Maybe we have caused the problem so it's better to let other
 		// things work.
@@ -511,20 +511,13 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 }
 
 func reloadProfiles(profiles []string, profileDir, cacheDir string) error {
+	files := []string{}
 	for _, profile := range profiles {
-		err := loadProfile(filepath.Join(profileDir, profile), cacheDir)
-		if err != nil {
-			return fmt.Errorf("cannot load apparmor profile %q: %s", profile, err)
-		}
+		files = append(files, filepath.Join(profileDir, profile))
 	}
-	return nil
-}
-
-func unloadProfiles(profiles []string, cacheDir string) error {
-	for _, profile := range profiles {
-		if err := unloadProfile(profile, cacheDir); err != nil {
-			return fmt.Errorf("cannot unload apparmor profile %q: %s", profile, err)
-		}
+	err := loadProfiles(files, cacheDir)
+	if err != nil {
+		return fmt.Errorf("cannot load apparmor profiles %q: %s", files, err)
 	}
 	return nil
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -122,8 +122,7 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsProfiles(c *C) {
 	c.Check(err, IsNil)
 	// apparmor_parser was used to load that file
 	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, profile},
 	})
 }
 
@@ -137,8 +136,7 @@ func (s *backendSuite) TestInstallingSnapWithHookWritesAndLoadsProfiles(c *C) {
 	c.Check(err, IsNil)
 	// apparmor_parser was used to load that file
 	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, profile},
 	})
 }
 
@@ -164,8 +162,7 @@ func (s *backendSuite) TestInstallingSnapWithLayoutWritesAndLoadsProfiles(c *C) 
 	// TODO: check for layout snippets inside the generated file once we have some snippets to check for.
 	// apparmor_parser was used to load them
 	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", appProfile},
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, appProfile},
 	})
 }
 
@@ -191,8 +188,7 @@ func (s *backendSuite) TestProfilesAreAlwaysLoaded(c *C) {
 		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, profile},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -213,8 +209,7 @@ func (s *backendSuite) TestRemovingSnapRemovesAndUnloadsProfiles(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to unload the profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--remove", "snap-update-ns.samba"},
-			{"apparmor_parser", "--remove", "snap.samba.smbd"},
+			{"apparmor_parser", "--remove", "snap-update-ns.samba", "snap.samba.smbd"},
 		})
 	}
 }
@@ -234,8 +229,7 @@ func (s *backendSuite) TestRemovingSnapWithHookRemovesAndUnloadsProfiles(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to unload the profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--remove", "snap-update-ns.foo"},
-			{"apparmor_parser", "--remove", "snap.foo.hook.configure"},
+			{"apparmor_parser", "--remove", "snap-update-ns.foo", "snap.foo.hook.configure"},
 		})
 	}
 }
@@ -250,8 +244,7 @@ func (s *backendSuite) TestUpdatingSnapMakesNeccesaryChanges(c *C) {
 		// apparmor_parser was used to reload the profile because snap revision
 		// is inside the generated policy.
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, profile},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -271,9 +264,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		c.Check(err, IsNil)
 		// apparmor_parser was used to load the both profiles
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", nmbdProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, nmbdProfile, smbdProfile},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -295,10 +286,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 		c.Check(err, IsNil)
 		// apparmor_parser was used to load all the profiles
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", hookProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", nmbdProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, hookProfile, nmbdProfile, smbdProfile},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -318,8 +306,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to remove the unused profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, smbdProfile},
 			{"apparmor_parser", "--remove", "snap.samba.nmbd"},
 		})
 		s.RemoveSnap(c, snapInfo)
@@ -342,9 +329,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to remove the unused profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", nmbdProfile},
-			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile, nmbdProfile, smbdProfile},
 			{"apparmor_parser", "--remove", "snap.samba.hook.configure"},
 		})
 		s.RemoveSnap(c, snapInfo)

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -111,13 +111,6 @@ func (b *Backend) Remove(snapName string) error {
 			logger.Noticef("cannot stop service %q: %s", service, err)
 		}
 	}
-	// Reload systemd whenever something is removed
-	if len(removed) > 0 {
-		err := systemd.DaemonReload()
-		if err != nil {
-			logger.Noticef("cannot reload systemd state: %s", err)
-		}
-	}
 	return errEnsure
 }
 

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -116,7 +116,6 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 			{"systemctl", "--root", dirs.GlobalRootDir, "disable", "snap.samba.interface.foo.service"},
 			{"systemctl", "stop", "snap.samba.interface.foo.service"},
 			{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.foo.service"},
-			{"systemctl", "daemon-reload"},
 		})
 	}
 }

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -42,12 +42,6 @@ func addMountUnit(s *snap.Info, meter progress.Meter) error {
 		return err
 	}
 
-	// we need to do a daemon-reload here to ensure that systemd really
-	// knows about this new mount unit file
-	if err := sysd.DaemonReload(); err != nil {
-		return err
-	}
-
 	if err := sysd.Enable(mountUnitName); err != nil {
 		return err
 	}
@@ -80,11 +74,6 @@ func removeMountUnit(baseDir string, meter progress.Meter) error {
 			return err
 		}
 		if err := os.Remove(unit); err != nil {
-			return err
-		}
-		// daemon-reload to ensure that systemd actually really
-		// forgets about this mount unit
-		if err := sysd.DaemonReload(); err != nil {
 			return err
 		}
 	}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -188,11 +188,6 @@ func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 				inter.Notify(fmt.Sprintf("while trying to remove %s due to previous failure: %v", s, e))
 			}
 		}
-		if len(written) > 0 {
-			if e := sysd.DaemonReload(); e != nil {
-				inter.Notify(fmt.Sprintf("while trying to perform systemd daemon-reload due to previous failure: %v", e))
-			}
-		}
 	}()
 
 	for _, app := range s.Apps {
@@ -248,12 +243,6 @@ func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 			return err
 		}
 		enabled = append(enabled, svcName)
-	}
-
-	if len(written) > 0 {
-		if err := sysd.DaemonReload(); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -346,13 +335,6 @@ func RemoveSnapServices(s *snap.Info, inter interacter) error {
 			logger.Noticef("Failed to remove service file for %q: %v", serviceName, err)
 		}
 
-	}
-
-	// only reload if we actually had services
-	if nservices > 0 {
-		if err := sysd.DaemonReload(); err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
This is an RFC that improves snap installation time in two ways:

1. Removes unneeded calls to `systemctl daemon-reload`. See https://forum.snapcraft.io/t/are-systemctl-daemon-reload-calls-before-enabling-a-service-needed/6086 for more information.
2. It makes sure to call `apparmor_parser` only once when we want to (un)load a set of profiles, instead of looping on them.