### PR TITLE
tests: ensure apt-hook is only run after catalog update ran

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -6,7 +6,15 @@ systems: [ubuntu-18.04-*, ubuntu-18.10-*]
 restore: |
     rm -f expected out
 
+debug: |
+    ls -lh /var/cache/snapd
+    
 execute: |
+    echo "Ensure we have a snap catalog in our cache"
+    while ! test -s /var/cache/snapd/commands.db; do
+        sleep 1
+    done
+
     echo "Creating expected file"
     cat > expected <<EOF
 


### PR DESCRIPTION
We saw some test failures in the apt-hook test. This might be
because there is was no snapd catalog update yet. This PR ensures
the catalog is up-to-date.

