### PR TITLE
tests: avoid using the journalctl cursor when it has not been created yet

### DIFF
--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -47,12 +47,19 @@ check_journalctl_log(){
 }
 
 get_journalctl_log(){
-    cursor=$(tail -n1 "$JOURNALCTL_CURSOR_FILE")
+    cursor=""
+    if [ -f "$JOURNALCTL_CURSOR_FILE" ]; then
+        cursor=$(tail -n1 "$JOURNALCTL_CURSOR_FILE")
+    fi
     get_journalctl_log_from_cursor "$cursor" "$@"
 }
 
 get_journalctl_log_from_cursor(){
     cursor=$1
     shift
-    journalctl "$@" --cursor "$cursor"
+    if [ -z "$cursor" ]; then
+        journalctl "$@"
+    else
+        journalctl "$@" --cursor "$cursor"
+    fi
 }


### PR DESCRIPTION
This is for the scenario when the cursor was not calculated and the test
suite fails on the first test during the preparation.

This is the error we want to fix:
https://paste.ubuntu.com/p/RJH7cZXSwT/