### PR TITLE
debian: ensure dependency on fixed apt on 18.04

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -60,7 +60,6 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: adduser,
-         ${snapd:Depends},
          apparmor (>= 2.10.95-0ubuntu2.2),
          ca-certificates,
          openssh-client,
@@ -70,7 +69,7 @@ Depends: adduser,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
+Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
 Recommends: gnupg
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -60,6 +60,7 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: adduser,
+         ${snapd:Depends},
          apparmor (>= 2.10.95-0ubuntu2.2),
          ca-certificates,
          openssh-client,

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -26,7 +26,7 @@ include /etc/os-release
 # problem on "apt purge snapd". To ensure this won't happen add the
 # right dependency on 18.04.
 ifeq (${VERSION_ID},"18.04")
-	SUBSTVARS = -Vsnapd:Depends="apt (>= 1.6.3)"
+	SUBSTVARS = -Vsnapd:Breaks="apt (<< 1.6.3)"
 endif
 
 # this is overridden in the ubuntu/14.04 release branch

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -22,6 +22,13 @@ export PATH:=/usr/lib/go-1.6/bin:${PATH}
 
 include /etc/os-release
 
+# On 18.04 the released version of apt (1.6.1) has a bug that causes
+# problem on "apt purge snapd". To ensure this won't happen add the
+# right dependency on 18.04.
+ifeq (${VERSION_ID},"18.04")
+	SUBSTVARS = -Vsnapd:Depends="apt (>= 1.6.3)"
+endif
+
 # this is overridden in the ubuntu/14.04 release branch
 SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
 
@@ -238,4 +245,4 @@ override_dh_auto_clean:
 	rm -vf snap.8
 
 override_dh_gencontrol:
-	dh_gencontrol -- -VBuilt-Using="$(BUILT_USING)"
+	dh_gencontrol -- -VBuilt-Using="$(BUILT_USING)" $(SUBSTVARS)

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -184,14 +184,6 @@ EOF
 }
 
 prepare_classic() {
-    # ensure apt is the latest version
-    # https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1776218
-    case "$SPREAD_SYSTEM" in
-        ubuntu-*|debian-*)
-            apt install -y apt
-            ;;
-    esac
-
     distro_install_build_snapd
     if snap --version |MATCH unknown; then
         echo "Package build incorrect, 'snap --version' mentions 'unknown'"


### PR DESCRIPTION
We use the new apt json-rpc hooks in 18.04. Unfortunately the
version in 18.04 (1.6.1) is buggy and "apt purge snapd" will
fail and break apt. To fix this this PR ensures that on 18.04
we have an apt dependency with the right version number.

This should fix the issue we saw right now on master.