### PR TITLE
daemon: make sure most change generating handlers can produce errors with kinds

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1203,79 +1203,11 @@ func (inst *snapInstruction) dispatch() snapActionFunc {
 }
 
 func (inst *snapInstruction) errToResponse(err error) Response {
-	var kind errorKind
-	var snapName string
-
-	switch err {
-	case store.ErrSnapNotFound:
-		switch len(inst.Snaps) {
-		case 1:
-			return SnapNotFound(inst.Snaps[0], err)
-		// store.ErrSnapNotFound should only be returned for individual
-		// snap queries; in all other cases something's wrong
-		case 0:
-			return InternalError("store.SnapNotFound with no snap given")
-		default:
-			return InternalError("store.SnapNotFound with %d snaps", len(inst.Snaps))
-		}
-	case store.ErrNoUpdateAvailable:
-		kind = errorKindSnapNoUpdateAvailable
-	case store.ErrLocalSnap:
-		kind = errorKindSnapLocal
-	default:
-		handled := true
-		switch err := err.(type) {
-		case *store.RevisionNotAvailableError:
-			// store.ErrRevisionNotAvailable should only be returned for
-			// individual snap queries; in all other cases something's wrong
-			switch len(inst.Snaps) {
-			case 1:
-				return SnapRevisionNotAvailable(inst.Snaps[0], err)
-			case 0:
-				return InternalError("store.RevisionNotAvailable with no snap given")
-			default:
-				return InternalError("store.RevisionNotAvailable with %d snaps", len(inst.Snaps))
-			}
-		case *snap.AlreadyInstalledError:
-			kind = errorKindSnapAlreadyInstalled
-			snapName = err.Snap
-		case *snap.NotInstalledError:
-			kind = errorKindSnapNotInstalled
-			snapName = err.Snap
-		case *snapstate.ChangeConflictError:
-			return SnapChangeConflict(err)
-		case *snapstate.SnapNeedsDevModeError:
-			kind = errorKindSnapNeedsDevMode
-			snapName = err.Snap
-		case *snapstate.SnapNeedsClassicError:
-			kind = errorKindSnapNeedsClassic
-			snapName = err.Snap
-		case *snapstate.SnapNeedsClassicSystemError:
-			kind = errorKindSnapNeedsClassicSystem
-			snapName = err.Snap
-		case net.Error:
-			if err.Timeout() {
-				kind = errorKindNetworkTimeout
-			} else {
-				handled = false
-			}
-		default:
-			handled = false
-		}
-
-		if !handled {
-			if len(inst.Snaps) == 0 {
-				return BadRequest("cannot %s: %v", inst.Action, err)
-			}
-			return BadRequest("cannot %s %s: %v", inst.Action, strutil.Quoted(inst.Snaps), err)
-		}
+	if len(inst.Snaps) == 0 {
+		return errToResponse(err, nil, BadRequest, "cannot %s: %v", inst.Action)
 	}
 
-	return SyncResponse(&resp{
-		Type:   ResponseTypeError,
-		Result: &errorResult{Message: err.Error(), Kind: kind, Value: snapName},
-		Status: 400,
-	}, nil)
+	return errToResponse(err, inst.Snaps, BadRequest, "cannot %s %s: %v", inst.Action, strutil.Quoted(inst.Snaps))
 }
 
 func postSnap(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -1365,7 +1297,7 @@ func trySnap(c *Command, r *http.Request, user *auth.UserState, trydir string, f
 
 	tset, err := snapstateTryPath(st, info.InstanceName(), trydir, flags)
 	if err != nil {
-		return BadRequest("cannot try %s: %s", trydir, err)
+		return errToResponse(err, []string{info.InstanceName()}, BadRequest, "cannot try %s: %s", trydir)
 	}
 
 	msg := fmt.Sprintf(i18n.G("Try %q snap from %s"), info.InstanceName(), trydir)
@@ -1583,7 +1515,7 @@ out:
 	// TODO parallel-install: pass instance key if needed
 	tset, err := snapstateInstallPath(st, sideInfo, tempPath, "", flags)
 	if err != nil {
-		return InternalError("cannot install snap file: %v", err)
+		return errToResponse(err, []string{snapName}, InternalError, "cannot install snap file: %v")
 	}
 
 	chg := newChange(st, "install-snap", msg, []*state.TaskSet{tset}, []string{snapName})
@@ -1713,10 +1645,11 @@ func setSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	taskset, err := configstate.ConfigureInstalled(st, snapName, patchValues, 0)
 	if err != nil {
+		// TODO: just return snap-not-installed instead ?
 		if _, ok := err.(*snap.NotInstalledError); ok {
 			return SnapNotFound(snapName, err)
 		}
-		return InternalError("%v", err)
+		return errToResponse(err, []string{snapName}, InternalError, "%v")
 	}
 
 	summary := fmt.Sprintf("Change configuration of %q snap", snapName)
@@ -1935,7 +1868,7 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 		}
 	}
 	if err != nil {
-		return BadRequest("%v", err)
+		return errToResponse(err, nil, BadRequest, "%v")
 	}
 
 	change := newChange(st, a.Action+"-snap", summary, tasksets, affected)
@@ -2706,7 +2639,7 @@ func changeAliases(c *Command, r *http.Request, user *auth.UserState) Response {
 		taskset, err = snapstate.Prefer(st, a.Snap)
 	}
 	if err != nil {
-		return BadRequest("%v", err)
+		return errToResponse(err, nil, BadRequest, "%v")
 	}
 
 	var summary string
@@ -2876,6 +2809,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	tss, err := servicestate.Control(st, appInfos, &inst, nil)
 	if err != nil {
+		// TODO: use errToResponse here too and introduce a proper error kind ?
 		if _, ok := err.(servicestate.ServiceActionConflictError); ok {
 			return Conflict(err.Error())
 		}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -7043,7 +7043,6 @@ func (e fakeNetError) Timeout() bool   { return e.timeout }
 func (e fakeNetError) Temporary() bool { return e.temporary }
 
 func (s *apiSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
-	c.Skip("silly one")
 	si := &snapInstruction{Action: "frobble"}
 	errors := []error{
 		store.ErrSnapNotFound,

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2337,6 +2337,82 @@ func (s *apiSuite) TestSideloadSnapJailMode(c *check.C) {
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
 }
 
+func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]string, expectedFlags snapstate.Flags) string {
+	d := s.daemonWithFakeSnapManager(c)
+
+	soon := 0
+	ensureStateSoon = func(st *state.State) {
+		soon++
+		ensureStateSoonImpl(st)
+	}
+
+	// setup done
+	installQueue := []string{}
+	unsafeReadSnapInfo = func(path string) (*snap.Info, error) {
+		return &snap.Info{SuggestedName: "local"}, nil
+	}
+
+	snapstateInstall = func(s *state.State, name, channel string, revision snap.Revision, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
+		// NOTE: ubuntu-core is not installed in developer mode
+		c.Check(flags, check.Equals, snapstate.Flags{})
+		installQueue = append(installQueue, name)
+
+		t := s.NewTask("fake-install-snap", "Doing a fake install")
+		return state.NewTaskSet(t), nil
+	}
+
+	snapstateInstallPath = func(s *state.State, si *snap.SideInfo, path, channel string, flags snapstate.Flags) (*state.TaskSet, error) {
+		c.Check(flags, check.DeepEquals, expectedFlags)
+
+		c.Check(path, testutil.FileEquals, "xyzzy")
+
+		installQueue = append(installQueue, si.RealName+"::"+path)
+		t := s.NewTask("fake-install-snap", "Doing a fake install")
+		return state.NewTaskSet(t), nil
+	}
+
+	buf := bytes.NewBufferString(content)
+	req, err := http.NewRequest("POST", "/v2/snaps", buf)
+	c.Assert(err, check.IsNil)
+	for k, v := range head {
+		req.Header.Set(k, v)
+	}
+
+	rsp := postSnaps(snapsCmd, req, nil).(*resp)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeAsync)
+	n := 1
+	c.Assert(installQueue, check.HasLen, n)
+	c.Check(installQueue[n-1], check.Matches, "local::.*/snapd-sideload-pkg-.*")
+
+	st := d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+
+	c.Check(soon, check.Equals, 1)
+
+	c.Assert(chg.Tasks(), check.HasLen, n)
+
+	st.Unlock()
+	s.waitTrivialChange(c, chg)
+	st.Lock()
+
+	c.Check(chg.Kind(), check.Equals, "install-snap")
+	var names []string
+	err = chg.Get("snap-names", &names)
+	c.Assert(err, check.IsNil)
+	c.Check(names, check.DeepEquals, []string{"local"})
+	var apiData map[string]interface{}
+	err = chg.Get("api-data", &apiData)
+	c.Assert(err, check.IsNil)
+	c.Check(apiData, check.DeepEquals, map[string]interface{}{
+		"snap-name": "local",
+	})
+
+	return chg.Summary()
+}
+
 func (s *apiSuite) TestSideloadSnapJailModeAndDevmode(c *check.C) {
 	body := "" +
 		"----hello--\r\n" +
@@ -2506,6 +2582,36 @@ func (s *apiSuite) TestSideloadSnapNotValidFormFile(c *check.C) {
 	c.Assert(rsp.Result.(*errorResult).Message, check.Matches, `cannot find "snap" file field in provided multipart/form-data payload`)
 }
 
+func (s *apiSuite) TestSideloadSnapChangeConflict(c *check.C) {
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"dangerous\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n"
+	s.daemonWithOverlordMock(c)
+
+	unsafeReadSnapInfo = func(path string) (*snap.Info, error) {
+		return &snap.Info{SuggestedName: "foo"}, nil
+	}
+
+	snapstateInstallPath = func(s *state.State, si *snap.SideInfo, path, channel string, flags snapstate.Flags) (*state.TaskSet, error) {
+		return nil, &snapstate.ChangeConflictError{Snap: "foo"}
+	}
+
+	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
+
+	rsp := postSnaps(snapsCmd, req, nil).(*resp)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Kind, check.Equals, errorKindSnapChangeConflict)
+}
+
 func (s *apiSuite) TestTrySnap(c *check.C) {
 	d := s.daemonWithFakeSnapManager(c)
 
@@ -2641,80 +2747,26 @@ func (s *apiSuite) TestTrySnapNotDir(c *check.C) {
 	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "not a snap directory")
 }
 
-func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]string, expectedFlags snapstate.Flags) string {
-	d := s.daemonWithFakeSnapManager(c)
+func (s *apiSuite) TestTryChangeConflict(c *check.C) {
+	s.daemonWithOverlordMock(c)
 
-	soon := 0
-	ensureStateSoon = func(st *state.State) {
-		soon++
-		ensureStateSoonImpl(st)
-	}
+	// mock a try dir
+	tryDir := c.MkDir()
 
-	// setup done
-	installQueue := []string{}
 	unsafeReadSnapInfo = func(path string) (*snap.Info, error) {
-		return &snap.Info{SuggestedName: "local"}, nil
+		return &snap.Info{SuggestedName: "foo"}, nil
 	}
 
-	snapstateInstall = func(s *state.State, name, channel string, revision snap.Revision, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
-		// NOTE: ubuntu-core is not installed in developer mode
-		c.Check(flags, check.Equals, snapstate.Flags{})
-		installQueue = append(installQueue, name)
-
-		t := s.NewTask("fake-install-snap", "Doing a fake install")
-		return state.NewTaskSet(t), nil
+	snapstateTryPath = func(s *state.State, name, path string, flags snapstate.Flags) (*state.TaskSet, error) {
+		return nil, &snapstate.ChangeConflictError{Snap: "foo"}
 	}
 
-	snapstateInstallPath = func(s *state.State, si *snap.SideInfo, path, channel string, flags snapstate.Flags) (*state.TaskSet, error) {
-		c.Check(flags, check.DeepEquals, expectedFlags)
-
-		c.Check(path, testutil.FileEquals, "xyzzy")
-
-		installQueue = append(installQueue, si.RealName+"::"+path)
-		t := s.NewTask("fake-install-snap", "Doing a fake install")
-		return state.NewTaskSet(t), nil
-	}
-
-	buf := bytes.NewBufferString(content)
-	req, err := http.NewRequest("POST", "/v2/snaps", buf)
+	req, err := http.NewRequest("POST", "/v2/snaps", nil)
 	c.Assert(err, check.IsNil)
-	for k, v := range head {
-		req.Header.Set(k, v)
-	}
 
-	rsp := postSnaps(snapsCmd, req, nil).(*resp)
-	c.Assert(rsp.Type, check.Equals, ResponseTypeAsync)
-	n := 1
-	c.Assert(installQueue, check.HasLen, n)
-	c.Check(installQueue[n-1], check.Matches, "local::.*/snapd-sideload-pkg-.*")
-
-	st := d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
-	chg := st.Change(rsp.Change)
-	c.Assert(chg, check.NotNil)
-
-	c.Check(soon, check.Equals, 1)
-
-	c.Assert(chg.Tasks(), check.HasLen, n)
-
-	st.Unlock()
-	s.waitTrivialChange(c, chg)
-	st.Lock()
-
-	c.Check(chg.Kind(), check.Equals, "install-snap")
-	var names []string
-	err = chg.Get("snap-names", &names)
-	c.Assert(err, check.IsNil)
-	c.Check(names, check.DeepEquals, []string{"local"})
-	var apiData map[string]interface{}
-	err = chg.Get("api-data", &apiData)
-	c.Assert(err, check.IsNil)
-	c.Check(apiData, check.DeepEquals, map[string]interface{}{
-		"snap-name": "local",
-	})
-
-	return chg.Summary()
+	rsp := trySnap(snapsCmd, req, nil, tryDir, snapstate.Flags{}).(*resp)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Kind, check.Equals, errorKindSnapChangeConflict)
 }
 
 func (s *apiSuite) runGetConf(c *check.C, snapName string, keys []string, statusCode int) map[string]interface{} {
@@ -2792,6 +2844,7 @@ func (s *apiSuite) TestGetRootDocument(c *check.C) {
 }
 
 func (s *apiSuite) TestGetConfBadKey(c *check.C) {
+	s.daemon(c)
 	// TODO: this one in particular should really be a 400 also
 	result := s.runGetConf(c, "test-snap", []string{"."}, 500)
 	c.Check(result, check.DeepEquals, map[string]interface{}{"message": `invalid option name: ""`})
@@ -2969,6 +3022,55 @@ func (s *apiSuite) TestSetConfBadSnap(c *check.C) {
 			"message": `snap "config-snap" is not installed`,
 			"kind":    "snap-not-found",
 			"value":   "config-snap",
+		},
+		"type": "error"})
+}
+
+func simulateConflict(o *overlord.Overlord, name string) {
+	st := o.State()
+	st.Lock()
+	defer st.Unlock()
+	t := st.NewTask("link-snap", "...")
+	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{
+		RealName: name,
+	}}
+	t.Set("snap-setup", snapsup)
+	chg := st.NewChange("manip", "...")
+	chg.AddTask(t)
+}
+
+func (s *apiSuite) TestSetConfChangeConflict(c *check.C) {
+	d := s.daemon(c)
+	s.mockSnap(c, configYaml)
+
+	simulateConflict(d.overlord, "config-snap")
+
+	text, err := json.Marshal(map[string]interface{}{"key": "value"})
+	c.Assert(err, check.IsNil)
+
+	buffer := bytes.NewBuffer(text)
+	req, err := http.NewRequest("PUT", "/v2/snaps/config-snap/conf", buffer)
+	c.Assert(err, check.IsNil)
+
+	s.vars = map[string]string{"name": "config-snap"}
+
+	rec := httptest.NewRecorder()
+	snapConfCmd.PUT(snapConfCmd, req, nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 409)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Assert(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"status-code": 409.,
+		"status":      "Conflict",
+		"result": map[string]interface{}{
+			"message": `snap "config-snap" has "manip" change in progress`,
+			"kind":    "snap-change-conflict",
+			"value": map[string]interface{}{
+				"change-kind": "manip",
+				"snap-name":   "config-snap",
+			},
 		},
 		"type": "error"})
 }
@@ -4008,6 +4110,47 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	repo := d.overlord.InterfaceManager().Repository()
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestConnectPlugChangeConflict(c *check.C) {
+	d := s.daemon(c)
+
+	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
+	// there is no producer, no slot defined
+
+	simulateConflict(d.overlord, "consumer")
+
+	action := &interfaceAction{
+		Action: "connect",
+		Plugs:  []plugJSON{{Snap: "consumer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "producer", Name: "slot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	req, err := http.NewRequest("POST", "/v2/interfaces", buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	interfacesCmd.POST(interfacesCmd, req, nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 409)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"status-code": 409.,
+		"status":      "Conflict",
+		"result": map[string]interface{}{
+			"message": `snap "consumer" has "manip" change in progress`,
+			"kind":    "snap-change-conflict",
+			"value": map[string]interface{}{
+				"change-kind": "manip",
+				"snap-name":   "consumer",
+			},
+		},
+		"type": "error"})
 }
 
 func (s *apiSuite) TestConnectCoreSystemAlias(c *check.C) {
@@ -5671,6 +5814,53 @@ func (s *apiSuite) TestAliasSuccess(c *check.C) {
 	c.Check(osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, "alias1")), check.Equals, true)
 }
 
+func (s *apiSuite) TestAliasChangeConflict(c *check.C) {
+	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
+	c.Assert(err, check.IsNil)
+	d := s.daemon(c)
+
+	s.mockSnap(c, aliasYaml)
+
+	simulateConflict(d.overlord, "alias-snap")
+
+	oldAutoAliases := snapstate.AutoAliases
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
+		return nil, nil
+	}
+	defer func() { snapstate.AutoAliases = oldAutoAliases }()
+
+	action := &aliasAction{
+		Action: "alias",
+		Snap:   "alias-snap",
+		App:    "app",
+		Alias:  "alias1",
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	req, err := http.NewRequest("POST", "/v2/aliases", buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	aliasesCmd.POST(aliasesCmd, req, nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 409)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"status-code": 409.,
+		"status":      "Conflict",
+		"result": map[string]interface{}{
+			"message": `snap "alias-snap" has "manip" change in progress`,
+			"kind":    "snap-change-conflict",
+			"value": map[string]interface{}{
+				"change-kind": "manip",
+				"snap-name":   "alias-snap",
+			},
+		},
+		"type": "error"})
+}
+
 func (s *apiSuite) TestAliasErrors(c *check.C) {
 	s.daemon(c)
 
@@ -6852,7 +7042,8 @@ func (e fakeNetError) Error() string   { return e.message }
 func (e fakeNetError) Timeout() bool   { return e.timeout }
 func (e fakeNetError) Temporary() bool { return e.temporary }
 
-func (s *appSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
+func (s *apiSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
+	c.Skip("silly one")
 	si := &snapInstruction{Action: "frobble"}
 	errors := []error{
 		store.ErrSnapNotFound,
@@ -6997,4 +7188,51 @@ func (s *apiSuite) TestErrToResponseForChangeConflict(c *check.C) {
 		},
 	})
 
+}
+
+func (s *appSuite) TestErrToResponse(c *check.C) {
+	aie := &snap.AlreadyInstalledError{Snap: "foo"}
+	nie := &snap.NotInstalledError{Snap: "foo"}
+	cce := &snapstate.ChangeConflictError{Snap: "foo"}
+	ndme := &snapstate.SnapNeedsDevModeError{Snap: "foo"}
+	nce := &snapstate.SnapNeedsClassicError{Snap: "foo"}
+	ncse := &snapstate.SnapNeedsClassicSystemError{Snap: "foo"}
+	netoe := fakeNetError{message: "other"}
+	nettoute := fakeNetError{message: "timeout", timeout: true}
+	nettmpe := fakeNetError{message: "temp", temporary: true}
+
+	e := errors.New("other error")
+
+	makeErrorRsp := func(kind errorKind, err error, value interface{}) Response {
+		return SyncResponse(&resp{
+			Type:   ResponseTypeError,
+			Result: &errorResult{Message: err.Error(), Kind: kind, Value: value},
+			Status: 400,
+		}, nil)
+	}
+
+	tests := []struct {
+		err         error
+		expectedRsp Response
+	}{
+		{store.ErrSnapNotFound, SnapNotFound("foo", store.ErrSnapNotFound)},
+		{store.ErrNoUpdateAvailable, makeErrorRsp(errorKindSnapNoUpdateAvailable, store.ErrNoUpdateAvailable, "")},
+		{store.ErrLocalSnap, makeErrorRsp(errorKindSnapLocal, store.ErrLocalSnap, "")},
+		{aie, makeErrorRsp(errorKindSnapAlreadyInstalled, aie, "foo")},
+		{nie, makeErrorRsp(errorKindSnapNotInstalled, nie, "foo")},
+		{ndme, makeErrorRsp(errorKindSnapNeedsDevMode, ndme, "foo")},
+		{nce, makeErrorRsp(errorKindSnapNeedsClassic, nce, "foo")},
+		{ncse, makeErrorRsp(errorKindSnapNeedsClassicSystem, ncse, "foo")},
+		{cce, SnapChangeConflict(cce)},
+		{nettoute, makeErrorRsp(errorKindNetworkTimeout, nettoute, "")},
+		{netoe, BadRequest("ERR: %v", netoe)},
+		{nettmpe, BadRequest("ERR: %v", nettmpe)},
+		{e, BadRequest("ERR: %v", e)},
+	}
+
+	for _, t := range tests {
+		com := check.Commentf("%v", t.err)
+		rsp := errToResponse(t.err, []string{"foo"}, BadRequest, "%s: %v", "ERR")
+		c.Check(rsp, check.DeepEquals, t.expectedRsp, com)
+	}
 }

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -34,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -454,4 +456,78 @@ func AppNotFound(format string, v ...interface{}) Response {
 		Result: res,
 		Status: 404,
 	}
+}
+
+func errToResponse(err error, snaps []string, fallback func(format string, v ...interface{}) Response, format string, v ...interface{}) Response {
+	var kind errorKind
+	var snapName string
+
+	switch err {
+	case store.ErrSnapNotFound:
+		switch len(snaps) {
+		case 1:
+			return SnapNotFound(snaps[0], err)
+		// store.ErrSnapNotFound should only be returned for individual
+		// snap queries; in all other cases something's wrong
+		case 0:
+			return InternalError("store.SnapNotFound with no snap given")
+		default:
+			return InternalError("store.SnapNotFound with %d snaps", len(snaps))
+		}
+	case store.ErrNoUpdateAvailable:
+		kind = errorKindSnapNoUpdateAvailable
+	case store.ErrLocalSnap:
+		kind = errorKindSnapLocal
+	default:
+		handled := true
+		switch err := err.(type) {
+		case *store.RevisionNotAvailableError:
+			// store.ErrRevisionNotAvailable should only be returned for
+			// individual snap queries; in all other cases something's wrong
+			switch len(snaps) {
+			case 1:
+				return SnapRevisionNotAvailable(snaps[0], err)
+			case 0:
+				return InternalError("store.RevisionNotAvailable with no snap given")
+			default:
+				return InternalError("store.RevisionNotAvailable with %d snaps", len(snaps))
+			}
+		case *snap.AlreadyInstalledError:
+			kind = errorKindSnapAlreadyInstalled
+			snapName = err.Snap
+		case *snap.NotInstalledError:
+			kind = errorKindSnapNotInstalled
+			snapName = err.Snap
+		case *snapstate.ChangeConflictError:
+			return SnapChangeConflict(err)
+		case *snapstate.SnapNeedsDevModeError:
+			kind = errorKindSnapNeedsDevMode
+			snapName = err.Snap
+		case *snapstate.SnapNeedsClassicError:
+			kind = errorKindSnapNeedsClassic
+			snapName = err.Snap
+		case *snapstate.SnapNeedsClassicSystemError:
+			kind = errorKindSnapNeedsClassicSystem
+			snapName = err.Snap
+		case net.Error:
+			if err.Timeout() {
+				kind = errorKindNetworkTimeout
+			} else {
+				handled = false
+			}
+		default:
+			handled = false
+		}
+
+		if !handled {
+			v = append(v, err)
+			return fallback(format, v...)
+		}
+	}
+
+	return SyncResponse(&resp{
+		Type:   ResponseTypeError,
+		Result: &errorResult{Message: err.Error(), Kind: kind, Value: snapName},
+		Status: 400,
+	}, nil)
 }


### PR DESCRIPTION
In particular so that they can all consistently return the new snap-change-conflict kind.
