### PR TITLE
snap-confine: mount internal tooling even for the core snap on core18

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -362,7 +362,11 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// Other base snaps do not, so whenever a base snap other than core is
 	// in use we need extra provisions for setting up internal tooling to
 	// be available.
-	if (!sc_streq(config->base_snap_name, "core")) {
+	//
+	// However on a core18 (and similar) system the core snap is not
+	// a special base anymore and we should map our own tooling in.
+	if (config->distro == SC_DISTRO_CORE_OTHER
+	    || !sc_streq(config->base_snap_name, "core")) {
 		// when bases are used we need to bind-mount the libexecdir
 		// (that contains snap-exec) into /usr/lib/snapd of the
 		// base snap so that snap-exec is available for the snaps


### PR DESCRIPTION
On a core18 system the core snap is just another base that is not
special. This means that we also need to mount our internal tooling
in /usr/lib/snapd on top of the core snap.

This fixes a test failure on core18 where the snap-run-hook test uses
a new feature of snap-exec that is not available in the stable core snap
yet.