### PR TITLE
configstate: accept refresh.timer=managed

### DIFF
--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -83,10 +83,20 @@ execute: |
     echo "Then the core refresh.schedule can be set to 'managed'"
     snap set core refresh.schedule=managed
     if get_journalctl_log -u snapd |grep 'cannot parse "managed"'; then
-        echo "refresh.schedule=managed was not rejected as it should be"
+        echo "refresh.schedule=managed was not accepted as it should be"
         exit 1
     fi
     snap refresh --time | MATCH 'schedule: managed'
+
+    echo "Reset refresh.schedule"
+    snap set core refresh.schedule=
+    if snap refresh --time | grep -q -E 'schedule: managed'; then
+        echo "Refresh schedule not reset, test broken"
+        exit 1
+    fi
+    echo "Then the core refresh.timer can be set to 'managed'"
+    snap set core refresh.timer=managed
+    snap refresh --time | MATCH 'timer: managed'
 
     # make sure we trigger a refresh for hints at least once
     systemctl stop snapd.socket snapd.service
@@ -115,5 +125,10 @@ execute: |
     echo "Then the snap refresh schedule cannot be set to managed"
     if snap set core refresh.schedule=managed; then
        echo "refresh.schedule=managed was not rejected as it should be"
+       exit 1
+    fi
+    echo "Then the snap refresh timer cannot be set to managed"
+    if snap set core refresh.timer=managed; then
+       echo "refresh.timer=managed was not rejected as it should be"
        exit 1
     fi


### PR DESCRIPTION
The previous PR to fix this was incomplete and it did not include
a required update for the configstate code. This is fixed now and
the spread test is updated to include the new setting.

