### PR TITLE
tests/main/apt-hooks: debug dump of commands.db

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -8,6 +8,8 @@ restore: |
 
 debug: |
     ls -lh /var/cache/snapd
+    # low tech dump of db
+    strings /var/cache/snapd/commands.db | sed  -e 's#"}\(]\)\?#"}\1\n#g'
     
 execute: |
     echo "Ensure we have a snap catalog in our cache"


### PR DESCRIPTION
apt-hooks test is a bit flaky. We already have a wait loop for the commands
file, nonetheless the test still occasionally fails. Attempt to dump the
contents of the database in debug section.

The magic sed line transforms:
```
wfc-cmars{"snap":"wfc-cmars","version":"0","summary":"This program generates
bitmaps that are locally similar to the input
bitmap."}whalebird{"snap":"whalebird","version":"1.5.3","summary":"Whalebird"}what-snap{"snap":"what-snap","version":"1.0","summary":"Turn
a snap id into a snap
name."}whatsdesk{"snap":"whatsdesk","version":"0.1.0","summary":"whatsdesk"}whois-snap
```
Into:
```
wfc-cmars{"snap":"wfc-cmars","version":"0","summary":"This program generates bitmaps that are locally similar to the input bitmap."}
whalebird{"snap":"whalebird","version":"1.5.3","summary":"Whalebird"}
what-snap{"snap":"what-snap","version":"1.0","summary":"Turn a snap id into a snap name."}
whatsdesk{"snap":"whatsdesk","version":"0.1.0","summary":"whatsdesk"}
```
