### PR TITLE
daemon, systemd: change journalctl -n=all to --no-tail

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2744,17 +2744,13 @@ func getAppsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 
 func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 	query := r.URL.Query()
-	n := "10"
+	n := 10
 	if s := query.Get("n"); s != "" {
 		m, err := strconv.ParseInt(s, 0, 32)
 		if err != nil {
 			return BadRequest(`invalid value for n: %q: %v`, s, err)
 		}
-		if m < 0 {
-			n = "all"
-		} else {
-			n = s
-		}
+		n = int(m)
 	}
 	follow := false
 	if s := query.Get("follow"); s != "" {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -102,7 +102,7 @@ type apiBaseSuite struct {
 
 	journalctlRestorer func()
 	jctlSvcses         [][]string
-	jctlNs             []string
+	jctlNs             []int
 	jctlFollows        []bool
 	jctlRCs            []io.ReadCloser
 	jctlErrs           []error
@@ -194,7 +194,7 @@ func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {
 	return buf, err
 }
 
-func (s *apiBaseSuite) journalctl(svcs []string, n string, follow bool) (rc io.ReadCloser, err error) {
+func (s *apiBaseSuite) journalctl(svcs []string, n int, follow bool) (rc io.ReadCloser, err error) {
 	s.jctlSvcses = append(s.jctlSvcses, svcs)
 	s.jctlNs = append(s.jctlNs, n)
 	s.jctlFollows = append(s.jctlFollows, follow)
@@ -6789,7 +6789,7 @@ func (s *appSuite) TestLogs(c *check.C) {
 	getLogs(logsCmd, req, nil).ServeHTTP(rec, req)
 
 	c.Check(s.jctlSvcses, check.DeepEquals, [][]string{{"snap.snap-a.svc2.service"}})
-	c.Check(s.jctlNs, check.DeepEquals, []string{"42"})
+	c.Check(s.jctlNs, check.DeepEquals, []int{42})
 	c.Check(s.jctlFollows, check.DeepEquals, []bool{false})
 
 	c.Check(rec.Code, check.Equals, 200)
@@ -6806,15 +6806,15 @@ func (s *appSuite) TestLogs(c *check.C) {
 func (s *appSuite) TestLogsN(c *check.C) {
 	type T struct {
 		in  string
-		out string
+		out int
 	}
 
 	for _, t := range []T{
-		{in: "", out: "10"},
-		{in: "0", out: "0"},
-		{in: "-1", out: "all"},
-		{in: strconv.Itoa(math.MinInt32), out: "all"},
-		{in: strconv.Itoa(math.MaxInt32), out: strconv.Itoa(math.MaxInt32)},
+		{in: "", out: 10},
+		{in: "0", out: 0},
+		{in: "-1", out: -1},
+		{in: strconv.Itoa(math.MinInt32), out: math.MinInt32},
+		{in: strconv.Itoa(math.MaxInt32), out: math.MaxInt32},
 	} {
 
 		s.jctlRCs = []io.ReadCloser{ioutil.NopCloser(strings.NewReader(""))}
@@ -6826,7 +6826,7 @@ func (s *appSuite) TestLogsN(c *check.C) {
 		rec := httptest.NewRecorder()
 		getLogs(logsCmd, req, nil).ServeHTTP(rec, req)
 
-		c.Check(s.jctlNs, check.DeepEquals, []string{t.out})
+		c.Check(s.jctlNs, check.DeepEquals, []int{t.out})
 	}
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -77,13 +77,18 @@ func Available() error {
 var osutilStreamCommand = osutil.StreamCommand
 
 // jctl calls journalctl to get the JSON logs of the given services.
-var jctl = func(svcs []string, n string, follow bool) (io.ReadCloser, error) {
+var jctl = func(svcs []string, n int, follow bool) (io.ReadCloser, error) {
 	// args will need two entries per service, plus a fixed number (give or take
 	// one) for the initial options.
-	args := make([]string, 0, 2*len(svcs)+6)
-	args = append(args, "-o", "json", "-n", n, "--no-pager") // len(this)+1 == that ^ fixed number
+	args := make([]string, 0, 2*len(svcs)+6)        // the fixed number is 6
+	args = append(args, "-o", "json", "--no-pager") //   3...
+	if n < 0 {
+		args = append(args, "--no-tail") // < 2
+	} else {
+		args = append(args, "-n", strconv.Itoa(n)) // ... + 2 ...
+	}
 	if follow {
-		args = append(args, "-f") // this is the +1 :-)
+		args = append(args, "-f") // ... + 1 == 6
 	}
 
 	for i := range svcs {
@@ -93,7 +98,7 @@ var jctl = func(svcs []string, n string, follow bool) (io.ReadCloser, error) {
 	return osutilStreamCommand("journalctl", args...)
 }
 
-func MockJournalctl(f func(svcs []string, n string, follow bool) (io.ReadCloser, error)) func() {
+func MockJournalctl(f func(svcs []string, n int, follow bool) (io.ReadCloser, error)) func() {
 	oldJctl := jctl
 	jctl = f
 	return func() {
@@ -111,7 +116,7 @@ type Systemd interface {
 	Kill(service, signal, who string) error
 	Restart(service string, timeout time.Duration) error
 	Status(services ...string) ([]*ServiceStatus, error)
-	LogReader(services []string, n string, follow bool) (io.ReadCloser, error)
+	LogReader(services []string, n int, follow bool) (io.ReadCloser, error)
 	WriteMountUnitFile(name, revision, what, where, fstype string) (string, error)
 	Mask(service string) error
 	Unmask(service string) error
@@ -185,7 +190,7 @@ func (*systemd) Start(serviceNames ...string) error {
 }
 
 // LogReader for the given services
-func (*systemd) LogReader(serviceNames []string, n string, follow bool) (io.ReadCloser, error) {
+func (*systemd) LogReader(serviceNames []string, n int, follow bool) (io.ReadCloser, error) {
 	return jctl(serviceNames, n, follow)
 }
 


### PR DESCRIPTION
Turns out `journalctl` on 14.04 does not understand `-n=all`.  It does
understand `--no-tail` which does the same thing, and every `journalctl` since
then understands this as well, so this change moves us to use it instead.

Kudos to @sergiocazzolato for writing the test that found this issue.
