### PR TITLE
overlord/devicestate: fix tests, set seeded in registration through proxy tests

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1292,8 +1292,8 @@ hooks:
 		Model: "pc2",
 	})
 
-	// avoid full seeding
-	s.seeding()
+	// mark it as seeded
+	s.state.Set("seeded", true)
 
 	// runs the whole device registration process
 	s.state.Unlock()


### PR DESCRIPTION
Now registration with a prepare-device hook requires seeding to be done.
