### PR TITLE
interfaces: miscellaneous policy updates

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -106,6 +106,8 @@ var defaultTemplate = `
   # Common utilities for shell scripts
   /{,usr/}bin/arch ixr,
   /{,usr/}bin/{,g,m}awk ixr,
+  /{,usr/}bin/base32 ixr,
+  /{,usr/}bin/base64 ixr,
   /{,usr/}bin/basename ixr,
   /{,usr/}bin/bunzip2 ixr,
   /{,usr/}bin/bzcat ixr,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -135,6 +135,7 @@ var defaultTemplate = `
   /{,usr/}bin/find ixr,
   /{,usr/}bin/flock ixr,
   /{,usr/}bin/fmt ixr,
+  /{,usr/}bin/fold ixr,
   /{,usr/}bin/getconf ixr,
   /{,usr/}bin/getent ixr,
   /{,usr/}bin/getopt ixr,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -191,7 +191,7 @@ deny /sys/devices/virtual/block/dm-[0-9]*/dm/name r,
 /run/udev/data/b252:[0-9]* r,
 /run/udev/data/b253:[0-9]* r,
 /run/udev/data/b259:[0-9]* r,
-/run/udev/data/c24[2-9]:[0-9]* r,
+/run/udev/data/c24[0-9]:[0-9]* r,
 /run/udev/data/c25[0-4]:[0-9]* r,
 
 /sys/bus/**/devices/ r,

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -35,8 +35,13 @@ const cameraConnectedPlugAppArmor = `
 
 # Allow detection of cameras. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
+/sys/devices/pci**/usb*/**/busnum r,
+/sys/devices/pci**/usb*/**/devnum r,
 /sys/devices/pci**/usb*/**/idVendor r,
 /sys/devices/pci**/usb*/**/idProduct r,
+/sys/devices/pci**/usb*/**/interface r,
+/sys/devices/pci**/usb*/**/modalias r,
+/sys/devices/pci**/usb*/**/speed r,
 /run/udev/data/c81:[0-9]* r, # video4linux (/dev/video*, etc)
 /sys/class/video4linux/ r,
 /sys/devices/pci**/usb*/**/video4linux/** r,

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -52,6 +52,9 @@ capability sys_admin,
 /sys/firmware/dmi/tables/DMI r,
 /sys/firmware/dmi/tables/smbios_entry_point r,
 
+# power information
+/sys/power/{,**} r,
+
 # interrupts
 @{PROC}/interrupts r,
 

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -64,6 +64,7 @@ capability sys_admin,
 network netlink raw,
 
 # util-linux
+/{,usr/}bin/lsblk ixr,
 /{,usr/}bin/lscpu ixr,
 /{,usr/}bin/lsmem ixr,
 

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -154,6 +154,9 @@ capability setuid,
 @{PROC}/@{pid}/loginuid r,
 @{PROC}/@{pid}/mounts r,
 
+# static host tables
+/etc/hosts w,
+
 # resolvconf
 /sbin/resolvconf ixr,
 /run/resolvconf/{,**} r,

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -43,6 +43,8 @@ capability sys_resource,
 capability sys_nice,
 
 signal (send),
+/{,usr/}bin/kill ixr,
+/{,usr/}bin/pkill ixr,
 `
 
 const processControlConnectedPlugSecComp = `


### PR DESCRIPTION
- interfaces/hardware-observe: add lsblk
- interfaces/process-control: add kill and pkill
- interfaces/camera: allow a few more /sys/devices for UVC cameras
- interfaces/hardware-observe: allow reads on /sys/power
- interfaces/browser-support: also allow reading /run/udev/data/c24[01]
- interfaces: allow /usr/bin/fold by default
- interfaces: allow base32/base64 in default template
- interfaces/network-control: allow write on /etc/hosts