### PR TITLE
wrappers: do not glob when removing desktop files

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -238,14 +238,16 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 
 // RemoveSnapDesktopFiles removes the added desktop files for the applications in the snap.
 func RemoveSnapDesktopFiles(s *snap.Info) error {
-	// TODO parallel-install: verify use of instance names here
-	glob := filepath.Join(dirs.SnapDesktopFilesDir, s.InstanceName()+"_*.desktop")
-	activeDesktopFiles, err := filepath.Glob(glob)
-	if err != nil {
-		return fmt.Errorf("cannot get desktop files for %v: %s", glob, err)
-	}
-	for _, f := range activeDesktopFiles {
-		os.Remove(f)
+	activeDesktopFiles := make([]string, 0, len(s.Apps))
+	for _, app := range s.Apps {
+		df := app.DesktopFile()
+		if err := os.Remove(df); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else {
+			activeDesktopFiles = append(activeDesktopFiles, app.DesktopFile())
+		}
 	}
 
 	// updates mime info etc

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -62,6 +62,8 @@ func (s *desktopSuite) TearDownTest(c *C) {
 var desktopAppYaml = `
 name: foo
 version: 1.0
+apps:
+    foobar:
 `
 
 var mockDesktopFile = []byte(`
@@ -110,11 +112,56 @@ func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
 	})
 }
 
+func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance_foobar.desktop")
+
+	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
+	c.Assert(err, IsNil)
+	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
+	c.Assert(err, IsNil)
+
+	err = wrappers.RemoveSnapDesktopFiles(info)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
+	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
+		{"update-desktop-database", dirs.SnapDesktopFilesDir},
+	})
+	// foo_instance file is still there
+	c.Assert(osutil.FileExists(mockDesktopInstanceFilePath), Equals, true)
+
+	// restore the non-instance file
+	err = ioutil.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
+	c.Assert(err, IsNil)
+
+	s.mockUpdateDesktopDatabase.ForgetCalls()
+
+	info.InstanceKey = "instance"
+	err = wrappers.RemoveSnapDesktopFiles(info)
+	c.Assert(osutil.FileExists(mockDesktopInstanceFilePath), Equals, false)
+	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
+		{"update-desktop-database", dirs.SnapDesktopFilesDir},
+	})
+	// foo file is still there
+	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, true)
+}
+
 func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar1.desktop")
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 
-	err := os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
+	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
+	c.Assert(err, IsNil)
+
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance_foobar.desktop")
+	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
+	c.Assert(err, IsNil)
+
+	err = os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
 	c.Assert(err, IsNil)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
@@ -133,6 +180,8 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	c.Check(err, NotNil)
 	c.Check(osutil.FileExists(mockDesktopFilePath), Equals, false)
 	c.Check(s.mockUpdateDesktopDatabase.Calls(), HasLen, 0)
+	// foo_instance file was not removed by cleanup
+	c.Check(osutil.FileExists(mockDesktopInstanceFilePath), Equals, true)
 }
 
 // sanitize


### PR DESCRIPTION
Do not use 'snap_*.desktop' globbing when removing desktop files. This would
accidentally remove desktop files of other snap instances of the same snap.


