### PR TITLE
tests: run all main tests on core18

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -431,8 +431,6 @@ restore-each: |
 suites:
     tests/main/:
         summary: Full-system tests for snapd
-        # TODO: cleanup tests and enable ubuntu-core-18 everywhere
-        systems: [-ubuntu-core-18-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -481,8 +479,6 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
-        # TODO: cleanup tests and enable ubuntu-core-18 everywhere
-        systems: [-ubuntu-core-18-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |

--- a/tests/main/snap-service-stop-mode/task.yaml
+++ b/tests/main/snap-service-stop-mode/task.yaml
@@ -3,7 +3,9 @@ summary: "Check that stop-modes works"
 kill-timeout: 5m
 
 # journald in ubuntu-14.04 not reliable
-systems: [-ubuntu-14.04-*]
+# FIXME: enable core18 once https://github.com/snapcore/snapd/pull/5526
+#        is merged
+systems: [-ubuntu-14.04-*, -ubuntu-core-18-*]
 
 debug: |
     stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all"


### PR DESCRIPTION
This enables all tests on core18. Only snap-service-stop-mode is disabled until  https://github.com/snapcore/snapd/pull/5526 gets merged.