### PR TITLE
tests: remove extra ' which breaks interfaces-bluetooth-control test

### DIFF
--- a/tests/main/interfaces-bluetooth-control/task.yaml
+++ b/tests/main/interfaces-bluetooth-control/task.yaml
@@ -57,4 +57,4 @@ execute: |
 
     echo "And the snap is able to read dev"
     cat "$BTDEV"/*/power/control | tee control
-    [ "$(su -l -c '/snap/bin/generic-consumer.cmd cat '"$BTDEV"'/*/power/control' test)'" = "$(cat control)" ]
+    [ "$(su -l -c '/snap/bin/generic-consumer.cmd cat '"$BTDEV"'/*/power/control' test)" = "$(cat control)" ]


### PR DESCRIPTION
This test is currently failing because there is an extra ' in the last line making fail the test