### PR TITLE
debian: do not ship snapd.apparmor.service on ubuntu

### DIFF
--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -196,8 +196,8 @@ override_dh_install:
 	# trusty doesn't need the .real workaround
 
 	# On Ubuntu and Debian we don't need to install the apparmor helper service.
-	rm -f $(CURDIR)/debian/tmp/$(SYSTEMD_UNITS_DESTDIR)/snapd.apparmor.service
-	rm -f $(CURDIR)/debian/tmp/usr/lib/snapd/snapd-apparmor
+	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.apparmor.service
+	rm $(CURDIR)/debian/tmp/usr/lib/snapd/snapd-apparmor
 
 	dh_install
 

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -222,8 +222,8 @@ override_dh_install:
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
 
 	# On Ubuntu and Debian we don't need to install the apparmor helper service.
-	rm -f $(CURDIR)/debian/tmp/$(SYSTEMD_UNITS_DESTDIR)/snapd.apparmor.service
-	rm -f $(CURDIR)/debian/tmp/usr/lib/snapd/snapd-apparmor
+	rm $(CURDIR)/debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.apparmor.service
+	rm $(CURDIR)/debian/tmp/usr/lib/snapd/snapd-apparmor
 
 	dh_install
 


### PR DESCRIPTION
We got a report about degraded boot on cosmic cloud images. After
investigating it turns out that the snap.apparmor.service is not
fully removed. The reason is that the wrong file is deleted in
the debian/rules file(s).

This PR fixes this issue.
