### PR TITLE
many: make Wait/Stop optional on StateManagers

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -345,12 +345,6 @@ func (m *fakeSnapManager) Ensure() error {
 	return nil
 }
 
-func (m *fakeSnapManager) Wait() {
-}
-
-func (m *fakeSnapManager) Stop() {
-}
-
 // sanity
 var _ overlord.StateManager = (*fakeSnapManager)(nil)
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -532,7 +532,7 @@ func (d *Daemon) Stop() error {
 			hookMgr.GracefullyWaitRunningHooks()
 			logger.Noticef("done waiting for running hooks")
 		}
-		hookMgr.Stop()
+		hookMgr.StopHooks()
 		d.snapListener.Close()
 	}
 

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -60,14 +60,6 @@ func (m *AssertManager) Ensure() error {
 	return nil
 }
 
-// Wait implements StateManager.Wait.
-func (m *AssertManager) Wait() {
-}
-
-// Stop implements StateManager.Stop.
-func (m *AssertManager) Stop() {
-}
-
 type cachedDBKey struct{}
 
 // ReplaceDB replaces the assertion database used by the manager.

--- a/overlord/cmdstate/cmdmgr.go
+++ b/overlord/cmdstate/cmdmgr.go
@@ -43,14 +43,6 @@ func (m *CommandManager) Ensure() error {
 	return nil
 }
 
-// Wait is part of the overlord.StateManager interface.
-func (m *CommandManager) Wait() {
-}
-
-// Stop is part of the overlord.StateManager interface.
-func (m *CommandManager) Stop() {
-}
-
 var defaultExecTimeout = 5 * time.Second
 
 func doExec(t *state.Task, tomb *tomb.Tomb) error {

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -246,12 +246,6 @@ func (wm *witnessManager) Ensure() error {
 	return nil
 }
 
-func (wm *witnessManager) Stop() {
-}
-
-func (wm *witnessManager) Wait() {
-}
-
 func (s *configcoreHijackSuite) TestHijack(c *C) {
 	configcoreRan := false
 	witnessCfg := false

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -457,14 +457,6 @@ func (m *DeviceManager) Ensure() error {
 	return nil
 }
 
-// Wait implements StateManager.Wait.
-func (m *DeviceManager) Wait() {
-}
-
-// Stop implements StateManager.Stop.
-func (m *DeviceManager) Stop() {
-}
-
 func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 	device, err := auth.Device(m.state)
 	if err != nil {

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -57,6 +57,7 @@ type HookManager struct {
 	hijackMap map[hijackKey]hijackFunc
 
 	runningHooks int32
+	runner       *state.TaskRunner
 }
 
 // Handler is the interface a client must satify to handle hooks.
@@ -117,6 +118,7 @@ func Manager(s *state.State, runner *state.TaskRunner) (*HookManager, error) {
 		repository: newRepository(),
 		contexts:   make(map[string]*Context),
 		hijackMap:  make(map[hijackKey]hijackFunc),
+		runner:     runner,
 	}
 
 	runner.AddHandler("run-hook", manager.doRunHook, manager.undoRunHook)
@@ -145,12 +147,10 @@ func (m *HookManager) Ensure() error {
 	return nil
 }
 
-// Wait implements StateManager.Wait.
-func (m *HookManager) Wait() {
-}
-
-// Stop implements StateManager.Stop.
-func (m *HookManager) Stop() {
+// StopHooks kills all currently running hooks and returns after
+// that's done.
+func (m *HookManager) StopHooks() {
+	m.runner.StopKinds("run-hook")
 }
 
 func (m *HookManager) hijacked(hookName, snapName string) hijackFunc {

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -147,6 +147,7 @@ func (s *hookManagerSuite) SetUpTest(c *C) {
 func (s *hookManagerSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 
+	s.manager.StopHooks()
 	s.se.Stop()
 	dirs.SetRootDir("")
 }

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -98,14 +98,6 @@ func (m *InterfaceManager) Ensure() error {
 	return nil
 }
 
-// Wait implements StateManager.Wait.
-func (m *InterfaceManager) Wait() {
-}
-
-// Stop implements StateManager.Stop.
-func (m *InterfaceManager) Stop() {
-}
-
 // Repository returns the interface repository used internally by the manager.
 //
 // This method has two use-cases:

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -181,12 +181,6 @@ func (wm *witnessManager) Ensure() error {
 	return nil
 }
 
-func (wm *witnessManager) Stop() {
-}
-
-func (wm *witnessManager) Wait() {
-}
-
 // markSeeded flags the state under the overlord as seeded to avoid running the seeding code in these tests
 func markSeeded(o *overlord.Overlord) {
 	st := o.State()
@@ -564,12 +558,6 @@ func (sm *sampleManager) Ensure() error {
 		sm.ensureCallback()
 	}
 	return nil
-}
-
-func (sm *sampleManager) Stop() {
-}
-
-func (sm *sampleManager) Wait() {
 }
 
 func (ovs *overlordSuite) TestTrivialSettle(c *C) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -551,11 +551,3 @@ func (m *SnapManager) Ensure() error {
 
 	return nil
 }
-
-// Wait implements StateManager.Wait.
-func (m *SnapManager) Wait() {
-}
-
-// Stop implements StateManager.Stop.
-func (m *SnapManager) Stop() {
-}

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -34,7 +34,11 @@ type StateManager interface {
 	// Ensure forces a complete evaluation of the current state.
 	// See StateEngine.Ensure for more details.
 	Ensure() error
+}
 
+// StateWaiterStopper is implemented by StateManagers that have
+// running activities that can be waited or terminated.
+type StateWaiterStopper interface {
 	// Wait asks manager to wait for all running activities to finish.
 	Wait()
 
@@ -120,7 +124,9 @@ func (se *StateEngine) Wait() {
 		return
 	}
 	for _, m := range se.managers {
-		m.Wait()
+		if waiter, ok := m.(StateWaiterStopper); ok {
+			waiter.Wait()
+		}
 	}
 }
 
@@ -132,7 +138,9 @@ func (se *StateEngine) Stop() {
 		return
 	}
 	for _, m := range se.managers {
-		m.Stop()
+		if stopper, ok := m.(StateWaiterStopper); ok {
+			stopper.Stop()
+		}
 	}
 	se.stopped = true
 }


### PR DESCRIPTION
Also make the stopping of hooks on shutdown fully clean again using the new TaskRunner.StopKinds, something we had lost in the switch to one single task runner.

