### PR TITLE
interfaces: allow invoking systemd-notify when daemon-notify is connected

### DIFF
--- a/interfaces/builtin/daemon_notify.go
+++ b/interfaces/builtin/daemon_notify.go
@@ -41,6 +41,9 @@ const daemoNotifyBaseDeclarationSlots = `
 const daemoNotifyConnectedPlugAppArmorTemplate = `
 # Allow sending notification messages to systemd through the notify socket
 {{notify-socket-rule}},
+
+# Allow using systemd-notify in shell scripts.
+/{,usr/}bin/systemd-notify ixr,
 `
 
 type daemoNotifyInterface struct {


### PR DESCRIPTION
The systemd-notify program allows simple scripts to tap into
sd_notify(3) APIs. It can be used to signal service readiness, indicate
the main process, set custom status text and perform other miscellaneous
tasks.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>