### PR TITLE
interfaces/builtin: create can-bus interface (2.34)

### DIFF
--- a/interfaces/builtin/can_bus.go
+++ b/interfaces/builtin/can_bus.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const canBusSummary = `allows access to the CAN bus`
+
+const canBusBaseDeclarationSlots = `
+  can-bus:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const canBusConnectedPlugAppArmor = `
+# Description: Can use CAN networking
+network can,
+`
+
+const canBusConnectedPlugSecComp = `
+# Description: Can use CAN networking
+bind
+
+# We allow AF_CAN in the default template since it is mediated via the AppArmor rule
+#socket AF_CAN
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "can-bus",
+		summary:               canBusSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  canBusBaseDeclarationSlots,
+		connectedPlugAppArmor: canBusConnectedPlugAppArmor,
+		connectedPlugSecComp:  canBusConnectedPlugSecComp,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/can_bus_test.go
+++ b/interfaces/builtin/can_bus_test.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type CanBusInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&CanBusInterfaceSuite{
+	iface: builtin.MustInterface("can-bus"),
+})
+
+const canBusConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [can-bus]
+`
+
+const canBusCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  can-bus:
+`
+
+func (s *CanBusInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, canBusConsumerYaml, nil, "can-bus")
+	s.slot, s.slotInfo = MockConnectedSlot(c, canBusCoreYaml, nil, "can-bus")
+}
+
+func (s *CanBusInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "can-bus")
+}
+
+func (s *CanBusInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "can-bus",
+		Interface: "can-bus",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"can-bus slots are reserved for the core snap")
+}
+
+func (s *CanBusInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *CanBusInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "network can,\n")
+}
+
+func (s *CanBusInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "bind\n")
+}
+
+func (s *CanBusInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to the CAN bus`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "can-bus")
+}
+
+func (s *CanBusInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -266,6 +266,9 @@ apps:
   service-watchdog:
     command: bin/run
     plugs: [ daemon-notify ]
+  can-bus:
+    command: bin/run
+    plugs: [ can-bus ]
   ssh-keys:
     command: bin/run
     plugs: [ ssh-keys ]


### PR DESCRIPTION
This is #5279 for the 2.34 branch.