### PR TITLE
packaging/opensuse: fix static build of snap-update-ns and snap-exec

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -194,13 +194,11 @@ go install -s -v -p 4 -x -tags withtestkeys github.com/snapcore/snapd/cmd/snapd
 %gobuild cmd/snap
 %gobuild cmd/snapctl
 # build snap-exec and snap-update-ns completely static for base snaps
-CGO_ENABLED=0 %gobuild cmd/snap-exec
-# gobuild --ldflags '-extldflags "-static"' bin/snap-update-ns
-# FIXME: ^ this doesn't work yet, it's going to be fixed with another PR.
-%gobuild cmd/snap-update-ns
-
-# This is ok because snap-seccomp only requires static linking when it runs from the core-snap via re-exec.
-sed -e "s/-Bstatic -lseccomp/-Bstatic/g" -i %{_builddir}/go/src/%{provider_prefix}/cmd/snap-seccomp/main.go
+# NOTE: openSUSE's golang rpm helpers pass -buildmode=pie, but glibc is not
+# built with -fPIC so it'll blow up during linking, need to pass
+# -buildmode=default to override this
+%gobuild -buildmode=default -ldflags=-extldflags=-static cmd/snap-exec
+%gobuild -buildmode=default -ldflags=-extldflags=-static cmd/snap-update-ns
 # build snap-seccomp
 %gobuild cmd/snap-seccomp
 


### PR DESCRIPTION
snap-update-ns and snap-exec must be built statically. Turns out those were not
build as such on openSUSE. This has worked by accident until now. Once we
started using C library calls such as islower(), isdigit() things started to
blow up and we ended up getting a segfault in the linker.

The patch enables snap-update-ns and snap-exec to be built statically.

