### PR TITLE
asserts,image: support gadget tracks in the model assertion

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -73,25 +73,40 @@ func (mod *Model) Architecture() string {
 	return mod.HeaderString("architecture")
 }
 
-// Gadget returns the gadget snap the model uses.
-func (mod *Model) Gadget() string {
-	return mod.HeaderString("gadget")
+// snapWithTrack represents a snap that includes optional track
+// information like `snapName=trackName`
+type snapWithTrack string
+
+func (s snapWithTrack) Snap() string {
+	return strings.SplitN(string(s), "=", 2)[0]
 }
 
-// Kernel returns the kernel snap the model uses.
-func (mod *Model) Kernel() string {
-	kernel := mod.HeaderString("kernel")
-	return strings.SplitN(kernel, "=", 2)[0]
-}
-
-// KernelTrack returns the kernel track the model uses.
-func (mod *Model) KernelTrack() string {
-	kernel := mod.HeaderString("kernel")
-	l := strings.SplitN(kernel, "=", 2)
+func (s snapWithTrack) Track() string {
+	l := strings.SplitN(string(s), "=", 2)
 	if len(l) > 1 {
 		return l[1]
 	}
 	return ""
+}
+
+// Gadget returns the gadget snap the model uses.
+func (mod *Model) Gadget() string {
+	return snapWithTrack(mod.HeaderString("gadget")).Snap()
+}
+
+// GadgetTrack returns the gadget track the model uses.
+func (mod *Model) GadgetTrack() string {
+	return snapWithTrack(mod.HeaderString("gadget")).Track()
+}
+
+// Kernel returns the kernel snap the model uses.
+func (mod *Model) Kernel() string {
+	return snapWithTrack(mod.HeaderString("kernel")).Snap()
+}
+
+// KernelTrack returns the kernel track the model uses.
+func (mod *Model) KernelTrack() string {
+	return snapWithTrack(mod.HeaderString("kernel")).Track()
 }
 
 // Base returns the base snap the model uses.

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -101,6 +101,7 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	c.Check(model.DisplayName(), Equals, "Baz 3000")
 	c.Check(model.Architecture(), Equals, "amd64")
 	c.Check(model.Gadget(), Equals, "brand-gadget")
+	c.Check(model.GadgetTrack(), Equals, "")
 	c.Check(model.Kernel(), Equals, "baz-linux")
 	c.Check(model.KernelTrack(), Equals, "")
 	c.Check(model.Base(), Equals, "core18")
@@ -189,6 +190,16 @@ func (mods *modelSuite) TestDecodeKernelTrack(c *C) {
 	model := a.(*asserts.Model)
 	c.Check(model.Kernel(), Equals, "baz-linux")
 	c.Check(model.KernelTrack(), Equals, "18")
+}
+
+func (mods *modelSuite) TestDecodeGadgetTrack(c *C) {
+	withTimestamp := strings.Replace(modelExample, "TSLINE", mods.tsLine, 1)
+	encoded := strings.Replace(withTimestamp, "gadget: brand-gadget\n", "gadget: brand-gadget=18\n", 1)
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	model := a.(*asserts.Model)
+	c.Check(model.Gadget(), Equals, "brand-gadget")
+	c.Check(model.GadgetTrack(), Equals, "18")
 }
 
 const (

--- a/image/image.go
+++ b/image/image.go
@@ -295,8 +295,8 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	}
 }
 
-func makeChannelFromTrack(track, defaultChannel string) (string, error) {
-	errPrefix := fmt.Sprintf("cannot use track %q from model assertion", track)
+func makeChannelFromTrack(what, track, defaultChannel string) (string, error) {
+	errPrefix := fmt.Sprintf("cannot use track %q for %s from model assertion", track, what)
 	mch, err := snap.ParseChannel(track, "")
 	if err != nil {
 		return "", fmt.Errorf("%s: %v", errPrefix, err)
@@ -405,14 +405,14 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 
 		snapChannel := opts.Channel
 		if name == model.Kernel() && model.KernelTrack() != "" {
-			kch, err := makeChannelFromTrack(model.KernelTrack(), opts.Channel)
+			kch, err := makeChannelFromTrack("kernel", model.KernelTrack(), opts.Channel)
 			if err != nil {
 				return err
 			}
 			snapChannel = kch
 		}
 		if name == model.Gadget() && model.GadgetTrack() != "" {
-			gch, err := makeChannelFromTrack(model.GadgetTrack(), opts.Channel)
+			gch, err := makeChannelFromTrack("gadget", model.GadgetTrack(), opts.Channel)
 			if err != nil {
 				return err
 			}

--- a/image/image.go
+++ b/image/image.go
@@ -295,9 +295,9 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	}
 }
 
-func makeKernelChannel(kernelTrack, defaultChannel string) (string, error) {
-	errPrefix := fmt.Sprintf("cannot use kernel-track %q from model assertion", kernelTrack)
-	kch, err := snap.ParseChannel(kernelTrack, "")
+func makeChannelFromTrack(track, defaultChannel string) (string, error) {
+	errPrefix := fmt.Sprintf("cannot use track %q from model assertion", track)
+	mch, err := snap.ParseChannel(track, "")
 	if err != nil {
 		return "", fmt.Errorf("%s: %v", errPrefix, err)
 	}
@@ -306,9 +306,9 @@ func makeKernelChannel(kernelTrack, defaultChannel string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("internal error: cannot parse channel %q", defaultChannel)
 		}
-		kch.Risk = dch.Risk
+		mch.Risk = dch.Risk
 	}
-	return kch.Clean().String(), nil
+	return mch.Clean().String(), nil
 }
 
 func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options, local *localInfos) error {
@@ -405,11 +405,18 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 
 		snapChannel := opts.Channel
 		if name == model.Kernel() && model.KernelTrack() != "" {
-			kch, err := makeKernelChannel(model.KernelTrack(), opts.Channel)
+			kch, err := makeChannelFromTrack(model.KernelTrack(), opts.Channel)
 			if err != nil {
 				return err
 			}
 			snapChannel = kch
+		}
+		if name == model.Gadget() && model.GadgetTrack() != "" {
+			gch, err := makeChannelFromTrack(model.GadgetTrack(), opts.Channel)
+			if err != nil {
+				return err
+			}
+			snapChannel = gch
 		}
 		dlOpts := &DownloadOptions{
 			TargetDir: snapSeedDir,

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1098,7 +1098,7 @@ func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 	c.Assert(err, ErrorMatches, `cannot use channel: channel name has too many components: x/x/x/x`)
 }
 
-func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
+func (s *imageSuite) TestBootstrapWithKernelAndGadgetTrack(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
 
@@ -1109,7 +1109,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 		"brand-id":     "my-brand",
 		"model":        "my-model",
 		"architecture": "amd64",
-		"gadget":       "pc",
+		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}, nil, "")
@@ -1151,9 +1151,10 @@ func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 		Channel: "18/stable",
 	})
 	c.Check(seed.Snaps[2], DeepEquals, &snap.SeedSnap{
-		Name:   "pc",
-		SnapID: "pc-Id",
-		File:   "pc_1.snap",
+		Name:    "pc",
+		SnapID:  "pc-Id",
+		File:    "pc_1.snap",
+		Channel: "18/stable",
 	})
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -266,6 +266,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "kernel-id":
 		name = "kernel"
 		typ = snap.TypeKernel
+	case "brand-gadget-id":
+		name = "brand-gadget"
+		typ = snap.TypeGadget
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -155,6 +155,10 @@ func MockModelWithKernelTrack(kernelTrack string) (restore func()) {
 	return mockModel(map[string]string{"kernel": "kernel=" + kernelTrack})
 }
 
+func MockModelWithGadgetTrack(gadgetTrack string) (restore func()) {
+	return mockModel(map[string]string{"gadget": "brand-gadget=" + gadgetTrack})
+}
+
 func MockModel() (restore func()) {
 	return mockModel(nil)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -957,18 +957,23 @@ func canSwitchChannel(st *state.State, snapName, newChannel string) error {
 		return nil
 	}
 
-	if snapName != model.Kernel() {
-		return nil
+	if snapName == model.Kernel() && model.KernelTrack() != "" {
+		nch, err := snap.ParseChannel(newChannel, "")
+		if err != nil {
+			return err
+		}
+		if nch.Track != model.KernelTrack() {
+			return fmt.Errorf("cannot switch from kernel-track %q to %q", model.KernelTrack(), nch.String())
+		}
 	}
-	if model.KernelTrack() == "" {
-		return nil
-	}
-	nch, err := snap.ParseChannel(newChannel, "")
-	if err != nil {
-		return err
-	}
-	if nch.Track != model.KernelTrack() {
-		return fmt.Errorf("cannot switch from kernel-track %q to %q", model.KernelTrack(), nch.String())
+	if snapName == model.Gadget() && model.GadgetTrack() != "" {
+		nch, err := snap.ParseChannel(newChannel, "")
+		if err != nil {
+			return err
+		}
+		if nch.Track != model.GadgetTrack() {
+			return fmt.Errorf("cannot switch from gadget-track %q to %q", model.GadgetTrack(), nch.String())
+		}
 	}
 
 	return nil

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -963,7 +963,7 @@ func canSwitchChannel(st *state.State, snapName, newChannel string) error {
 			return err
 		}
 		if nch.Track != model.KernelTrack() {
-			return fmt.Errorf("cannot switch from kernel-track %q to %q", model.KernelTrack(), nch.String())
+			return fmt.Errorf("cannot switch from kernel track %q to %q", model.KernelTrack(), nch.String())
 		}
 	}
 	if snapName == model.Gadget() && model.GadgetTrack() != "" {
@@ -972,7 +972,7 @@ func canSwitchChannel(st *state.State, snapName, newChannel string) error {
 			return err
 		}
 		if nch.Track != model.GadgetTrack() {
-			return fmt.Errorf("cannot switch from gadget-track %q to %q", model.GadgetTrack(), nch.String())
+			return fmt.Errorf("cannot switch from gadget track %q to %q", model.GadgetTrack(), nch.String())
 		}
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1235,6 +1235,42 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackRiskOnlyIsOK(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *snapmgrTestSuite) TestSwitchGadgetTrackForbidden(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "brand-gadget", Revision: snap.R(11)},
+		},
+		Channel: "18/stable",
+		Current: snap.R(11),
+		Active:  true,
+	})
+
+	_, err := snapstate.Switch(s.state, "brand-gadget", "new-channel")
+	c.Assert(err, ErrorMatches, `cannot switch from gadget-track "18" to "new-channel/stable"`)
+}
+
+func (s *snapmgrTestSuite) TestSwitchGadgetTrackRiskOnlyIsOK(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "brand-gadget", Revision: snap.R(11)},
+		},
+		Channel: "18/stable",
+		Current: snap.R(11),
+		Active:  true,
+	})
+
+	_, err := snapstate.Switch(s.state, "brand-gadget", "18/beta")
+	c.Assert(err, IsNil)
+}
+
 func (s *snapmgrTestSuite) TestDisableTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -4351,6 +4387,38 @@ func (s *snapmgrTestSuite) TestUpdateKernelTrackChecksSwitchingTracks(c *C) {
 
 	// switching risk level is ok
 	_, err = snapstate.Update(s.state, "kernel", "18/beta", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+}
+
+func (s *snapmgrTestSuite) TestUpdateGadgetTrackChecksSwitchingTracks(c *C) {
+	si := snap.SideInfo{
+		RealName: "brand-gadget",
+		SnapID:   "brand-gadget-id",
+		Revision: snap.R(7),
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Current:  si.Revision,
+		Channel:  "18/stable",
+	})
+
+	// switching tracks is not ok
+	_, err := snapstate.Update(s.state, "brand-gadget", "new-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `cannot switch from gadget-track "18" to "new-channel/stable"`)
+
+	// no change to the channel is ok
+	_, err = snapstate.Update(s.state, "brand-gadget", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	// switching risk level is ok
+	_, err = snapstate.Update(s.state, "brand-gadget", "18/beta", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 }
@@ -10243,7 +10311,7 @@ layout:
 	c.Assert(err, IsNil)
 }
 
-func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitch(c *C) {
+func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchKernel(c *C) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
@@ -10271,6 +10339,36 @@ version: 1.0`)
 	}
 	_, err := snapstate.InstallPath(s.state, si, someSnap, "some-channel", snapstate.Flags{Required: true})
 	c.Assert(err, ErrorMatches, `cannot switch from kernel-track "18" to "some-channel/stable"`)
+}
+
+func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchGadget(c *C) {
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// snapd cannot be installed unless the model uses a base snap
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "brand-gadget", Revision: snap.R(11)},
+		},
+		Channel: "18/stable",
+		Current: snap.R(11),
+		Active:  true,
+	})
+
+	someSnap := makeTestSnap(c, `name: brand-gadget
+version: 1.0`)
+	si := &snap.SideInfo{
+		RealName: "brand-gadget",
+		SnapID:   "brand-gadget-id",
+		Revision: snap.R(42),
+		Channel:  "some-channel",
+	}
+	_, err := snapstate.InstallPath(s.state, si, someSnap, "some-channel", snapstate.Flags{Required: true})
+	c.Assert(err, ErrorMatches, `cannot switch from gadget-track "18" to "some-channel/stable"`)
 }
 
 func (s *snapmgrTestSuite) TestInstallLayoutsChecksFeatureFlag(c *C) {


### PR DESCRIPTION
The model assertion supports "kernel: snapName=trackName" already.

This PR adds support for "gadget: snapname=trackName" so that this
also works for gadget snaps and adds the coresponding policy checks
and tests in snapstate.
