### PR TITLE
udev: skip TestParseUdevEvent on s390x

### DIFF
--- a/osutil/udev/netlink/uevent_test.go
+++ b/osutil/udev/netlink/uevent_test.go
@@ -1,6 +1,9 @@
 package netlink
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 type testingWrapper struct {
 	*testing.T
@@ -62,6 +65,10 @@ func TestParseUEvent(testing *testing.T) {
 }
 
 func TestParseUdevEvent(testing *testing.T) {
+	if runtime.GOARCH == "s390x" {
+		testing.Skip("This test assumes little-endian architecture")
+	}
+
 	t := testingWrapper{testing}
 
 	// Input samples obtained by running the main testing binary in monitor mode


### PR DESCRIPTION
The input byte data is hardcoded for little-endian architectures.
However the s390x is big endian so this test always fails because
the data is incorrectly aligned.

This will fix the build of snapd on s390x which is broken since
udev got merged.

