### PR TITLE
devicestate: only run device-hook when fully seeded

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -248,6 +248,8 @@ func (m *DeviceManager) ensureOperational() error {
 	}
 
 	// if there's a gadget specified wait for it
+	var hasPrepareDeviceHook bool
+
 	var gadgetInfo *snap.Info
 	if gadget != "" {
 		var err error
@@ -259,14 +261,16 @@ func (m *DeviceManager) ensureOperational() error {
 		if err != nil {
 			return err
 		}
+		hasPrepareDeviceHook = (gadgetInfo.Hooks["prepare-device"] != nil)
 	}
 
-	hasPrepareDeviceHook := (gadgetInfo != nil && gadgetInfo.Hooks["prepare-device"] != nil)
 	// When the prepare-device hook is used we need a fully seeded system
 	// to ensure the prepare-device hook has access to the things it
 	// needs
 	if !seeded && hasPrepareDeviceHook {
-		return &state.Retry{}
+		// this will be run again, so eventually when the system is
+		// seeded the code below runs
+		return nil
 	}
 
 	// have some backoff between full retries

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -247,10 +247,9 @@ func (m *DeviceManager) ensureOperational() error {
 		}
 	}
 
-	// if there's a gadget specified wait for it
-	var hasPrepareDeviceHook bool
-
 	var gadgetInfo *snap.Info
+	var hasPrepareDeviceHook bool
+	// if there's a gadget specified wait for it
 	if gadget != "" {
 		var err error
 		gadgetInfo, err = snapstate.GadgetInfo(m.state)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1060,14 +1060,25 @@ hooks:
 
 	// avoid full seeding
 	s.seeding()
-	s.state.Set("seeded", true)
 
-	// runs the whole device registration process
+	// runs the whole device registration process, note that the
+	// device is not seeded yet
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
 
+	// without a seeded device, there is no become-operational change
 	becomeOperational := s.findBecomeOperationalChange()
+	c.Assert(becomeOperational, IsNil)
+
+	// now mark it as seeded
+	s.state.Set("seeded", true)
+	// and run the device registration again
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	becomeOperational = s.findBecomeOperationalChange()
 	c.Assert(becomeOperational, NotNil)
 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1060,6 +1060,7 @@ hooks:
 
 	// avoid full seeding
 	s.seeding()
+	s.state.Set("seeded", true)
 
 	// runs the whole device registration process
 	s.state.Unlock()


### PR DESCRIPTION
We currently run the "seeding" and "become-operational" changes in
parallel. This is fine most of the time. However if the prepare-device
hook is used it may run before the system is fully seeded. This can
be problematic in the general case. It is especially problematic on
core18 devices that will use snap-confine to setup the environment
based on the installed core18 snap. If that snap is not available
yet things will fail.

