### PR TITLE
overlord/devicestate: DTRT w/a snap proxy to reach a serial vault

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -183,8 +183,7 @@ func (s *deviceMgrSuite) settle(c *C) {
 
 const (
 	requestIDURLPath = "/api/v1/snaps/auth/request-id"
-	serialURLPath    = "/api/v1/snaps/auth/serial"  // /serial is to a custom serial vault
-	devicesURLPath   = "/api/v1/snaps/auth/devices" // /devices is to the proxy or direct to the canonical serial vault
+	serialURLPath    = "/api/v1/snaps/auth/devices"
 )
 
 // seeding avoids triggering a real full seeding, it simulates having it in process instead
@@ -214,7 +213,7 @@ func (s *deviceMgrSuite) mockServer(c *C) *httptest.Server {
 		case "/svc/serial":
 			c.Check(r.Header.Get("X-Extra-Header"), Equals, "extra")
 			fallthrough
-		case serialURLPath, devicesURLPath:
+		case serialURLPath:
 			if s.reqID == "REQID-42" {
 				c.Check(r.Header.Get("X-Snap-Device-Service-URL"), Matches, "http://[^/]*/bad/svc/")
 			}

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -40,7 +40,7 @@ func MockKeyLength(n int) (restore func()) {
 
 func MockBaseStoreURL(url string) (restore func()) {
 	oldURL := baseStoreURL
-	baseStoreURL = url
+	baseStoreURL = mustParse(url).ResolveReference(authRef)
 	return func() {
 		baseStoreURL = oldURL
 	}

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -112,6 +112,7 @@ var (
 	ImportAssertionsFromSeed = importAssertionsFromSeed
 	CheckGadgetOrKernel      = checkGadgetOrKernel
 	CanAutoRefresh           = canAutoRefresh
+	NewEnoughProxy           = newEnoughProxy
 
 	IncEnsureOperationalAttempts = incEnsureOperationalAttempts
 	EnsureOperationalAttempts    = ensureOperationalAttempts

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -100,7 +100,7 @@ func (cfg *serialRequestConfig) setURLs(proxyURL, svcURL *url.URL) {
 	}
 
 	cfg.requestIDURL = base.ResolveReference(reqIdRef).String()
-	if svcURL != nil {
+	if svcURL != nil && proxyURL == nil {
 		cfg.serialRequestURL = base.ResolveReference(serialRef).String()
 	} else {
 		cfg.serialRequestURL = base.ResolveReference(devicesRef).String()

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -133,6 +133,7 @@ func (cfg *serialRequestConfig) setURLs(proxyURL, svcURL *url.URL) {
 
 	cfg.requestIDURL = base.ResolveReference(reqIdRef).String()
 	if svcURL != nil && proxyURL == nil {
+		// talking directly to the custom device service
 		cfg.serialRequestURL = base.ResolveReference(serialRef).String()
 	} else {
 		cfg.serialRequestURL = base.ResolveReference(devicesRef).String()


### PR DESCRIPTION
Without this change, if `proxy.store` was set on core, and
`device-service.url` was set on the gadget, snapd would attempt to
talk directly to the device service.

This change adds the logic so that, in this case, if the proxy is new enough, we talk to its appropriate endpoint, specifying the serial vault we want in a header. If the proxy is not new enough we fall back to the old behaviour of trying to talk to the custom serial vault directly.
