### PR TITLE
overlord/snapstate: dedupe default content providers

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -135,6 +135,8 @@ var (
 	DoInstall              = doInstall
 	UserFromUserID         = userFromUserID
 	ValidateFeatureFlags   = validateFeatureFlags
+
+	DefaultContentPlugProviders = defaultContentPlugProviders
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -421,6 +421,7 @@ func contentIfaceAvailable(st *state.State, contentTag string) bool {
 // default providers there are.
 func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
 	out := []string{}
+	seen := map[string]bool{}
 	for _, plug := range info.Plugs {
 		if plug.Interface == "content" {
 			if contentAttr(plug) == "" {
@@ -436,7 +437,10 @@ func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
 				// documentation said it is "snapname:ifname",
 				// we deal with this gracefully by just
 				// stripping of the part after the ":"
-				out = append(out, strings.Split(dprovider, ":")[0])
+				if name := strings.SplitN(dprovider, ":", 2)[0]; !seen[name] {
+					out = append(out, name)
+					seen[name] = true
+				}
 			}
 		}
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7316,6 +7316,43 @@ func (s *snapStateSuite) TestCurrentSideInfoInconsistentWithCurrent(c *C) {
 	c.Check(func() { snapst.CurrentSideInfo() }, PanicMatches, `cannot find snapst.Current in the snapst.Sequence`)
 }
 
+func (snapStateSuite) TestDefaultContentPlugProviders(c *C) {
+	info := &snap.Info{
+		Plugs: map[string]*snap.PlugInfo{},
+	}
+
+	info.Plugs["foo"] = &snap.PlugInfo{
+		Snap:      info,
+		Name:      "sound-themes",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"default-provider": "common-themes", "content": "foo"},
+	}
+	info.Plugs["bar"] = &snap.PlugInfo{
+		Snap:      info,
+		Name:      "visual-themes",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"default-provider": "common-themes", "content": "bar"},
+	}
+	info.Plugs["baz"] = &snap.PlugInfo{
+		Snap:      info,
+		Name:      "not-themes",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"default-provider": "some-snap", "content": "baz"},
+	}
+	info.Plugs["qux"] = &snap.PlugInfo{Snap: info, Interface: "not-content"}
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(st, repo)
+
+	providers := snapstate.DefaultContentPlugProviders(st, info)
+	sort.Strings(providers)
+	c.Check(providers, DeepEquals, []string{"common-themes", "some-snap"})
+}
+
 type snapSetupSuite struct{}
 
 var _ = Suite(&snapSetupSuite{})


### PR DESCRIPTION
Without this change, when a snap has more than one content plug to the
same default content provider, we tried to install the provider twice,
with hilarious results.
