### PR TITLE
cmd/snap-confine: add minimal test for snap-device-helper

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -39,7 +39,7 @@ check-syntax-c:
 if WITH_UNIT_TESTS
 check-unit-tests: snap-confine/unit-tests system-shutdown/unit-tests libsnap-confine-private/unit-tests
 	$(HAVE_VALGRIND) ./libsnap-confine-private/unit-tests
-	$(HAVE_VALGRIND) ./snap-confine/unit-tests
+	SNAP_DEVICE_HELPER=$(srcdir)/snap-confine/snap-device-helper $(HAVE_VALGRIND) ./snap-confine/unit-tests
 	$(HAVE_VALGRIND) ./system-shutdown/unit-tests
 else
 check-unit-tests:

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -288,7 +288,8 @@ snap_confine_unit_tests_SOURCES = \
 	snap-confine/ns-support-test.c \
 	snap-confine/quirks.c \
 	snap-confine/quirks.h \
-	snap-confine/snap-confine-args-test.c
+	snap-confine/snap-confine-args-test.c \
+	snap-confine/snap-device-helper-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)

--- a/cmd/snap-confine/snap-device-helper
+++ b/cmd/snap-confine/snap-device-helper
@@ -16,7 +16,8 @@ MAJMIN="$4"
 [ -n "$MAJMIN" ] || { echo "no major/minor given" >&2; exit 0; }
 
 APPNAME="$( echo "$APPNAME" | tr '_' '.' )"
-app_dev_cgroup="/sys/fs/cgroup/devices/$APPNAME"
+DEVICES_CGROUP=${DEVICES_CGROUP:="/sys/fs/cgroup/devices"}
+app_dev_cgroup="$DEVICES_CGROUP/$APPNAME"
 
 # The cgroup is only present after snap start so ignore any cgroup changes
 # (eg, 'add' on boot, hotplug, hotunplug) when the cgroup doesn't exist

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <string.h>
 
 // TODO: build at runtime
 static char *sdh_path = "snap-confine/snap-device-helper";
@@ -30,7 +31,7 @@ static char *sdh_path = "snap-confine/snap-device-helper";
 // A variant of unsetenv that is compatible with GDestroyNotify
 static void my_unsetenv(const char *k)
 {
-	unsetenv(k);
+	g_unsetenv(k);
 }
 
 // A variant of rm_rf_tmp that calls g_free() on its parameter

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -60,6 +60,7 @@ static int run_sdh(gchar * action,
 	for (size_t i = 0; i < strlen(mod_appname); i++) {
 		if (mod_appname[i] == '.') {
 			mod_appname[i] = '_';
+			break;
 		}
 	}
 	g_debug("appname modified from %s to %s", appname, mod_appname);
@@ -103,6 +104,7 @@ static void test_sdh_action(gconstpointer test_data)
 	struct sdh_test_data *td = (struct sdh_test_data *)test_data;
 
 	gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
+	g_assert_nonnull(mock_dir);
 	gchar *app_dir = g_build_filename(mock_dir, td->app, NULL);
 	gchar *with_data = g_build_filename(mock_dir,
 					    td->app,
@@ -161,6 +163,7 @@ static void test_sdh_err(void)
 
 	// mock some stuff so that we can reach the 'action' checks
 	gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
+	g_assert_nonnull(mock_dir);
 	gchar *app_dir = g_build_filename(mock_dir, "foo.bar", NULL);
 	g_assert(g_mkdir_with_parents(app_dir, 0755) == 0);
 	g_free(app_dir);

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -105,6 +105,8 @@ static void test_sdh_action(gconstpointer test_data)
 
 	gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
 	g_assert_nonnull(mock_dir);
+	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp_free, mock_dir);
+
 	gchar *app_dir = g_build_filename(mock_dir, td->app, NULL);
 	gchar *with_data = g_build_filename(mock_dir,
 					    td->app,
@@ -114,7 +116,6 @@ static void test_sdh_action(gconstpointer test_data)
 					       td->app,
 					       td->file_with_no_data,
 					       NULL);
-	int ret = 0;
 	gchar *data = NULL;
 
 	g_assert(g_mkdir_with_parents(app_dir, 0755) == 0);
@@ -125,9 +126,8 @@ static void test_sdh_action(gconstpointer test_data)
 	g_setenv("DEVICES_CGROUP", mock_dir, TRUE);
 
 	g_test_queue_destroy((GDestroyNotify) my_unsetenv, "DEVICES_CGROUP");
-	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp_free, mock_dir);
 
-	ret =
+	int ret =
 	    run_sdh(td->action, td->app, "/devices/foo/block/sda/sda4", "8:4");
 	g_assert_cmpint(ret, ==, 0);
 	g_assert_true(g_file_get_contents(with_data, &data, NULL, NULL));
@@ -152,9 +152,7 @@ static void test_sdh_action(gconstpointer test_data)
 
 static void test_sdh_err(void)
 {
-	int ret = 0;
-
-	ret = run_sdh("add", "", "/devices/foo/block/sda/sda4", "8:4");
+	int ret = run_sdh("add", "", "/devices/foo/block/sda/sda4", "8:4");
 	g_assert_cmpint(ret, ==, 1);
 	ret = run_sdh("add", "foo_bar", "", "8:4");
 	g_assert_cmpint(ret, ==, 1);
@@ -164,13 +162,14 @@ static void test_sdh_err(void)
 	// mock some stuff so that we can reach the 'action' checks
 	gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
 	g_assert_nonnull(mock_dir);
+	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp_free, mock_dir);
+
 	gchar *app_dir = g_build_filename(mock_dir, "foo.bar", NULL);
 	g_assert(g_mkdir_with_parents(app_dir, 0755) == 0);
 	g_free(app_dir);
 	g_setenv("DEVICES_CGROUP", mock_dir, TRUE);
 
 	g_test_queue_destroy((GDestroyNotify) my_unsetenv, "DEVICES_CGROUP");
-	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp_free, mock_dir);
 
 	ret =
 	    run_sdh("badaction", "foo_bar", "/devices/foo/block/sda/sda4",

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../libsnap-confine-private/test-utils.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+// TODO: build at runtime
+static char *sdh_path = "snap-confine/snap-device-helper";
+
+// A variant of unsetenv that is compatible with GDestroyNotify
+static void my_unsetenv(const char *k)
+{
+	unsetenv(k);
+}
+
+// A variant of rm_rf_tmp that calls g_free() on its parameter
+static void rm_rf_tmp_free(gchar * dirpath)
+{
+	rm_rf_tmp(dirpath);
+	g_free(dirpath);
+}
+
+static int run_sdh(gchar * action,
+		   gchar * appname, gchar * devpath, gchar * majmin)
+{
+	g_autofree gchar *mod_appname = g_strdup(appname);
+	for (size_t i = 0; i < strlen(mod_appname); i++) {
+		if (mod_appname[i] == '.') {
+			mod_appname[i] = '_';
+		}
+	}
+	g_debug("appname modified from %s to %s", appname, mod_appname);
+
+	g_autoptr(GError) err = NULL;
+
+	g_autoptr(GPtrArray) argv = g_ptr_array_new();
+	g_ptr_array_add(argv, sdh_path);
+	g_ptr_array_add(argv, action);
+	g_ptr_array_add(argv, mod_appname);
+	g_ptr_array_add(argv, devpath);
+	g_ptr_array_add(argv, majmin);
+	g_ptr_array_add(argv, NULL);
+
+	int status = 0;
+
+	gboolean ret = g_spawn_sync(NULL, (gchar **) argv->pdata, NULL, 0,
+				    NULL, NULL, NULL, NULL, &status, &err);
+	if (!ret) {
+		g_debug("failed with: %s", err->message);
+		return -2;
+	}
+
+	return WEXITSTATUS(status);
+}
+
+struct sdh_test_data {
+	char *action;
+	char *app;
+	char *file_with_data;
+	char *file_with_no_data;
+};
+
+static void test_sdh_action(gconstpointer test_data)
+{
+	struct sdh_test_data *td = (struct sdh_test_data *)test_data;
+
+	gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
+	g_autofree gchar *app_dir = g_build_filename(mock_dir, td->app, NULL);
+	g_autofree gchar *with_data = g_build_filename(mock_dir,
+						       td->app,
+						       td->file_with_data,
+						       NULL);
+	g_autofree gchar *without_data = g_build_filename(mock_dir,
+							  td->app,
+							  td->file_with_no_data,
+							  NULL);
+	int ret = 0;
+	gchar *data = NULL;
+
+	g_assert(g_mkdir_with_parents(app_dir, 0755) == 0);
+
+	g_debug("mock cgroup dir: %s", mock_dir);
+
+	g_setenv("DEVICES_CGROUP", mock_dir, TRUE);
+
+	g_test_queue_destroy((GDestroyNotify) my_unsetenv, "DEVICES_CGROUP");
+	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp_free, mock_dir);
+
+	ret =
+	    run_sdh(td->action, td->app, "/devices/foo/block/sda/sda4", "8:4");
+	g_assert_cmpint(ret, ==, 0);
+	g_assert_true(g_file_get_contents(with_data, &data, NULL, NULL));
+	g_assert_cmpstr(data, ==, "b 8:4 rwm\n");
+	g_clear_pointer(&data, g_free);
+	g_assert(g_remove(with_data) == 0);
+
+	g_assert_false(g_file_get_contents(without_data, &data, NULL, NULL));
+
+	ret = run_sdh(td->action, td->app, "/devices/foo/tty/ttyS0", "4:64");
+	g_assert_cmpint(ret, ==, 0);
+	g_assert_true(g_file_get_contents(with_data, &data, NULL, NULL));
+	g_assert_cmpstr(data, ==, "c 4:64 rwm\n");
+	g_clear_pointer(&data, g_free);
+	g_assert(g_remove(with_data) == 0);
+
+	g_assert_false(g_file_get_contents(without_data, &data, NULL, NULL));
+
+}
+
+static void test_sdh_err(void)
+{
+	int ret = 0;
+
+	ret = run_sdh("add", "", "/devices/foo/block/sda/sda4", "8:4");
+	g_assert_cmpint(ret, ==, 1);
+	ret = run_sdh("add", "foo_bar", "", "8:4");
+	g_assert_cmpint(ret, ==, 1);
+	ret = run_sdh("add", "foo_bar", "/devices/foo/block/sda/sda4", "");
+	g_assert_cmpint(ret, ==, 0);
+
+	// mock some stuff so that we can reach the 'action' checks
+	gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
+	g_autofree gchar *app_dir = g_build_filename(mock_dir, "foo.bar", NULL);
+	g_assert(g_mkdir_with_parents(app_dir, 0755) == 0);
+	g_setenv("DEVICES_CGROUP", mock_dir, TRUE);
+
+	g_test_queue_destroy((GDestroyNotify) my_unsetenv, "DEVICES_CGROUP");
+	g_test_queue_destroy((GDestroyNotify) rm_rf_tmp_free, mock_dir);
+
+	ret =
+	    run_sdh("badaction", "foo_bar", "/devices/foo/block/sda/sda4",
+		    "8:4");
+	g_assert_cmpint(ret, ==, 1);
+}
+
+static struct sdh_test_data add_data =
+    { "add", "foo.bar", "devices.allow", "devices.deny" };
+static struct sdh_test_data change_data =
+    { "change", "foo.bar", "devices.allow", "devices.deny" };
+static struct sdh_test_data remove_data =
+    { "remove", "foo.bar", "devices.deny", "devices.allow" };
+
+static void __attribute__ ((constructor)) init(void)
+{
+
+	g_test_add_data_func("/snap-device-helper/add",
+			     &add_data, test_sdh_action);
+	g_test_add_data_func("/snap-device-helper/change", &change_data,
+			     test_sdh_action);
+	g_test_add_data_func("/snap-device-helper/remove", &remove_data,
+			     test_sdh_action);
+	g_test_add_func("/snap-device-helper/err", test_sdh_err);
+}

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -26,7 +26,7 @@
 #include <string.h>
 
 // TODO: build at runtime
-static char *sdh_path = "snap-confine/snap-device-helper";
+static const char *sdh_path_default = "snap-confine/snap-device-helper";
 
 // A variant of unsetenv that is compatible with GDestroyNotify
 static void my_unsetenv(const char *k)
@@ -41,10 +41,19 @@ static void rm_rf_tmp_free(gchar * dirpath)
 	g_free(dirpath);
 }
 
+static gchar *find_sdh_path(void) {
+	const char *sdh_from_env = g_getenv("SNAP_DEVICE_HELPER");
+	if (sdh_from_env != NULL) {
+		return g_strdup(sdh_from_env);
+	}
+	return g_strdup(sdh_path_default);
+}
+
 static int run_sdh(gchar * action,
 		   gchar * appname, gchar * devpath, gchar * majmin)
 {
 	g_autofree gchar *mod_appname = g_strdup(appname);
+	g_autofree gchar *sdh_path = find_sdh_path();
 	for (size_t i = 0; i < strlen(mod_appname); i++) {
 		if (mod_appname[i] == '.') {
 			mod_appname[i] = '_';


### PR DESCRIPTION
snap-device-helper is not covered by unit tests. Add some tests to snap-confine
suite to check the basic functionality at least.

