### PR TITLE
tests: remove unneeded setup code in snap-run-symlink

### DIFF
--- a/tests/main/snap-run-alias/task.yaml
+++ b/tests/main/snap-run-alias/task.yaml
@@ -3,9 +3,6 @@ summary: Check that alias symlinks work correctly
 systems: [-ubuntu-core-*]
 
 prepare: |
-    echo Ensure we have a os snap with snap run
-    $TESTSLIB/reset.sh
-    snap install --channel=beta core
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
 

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -3,9 +3,6 @@ summary: Check that symlinks to /usr/bin/snap trigger `snap run`
 systems: [-ubuntu-core-*]
 
 prepare: |
-    echo Ensure we have a os snap with snap run
-    $TESTSLIB/reset.sh
-    snap install --channel=beta core
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
 


### PR DESCRIPTION
Thanks to Samuele
