### PR TITLE
spread: switch Fedora and openSUSE images (2.34)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -86,7 +86,6 @@ backends:
                 workers: 4
 
             - opensuse-42.3-64:
-                image: opensuse-cloud/opensuse-leap-42-3-v20180116
                 workers: 4
             - arch-linux-64:
                 workers: 4

--- a/spread.yaml
+++ b/spread.yaml
@@ -82,7 +82,6 @@ backends:
                 workers: 4
                 manual: true
             - fedora-28-64:
-                image: fedora-28-64-selinux-permissive
                 workers: 4
 
             - opensuse-42.3-64:


### PR DESCRIPTION
Backport 2 commits that switched the images for Fedora and openSUSE to the same as used in the master branch.
