### PR TITLE
snap/squashfs, tests: pass -n[o-progress] to {mk,un}squashfs

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -142,8 +142,9 @@ func (u *unsquashfsStderrWriter) Err() error {
 func (s *Snap) Unpack(src, dstDir string) error {
 	usw := newUnsquashfsStderrWriter()
 
-	cmd := exec.Command("unsquashfs", "-f", "-d", dstDir, s.path, src)
+	cmd := exec.Command("unsquashfs", "-n", "-f", "-d", dstDir, s.path, src)
 	cmd.Stderr = usw
+	cmd.Stdout = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return err
 	}
@@ -172,7 +173,7 @@ func (s *Snap) ReadFile(filePath string) (content []byte, err error) {
 	defer os.RemoveAll(tmpdir)
 
 	unpackDir := filepath.Join(tmpdir, "unpack")
-	if err := exec.Command("unsquashfs", "-i", "-d", unpackDir, s.path, filePath).Run(); err != nil {
+	if err := exec.Command("unsquashfs", "-n", "-i", "-d", unpackDir, s.path, filePath).Run(); err != nil {
 		return nil, err
 	}
 
@@ -311,6 +312,7 @@ func (s *Snap) Build(buildDir string) error {
 			"-comp", "xz",
 			"-no-xattrs",
 			"-no-fragments",
+			"-no-progress",
 		).Run()
 	})
 }
@@ -330,7 +332,7 @@ func BuildDate(path string) time.Time {
 		N:      1,
 	}
 
-	cmd := exec.Command("unsquashfs", "-s", path)
+	cmd := exec.Command("unsquashfs", "-n", "-s", path)
 	cmd.Env = []string{"TZ=UTC"}
 	cmd.Stdout = m
 	cmd.Stderr = m

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -105,7 +105,7 @@ update_core_snap_for_classic_reexec() {
     umount --verbose "$core"
 
     # Now unpack the core, inject the new snap-exec/snapctl into it
-    unsquashfs "$snap"
+    unsquashfs -no-progress "$snap"
     # clean the old snapd binaries, just in case
     rm squashfs-root/usr/lib/snapd/* squashfs-root/usr/bin/{snap,snapctl}
     # and copy in the current libexec
@@ -305,7 +305,7 @@ setup_reflash_magic() {
     if is_core18_system; then
         # modify the snapd snap so that it has our snapd
         UNPACK_DIR="/tmp/snapd-snap"
-        unsquashfs -d "$UNPACK_DIR" snapd_*.snap
+        unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
         dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
         snap pack "$UNPACK_DIR" "$IMAGE_HOME"
         
@@ -340,7 +340,7 @@ setup_reflash_magic() {
         # modify the core snap so that the current root-pw works there
         # for spread to do the first login
         UNPACK_DIR="/tmp/core-snap"
-        unsquashfs -d "$UNPACK_DIR" /var/lib/snapd/snaps/core_*.snap
+        unsquashfs -no-progress -d "$UNPACK_DIR" /var/lib/snapd/snaps/core_*.snap
 
         # FIXME: install would be better but we don't have dpkg on
         #        the image
@@ -431,7 +431,7 @@ EOF
     # now modify the image
     if is_core18_system; then
         UNPACK_DIR="/tmp/core18-snap"
-        unsquashfs -d "$UNPACK_DIR" /var/lib/snapd/snaps/core18_*.snap
+        unsquashfs -no-progress -d "$UNPACK_DIR" /var/lib/snapd/snaps/core18_*.snap
     fi
 
     # create test user and ubuntu user inside the writable partition
@@ -516,7 +516,7 @@ EOF
     # the writeable-path sync-boot won't work
     mkdir -p /mnt/system-data/etc/systemd
 
-    (cd /tmp ; unsquashfs -v  /var/lib/snapd/snaps/"$core_name"_*.snap etc/systemd/system)
+    (cd /tmp ; unsquashfs -no-progress -v  /var/lib/snapd/snaps/"$core_name"_*.snap etc/systemd/system)
     cp -avr /tmp/squashfs-root/etc/systemd/system /mnt/system-data/etc/systemd/
     umount /mnt
     kpartx -d  "$IMAGE_HOME/$IMAGE"

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -41,9 +41,9 @@ mksnap_fast() {
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         # trusty does not support  -Xcompression-level 1
-        mksquashfs "$dir" "$snap" -comp gzip -no-fragments
+        mksquashfs "$dir" "$snap" -comp gzip -no-fragments -no-progress
     else
-        mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1 -no-fragments
+        mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1 -no-fragments -no-progress
     fi
 }
 

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -79,7 +79,7 @@ execute: |
         snap list | awk "/^${TARGET_SNAP_NAME} / {print(\$3)}" > prevBoot
 
         # unpack current target snap
-        unsquashfs -d "$BUILD_DIR/unpack" "/var/lib/snapd/snaps/${TARGET_SNAP_NAME}_$(cat prevBoot).snap"
+        unsquashfs -no-progress -d "$BUILD_DIR/unpack" "/var/lib/snapd/snaps/${TARGET_SNAP_NAME}_$(cat prevBoot).snap"
 
         # set failure condition
         eval "${INJECT_FAILURE}"

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -22,7 +22,7 @@ prepare: |
 
     # We will also need to prepare a hacked core snap that just differs from
     # our own in some detail that we can measure.
-    unsquashfs $(ls /var/lib/snapd/snaps/core_*.snap | sort -r -n | head -n 1)
+    unsquashfs -no-progress $(ls /var/lib/snapd/snaps/core_*.snap | sort -r -n | head -n 1)
     touch squashfs-root/customized
     sed -i -e 's/version: .*/version: customized/' squashfs-root/meta/snap.yaml
 

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -13,10 +13,10 @@ prepare: |
     rm -rf /var/lib/snapd/assertions/*
     rm -rf /var/lib/snapd/device
     rm -rf /var/lib/snapd/state.json
-    unsquashfs /var/lib/snapd/snaps/pc_*.snap
+    unsquashfs -no-progress /var/lib/snapd/snaps/pc_*.snap
     mkdir -p squashfs-root/meta/hooks
     cp prepare-device squashfs-root/meta/hooks
-    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
+    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments -no-progress
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     mv /var/lib/snapd/seed/assertions/model model.bak

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -12,10 +12,10 @@ prepare: |
     rm -rf /var/lib/snapd/assertions/*
     rm -rf /var/lib/snapd/device
     rm -rf /var/lib/snapd/state.json
-    unsquashfs /var/lib/snapd/snaps/pc_*.snap
+    unsquashfs -no-progress /var/lib/snapd/snaps/pc_*.snap
     mkdir -p squashfs-root/meta/hooks
     cp prepare-device squashfs-root/meta/hooks
-    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
+    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments -no-progress
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     mv /var/lib/snapd/seed/assertions/model model.bak

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -13,7 +13,7 @@ prepare: |
     rm -rf /var/lib/snapd/device
     rm -rf /var/lib/snapd/state.json
     snap download --edge test-snapd-with-configure
-    unsquashfs /var/lib/snapd/snaps/pc_*.snap
+    unsquashfs -no-progress /var/lib/snapd/snaps/pc_*.snap
     # fill in defaults
     TEST_SNAP_ID=
     if [ "$SNAPPY_USE_STAGING_STORE" = 1 ]; then
@@ -32,7 +32,7 @@ prepare: |
            rsyslog:
              disable: true
     EOF
-    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
+    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments -no-progress
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     cp test-snapd-with-configure_*.snap /var/lib/snapd/seed/snaps/


### PR DESCRIPTION
We were logging a lot of progress bars during tests, and it seems wasteful. This puts an end to that.