### PR TITLE
dirs: improve distro detection for Antegros 

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -179,7 +179,7 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	if release.DistroLike("fedora", "archlinux", "manjaro") {
+	if release.DistroLike("fedora", "arch", "manjaro") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -179,7 +179,7 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	if release.DistroLike("fedora", "arch", "manjaro") {
+	if release.DistroLike("fedora", "arch", "manjaro", "antegros") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
Previous attempt https://github.com/snapcore/snapd/commit/043ea8a4831975373e1cb5c63dc09ee5609f5d36 to use ID_LIKE=archlinux for detecting Arch Linux like distros failed. It seems that there is no consensus about using ID/ID_LIKE.

For reference, this is what is contained in /etc/os-release for Arch like
distros:

- Arch:
    ID=arch
    ID_LIKE=archlinux

- Manjaro (no ID_LIKE):
    ID=manjaro

- Antegros:
    ID="antergos"
    ID_LIKE="arch"

Relying on ID_LIKE seems to have little sense since there seems to be no
agreement as to what that variable should be set to.

See https://forum.snapcraft.io/t/arch-linux-missing-symlinks/6220/ for details