### PR TITLE
debian: add tzdata to build-dep to ensure snapd builds correctly

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -33,6 +33,7 @@ Build-Depends: autoconf,
                python3-docutils,
                python3-markdown,
                squashfs-tools,
+               tzdata,
                udev,
                xfslibs-dev
 Standards-Version: 3.9.7


### PR DESCRIPTION
In the cosmic (18.10) build chroot there is no "tzdata" package
anymore. We need that in timeutil/human_test.go so that
time.LoadLocation("Europe/London") works.

This PR adds the tzdata package to the build-deps to ensure that
the test works correctly.
