### PR TITLE
udev: skip TestParseUdevEvent on ppc 

### DIFF
--- a/osutil/udev/netlink/uevent_test.go
+++ b/osutil/udev/netlink/uevent_test.go
@@ -65,7 +65,7 @@ func TestParseUEvent(testing *testing.T) {
 }
 
 func TestParseUdevEvent(testing *testing.T) {
-	if runtime.GOARCH == "s390x" {
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "ppc" {
 		testing.Skip("This test assumes little-endian architecture")
 	}
 


### PR DESCRIPTION
The ppc golang architecture uses big-endian so the TestParseUdevEvent
cannot run there. This PR skips it when ppc is detected.

The corresponding upstream change is here: https://github.com/pilebones/go-udev/pull/14