### PR TITLE
tests: add the original function to fix the errors on new kernels

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -560,14 +560,14 @@ pkg_dependencies_ubuntu_classic(){
 }
 
 pkg_linux_image_extra(){
-    if apt-cache policy "linux-image-extra-$(uname -r)" >/dev/null 2>&1; then
+    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
+    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
         echo "linux-image-extra-$(uname -r)"
-    elif apt-cache policy "linux-image-extra-$(uname -r | cut -d- -f1)" >/dev/null 2>&1; then
-        echo "linux-image-extra-$(uname -r | cut -d- -f1)"
-    else
-        echo "cannot find a matching kernel modules package"
-        exit 1
+        return
     fi
+
+    kernel_version="$(uname -r | cut -d- -f1)"
+    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
 }
 
 pkg_dependencies_ubuntu_core(){

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -559,15 +559,17 @@ pkg_dependencies_ubuntu_classic(){
     esac
 }
 
-pkg_linux_image_extra(){
-    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
-    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
-        echo "linux-image-extra-$(uname -r)"
-        return
+pkg_linux_image_extra (){
+    if apt-cache show "linux-image-extra-$(uname -r)" > /dev/null 2>&1; then
+        echo "linux-image-extra-$(uname -r)";
+    else
+        if apt-cache show "linux-modules-extra-$(uname -r)" > /dev/null 2>&1; then
+            echo "linux-modules-extra-$(uname -r)";
+        else
+            echo "cannot find a matching kernel modules package";
+            exit 1;
+        fi;
     fi
-
-    kernel_version="$(uname -r | cut -d- -f1)"
-    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
 }
 
 pkg_dependencies_ubuntu_core(){


### PR DESCRIPTION
Sadly the other method is failing with the new kernel for xenial 64bits.

function output: https://paste.ubuntu.com/p/yKhXfjHkTX/
test error: https://paste.ubuntu.com/p/MngHCnCTcJ/