### PR TITLE
tests/lib/snaps: avoid using relative command paths that go up in the  directory tree

### DIFF
--- a/tests/lib/snaps/config-versions-v2/bin/sh
+++ b/tests/lib/snaps/config-versions-v2/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/config-versions-v2/meta/snap.yaml
+++ b/tests/lib/snaps/config-versions-v2/meta/snap.yaml
@@ -3,5 +3,5 @@ version: 2.0
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [home]

--- a/tests/lib/snaps/config-versions/bin/sh
+++ b/tests/lib/snaps/config-versions/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/config-versions/meta/snap.yaml
+++ b/tests/lib/snaps/config-versions/meta/snap.yaml
@@ -3,5 +3,5 @@ version: 1.0
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [home]

--- a/tests/lib/snaps/test-snapd-broadcom-asic-control/bin/sh
+++ b/tests/lib/snaps/test-snapd-broadcom-asic-control/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-broadcom-asic-control/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-broadcom-asic-control/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which allow access to broadcom asic kernel module
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [broadcom-asic-control]

--- a/tests/lib/snaps/test-snapd-content-advanced-plug/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-advanced-plug/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-advanced-plug/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-advanced-plug/meta/snap.yaml
@@ -3,7 +3,7 @@ summary: A more complex snap for testing content interface
 version: 1.0
 apps:
     sh:
-        command: ../../../bin/sh
+        command: bin/sh
 plugs:
     # NOTE: The following content interface relies on the fact that when
     # content interface attribute "content" is not provided it defaults to the

--- a/tests/lib/snaps/test-snapd-content-advanced-slot/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-advanced-slot/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-advanced-slot/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-advanced-slot/meta/snap.yaml
@@ -3,7 +3,7 @@ summary: A more complex snap for testing content interface
 version: 1.0
 apps:
     sh:
-        command: ../../../bin/sh
+        command: bin/sh
 slots:
     data:
         interface: content

--- a/tests/lib/snaps/test-snapd-content-mimic-plug/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-mimic-plug/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-mimic-plug/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-mimic-plug/meta/snap.yaml
@@ -3,7 +3,7 @@ summary: A snap designed to test the writable mimic
 version: 1.0
 apps:
     sh:
-        command: ../../../bin/sh
+        command: bin/sh
 plugs:
     # NOTE: The following content interface relies on the fact that when
     # content interface attribute "content" is not provided it defaults to the

--- a/tests/lib/snaps/test-snapd-content-mimic-slot/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-mimic-slot/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-mimic-slot/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-mimic-slot/meta/snap.yaml
@@ -3,7 +3,7 @@ summary: A snap designed to test the writable mimic
 version: 1.0
 apps:
     sh:
-        command: ../../../bin/sh
+        command: bin/sh
 slots:
     content:
         interface: content

--- a/tests/lib/snaps/test-snapd-gpg-keys/bin/sh
+++ b/tests/lib/snaps/test-snapd-gpg-keys/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-gpg-keys/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-gpg-keys/meta/snap.yaml
@@ -5,5 +5,5 @@ version: 1.0
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [gpg-keys]

--- a/tests/lib/snaps/test-snapd-gpg-public-keys/bin/sh
+++ b/tests/lib/snaps/test-snapd-gpg-public-keys/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-gpg-public-keys/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-gpg-public-keys/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which access to public gpg keys
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [gpg-public-keys]

--- a/tests/lib/snaps/test-snapd-joystick/bin/sh
+++ b/tests/lib/snaps/test-snapd-joystick/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-joystick/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-joystick/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which allows reading and writing to joystick devices
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [joystick]

--- a/tests/lib/snaps/test-snapd-kvm/bin/sh
+++ b/tests/lib/snaps/test-snapd-kvm/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-kvm/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-kvm/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which access to kvm device
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [kvm]

--- a/tests/lib/snaps/test-snapd-layout/bin/sh
+++ b/tests/lib/snaps/test-snapd-layout/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
@@ -3,7 +3,7 @@ version: 1.0
 summary: Sample illustrating very basic layout support
 apps:
     sh:
-        command: ../../../bin/sh
+        command: bin/sh
 layout:
   # Layouts can be used to inject configuration files and directories.
   /etc/demo:

--- a/tests/lib/snaps/test-snapd-raw-usb/bin/sh
+++ b/tests/lib/snaps/test-snapd-raw-usb/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-raw-usb/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-raw-usb/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which access to raw usb
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [raw-usb]

--- a/tests/lib/snaps/test-snapd-removable-media/bin/sh
+++ b/tests/lib/snaps/test-snapd-removable-media/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-removable-media/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-removable-media/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which access to removable storage filesystems
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [removable-media]

--- a/tests/lib/snaps/test-snapd-sh/bin/sh
+++ b/tests/lib/snaps/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
@@ -3,7 +3,7 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 apps:
     test-snapd-sh:
-        command: ../../../bin/sh
+        command: bin/sh
     with-home-plug:
-        command: ../../../bin/sh
+        command: bin/sh
         plugs: [home]

--- a/tests/lib/snaps/test-snapd-ssh-keys/bin/sh
+++ b/tests/lib/snaps/test-snapd-ssh-keys/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-ssh-keys/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-ssh-keys/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which access to ssh keys
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [ssh-keys]

--- a/tests/lib/snaps/test-snapd-ssh-public-keys/bin/sh
+++ b/tests/lib/snaps/test-snapd-ssh-public-keys/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-ssh-public-keys/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-ssh-public-keys/meta/snap.yaml
@@ -5,5 +5,5 @@ description: A basic snap which access to public ssh keys
 
 apps:
   sh:
-    command: ../../../bin/sh
+    command: bin/sh
     plugs: [ssh-public-keys]

--- a/tests/lib/snaps/test-snapd-unknown-interfaces/bin/sh
+++ b/tests/lib/snaps/test-snapd-unknown-interfaces/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-unknown-interfaces/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-unknown-interfaces/meta/snap.yaml
@@ -3,7 +3,7 @@ summary: A snap with unknown plus and slot interfaces.
 version: 1.0
 apps:
     test-snapd-unknown-interfaces:
-        command: ../../../bin/sh
+        command: bin/sh
 plugs:
     bogus-plug:
 slots:


### PR DESCRIPTION
Use of relative command paths that go outside of $SNAP tree is problematic and
may produce unexpected absolute paths.

In an example case of AMZN2, the distro ships /etc/os-release as a file (not a
symlink to /usr/lib/os-release like other distros do). Because of this, when the
mount namespace is set up, the /etc/os-release files appears directly in the
namespace, but contains host specific information, i.e ID=amzn,
ID_LIKE="..rhel..". This confuses snap-exec as to the snap mount point location,
which is now /var/lib/snapd/snap instead of /snap (as would be in case when
distro is Ubuntu Core in the 'core' snap).

In case of the test snaps affecte by this patch, the paths ../../../bin/sh ended
up being /var/lib/snapd/bin/sh instead of /bin/sh, thus preventing the snaps
from working correctly.
