### PR TITLE
tests: reduce nc wait time from 2 to 1 second

### DIFF
--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -43,7 +43,7 @@ execute: |
     snap interfaces -i network-bind | MATCH ":network-bind .*$SNAP_NAME"
 
     echo "Then the service is accessible by a client"
-    nc -w 2 localhost "$PORT" < "$REQUEST_FILE" | grep -Pqz 'ok\n'
+    nc -w 1 localhost "$PORT" < "$REQUEST_FILE" | grep -Pqz 'ok\n'
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
@@ -53,7 +53,7 @@ execute: |
     snap disconnect "$SNAP_NAME:network-bind"
 
     echo "Then the service is not accessible by a client"
-    response=$(nc -w 2 localhost "$PORT" < "$REQUEST_FILE")
+    response=$(nc -w 1 localhost "$PORT" < "$REQUEST_FILE")
     [ "$response" = "" ]
 
     echo "Then the plug can be connected again"


### PR DESCRIPTION
This is done to reduce the time the network-bind-consumer snap denials
are being logged in the journal.

This is the error that we fixing with this change:
https://travis-ci.org/snapcore/snapd/builds/411686197#L4607
