### PR TITLE
interfaces: match all possible tty but console

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1249,7 +1249,7 @@ func (iface *modemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, 
 
 func (iface *modemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(modemManagerPermanentSlotUDev)
-	spec.TagDevice(`KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1249,7 +1249,7 @@ func (iface *modemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, 
 
 func (iface *modemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(modemManagerPermanentSlotUDev)
-	spec.TagDevice(`KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1249,7 +1249,7 @@ func (iface *modemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, 
 
 func (iface *modemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(modemManagerPermanentSlotUDev)
-	spec.TagDevice(`KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -206,7 +206,7 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(udevSpec.Snippets(), HasLen, 3)
 	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# modem-manager
-KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
+KERNEL=="tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `TAG=="snap_modem-manager_mm", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_modem-manager_mm $devpath $major:$minor"`)
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -206,7 +206,7 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(udevSpec.Snippets(), HasLen, 3)
 	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# modem-manager
-KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
+KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `TAG=="snap_modem-manager_mm", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_modem-manager_mm $devpath $major:$minor"`)
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -206,7 +206,7 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(udevSpec.Snippets(), HasLen, 3)
 	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# modem-manager
-KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
+KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `TAG=="snap_modem-manager_mm", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_modem-manager_mm $devpath $major:$minor"`)
 }
 

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -334,7 +334,7 @@ func (iface *ofonoInterface) UDevPermanentSlot(spec *udev.Specification, slot *s
 	     Similar case for chnlat*.
 	   So we intetionally skipped modem, rild and chnlat.
 	*/
-	spec.TagDevice(`KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*"`)
 	spec.TagDevice(`KERNEL=="tun"`)
 	spec.TagDevice(`KERNEL=="dsp"`)
 	return nil

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -334,7 +334,7 @@ func (iface *ofonoInterface) UDevPermanentSlot(spec *udev.Specification, slot *s
 	     Similar case for chnlat*.
 	   So we intetionally skipped modem, rild and chnlat.
 	*/
-	spec.TagDevice(`KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*"`)
 	spec.TagDevice(`KERNEL=="tun"`)
 	spec.TagDevice(`KERNEL=="dsp"`)
 	return nil

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -334,7 +334,7 @@ func (iface *ofonoInterface) UDevPermanentSlot(spec *udev.Specification, slot *s
 	     Similar case for chnlat*.
 	   So we intetionally skipped modem, rild and chnlat.
 	*/
-	spec.TagDevice(`KERNEL=="[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*"`)
 	spec.TagDevice(`KERNEL=="tun"`)
 	spec.TagDevice(`KERNEL=="dsp"`)
 	return nil

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -334,7 +334,7 @@ func (iface *ofonoInterface) UDevPermanentSlot(spec *udev.Specification, slot *s
 	     Similar case for chnlat*.
 	   So we intetionally skipped modem, rild and chnlat.
 	*/
-	spec.TagDevice(`KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*"`)
+	spec.TagDevice(`KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*"`)
 	spec.TagDevice(`KERNEL=="tun"`)
 	spec.TagDevice(`KERNEL=="dsp"`)
 	return nil

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -201,7 +201,7 @@ func (s *OfonoInterfaceSuite) TestPermanentSlotSnippetUDev(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 5)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `LABEL="ofono_isi_end"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
-KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
+KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
 KERNEL=="tun", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -201,7 +201,7 @@ func (s *OfonoInterfaceSuite) TestPermanentSlotSnippetUDev(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 5)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `LABEL="ofono_isi_end"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
-KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
+KERNEL=="tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
 KERNEL=="tun", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -201,7 +201,7 @@ func (s *OfonoInterfaceSuite) TestPermanentSlotSnippetUDev(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 5)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `LABEL="ofono_isi_end"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
-KERNEL=="tty[^0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
+KERNEL=="tty[a-zA-Z].*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
 KERNEL=="tun", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -57,7 +57,7 @@ var pppConnectedPlugKmod = []string{
 
 var pppConnectedPlugUDev = []string{
 	`KERNEL=="ppp"`,
-	`KERNEL=="tty[A-Z]*[0-9]*"`,
+	`KERNEL=="tty[^0-9]*"`,
 }
 
 func init() {

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -57,7 +57,7 @@ var pppConnectedPlugKmod = []string{
 
 var pppConnectedPlugUDev = []string{
 	`KERNEL=="ppp"`,
-	`KERNEL=="tty[a-zA-Z].*"`,
+	`KERNEL=="tty[a-zA-Z]*[0-9]*"`,
 }
 
 func init() {

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -57,7 +57,7 @@ var pppConnectedPlugKmod = []string{
 
 var pppConnectedPlugUDev = []string{
 	`KERNEL=="ppp"`,
-	`KERNEL=="tty[^0-9]*"`,
+	`KERNEL=="tty[a-zA-Z].*"`,
 }
 
 func init() {


### PR DESCRIPTION
Some interfaces matched only ttys that started with capital
letter, leaving interfaces like ttymxc* out of them. Change this to
a more general case where only console devices are excluded.
