### PR TITLE
tests: set ubuntu-core-18 as manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -68,6 +68,7 @@ backends:
             - ubuntu-core-18-64:
                 image: ubuntu-16.04-64
                 workers: 6
+                manual: true
 
             - debian-9-64:
                 workers: 6


### PR DESCRIPTION
builds are failing for ubuntu-core-18. The ubuntu-core-18 image is failing during its setup and the instances are not returning from the reboot done during the prepare. 

I propose to disable it, until this is fixed. 

See error: https://api.travis-ci.org/v3/job/416307968/log.txt
See serial port output: https://paste.ubuntu.com/p/bpzFBFMmy8/