### PR TITLE
interfaces/pulseaudio: be clear that the interface allows playback and record

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -41,6 +41,8 @@ const pulseaudioBaseDeclarationSlots = `
 `
 
 const pulseaudioConnectedPlugAppArmor = `
+# Allow communicating with pulseaudio service for playback and, on some
+# distributions, recording.
 /{run,dev}/shm/pulse-shm-* mrwk,
 
 owner /{,var/}run/pulse/ r,


### PR DESCRIPTION
When the pulseaudio interface was first written, it was planned that it would
only support playback and that recording would come later. This was reflected
in the interface documentation at https://forum.snapcraft.io/t/interfaces/6154
until it was corrected today.

On Ubuntu Touch, pulseaudio was modified to include patches that would not
allow record but these patches were never upstreamed. Classic Ubuntu, its
flavors and derivatives (since Ubuntu 16.10) include a patch to deny audio
recording unconditionally when the connecting application is a snap
(LP: #1583057), but this patch is broken (LP: #1781428).

Upstream prefers to implement access controls instead of the patch included in
Ubuntu:
* https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/AccessControl/
* https://github.com/a-darwish/pulseaudio/commits/access-control-v1

and patches have been submitted, but still not upstreamed:
* https://cgit.freedesktop.org/%7Ewtay/pulseaudio/log/?h=access-hooks
* https://github.com/flatpak/xdg-desktop-portal/issues/27#issuecomment-228814105

Fedora 26 and later apparently have these patches with portals now supporting
pulseaudio:
* https://github.com/matthiasclasen/xdg-desktop-portal/tree/device

Until snapd/pulseaudio can mediate access to recording everywhere, we should be
clear on what may be allowed.
