### PR TITLE
tests/main/interfaces-timeserver-control: account for non-immediate changes with systemd >= 239

### DIFF
--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -10,7 +10,8 @@ details: |
 systems: [-debian-sid-*]
 
 prepare: |
-    . $TESTSLIB/snaps.sh
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
 
     # Install a snap declaring a plug on timeserver-control
     install_local test-snapd-timedate-control-consumer
@@ -25,7 +26,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces -i timeserver-control | MATCH "\- +test-snapd-timedate-control-consumer:timeserver-control"
+    snap interfaces -i timeserver-control | MATCH -- '- +test-snapd-timedate-control-consumer:timeserver-control'
 
     echo "When the interface is connected"
     snap connect test-snapd-timedate-control-consumer:timeserver-control
@@ -67,7 +68,7 @@ execute: |
 
     # Disconnect the interface and check access to timedatectl status
     snap disconnect test-snapd-timedate-control-consumer:timeserver-control
-    if test-snapd-timedate-control-consumer.timedatectl-timeserver status 2>${PWD}/call.error; then
+    if test-snapd-timedate-control-consumer.timedatectl-timeserver status 2> call.error; then
         echo "Expected permission error calling timedatectl status with disconnected plug"
         exit 1
     fi

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -33,13 +33,33 @@ execute: |
     # Save the default timeserver to be restored at the end
     test-snapd-timedate-control-consumer.timedatectl-timeserver status | grep -oP '(Network time on|System clock synchronized): \K(.*)' > timeserver.txt
 
+    get_ntp_status() {
+        test-snapd-timedate-control-consumer.timedatectl-timeserver status | \
+            grep -oP '(Network time on|System clock synchronized): \K(.*)'
+    }
+
+    # NOTE: with systemd >= 239, switching the ntp setting it takes a while for
+    # it to become visible
+
     # Set the ntp value and check the status
     test-snapd-timedate-control-consumer.timedatectl-timeserver set-ntp yes
-    [ "$(test-snapd-timedate-control-consumer.timedatectl-timeserver status | grep -oP '(Network time on|System clock synchronized): \K(.*)')" = "yes" ]
+    for _ in $(seq 10); do
+        if [ "$(get_ntp_status)" = "yes" ] ; then
+            break
+        fi
+        sleep 1
+    done
+    [ "$(get_ntp_status)" = "yes" ]
 
     # Set the ntp value and check the status
     test-snapd-timedate-control-consumer.timedatectl-timeserver set-ntp no
-    [ "$(test-snapd-timedate-control-consumer.timedatectl-timeserver status | grep -oP '(Network time on|System clock synchronized): \K(.*)')" = "no" ]
+    for _ in $(seq 10); do
+        if [ "$(get_ntp_status)" = "no" ]; then
+            break
+        fi
+        sleep 1
+    done
+    [ "$(get_ntp_status)" = "no" ]
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0

--- a/tests/unit/spread-shellcheck/can-fail
+++ b/tests/unit/spread-shellcheck/can-fail
@@ -27,7 +27,6 @@ tests/main/interfaces-ssh-keys/task.yaml
 tests/main/interfaces-ssh-public-keys/task.yaml
 tests/main/interfaces-system-observe/task.yaml
 tests/main/interfaces-time-control/task.yaml
-tests/main/interfaces-timeserver-control/task.yaml
 tests/main/interfaces-timezone-control/task.yaml
 tests/main/interfaces-udev/task.yaml
 tests/main/interfaces-uhid/task.yaml


### PR DESCRIPTION
With systemd updated to 239 on Arch, the test started to fail. After
investigation the switching on set-ntp setting was found to have a non-immediate
effect. Add a relevant workaround in the test.
