### PR TITLE
debian: use deb-systemd-invoke instead of systemctl directly

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -31,7 +31,7 @@ case "$1" in
                 fi
 
                 echo "Starting $unit"
-                systemctl start "$unit" || true
+                deb-systemd-invoke start "$unit" || true
             done
         fi
 esac


### PR DESCRIPTION
This fixes a bug when snapd is installed during e.g. shutdown,
see LP:#1778219.
