### PR TITLE
strutil: detect and bail out of Unmarshal on duplicate key

### DIFF
--- a/strutil/map.go
+++ b/strutil/map.go
@@ -109,6 +109,9 @@ func (o *OrderedMap) UnmarshalYAML(u func(interface{}) error) error {
 		if !ok || !good {
 			return fmt.Errorf("cannot read %q", item.Key)
 		}
+		if seen[k] {
+			return fmt.Errorf("found duplicate key %q", k)
+		}
 		seen[k] = true
 		keys[i] = k
 	}

--- a/strutil/map_test.go
+++ b/strutil/map_test.go
@@ -74,6 +74,17 @@ k0: v0
 	c.Check(om.Keys(), DeepEquals, []string{"k", "k2", "k0"})
 }
 
+func (s *orderedMapSuite) TestYamlDupe(c *C) {
+	yamlStr := []byte(`
+k: v
+k0: v0
+k: v
+`)
+	var om strutil.OrderedMap
+	err := yaml.Unmarshal(yamlStr, &om)
+	c.Assert(err, ErrorMatches, `found duplicate key "k"`)
+}
+
 func (s *orderedMapSuite) TestYamlErr(c *C) {
 	yamlStr := []byte(`
 k: 


### PR DESCRIPTION
Without this change strutil.OrderedMap would panic on a duplicate
key. This change instead makes it return an error.

This means that, if you're `try`ing a snap, edit its `snap.yaml` to
accidentally have a duplicate key, instead of snapd getting
depramestrated the user will see an error. See [lp:1782990] for the
panic you used to get; with this change instead you get

```
$ snap info xyzzy --verbose
name:      xyzzy
summary:   ""
publisher: –
license:   unset
description: |

notes:
  private:           false
  confinement:
  devmode:           false
  jailmode:          false
  trymode:           true
  enabled:           true
  broken:            true (cannot use installed snap "xyzzy" at revision x1: cannot parse snap.yaml: found duplicate key "foo")
  ignore-validation: false
refresh-date: today at 11:22 BST
installed:     (x1) 0B
```

[lp:1782990]: https://bugs.launchpad.net/snapd/+bug/1782990
