### PR TITLE
interfaces: make core-support a no-op interface

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const coreSupportSummary = `formerly special permissions for the core snap`
+const coreSupportSummary = `special permissions for the core snap`
 
 const coreSupportBaseDeclarationPlugs = `
   core-support:

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,7 @@
 
 package builtin
 
-const coreSupportSummary = `special permissions for the core snap`
+const coreSupportSummary = `formerly special permissions for the core snap`
 
 const coreSupportBaseDeclarationPlugs = `
   core-support:
@@ -36,71 +36,9 @@ const coreSupportBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-const coreSupportConnectedPlugAppArmor = `
-# Description: Can control all aspects of systemd via the systemctl command,
-# update rsyslog configuration, update systemd-timesyncd configuration and
-# update/apply sysctl configuration. The interface allows execution of the
-# systemctl binary unconfined and modifying all sysctl configuration. As such,
-# this gives device ownership to the snap.
-
-/bin/systemctl Uxr,
-
-/usr/bin/snapctl ixr,
-
-# Allow modifying rsyslog configuration for such things as remote logging. For
-# now, only allow modifying NN-snap*.conf and snap*.conf files.
-/etc/rsyslog.d/{,*}                     r,
-/etc/rsyslog.d/{,[0-9][0-9]-}snap*.conf w,
-
-# Allow modifying /etc/systemd/timesyncd.conf for adjusting systemd-timesyncd's
-# timeservers
-/etc/systemd/timesyncd.conf rw,
-
-# Allow modifying sysctl configuration and applying the changes. For now, allow
-# reading all sysctl files but only allow modifying NN-snap*.conf and
-# snap*.conf files in /etc/sysctl.d.
-/etc/sysctl.conf                       r,
-/etc/sysctl.d/{,*}                     r,
-/etc/sysctl.d/{,[0-9][0-9]-}snap*.conf w,
-/{,usr/}{,s}bin/sysctl                 ixr,
-@{PROC}/sys/{,**}                      r,
-@{PROC}/sys/**                         w,
-
-# Allow modifying logind configuration. For now, allow reading all logind
-# configuration but only allow modifying NN-snap*.conf and snap*.conf files
-# in /etc/systemd/logind.conf.d. Also allow creating the logind.conf.d
-# directory as it may not be there for existing installs (wirtable-path
-# magic oddness).
-/etc/systemd/logind.conf                             r,
-/etc/systemd/logind.conf.d/                          rw,
-/etc/systemd/logind.conf.d/{,*}                      r,
-/etc/systemd/logind.conf.d/{,[0-9][0-9]-}snap*.conf* w,
-
-# Allow managing the hostname with a core config option
-/etc/hostname                         rw,
-/{,usr/}{,s}bin/hostnamectl           ixr,
-
-# Allow sync to be used
-/bin/sync ixr,
-
-# Allow modifying swapfile configuration for swapfile.service shipped in
-# the core snap, general mgmt of the service is handled via systemctl
-/etc/default/swapfile rw,
-
-# Allow read/write access to the pi2 boot config.txt and the directory
-# so that it can dirsync it. 
-# WARNING: improperly editing this file may render the system unbootable.
-owner /boot/uboot/           r,
-owner /boot/uboot/config.txt rwk,
-owner /boot/uboot/config.txt.* rwk,
-
-# Allow read/write /etc/environment so that proxy configuration can
-# be written
-owner /etc/              r,
-owner /etc/environment   rwk,
-owner /etc/environment.* rwk,
-`
-
+// This interface is deprecated and doesn't grant any permissions but for the
+// moment we chose not to remove it in case something tests for its presence.
+// This hollow interface should be removed once it is deemed safe to do so.
 func init() {
 	registerIface(&commonInterface{
 		name:                 "core-support",
@@ -109,9 +47,6 @@ func init() {
 		implicitOnClassic:    true,
 		baseDeclarationPlugs: coreSupportBaseDeclarationPlugs,
 		baseDeclarationSlots: coreSupportBaseDeclarationSlots,
-		// NOTE: core-support implicitly contains the rules from network-bind.
-		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor + networkBindConnectedPlugAppArmor,
-		connectedPlugSecComp:  "" + networkBindConnectedPlugSecComp,
-		reservedForOS:         true,
+		reservedForOS:        true,
 	})
 }

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -80,20 +81,13 @@ func (s *CoreSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 }
 
-func (s *CoreSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
+func (s *CoreSupportInterfaceSuite) TestNoSecuritySystems(c *C) {
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
-}
-
-func (s *CoreSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.hook.prepare-device"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.hook.prepare-device"), testutil.Contains, `/bin/systemctl Uxr,`)
+	c.Assert(apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
+	seccompSpec := &seccomp.Specification{}
+	c.Assert(seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(seccompSpec.SecurityTags(), HasLen, 0)
 }
 
 func (s *CoreSupportInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
We wish to remove the core-support interface but we found that it is
(ab)used by a branded store. We chose to keep the interface but remove
any permissions granted by it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

