### PR TITLE
tests: prepare needs to handle bin/snapctl being a symlink

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -106,12 +106,17 @@ update_core_snap_for_classic_reexec() {
 
     # Now unpack the core, inject the new snap-exec/snapctl into it
     unsquashfs "$snap"
-    # clean the old snapd libexec binaries, just in case
-    rm squashfs-root/usr/lib/snapd/*
-    # and copy in the current ones
+    # clean the old snapd binaries, just in case
+    rm squashfs-root/usr/lib/snapd/* squashfs-root/usr/bin/{snap,snapctl}
+    # and copy in the current libexec
     cp -a "$LIBEXECDIR"/snapd/* squashfs-root/usr/lib/snapd/
     # also the binaries themselves
     cp -a /usr/bin/{snap,snapctl} squashfs-root/usr/bin/
+    # make sure bin/snapctl is a symlink to lib/
+    if [ ! -L squashfs-root/usr/bin/snapctl ]; then
+        mv squashfs-root/usr/bin/snapctl squashfs-root/usr/lib/snapd
+        ln -s ../lib/snapd/snapctl squashfs-root/usr/bin/snapctl
+    fi
 
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)


### PR DESCRIPTION
in particular, update_core_snap_for_classic_reexec wasn't handling it
at all well.
