### PR TITLE
image: add support for "kernel-track" in `snap prepare-image`

### DIFF
--- a/image/export_test.go
+++ b/image/export_test.go
@@ -39,6 +39,10 @@ func (tsto *ToolingStore) User() *auth.UserState {
 	return tsto.user
 }
 
+func (ls *localInfos) NameToPath() map[string]string {
+	return ls.nameToPath
+}
+
 func ToolingAuthContext() auth.AuthContext {
 	return toolingAuthContext{}
 }

--- a/image/image.go
+++ b/image/image.go
@@ -443,6 +443,8 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 			}
 		} else {
 			locals = append(locals, name)
+			// local snaps have no channel
+			snapChannel = ""
 		}
 
 		// kernel/os/model.base are required for booting
@@ -466,7 +468,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		seedYaml.Snaps = append(seedYaml.Snaps, &snap.SeedSnap{
 			Name:    info.InstanceName(),
 			SnapID:  info.SnapID, // cross-ref
-			Channel: dlOpts.Channel,
+			Channel: snapChannel,
 			File:    filepath.Base(fn),
 			DevMode: info.NeedsDevMode(),
 			Contact: info.Contact,

--- a/image/image.go
+++ b/image/image.go
@@ -114,7 +114,7 @@ func localSnaps(tsto *ToolingStore, opts *Options, model *asserts.Model) (*local
 				info.Channel = opts.Channel
 			}
 			// ensure the kernel-track is honored
-			if model.Kernel() != "" && model.KernelTrack() != "" {
+			if model.Kernel() == info.SnapName() && model.KernelTrack() != "" {
 				info.Channel, err = makeKernelChannel(model.KernelTrack(), opts.Channel)
 				if err != nil {
 					return nil, err

--- a/image/image.go
+++ b/image/image.go
@@ -294,10 +294,17 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 }
 
 func makeKernelChannel(kernelTrack, defaultChannel string) (string, error) {
+	if strings.Count(kernelTrack, "/") != 0 {
+		return "", fmt.Errorf("cannot use kernel-track %q: must be a track name only", kernelTrack)
+	}
 	kch, err := snap.ParseChannel(kernelTrack, "")
 	if err != nil {
 		return "", fmt.Errorf("cannot use kernel-track %q: %v", kernelTrack, err)
 	}
+	if kch.Track == "" {
+		return "", fmt.Errorf("cannot use kernel-track %q: please specify a track", kernelTrack)
+	}
+
 	if defaultChannel != "" {
 		dch, err := snap.ParseChannel(defaultChannel, "")
 		if err != nil {
@@ -308,6 +315,7 @@ func makeKernelChannel(kernelTrack, defaultChannel string) (string, error) {
 	return kch.Clean().String(), nil
 }
 
+// amendKernelTrack will amend channel data to local kernel snap (if any)
 func amendKernelTrack(model *asserts.Model, defaultChannel string, local *localInfos) error {
 	if model.Kernel() == "" || model.KernelTrack() == "" {
 		return nil

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1302,16 +1302,18 @@ func (s *imageSuite) TestBootstrapWithKernelTrackOnLocalSnap(c *C) {
 		"pc-kernel": "canonical",
 	})
 
-	// pretend we downloaded the kernel already
+	// pretend we downloaded the core,kernel already
+	cfn := s.downloadedSnaps["core"]
 	kfn := s.downloadedSnaps["pc-kernel"]
 	opts := &image.Options{
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
-		Snaps:           []string{kfn},
+		Snaps:           []string{kfn, cfn},
+		Channel:         "beta",
 	}
 	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
-	c.Check(local.NameToPath(), HasLen, 1)
+	c.Check(local.NameToPath(), HasLen, 2)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
 	c.Assert(err, IsNil)
@@ -1321,11 +1323,17 @@ func (s *imageSuite) TestBootstrapWithKernelTrackOnLocalSnap(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(seed.Snaps, HasLen, 3)
+	c.Check(seed.Snaps[0], DeepEquals, &snap.SeedSnap{
+		Name:    "core",
+		SnapID:  "core-Id",
+		File:    "core_3.snap",
+		Channel: "beta",
+	})
 	c.Check(seed.Snaps[1], DeepEquals, &snap.SeedSnap{
 		Name:    "pc-kernel",
 		SnapID:  "pc-kernel-Id",
 		File:    "pc-kernel_2.snap",
-		Channel: "18/stable",
+		Channel: "18/beta",
 	})
 }
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -721,6 +721,7 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
+		Channel:         "beta",
 	}
 	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
@@ -734,25 +735,29 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 
 	c.Check(seed.Snaps, HasLen, 5)
 	c.Check(seed.Snaps[0], DeepEquals, &snap.SeedSnap{
-		Name:   "core",
-		SnapID: "core-Id",
-		File:   "core_3.snap",
+		Name:    "core",
+		SnapID:  "core-Id",
+		File:    "core_3.snap",
+		Channel: "beta",
 	})
 	c.Check(seed.Snaps[1], DeepEquals, &snap.SeedSnap{
-		Name:   "pc-kernel",
-		SnapID: "pc-kernel-Id",
-		File:   "pc-kernel_2.snap",
+		Name:    "pc-kernel",
+		SnapID:  "pc-kernel-Id",
+		File:    "pc-kernel_2.snap",
+		Channel: "beta",
 	})
 	c.Check(seed.Snaps[2], DeepEquals, &snap.SeedSnap{
-		Name:   "pc",
-		SnapID: "pc-Id",
-		File:   "pc_1.snap",
+		Name:    "pc",
+		SnapID:  "pc-Id",
+		File:    "pc_1.snap",
+		Channel: "beta",
 	})
 	c.Check(seed.Snaps[3], DeepEquals, &snap.SeedSnap{
 		Name:    "required-snap1",
 		SnapID:  "required-snap1-Id",
 		File:    "required-snap1_3.snap",
 		Contact: "foo@example.com",
+		Channel: "beta",
 	})
 	// ensure local snaps are put last in seed.yaml
 	c.Check(seed.Snaps[4], DeepEquals, &snap.SeedSnap{
@@ -760,6 +765,8 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 		DevMode:    true,
 		Unasserted: true,
 		File:       "devmode-snap_x1.snap",
+		// no channel for unasserted snaps
+		Channel: "",
 	})
 
 	// check devmode-snap

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -462,7 +462,7 @@ func (s *imageSuite) TestDownloadUnpackGadget(c *C) {
 	opts := &image.Options{
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, s.model)
 	c.Assert(err, IsNil)
 
 	err = image.DownloadUnpackGadget(s.tsto, s.model, opts, local)
@@ -533,7 +533,7 @@ func (s *imageSuite) TestBootstrapToRootDir(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, s.model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -616,7 +616,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalCoreBrandKernel(c *C) {
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
 	emptyToolingStore := image.MockToolingStore(&emptyStore{})
-	local, err := image.LocalSnaps(emptyToolingStore, opts)
+	local, err := image.LocalSnaps(emptyToolingStore, opts, s.model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -722,7 +722,7 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, s.model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -817,7 +817,7 @@ func (s *imageSuite) TestBootstrapWithBase(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -888,7 +888,7 @@ func (s *imageSuite) TestBootstrapToRootDirKernelPublisherMismatch(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, s.model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -978,7 +978,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalSnapsWithStoreAsserts(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, s.model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -1107,7 +1107,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1168,7 +1168,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackWithDefaultChannel(c *C) {
 		GadgetUnpackDir: gadgetUnpackDir,
 		Channel:         "edge",
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1230,7 +1230,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackWithRisk(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1268,7 +1268,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackIsRiskOnly(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1309,7 +1309,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackOnLocalSnap(c *C) {
 		GadgetUnpackDir: gadgetUnpackDir,
 		Snaps:           []string{kfn},
 	}
-	local, err := image.LocalSnaps(s.tsto, opts)
+	local, err := image.LocalSnaps(s.tsto, opts, model)
 	c.Assert(err, IsNil)
 	c.Check(local.NameToPath(), HasLen, 1)
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -462,7 +462,7 @@ func (s *imageSuite) TestDownloadUnpackGadget(c *C) {
 	opts := &image.Options{
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, s.model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.DownloadUnpackGadget(s.tsto, s.model, opts, local)
@@ -533,7 +533,7 @@ func (s *imageSuite) TestBootstrapToRootDir(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, s.model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -616,7 +616,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalCoreBrandKernel(c *C) {
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
 	emptyToolingStore := image.MockToolingStore(&emptyStore{})
-	local, err := image.LocalSnaps(emptyToolingStore, opts, s.model)
+	local, err := image.LocalSnaps(emptyToolingStore, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -722,7 +722,7 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, s.model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -817,7 +817,7 @@ func (s *imageSuite) TestBootstrapWithBase(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -888,7 +888,7 @@ func (s *imageSuite) TestBootstrapToRootDirKernelPublisherMismatch(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, s.model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -978,7 +978,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalSnapsWithStoreAsserts(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, s.model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
@@ -1085,7 +1085,7 @@ func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 		ModelFile: fn,
 		Channel:   "x/x/x/x",
 	})
-	c.Assert(err, ErrorMatches, `cannot use channel "x/x/x/x": channel name has too many components: x/x/x/x`)
+	c.Assert(err, ErrorMatches, `cannot use channel: channel name has too many components: x/x/x/x`)
 }
 
 func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
@@ -1119,7 +1119,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1180,7 +1180,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackWithDefaultChannel(c *C) {
 		GadgetUnpackDir: gadgetUnpackDir,
 		Channel:         "edge",
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1242,7 +1242,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackWithRisk(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1280,7 +1280,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackIsRiskOnly(c *C) {
 		RootDir:         rootdir,
 		GadgetUnpackDir: gadgetUnpackDir,
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
@@ -1323,7 +1323,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackOnLocalSnap(c *C) {
 		Snaps:           []string{kfn, cfn},
 		Channel:         "beta",
 	}
-	local, err := image.LocalSnaps(s.tsto, opts, model)
+	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 	c.Check(local.NameToPath(), HasLen, 2)
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1076,6 +1076,18 @@ func (s *imageSuite) TestNoLocalParallelSnapInstances(c *C) {
 	c.Assert(err, ErrorMatches, `cannot use snap "foo_instance", parallel snap instances are unsupported`)
 }
 
+func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		ModelFile: fn,
+		Channel:   "x/x/x/x",
+	})
+	c.Assert(err, ErrorMatches, `cannot use channel "x/x/x/x": channel name has too many components: x/x/x/x`)
+}
+
 func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
@@ -1234,7 +1246,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackWithRisk(c *C) {
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
-	c.Assert(err, ErrorMatches, `cannot use kernel-track "18/beta": must be a track name only`)
+	c.Assert(err, ErrorMatches, `cannot use kernel-track "18/beta" from model assertion: must be a track name only`)
 }
 
 func (s *imageSuite) TestBootstrapWithKernelTrackIsRiskOnly(c *C) {
@@ -1272,7 +1284,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrackIsRiskOnly(c *C) {
 	c.Assert(err, IsNil)
 
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
-	c.Assert(err, ErrorMatches, `cannot use kernel-track "beta": please specify a track`)
+	c.Assert(err, ErrorMatches, `cannot use kernel-track "beta" from model assertion: not a track`)
 }
 
 func (s *imageSuite) TestBootstrapWithKernelTrackOnLocalSnap(c *C) {

--- a/store/errors.go
+++ b/store/errors.go
@@ -73,6 +73,9 @@ type RevisionNotAvailableError struct {
 }
 
 func (e *RevisionNotAvailableError) Error() string {
+	if e.Channel != "" {
+		return fmt.Sprintf("no snap revision available in %q", e.Channel)
+	}
 	return "no snap revision available as specified"
 }
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -73,9 +73,6 @@ type RevisionNotAvailableError struct {
 }
 
 func (e *RevisionNotAvailableError) Error() string {
-	if e.Channel != "" {
-		return fmt.Sprintf("no snap revision available in %q", e.Channel)
-	}
 	return "no snap revision available as specified"
 }
 


### PR DESCRIPTION
This PR will make sure that `snap prepare-image` honors when the
model uses the new "kernel-track" feature. It will download
the kernel from the given track (adjusting the risk level based
on the default channel parameter) and ensure the seed.yaml
contains the right kernel channel.

It also cleans the existing image tests a bit and improves the error message
when there is no snap in the given channel (I can pull that out again and
propose separately, it was a bit of a drive-by):
```
$ snap prepare-image core-amd64-18.model
...
Error: cannot download snap "pc-kernel": no snap revision available in "4.15/edge"
```
