### PR TITLE
image: ensure "core" is ordered early if base: and core is used

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -365,6 +365,16 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 	// always add an implicit snapd first when a base is used
 	if model.Base() != "" {
 		snaps = append(snaps, "snapd")
+		// TODO: once we order snaps by what they need this
+		//       can go aways
+		// Here we ensure that "core" is seeded very early
+		// when bases are in use. This fixes the issue
+		// that when people use model assertions with
+		// required snaps like bluez which at this point
+		// still requires core will hang forever in seeding.
+		if strutil.ListContains(opts.Snaps, "core") {
+			snaps = append(snaps, "core")
+		}
 	}
 	// core/base,kernel,gadget first
 	snaps = append(snaps, local.PreferLocal(baseName))


### PR DESCRIPTION
We got a urgent bugreport from a user. The issue is that they are
building a core18 system with a model assertion that has
`required-snaps: [bluez]`. This snap is still the legacy core
snap as its base. With this setup the seed.yaml is written in
a way that puts bluez into the seed before core. This means that
the seeding hangs. This PR adds special handling for "core"
until we fix the ordering of the seed.yaml in a more general
way.

Note that the alternative would be to add "core" to the
required-snaps which is not desirable because bluez will
eventually start using a different base.

