### PR TITLE
interfaces/builtin: addtl network-manager resolved DBus fix

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -148,7 +148,7 @@ dbus (send)
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
      member="SetLink{DNS,Domains}"
-     peer=(name="org.freedesktop.resolve1"),
+     peer=(label=unconfined),
 
 dbus (send)
    bus=system


### PR DESCRIPTION
The previous commit was based on resolvd changes made in
commit 4b73774a which added a stanza for the resolved method's
Resolve{Address,Hostname,Record,Service}, however the peer as
specified (name="org.freedesktop.resolve1") doesn't work for
the case where NetworkManager called SetLinkDNS or SetLinkDomains.
In this case, the peer needs to be specified as (label=unconfined)
for the methods to work properly.

This time around the changes were actually tested by manually modifying
the installed apparmor policy, and ensuring that it works.