### PR TITLE
cmd/snap, daemon: error out if trying to install a snap using empty name

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -466,6 +466,15 @@ func (x *cmdInstall) Execute([]string) error {
 	x.setModes(opts)
 
 	names := remoteSnapNames(x.Positional.Snaps)
+	if len(names) == 0 {
+		return errors.New(i18n.G("cannot install zero snaps"))
+	}
+	for _, name := range names {
+		if len(name) == 0 {
+			return errors.New(i18n.G("cannot install snap with empty name"))
+		}
+	}
+
 	if len(names) == 1 {
 		return x.installOne(names[0], x.Name, opts)
 	}

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1468,6 +1468,15 @@ func (s *SnapOpSuite) TestInstallMany(c *check.C) {
 	c.Check(n, check.Equals, total)
 }
 
+func (s *SnapOpSuite) TestInstallZeroEmpty(c *check.C) {
+	_, err := snap.Parser().ParseArgs([]string{"install"})
+	c.Assert(err, check.ErrorMatches, "cannot install zero snaps")
+	_, err = snap.Parser().ParseArgs([]string{"install", ""})
+	c.Assert(err, check.ErrorMatches, "cannot install snap with empty name")
+	_, err = snap.Parser().ParseArgs([]string{"install", "", "bar"})
+	c.Assert(err, check.ErrorMatches, "cannot install snap with empty name")
+}
+
 func (s *SnapOpSuite) TestNoWait(c *check.C) {
 	s.srv.checker = func(r *http.Request) {}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1013,6 +1013,11 @@ func verifySnapInstructions(inst *snapInstruction) error {
 }
 
 func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
+	for _, name := range inst.Snaps {
+		if len(name) == 0 {
+			return nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
+		}
+	}
 	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID)
 	if err != nil {
 		return nil, err
@@ -1038,6 +1043,10 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 }
 
 func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {
+	if len(inst.Snaps[0]) == 0 {
+		return "", nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
+	}
+
 	flags, err := inst.installFlags()
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
This is now possible:
```
$ snap install '' bar
error: cannot install "", "bar": internal error: action without instance name
```
The error comes from `store.SnapAction()`, meaning all upper layers passed the empty snap name without any errors. The change will block such operations earlier in the stack.