### PR TITLE
cmd/snap: support `--last=<type>?` to mean "no error on empty"

### DIFF
--- a/cmd/snap/cmd_abort.go
+++ b/cmd/snap/cmd_abort.go
@@ -53,6 +53,9 @@ func (x *cmdAbort) Execute(args []string) error {
 	cli := Client()
 	id, err := x.GetChangeID(cli)
 	if err != nil {
+		if err == noChangeFoundOK {
+			return nil
+		}
 		return err
 	}
 	_, err = cli.Abort(id)

--- a/cmd/snap/cmd_abort_test.go
+++ b/cmd/snap/cmd_abort_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+func (s *SnapSuite) TestAbortLast(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes")
+			fmt.Fprintln(w, mockChangesJSON)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/two")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "abort"})
+			fmt.Fprintln(w, mockChangeJSON)
+		default:
+			c.Errorf("expected 2 queries, currently on %d", n)
+		}
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"abort", "--last=install"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+
+	c.Assert(n, check.Equals, 2)
+}
+
+func (s *SnapSuite) TestAbortLastQuestionmark(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		c.Check(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v2/changes")
+		switch n {
+		case 1, 2:
+			fmt.Fprintln(w, `{"type": "sync", "result": []}`)
+		case 3, 4:
+			fmt.Fprintln(w, mockChangesJSON)
+		default:
+			c.Errorf("expected 4 calls, now on %d", n)
+		}
+	})
+	for i := 0; i < 2; i++ {
+		rest, err := snap.Parser().ParseArgs([]string{"abort", "--last=foobar?"})
+		c.Assert(err, check.IsNil)
+		c.Assert(rest, check.DeepEquals, []string{})
+		c.Check(s.Stdout(), check.Matches, "")
+		c.Check(s.Stderr(), check.Equals, "")
+
+		_, err = snap.Parser().ParseArgs([]string{"abort", "--last=foobar"})
+		if i == 0 {
+			c.Assert(err, check.ErrorMatches, `no changes found`)
+		} else {
+			c.Assert(err, check.ErrorMatches, `no changes of type "foobar" found`)
+		}
+	}
+
+	c.Check(n, check.Equals, 4)
+}

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -134,6 +134,9 @@ func (c *cmdTasks) Execute([]string) error {
 	cli := Client()
 	chid, err := c.GetChangeID(cli)
 	if err != nil {
+		if err == noChangeFoundOK {
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/snap/cmd_changes_test.go
+++ b/cmd/snap/cmd_changes_test.go
@@ -158,17 +158,17 @@ Do +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary
 func (s *SnapSuite) TestTasksLastQuestionmark(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
 		c.Check(r.Method, check.Equals, "GET")
 		c.Assert(r.URL.Path, check.Equals, "/v2/changes")
 		switch n {
-		case 0, 1:
+		case 1, 2:
 			fmt.Fprintln(w, `{"type": "sync", "result": []}`)
-		case 2, 3:
+		case 3, 4:
 			fmt.Fprintln(w, mockChangesJSON)
 		default:
 			c.Errorf("expected 4 calls, now on %d", n)
 		}
-		n++
 	})
 	for i := 0; i < 2; i++ {
 		rest, err := snap.Parser().ParseArgs([]string{"tasks", "--last=foobar?"})

--- a/cmd/snap/cmd_watch.go
+++ b/cmd/snap/cmd_watch.go
@@ -46,6 +46,9 @@ func (x *cmdWatch) Execute(args []string) error {
 	cli := Client()
 	id, err := x.GetChangeID(cli)
 	if err != nil {
+		if err == noChangeFoundOK {
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -61,6 +61,7 @@ func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
 		return string(l.Positional.ID), nil
 	}
 
+	// note that at this point we know l.LastChangeType != ""
 	kind := l.LastChangeType
 	optional := false
 	if l := len(kind) - 1; kind[l] == '?' {

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/snapcore/snapd/client"
@@ -34,7 +35,7 @@ type changeIDMixin struct {
 }
 
 var changeIDMixinOptDesc = mixinDescs{
-	"last": i18n.G("Select last change of given type (install, refresh, remove, try, auto-refresh etc.)"),
+	"last": i18n.G("Select last change of given type (install, refresh, remove, try, auto-refresh, etc.). A question mark at the end of the type means to do nothing (instead of returning an error) if no change of the given type is found. Note the question mark could need protecting from the shell."),
 }
 
 var changeIDMixinArgDesc = []argDesc{{
@@ -43,6 +44,9 @@ var changeIDMixinArgDesc = []argDesc{{
 	// TRANSLATORS: This should probably not start with a lowercase letter.
 	desc: i18n.G("Change ID"),
 }}
+
+// should not be user-visible, but keep it clear and polite because mistakes happen
+var noChangeFoundOK = errors.New("no change found but that's ok")
 
 func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
 	if l.Positional.ID == "" && l.LastChangeType == "" {
@@ -58,6 +62,11 @@ func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
 	}
 
 	kind := l.LastChangeType
+	optional := false
+	if l := len(kind) - 1; kind[l] == '?' {
+		optional = true
+		kind = kind[:l]
+	}
 	// our internal change types use "-snap" postfix but let user skip it and use short form.
 	if kind == "refresh" || kind == "install" || kind == "remove" || kind == "connect" || kind == "disconnect" || kind == "configure" || kind == "try" {
 		kind += "-snap"
@@ -67,10 +76,16 @@ func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
 		return "", err
 	}
 	if len(changes) == 0 {
+		if optional {
+			return "", noChangeFoundOK
+		}
 		return "", fmt.Errorf(i18n.G("no changes found"))
 	}
 	chg := findLatestChangeByKind(changes, kind)
 	if chg == nil {
+		if optional {
+			return "", noChangeFoundOK
+		}
 		return "", fmt.Errorf(i18n.G("no changes of type %q found"), l.LastChangeType)
 	}
 


### PR DESCRIPTION
In some situations a shell script needs to ensure a certain change
can't be initiated, and then check that it hadn't been initiated
before inhibiting. Something like

    # do not auto-refresh for 2 hours
    snap set system refresh.hold=+2h
    # wait for any auto-refreshes already in progress
    snap watch --last=auto-refresh

however if there is no auto-refresh change the above will fail with
`error: no changes of type "auto-refresh" found`.

With this change, simply

    snap watch --last="auto-refresh?"

and the watch will exit with no output and no error.

Note this also works for `abort` and `tasks`.
