### PR TITLE
timeutil: fix first weekday of the month schedule

### DIFF
--- a/timeutil/export_test.go
+++ b/timeutil/export_test.go
@@ -23,6 +23,7 @@ import "time"
 
 var (
 	ParseClockSpan = parseClockSpan
+	ParseWeekSpan  = parseWeekSpan
 	HumanTimeSince = humanTimeSince
 )
 

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -137,11 +137,15 @@ func findNthWeekDay(t time.Time, weekday time.Weekday, nthInMonth uint) time.Tim
 	// move to the beginning of the month
 	t = t.AddDate(0, 0, -t.Day()+1)
 
-	for nth := uint(0); t.Weekday() != weekday || nth != nthInMonth; {
-		t = t.Add(24 * time.Hour)
+	var nth uint
+	for {
 		if t.Weekday() == weekday {
 			nth++
+			if nth == nthInMonth {
+				break
+			}
 		}
+		t = t.Add(24 * time.Hour)
 	}
 	return t
 }


### PR DESCRIPTION
Given a schedule with first weekday of the month (eg. wed1 - first Wednesday),
if a matching weekday happens on the first day of the month, it will be skipped
and instead the schedule will fall on the next same weekday of the month.

Consider the calendar:
```
    August 2018
Su Mo Tu We Th Fr Sa
          1  2  3  4
 5  6  7  8  9 10 11
12 13 14 15 16 17 18
19 20 21 22 23 24 25
26 27 28 29 30 31
```
In case the schedule is on wed1, we are expecting the next window on 2018.08.01,
but instead the next window is scheduled for 2018.08.08.

The patch fixes buggy nth-weekday-of-the-month calculation for this edge case.

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>