### PR TITLE
wrappers: make sure that the tests pass on non-Ubuntu too

### DIFF
--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -52,6 +52,12 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCore(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
+	restore = release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
+	defer restore()
+
+	// reset root dir
+	dirs.SetRootDir(s.tempdir)
+
 	info := makeMockSnapdSnap(c)
 	// add the snapd service
 	err := wrappers.AddSnapServices(info, nil)


### PR DESCRIPTION
Make sure that the paths are what we expect them to be when generating snapd wrappers on non-Ubuntu distros.
