### PR TITLE
snap: support hook environment

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -689,6 +689,8 @@ type HookInfo struct {
 	Name  string
 	Plugs map[string]*PlugInfo
 	Slots map[string]*SlotInfo
+
+	Environment strutil.OrderedMap
 }
 
 // File returns the path to the *.socket file
@@ -796,7 +798,12 @@ func (hook *HookInfo) SecurityTag() string {
 
 // Env returns the hook-specific environment overrides
 func (hook *HookInfo) Env() []string {
-	return envFromMap(hook.Snap.Environment.Copy())
+	hookEnv := hook.Snap.Environment.Copy()
+	for _, k := range hook.Environment.Keys() {
+		hookEnv.Set(k, hook.Environment.Get(k))
+	}
+
+	return envFromMap(hookEnv)
 }
 
 func envFromMap(envMap *strutil.OrderedMap) []string {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -91,8 +91,9 @@ type appYaml struct {
 }
 
 type hookYaml struct {
-	PlugNames []string `yaml:"plugs,omitempty"`
-	SlotNames []string `yaml:"slots,omitempty"`
+	PlugNames   []string           `yaml:"plugs,omitempty"`
+	SlotNames   []string           `yaml:"slots,omitempty"`
+	Environment strutil.OrderedMap `yaml:"environment,omitempty"`
 }
 
 type layoutYaml struct {
@@ -387,8 +388,9 @@ func setHooksFromSnapYaml(y snapYaml, snap *Info) {
 
 		// Collect all hooks
 		hook := &HookInfo{
-			Snap: snap,
-			Name: hookName,
+			Snap:        snap,
+			Name:        hookName,
+			Environment: yHook.Environment,
 		}
 		if len(y.Plugs) > 0 || len(yHook.PlugNames) > 0 {
 			hook.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1528,6 +1528,21 @@ apps:
 	c.Assert(info.Apps["foo"].Environment, DeepEquals, *strutil.NewOrderedMap("k1", "v1", "k2", "v2"))
 }
 
+func (s *YamlSuite) TestSnapYamlPerHookEnvironment(c *C) {
+	y := []byte(`
+name: foo
+version: 1.0
+hooks:
+ foo:
+  environment:
+   k1: v1
+   k2: v2
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, IsNil)
+	c.Assert(info.Hooks["foo"].Environment, DeepEquals, *strutil.NewOrderedMap("k1", "v1", "k2", "v2"))
+}
+
 // classic confinement
 func (s *YamlSuite) TestClassicConfinement(c *C) {
 	y := []byte(`

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -523,7 +523,7 @@ apps:
 	})
 }
 
-func (s *infoSuite) TestHookTakesGlobalEnv(c *C) {
+func (s *infoSuite) TestHookEnvSimple(c *C) {
 	yaml := `name: foo
 version: 1.0
 type: app
@@ -531,6 +531,8 @@ environment:
  global-k: global-v
 hooks:
  foo:
+  environment:
+   app-k: app-v
 `
 	info, err := snap.InfoFromSnapYaml([]byte(yaml))
 	c.Assert(err, IsNil)
@@ -538,6 +540,32 @@ hooks:
 	env := info.Hooks["foo"].Env()
 	sort.Strings(env)
 	c.Check(env, DeepEquals, []string{
+		"app-k=app-v",
+		"global-k=global-v",
+	})
+}
+
+func (s *infoSuite) TestHookEnvOverrideGlobal(c *C) {
+	yaml := `name: foo
+version: 1.0
+type: app
+environment:
+ global-k: global-v
+ global-and-local: global-v
+hooks:
+ foo:
+  environment:
+   app-k: app-v
+   global-and-local: local-v
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yaml))
+	c.Assert(err, IsNil)
+
+	env := info.Hooks["foo"].Env()
+	sort.Strings(env)
+	c.Check(env, DeepEquals, []string{
+		"app-k=app-v",
+		"global-and-local=local-v",
 		"global-k=global-v",
 	})
 }

--- a/tests/lib/snaps/basic-hooks/meta/snap.yaml
+++ b/tests/lib/snaps/basic-hooks/meta/snap.yaml
@@ -4,3 +4,8 @@ environment:
   TEST_SNAP: $SNAP
   TEST_COMMON: $SNAP_COMMON
   TEST_DATA: $SNAP_DATA
+
+hooks:
+  configure:
+    environment:
+      TEST_EXTRA: extra-stuff

--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -50,3 +50,4 @@ execute: |
     cat $ENVDUMP | MATCH "^TEST_COMMON=/var/snap/basic-hooks/common$"
     cat $ENVDUMP | MATCH "^TEST_DATA=/var/snap/basic-hooks/.*$"
     cat $ENVDUMP | MATCH "^TEST_SNAP=/snap/basic-hooks/.*$"
+    cat $ENVDUMP | MATCH "^TEST_EXTRA=extra-stuff$"


### PR DESCRIPTION
Currently, snapd supports the `environment` keyword in the root of the `snap.yaml`, as well as nested under individual `apps`. However, it does not support them under individual `hooks`. Add support for this, which lays more of the groundwork necessary for the snapcraft CLI to get rid of its wrappers.