### PR TITLE
snap/squashfs: stop printing unsquashfs info to stderr

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -144,7 +144,6 @@ func (s *Snap) Unpack(src, dstDir string) error {
 
 	cmd := exec.Command("unsquashfs", "-n", "-f", "-d", dstDir, s.path, src)
 	cmd.Stderr = usw
-	cmd.Stdout = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return err
 	}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -106,6 +106,7 @@ func (s *SquashfsTestSuite) TearDownTest(c *C) {
 	_, err := s.outf.Seek(0, 0)
 	c.Assert(err, IsNil)
 	outbuf, err := ioutil.ReadAll(s.outf)
+	c.Assert(err, IsNil)
 	c.Check(string(outbuf), Equals, "")
 }
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -42,6 +42,7 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type SquashfsTestSuite struct {
+	oldStdout, oldStderr, outf *os.File
 }
 
 var _ = Suite(&SquashfsTestSuite{})
@@ -91,6 +92,21 @@ func (s *SquashfsTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(d)
 	err := os.Chdir(d)
 	c.Assert(err, IsNil)
+
+	s.outf, err = ioutil.TempFile(c.MkDir(), "")
+	c.Assert(err, IsNil)
+	s.oldStdout, s.oldStderr = os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = s.outf, s.outf
+}
+
+func (s *SquashfsTestSuite) TearDownTest(c *C) {
+	os.Stdout, os.Stderr = s.oldStdout, s.oldStderr
+
+	// this ensures things were quiet
+	_, err := s.outf.Seek(0, 0)
+	c.Assert(err, IsNil)
+	outbuf, err := ioutil.ReadAll(s.outf)
+	c.Check(string(outbuf), Equals, "")
 }
 
 func (s *SquashfsTestSuite) TestInstallSimpleNoCp(c *C) {


### PR DESCRIPTION
in #5494 I accidentally included a change that has us printing
unsquashfs info (“Parallel unsquashfs: Using 4 processors” etc.) to
stderr. That change was a debugging aid and not meant for inclusion in
the PR.

This drops the change, and adds a check to the suite teardown to make
sure it doesn't happen again by accident.
