### PR TITLE
logger: try to not have double dates

### DIFF
--- a/logger/export_test.go
+++ b/logger/export_test.go
@@ -25,3 +25,12 @@ func GetLogger() Logger {
 
 	return logger
 }
+
+func GetLoggerFlags() int {
+	log, ok := GetLogger().(Log)
+	if !ok {
+		return -1
+	}
+
+	return log.log.Flags()
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -133,7 +133,12 @@ func New(w io.Writer, flag int) (Logger, error) {
 
 // SimpleSetup creates the default (console) logger
 func SimpleSetup() error {
-	l, err := New(os.Stderr, DefaultFlags)
+	flags := log.Lshortfile
+	if term := os.Getenv("TERM"); term != "" {
+		// snapd is probably not running under systemd
+		flags = DefaultFlags
+	}
+	l, err := New(os.Stderr, flags)
 	if err == nil {
 		SetLogger(l)
 	}


### PR DESCRIPTION
Before this change, logger was inconditionally adding a timestamp to
our logs. Then systemd picks them up and adds a timestamp. This
results in silly logs like

    Jul 19 16:40:30 fleet snapd[8498]: 2018/07/19 16:40:30.298179 retry.go:52: DEBUG: <blah blah blah>

With this change we take advantage of the fact that systemd services
run with a very limited environment, and check for TERM being set: if
not set, we disable logging the timestamp ourselves. That way you can
still run snapd by hand to debug things and get timestamps, but let
systemd do it itself otherwise.
