### PR TITLE
snapstate: ensure kernel-track is honored on switch/refresh

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -260,6 +260,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		name = "snap-content-plug"
 	case "snapd-id":
 		name = "snapd"
+	case "kernel-id":
+		name = "kernel"
+		typ = snap.TypeKernel
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -166,7 +166,7 @@ func mockModel(extras ...string) (restore func()) {
 
 	var extra string
 	if len(extras) > 0 {
-		extra = strings.Join(extras, "\n")
+		extra = "\n" + strings.Join(extras, "\n")
 	}
 
 	mod := fmt.Sprintf(`type: model

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -22,6 +22,7 @@ package snapstate
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
@@ -149,19 +150,24 @@ func ByKindOrder(snaps ...*snap.Info) []*snap.Info {
 }
 
 func MockModelWithBase(baseName string) (restore func()) {
-	return mockModel(fmt.Sprintf("\nbase: %s", baseName))
+	return mockModel(fmt.Sprintf("base: %s", baseName))
 }
 
 func MockModelWithKernelTrack(kernelTrack string) (restore func()) {
-	return mockModel(fmt.Sprintf("\nkernel-track: %s", kernelTrack))
+	return mockModel(fmt.Sprintf("kernel-track: %s", kernelTrack))
 }
 
 func MockModel() (restore func()) {
-	return mockModel("")
+	return mockModel()
 }
 
-func mockModel(extra string) (restore func()) {
+func mockModel(extras ...string) (restore func()) {
 	oldModel := Model
+
+	var extra string
+	if len(extras) > 0 {
+		extra = strings.Join(extras, "\n")
+	}
 
 	mod := fmt.Sprintf(`type: model
 authority-id: brand

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -149,20 +149,20 @@ func ByKindOrder(snaps ...*snap.Info) []*snap.Info {
 }
 
 func MockModelWithBase(baseName string) (restore func()) {
-	return mockModel(baseName)
+	return mockModel(fmt.Sprintf("\nbase: %s", baseName))
+}
+
+func MockModelWithKernelTrack(kernelTrack string) (restore func()) {
+	return mockModel(fmt.Sprintf("\nkernel-track: %s", kernelTrack))
 }
 
 func MockModel() (restore func()) {
 	return mockModel("")
 }
 
-func mockModel(baseName string) (restore func()) {
+func mockModel(extra string) (restore func()) {
 	oldModel := Model
 
-	base := ""
-	if baseName != "" {
-		base = fmt.Sprintf("\nbase: %s", baseName)
-	}
 	mod := fmt.Sprintf(`type: model
 authority-id: brand
 series: 16
@@ -175,7 +175,7 @@ timestamp: 2018-01-01T08:00:00+00:00
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
 AXNpZw==
-`, base)
+`, extra)
 	a, err := asserts.Decode([]byte(mod))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
With this PR the snapstate adds checks that ensure that the
kernel snap does not switch aways from the kernel-track (if
specified in the model).

