### PR TITLE
daemon: if a snap is inactive, don't ask systemd about its services.

### DIFF
--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -285,14 +285,14 @@ func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []client.AppInfo {
 			out[i].DesktopFile = fn
 		}
 
-		if app.IsService() {
+		out[i].Daemon = app.Daemon
+		if app.IsService() && app.Snap.IsActive() {
 			// TODO: look into making a single call to Status for all services
 			if sts, err := sysd.Status(app.ServiceName()); err != nil {
 				logger.Noticef("cannot get status of service %q: %v", app.Name, err)
 			} else if len(sts) != 1 {
 				logger.Noticef("cannot get status of service %q: expected 1 result, got %d", app.Name, len(sts))
 			} else {
-				out[i].Daemon = sts[0].Daemon
 				out[i].Enabled = sts[0].Enabled
 				out[i].Active = sts[0].Active
 			}

--- a/snap/info.go
+++ b/snap/info.go
@@ -415,6 +415,14 @@ func (s *Info) InstallDate() time.Time {
 	return time.Time{}
 }
 
+// IsActive returns whether this snap revision is active.
+func (s *Info) IsActive() bool {
+	dir, rev := filepath.Split(s.MountDir())
+	cur := filepath.Join(dir, "current")
+	tag, err := os.Readlink(cur)
+	return err == nil && tag == rev
+}
+
 // BadInterfacesSummary returns a summary of the problems of bad plugs
 // and slots in the snap.
 func BadInterfacesSummary(snapInfo *Info) string {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1251,3 +1251,21 @@ func (s *infoSuite) TestInstanceNameInSnapInfo(c *C) {
 	c.Check(info.InstanceName(), Equals, "snap-name")
 	c.Check(info.SnapName(), Equals, "snap-name")
 }
+
+func (s *infoSuite) TestIsActive(c *C) {
+	info1 := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(1)})
+	info2 := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(2)})
+	// no current -> not active
+	c.Check(info1.IsActive(), Equals, false)
+	c.Check(info2.IsActive(), Equals, false)
+
+	mountdir := info1.MountDir()
+	dir, rev := filepath.Split(mountdir)
+	c.Assert(os.MkdirAll(dir, 0755), IsNil)
+	cur := filepath.Join(dir, "current")
+	c.Assert(os.Symlink(rev, cur), IsNil)
+
+	// is current -> is active
+	c.Check(info1.IsActive(), Equals, true)
+	c.Check(info2.IsActive(), Equals, false)
+}


### PR DESCRIPTION
Without this change, [lp:1783772] happens: the system journal receives a lot of non-debug error messages when there is a disabled snap that has (had?) services.

[lp:1783772]: https://bugs.launchpad.net/snappy/+bug/1783772