### PR TITLE
interfaces: workaround for activated services and newer DBus

### DIFF
--- a/interfaces/builtin/accounts_service.go
+++ b/interfaces/builtin/accounts_service.go
@@ -56,12 +56,17 @@ dbus (receive, send)
     peer=(label=unconfined),
 
 # Allow clients to introspect the service
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/gnome/OnlineAccounts{,/**}
+    member="Get{,All}",
 dbus (send)
     bus=session
     interface=org.freedesktop.DBus.Introspectable
     path=/com/ubuntu/OnlineAccounts{,/**}
-    member=Introspect
-    peer=(label=unconfined),
+    member=Introspect,
 `
 
 func init() {

--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -256,12 +256,12 @@ dbus (receive)
 
 # Don't allow introspection since it reveals too much (path is not service
 # specific for unconfined)
+# do not use peer=(label=unconfined) here since this is DBus activated
 #dbus (send)
 #    bus=system
 #    path=/
 #    interface=org.freedesktop.DBus.Introspectable
-#    member=Introspect
-#    peer=(label=unconfined),
+#    member=Introspect,
 
 # These allows tampering with other snap's browsers, so don't autoconnect for
 # now.

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -121,6 +121,18 @@ const bluezPermanentSlotAppArmor = `
       path=/org/freedesktop/hostname1
       interface=org.freedesktop.DBus.Properties
       peer=(label=unconfined),
+
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}",
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
 `
 
 const bluezConnectedSlotAppArmor = `

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -48,79 +48,79 @@ const bluezPermanentSlotAppArmor = `
 # Description: Allow operating as the bluez service. This gives privileged
 # access to the system.
 
-  network bluetooth,
+network bluetooth,
 
-  capability net_admin,
-  capability net_bind_service,
+capability net_admin,
+capability net_bind_service,
 
-  # libudev
-  network netlink raw,
+# libudev
+network netlink raw,
 
-  # File accesses
-  /sys/bus/usb/drivers/btusb/     r,
-  /sys/bus/usb/drivers/btusb/**   r,
-  /sys/class/bluetooth/           r,
-  /sys/devices/**/bluetooth/      rw,
-  /sys/devices/**/bluetooth/**    rw,
-  /sys/devices/**/id/chassis_type r,
+# File accesses
+/sys/bus/usb/drivers/btusb/     r,
+/sys/bus/usb/drivers/btusb/**   r,
+/sys/class/bluetooth/           r,
+/sys/devices/**/bluetooth/      rw,
+/sys/devices/**/bluetooth/**    rw,
+/sys/devices/**/id/chassis_type r,
 
-  # TODO: use snappy hardware assignment for this once LP: #1498917 is fixed
-  /dev/rfkill rw,
+# TODO: use snappy hardware assignment for this once LP: #1498917 is fixed
+/dev/rfkill rw,
 
-  # DBus accesses
-  #include <abstractions/dbus-strict>
-  dbus (send)
-     bus=system
-     path=/org/freedesktop/DBus
-     interface=org.freedesktop.DBus
-     member={Request,Release}Name
-     peer=(name=org.freedesktop.DBus, label=unconfined),
+# DBus accesses
+#include <abstractions/dbus-strict>
+dbus (send)
+   bus=system
+   path=/org/freedesktop/DBus
+   interface=org.freedesktop.DBus
+   member={Request,Release}Name
+   peer=(name=org.freedesktop.DBus, label=unconfined),
 
-  dbus (send)
+dbus (send)
+  bus=system
+  path=/org/freedesktop/*
+  interface=org.freedesktop.DBus.Properties
+  peer=(label=unconfined),
+
+# Allow binding the service to the requested connection name
+dbus (bind)
     bus=system
-    path=/org/freedesktop/*
-    interface=org.freedesktop.DBus.Properties
+    name="org.bluez",
+
+# Allow binding the service to the requested connection name
+dbus (bind)
+    bus=system
+    name="org.bluez.obex",
+
+# Allow traffic to/from our interface with any method for unconfined clients
+# to talk to our bluez services. For the org.bluez interface we don't specify
+# an Object Path since according to the bluez specification these can be
+# anything (https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc).
+dbus (receive, send)
+    bus=system
+    interface=org.bluez.*
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=system
+    path=/org/bluez{,/**}
+    interface=org.freedesktop.DBus.*
     peer=(label=unconfined),
 
-  # Allow binding the service to the requested connection name
-  dbus (bind)
-      bus=system
-      name="org.bluez",
+# Allow traffic to/from org.freedesktop.DBus for bluez service. This rule is
+# not snap-specific and grants privileged access to the org.freedesktop.DBus
+# on the system bus.
+dbus (receive, send)
+    bus=system
+    path=/
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
 
-  # Allow binding the service to the requested connection name
-  dbus (bind)
-      bus=system
-      name="org.bluez.obex",
-
-  # Allow traffic to/from our interface with any method for unconfined clients
-  # to talk to our bluez services. For the org.bluez interface we don't specify
-  # an Object Path since according to the bluez specification these can be
-  # anything (https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc).
-  dbus (receive, send)
-      bus=system
-      interface=org.bluez.*
-      peer=(label=unconfined),
-  dbus (receive, send)
-      bus=system
-      path=/org/bluez{,/**}
-      interface=org.freedesktop.DBus.*
-      peer=(label=unconfined),
-
-  # Allow traffic to/from org.freedesktop.DBus for bluez service. This rule is
-  # not snap-specific and grants privileged access to the org.freedesktop.DBus
-  # on the system bus.
-  dbus (receive, send)
-      bus=system
-      path=/
-      interface=org.freedesktop.DBus.*
-      peer=(label=unconfined),
-
-  # Allow access to hostname system service
-  dbus (receive, send)
-      bus=system
-      path=/org/freedesktop/hostname1
-      interface=org.freedesktop.DBus.Properties
-      peer=(label=unconfined),
+# Allow access to hostname system service
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Properties
+    peer=(label=unconfined),
 
 # do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)

--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -38,23 +38,23 @@ const hostnameControlConnectedPlugAppArmor = `
 /{,usr/}{,s}bin/hostnamectl           ixr,
 
 # Allow access to hostname system service
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Properties
-    member="Get{,All}"
-    peer=(label=unconfined),
+    member="Get{,All}",
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
+
 dbus (receive)
     bus=system
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
-    peer=(label=unconfined),
-dbus (send)
-    bus=system
-    path=/org/freedesktop/hostname1
-    interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
     peer=(label=unconfined),
 dbus(receive, send)
     bus=system
@@ -63,9 +63,8 @@ dbus(receive, send)
     member=Set{,Pretty,Static}Hostname
     peer=(label=unconfined),
 
-# Needed to use 'sethostname'. See man 7 capabilities
-capability sys_admin,
-# Needed to use 'hostnamectl set-hostname'
+# Needed to use 'sethostname' and 'hostnamectl set-hostname'. See man 7
+# capabilities
 capability sys_admin,
 `
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -127,12 +127,12 @@ dbus (receive)
     interface=org.freedesktop.login1.Manager
     member={PrepareForSleep,SessionNew,SessionRemoved}
     peer=(label=unconfined),
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member=Inhibit
-    peer=(label=unconfined),
+    member=Inhibit,
 `
 
 const modemManagerConnectedSlotAppArmor = `
@@ -184,6 +184,18 @@ dbus (receive, send)
     path=/org/freedesktop/ModemManager1{,/**}
     interface=org.freedesktop.DBus.*
     peer=(label=unconfined),
+
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
+dbus (send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}",
 `
 
 const modemManagerPermanentSlotSecComp = `

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -197,6 +197,13 @@ dbus (receive, send)
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}",
+
 dbus(receive, send)
     bus=system
     path=/org/freedesktop/hostname1

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -205,12 +205,12 @@ dbus(receive, send)
     peer=(label=unconfined),
 
 # Sleep monitor inside NetworkManager needs this
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/login1
     member=Inhibit
-    interface=org.freedesktop.login1.Manager
-    peer=(label=unconfined),
+    interface=org.freedesktop.login1.Manager,
 dbus (receive)
     bus=system
     path=/org/freedesktop/login1

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -49,19 +49,17 @@ dbus (send)
     peer=(label=unconfined),
 
 # Allow clients to introspect
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/systemd1
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=unconfined),
-
+    member=Introspect,
 dbus (send)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=unconfined),
+    member=Introspect,
 `
 
 func init() {

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -74,20 +74,20 @@ deny ptrace (trace),
 
 #include <abstractions/dbus-strict>
 
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=unconfined),
+    member=Get{,All},
 
 # Allow clients to introspect hostname1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=unconfined),
+    member=Introspect,
 
 # Allow clients to enumerate DBus connection names on common buses
 dbus (send)

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -38,12 +38,12 @@ const timeControlConnectedPlugAppArmor = `
 #include <abstractions/dbus-strict>
 
 # Introspection of org.freedesktop.timedate1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/timedate1
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=unconfined),
+    member=Introspect,
 
 dbus (send)
     bus=system
@@ -53,12 +53,12 @@ dbus (send)
     peer=(label=unconfined),
 
 # Read all properties from timedate1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/timedate1
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=unconfined),
+    member=Get{,All},
 
 # Receive timedate1 property changed events
 dbus (receive)

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -43,12 +43,12 @@ const timeserverControlConnectedPlugAppArmor = `
 /etc/systemd/timesyncd.conf rw,
 
 # Introspection of org.freedesktop.timedate1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/timedate1
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=unconfined),
+    member=Introspect,
 
 dbus (send)
     bus=system
@@ -58,12 +58,12 @@ dbus (send)
     peer=(label=unconfined),
 
 # Read all properties from timedate1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/timedate1
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=unconfined),
+    member=Get{,All},
 
 # Receive timedate1 property changed events
 dbus (receive)

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -45,12 +45,12 @@ const timezoneControlConnectedPlugAppArmor = `
 /etc/{,writable/}localtime.tmp rw, # Required for the timedatectl wrapper (LP: #1650688)
 
 # Introspection of org.freedesktop.timedate1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/timedate1
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=unconfined),
+    member=Introspect,
 
 dbus (send)
     bus=system
@@ -60,12 +60,12 @@ dbus (send)
     peer=(label=unconfined),
 
 # Read all properties from timedate1
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/timedate1
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=unconfined),
+    member=Get{,All},
 
 # Receive timedate1 property changed events
 dbus (receive)

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -155,6 +155,12 @@ dbus (receive, send)
     path=/org/freedesktop/UDisks2/**
     interface=org.freedesktop.DBus.Properties
     peer=(label=###SLOT_SECURITY_TAGS###),
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/UDisks2/**
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}",
 
 dbus (receive, send)
     bus=system
@@ -170,12 +176,12 @@ dbus (receive, send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 
 # Allow clients to introspect the service
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/UDisks2
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect
-    peer=(label=###SLOT_SECURITY_TAGS###),
+    member=Introspect,
 `
 
 const udisks2PermanentSlotSecComp = `

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -169,19 +169,12 @@ dbus (send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 
 # Read all properties from UPower and devices
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
-    path=/org/freedesktop/UPower{,/devices/**}
+    path=/org/freedesktop/UPower{,/Wakeups,/devices/**}
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=###SLOT_SECURITY_TAGS###),
-
-dbus (send)
-    bus=system
-    path=/org/freedesktop/UPower/Wakeups
-    interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=###SLOT_SECURITY_TAGS###),
+    member=Get{,All},
 
 dbus (send)
     bus=system
@@ -213,12 +206,12 @@ dbus (receive)
     peer=(label=###SLOT_SECURITY_TAGS###),
 
 # Allow clients to introspect the service
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     interface=org.freedesktop.DBus.Introspectable
     path=/org/freedesktop/UPower
-    member=Introspect
-    peer=(label=###SLOT_SECURITY_TAGS###),
+    member=Introspect,
 `
 
 type upowerObserveInterface struct{}

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -96,7 +96,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1{,/**}
     interface=org.freedesktop.login1.Manager
-    member={CanPowerOff,CanSuspend,CanHibernate,CanHybridSleep,PowerOff,Suspend,Hibernate,HybrisSleep}
+    member={CanPowerOff,CanSuspend,CanHibernate,CanHybridSleep,PowerOff,Suspend,Hibernate,HybridSleep}
     peer=(label=unconfined),
 `
 

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -75,12 +75,12 @@ dbus (receive)
     path=/org/freedesktop/login1{,/**}
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/login1{,/**}
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All}
-    peer=(label=unconfined),
+    member=Get{,All},
 
 # Allow receiving any signals from the logind service
 dbus (receive)


### PR DESCRIPTION
Upstream DBus changed how the label is calculated with DBus activated services in https://cgit.freedesktop.org/dbus/dbus/commit/?id=dc25979eb. Specifically, activated services must have AssumedAppArmorLabel set in the DBus service file to match 'peer=(label=...)' rules, otherwise a peer label should not be specified. Adjust the Introspect(), Get() and GetAll() rules using interface=org.freedesktop.DBus.Properties to not use 'peer=(label=unconfined)'. This should effectively workaround the issue since services will tend to use these methods before anything else, which will activate the service. Importantly, the risk of regression is deemed low because while there are a number of rule updates, they only allow more access than was provided before (either by stripping the peer label check or adding additional rules that lack the peer label check).

While this is slightly less secure without the peer label check, it should be noted that these services are all system services that must run as root and snaps or session services can't to bind to (most of) these names. For the services that can be provided via a slot implementation, the slot side requires a corresponding rule that will continue to require a matching peer label for the plugs side.

Note that I fixed (in separate commits) a typo in upower-observe, a redundant rule in hostname-control and removed leading whitespace in bluez.