### PR TITLE
tests/lib/prepare-restore: update Arch Linux kernel LOCALVERSION handling

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -296,8 +296,13 @@ prepare_project() {
             fi
         fi
         # double check we are running the installed kernel
-        # NOTE: arch kernels use ARCH as local version, eg. 4.16.13-2-ARCH
-        if [[ "$(pacman -Qi linux | grep '^Version' | awk '{print $3}')" != "$(uname -r | sed -e 's/-ARCH//')" ]]; then
+        # NOTE: LOCALVERSION is set by scripts/setlocalversion and loos like
+        # 4.17.11-arch1, since this may not match pacman -Qi output, we'll list
+        # the files within the package instead
+        # pacman -Ql linux output:
+        # ...
+        # linux /usr/lib/modules/4.17.11-arch1/modules.alias
+        if [[ "$(pacman -Ql linux | cut -f2 -d' ' |grep '/usr/lib/modules/.*/modules'|cut -f5 -d/ | uniq)" != "$(uname -r)" ]]; then
             echo "running unexpected kernel version $(uname -r)"
             exit 1
         fi


### PR DESCRIPTION
Since 2018.07.30 the kernel localversion is set by scripts/setlocalversion in
the kernel tree and no longer matches the package version as seen in `pacman -Qi
linux` output. What before was eg. 4.16.13-2-ARCH with package version 4.16.13-2
is now changed to 4.17.11-arch1, package version 4.17.11-1.

Refactor the check look at the contents of the linux package instead and match
that with the running kernel. This will make us immune to any future package
versioning changes.

