### PR TITLE
interfaces/builtin: network-manager resolved DBus changes

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -144,6 +144,13 @@ dbus send
      peer=(name="org.freedesktop.resolve1"),
 
 dbus (send)
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="SetLink{DNS,Domains}"
+     peer=(name="org.freedesktop.resolve1"),
+
+dbus (send)
    bus=system
    path=/org/freedesktop/DBus
    interface=org.freedesktop.DBus


### PR DESCRIPTION
Extend networkManagerPermanentSlotAppArmor to allow
NetworkManager to use systemd-resolved's SetLinkDNS and
SetLinkDomain DBus methods. NetworkManager 1.6.x added
support to allow systemd-resolved to be used for managing
system DNS configuration, and this is used by default in
network-manager 1.10.x, as shipped in Ubuntu 18.04 LTS.
