### PR TITLE
wayland: add extra sockets that are used by older toolkits (e.g. gtk3)

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -55,9 +55,7 @@ capability sys_tty_config,
 # Create the Wayland socket and lock file
 owner /run/user/[0-9]*/wayland-[0-9]* rw,
 # Allow access to common client Wayland sockets from non-snap clients
-/run/user/[0-9]*/wayland-shared-* rw,
-/run/user/[0-9]*/wayland-cursor-shared-* rw,
-/run/user/[0-9]*/xwayland-shared-* rw,
+/run/user/[0-9]*/{mesa,mutter,sdl,wayland-cursor,weston,xwayland}-shared-* rw,
 
 # Allow write access to create /run/user/* to create XDG_RUNTIME_DIR (until lp:1738197 is fixed)
 /run/user/[0-9]*/ w,
@@ -93,9 +91,7 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 
 const waylandConnectedSlotAppArmor = `
 # Allow access to common client Wayland sockets for connected snaps
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/wayland-shared-* rw,
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/wayland-cursor-shared-* rw,
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/xwayland-shared-* rw,
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/{mesa,mutter,sdl,wayland-cursor,weston,xwayland}-shared-* rw,
 `
 
 const waylandConnectedPlugAppArmor = `

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -104,7 +104,7 @@ func (s *WaylandInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.wayland.app1"})
-	c.Assert(spec.SnippetForTag("snap.wayland.app1"), testutil.Contains, "owner /run/user/[0-9]*/snap.consumer/wayland-shared-* rw,")
+	c.Assert(spec.SnippetForTag("snap.wayland.app1"), testutil.Contains, "owner /run/user/[0-9]*/snap.consumer/{mesa,mutter,sdl,wayland-cursor,weston,xwayland}-shared-* rw,")
 
 	// permanent core slot
 	spec = &apparmor.Specification{}


### PR DESCRIPTION
Inspired by https://gitlab.com/apparmor/apparmor/blob/master/profiles/apparmor.d/abstractions/wayland