### PR TITLE
overlord/devicestate: have the serial request talk to the proxy if set

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -210,7 +210,10 @@ func delayedCrossMgrInit() {
 
 // ProxyStore returns the store assertion for the proxy store if one is set.
 func ProxyStore(st *state.State) (*asserts.Store, error) {
-	tr := config.NewTransaction(st)
+	return proxyStore(st, config.NewTransaction(st))
+}
+
+func proxyStore(st *state.State, tr *config.Transaction) (*asserts.Store, error) {
 	var proxyStore string
 	err := tr.GetMaybe("core", "proxy.store", &proxyStore)
 	if err != nil {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -38,19 +38,11 @@ func MockKeyLength(n int) (restore func()) {
 	}
 }
 
-func MockRequestIDURL(url string) (restore func()) {
-	oldURL := requestIDURL
-	requestIDURL = url
+func MockBaseStoreURL(url string) (restore func()) {
+	oldURL := baseStoreURL
+	baseStoreURL = url
 	return func() {
-		requestIDURL = oldURL
-	}
-}
-
-func MockSerialRequestURL(url string) (restore func()) {
-	oldURL := serialRequestURL
-	serialRequestURL = url
-	return func() {
-		serialRequestURL = oldURL
+		baseStoreURL = oldURL
 	}
 }
 


### PR DESCRIPTION
Without this change, the serial request ignored proxy.store set on
core, meaning it tried to connect directly instead of going through
the proxy. [lp:1781443] is an instance of the problems caused by this.

This change fixes that, and also prepares things so that we can
support talking to the proxy when a gadget sets device-service.url (a
device with device-service.url set on the gadget *and* proxy.store set
on core will today attempt talking directly to device-service.url).

[lp:1781443]: https://bugs.launchpad.net/snapd/+bug/1781443