### PR TITLE
tests: add dbus monitor log to interfaces-accounts-service

### DIFF
--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -19,9 +19,15 @@ prepare: |
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
+    # this will also kill the "gdbus monitor" command
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
     rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+    # usually not needed, this should die when dbus goes down
+    kill "$(cat gdbus-monitor.pid)" || true
+
+debug: |
+    cat gdbus.log || true
 
 execute: |
     echo "Ensure things run"
@@ -29,6 +35,9 @@ execute: |
     echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
     eval "$(printf password|gnome-keyring-daemon --login)"
     eval "$(gnome-keyring-daemon --start)"
+    # add debug
+    gdbus monitor --session --dest org.gnome.OnlineAccounts >gdbus.log 2>&1 &
+    echo "$!" > gdbus-monitor.pid
 
     echo "Creating account"
     # We set a long timeout here because goa-daemon will be activated


### PR DESCRIPTION
We saw some failures in the tests:
```
Creating account
+ gdbus call --session --timeout 300 --dest=org.gnome.OnlineAccounts --object-path=/org/gnome/OnlineAccounts/Manager --method=org.gnome.OnlineAccounts.Manager.AddAccount imap_smtp test@example.com 'Display Name' '{}' '{'\''Enabled'\'': '\''true'\'', '\''EmailAddress'\'': '\''test@example.com'\'', '\''Name'\'': '\''Test User'\'', '\''ImapHost'\'': '\''imap.example.com'\'', '\''SmtpHost'\'': '\''mail.example.com'\''}'
Error: GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: Type of message, '(ssssa{ss})', does not match expected type '(sssa{sv}a{ss})'
```
and it would be nice to get to the bottom of this.
