### PR TITLE
advise: make the bolt database do the atomic rename dance

### DIFF
--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -70,7 +70,13 @@ func (r *catalogRefresh) Ensure() error {
 
 	logger.Debugf("Catalog refresh starting now; next scheduled for %s.", next)
 
-	return refreshCatalogs(r.state, theStore)
+	err := refreshCatalogs(r.state, theStore)
+	if err == nil {
+		logger.Debugf("Catalog refresh succeeded.")
+	} else {
+		logger.Debugf("Catalog refresh failed: %v.", err)
+	}
+	return err
 }
 
 var newCmdDB = advisor.Create


### PR DESCRIPTION
Before this change, `advise.Create` was opening the commands database
and holding it open while querying the store and repopulating it, which
blocked concurrent read-only clients (as returned by `advise.Open`).

This change instead has `advise.Create` write to a new database every
time, which is then renamed after Close using the atomic dance. This
together with the 1s timeout on `advise.Open` should minimise the
unavailability of `snap advise` results that were impacting the apt
integration test (and, possibly, users).
