### PR TITLE
tests: add strace to default arch packages

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -597,6 +597,7 @@ pkg_dependencies_arch(){
     python3-yaml
     squashfs-tools
     shellcheck
+    strace
     xdg-user-dirs
     xfsprogs
     "


### PR DESCRIPTION
We currently see test failures in the snap run test on arch
because the strace-static snap does not work correctly there.

While this is being investigated we should simply use the system
strace of arch to fix the issue.

