### PR TITLE
tests: enable snapctl test on core18

### DIFF
--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -1,11 +1,13 @@
 summary: Check that `snapctl` can be run from within hooks
 
-# core18 has no curl
-systems: [-ubuntu-core-18-*]
-
 prepare: |
     snap pack $TESTSLIB/snaps/snapctl-hooks
     snap install --dangerous snapctl-hooks_1.0_all.snap
+    # ensure curl is available (needed for e.g. core18)
+    if ! command -v curl; then
+        snap install --devmode --edge test-snapd-curl
+        snap alias test-snapd-curl.curl curl
+    fi
 
 restore: |
     rm -f snapctl-hooks_1.0_all.snap


### PR DESCRIPTION
The snapctl test was disabled on core18 because there was is no
curl on core18. We created a test-snapd-curl snap now and will
task snapcrafters (and/or upstream) to adopt it.

