### PR TITLE
cmd/snap-confine: snap-device-helper parallel installs support

### DIFF
--- a/cmd/snap-confine/snap-device-helper
+++ b/cmd/snap-confine/snap-device-helper
@@ -15,12 +15,15 @@ MAJMIN="$4"
 [ -n "$DEVPATH" ] || { echo "no devpath given" >&2; exit 1; }
 [ -n "$MAJMIN" ] || { echo "no major/minor given" >&2; exit 0; }
 
-if [ "${APPNAME#*_*_}" = "${APPNAME}" ]; then
-    # <snap>_<app> -> <snap>.<app>
-    SNAPAPP="${APPNAME%_*}.${APPNAME#*_}"
+NOSNAP="${APPNAME#snap_}"
+[ "$NOSNAP" != "$APPNAME" ] || { echo "malformed appname $APPNAME" >&2; exit 1; }
+
+if [ "${NOSNAP#*_*_}" = "${NOSNAP}" ]; then
+    # snap_<snap>_<app> -> snap.<snap>.<app>
+    SNAPAPP="snap.${NOSNAP%_*}.${NOSNAP#*_}"
 else
-    # <snap>_<instance>_<app> -> <snap>_<instance>.<app>
-    SNAPAPP="${APPNAME%_*}.${APPNAME#*_*_}"
+    # snap_<snap>_<instance>_<app> -> snap.<snap>_<instance>.<app>
+    SNAPAPP="snap.${NOSNAP%_*}.${NOSNAP#*_*_}"
 fi
 
 DEVICES_CGROUP=${DEVICES_CGROUP:="/sys/fs/cgroup/devices"}

--- a/cmd/snap-confine/snap-device-helper
+++ b/cmd/snap-confine/snap-device-helper
@@ -15,9 +15,16 @@ MAJMIN="$4"
 [ -n "$DEVPATH" ] || { echo "no devpath given" >&2; exit 1; }
 [ -n "$MAJMIN" ] || { echo "no major/minor given" >&2; exit 0; }
 
-APPNAME="$( echo "$APPNAME" | tr '_' '.' )"
+if [ "${APPNAME#*_*_}" = "${APPNAME}" ]; then
+    # <snap>_<app> -> <snap>.<app>
+    SNAPAPP="${APPNAME%_*}.${APPNAME#*_}"
+else
+    # <snap>_<instance>_<app> -> <snap>_<instance>.<app>
+    SNAPAPP="${APPNAME%_*}.${APPNAME#*_*_}"
+fi
+
 DEVICES_CGROUP=${DEVICES_CGROUP:="/sys/fs/cgroup/devices"}
-app_dev_cgroup="$DEVICES_CGROUP/$APPNAME"
+app_dev_cgroup="$DEVICES_CGROUP/$SNAPAPP"
 
 # The cgroup is only present after snap start so ignore any cgroup changes
 # (eg, 'add' on boot, hotplug, hotunplug) when the cgroup doesn't exist

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -181,6 +181,12 @@ static struct sdh_test_data change_data =
     { "change", "foo.bar", "devices.allow", "devices.deny" };
 static struct sdh_test_data remove_data =
     { "remove", "foo.bar", "devices.deny", "devices.allow" };
+static struct sdh_test_data instance_add_data =
+    { "add", "foo_bar.baz", "devices.allow", "devices.deny" };
+static struct sdh_test_data instance_change_data =
+    { "change", "foo_bar.baz", "devices.allow", "devices.deny" };
+static struct sdh_test_data instance_remove_data =
+    { "remove", "foo_bar.baz", "devices.deny", "devices.allow" };
 
 static void __attribute__ ((constructor)) init(void)
 {
@@ -192,4 +198,10 @@ static void __attribute__ ((constructor)) init(void)
 	g_test_add_data_func("/snap-device-helper/remove", &remove_data,
 			     test_sdh_action);
 	g_test_add_func("/snap-device-helper/err", test_sdh_err);
+	g_test_add_data_func("/snap-device-helper/parallel/add",
+			     &instance_add_data, test_sdh_action);
+	g_test_add_data_func("/snap-device-helper/parallel/change",
+			     &instance_change_data, test_sdh_action);
+	g_test_add_data_func("/snap-device-helper/parallel/remove",
+			     &instance_remove_data, test_sdh_action);
 }

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -58,7 +58,7 @@ static int run_sdh(gchar * action,
 
 	// appnames have the following format:
 	// - snap.<snap>.<app>
-	// - snap.<snap>_<instance>.<app>,
+	// - snap.<snap>_<instance>.<app>
 	// snap-device-helper expects:
 	// - snap_<snap>_<app>
 	// - snap_<snap>_<instance>_<app>


### PR DESCRIPTION
Add support for unpacking APPNAME when a snap has an instance key. The input
format is either `<snap>_<app>` or `<snap>_<instance>_<app>`. Those are translated
to `<snap>.<app>` and `<snap>_<instance>.<app>` respectively.

