### PR TITLE
tests: fix snapd-failover for core18 with external backend

### DIFF
--- a/tests/core18/snapd-failover/task.yaml
+++ b/tests/core18/snapd-failover/task.yaml
@@ -17,7 +17,7 @@ execute: |
     systemctl kill --signal=SIGSEGV snapd.service
     systemctl status snapd.failure.service | MATCH inactive
     echo "Snap list is working still"
-    snap list | MATCH "^snapd.*x1.*"
+    snap list | MATCH "^snapd .* $current .*"
 
     echo "Break snapd"
     unsquashfs -d ./snapd-broken "$SNAPD_SNAP"
@@ -30,7 +30,7 @@ execute: |
     fi
 
     echo "And verify that snap commands still work and snapd is reverted"
-    snap list | MATCH "^snapd.*x1.*"
+    snap list | MATCH "^snapd .* $current .*"
 
     echo "Verify we got the expected error message"
     snap change --last=install|MATCH "there was a snapd rollback across the restart"


### PR DESCRIPTION
This change makes the test work in case the snapd version is not X1. 

It can be reproduces by using the image provided by mvo: core18-amd64-18-alpha20180803-with-lp1783810.img

error: https://paste.ubuntu.com/p/NVrKwmmT7P/