### PR TITLE
snap: fix mocking of systemkey in snap-run tests

### DIFF
--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -79,15 +79,16 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(snapdsnap.MockSanitizePlugsSlots(func(snapInfo *snapdsnap.Info) {}))
 
-	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
-	c.Assert(err, IsNil)
-	err = interfaces.WriteSystemKey()
-	c.Assert(err, IsNil)
 	s.AddCleanup(interfaces.MockSystemKey(`
 {
 "build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
 "apparmor-features": ["caps", "dbus"]
 }`))
+	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
+	c.Assert(err, IsNil)
+	err = interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
+
 	s.AddCleanup(snap.MockIsStdoutTTY(false))
 	s.AddCleanup(snap.MockIsStdinTTY(false))
 }


### PR DESCRIPTION
The fix fb730e1 broke the snap run related tests when there is
no snapd running. The reason is that the order of the system-key
mocking and writing of the system key was wrong. Because there
was a cleanup missing this never was a problem. However with the
fixed cleanup it became one. This PR fixes the order and snapd
will build again. This will give us a working "edge" snap again.
