### PR TITLE
tests: use install_local in snap-run-hooks

### DIFF
--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -8,12 +8,9 @@ environment:
     ENVDUMP: /var/snap/basic-hooks/current/hooks-env
 
 prepare: |
-    echo "Build test hooks package"
-    snap pack $TESTSLIB/snaps/basic-hooks
-    snap install --dangerous basic-hooks_1.0_all.snap
-
-restore: |
-    rm -f basic-hooks_1.0_all.snap
+    #shellcheck source=tests/lib/snaps.sh
+    . $TESTSLIB/snaps.sh
+    install_local basic-hooks
 
 execute: |
     # Note that `snap run` doesn't exit non-zero if the hook is missing, so we


### PR DESCRIPTION
A drive-by simplification - I was looking at this test anyway as it fails on core18 right now for unknown reasons.