### PR TITLE
snap: validate instance name as part of Validate()

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -68,7 +68,7 @@ func isValidName(name string) bool {
 	return true
 }
 
-// ValidateName checks if a string can be used as a snap instance name.
+// ValidateInstanceName checks if a string can be used as a snap instance name.
 func ValidateInstanceName(instanceName string) error {
 	// NOTE: This function should be synchronized with the two other
 	// implementations: sc_instance_name_validate and validate_instance_name .
@@ -325,8 +325,10 @@ func Validate(info *Info) error {
 		return fmt.Errorf("snap name cannot be empty")
 	}
 
-	// TODO parallel-install: use of proper instance/store name, validate instance key
-	if err := ValidateName(name); err != nil {
+	if err := ValidateName(info.SnapName()); err != nil {
+		return err
+	}
+	if err := ValidateInstanceName(name); err != nil {
 		return err
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1399,3 +1399,26 @@ func (s *validateSuite) TestValidatePlugSlotName(c *C) {
 		c.Assert(ValidateInterfaceName(name), ErrorMatches, `invalid interface name: ".*"`)
 	}
 }
+
+func (s *ValidateSuite) TestValidateSnapInstanceNameBadSnapName(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo_bad
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `invalid snap name: "foo_bad"`)
+}
+
+func (s *ValidateSuite) TestValidateSnapInstanceNameBadInstanceKey(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+
+	for _, s := range []string{"toolonginstance", "ABCD", "_", "inst@nce", "012345678901"} {
+		info.InstanceKey = s
+		err = Validate(info)
+		c.Check(err, ErrorMatches, fmt.Sprintf("invalid instance key: %q", s))
+	}
+}


### PR DESCRIPTION
Validation of instance name as a string is already substantially tested. This change makes snap.Validate() instance name aware.
