### PR TITLE
(2.34) cmd/snap-confine: allow ptrace read for 4.18 kernels

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -365,6 +365,8 @@
     # support for the mount namespace sharing
     capability sys_ptrace,
     # allow snap-confine to read /proc/1/ns/mnt
+    ptrace read peer=unconfined,
+    # https://forum.snapcraft.io/t/custom-kernel-error-on-readlinkat-in-mount-namespace/6097/21
     ptrace trace peer=unconfined,
 
     mount options=(rw rbind) /run/snapd/ns/ -> /run/snapd/ns/,


### PR DESCRIPTION
Kernels < 4.18 incorrectly require 'ptrace trace' to read /proc/1/ns/mnt and
this was corrected to only require 'ptrace read'. This commit simply adds
'ptrace read peer=unconfined,', leaving the old 'trace' rule. A future commit
will remove the 'trace' rule by default and interrogate the kernel to
conditionally add it back when needed.

Reference:
https://forum.snapcraft.io/t/custom-kernel-error-on-readlinkat-in-mount-namespace/6097/19