### PR TITLE
store: be less verbose in the common refresh case of "no updates"

### DIFF
--- a/store/errors.go
+++ b/store/errors.go
@@ -23,9 +23,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -142,7 +144,13 @@ func (e SnapActionError) Error() string {
 	nOther := len(e.Other)
 
 	// single error
-	if nRefresh+nInstall+nDownload+nOther == 1 {
+	switch nRefresh + nInstall + nDownload + nOther {
+	case 0:
+		if e.NoResults {
+			// this is an atypical result
+			return "no install/refresh information results from the store"
+		}
+	case 1:
 		if nOther == 0 {
 			var op string
 			var errs map[string]error
@@ -183,28 +191,38 @@ func (e SnapActionError) Error() string {
 			header = "cannot install or download:"
 		}
 	}
-	es := []string{header}
 
-	for name, e := range e.Refresh {
-		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
+	// reverse the maps, as the common case is that they're all the same
+	reversed := map[string][]string{}
+	revkeys := []string{} // poorman's ordered map
+
+	for _, m := range []map[string]error{e.Refresh, e.Install, e.Download} {
+		for name, err := range m {
+			k := err.Error()
+			v, ok := reversed[k]
+			if !ok {
+				revkeys = append(revkeys, k)
+			}
+			reversed[k] = append(v, name)
+		}
 	}
 
-	for name, e := range e.Install {
-		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
-	}
-
-	for name, e := range e.Download {
-		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
+	es := make([]string, 1, 1+len(reversed)+nOther)
+	es[0] = header
+	for _, k := range revkeys {
+		sort.Strings(reversed[k])
+		es = append(es, fmt.Sprintf("%s: %s", k, strutil.Quoted(reversed[k])))
 	}
 
 	for _, e := range e.Other {
-		es = append(es, fmt.Sprintf("* %v", e))
+		es = append(es, e.Error())
 	}
 
-	if e.NoResults && len(es) == 1 {
-		// this is an atypical result
-		return "no install/refresh information results from the store"
+	if len(es) == 2 {
+		// header + 1 reason
+		return strings.Join(es, " ")
 	}
+
 	return strings.Join(es, "\n")
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -6043,9 +6043,9 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 		"bar": fmt.Errorf("sad refresh 2"),
 	}}
 	errMsg := e.Error()
-	c.Check(strings.HasPrefix(errMsg, "cannot refresh:\n"), Equals, true)
-	c.Check(errMsg, testutil.Contains, "\nsnap \"foo\": sad refresh 1")
-	c.Check(errMsg, testutil.Contains, "\nsnap \"bar\": sad refresh 2")
+	c.Check(strings.HasPrefix(errMsg, "cannot refresh:"), Equals, true)
+	c.Check(errMsg, testutil.Contains, "\nsad refresh 1: \"foo\"")
+	c.Check(errMsg, testutil.Contains, "\nsad refresh 2: \"bar\"")
 
 	e = &SnapActionError{Install: map[string]error{
 		"foo": fmt.Errorf("sad install"),
@@ -6058,8 +6058,8 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 	}}
 	errMsg = e.Error()
 	c.Check(strings.HasPrefix(errMsg, "cannot install:\n"), Equals, true)
-	c.Check(errMsg, testutil.Contains, "\nsnap \"foo\": sad install 1")
-	c.Check(errMsg, testutil.Contains, "\nsnap \"bar\": sad install 2")
+	c.Check(errMsg, testutil.Contains, "\nsad install 1: \"foo\"")
+	c.Check(errMsg, testutil.Contains, "\nsad install 2: \"bar\"")
 
 	e = &SnapActionError{Download: map[string]error{
 		"foo": fmt.Errorf("sad download"),
@@ -6072,8 +6072,8 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 	}}
 	errMsg = e.Error()
 	c.Check(strings.HasPrefix(errMsg, "cannot download:\n"), Equals, true)
-	c.Check(errMsg, testutil.Contains, "\nsnap \"foo\": sad download 1")
-	c.Check(errMsg, testutil.Contains, "\nsnap \"bar\": sad download 2")
+	c.Check(errMsg, testutil.Contains, "\nsad download 1: \"foo\"")
+	c.Check(errMsg, testutil.Contains, "\nsad download 2: \"bar\"")
 
 	e = &SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
@@ -6082,8 +6082,8 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 			"bar": fmt.Errorf("sad install 2"),
 		}}
 	c.Check(e.Error(), Equals, `cannot refresh or install:
-snap "foo": sad refresh 1
-snap "bar": sad install 2`)
+sad refresh 1: "foo"
+sad install 2: "bar"`)
 
 	e = &SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
@@ -6092,8 +6092,8 @@ snap "bar": sad install 2`)
 			"bar": fmt.Errorf("sad download 2"),
 		}}
 	c.Check(e.Error(), Equals, `cannot refresh or download:
-snap "foo": sad refresh 1
-snap "bar": sad download 2`)
+sad refresh 1: "foo"
+sad download 2: "bar"`)
 
 	e = &SnapActionError{Install: map[string]error{
 		"foo": fmt.Errorf("sad install 1"),
@@ -6102,8 +6102,8 @@ snap "bar": sad download 2`)
 			"bar": fmt.Errorf("sad download 2"),
 		}}
 	c.Check(e.Error(), Equals, `cannot install or download:
-snap "foo": sad install 1
-snap "bar": sad download 2`)
+sad install 1: "foo"
+sad download 2: "bar"`)
 
 	e = &SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
@@ -6115,9 +6115,9 @@ snap "bar": sad download 2`)
 			"baz": fmt.Errorf("sad download 3"),
 		}}
 	c.Check(e.Error(), Equals, `cannot refresh, install, or download:
-snap "foo": sad refresh 1
-snap "bar": sad install 2
-snap "baz": sad download 3`)
+sad refresh 1: "foo"
+sad install 2: "bar"
+sad download 3: "baz"`)
 
 	e = &SnapActionError{
 		NoResults: true,
@@ -6129,8 +6129,8 @@ snap "baz": sad download 3`)
 		Other: []error{fmt.Errorf("other error 1"), fmt.Errorf("other error 2")},
 	}
 	c.Check(e.Error(), Equals, `cannot refresh, install, or download:
-* other error 1
-* other error 2`)
+other error 1
+other error 2`)
 
 	e = &SnapActionError{
 		Install: map[string]error{
@@ -6139,9 +6139,9 @@ snap "baz": sad download 3`)
 		Other: []error{fmt.Errorf("other error 1"), fmt.Errorf("other error 2")},
 	}
 	c.Check(e.Error(), Equals, `cannot refresh, install, or download:
-snap "bar": sad install
-* other error 1
-* other error 2`)
+sad install: "bar"
+other error 1
+other error 2`)
 
 	e = &SnapActionError{
 		NoResults: true,


### PR DESCRIPTION
Before this change, every snap refresh would log, even without DEBUG,
something like:

    Jul 17 08:03:16 fleet snapd[4819]: 2018/07/17 08:03:16.096014 storehelpers.go:398: cannot refresh:
    Jul 17 08:03:16 fleet snapd[4819]: snap "bofh": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "interdenominational-counterintelligences": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "shellcheck": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "unifonter": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "hello-world": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "wethr": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "cavestory": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "nethack": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "tmnationsforever": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "flare-rpg": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "xbill-xaw": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "quake-shareware": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "telegram-desktop": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "bash-shell-rpg": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "go": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "shattered-pixel-dungeon": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "xonotic": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "youtube-dl-casept": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "mosaic": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "spotify": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "firefox": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "http": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "minecraft": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "vlc": snap has no updates available
    Jul 17 08:03:16 fleet snapd[4819]: snap "test-snapd-tools": snap has no updates available

this change turns things around, and instead you'll get

    Jul 17 16:02:49 fleet snapd[5123]: 2018/07/19 16:02:49.310941 storehelpers.go:398: cannot refresh: snap has no updates available: "atom", "bash-shell-rpg", "cavestory", "core", "firefox", "flare-rpg", "gnome-3-26-1604", "gnome-calculator", "go", "gtk-common-themes", "hello-world", "http", "interdenominational-counterintelligences", "minecraft", "mosaic", "nethack", "quake-shareware", "shattered-pixel-dungeon", "shellcheck", "spotify", "telegram-desktop", "test-snapd-tools", "tmnationsforever", "unifonter", "vlc", "wethr", "xbill-xaw", "xonotic", "youtube-dl-casept"

which is IMHO better.

It still goes multi-line if there's more than one "kind" of error
(still reversed, “error message: quoted list of snaps”, though).
