### PR TITLE
tests: fixes for the autopkgtest failures in cosmic

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -16,12 +16,12 @@ prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
     distro_install_package evolution-data-server
-    snap install --edge test-snapd-eds
-    mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
 
 restore: |
-    kill "$(cat dbus-launch.pid)"
-    rm -f dbus-launch.pid
+    if [ -e dbus-launch.pid ]; then
+        kill "$(cat dbus-launch.pid)"
+        rm -f dbus-launch.pid
+    fi
 
     # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
     # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
@@ -32,6 +32,16 @@ restore: |
     rm -rf "$XDG"
 
 execute: |
+    if ! snap install --edge test-snapd-eds ; then
+        if [ "$SPREAD_SYSTEM" = ubuntu-16.04-64 ]; then
+            echo "The test-snapd-eds must be available on ubuntu-16.04-64"
+            exit 1
+        fi
+        echo "SKIP: test-snapd-eds not available"
+        exit 0
+    fi
+    mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
     echo "Setting up D-Bus session bus"
     eval "$(dbus-launch --sh-syntax)"
     echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid

--- a/tests/main/interfaces-framebuffer/task.yaml
+++ b/tests/main/interfaces-framebuffer/task.yaml
@@ -18,8 +18,13 @@ execute: |
     snap interfaces -i framebuffer | MATCH '^- +test-snapd-framebuffer:framebuffer'
 
     if [ ! -e /dev/fb0 ]; then
-        echo "Framebuffer not available on /dev/fb0"
-        exit 1
+        # ensure this test runs on at least one system
+        if [[ "$SPREAD_SYSTEM" = ubuntu-core-16-arm-* ]]; then
+            echo "ubuntu-core-16-arm-32 must have a framebuffer"
+            exit 1
+        fi
+        echo "SKIP: Framebuffer not available on /dev/fb0"
+        exit 0
     fi
 
     echo "When the interface is connected"


### PR DESCRIPTION
This fixes the current autopkgtest failures observed in cosmic. We will need to make sure to build the test-snapd-eds snap on more arches, I asked @jhenstridge to push the code to LP so that we can setup automatic snap building for that. In the meantime the below diff should be fine.
