### PR TITLE
wrappers: account for changed app wrapper in parallel installed snaps

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -108,10 +108,14 @@ func rewriteExecLine(s *snap.Info, desktopFile, line string) (string, error) {
 
 	cmd := strings.SplitN(line, "=", 2)[1]
 	for _, app := range s.Apps {
-		// TODO parallel-install: adjust valid command checks to account
-		// for instance name
 		wrapper := app.WrapperPath()
 		validCmd := filepath.Base(wrapper)
+		if s.InstanceKey != "" {
+			// wrapper uses s.InstanceName(), with the instance key
+			// set the command will be 'snap_foo.app' instead of
+			// 'snap.app', need to account for that
+			validCmd = snap.JoinSnapApp(s.SnapName(), app.Name)
+		}
 		// check the prefix to allow %flag style args
 		// this is ok because desktop files are not run through sh
 		// so we don't have to worry about the arguments too much

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -326,6 +326,50 @@ TargetEnvironment=Unity
 	c.Assert(string(e), Equals, string(desktopContent))
 }
 
+func (s *sanitizeDesktopFileSuite) TestSanitizeParallelInstancesPlain(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+apps:
+ app:
+  command: cmd
+`))
+	snap.InstanceKey = "bar"
+	c.Assert(err, IsNil)
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+Exec=snap.app
+`)
+
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+Name=foo
+Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap_bar.app
+`, dirs.SnapMountDir))
+}
+
+func (s *sanitizeDesktopFileSuite) TestSanitizeParallelInstancesWithArgs(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+apps:
+ app:
+  command: cmd
+`))
+	snap.InstanceKey = "bar"
+	c.Assert(err, IsNil)
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+Exec=snap.app %U
+`)
+
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+Name=foo
+Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap_bar.app %%U
+`, dirs.SnapMountDir))
+}
+
 func (s *sanitizeDesktopFileSuite) TestRewriteExecLineInvalid(c *C) {
 	snap := &snap.Info{}
 	_, err := wrappers.RewriteExecLine(snap, "foo.desktop", "Exec=invalid")

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -340,11 +340,11 @@ apps:
 Name=foo
 Exec=snap.app
 `)
-
-	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	df := filepath.Base(snap.Apps["app"].DesktopFile())
+	e := wrappers.SanitizeDesktopFile(snap, df, desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap_bar.app
+Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app
 `, dirs.SnapMountDir))
 }
 
@@ -363,10 +363,11 @@ Name=foo
 Exec=snap.app %U
 `)
 
-	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	df := filepath.Base(snap.Apps["app"].DesktopFile())
+	e := wrappers.SanitizeDesktopFile(snap, df, desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap_bar.app %%U
+Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app %%U
 `, dirs.SnapMountDir))
 }
 


### PR DESCRIPTION
App wrapper uses s.InstanceName(), with the instance key set the command will be
'snap_foo.app' instead of 'snap.app'. We need to account for that to be able to
sanitize the desktop file correctly. However, the resulting Exec= line should
still run the instance's app wrapper.


