### PR TITLE
vendor: switch to latest bson

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,10 +171,10 @@
 			"revisionTime": "2015-01-21T11:42:31Z"
 		},
 		{
-			"checksumSHA1": "YsB2DChSV9HxdzHaKATllAUKWSI=",
+			"checksumSHA1": "/xRHTpN8WOK4nmZjJ1f96ER1b/o=",
 			"path": "gopkg.in/mgo.v2/bson",
-			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
-			"revisionTime": "2016-08-18T02:01:20Z"
+			"revision": "a7e2c1d573e19a65a0caa1c2f70758cd889c416e",
+			"revisionTime": "2018-07-04T14:44:55Z"
 		},
 		{
 			"checksumSHA1": "XQsrqoNT1U0KzLxOFcAZVvqhLfk=",


### PR DESCRIPTION
This will switch to the latest bson release. This release fixes
the use of urandom on init. This prevents snapd blocking on boot
when no entropy is available and urandom is not initialized yet.
