### PR TITLE
daemon, overlord/state: warnings pipeline

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -94,6 +94,7 @@ var api = []*Command{
 	aliasesCmd,
 	appsCmd,
 	logsCmd,
+	warningsCmd,
 	debugCmd,
 }
 
@@ -249,6 +250,14 @@ var (
 		POST:   changeAliases,
 	}
 
+	warningsCmd = &Command{
+		Path:     "/v2/warnings",
+		UserOK:   true,
+		PolkitOK: "io.snapcraft.snapd.manage",
+		GET:      getWarnings,
+		POST:     ackWarnings,
+	}
+
 	buildID = "unknown"
 )
 
@@ -329,7 +338,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		m["sandbox-features"] = features
 	}
 
-	return SyncResponse(m, nil)
+	return SyncResponse(m, newMeta(st))
 }
 
 func sandboxFeatures(backends []interfaces.SecurityBackend) map[string][]string {
@@ -456,6 +465,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	overlord := c.d.overlord
 	state := overlord.State()
 	state.Lock()
+	defer state.Unlock()
 	if user != nil {
 		// local user logged-in, set its store macaroons
 		user.StoreMacaroon = macaroon
@@ -466,7 +476,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	} else {
 		user, err = auth.NewUser(state, loginData.Username, loginData.Email, macaroon, []string{discharge})
 	}
-	state.Unlock()
+	meta := newMeta(state)
 	if err != nil {
 		return InternalError("cannot persist authentication details: %v", err)
 	}
@@ -478,7 +488,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		Macaroon:   user.Macaroon,
 		Discharges: user.Discharges,
 	}
-	return SyncResponse(result, nil)
+	return SyncResponse(result, meta)
 }
 
 func logoutUser(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -494,7 +504,7 @@ func logoutUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError(err.Error())
 	}
 
-	return SyncResponse(nil, nil)
+	return SyncResponse(nil, newMeta(state))
 }
 
 // UserFromRequest extracts user information from request and return the respective user in state, if valid
@@ -557,7 +567,12 @@ func getSnapInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	result := webify(mapLocal(about), url.String())
 
-	return SyncResponse(result, nil)
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(result, meta)
 }
 
 func webify(result *client.Snap, resource string) *client.Snap {
@@ -610,7 +625,12 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("%v", err)
 	}
 
-	return SyncResponse(sections, &Meta{})
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(sections, meta)
 }
 
 func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -683,10 +703,13 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("%v", err)
 	}
 
-	meta := &Meta{
-		SuggestedCurrency: theStore.SuggestedCurrency(),
-		Sources:           []string{"store"},
-	}
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	meta.SuggestedCurrency = theStore.SuggestedCurrency()
+	meta.Sources = []string{"store"}
 
 	return sendStorePackages(route, meta, found)
 }
@@ -712,10 +735,13 @@ func findOne(c *Command, r *http.Request, user *auth.UserState, name string) Res
 		return InternalError("%v", err)
 	}
 
-	meta := &Meta{
-		SuggestedCurrency: theStore.SuggestedCurrency(),
-		Sources:           []string{"store"},
-	}
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	meta.SuggestedCurrency = theStore.SuggestedCurrency()
+	meta.Sources = []string{"store"}
 
 	results := make([]*json.RawMessage, 1)
 	data, err := json.Marshal(webify(mapRemote(snapInfo), r.URL.String()))
@@ -756,13 +782,14 @@ func storeUpdates(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	state := c.d.overlord.State()
 	state.Lock()
+	defer state.Unlock()
 	updates, err := snapstateRefreshCandidates(state, user)
-	state.Unlock()
+	meta := newMeta(state)
 	if err != nil {
 		return InternalError("cannot list updates: %v", err)
 	}
 
-	return sendStorePackages(route, nil, updates)
+	return sendStorePackages(route, meta, updates)
 }
 
 func sendStorePackages(route *mux.Route, meta *Meta, found []*snap.Info) Response {
@@ -818,7 +845,8 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	}
 
-	found, err := allLocalSnapInfos(c.d.overlord.State(), all, wanted)
+	state := c.d.overlord.State()
+	found, err := allLocalSnapInfos(state, all, wanted)
 	if err != nil {
 		return InternalError("cannot list local snaps! %v", err)
 	}
@@ -843,7 +871,12 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		results[i] = &raw
 	}
 
-	return SyncResponse(results, &Meta{Sources: []string{"local"}})
+	state.Lock()
+	meta := newMeta(state)
+	state.Unlock()
+	meta.Sources = []string{"local"}
+
+	return SyncResponse(results, meta)
 }
 
 func resultHasType(r map[string]interface{}, allowedTypes []string) bool {
@@ -1652,6 +1685,7 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 	s := c.d.overlord.State()
 	s.Lock()
 	tr := config.NewTransaction(s)
+	meta := newMeta(s)
 	s.Unlock()
 
 	currentConfValues := make(map[string]interface{})
@@ -1685,13 +1719,13 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 			if len(keys) > 1 {
 				return BadRequest("keys contains zero-length string")
 			}
-			return SyncResponse(value, nil)
+			return SyncResponse(value, meta)
 		}
 
 		currentConfValues[key] = value
 	}
 
-	return SyncResponse(currentConfValues, nil)
+	return SyncResponse(currentConfValues, meta)
 }
 
 func setSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -1754,7 +1788,12 @@ func getInterfaces(c *Command, r *http.Request, user *auth.UserState) Response {
 		Connected: pselect == "connected",
 	}
 	repo := c.d.overlord.InterfaceManager().Repository()
-	return SyncResponse(repo.Info(opts), nil)
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(repo.Info(opts), meta)
 }
 
 func getLegacyConnections(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -1807,7 +1846,12 @@ func getLegacyConnections(c *Command, r *http.Request, user *auth.UserState) Res
 		ifjson.Slots = append(ifjson.Slots, sj)
 	}
 
-	return SyncResponse(ifjson, nil)
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(ifjson, meta)
 }
 
 // plugJSON aids in marshaling Plug into JSON.
@@ -1946,9 +1990,14 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 }
 
 func getAssertTypeNames(c *Command, r *http.Request, user *auth.UserState) Response {
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
 	return SyncResponse(map[string][]string{
 		"types": asserts.TypeNames(),
-	}, nil)
+	}, meta)
 }
 
 func doAssert(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2094,7 +2143,7 @@ func getChange(c *Command, r *http.Request, user *auth.UserState) Response {
 		return NotFound("cannot find change with id %q", chID)
 	}
 
-	return SyncResponse(change2changeInfo(chg), nil)
+	return SyncResponse(change2changeInfo(chg), newMeta(state))
 }
 
 func getChanges(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2149,7 +2198,7 @@ func getChanges(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 		chgInfos = append(chgInfos, change2changeInfo(chg))
 	}
-	return SyncResponse(chgInfos, nil)
+	return SyncResponse(chgInfos, newMeta(state))
 }
 
 func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2185,7 +2234,7 @@ func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
 	// actually ask to proceed with the abort
 	ensureStateSoon(state)
 
-	return SyncResponse(change2changeInfo(chg), nil)
+	return SyncResponse(change2changeInfo(chg), newMeta(state))
 }
 
 var (
@@ -2264,7 +2313,11 @@ func createAllKnownSystemUsers(st *state.State, createData *postUserCreateData) 
 		})
 	}
 
-	return SyncResponse(createdUsers, nil)
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(createdUsers, meta)
 }
 
 func getUserDetailsFromAssertion(st *state.State, email string) (string, *osutil.AddUserOptions, error) {
@@ -2437,10 +2490,14 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		return InternalError("%s", err)
 	}
 
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
 	return SyncResponse(&userResponseData{
 		Username: username,
 		SSHKeys:  opts.SSHKeys,
-	}, nil)
+	}, meta)
 }
 
 func convertBuyError(err error) Response {
@@ -2491,7 +2548,8 @@ func convertBuyError(err error) Response {
 }
 
 type debugAction struct {
-	Action string `json:"action"`
+	Action  string `json:"action"`
+	Message string `json:"message"`
 }
 
 type ConnectivityStatus struct {
@@ -2511,9 +2569,15 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 	defer st.Unlock()
 
 	switch a.Action {
+	case "add-warning":
+		st.AddWarning(a.Message)
+		return SyncResponse(true, newMeta(st))
+	case "unshow-warnings":
+		st.UnshowAllWarnings()
+		return SyncResponse(true, newMeta(st))
 	case "ensure-state-soon":
 		ensureStateSoon(st)
-		return SyncResponse(true, nil)
+		return SyncResponse(true, newMeta(st))
 	case "get-base-declaration":
 		bd, err := assertstate.BaseDeclaration(st)
 		if err != nil {
@@ -2521,9 +2585,9 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 		return SyncResponse(map[string]interface{}{
 			"base-declaration": string(asserts.Encode(bd)),
-		}, nil)
+		}, newMeta(st))
 	case "can-manage-refreshes":
-		return SyncResponse(devicestate.CanManageRefreshes(st), nil)
+		return SyncResponse(devicestate.CanManageRefreshes(st), newMeta(st))
 	case "connectivity":
 		s := snapstate.Store(st)
 		st.Unlock()
@@ -2541,7 +2605,7 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 		sort.Strings(status.Unreachable)
 
-		return SyncResponse(status, nil)
+		return SyncResponse(status, newMeta(st))
 	default:
 		return BadRequest("unknown debug action: %v", a.Action)
 	}
@@ -2564,7 +2628,12 @@ func postBuy(c *Command, r *http.Request, user *auth.UserState) Response {
 		return resp
 	}
 
-	return SyncResponse(buyResult, nil)
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(buyResult, meta)
 }
 
 func readyToBuy(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2574,7 +2643,12 @@ func readyToBuy(c *Command, r *http.Request, user *auth.UserState) Response {
 		return resp
 	}
 
-	return SyncResponse(true, nil)
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(true, meta)
 }
 
 func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2648,7 +2722,12 @@ func getUsers(c *Command, r *http.Request, user *auth.UserState) Response {
 			ID:       u.ID,
 		}
 	}
-	return SyncResponse(resp, nil)
+
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(resp, meta)
 }
 
 // aliasAction is an action performed on aliases
@@ -2778,7 +2857,7 @@ func getAliases(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	}
 
-	return SyncResponse(res, nil)
+	return SyncResponse(res, newMeta(state))
 }
 
 func getAppsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2799,7 +2878,12 @@ func getAppsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		return rsp
 	}
 
-	return SyncResponse(clientAppInfosFromSnapAppInfos(appInfos), nil)
+	st := c.d.overlord.State()
+	st.Lock()
+	meta := newMeta(st)
+	st.Unlock()
+
+	return SyncResponse(clientAppInfosFromSnapAppInfos(appInfos), meta)
 }
 
 func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2887,4 +2971,63 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	chg := newChange(st, "service-control", fmt.Sprintf("Running service command"), tss, inst.Names)
 	st.EnsureBefore(0)
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
+}
+
+var (
+	stateOkayWarnings   = (*state.State).OkayWarnings
+	stateAllWarnings    = (*state.State).AllWarnings
+	stateWarningsToShow = (*state.State).WarningsToShow
+)
+
+func ackWarnings(c *Command, r *http.Request, _ *auth.UserState) Response {
+	defer r.Body.Close()
+	var op struct {
+		Action    string    `json:"action"`
+		Timestamp time.Time `json:"timestamp"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&op); err != nil {
+		return BadRequest("cannot decode request body into warnings operation: %v", err)
+	}
+	if op.Action != "okay" {
+		return BadRequest("unknown warning action %q", op.Action)
+	}
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	// make sure you Ok the warnings before calling newMeta
+	n := stateOkayWarnings(st, op.Timestamp)
+
+	return SyncResponse(n, newMeta(st))
+}
+
+func getWarnings(c *Command, r *http.Request, _ *auth.UserState) Response {
+	query := r.URL.Query()
+	var all bool
+	sel := query.Get("select")
+	switch sel {
+	case "all":
+		all = true
+	case "to-show", "":
+		all = false
+	default:
+		return BadRequest("invalid select parameter: %q", sel)
+	}
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var ws []*state.Warning
+	meta := newMeta(st)
+	if all {
+		ws = stateAllWarnings(st)
+	} else {
+		ws, _ = stateWarningsToShow(st)
+	}
+	if len(ws) == 0 {
+		// no need to confuse the issue
+		return SyncResponse([]state.Warning{}, nil)
+	}
+
+	return SyncResponse(ws, meta)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6932,3 +6932,58 @@ func (s *apiSuite) TestErrToResponseForRevisionNotAvailable(c *check.C) {
 		},
 	})
 }
+
+func (s *apiSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result interface{}) {
+	s.daemon(c)
+
+	oldOK := stateOkayWarnings
+	oldAll := stateAllWarnings
+	oldShow := stateWarningsToShow
+	stateOkayWarnings = func(*state.State, time.Time) int { calls += "ok"; return 0 }
+	stateAllWarnings = func(*state.State) []*state.Warning { calls += "all"; return nil }
+	stateWarningsToShow = func(*state.State) ([]*state.Warning, time.Time) { calls += "show"; return nil, time.Time{} }
+	defer func() {
+		stateOkayWarnings = oldOK
+		stateAllWarnings = oldAll
+		stateWarningsToShow = oldShow
+	}()
+
+	method := "GET"
+	f := warningsCmd.GET
+	if body != nil {
+		method = "POST"
+		f = warningsCmd.POST
+	}
+	q := url.Values{}
+	if all {
+		q.Set("select", "all")
+	}
+	req, err := http.NewRequest(method, "/v2/warnings?"+q.Encode(), body)
+	c.Assert(err, check.IsNil)
+
+	rsp, ok := f(warningsCmd, req, nil).(*resp)
+	c.Assert(ok, check.Equals, true)
+
+	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Assert(rsp.Result, check.NotNil)
+	return calls, rsp.Result
+}
+
+func (s *apiSuite) TestAllWarnings(c *check.C) {
+	calls, result := s.testWarnings(c, true, nil)
+	c.Check(calls, check.Equals, "all")
+	c.Check(result, check.DeepEquals, []state.Warning{})
+}
+
+func (s *apiSuite) TestSomeWarnings(c *check.C) {
+	calls, result := s.testWarnings(c, false, nil)
+	c.Check(calls, check.Equals, "show")
+	c.Check(result, check.DeepEquals, []state.Warning{})
+}
+
+func (s *apiSuite) TestAckWarnings(c *check.C) {
+	calls, result := s.testWarnings(c, false, bytes.NewReader([]byte(`{"action": "okay", "timestamp": "2006-01-02T15:04:05Z"}`)))
+	c.Check(calls, check.Equals, "ok")
+	c.Check(result, check.DeepEquals, 0)
+}

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
@@ -74,9 +75,25 @@ func (r *resp) transmitMaintenance(kind errorKind, message string) {
 //      The right code style takes a bit more work and unifies
 //      these fields inside resp.
 type Meta struct {
-	Sources           []string `json:"sources,omitempty"`
-	SuggestedCurrency string   `json:"suggested-currency,omitempty"`
-	Change            string   `json:"change,omitempty"`
+	Sources           []string   `json:"sources,omitempty"`
+	SuggestedCurrency string     `json:"suggested-currency,omitempty"`
+	Change            string     `json:"change,omitempty"`
+	WarningTimestamp  *time.Time `json:"warning-timestamp,omitempty"`
+	WarningCount      int        `json:"warning-count,omitempty"`
+}
+
+type warningsSummariser interface {
+	WarningsSummary() (int, time.Time)
+}
+
+func newMeta(w warningsSummariser) *Meta {
+	count, stamp := w.WarningsSummary()
+	meta := &Meta{WarningCount: count}
+	if !stamp.IsZero() {
+		meta.WarningTimestamp = &stamp
+	}
+
+	return meta
 }
 
 type respJSON struct {

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -88,8 +88,9 @@ type warningsSummariser interface {
 
 func newMeta(w warningsSummariser) *Meta {
 	count, stamp := w.WarningsSummary()
-	meta := &Meta{WarningCount: count}
-	if !stamp.IsZero() {
+	meta := &Meta{}
+	if count > 0 {
+		meta.WarningCount = count
 		meta.WarningTimestamp = &stamp
 	}
 

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -44,3 +44,16 @@ func MockTaskTimes(t *Task, spawnTime, readyTime time.Time) {
 	t.spawnTime = spawnTime
 	t.readyTime = readyTime
 }
+
+func (s *State) AddWarningFull(message string, lastSeen, lastShown time.Time, deleteAfter, repeatAfter time.Duration) {
+	s.addWarningFull(Warning{
+		message:     message,
+		lastShown:   lastShown,
+		deleteAfter: deleteAfter,
+		repeatAfter: repeatAfter,
+	}, lastSeen)
+}
+
+func (w Warning) LastSeen() time.Time {
+	return w.lastSeen
+}

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -693,6 +693,9 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.NewTask("download", "...") },
 		func() { st.UnmarshalJSON(nil) },
 		func() { st.NewLane() },
+		func() { st.AddWarning("hello") },
+		func() { st.OkayWarnings(time.Time{}) },
+		func() { st.UnshowAllWarnings() },
 	}
 
 	reads := []func(){
@@ -706,6 +709,10 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.MarshalJSON() },
 		func() { st.Prune(time.Hour, time.Hour, 100) },
 		func() { st.TaskCount() },
+		func() { st.AllWarnings() },
+		func() { st.WarningsToShow() },
+		func() { st.WarningsSummary() },
+		func() { st.DeleteOldWarnings() }, // only reading, because no warnings are too old
 	}
 
 	for i, f := range reads {

--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -1,0 +1,246 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package state
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+)
+
+var (
+	DefaultRepeatAfter = time.Hour * 24
+	DefaultDeleteAfter = time.Hour * 24 * 28
+)
+
+type jsonWarning struct {
+	Message     string     `json:"message"`
+	FirstSeen   time.Time  `json:"first-seen"`
+	LastSeen    time.Time  `json:"last-seen"`
+	LastShown   *time.Time `json:"last-shown,omitempty"`
+	DeleteAfter string     `json:"delete-after,omitempty"`
+	RepeatAfter string     `json:"repeat-after,omitempty"`
+}
+
+type Warning struct {
+	// the warning text itself. Only one of these in the system at a time.
+	message string
+	// the first time one of these messages was created
+	firstSeen time.Time
+	// the last time one of these was created
+	lastSeen time.Time
+	// the last time one of these was shown to the user
+	lastShown time.Time
+	// how much time since one of these was last seen should we drop the message
+	deleteAfter time.Duration
+	// how much time since one of these was last shown should we repeat it
+	repeatAfter time.Duration
+}
+
+func (w *Warning) String() string {
+	return w.message
+}
+
+func (w *Warning) MarshalJSON() ([]byte, error) {
+	jw := jsonWarning{
+		Message:     w.message,
+		FirstSeen:   w.firstSeen,
+		LastSeen:    w.lastSeen,
+		DeleteAfter: w.deleteAfter.String(),
+		RepeatAfter: w.repeatAfter.String(),
+	}
+	if !w.lastShown.IsZero() {
+		jw.LastShown = &w.lastShown
+	}
+
+	return json.Marshal(jw)
+}
+
+func (w *Warning) UnmarshalJSON(data []byte) error {
+	var jw jsonWarning
+	err := json.Unmarshal(data, &jw)
+	if err != nil {
+		return err
+	}
+	w.message = jw.Message
+	w.firstSeen = jw.FirstSeen
+	w.lastSeen = jw.LastSeen
+	if jw.LastShown != nil {
+		w.lastShown = *jw.LastShown
+	}
+	w.deleteAfter, err = time.ParseDuration(jw.DeleteAfter)
+	if err != nil {
+		return err
+	}
+	w.repeatAfter, err = time.ParseDuration(jw.RepeatAfter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *Warning) IsDeletable(now time.Time) bool {
+	return w.lastSeen.Add(w.deleteAfter).Before(now)
+}
+
+func (w *Warning) IsShowable(t time.Time) bool {
+	return (w.lastShown.IsZero() || w.lastShown.Add(w.repeatAfter).Before(t)) && !w.firstSeen.After(t)
+}
+
+// flattenWarning loops over the warnings map, and returns all
+// warnings therein as a flat list, for serialising.
+// Call with the lock held.
+func (s *State) flattenWarnings() []*Warning {
+	flat := make([]*Warning, 0, len(s.warnings))
+	for _, w := range s.warnings {
+		flat = append(flat, w)
+	}
+	return flat
+}
+
+// unflattenWarnings takes a flat list of warnings and replaces the
+// warning map with them.
+// Call with the lock held.
+func (s *State) unflattenWarnings(flat []*Warning) {
+	s.warnings = make(map[string]*Warning, len(flat))
+	for _, w := range flat {
+		s.warnings[w.message] = w
+	}
+}
+
+// AddWarning records a warning: if it's the first Warning with this
+// message it'll be added (with its firstSeen and lastSeen set to the
+// current time), otherwise the existing one will have its lastSeen
+// updated.
+func (s *State) AddWarning(message string) {
+	s.addWarningFull(Warning{
+		message:     message,
+		deleteAfter: DefaultDeleteAfter,
+		repeatAfter: DefaultRepeatAfter,
+	}, time.Now().UTC())
+}
+
+func (s *State) addWarningFull(w Warning, t time.Time) {
+	s.writing()
+
+	if s.warnings[w.message] == nil {
+		w.firstSeen = t
+		s.warnings[w.message] = &w
+	}
+	s.warnings[w.message].lastSeen = t
+}
+
+// DeleteOldWarnings delets warnings that up for deletion.
+func (s *State) DeleteOldWarnings() int {
+	s.reading()
+
+	now := time.Now().UTC()
+
+	n := 0
+	for k, w := range s.warnings {
+		if w.IsDeletable(now) {
+			delete(s.warnings, k)
+			s.modified = true
+			n++
+		}
+	}
+	return n
+}
+
+type byLastSeen []*Warning
+
+func (a byLastSeen) Len() int           { return len(a) }
+func (a byLastSeen) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byLastSeen) Less(i, j int) bool { return a[i].lastSeen.Before(a[j].lastSeen) }
+
+// AllWarnings returns all the warnings in the system, whether they're
+// due to be shown or not. They'll be sorted by lastSeen.
+func (s *State) AllWarnings() []*Warning {
+	s.reading()
+
+	all := s.flattenWarnings()
+	sort.Sort(byLastSeen(all))
+
+	return all
+}
+
+// OkayWarnings marks warnings that were showable at the given time as shown.
+func (s *State) OkayWarnings(t time.Time) int {
+	t = t.UTC()
+	s.writing()
+
+	n := 0
+	for _, w := range s.warnings {
+		if w.IsShowable(t) {
+			w.lastShown = t
+			n++
+		}
+	}
+
+	return n
+}
+
+// WarningsToShow returns the list of warnings to show the user, sorted by
+// lastSeen, and a timestamp than can be used to refer to these warnings.
+//
+// Warnings to show to the user are those that have not been shown before,
+// or that have been shown earlier than repeatAfter ago.
+func (s *State) WarningsToShow() ([]*Warning, time.Time) {
+	s.reading()
+	now := time.Now().UTC()
+
+	var toShow []*Warning
+	for _, w := range s.warnings {
+		if !w.IsShowable(now) {
+			continue
+		}
+		toShow = append(toShow, w)
+	}
+
+	sort.Sort(byLastSeen(toShow))
+	return toShow, now
+}
+
+// WarningsSummary returns the number of warnings that are ready to be
+// shown to the user, and the current timestamp (useful for ACKing the
+// returned warnings).
+func (s *State) WarningsSummary() (int, time.Time) {
+	s.reading()
+	now := time.Now().UTC()
+
+	var n int
+	for _, w := range s.warnings {
+		if w.IsShowable(now) {
+			n++
+		}
+	}
+
+	return n, now
+}
+
+// UnshowAllWarnings clears the lastShown timestamp from all the
+// warnings. For use in debugging.
+func (s *State) UnshowAllWarnings() {
+	s.writing()
+	for _, w := range s.warnings {
+		w.lastShown = time.Time{}
+	}
+}

--- a/overlord/state/warning_test.go
+++ b/overlord/state/warning_test.go
@@ -1,0 +1,209 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package state_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var never time.Time
+
+func (stateSuite) testMarshalWarning(shown bool, c *check.C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddWarning("hello")
+	now := time.Now()
+
+	expectedNumKeys := 5
+	if shown {
+		expectedNumKeys++ // last-shown
+		st.OkayWarnings(now)
+	}
+
+	ws := st.AllWarnings()
+	c.Assert(ws, check.HasLen, 1)
+	c.Check(ws[0].String(), check.Equals, "hello")
+	buf, err := json.Marshal(ws)
+	c.Assert(err, check.IsNil)
+
+	var v []map[string]string
+	c.Assert(json.Unmarshal(buf, &v), check.IsNil)
+	c.Assert(v, check.HasLen, 1)
+	c.Check(v[0], check.HasLen, expectedNumKeys)
+	c.Check(v[0]["message"], check.DeepEquals, "hello")
+	c.Check(v[0]["delete-after"], check.Equals, state.DefaultDeleteAfter.String())
+	c.Check(v[0]["repeat-after"], check.Equals, state.DefaultRepeatAfter.String())
+	c.Check(v[0]["first-seen"], check.Equals, v[0]["last-seen"])
+	t, err := time.Parse(time.RFC3339, v[0]["first-seen"])
+	c.Assert(err, check.IsNil)
+	dt := t.Sub(now)
+	// 'now' was just *after* creating the warning
+	c.Check(dt <= 0, check.Equals, true)
+	c.Check(-time.Minute < dt, check.Equals, true)
+	if shown {
+		t, err := time.Parse(time.RFC3339, v[0]["last-shown"])
+		c.Assert(err, check.IsNil)
+		dt := t.Sub(now)
+		// 'now' was just *before* marking the warning as shown
+		c.Check(0 <= dt, check.Equals, true)
+		c.Check(dt < time.Minute, check.Equals, true)
+	}
+
+	var ws2 []*state.Warning
+	c.Assert(json.Unmarshal(buf, &ws2), check.IsNil)
+	c.Assert(ws2, check.HasLen, 1)
+	c.Check(ws2[0], check.DeepEquals, ws[0])
+}
+
+func (s stateSuite) TestMarshalWarning(c *check.C) {
+	s.testMarshalWarning(false, c)
+}
+
+func (s stateSuite) TestMarshalShownWarning(c *check.C) {
+	s.testMarshalWarning(true, c)
+}
+
+func (stateSuite) TestEmptyStateWarnings(c *check.C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+	ws := st.AllWarnings()
+	c.Check(ws, check.HasLen, 0)
+}
+
+func (stateSuite) TestOldWarning(c *check.C) {
+	oldTime := time.Now().UTC().Add(-2 * state.DefaultDeleteAfter)
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+	st.AddWarningFull("hello", oldTime, never, state.DefaultDeleteAfter, state.DefaultRepeatAfter)
+	st.AddWarning("hello again")
+	now := time.Now()
+
+	allWs := st.AllWarnings()
+	c.Assert(allWs, check.HasLen, 2)
+	c.Check(fmt.Sprintf("%q", allWs), check.Equals, `["hello" "hello again"]`)
+	c.Check(allWs[0].IsDeletable(now), check.Equals, true)
+	c.Check(allWs[0].IsShowable(now), check.Equals, true)
+	c.Check(allWs[1].IsDeletable(now), check.Equals, false)
+	c.Check(allWs[1].IsShowable(now), check.Equals, true)
+
+	c.Check(st.DeleteOldWarnings(), check.Equals, 1)
+	c.Check(fmt.Sprintf("%q", st.AllWarnings()), check.Equals, `["hello again"]`)
+}
+
+func (stateSuite) TestOldRepeatedWarning(c *check.C) {
+	now := time.Now()
+	oldTime := now.UTC().Add(-2 * state.DefaultDeleteAfter)
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+	st.AddWarningFull("hello", oldTime, never, state.DefaultDeleteAfter, state.DefaultRepeatAfter)
+	st.AddWarning("hello")
+
+	allWs := st.AllWarnings()
+	c.Assert(allWs, check.HasLen, 1)
+	w := allWs[0]
+	c.Check(w.IsDeletable(now), check.Equals, false)
+	c.Check(w.IsShowable(now), check.Equals, true)
+}
+
+func (stateSuite) TestCheckpoint(c *check.C) {
+	b := &fakeStateBackend{}
+	st := state.New(b)
+	st.Lock()
+	st.AddWarning("hello")
+	st.Unlock()
+	c.Assert(b.checkpoints, check.HasLen, 1)
+
+	st2, err := state.ReadState(nil, bytes.NewReader(b.checkpoints[0]))
+	c.Assert(err, check.IsNil)
+	st2.Lock()
+	defer st2.Unlock()
+	ws := st2.AllWarnings()
+	c.Assert(ws, check.HasLen, 1)
+	c.Check(fmt.Sprintf("%q", ws), check.Equals, `["hello"]`)
+}
+
+func (stateSuite) TestShowAndOkay(c *check.C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+	st.AddWarning("number one")
+	n, _ := st.WarningsSummary()
+	c.Check(n, check.Equals, 1)
+	ws1, t1 := st.WarningsToShow()
+	c.Assert(ws1, check.HasLen, 1)
+	c.Check(fmt.Sprintf("%q", ws1), check.Equals, `["number one"]`)
+
+	st.AddWarning("number two")
+	ws2, t2 := st.WarningsToShow()
+	c.Assert(ws2, check.HasLen, 2)
+	c.Check(fmt.Sprintf("%q", ws2), check.Equals, `["number one" "number two"]`)
+	c.Assert(t2.After(t1), check.Equals, true)
+
+	n = st.OkayWarnings(t1)
+	c.Check(n, check.Equals, 1)
+
+	ws, _ := st.WarningsToShow()
+	c.Assert(ws, check.HasLen, 1)
+	c.Check(fmt.Sprintf("%q", ws), check.Equals, `["number two"]`)
+
+	n = st.OkayWarnings(t2)
+	c.Check(n, check.Equals, 1)
+
+	ws, _ = st.WarningsToShow()
+	c.Check(ws, check.HasLen, 0)
+}
+
+func (stateSuite) TestShowAndOkayWithRepeats(c *check.C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+	const myRepeatAfter = 2 * time.Second
+	t0 := time.Now()
+	st.AddWarningFull("hello", t0, never, state.DefaultDeleteAfter, myRepeatAfter)
+	ws, t1 := st.WarningsToShow()
+	c.Assert(ws, check.HasLen, 1)
+	c.Check(fmt.Sprintf("%q", ws), check.Equals, `["hello"]`)
+
+	n := st.OkayWarnings(t1)
+	c.Check(n, check.Equals, 1)
+
+	st.AddWarning("hello")
+
+	ws, _ = st.WarningsToShow()
+	c.Check(ws, check.HasLen, 0) // not enough time has passed
+
+	time.Sleep(myRepeatAfter)
+
+	ws, _ = st.WarningsToShow()
+	c.Check(ws, check.HasLen, 1)
+	c.Check(fmt.Sprintf("%q", ws), check.Equals, `["hello"]`)
+}


### PR DESCRIPTION
This is the backend work for the warnings pipeline. It has some
(possibly ephemeral) debug verbs added as well, to let you play with
it via http if that's your thing.

Missing is:

* the frontend work: namely 'snap warnings', 'snap okay', and the
  messages after any command.

* deleting warnings when they expire.
