### PR TITLE
cmd/snap: print unset license as "unset", instead of "unknown

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -411,7 +411,7 @@ func (x *infoCmd) Execute([]string) error {
 		}
 		license := both.License
 		if license == "" {
-			license = "unknown"
+			license = "unset"
 		}
 		fmt.Fprintf(w, "license:\t%s\n", license)
 		maybePrintPrice(w, remote, resInfo)

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -374,7 +374,7 @@ func (s *infoSuite) TestInfoWithLocalNoLicense(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
 publisher: canonical
-license:   unknown
+license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
   https://snapcraft.io/
@@ -410,7 +410,7 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
 publisher: canonical
-license:   unknown
+license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
   https://snapcraft.io/
@@ -455,7 +455,7 @@ func (s *infoSuite) TestInfoHumanTimes(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
 publisher: canonical
-license:   unknown
+license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
   https://snapcraft.io/

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -87,7 +87,7 @@ check("test-snapd-tools", res[2],
     ("edge", matches, verRevNotesRx("-")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-tools"]),
-   ("license", equals, "unknown"), # TODO: update once snap.yaml contains the right license
+   ("license", equals, "unset"), # TODO: update once snap.yaml contains the right license
 )
 
 check("test-snapd-devmode", res[3],
@@ -106,7 +106,7 @@ check("test-snapd-devmode", res[3],
     ("edge", matches, verRevNotesRx("devmode")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-devmode"]),
-   ("license", equals, "unknown"), # TODO: update once snap.yaml contains the right license
+   ("license", equals, "unset"), # TODO: update once snap.yaml contains the right license
 )
 
 check("core", res[4],
@@ -124,7 +124,7 @@ check("core", res[4],
       # sideload "core"
       ("contact", maybe),
       ("snap-id", maybe),
-      ("license", equals, "unknown"), # TODO: update once snap.yaml contains the right license
+      ("license", equals, "unset"), # TODO: update once snap.yaml contains the right license
 )
 
 check("error", res[5],


### PR DESCRIPTION
Seems I forgot to circle back on this once the store-side changes were
done.  This wording (unset vs unknown) was agreed to [ages ago][1] and
implemented for the store side but not for local snaps (resulting in a
snap with no license going from "unset" to "unknown" once installed).

More info [in the forum][1].

[1]: https://forum.snapcraft.io/t/3671/26?u=chipaca
