### PR TITLE
overlod/ifacestate: always use a new SnapState when fetching the snap state

### DIFF
--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -250,12 +250,12 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 }
 
 func initialConnectAttributes(st *state.State, plugSnap string, plugName string, slotSnap string, slotName string) (plugStatic, slotStatic map[string]interface{}, err error) {
-	var snapst snapstate.SnapState
+	var plugSnapst snapstate.SnapState
 
-	if err = snapstate.Get(st, plugSnap, &snapst); err != nil {
+	if err = snapstate.Get(st, plugSnap, &plugSnapst); err != nil {
 		return nil, nil, err
 	}
-	snapInfo, err := snapst.CurrentInfo()
+	snapInfo, err := plugSnapst.CurrentInfo()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -265,10 +265,12 @@ func initialConnectAttributes(st *state.State, plugSnap string, plugName string,
 		return nil, nil, fmt.Errorf("snap %q has no plug named %q", plugSnap, plugName)
 	}
 
-	if err = snapstate.Get(st, slotSnap, &snapst); err != nil {
+	var slotSnapst snapstate.SnapState
+
+	if err = snapstate.Get(st, slotSnap, &slotSnapst); err != nil {
 		return nil, nil, err
 	}
-	snapInfo, err = snapst.CurrentInfo()
+	snapInfo, err = slotSnapst.CurrentInfo()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The state is serialized to JSON. When unmarshalling to a struct, the fields not
appearing in the original JSON input will not be assigned to. In this case, the
SnapState was filled with some data from the first .Get() call. When JSON input
was unmarshalled in the second .Get() call, the input data did not have
instance-key set and the resulting snapstate data retained the instance key from
the first call.
