### PR TITLE
overlord: have SnapManager use a passed in TaskRunner created by Overlord

### DIFF
--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -73,6 +73,8 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
 
+	c.Check(o.StateEngine(), NotNil)
+	c.Check(o.TaskRunner(), NotNil)
 	c.Check(o.SnapManager(), NotNil)
 	c.Check(o.AssertManager(), NotNil)
 	c.Check(o.InterfaceManager(), NotNil)

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -553,7 +553,7 @@ func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	defer s.snapmgr.Stop()
+	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
 
@@ -604,8 +604,8 @@ func (s *snapmgrTestSuite) TestAliasNoTarget(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -630,8 +630,8 @@ func (s *snapmgrTestSuite) TestAliasTargetIsDaemon(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -668,7 +668,7 @@ func (s *snapmgrTestSuite) TestAliasOverAutoRunThrough(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	defer s.snapmgr.Stop()
+	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
 
@@ -764,8 +764,8 @@ func (s *snapmgrTestSuite) TestAliasAliasConflict(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
@@ -816,7 +816,7 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesRunThrough(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	defer s.snapmgr.Stop()
+	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
 
@@ -904,7 +904,7 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasRunThrough(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	defer s.snapmgr.Stop()
+	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
 
@@ -956,7 +956,7 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasOverAutoRunThrough(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	defer s.snapmgr.Stop()
+	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
 
@@ -1124,7 +1124,7 @@ func (s *snapmgrTestSuite) TestPreferRunThrough(c *C) {
 	chg.AddAll(ts)
 
 	s.state.Unlock()
-	defer s.snapmgr.Stop()
+	defer s.se.Stop()
 	s.settle(c)
 	s.state.Lock()
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -73,11 +73,13 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	bs.fakeBackend = &fakeSnappyBackend{}
 	bs.o = overlord.Mock()
 	bs.state = bs.o.State()
-	bs.snapmgr, err = snapstate.Manager(bs.state)
+	bs.snapmgr, err = snapstate.Manager(bs.state, bs.o.TaskRunner())
 	c.Assert(err, IsNil)
-	bs.snapmgr.AddForeignTaskHandlers(bs.fakeBackend)
+
+	AddForeignTaskHandlers(bs.o.TaskRunner(), bs.fakeBackend)
 
 	bs.o.AddManager(bs.snapmgr)
+	bs.o.AddManager(bs.o.TaskRunner())
 
 	snapstate.SetSnapManagerBackend(bs.snapmgr, bs.fakeBackend)
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {

--- a/overlord/snapstate/cookies_test.go
+++ b/overlord/snapstate/cookies_test.go
@@ -45,7 +45,7 @@ func (s *cookiesSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
 	s.st = state.New(nil)
-	s.snapmgr, _ = Manager(s.st)
+	s.snapmgr, _ = Manager(s.st, state.NewTaskRunner(s.st))
 }
 
 func (s *cookiesSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers_aliasesv2_test.go
+++ b/overlord/snapstate/handlers_aliasesv2_test.go
@@ -66,8 +66,8 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliases(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -114,8 +114,8 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesFirstInstall(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -175,8 +175,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliases(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -242,8 +242,8 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesConflict(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -304,7 +304,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesConflict(c *C) {
 
 		return nil
 	}
-	s.snapmgr.AddAdhocTaskHandler("grab-alias3", grabAlias3, nil)
+
+	s.o.TaskRunner().AddHandler("grab-alias3", grabAlias3, nil)
 
 	t := s.state.NewTask("set-auto-aliases", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
@@ -324,8 +325,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesConflict(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 5; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -379,8 +380,8 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesFirstInstallUnaliased(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -435,8 +436,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallUnaliased(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -478,8 +479,8 @@ func (s *snapmgrTestSuite) TestDoSetupAliases(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -533,8 +534,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliases(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -588,8 +589,8 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesAuto(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -643,8 +644,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -694,8 +695,8 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesNothing(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -744,8 +745,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesNothing(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -800,8 +801,8 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAuto(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -857,8 +858,8 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAutoPending(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -906,8 +907,8 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesManualAndDisabled(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -969,8 +970,8 @@ func (s *snapmgrTestSuite) TestDoRefreshAliases(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -1047,8 +1048,8 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliases(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -1132,8 +1133,8 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesFromEmpty(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -1207,8 +1208,8 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesPending(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -1271,8 +1272,8 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesPending(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -1340,8 +1341,8 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesConflict(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -1396,7 +1397,7 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesConflict(c *C) {
 		return nil
 	}
 
-	s.snapmgr.AddAdhocTaskHandler("grab-alias3", grabAlias3, nil)
+	s.o.TaskRunner().AddHandler("grab-alias3", grabAlias3, nil)
 
 	t := s.state.NewTask("refresh-aliases", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
@@ -1416,8 +1417,8 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesConflict(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 5; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -1504,8 +1505,8 @@ func (s *snapmgrTestSuite) TestDoUndoDisableAliases(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -1605,8 +1606,8 @@ func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 
 	s.state.Unlock()
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 	s.state.Lock()
 	c.Check(t.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
@@ -1733,8 +1734,8 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 
 	s.state.Unlock()
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 	s.state.Lock()
 	c.Check(t.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))
@@ -1867,7 +1868,7 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 		return nil
 	}
 
-	s.snapmgr.AddAdhocTaskHandler("conflict-alias5", conflictAlias5, nil)
+	s.o.TaskRunner().AddHandler("conflict-alias5", conflictAlias5, nil)
 
 	t := s.state.NewTask("prefer-aliases", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
@@ -1886,8 +1887,8 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 
 	s.state.Unlock()
 	for i := 0; i < 5; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 	s.state.Lock()
 	c.Check(t.Status(), Equals, state.UndoneStatus, Commentf("%v", chg.Err()))

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -22,43 +22,16 @@ package snapstate_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
 
 type discardSnapSuite struct {
-	state   *state.State
-	snapmgr *snapstate.SnapManager
-
-	fakeBackend *fakeSnappyBackend
-
-	reset func()
+	baseHandlerSuite
 }
 
 var _ = Suite(&discardSnapSuite{})
-
-func (s *discardSnapSuite) SetUpTest(c *C) {
-	// use fake root
-	dirs.SetRootDir(c.MkDir())
-
-	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(nil)
-
-	var err error
-	s.snapmgr, err = snapstate.Manager(s.state)
-	c.Assert(err, IsNil)
-	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
-
-	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
-
-	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
-}
-
-func (s *discardSnapSuite) TearDownTest(c *C) {
-	s.reset()
-}
 
 func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 	s.state.Lock()
@@ -81,8 +54,8 @@ func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -115,8 +88,8 @@ func (s *discardSnapSuite) TestDoDiscardSnapToEmpty(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -147,8 +120,8 @@ func (s *discardSnapSuite) TestDoDiscardSnapErrorsForActive(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -180,8 +153,8 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -29,41 +29,23 @@ import (
 )
 
 type downloadSnapSuite struct {
-	state     *state.State
-	snapmgr   *snapstate.SnapManager
+	baseHandlerSuite
+
 	fakeStore *fakeStore
-
-	fakeBackend *fakeSnappyBackend
-
-	reset func()
 }
 
 var _ = Suite(&downloadSnapSuite{})
 
 func (s *downloadSnapSuite) SetUpTest(c *C) {
-	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(nil)
-	s.state.Lock()
-	defer s.state.Unlock()
+	s.setup(c, nil)
 
 	s.fakeStore = &fakeStore{
 		state:       s.state,
 		fakeBackend: s.fakeBackend,
 	}
+	s.state.Lock()
+	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
-
-	var err error
-	s.snapmgr, err = snapstate.Manager(s.state)
-	c.Assert(err, IsNil)
-	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
-
-	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
-
-	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
-}
-
-func (s *downloadSnapSuite) TearDownTest(c *C) {
-	s.reset()
 }
 
 func (s *downloadSnapSuite) TestDoDownloadSnapCompatbility(c *C) {
@@ -85,8 +67,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatbility(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	// the compat code called the store "Snap" endpoint
 	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -145,8 +127,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapNormal(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	// only the download endpoint of the store was hit
 	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -188,8 +170,8 @@ func (s *downloadSnapSuite) TestDoUndoDownloadSnap(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -37,14 +37,9 @@ import (
 )
 
 type linkSnapSuite struct {
-	state   *state.State
-	snapmgr *snapstate.SnapManager
-
-	fakeBackend *fakeSnappyBackend
+	baseHandlerSuite
 
 	stateBackend *witnessRestartReqStateBackend
-
-	reset func()
 }
 
 var _ = Suite(&linkSnapSuite{})
@@ -64,30 +59,11 @@ func (b *witnessRestartReqStateBackend) RequestRestart(t state.RestartType) {
 func (b *witnessRestartReqStateBackend) EnsureBefore(time.Duration) {}
 
 func (s *linkSnapSuite) SetUpTest(c *C) {
-	dirs.SetRootDir(c.MkDir())
-
 	s.stateBackend = &witnessRestartReqStateBackend{}
-	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(s.stateBackend)
 
-	var err error
-	s.snapmgr, err = snapstate.Manager(s.state)
-	c.Assert(err, IsNil)
-	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
-
-	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
-
-	resetReadInfo := snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
-	s.reset = func() {
-		resetReadInfo()
-		dirs.SetRootDir("/")
-	}
+	s.setup(c, s.stateBackend)
 
 	snapstate.MockModel()
-}
-
-func (s *linkSnapSuite) TearDownTest(c *C) {
-	s.reset()
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, snapName string) {
@@ -119,8 +95,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccess(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -156,8 +132,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessNoUserID(c *C) {
 	s.state.NewChange("dummy", "...").AddTask(t)
 
 	s.state.Unlock()
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -200,8 +176,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessUserIDAlreadySet(c *C) {
 	s.state.NewChange("dummy", "...").AddTask(t)
 
 	s.state.Unlock()
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -234,8 +210,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessUserLoggedOut(c *C) {
 	s.state.NewChange("dummy", "...").AddTask(t)
 
 	s.state.Unlock()
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -269,8 +245,8 @@ func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 6; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -297,8 +273,8 @@ func (s *linkSnapSuite) TestDoLinkSnapTryToCleanupOnError(c *C) {
 	s.state.NewChange("dummy", "...").AddTask(t)
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 
@@ -341,8 +317,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreRestarts(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -381,8 +357,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnCoreWithBase(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -418,8 +394,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdNoRestartWithoutBase(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -454,8 +430,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdNoRestartOnClassic(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -503,8 +479,8 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceDidNotHaveCandidate(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 6; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -547,8 +523,8 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceHadCandidate(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 6; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -595,8 +571,8 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCore(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -639,8 +615,8 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapCoreClassic(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -690,8 +666,8 @@ func (s *linkSnapSuite) TestLinkSnapInjectsAutoConnectIfMissing(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 10; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -28,46 +28,15 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
-	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type mountSnapSuite struct {
-	state   *state.State
-	snapmgr *snapstate.SnapManager
-
-	fakeBackend *fakeSnappyBackend
-
-	reset func()
+	baseHandlerSuite
 }
 
 var _ = Suite(&mountSnapSuite{})
-
-func (s *mountSnapSuite) SetUpTest(c *C) {
-	oldDir := dirs.GlobalRootDir
-	dirs.SetRootDir(c.MkDir())
-
-	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(nil)
-
-	var err error
-	s.snapmgr, err = snapstate.Manager(s.state)
-	c.Assert(err, IsNil)
-	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
-
-	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
-
-	reset1 := snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
-	s.reset = func() {
-		reset1()
-		dirs.SetRootDir(oldDir)
-	}
-}
-
-func (s *mountSnapSuite) TearDownTest(c *C) {
-	s.reset()
-}
 
 func (s *mountSnapSuite) TestDoMountSnapDoesNotRemovesSnaps(c *C) {
 	v1 := "name: mock\nversion: 1.0\n"
@@ -88,8 +57,8 @@ func (s *mountSnapSuite) TestDoMountSnapDoesNotRemovesSnaps(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	c.Assert(osutil.FileExists(testSnap), Equals, true)
 }
@@ -129,8 +98,8 @@ func (s *mountSnapSuite) TestDoUndoMountSnap(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -186,8 +155,8 @@ func (s *mountSnapSuite) TestDoMountSnapError(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -246,8 +215,8 @@ func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()
@@ -319,8 +288,8 @@ func (s *mountSnapSuite) TestDoMountNotMountedRetryRetry(c *C) {
 	s.state.Unlock()
 
 	for i := 0; i < 3; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 	}
 
 	s.state.Lock()

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -23,13 +23,16 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
 
-type prepareSnapSuite struct {
+type baseHandlerSuite struct {
 	state   *state.State
+	runner  *state.TaskRunner
+	se      *overlord.StateEngine
 	snapmgr *snapstate.SnapManager
 
 	fakeBackend *fakeSnappyBackend
@@ -37,18 +40,22 @@ type prepareSnapSuite struct {
 	reset func()
 }
 
-var _ = Suite(&prepareSnapSuite{})
-
-func (s *prepareSnapSuite) SetUpTest(c *C) {
+func (s *baseHandlerSuite) setup(c *C, b state.Backend) {
 	dirs.SetRootDir(c.MkDir())
 
 	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(nil)
+	s.state = state.New(b)
+	s.runner = state.NewTaskRunner(s.state)
 
 	var err error
-	s.snapmgr, err = snapstate.Manager(s.state)
+	s.snapmgr, err = snapstate.Manager(s.state, s.runner)
 	c.Assert(err, IsNil)
-	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
+
+	s.se = overlord.NewStateEngine(s.state)
+	s.se.AddManager(s.snapmgr)
+	s.se.AddManager(s.runner)
+
+	AddForeignTaskHandlers(s.runner, s.fakeBackend)
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
@@ -59,9 +66,19 @@ func (s *prepareSnapSuite) SetUpTest(c *C) {
 	}
 }
 
-func (s *prepareSnapSuite) TearDownTest(c *C) {
+func (s *baseHandlerSuite) SetUpTest(c *C) {
+	s.setup(c, nil)
+}
+
+func (s *baseHandlerSuite) TearDownTest(c *C) {
 	s.reset()
 }
+
+type prepareSnapSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&prepareSnapSuite{})
 
 func (s *prepareSnapSuite) TestDoPrepareSnapSimple(c *C) {
 	s.state.Lock()
@@ -75,8 +92,8 @@ func (s *prepareSnapSuite) TestDoPrepareSnapSimple(c *C) {
 
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -27,7 +27,6 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -35,41 +34,23 @@ import (
 )
 
 type prereqSuite struct {
-	state     *state.State
-	snapmgr   *snapstate.SnapManager
+	baseHandlerSuite
+
 	fakeStore *fakeStore
-
-	fakeBackend *fakeSnappyBackend
-
-	reset func()
 }
 
 var _ = Suite(&prereqSuite{})
 
 func (s *prereqSuite) SetUpTest(c *C) {
-	dirs.SetRootDir(c.MkDir())
-	s.fakeBackend = &fakeSnappyBackend{}
-	s.state = state.New(nil)
-	s.state.Lock()
-	defer s.state.Unlock()
+	s.setup(c, nil)
 
 	s.fakeStore = &fakeStore{
 		state:       s.state,
 		fakeBackend: s.fakeBackend,
 	}
+	s.state.Lock()
+	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
-
-	var err error
-	s.snapmgr, err = snapstate.Manager(s.state)
-	c.Assert(err, IsNil)
-	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
-	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
-
-	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
-}
-
-func (s *prereqSuite) TearDownTest(c *C) {
-	s.reset()
 }
 
 func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {
@@ -94,8 +75,8 @@ func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {
 	s.state.NewChange("dummy", "...").AddTask(t)
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -119,8 +100,8 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 	chg.AddTask(t)
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -182,7 +163,7 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 	defer restore()
 
 	calls := 0
-	s.snapmgr.AddAdhocTaskHandler("link-snap",
+	s.runner.AddHandler("link-snap",
 		func(task *state.Task, _ *tomb.Tomb) error {
 			if calls == 0 {
 				// retry again later, this forces ordering of
@@ -236,8 +217,8 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 	for i := 0; i < 10; i++ {
 		time.Sleep(1 * time.Millisecond)
 		s.state.Unlock()
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 		s.state.Lock()
 		if tCore.Status() == state.DoneStatus {
 			break
@@ -253,8 +234,8 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 	for i := 0; i < 50; i++ {
 		time.Sleep(10 * time.Millisecond)
 		s.state.Unlock()
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 		s.state.Lock()
 		if t.Status() == state.DoneStatus {
 			break
@@ -283,8 +264,8 @@ func (s *prereqSuite) TestDoPrereqChannelEnvvars(c *C) {
 	chg.AddTask(t)
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -349,8 +330,8 @@ func (s *prereqSuite) TestDoPrereqNothingToDoForBase(c *C) {
 		s.state.NewChange("dummy", "...").AddTask(t)
 		s.state.Unlock()
 
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
+		s.se.Ensure()
+		s.se.Wait()
 
 		s.state.Lock()
 		c.Assert(s.fakeBackend.ops, HasLen, 0)
@@ -371,8 +352,8 @@ func (s *prereqSuite) TestDoPrereqNothingToDoForSnapdSnap(c *C) {
 	s.state.NewChange("dummy", "...").AddTask(t)
 	s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+	s.se.Ensure()
+	s.se.Wait()
 
 	s.state.Lock()
 	c.Assert(s.fakeBackend.ops, HasLen, 0)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -51,8 +51,6 @@ type SnapManager struct {
 	catalogRefresh *catalogRefresh
 
 	lastUbuntuCoreTransitionAttempt time.Time
-
-	runner *state.TaskRunner
 }
 
 // SnapSetup holds the necessary snap details to perform most snap manager tasks.
@@ -298,13 +296,10 @@ func Store(st *state.State) StoreService {
 }
 
 // Manager returns a new snap manager.
-func Manager(st *state.State) (*SnapManager, error) {
-	runner := state.NewTaskRunner(st)
-
+func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	m := &SnapManager{
 		state:          st,
 		backend:        backend.Backend{},
-		runner:         runner,
 		autoRefresh:    newAutoRefresh(st),
 		refreshHints:   newRefreshHints(st),
 		catalogRefresh: newCatalogRefresh(st),
@@ -362,7 +357,7 @@ func Manager(st *state.State) (*SnapManager, error) {
 	runner.AddHandler("switch-snap", m.doSwitchSnap, nil)
 
 	// control serialisation
-	runner.SetBlocked(m.blockedTask)
+	runner.AddBlocked(m.blockedTask)
 
 	writeSnapReadme()
 
@@ -543,8 +538,6 @@ func (m *SnapManager) Ensure() error {
 		m.catalogRefresh.Ensure(),
 	}
 
-	m.runner.Ensure()
-
 	//FIXME: use firstErr helper
 	for _, e := range errs {
 		if e != nil {
@@ -556,15 +549,14 @@ func (m *SnapManager) Ensure() error {
 }
 
 func (m *SnapManager) KnownTaskKinds() []string {
-	return m.runner.KnownTaskKinds()
+	// XXX go away
+	return nil
 }
 
 // Wait implements StateManager.Wait.
 func (m *SnapManager) Wait() {
-	m.runner.Wait()
 }
 
 // Stop implements StateManager.Stop.
 func (m *SnapManager) Stop() {
-	m.runner.Stop()
 }

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -537,7 +537,7 @@ func (ts *taskRunnerSuite) TestRetryAfterDuration(c *C) {
 	c.Check(t.AtTime().IsZero(), Equals, true)
 }
 
-func (ts *taskRunnerSuite) TestTaskSerialization(c *C) {
+func (ts *taskRunnerSuite) testTaskSerialization(c *C, setupBlocked func(r *state.TaskRunner)) {
 	ensureBeforeTick := make(chan bool, 1)
 	sb := &stateBackend{
 		ensureBefore:     time.Hour,
@@ -559,17 +559,8 @@ func (ts *taskRunnerSuite) TestTaskSerialization(c *C) {
 		return nil
 	}, nil)
 
-	// start first do1, and then do2 when nothing else is running
-	startedDo1 := false
-	r.SetBlocked(func(t *state.Task, running []*state.Task) bool {
-		if t.Kind() == "do2" && (len(running) != 0 || !startedDo1) {
-			return true
-		}
-		if t.Kind() == "do1" {
-			startedDo1 = true
-		}
-		return false
-	})
+	// setup blocked predicates
+	setupBlocked(r)
 
 	st.Lock()
 	chg := st.NewChange("install", "...")
@@ -620,6 +611,41 @@ func (ts *taskRunnerSuite) TestTaskSerialization(c *C) {
 
 	// no more EnsureBefore calls
 	c.Check(ensureBeforeTick, HasLen, 0)
+}
+
+func (ts *taskRunnerSuite) TestTaskSerializationSetBlocked(c *C) {
+	// start first do1, and then do2 when nothing else is running
+	startedDo1 := false
+	ts.testTaskSerialization(c, func(r *state.TaskRunner) {
+		r.SetBlocked(func(t *state.Task, running []*state.Task) bool {
+			if t.Kind() == "do2" && (len(running) != 0 || !startedDo1) {
+				return true
+			}
+			if t.Kind() == "do1" {
+				startedDo1 = true
+			}
+			return false
+		})
+	})
+}
+
+func (ts *taskRunnerSuite) TestTaskSerializationAddBlocked(c *C) {
+	// start first do1, and then do2 when nothing else is running
+	startedDo1 := false
+	ts.testTaskSerialization(c, func(r *state.TaskRunner) {
+		r.AddBlocked(func(t *state.Task, running []*state.Task) bool {
+			if t.Kind() == "do2" && (len(running) != 0 || !startedDo1) {
+				return true
+			}
+			return false
+		})
+		r.AddBlocked(func(t *state.Task, running []*state.Task) bool {
+			if t.Kind() == "do1" {
+				startedDo1 = true
+			}
+			return false
+		})
+	})
 }
 
 func (ts *taskRunnerSuite) TestPrematureChangeReady(c *C) {


### PR DESCRIPTION
This is the start of the work toward having a single shared task runner created and held by Overlord and passed in to each manager for use. This starts from snapstate and the creation of such a TaskRunner. Notice that this TaskRunner itself could be plugged by basically adding it to the StateEngine as the last manager.

Given that many tests now need to run the Ensure of  possibly both the manager and the TaskRunner but the Wait of the TaskRunner use a test created StateEngine holding both or the one from the main Overlord as sensible.