### PR TITLE
tests/interfaces-contacts-service: use random XDG dir via mktemp

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -7,7 +7,7 @@ systems:
     - -ubuntu-14.04-*
 
 environment:
-    XDG: $(pwd)/xdg
+    XDG: $(mktemp -d -p $(pwd) xdgXXXXXXXX)
     XDG_CONFIG_HOME: $XDG/config
     XDG_DATA_HOME: $XDG/share
     XDG_CACHE_HOME: $XDG/cache


### PR DESCRIPTION
The interfaces-contacts-service is still a bit flaky (it's better than before, but not ideal); I hit an issue with this test twice today when running spread suite locally, however when I was dropped in the shell to debug it, I couldn't trigger the error manually folliwing what we do in the task.yaml. It looks like something prevents proper cleanup sometimes, and it's for a brief moment only, so it's hard to reproduce.

This PR makes the test use a unique temporary directory for XDG root. Not ideal but I'd like to see if it eliminates the failures.