### PR TITLE
interfaces/network-control: update for wpa-supplicant and ifupdown

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -101,7 +101,11 @@ network sna,
 /{,usr/}{,s}bin/arpd ixr,
 /{,usr/}{,s}bin/bridge ixr,
 /{,usr/}{,s}bin/dhclient Pxr,             # use ixr instead if want to limit to snap dirs
+/{,usr/}{,s}bin/dhclient-script ixr,
 /{,usr/}{,s}bin/ifconfig ixr,
+/{,usr/}{,s}bin/ifdown ixr,
+/{,usr/}{,s}bin/ifquery ixr,
+/{,usr/}{,s}bin/ifup ixr,
 /{,usr/}{,s}bin/ip ixr,
 /{,usr/}{,s}bin/ipmaddr ixr,
 /{,usr/}{,s}bin/iptunnel ixr,
@@ -159,6 +163,20 @@ capability setuid,
 # Required by resolvconf
 /bin/run-parts ixr,
 /etc/resolvconf/update.d/* ix,
+
+# wpa_suplicant
+/{,var/}run/wpa_supplicant/** rw,
+/etc/wpa_supplicant/{,**} ixr,
+
+#ifup,ifdown, dhclient
+/{,var/}run/dhclient.*.pid rw,
+/var/lib/dhcp/ r,
+/var/lib/dhcp/** rw,
+
+/run/network/ifstate* rw,
+/run/network/.ifstate* rw,
+/run/network/ifup-* rw,
+/run/network/ifdown-* rw,
 
 # route
 /etc/networks r,


### PR DESCRIPTION
 - allow wpa_supplicant function correctly
 - adding ifup, ifdown support

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
