### PR TITLE
tests: use pkill instead of kilall

### DIFF
--- a/tests/main/interfaces-wayland/task.yaml
+++ b/tests/main/interfaces-wayland/task.yaml
@@ -9,7 +9,7 @@ prepare: |
 
 restore: |
     echo "Stop weston compositor"
-    /usr/bin/killall -9 /usr/bin/weston || true
+    pkill -SIGKILL /usr/bin/weston || true
 
 execute: |
     echo "The interface is connected by default"
@@ -56,4 +56,4 @@ execute: |
     # If this is in 'restore', execute doesn't exit and spread must timeout
     # the test.
     echo "Stop weston compositor"
-    /usr/bin/killall -9 /usr/bin/weston || true
+    pkill -SIGKILL /usr/bin/weston || true

--- a/tests/main/interfaces-wayland/task.yaml
+++ b/tests/main/interfaces-wayland/task.yaml
@@ -9,7 +9,7 @@ prepare: |
 
 restore: |
     echo "Stop weston compositor"
-    pkill -SIGKILL /usr/bin/weston || true
+    pkill -SIGKILL weston || true
 
 execute: |
     echo "The interface is connected by default"
@@ -56,4 +56,4 @@ execute: |
     # If this is in 'restore', execute doesn't exit and spread must timeout
     # the test.
     echo "Stop weston compositor"
-    pkill -SIGKILL /usr/bin/weston || true
+    pkill -SIGKILL weston || true

--- a/tests/main/snap-service-stop-mode-sigkill/task.yaml
+++ b/tests/main/snap-service-stop-mode-sigkill/task.yaml
@@ -5,14 +5,14 @@ kill-timeout: 5m
 restore: |
     # remove to ensure all services are stopped
     snap remove test-snapd-service || true
-    killall sleep || true
+    pkill sleep || true
 
 debug: |
     ps afx
 
 execute: |
     echo "Ensure no stray sleep processes are around"
-    killall sleep || true
+    pkill sleep || true
 
     echo "When the service snap is installed"
     . $TESTSLIB/snaps.sh


### PR DESCRIPTION
The `killall` binary, interestingly enough, always used with `|| true`
doesn't exist in the core snap so it was never actually used. Switch all
the test code to `pkill` instead.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
