### PR TITLE
snap/snapenv: add snap instance specific variables

### DIFF
--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -105,14 +105,17 @@ func basicEnv(info *snap.Info) map[string]string {
 		// the environment of each snap instance appear as if it's the
 		// only snap, i.e. SNAP paths point to the same locations within
 		// the mount namespace
-		"SNAP":          filepath.Join(dirs.CoreSnapMountDir, info.SnapName(), info.Revision.String()),
-		"SNAP_COMMON":   snap.CommonDataDir(info.SnapName()),
-		"SNAP_DATA":     snap.DataDir(info.SnapName(), info.Revision),
-		"SNAP_NAME":     info.SnapName(),
-		"SNAP_INSTANCE": info.InstanceName(),
-		"SNAP_VERSION":  info.Version,
-		"SNAP_REVISION": info.Revision.String(),
-		"SNAP_ARCH":     arch.UbuntuArchitecture(),
+		"SNAP":                 filepath.Join(dirs.CoreSnapMountDir, info.SnapName(), info.Revision.String()),
+		"SNAP_COMMON":          snap.CommonDataDir(info.SnapName()),
+		"SNAP_DATA":            snap.DataDir(info.SnapName(), info.Revision),
+		"SNAP_NAME":            info.SnapName(),
+		"SNAP_INSTANCE":        filepath.Join(dirs.CoreSnapMountDir, info.InstanceName(), info.Revision.String()),
+		"SNAP_INSTANCE_NAME":   info.InstanceName(),
+		"SNAP_INSTANCE_COMMON": info.CommonDataDir(),
+		"SNAP_INSTANCE_DATA":   info.DataDir(),
+		"SNAP_VERSION":         info.Version,
+		"SNAP_REVISION":        info.Revision.String(),
+		"SNAP_ARCH":            arch.UbuntuArchitecture(),
 		// see https://github.com/snapcore/snapd/pull/2732#pullrequestreview-18827193
 		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
 		"SNAP_REEXEC":       os.Getenv("SNAP_REEXEC"),
@@ -126,9 +129,11 @@ func basicEnv(info *snap.Info) map[string]string {
 func userEnv(info *snap.Info, home string) map[string]string {
 	// TODO parallel-install: use of proper instance/store name
 	result := map[string]string{
-		"SNAP_USER_COMMON": snap.UserCommonDataDir(home, info.SnapName()),
-		"SNAP_USER_DATA":   snap.UserDataDir(home, info.SnapName(), info.Revision),
-		"XDG_RUNTIME_DIR":  snap.UserXdgRuntimeDir(sys.Geteuid(), info.SnapName()),
+		"SNAP_USER_COMMON":          snap.UserCommonDataDir(home, info.SnapName()),
+		"SNAP_USER_DATA":            snap.UserDataDir(home, info.SnapName(), info.Revision),
+		"SNAP_INSTANCE_USER_COMMON": info.UserCommonDataDir(home),
+		"SNAP_INSTANCE_USER_DATA":   info.UserDataDir(home),
+		"XDG_RUNTIME_DIR":           info.UserXdgRuntimeDir(sys.Geteuid()),
 	}
 	// For non-classic snaps, we set HOME but on classic allow snaps to see real HOME
 	if !info.NeedsClassic() {

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -81,16 +81,19 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	env := basicEnv(mockSnapInfo)
 
 	c.Assert(env, DeepEquals, map[string]string{
-		"SNAP":              fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
-		"SNAP_ARCH":         arch.UbuntuArchitecture(),
-		"SNAP_COMMON":       "/var/snap/foo/common",
-		"SNAP_DATA":         "/var/snap/foo/17",
-		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
-		"SNAP_NAME":         "foo",
-		"SNAP_INSTANCE":     "foo",
-		"SNAP_REEXEC":       "",
-		"SNAP_REVISION":     "17",
-		"SNAP_VERSION":      "1.0",
+		"SNAP":                 fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
+		"SNAP_ARCH":            arch.UbuntuArchitecture(),
+		"SNAP_COMMON":          "/var/snap/foo/common",
+		"SNAP_DATA":            "/var/snap/foo/17",
+		"SNAP_LIBRARY_PATH":    "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+		"SNAP_NAME":            "foo",
+		"SNAP_INSTANCE":        fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
+		"SNAP_INSTANCE_NAME":   "foo",
+		"SNAP_INSTANCE_COMMON": "/var/snap/foo/common",
+		"SNAP_INSTANCE_DATA":   "/var/snap/foo/17",
+		"SNAP_REEXEC":          "",
+		"SNAP_REVISION":        "17",
+		"SNAP_VERSION":         "1.0",
 	})
 
 }
@@ -99,10 +102,12 @@ func (ts *HTestSuite) TestUser(c *C) {
 	env := userEnv(mockSnapInfo, "/root")
 
 	c.Assert(env, DeepEquals, map[string]string{
-		"HOME":             "/root/snap/foo/17",
-		"SNAP_USER_COMMON": "/root/snap/foo/common",
-		"SNAP_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
+		"HOME":                      "/root/snap/foo/17",
+		"SNAP_USER_COMMON":          "/root/snap/foo/common",
+		"SNAP_USER_DATA":            "/root/snap/foo/17",
+		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo/common",
+		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo/17",
+		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
 	})
 }
 
@@ -111,9 +116,11 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 
 	c.Assert(env, DeepEquals, map[string]string{
 		// NOTE HOME Is absent! we no longer override it
-		"SNAP_USER_COMMON": "/root/snap/foo/common",
-		"SNAP_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
+		"SNAP_USER_COMMON":          "/root/snap/foo/common",
+		"SNAP_USER_DATA":            "/root/snap/foo/17",
+		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo/common",
+		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo/17",
+		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
 	})
 }
 
@@ -135,20 +142,25 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
-			"SNAP_ARCH":         arch.UbuntuArchitecture(),
-			"SNAP_COMMON":       "/var/snap/snapname/common",
-			"SNAP_DATA":         "/var/snap/snapname/42",
-			"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
-			"SNAP_NAME":         "snapname",
-			"SNAP_INSTANCE":     "snapname",
-			"SNAP_REEXEC":       "",
-			"SNAP_REVISION":     "42",
-			"SNAP_USER_COMMON":  fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_USER_DATA":    fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP_VERSION":      "1.0",
-			"XDG_RUNTIME_DIR":   fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
+			"HOME":                      fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP":                      fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_ARCH":                 arch.UbuntuArchitecture(),
+			"SNAP_COMMON":               "/var/snap/snapname/common",
+			"SNAP_DATA":                 "/var/snap/snapname/42",
+			"SNAP_LIBRARY_PATH":         "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+			"SNAP_NAME":                 "snapname",
+			"SNAP_INSTANCE":             fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_INSTANCE_NAME":        "snapname",
+			"SNAP_INSTANCE_COMMON":      "/var/snap/snapname/common",
+			"SNAP_INSTANCE_DATA":        "/var/snap/snapname/42",
+			"SNAP_REEXEC":               "",
+			"SNAP_REVISION":             "42",
+			"SNAP_USER_COMMON":          fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
+			"SNAP_USER_DATA":            fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP_INSTANCE_USER_COMMON": fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
+			"SNAP_INSTANCE_USER_DATA":   fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP_VERSION":              "1.0",
+			"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
 		})
 	}
 }
@@ -174,22 +186,57 @@ func (s *HTestSuite) TestParallelInstallSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
-			"SNAP_ARCH":         arch.UbuntuArchitecture(),
-			"SNAP_COMMON":       "/var/snap/snapname/common",
-			"SNAP_DATA":         "/var/snap/snapname/42",
-			"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
-			"SNAP_NAME":         "snapname",
-			"SNAP_INSTANCE":     "snapname_foo",
-			"SNAP_REEXEC":       "",
-			"SNAP_REVISION":     "42",
-			"SNAP_USER_COMMON":  fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_USER_DATA":    fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP_VERSION":      "1.0",
-			"XDG_RUNTIME_DIR":   fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
+			"HOME":                      fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP":                      fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_ARCH":                 arch.UbuntuArchitecture(),
+			"SNAP_COMMON":               "/var/snap/snapname/common",
+			"SNAP_DATA":                 "/var/snap/snapname/42",
+			"SNAP_LIBRARY_PATH":         "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+			"SNAP_NAME":                 "snapname",
+			"SNAP_INSTANCE":             fmt.Sprintf("%s/snapname_foo/42", dirs.CoreSnapMountDir),
+			"SNAP_INSTANCE_NAME":        "snapname_foo",
+			"SNAP_INSTANCE_COMMON":      "/var/snap/snapname_foo/common",
+			"SNAP_INSTANCE_DATA":        "/var/snap/snapname_foo/42",
+			"SNAP_REEXEC":               "",
+			"SNAP_REVISION":             "42",
+			"SNAP_USER_COMMON":          fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
+			"SNAP_USER_DATA":            fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP_INSTANCE_USER_COMMON": fmt.Sprintf("%s/snap/snapname_foo/common", usr.HomeDir),
+			"SNAP_INSTANCE_USER_DATA":   fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
+			"SNAP_VERSION":              "1.0",
+			"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),
 		})
 	}
+}
+
+func (ts *HTestSuite) TestParallelInstallUser(c *C) {
+	info := *mockSnapInfo
+	info.InstanceKey = "bar"
+	env := userEnv(&info, "/root")
+
+	c.Assert(env, DeepEquals, map[string]string{
+		"HOME":                      "/root/snap/foo/17",
+		"SNAP_USER_COMMON":          "/root/snap/foo/common",
+		"SNAP_USER_DATA":            "/root/snap/foo/17",
+		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo_bar/common",
+		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo_bar/17",
+		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
+	})
+}
+
+func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
+	info := *mockClassicSnapInfo
+	info.InstanceKey = "bar"
+	env := userEnv(&info, "/root")
+
+	c.Assert(env, DeepEquals, map[string]string{
+		// NOTE HOME Is absent! we no longer override it
+		"SNAP_USER_COMMON":          "/root/snap/foo/common",
+		"SNAP_USER_DATA":            "/root/snap/foo/17",
+		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo_bar/common",
+		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo_bar/17",
+		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
+	})
 }
 
 func envValue(env []string, key string) (bool, string) {

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -31,7 +31,7 @@ execute: |
     CTX=$(cat /var/lib/snapd/cookie/snap.test-snapd-tools)
     MATCH "^SNAP_COOKIE=$CTX"                                             < snap-vars.txt
     MATCH "^SNAP_CONTEXT=$CTX"                                            < snap-vars.txt
-    test $(wc -l < snap-vars.txt) -eq 12
+    test $(wc -l < snap-vars.txt) -eq 18
 
     echo "Enure that XDG environment variables are what we expect"
     MATCH '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$'  < xdg-vars.txt

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -31,6 +31,12 @@ execute: |
     CTX=$(cat /var/lib/snapd/cookie/snap.test-snapd-tools)
     MATCH "^SNAP_COOKIE=$CTX"                                             < snap-vars.txt
     MATCH "^SNAP_CONTEXT=$CTX"                                            < snap-vars.txt
+    # TODO parallel-install: install snap with instance key and verify variables
+    MATCH '^SNAP_INSTANCE_NAME=test-snapd-tools$'                         < snap-vars.txt
+    MATCH '^SNAP_INSTANCE_COMMON=/var/snap/test-snapd-tools/common$'      < snap-vars.txt
+    MATCH '^SNAP_INSTANCE_DATA=/var/snap/test-snapd-tools/x1$'            < snap-vars.txt
+    MATCH '^SNAP_INSTANCE_USER_COMMON=/root/snap/test-snapd-tools/common$' < snap-vars.txt
+    MATCH '^SNAP_INSTANCE_USER_DATA=/root/snap/test-snapd-tools/x1$'      < snap-vars.txt
     test $(wc -l < snap-vars.txt) -eq 18
 
     echo "Enure that XDG environment variables are what we expect"


### PR DESCRIPTION
Extend snap environment with snap instance specific variables. Those are used by the application run inside the snap and by `snap-confine`. 

Currently, in the branch still waiting to be proposed, `snap-confine` makes use of `SNAP_INSTANCE_NAME` and `SNAP_INSTANCE_USER_DATA`.

Note, `XDG_RUNTIME_DIR` is currently only set to snap instance specific value. In contrast to snap user data directory, which we make in snap-confine, XDG runtime directory is not touched or made. The code to create is on demand in snap-confine is currently between `#if 0 .. #endif`.
