### PR TITLE
snap-confine: update snappy-app-dev path

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -68,7 +68,7 @@
     /etc/udev/udev.conf r,
     /sys/**/uevent r,
     /usr/lib/snapd/snap-device-helper ixr, # drop
-    /lib/udev/snappy-app-dev ixr, # drop
+    /{,usr/}lib/udev/snappy-app-dev ixr, # drop
     /run/udev/** rw,
     /{,usr/}bin/tr ixr,
     /usr/lib/locale/** r,


### PR DESCRIPTION
From https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1784394:

Forking https://bugs.launchpad.net/ubuntu/+source/apparmor-profiles-extra/+bug/1784023 with a patch for snapd.