### PR TITLE
cmd/snap-confine: (nvidia) pick up libnvidia-glvkspirv.so

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -108,6 +108,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-fbc.so*",
 	"libnvidia-glcore.so*",
 	"libnvidia-glsi.so*",
+	"libnvidia-glvkspirv.so*",
 	"libnvidia-ifr.so*",
 	"libnvidia-ml.so*",
 	"libnvidia-ptxjitcompiler.so*",


### PR DESCRIPTION
When attempting to use vulkaninfo with nvidia the following error is reported
when trying to load nvidia ICD library:

INFO: [loader] Code 0 : Found ICD manifest file /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json, version "1.0.0"
The NVIDIA driver was unable to open 'libnvidia-glvkspirv.so.396.24'.  This library is required at run time.

Make sure that we pick up the library from the host.

