### PR TITLE
snap: introduce package-level helpers for building snap related directory/file paths

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -150,7 +150,7 @@ func UserCommonDataDir(home string, name string) string {
 // UserXdgRuntimeDir returns the user-specific XDG_RUNTIME_DIR directory for
 // given snap name. The name can be either a snap name or snap instance name.
 func UserXdgRuntimeDir(euid sys.UserID, name string) string {
-	return filepath.Join("/run/user", fmt.Sprintf("%d/snap.%s", euid, name))
+	return filepath.Join(dirs.XdgRuntimeDirBase, fmt.Sprintf("%d/snap.%s", euid, name))
 }
 
 // SideInfo holds snap metadata that is crucial for the tracking of

--- a/snap/info.go
+++ b/snap/info.go
@@ -117,6 +117,36 @@ func NoneSecurityTag(snapName, uniqueName string) string {
 	return ScopedSecurityTag(snapName, "none", uniqueName)
 }
 
+// DataDir returns the data directory of the snap.
+func DataDir(snapName string, revision Revision) string {
+	return filepath.Join(dirs.SnapDataDir, snapName, revision.String())
+}
+
+// CommonDataDir returns the data directory common across revisions of the snap.
+func CommonDataDir(snapName string) string {
+	return filepath.Join(dirs.SnapDataDir, snapName, "common")
+}
+
+// HooksDir returns the directory containing the snap's hooks.
+func HooksDir(snapName string, revision Revision) string {
+	return filepath.Join(MountDir(snapName, revision), "meta", "hooks")
+}
+
+// UserDataDir returns the user-specific data directory of the snap.
+func UserDataDir(home string, snapName string, revision Revision) string {
+	return filepath.Join(home, dirs.UserHomeSnapDir, snapName, revision.String())
+}
+
+// UserCommonDataDir returns the user-specific data directory common across revision of the snap.
+func UserCommonDataDir(home string, snapName string) string {
+	return filepath.Join(home, dirs.UserHomeSnapDir, snapName, "common")
+}
+
+// UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a particular user.
+func UserXdgRuntimeDir(euid sys.UserID, snapName string) string {
+	return filepath.Join("/run/user", fmt.Sprintf("%d/snap.%s", euid, snapName))
+}
+
 // SideInfo holds snap metadata that is crucial for the tracking of
 // snaps and for the working of the system offline and which is not
 // included in snap.yaml or for which the store is the canonical
@@ -313,27 +343,27 @@ func (s *Info) MountFile() string {
 
 // HooksDir returns the directory containing the snap's hooks.
 func (s *Info) HooksDir() string {
-	return filepath.Join(s.MountDir(), "meta", "hooks")
+	return HooksDir(s.InstanceName(), s.Revision)
 }
 
 // DataDir returns the data directory of the snap.
 func (s *Info) DataDir() string {
-	return filepath.Join(dirs.SnapDataDir, s.InstanceName(), s.Revision.String())
+	return DataDir(s.InstanceName(), s.Revision)
 }
 
 // UserDataDir returns the user-specific data directory of the snap.
 func (s *Info) UserDataDir(home string) string {
-	return filepath.Join(home, dirs.UserHomeSnapDir, s.InstanceName(), s.Revision.String())
+	return UserDataDir(home, s.InstanceName(), s.Revision)
 }
 
 // UserCommonDataDir returns the user-specific data directory common across revision of the snap.
 func (s *Info) UserCommonDataDir(home string) string {
-	return filepath.Join(home, dirs.UserHomeSnapDir, s.InstanceName(), "common")
+	return UserCommonDataDir(home, s.InstanceName())
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.
 func (s *Info) CommonDataDir() string {
-	return filepath.Join(dirs.SnapDataDir, s.InstanceName(), "common")
+	return CommonDataDir(s.InstanceName())
 }
 
 // DataHomeDir returns the per user data directory of the snap.
@@ -348,7 +378,7 @@ func (s *Info) CommonDataHomeDir() string {
 
 // UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a particular user.
 func (s *Info) UserXdgRuntimeDir(euid sys.UserID) string {
-	return filepath.Join("/run/user", fmt.Sprintf("%d/snap.%s", euid, s.InstanceName()))
+	return UserXdgRuntimeDir(euid, s.InstanceName())
 }
 
 // XdgRuntimeDirs returns the XDG_RUNTIME_DIR directories for all users of the snap.

--- a/snap/info.go
+++ b/snap/info.go
@@ -117,34 +117,40 @@ func NoneSecurityTag(snapName, uniqueName string) string {
 	return ScopedSecurityTag(snapName, "none", uniqueName)
 }
 
-// DataDir returns the data directory of the snap.
-func DataDir(snapName string, revision Revision) string {
-	return filepath.Join(dirs.SnapDataDir, snapName, revision.String())
+// DataDir returns the data directory for given snap name. The name can be
+// either a snap name or snap instance name.
+func DataDir(name string, revision Revision) string {
+	return filepath.Join(dirs.SnapDataDir, name, revision.String())
 }
 
-// CommonDataDir returns the data directory common across revisions of the snap.
-func CommonDataDir(snapName string) string {
-	return filepath.Join(dirs.SnapDataDir, snapName, "common")
+// CommonDataDir returns the common data directory for given snap name. The name
+// can be either a snap name or snap instance name.
+func CommonDataDir(name string) string {
+	return filepath.Join(dirs.SnapDataDir, name, "common")
 }
 
-// HooksDir returns the directory containing the snap's hooks.
-func HooksDir(snapName string, revision Revision) string {
-	return filepath.Join(MountDir(snapName, revision), "meta", "hooks")
+// HooksDir returns the directory containing the snap's hooks for given snap
+// name. The name can be either a snap name or snap instance name.
+func HooksDir(name string, revision Revision) string {
+	return filepath.Join(MountDir(name, revision), "meta", "hooks")
 }
 
-// UserDataDir returns the user-specific data directory of the snap.
-func UserDataDir(home string, snapName string, revision Revision) string {
-	return filepath.Join(home, dirs.UserHomeSnapDir, snapName, revision.String())
+// UserDataDir returns the user-specific data directory for given snap name. The
+// name can be either a snap name or snap instance name.
+func UserDataDir(home string, name string, revision Revision) string {
+	return filepath.Join(home, dirs.UserHomeSnapDir, name, revision.String())
 }
 
-// UserCommonDataDir returns the user-specific data directory common across revision of the snap.
-func UserCommonDataDir(home string, snapName string) string {
-	return filepath.Join(home, dirs.UserHomeSnapDir, snapName, "common")
+// UserCommonDataDir returns the user-specific common data directory for given
+// snap name. The name can be either a snap name or snap instance name.
+func UserCommonDataDir(home string, name string) string {
+	return filepath.Join(home, dirs.UserHomeSnapDir, name, "common")
 }
 
-// UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a particular user.
-func UserXdgRuntimeDir(euid sys.UserID, snapName string) string {
-	return filepath.Join("/run/user", fmt.Sprintf("%d/snap.%s", euid, snapName))
+// UserXdgRuntimeDir returns the user-specific XDG_RUNTIME_DIR directory for
+// given snap name. The name can be either a snap name or snap instance name.
+func UserXdgRuntimeDir(euid sys.UserID, name string) string {
+	return filepath.Join("/run/user", fmt.Sprintf("%d/snap.%s", euid, name))
 }
 
 // SideInfo holds snap metadata that is crucial for the tracking of

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1269,3 +1269,25 @@ func (s *infoSuite) TestIsActive(c *C) {
 	c.Check(info1.IsActive(), Equals, true)
 	c.Check(info2.IsActive(), Equals, false)
 }
+
+func (s *infoSuite) TestDirAndFileHelpers(c *C) {
+	dirs.SetRootDir("")
+
+	c.Check(snap.MountDir("name", snap.R(1)), Equals, fmt.Sprintf("%s/name/1", dirs.SnapMountDir))
+	c.Check(snap.MountFile("name", snap.R(1)), Equals, "/var/lib/snapd/snaps/name_1.snap")
+	c.Check(snap.HooksDir("name", snap.R(1)), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapMountDir))
+	c.Check(snap.DataDir("name", snap.R(1)), Equals, "/var/snap/name/1")
+	c.Check(snap.CommonDataDir("name"), Equals, "/var/snap/name/common")
+	c.Check(snap.UserDataDir("/home/bob", "name", snap.R(1)), Equals, "/home/bob/snap/name/1")
+	c.Check(snap.UserCommonDataDir("/home/bob", "name"), Equals, "/home/bob/snap/name/common")
+	c.Check(snap.UserXdgRuntimeDir(12345, "name"), Equals, "/run/user/12345/snap.name")
+
+	c.Check(snap.MountDir("name_instance", snap.R(1)), Equals, fmt.Sprintf("%s/name_instance/1", dirs.SnapMountDir))
+	c.Check(snap.MountFile("name_instance", snap.R(1)), Equals, "/var/lib/snapd/snaps/name_instance_1.snap")
+	c.Check(snap.HooksDir("name_instance", snap.R(1)), Equals, fmt.Sprintf("%s/name_instance/1/meta/hooks", dirs.SnapMountDir))
+	c.Check(snap.DataDir("name_instance", snap.R(1)), Equals, "/var/snap/name_instance/1")
+	c.Check(snap.CommonDataDir("name_instance"), Equals, "/var/snap/name_instance/common")
+	c.Check(snap.UserDataDir("/home/bob", "name_instance", snap.R(1)), Equals, "/home/bob/snap/name_instance/1")
+	c.Check(snap.UserCommonDataDir("/home/bob", "name_instance"), Equals, "/home/bob/snap/name_instance/common")
+	c.Check(snap.UserXdgRuntimeDir(12345, "name_instance"), Equals, "/run/user/12345/snap.name_instance")
+}


### PR DESCRIPTION
The current snap.Info methods build paths using InstanceName(). Introduce
package-level helpers for building snap related paths. With this the callers can
easily build paths that are snap (as in SnapName()) specific having a snap
instance.

