### PR TITLE
systemd: fix snapd.apparmor.service.in dependencies

### DIFF
--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -7,7 +7,7 @@
 [Unit]
 Description=Load AppArmor profiles managed internally by snapd
 DefaultDependencies=no
-Before=sysinit.target
+Before=snapd.service
 Requisite=snapd.service
 # This dependency is meant to ensure that apparmor initialization (whatever that might entail) is complete.
 After=apparmor.service

--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -7,8 +7,7 @@
 [Unit]
 Description=Load AppArmor profiles managed internally by snapd
 DefaultDependencies=no
-Before=snapd.service
-Requisite=snapd.service
+Before=sysinit.target
 # This dependency is meant to ensure that apparmor initialization (whatever that might entail) is complete.
 After=apparmor.service
 ConditionSecurity=apparmor


### PR DESCRIPTION
We had "Before=sysinit.target" and also "Requisite=snapd.service".
This is an impossible condition as snapd runs after sysinit.target
and it leaves this unit in permanent dependency-fail state on
Ubuntu systems.
