### PR TITLE
cmd/snap: fix some corner-case test setup weirdness

### DIFF
--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -22,14 +22,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/i18n"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var shortGetHelp = i18n.G("Print configuration options")
@@ -176,10 +174,6 @@ func (x *cmdGet) outputList(conf map[string]interface{}) error {
 	return nil
 }
 
-var isTerminal = func() bool {
-	return terminal.IsTerminal(int(os.Stdin.Fd()))
-}
-
 // outputDefault will be used when no commandline switch to override the
 // output where used. The output follows the following rules:
 // - a single key with a string value is printed directly
@@ -204,7 +198,7 @@ func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, con
 
 	// conf looks like a map
 	if cfg, ok := confToPrint.(map[string]interface{}); ok {
-		if isTerminal() {
+		if isStdinTTY {
 			return x.outputList(cfg)
 		}
 

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -109,7 +109,7 @@ func (s *SnapSuite) runTests(cmds []getCmdArgs, c *C) {
 
 		c.Logf("Test: %s", test.args)
 
-		restore := snapset.MockIsTerminal(test.isTerminal)
+		restore := snapset.MockIsStdinTTY(test.isTerminal)
 		defer restore()
 
 		_, err := snapset.Parser().ParseArgs(strings.Fields(test.args))

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -71,8 +71,7 @@ func canUnicode(mode string) bool {
 	return strings.Contains(lang, "UTF-8") || strings.Contains(lang, "UTF8")
 }
 
-// TODO: maybe unify isTTY (~3 calls just in cmd/snap) (but note stdout vs stdin)
-var isTTY = terminal.IsTerminal(1)
+var isStdoutTTY = terminal.IsTerminal(1)
 
 func colorTable(mode string) escapes {
 	switch mode {
@@ -81,7 +80,7 @@ func colorTable(mode string) escapes {
 	case "never":
 		return noesc
 	}
-	if !isTTY {
+	if !isStdoutTTY {
 		return noesc
 	}
 	if _, ok := os.LookupEnv("NO_COLOR"); ok {

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -108,7 +108,7 @@ func (s *SnapSuite) TestColorTable(c *check.C) {
 		{isTTY: true, term: "linux-m", expected: cmdsnap.MonoColorTable, desc: "is a tty, but TERM=linux-m"},
 		{isTTY: true, term: "xterm-mono", expected: cmdsnap.MonoColorTable, desc: "is a tty, but TERM=xterm-mono"},
 	} {
-		restoreIsTTY := cmdsnap.MockIsTTY(t.isTTY)
+		restoreIsTTY := cmdsnap.MockIsStdoutTTY(t.isTTY)
 		restoreEnv := setEnviron(map[string]string{"NO_COLOR": t.noColor, "TERM": t.term})
 		c.Check(cmdsnap.ColorTable("never"), check.DeepEquals, cmdsnap.NoEscColorTable, check.Commentf(t.desc))
 		c.Check(cmdsnap.ColorTable("always"), check.DeepEquals, cmdsnap.ColorColorTable, check.Commentf(t.desc))

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -142,19 +142,19 @@ func AssertTypeNameCompletion(match string) []flags.Completion {
 	return assertTypeName("").Complete(match)
 }
 
-func MockIsTTY(t bool) (restore func()) {
-	oldIsTTY := isTTY
-	isTTY = t
+func MockIsStdoutTTY(t bool) (restore func()) {
+	oldIsStdoutTTY := isStdoutTTY
+	isStdoutTTY = t
 	return func() {
-		isTTY = oldIsTTY
+		isStdoutTTY = oldIsStdoutTTY
 	}
 }
 
-func MockIsTerminal(t bool) (restore func()) {
-	oldIsTerminal := isTerminal
-	isTerminal = func() bool { return t }
+func MockIsStdinTTY(t bool) (restore func()) {
+	oldIsStdinTTY := isStdinTTY
+	isStdinTTY = t
 	return func() {
-		isTerminal = oldIsTerminal
+		isStdinTTY = oldIsStdinTTY
 	}
 }
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -286,12 +286,14 @@ snaps on the system. Start with 'snap list' to see installed snaps.`)
 	return parser
 }
 
+var isStdinTTY = terminal.IsTerminal(0)
+
 // ClientConfig is the configuration of the Client used by all commands.
 var ClientConfig = client.Config{
 	// we need the powerful snapd socket
 	Socket: dirs.SnapdSocket,
 	// Allow interactivity if we have a terminal
-	Interactive: terminal.IsTerminal(0),
+	Interactive: isStdinTTY,
 }
 
 // Client returns a new client using ClientConfig as configuration.

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -77,17 +77,19 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 	s.AuthFile = filepath.Join(c.MkDir(), "json")
 	os.Setenv(TestAuthFileEnvKey, s.AuthFile)
 
-	snapdsnap.MockSanitizePlugsSlots(func(snapInfo *snapdsnap.Info) {})
+	s.AddCleanup(snapdsnap.MockSanitizePlugsSlots(func(snapInfo *snapdsnap.Info) {}))
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
 	c.Assert(err, IsNil)
 	err = interfaces.WriteSystemKey()
 	c.Assert(err, IsNil)
-	interfaces.MockSystemKey(`
+	s.AddCleanup(interfaces.MockSystemKey(`
 {
 "build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
 "apparmor-features": ["caps", "dbus"]
-}`)
+}`))
+	s.AddCleanup(snap.MockIsStdoutTTY(false))
+	s.AddCleanup(snap.MockIsStdinTTY(false))
 }
 
 func (s *BaseSnapSuite) TearDownTest(c *C) {

--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -20,6 +20,7 @@
 package testutil
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,11 +51,17 @@ func (s *DBusTest) SetUpSuite(c *C) {
 	}
 
 	s.tmpdir = c.MkDir()
-	s.dbusDaemon = exec.Command("dbus-daemon", "--session", fmt.Sprintf("--address=unix:%s/user_bus_socket", s.tmpdir))
-	err := s.dbusDaemon.Start()
+	s.dbusDaemon = exec.Command("dbus-daemon", "--session", "--print-address", fmt.Sprintf("--address=unix:path=%s/user_bus_socket", s.tmpdir))
+	pout, err := s.dbusDaemon.StdoutPipe()
 	c.Assert(err, IsNil)
+	err = s.dbusDaemon.Start()
+	c.Assert(err, IsNil)
+
+	scanner := bufio.NewScanner(pout)
+	scanner.Scan()
+	c.Assert(scanner.Err(), IsNil)
 	s.oldSessionBusEnv = os.Getenv("DBUS_SESSION_BUS_ADDRESS")
-	os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
+	os.Setenv("DBUS_SESSION_BUS_ADDRESS", scanner.Text())
 
 	s.SessionBus, err = dbus.SessionBus()
 	c.Assert(err, IsNil)
@@ -65,6 +72,8 @@ func (s *DBusTest) TearDownSuite(c *C) {
 	if s.dbusDaemon != nil && s.dbusDaemon.Process != nil {
 		err := s.dbusDaemon.Process.Kill()
 		c.Assert(err, IsNil)
+		err = s.dbusDaemon.Wait() // do cleanup
+		c.Assert(err, ErrorMatches, `signal: killed`)
 	}
 
 }

--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -54,6 +54,7 @@ func (s *DBusTest) SetUpSuite(c *C) {
 	err := s.dbusDaemon.Start()
 	c.Assert(err, IsNil)
 	s.oldSessionBusEnv = os.Getenv("DBUS_SESSION_BUS_ADDRESS")
+	os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
 
 	s.SessionBus, err = dbus.SessionBus()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
In some cases, when running the tests in a particular way, some bits
of the environment were not set up properly and tests would fail. In
particular colour support was getting isatty for stdout wrong, as it
was never mocked outside of the colour tests. And dbus tests were
failing to unset the session bus env var. It's a mystery how these
things sometimes worked :-) but this should fix it for good.

I've also taken the opportunity to unify our isatty handling (at least
within cmd/snap; there's still code in progress/ doing it separately).
