### PR TITLE
overlord/snapstate: always clean SnapState when doing Get()

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1764,6 +1764,12 @@ func Get(st *state.State, name string, snapst *SnapState) error {
 	if snapst == nil {
 		return fmt.Errorf("internal error: snapst is nil")
 	}
+	// SnapState is (un-)marshalled from/to JSON, fields having omitempty
+	// tag will not appear in the output (if empty) and subsequently will
+	// not be unmarshalled to (or cleared); if the caller reuses the same
+	// struct though subsequent calls, it is possible that they end up with
+	// garbage inside, clear the destination struct so that we always
+	// unmarshal to a clean state
 	*snapst = SnapState{}
 
 	var snaps map[string]*json.RawMessage

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1761,6 +1761,11 @@ func CurrentInfo(st *state.State, name string) (*snap.Info, error) {
 
 // Get retrieves the SnapState of the given snap.
 func Get(st *state.State, name string, snapst *SnapState) error {
+	if snapst == nil {
+		return fmt.Errorf("internal error: snapst is nil")
+	}
+	*snapst = SnapState{}
+
 	var snaps map[string]*json.RawMessage
 	err := st.Get("snaps", &snaps)
 	if err != nil {


### PR DESCRIPTION
SnapState is (un-)marshalled from/to JSON. Some fields some with omitempty tag,
meaning those will not be included in the output when marshalling and the will
not be cleared in the destination structure when unmarshalling.

Sometimes in the code we reuse snapst for subsequent snapstate.Get() calls.
Should the destination struct not be cleared between the calls, we may end up
with data from the previous calls inside.

