### PR TITLE
interfaces: add new "sysfs-name" to i2c interfaces code

### DIFF
--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -42,11 +42,17 @@ const i2cBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-const i2cConnectedPlugAppArmor = `
+const i2cConnectedPlugAppArmorPath = `
 # Description: Can access I2C controller
 
 %s rw,
 /sys/devices/platform/{*,**.i2c}/%s/** rw,
+`
+
+const i2cConnectedPlugAppArmorSysfsName = `
+# Description: Can access I2C sysfs name
+
+/sys/bus/i2c/devices/%s/** rw,
 `
 
 // The type for i2c interface
@@ -73,18 +79,31 @@ func (iface *i2cInterface) String() string {
 // identification
 var i2cControlDeviceNodePattern = regexp.MustCompile("^/dev/i2c-[0-9]+$")
 
+// Pattern to match allowed i2c sysfs names.
+var i2cValidSysfsName = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
+
 // Check validity of the defined slot
 func (iface *i2cInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
 
+	sysfsName, ok := slot.Attrs["sysfs-name"].(string)
+	if ok {
+		if !i2cValidSysfsName.MatchString(sysfsName) {
+			return fmt.Errorf("%s sysfs-name attribute must be a valid sysfs-name", iface.Name())
+		}
+		if _, ok := slot.Attrs["path"].(string); ok {
+			return fmt.Errorf("%s slot can only use path or sysfs-name", iface.Name())
+		}
+		return nil
+	}
+
 	// Validate the path
 	path, ok := slot.Attrs["path"].(string)
 	if !ok || path == "" {
-		return fmt.Errorf("%s slot must have a path attribute", iface.Name())
+		return fmt.Errorf("%s slot must have a path or sysfs-name attribute", iface.Name())
 	}
-
 	path = filepath.Clean(path)
 
 	if !i2cControlDeviceNodePattern.MatchString(path) {
@@ -95,13 +114,22 @@ func (iface *i2cInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 }
 
 func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+
+	// check if sysfsName is set and if so stop after that
+	var sysfsName string
+	if err := slot.Attr("sysfs-name", &sysfsName); err == nil {
+		spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorSysfsName, sysfsName))
+		return nil
+	}
+
+	// do path if sysfsName is not set (they can't be set both)
 	var path string
 	if err := slot.Attr("path", &path); err != nil {
 		return nil
 	}
 
 	cleanedPath := filepath.Clean(path)
-	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmor, cleanedPath, strings.TrimPrefix(path, "/dev/")))
+	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath, strings.TrimPrefix(path, "/dev/")))
 	return nil
 }
 

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -68,6 +68,8 @@ type I2cInterfaceSuite struct {
 	testSysfsNameBadValue1Info *snap.SlotInfo
 	testSysfsNameAndPath       *interfaces.ConnectedSlot
 	testSysfsNameAndPathInfo   *snap.SlotInfo
+	testSysfsNameEmpty         *interfaces.ConnectedSlot
+	testSysfsNameEmptyInfo     *snap.SlotInfo
 
 	// Consuming Snap
 	testPlugPort1     *interfaces.ConnectedPlug
@@ -138,6 +140,9 @@ slots:
     interface: i2c
     path: /dev/i2c-0
     sysfs-name: 1-0050
+  test-sysfs-name-empty:
+    interface: i2c
+    sysfs-name: ""
 `, nil)
 	s.testUDev1Info = gadgetSnapInfo.Slots["test-udev-1"]
 	s.testUDev1 = interfaces.NewConnectedSlot(s.testUDev1Info, nil)
@@ -166,6 +171,8 @@ slots:
 	s.testSysfsNameBadValue1 = interfaces.NewConnectedSlot(s.testSysfsNameBadValue1Info, nil)
 	s.testSysfsNameAndPathInfo = gadgetSnapInfo.Slots["test-sysfs-name-and-path"]
 	s.testSysfsNameAndPath = interfaces.NewConnectedSlot(s.testSysfsNameAndPathInfo, nil)
+	s.testSysfsNameEmptyInfo = gadgetSnapInfo.Slots["test-sysfs-name-empty"]
+	s.testSysfsNameEmpty = interfaces.NewConnectedSlot(s.testSysfsNameEmptyInfo, nil)
 
 	// Snap Consumers
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -208,6 +215,7 @@ func (s *I2cInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue7Info), ErrorMatches, "i2c slot must have a path or sysfs-name attribute")
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testSysfsNameBadValue1Info), ErrorMatches, "i2c sysfs-name attribute must be a valid sysfs-name")
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testSysfsNameAndPathInfo), ErrorMatches, "i2c slot can only use path or sysfs-name")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testSysfsNameEmptyInfo), ErrorMatches, "i2c sysfs-name attribute must be a valid sysfs-name")
 }
 
 func (s *I2cInterfaceSuite) TestUDevSpec(c *C) {

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -40,28 +40,34 @@ type I2cInterfaceSuite struct {
 	testSlot1Info *snap.SlotInfo
 
 	// Gadget Snap
-	testUDev1                 *interfaces.ConnectedSlot
-	testUDev1Info             *snap.SlotInfo
-	testUDev2                 *interfaces.ConnectedSlot
-	testUDev2Info             *snap.SlotInfo
-	testUDev3                 *interfaces.ConnectedSlot
-	testUDev3Info             *snap.SlotInfo
-	testUDevBadValue1         *interfaces.ConnectedSlot
-	testUDevBadValue1Info     *snap.SlotInfo
-	testUDevBadValue2         *interfaces.ConnectedSlot
-	testUDevBadValue2Info     *snap.SlotInfo
-	testUDevBadValue3         *interfaces.ConnectedSlot
-	testUDevBadValue3Info     *snap.SlotInfo
-	testUDevBadValue4         *interfaces.ConnectedSlot
-	testUDevBadValue4Info     *snap.SlotInfo
-	testUDevBadValue5         *interfaces.ConnectedSlot
-	testUDevBadValue5Info     *snap.SlotInfo
-	testUDevBadValue6         *interfaces.ConnectedSlot
-	testUDevBadValue6Info     *snap.SlotInfo
-	testUDevBadValue7         *interfaces.ConnectedSlot
-	testUDevBadValue7Info     *snap.SlotInfo
-	testUDevBadInterface1     *interfaces.ConnectedSlot
-	testUDevBadInterface1Info *snap.SlotInfo
+	testUDev1                  *interfaces.ConnectedSlot
+	testUDev1Info              *snap.SlotInfo
+	testUDev2                  *interfaces.ConnectedSlot
+	testUDev2Info              *snap.SlotInfo
+	testUDev3                  *interfaces.ConnectedSlot
+	testUDev3Info              *snap.SlotInfo
+	testSysfsName1             *interfaces.ConnectedSlot
+	testSysfsName1Info         *snap.SlotInfo
+	testUDevBadValue1          *interfaces.ConnectedSlot
+	testUDevBadValue1Info      *snap.SlotInfo
+	testUDevBadValue2          *interfaces.ConnectedSlot
+	testUDevBadValue2Info      *snap.SlotInfo
+	testUDevBadValue3          *interfaces.ConnectedSlot
+	testUDevBadValue3Info      *snap.SlotInfo
+	testUDevBadValue4          *interfaces.ConnectedSlot
+	testUDevBadValue4Info      *snap.SlotInfo
+	testUDevBadValue5          *interfaces.ConnectedSlot
+	testUDevBadValue5Info      *snap.SlotInfo
+	testUDevBadValue6          *interfaces.ConnectedSlot
+	testUDevBadValue6Info      *snap.SlotInfo
+	testUDevBadValue7          *interfaces.ConnectedSlot
+	testUDevBadValue7Info      *snap.SlotInfo
+	testUDevBadInterface1      *interfaces.ConnectedSlot
+	testUDevBadInterface1Info  *snap.SlotInfo
+	testSysfsNameBadValue1     *interfaces.ConnectedSlot
+	testSysfsNameBadValue1Info *snap.SlotInfo
+	testSysfsNameAndPath       *interfaces.ConnectedSlot
+	testSysfsNameAndPathInfo   *snap.SlotInfo
 
 	// Consuming Snap
 	testPlugPort1     *interfaces.ConnectedPlug
@@ -100,6 +106,9 @@ slots:
   test-udev-3:
     interface: i2c
     path: /dev/i2c-0
+  test-sysfs-name-1:
+    interface: i2c
+    sysfs-name: 1-0050
   test-udev-bad-value-1:
     interface: i2c
     path: /dev/i2c
@@ -122,6 +131,13 @@ slots:
     interface: i2c
   test-udev-bad-interface-1:
     interface: other-interface
+  test-sysfs-name-bad-value-1:
+    interface: i2c
+    sysfs-name: /slash/not/allowed
+  test-sysfs-name-and-path:
+    interface: i2c
+    path: /dev/i2c-0
+    sysfs-name: 1-0050
 `, nil)
 	s.testUDev1Info = gadgetSnapInfo.Slots["test-udev-1"]
 	s.testUDev1 = interfaces.NewConnectedSlot(s.testUDev1Info, nil)
@@ -129,6 +145,8 @@ slots:
 	s.testUDev2 = interfaces.NewConnectedSlot(s.testUDev2Info, nil)
 	s.testUDev3Info = gadgetSnapInfo.Slots["test-udev-3"]
 	s.testUDev3 = interfaces.NewConnectedSlot(s.testUDev3Info, nil)
+	s.testSysfsName1Info = gadgetSnapInfo.Slots["test-sysfs-name-1"]
+	s.testSysfsName1 = interfaces.NewConnectedSlot(s.testSysfsName1Info, nil)
 	s.testUDevBadValue1Info = gadgetSnapInfo.Slots["test-udev-bad-value-1"]
 	s.testUDevBadValue1 = interfaces.NewConnectedSlot(s.testUDevBadValue1Info, nil)
 	s.testUDevBadValue2Info = gadgetSnapInfo.Slots["test-udev-bad-value-2"]
@@ -144,6 +162,10 @@ slots:
 	s.testUDevBadValue7Info = gadgetSnapInfo.Slots["test-udev-bad-value-7"]
 	s.testUDevBadValue7 = interfaces.NewConnectedSlot(s.testUDevBadValue7Info, nil)
 	s.testUDevBadInterface1Info = gadgetSnapInfo.Slots["test-udev-bad-interface-1"]
+	s.testSysfsNameBadValue1Info = gadgetSnapInfo.Slots["test-sysfs-name-bad-value-1"]
+	s.testSysfsNameBadValue1 = interfaces.NewConnectedSlot(s.testSysfsNameBadValue1Info, nil)
+	s.testSysfsNameAndPathInfo = gadgetSnapInfo.Slots["test-sysfs-name-and-path"]
+	s.testSysfsNameAndPath = interfaces.NewConnectedSlot(s.testSysfsNameAndPathInfo, nil)
 
 	// Snap Consumers
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -173,6 +195,7 @@ func (s *I2cInterfaceSuite) TestSanitizeGadgetSnapSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDev1Info), IsNil)
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDev2Info), IsNil)
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDev3Info), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testSysfsName1Info), IsNil)
 }
 
 func (s *I2cInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
@@ -181,8 +204,10 @@ func (s *I2cInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue3Info), ErrorMatches, "i2c path attribute must be a valid device node")
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue4Info), ErrorMatches, "i2c path attribute must be a valid device node")
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue5Info), ErrorMatches, "i2c path attribute must be a valid device node")
-	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue6Info), ErrorMatches, "i2c slot must have a path attribute")
-	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue7Info), ErrorMatches, "i2c slot must have a path attribute")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue6Info), ErrorMatches, "i2c slot must have a path or sysfs-name attribute")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testUDevBadValue7Info), ErrorMatches, "i2c slot must have a path or sysfs-name attribute")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testSysfsNameBadValue1Info), ErrorMatches, "i2c sysfs-name attribute must be a valid sysfs-name")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testSysfsNameAndPathInfo), ErrorMatches, "i2c slot can only use path or sysfs-name")
 }
 
 func (s *I2cInterfaceSuite) TestUDevSpec(c *C) {
@@ -194,12 +219,29 @@ KERNEL=="i2c-1", TAG+="snap_client-snap_app-accessing-1-port"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_client-snap_app-accessing-1-port", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-1-port $devpath $major:$minor"`)
 }
 
-func (s *I2cInterfaceSuite) TestAppArmorSpec(c *C) {
+func (s *I2cInterfaceSuite) TestUDevSpecSysfsName(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testSysfsName1), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 0)
+}
+
+func (s *I2cInterfaceSuite) TestAppArmorSpecPath(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
 	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/dev/i2c-1 rw,`)
 	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), testutil.Contains, `/sys/devices/platform/{*,**.i2c}/i2c-1/** rw,`)
+}
+
+func (s *I2cInterfaceSuite) TestAppArmorSpecSysfsName(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testSysfsName1), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
+	c.Assert(spec.SnippetForTag("snap.client-snap.app-accessing-1-port"), Equals, `
+# Description: Can access I2C sysfs name
+
+/sys/bus/i2c/devices/1-0050/** rw,
+`)
 }
 
 func (s *I2cInterfaceSuite) TestAutoConnect(c *C) {


### PR DESCRIPTION
We got a request from a customer how needs access to i2c devices
that behave differently from what our i2c code expects. The
device apparently only shows up in /sys/bus/i2c/devices/xxxx
and our code does not support this mode of operation.

This PR provides a way to set a "sysfs-name" that is complementary
to the current "path" we support. If "sysfs-name" is choosen
a apparmor rule is genreated that allows access in
/sys/bus/i2c/devices/$name/**

The "sysfs-name" and "path" cannot be used at the same time in
the same interfce slot.

