### PR TITLE
hookstate: simplify some hook tests

### DIFF
--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -429,16 +429,7 @@ func (s *hookManagerSuite) TestHookTaskEnforcesTimeout(c *C) {
 	defer cmd.Restore()
 
 	s.se.Ensure()
-	completed := make(chan struct{})
-	go func() {
-		s.se.Wait()
-		close(completed)
-	}()
-
-	s.state.Lock()
-	s.state.Unlock()
-	s.se.Ensure()
-	<-completed
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -494,16 +485,7 @@ func (s *hookManagerSuite) TestHookTaskEnforcedTimeoutWithIgnoreError(c *C) {
 	defer cmd.Restore()
 
 	s.se.Ensure()
-	completed := make(chan struct{})
-	go func() {
-		s.se.Wait()
-		close(completed)
-	}()
-
-	s.state.Lock()
-	s.state.Unlock()
-	s.se.Ensure()
-	<-completed
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -525,19 +507,14 @@ func (s *hookManagerSuite) TestHookTaskCanKillHook(c *C) {
 	defer cmd.Restore()
 
 	s.se.Ensure()
-	completed := make(chan struct{})
-	go func() {
-		s.se.Wait()
-		close(completed)
-	}()
 
-	// Abort the change, which should kill the hanging hook, and wait for the
-	// task to complete.
+	// Abort the change, which should kill the hanging hook, and
+	// wait for the task to complete.
 	s.state.Lock()
 	s.change.Abort()
 	s.state.Unlock()
 	s.se.Ensure()
-	<-completed
+	s.se.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
The TestHookTaskCanKillHook test was hanging on armhf. After some
debugging it turns out there is a race condition in the test.

The test sets up a go-routine that calls stateEngine.Wait()
concurrently with aborting a change and calling
stateEngine.Ensure(). If Wait runs before Ensure this leads to a
dead-lock in the StateEngine.mgrLock because StateEngine.Wait()
will only release the lock until all StateWaiterStopper have
returned from their Waits. One of the StateWaiterStopper is the
taskrunner. That will go over each task and call "Wait" on
that. But tomb.Wait will only return once the tomb got killed
which will happen when Ensure runs but that can't run because it
is waiting on the lock from Wait().

However looking close at the code the concurrent run of wait is
not needed, we can simply run it sequentially and the race is
gone. While at it I also simplified two more tests that look
like they just cargo-culted the above pattern.

