### PR TITLE
tests: enable interfaces-framebuffer everywhere

### DIFF
--- a/tests/main/interfaces-framebuffer/task.yaml
+++ b/tests/main/interfaces-framebuffer/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensure that the framebuffer interface works.
 
-# systems listed below do not have /dev/fb0
-systems: [ -ubuntu-14.04-*, -ubuntu-16.04-*, -ubuntu-18.04-*, -fedora-28-*, -debian-9-*, -ubuntu-core-16-64, -ubuntu-core-18-64 ]
-
 details: |
     The framebuffer interface allows to access the /dev/fb* buffer files.
 


### PR DESCRIPTION
The test itself will now check for /dev/fb0 so there is no need
to blacklist/whitelist it.
