### PR TITLE
tests: change the service snap used instead of network-bind-consumer

### DIFF
--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -10,7 +10,12 @@ make_snap() {
     if [ ! -f "$SNAP_FILE" ]; then
         snap pack "$SNAP_DIR" "$SNAP_DIR" >/dev/null
     fi
-    echo "$SNAP_FILE"
+    # echo the snap name
+    if [ -f "$SNAP_FILE" ]; then
+        echo "$SNAP_FILE"
+    else
+        find "$TESTSLIB/snaps/${SNAP_NAME}" -name *.snap | head -n1
+    fi
 }
 
 install_local() {

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -14,7 +14,7 @@ make_snap() {
     if [ -f "$SNAP_FILE" ]; then
         echo "$SNAP_FILE"
     else
-        find "$TESTSLIB/snaps/${SNAP_NAME}" -name *.snap | head -n1
+        find "$TESTSLIB/snaps/${SNAP_NAME}" -name '*.snap' | head -n1
     fi
 }
 

--- a/tests/lib/snaps/network-bind-consumer/bin/consumer
+++ b/tests/lib/snaps/network-bind-consumer/bin/consumer
@@ -16,7 +16,7 @@ class testRequestHandler(BaseHTTPRequestHandler):
 def run():
     server_address = ('localhost', 8081)
     httpd = HTTPServer(server_address, testRequestHandler)
-    httpd.serve_forever()
+    httpd.serve_forever(poll_interval=0.5)
 
 if __name__ == '__main__':
   sys.exit(run())

--- a/tests/lib/snaps/network-bind-consumer/bin/consumer
+++ b/tests/lib/snaps/network-bind-consumer/bin/consumer
@@ -16,7 +16,7 @@ class testRequestHandler(BaseHTTPRequestHandler):
 def run():
     server_address = ('localhost', 8081)
     httpd = HTTPServer(server_address, testRequestHandler)
-    httpd.serve_forever(poll_interval=0.5)
+    httpd.serve_forever()
 
 if __name__ == '__main__':
   sys.exit(run())

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -31,12 +31,6 @@ prepare: |
 
     EOF
 
-restore: |
-    # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
-    # are sent after the journalctl cursor for following test is determined producing errors while
-    # preparing the test.
-    snap remove network-bind-consumer
-
 execute: |
     echo "The interface is connected by default"
     snap interfaces -i network-bind | MATCH ":network-bind .*$SNAP_NAME"

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -31,12 +31,6 @@ prepare: |
 
     EOF
 
-restore: |
-    # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
-    # are sent after the journalctl cursor for following test is determined producing errors while
-    # preparing the test.
-    snap remove network-bind-consumer
-
 execute: |
     echo "The interface is connected by default"
     snap interfaces -i network-bind | MATCH ":network-bind .*$SNAP_NAME"
@@ -60,3 +54,8 @@ execute: |
     echo "Then the service is not accessible by a client"
     response=$(nc -w 2 localhost "$PORT" < $REQUEST_FILE)
     [ "$response" = "" ]
+
+    # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
+    # are sent after the journalctl cursor for following test is determined producing errors while
+    # preparing the test.
+    snap remove network-bind-consumer

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -31,15 +31,15 @@ prepare: |
 
     EOF
 
+restore: |
+    # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
+    # are sent after the journalctl cursor for following test is determined producing errors while
+    # preparing the test.
+    snap remove network-bind-consumer
+
 execute: |
     echo "The interface is connected by default"
     snap interfaces -i network-bind | MATCH ":network-bind .*$SNAP_NAME"
-
-    echo "When the plug is disconnected"
-    snap disconnect $SNAP_NAME:network-bind
-
-    echo "Then the plug can be connected again"
-    snap connect $SNAP_NAME:network-bind
 
     echo "Then the service is accessible by a client"
     nc -w 2 localhost "$PORT" < $REQUEST_FILE | grep -Pqz "ok\n"
@@ -55,7 +55,5 @@ execute: |
     response=$(nc -w 2 localhost "$PORT" < $REQUEST_FILE)
     [ "$response" = "" ]
 
-    # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
-    # are sent after the journalctl cursor for following test is determined producing errors while
-    # preparing the test.
-    snap remove network-bind-consumer
+    echo "Then the plug can be connected again"
+    snap connect $SNAP_NAME:network-bind

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -31,6 +31,12 @@ prepare: |
 
     EOF
 
+restore: |
+    # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
+    # are sent after the journalctl cursor for following test is determined producing errors while
+    # preparing the test.
+    snap remove network-bind-consumer
+
 execute: |
     echo "The interface is connected by default"
     snap interfaces -i network-bind | MATCH ":network-bind .*$SNAP_NAME"

--- a/tests/main/systemd-service/task.yaml
+++ b/tests/main/systemd-service/task.yaml
@@ -1,13 +1,13 @@
 summary: Check that a service installed by a snap is reported as active by systemd
 
 environment:
-    SERVICE_NAME: snap.test-snapd-service-try.service.service
+    SERVICE_NAME: snap.test-snapd-service.test-snapd-service.service
 
 execute: |
     . "$TESTSLIB/snaps.sh"
 
     echo "Given a service snap is installed"
-    install_local test-snapd-service-try-v2
+    install_local test-snapd-service
 
     echo "When the service state is reported as active"
     while ! systemctl show -p ActiveState $SERVICE_NAME | grep -Pq "ActiveState=active"; do sleep 0.5; done

--- a/tests/main/systemd-service/task.yaml
+++ b/tests/main/systemd-service/task.yaml
@@ -1,12 +1,13 @@
 summary: Check that a service installed by a snap is reported as active by systemd
 
 environment:
-    SERVICE_NAME: snap.network-bind-consumer.network-consumer.service
+    SERVICE_NAME: snap.test-snapd-service-try.service.service
 
 execute: |
+    . "$TESTSLIB/snaps.sh"
+
     echo "Given a service snap is installed"
-    snap pack $TESTSLIB/snaps/network-bind-consumer
-    snap install --dangerous network-bind-consumer_1.0_all.snap
+    install_local test-snapd-service-try-v2
 
     echo "When the service state is reported as active"
     while ! systemctl show -p ActiveState $SERVICE_NAME | grep -Pq "ActiveState=active"; do sleep 0.5; done
@@ -14,5 +15,6 @@ execute: |
     echo "Then systemctl reports the status of the service as loaded, active and running"
     expected="(?s).*?Loaded: loaded .*?Active: active \(running\)"
     systemctl status $SERVICE_NAME | grep -Pqz "$expected"
+
 restore: |
     rm -f *.snap

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -5,7 +5,7 @@ details: |
 
 environment:
     SNAP_NAME/test_snapd_tools: test-snapd-tools
-    SNAP_NAME/test-snapd-service-try-v2: test-snapd-service-try-v2
+    SNAP_NAME/test_snapd_service_try_v2: test-snapd-service-try-v2
     TRYDIR: $(pwd)/trydir
 
 restore: |

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -5,7 +5,7 @@ details: |
 
 environment:
     SNAP_NAME/test_snapd_tools: test-snapd-tools
-    SNAP_NAME/test_snapd_service_try_v2: test-snapd-service-try-v2
+    SNAP_NAME/test_snapd_service: test-snapd-service
     TRYDIR: $(pwd)/trydir
 
 restore: |

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -5,7 +5,7 @@ details: |
 
 environment:
     SNAP_NAME/test_snapd_tools: test-snapd-tools
-    SNAP_NAME/network_bind_consumer: network-bind-consumer
+    SNAP_NAME/test-snapd-service-try-v2: test-snapd-service-try-v2
     TRYDIR: $(pwd)/trydir
 
 restore: |

--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -12,16 +12,16 @@ priority: 100
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
-    install_local network-bind-consumer
+    install_local test-snapd-service-try-v2
 
 execute: |
     echo "Ensure snaps are (still) there."
     snap list | MATCH test-snapd-tools
-    snap list | MATCH network-bind-consumer
+    snap list | MATCH test-snapd-service-try-v2
 
     echo "Ensure the service is (still) running."
     retries=120
-    while ! systemctl is-active snap.network-bind-consumer.network-consumer.service; do
+    while ! systemctl is-active snap.test-snapd-service-try.service.service; do
         if [ $retries -eq 0 ]; then
             echo "Service did not activate."
             exit 1

--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -12,16 +12,16 @@ priority: 100
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
-    install_local test-snapd-service-try-v2
+    install_local test-snapd-service
 
 execute: |
     echo "Ensure snaps are (still) there."
     snap list | MATCH test-snapd-tools
-    snap list | MATCH test-snapd-service-try-v2
+    snap list | MATCH test-snapd-service
 
     echo "Ensure the service is (still) running."
     retries=120
-    while ! systemctl is-active snap.test-snapd-service-try.service.service; do
+    while ! systemctl is-active snap.test-snapd-service.test-snapd-service.service; do
         if [ $retries -eq 0 ]; then
             echo "Service did not activate."
             exit 1


### PR DESCRIPTION
This is done to avoid this kind of issues: https://api.travis-
ci.org/v3/job/400483290/log.txt
