### PR TITLE
cmd/snap: check for typographic dashes in command

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -386,6 +386,19 @@ func (e *exitStatus) Error() string {
 	return fmt.Sprintf("internal error: exitStatus{%d} being handled as normal error", e.code)
 }
 
+var wrongDashes = string([]rune{
+	0x2010, // hyphen
+	0x2011, // non-breaking hyphen
+	0x2012, // figure dash
+	0x2013, // en dash
+	0x2014, // em dash
+	0x2015, // horizontal bar
+	0xfe58, // small em dash
+	0x2015, // figure dash
+	0x2e3a, // two-em dash
+	0x2e3b, // three-em dash
+})
+
 func run() error {
 	parser := Parser()
 	_, err := parser.Parse()
@@ -404,6 +417,19 @@ func run() error {
 		}
 
 		msg, err := errorToCmdMessage("", err, nil)
+
+		if cmdline := strings.Join(os.Args, " "); strings.ContainsAny(cmdline, wrongDashes) {
+			// TRANSLATORS: the %+q is the commandline (+q means quoted, with any non-ascii character called out). Please keep the lines to at most 80 characters.
+			fmt.Fprintf(Stderr, i18n.G(`Your command included some characters that look like dashes but are not:
+    %+q
+in some situations you might find that when copying from an online source such
+as a blog you need to replace “typographic” dashes and quotes with their ASCII
+equivalent.  Dashes in particular are homoglyphs on most terminals and in most
+fixed-width fonts, so it can be hard to tell.
+
+`), cmdline)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -81,3 +81,10 @@ execute: |
         fi
         MATCH 'error: snap "pi2-kernel" is not available on stable for this architecture' < stderr.out
     fi
+
+    echo "Install a snap with suspicious characters in its name"
+    if snap install atom ––classic 2>stderr.out; then
+        echo "snap install atom ––classic should have failed but did not"
+        exit 1
+    fi
+    MATCH 'characters that look like dashes but are not' < stderr.out


### PR DESCRIPTION
If somebody copy-pastes a snap command from a blog they might end up
getting something like

    snap install atom ––classic

which looks OK until you realise those are en dashes. The resulting
error will be very hard to understand (even ignoring the fact that the
error itself right now is wrong; that's a separate issue).

This detects the situation and prints a hopefully helpful hint before
the error.
