### PR TITLE
snapcraft: set version information for the snapd snap

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -26,6 +26,12 @@ if [ "$GOPACKAGE" = "cmd" ]; then
     GO_GENERATE_BUILDDIR="$(pwd)/.."
 fi
 
+OUTPUT_ONLY=false
+if [ "$1" = "--output-only" ]; then
+    OUTPUT_ONLY=true
+    shift
+fi
+
 # If the version is passed in as an argument to mkversion.sh, let's use that.
 if [ ! -z "$1" ]; then
     v="$1"
@@ -50,6 +56,11 @@ fi
 
 if [ -z "$v" ]; then
     exit 1
+fi
+
+if [ "$OUTPUT_ONLY" = true ]; then
+    echo "$v"
+    exit 0
 fi
 
 echo "*** Setting version to '$v' from $o." >&2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,8 +9,14 @@ description: |
  Start with 'snap list' to see installed snaps.
 version: set-by-version-script-thxbye
 version-script: |
-  # extract the version from the debian/changelog
-  dpkg-parsechangelog -Sversion
+  # extract the version from the debian/changelog + git
+  DEBVER="$(dpkg-parsechangelog -Sversion)"
+  GITVER="$(git describe |cut -s -f2- -d-)"
+  if [ -n "$GITVER" ]; then
+      echo "$DEBVER+$GITVER"
+  else
+      echo "$DEBVER"
+  fi
 grade: devel
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,14 +9,7 @@ description: |
  Start with 'snap list' to see installed snaps.
 version: set-by-version-script-thxbye
 version-script: |
-  # extract the version from the debian/changelog + git
-  DEBVER="$(dpkg-parsechangelog -Sversion)"
-  GITVER="$(git describe |cut -s -f2- -d-)"
-  if [ -n "$GITVER" ]; then
-      echo "$DEBVER+$GITVER"
-  else
-      echo "$DEBVER"
-  fi
+  ./mkversion.sh --output-only
 grade: devel
 
 parts:


### PR DESCRIPTION
The current version-script for the snapcraft.yaml is a bit too
simplistic. It will only look at the debian/changelog. However
for edge versions we do not update debian/changelog so the version
is misleading (e.g. 2.34.3 for current edge).

Instead it should use a combination of the version in the debian
changelog and the git describe output. This means we get:
```
master:       2.35~pre1+721-g385efa21c
release/2.34: 2.34.3+5-gde24f94dd
2.34.3:       2.34.3
```
for the snapd version (note that release/2.34 indeed has some not-yet released commits so the version is accurate).
