### PR TITLE
[RFC] image: do simple seed.yaml snap sorting

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -365,6 +365,16 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 	// always add an implicit snapd first when a base is used
 	if model.Base() != "" {
 		snaps = append(snaps, "snapd")
+		// TODO: once we order snaps by what they need this
+		//       can go aways
+		// Here we ensure that "core" is seeded very early
+		// when bases are in use. This fixes the issue
+		// that when people use model assertions with
+		// required snaps like bluez which at this point
+		// still requires core will hang forever in seeding.
+		if strutil.ListContains(opts.Snaps, "core") {
+			snaps = append(snaps, "core")
+		}
 	}
 	// core/base,kernel,gadget first
 	snaps = append(snaps, local.PreferLocal(baseName))

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1331,24 +1331,24 @@ func (s *imageSuite) TestBootstrapWithBaseAndLegacyCoreOrdering(c *C) {
 		File:   "snapd_18.snap",
 	})
 	c.Check(seed.Snaps[1], DeepEquals, &snap.SeedSnap{
-		Name:   "core",
-		SnapID: "core-Id",
-		File:   "core_3.snap",
-	})
-	c.Check(seed.Snaps[2], DeepEquals, &snap.SeedSnap{
 		Name:   "core18",
 		SnapID: "core18-Id",
 		File:   "core18_18.snap",
 	})
-	c.Check(seed.Snaps[3], DeepEquals, &snap.SeedSnap{
+	c.Check(seed.Snaps[2], DeepEquals, &snap.SeedSnap{
 		Name:   "pc-kernel",
 		SnapID: "pc-kernel-Id",
 		File:   "pc-kernel_2.snap",
 	})
-	c.Check(seed.Snaps[4], DeepEquals, &snap.SeedSnap{
+	c.Check(seed.Snaps[3], DeepEquals, &snap.SeedSnap{
 		Name:   "pc",
 		SnapID: "pc-Id",
 		File:   "pc_1.snap",
+	})
+	c.Check(seed.Snaps[4], DeepEquals, &snap.SeedSnap{
+		Name:   "core",
+		SnapID: "core-Id",
+		File:   "core_3.snap",
 	})
 	c.Check(seed.Snaps[5], DeepEquals, &snap.SeedSnap{
 		Name:    "required-snap1",

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -51,6 +51,9 @@ type SeedSnap struct {
 	Unasserted bool `yaml:"unasserted,omitempty"`
 
 	File string `yaml:"file"`
+
+	// internally used for sorting
+	Order int `yaml:"-"`
 }
 
 type Seed struct {


### PR DESCRIPTION
We ran into some issues with projects that had the order in the
seed.yaml wrong. I.e. installing snaps that require content
providers before the content provider. This PR adds a very simple
sorting for seed.yaml:

1. base/core,kernel,gadget,"snapd" are never reordered
2. other bases
3. snaps that provide any content interface slot
4. other snaps

It will also warn if any of the content provider themself use a
content plug that this nees manual resolving.

The above sorting should be fine because:
- we order the boot base/core/gadget/kernel manually already
  so (1) should be fine
- bases can not depend on bases so (2) should be fine
- snaps that provide content must go before snaps that use content,
  this is why we have (3)
- then remaining snaps have any needed bases or content providers
  installed at this point

One caveat for (3) is of course any snaps that both provide and
require content. This case is not handled just warned about.

If the basic approach sounds sane I will add a bunch more tests. If we
decide to use a different (e.g. full topsort) approach I won't bother spending
more time on this :)