### PR TITLE
tests: add missing slots in classic and core provider test snaps

### DIFF
--- a/tests/lib/snaps/test-snapd-policy-app-provider-classic/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-provider-classic/meta/snap.yaml
@@ -18,6 +18,7 @@ slots:
     interface: dbus
     bus: system
     name: test.system
+  fwupd: null
   location-control: null
   location-observe: null
   lxd: null
@@ -48,6 +49,9 @@ apps:
   docker:
     command: bin/run
     slots: [ docker ]
+  fwupd:
+    command: bin/run
+    slots: [ fwupd ]
   location-control:
     command: bin/run
     slots: [ location-control ]

--- a/tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml
@@ -43,6 +43,8 @@ slots:
   unity8-calendar: null
   unity8-contacts: null
   upower-observe: null
+  wayland: null
+  x11: null
 
 apps:
   avahi-control:
@@ -129,3 +131,9 @@ apps:
   upower-observe:
     command: bin/run
     slots: [ upower-observe ]
+  wayland:
+    command: bin/run
+    slots: [ wayland ]
+  x11:
+    command: bin/run
+    slots: [ x11 ]


### PR DESCRIPTION
Since there may be policy differences when a slot implementation is installed
on classic distro vs all-snaps, it is important that the testsuite generates
policy for both. When doing other work, it was discovered that when creating
the test-snapd-policy-app-provider-classic snap, the fwupd slot was omitted.
Recently, wayland and x11 were updated to be installed as app snaps, but the
test-snapd-policy-app-provider-core snap was not updated.