### PR TITLE
cmd,dirs: fix various issues discovered by a Fedora base snap

### DIFF
--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -86,6 +86,30 @@ static void test_is_on_classic_with_long_line(void)
 	unlink("os-release.classic-with-long-line");
 }
 
+const char *os_release_fedora_base = ""
+    "NAME=Fedora\nID=fedora\nVARIANT_ID=snappy\n";
+
+static void test_is_on_fedora_base(void)
+{
+	g_file_set_contents("os-release.core", os_release_fedora_base,
+			    strlen(os_release_fedora_base), NULL);
+	os_release = "os-release.core";
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CORE_OTHER);
+	unlink("os-release.core");
+}
+
+const char *os_release_fedora_ws = ""
+    "NAME=Fedora\nID=fedora\nVARIANT_ID=workstation\n";
+
+static void test_is_on_fedora_ws(void)
+{
+	g_file_set_contents("os-release.core", os_release_fedora_ws,
+			    strlen(os_release_fedora_ws), NULL);
+	os_release = "os-release.core";
+	g_assert_cmpint(sc_classify_distro(), ==, SC_DISTRO_CLASSIC);
+	unlink("os-release.core");
+}
+
 static void test_should_use_normal_mode(void)
 {
 	g_assert_false(sc_should_use_normal_mode(SC_DISTRO_CORE16, "core"));
@@ -106,6 +130,8 @@ static void __attribute__ ((constructor)) init(void)
 	g_test_add_func("/classic/on-core-on16", test_is_on_core_on16);
 	g_test_add_func("/classic/on-core-on18", test_is_on_core_on18);
 	g_test_add_func("/classic/on-core-on20", test_is_on_core_on20);
+	g_test_add_func("/classic/on-fedora-base", test_is_on_fedora_base);
+	g_test_add_func("/classic/on-fedora-ws", test_is_on_fedora_ws);
 	g_test_add_func("/classic/should-use-normal-mode",
 			test_should_use_normal_mode);
 }

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -32,6 +32,9 @@ sc_distro sc_classify_distro(void)
 		} else if (sc_streq(buf, "VERSION_ID=\"16\"")
 			   || sc_streq(buf, "VERSION_ID=16")) {
 			core_version = 16;
+		} else if (sc_streq(buf, "VARIANT_ID=\"snappy\"")
+			   || sc_streq(buf, "VARIANT_ID=snappy")) {
+			is_core = true;
 		}
 	}
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -173,6 +173,21 @@ func SupportsClassicConfinement() bool {
 	return false
 }
 
+var metaSnapPath = "/meta/snap.yaml"
+
+// isInsideBaseSnap returns true if the process is inside a base snap environment.
+//
+// The things that count as a base snap are:
+// - any base snap mounted at /
+// - any os snap mounted at /
+func isInsideBaseSnap() (bool, error) {
+	_, err := os.Stat(metaSnapPath)
+	if err != nil && os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 // SetRootDir allows settings a new global root directory, this is useful
 // for e.g. chroot operations
 func SetRootDir(rootdir string) {
@@ -181,7 +196,8 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	if release.DistroLike("fedora", "arch", "manjaro", "antergos") {
+	isInsideBase, _ := isInsideBaseSnap()
+	if !isInsideBase && release.DistroLike("fedora", "arch", "manjaro", "antergos") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -20,6 +20,7 @@
 package dirs_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -102,4 +103,23 @@ func (s *DirsTestSuite) TestClassicConfinementSupportOnSpecificDistributions(c *
 		dirs.SetRootDir(c.MkDir())
 		c.Check(dirs.SupportsClassicConfinement(), Equals, t.Expected, Commentf("unexpected result for %v", t.ID))
 	}
+}
+
+func (s *DirsTestSuite) TestInsideBaseSnap(c *C) {
+	d := c.MkDir()
+
+	snapYaml := filepath.Join(d, "snap.yaml")
+	restore := dirs.MockMetaSnapPath(snapYaml)
+	defer restore()
+
+	inside, err := dirs.IsInsideBaseSnap()
+	c.Assert(err, IsNil)
+	c.Assert(inside, Equals, false)
+
+	err = ioutil.WriteFile(snapYaml, []byte{}, 0755)
+	c.Assert(err, IsNil)
+
+	inside, err = dirs.IsInsideBaseSnap()
+	c.Assert(err, IsNil)
+	c.Assert(inside, Equals, true)
 }

--- a/dirs/export_test.go
+++ b/dirs/export_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package dirs
+
+var (
+	IsInsideBaseSnap = isInsideBaseSnap
+)
+
+func MockMetaSnapPath(path string) (restore func()) {
+	old := metaSnapPath
+	metaSnapPath = path
+	return func() {
+		metaSnapPath = old
+	}
+}

--- a/tests/main/fedora-base-smoke/task.yaml
+++ b/tests/main/fedora-base-smoke/task.yaml
@@ -1,0 +1,11 @@
+summary: smoke test for Fedora 29 base snap
+# The hello-fedora snap is not yet available for i386
+systems: [-*-32]
+details: |
+  Smoke test for checking if we can run hello-world like application against a
+  Fedora 29 base snap correctly.
+execute: |
+  # This is explicit because fedora29 snap is still in edge.
+  snap install --edge fedora29
+  snap install hello-fedora
+  hello-fedora


### PR DESCRIPTION
This patch fixes the algorithm that dertermines the mount point for snaps.  The
old code used to work because it was looking at /etc/os-release and looking for
specific ID or ID_LIKE values. With the introduction of base snaps that can
have arbitrary os-release files we cannot rely on this information alone.

When a process is inside a snap mount namespace that has a base snap mounted as
the root filesystem then the os-release level information is not useful and
must not be used anymore. Inside that environment the snaps are always mounted
at /snap.

On the outside of a mount namespace the current algorithm is correct, it will
identify the distribution and apply any differences mandated by the
distribution policy.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
