### PR TITLE
tests: new gce image for fedora 27

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -78,7 +78,6 @@ backends:
                 workers: 4
                 manual: true
             - fedora-27-64:
-                image: fedora-27-64-selinux-permissive
                 workers: 4
                 manual: true
             - fedora-28-64:


### PR DESCRIPTION
The image was updated following the same logic for the other images.
