### PR TITLE
[RFC] tests: remove `-o pipefail` again

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -4,9 +4,6 @@ set -x
 # statements we execute stops the build. The code is not (yet) written to
 # handle errors in general.
 set -e
-# Set pipefail option so that "foo | bar" behaves with fewer surprises by
-# failing if foo fails, not just if bar fails.
-set -o pipefail
 
 # shellcheck source=tests/lib/quiet.sh
 . "$TESTSLIB/quiet.sh"


### PR DESCRIPTION
This will fix the spread MATCH breaking we see in out tests. It
also seems like the side-effects from `-o pipefail` are subtle
and confusing. Like `echo "foo\nfoo\nfoo"|grep foo` can break
echo with SIGPIPE and abort the script. So we trade one set of
bugs (early bits in the pipeline fail and we don't notice)
for another set of bugs that is arguable more subtle.