### PR TITLE
snapstate: ensure normal snaps wait for the "snapd" snap on refresh

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -247,6 +247,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "core-snap-id":
 		name = "core"
 		typ = snap.TypeOS
+	case "core18-snap-id":
+		name = "core18"
+		typ = snap.TypeBase
 	case "snap-with-snapd-control-id":
 		name = "snap-with-snapd-control"
 	case "producer-id":

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -336,7 +336,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 	if len(currentSnaps) == 0 && len(actions) == 0 {
 		return nil, nil
 	}
-	if len(actions) > 3 {
+	if len(actions) > 4 {
 		panic("fake SnapAction unexpectedly called with more than 3 actions")
 	}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -763,7 +763,7 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 		// because of the sorting of updates we fill prereqs
 		// first (if branch) and only then use it to setup
 		// waits (else branch)
-		if update.Type == snap.TypeOS || update.Type == snap.TypeBase {
+		if update.Type == snap.TypeOS || update.Type == snap.TypeBase || update.InstanceName() == "snapd" {
 			// prereq types come first in updates, we
 			// also assume bases don't have hooks, otherwise
 			// they would need to wait on core
@@ -773,6 +773,7 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 			// them as necessary for the other kind of
 			// snaps
 			waitPrereq(ts, defaultCoreSnapName)
+			waitPrereq(ts, "snapd")
 			if update.Base != "" {
 				waitPrereq(ts, update.Base)
 			}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -766,7 +766,7 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 		if update.Type == snap.TypeOS || update.Type == snap.TypeBase || update.InstanceName() == "snapd" {
 			// prereq types come first in updates, we
 			// also assume bases don't have hooks, otherwise
-			// they would need to wait on core
+			// they would need to wait on core or snapd
 			prereqs[update.InstanceName()] = ts
 		} else {
 			// prereqs were processed already, wait for

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -834,6 +834,8 @@ func (s *snapmgrTestSuite) TestByKindOrder(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyWaitForBases(c *C) {
+	snapstate.MockModelWithBase("core18")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -855,6 +857,15 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBases(c *C) {
 		SnapType: "base",
 	})
 
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", SnapID: "snapd-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
@@ -865,10 +876,10 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBases(c *C) {
 		Channel:  "channel-for-base",
 	})
 
-	updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap", "core", "some-base"}, 0)
+	updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap", "core", "some-base", "snapd"}, 0)
 	c.Assert(err, IsNil)
-	c.Assert(tts, HasLen, 3)
-	c.Check(updates, HasLen, 3)
+	c.Assert(tts, HasLen, 4)
+	c.Check(updates, HasLen, 4)
 
 	// to make TaskSnapSetup work
 	chg := s.state.NewChange("refresh", "...")
@@ -876,9 +887,9 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBases(c *C) {
 		chg.AddAll(ts)
 	}
 
-	prereqTotal := len(tts[0].Tasks()) + len(tts[1].Tasks())
+	prereqTotal := len(tts[0].Tasks()) + len(tts[1].Tasks()) + len(tts[2].Tasks())
 	prereqs := map[string]bool{}
-	for i, task := range tts[2].Tasks() {
+	for i, task := range tts[3].Tasks() {
 		waitTasks := task.WaitTasks()
 		if i == 0 {
 			c.Check(len(waitTasks), Equals, prereqTotal)
@@ -897,6 +908,7 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBases(c *C) {
 	c.Check(prereqs, DeepEquals, map[string]bool{
 		"core":      true,
 		"some-base": true,
+		"snapd":     true,
 	})
 }
 


### PR DESCRIPTION
The snapd snap is special because it carries information about
e.g. implicit slots. This means that on refresh it shold be
refreshed first and other application snaps need to wait for it.
