### PR TITLE
DON'T MERGE: New test execution to reproduce mount issue

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -249,7 +249,7 @@ if [ "$SPREAD" = 1 ]; then
     export PATH=$TMP_SPREAD:$PATH
     ( cd "$TMP_SPREAD" && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    spread google: linode:
+    spread google:tests/main/check-mount
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/tests/main/check-mount/task.yaml
+++ b/tests/main/check-mount/task.yaml
@@ -1,0 +1,7 @@
+summary: Check mount issue
+
+execute: |
+    for _ in $(seq 50); do
+        snap install test-snapd-tools test-snapd-public
+        snap remove test-snapd-tools test-snapd-public
+    done


### PR DESCRIPTION
This is what I found so far:

I can reproduce it on fedora 28 and arch linux on google, for those systems I am sharing the kernel version and systemd version. I can also reproduce it when we install 2 snaps with the following spread task:

summary: Check mount issue
execute: |
    for _ in $(seq 50); do
        snap install test-snapd-tools test-snapd-public
        snap remove test-snapd-tools test-snapd-public
    done
Results:

System: arch-linux-64

snap install test-snapd-tools test-snapd-public
2018-07-20T16:13:28Z INFO Waiting for var-lib-snapd-snap-test\x2dsnapd\x2dpublic-1.mount to stop.
error: cannot perform the following tasks:
Mount snap “test-snapd-public” (1) ([start var-lib-snapd-snap-test\x2dsnapd\x2dpublic-1.mount] failed with exit status 1: Job for var-lib-snapd-snap-test\x2dsnapd\x2dpublic-1.mount failed.
See “systemctl status “var-lib-snapd-snap-test\x2dsnapd\x2dpublic-1.mount”” and “journalctl -xe” for details.
)
Linux arch 4.17.6-1-ARCH #1 SMP PREEMPT Wed Jul 11 19:14:29 UTC 2018 x86_64 GNU/Linux
systemd 239
+PAM -AUDIT -SELINUX -IMA -APPARMOR +SMACK -SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN +PCRE2 default-hierarchy=hybrid

System: fedora-28-64

snap remove test-snapd-tools test-snapd-public
test-snapd-tools removed
test-snapd-public removed
for _ in $(seq 50)
snap install test-snapd-tools test-snapd-public
error: cannot perform the following tasks:
Mount snap “test-snapd-tools” (6) ([start var-lib-snapd-snap-test\x2dsnapd\x2dtools-6.mount] failed with exit status 1: Job for var-lib-snapd-snap-test\x2dsnapd\x2dtools-6.mount failed.
See “systemctl status “var-lib-snapd-snap-test\x2dsnapd\x2dtools-6.mount”” and “journalctl -xe” for details.
)
Linux jul201435-630697 4.17.2-200.fc28.x86_64 #1 SMP Mon Jun 18 20:09:31 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

systemd 238
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=hybrid