### PR TITLE
 image: add support for "gadget=track"

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -73,25 +73,40 @@ func (mod *Model) Architecture() string {
 	return mod.HeaderString("architecture")
 }
 
-// Gadget returns the gadget snap the model uses.
-func (mod *Model) Gadget() string {
-	return mod.HeaderString("gadget")
+// snapWithTrack represents a snap that includes optional track
+// information like `snapName=trackName`
+type snapWithTrack string
+
+func (s snapWithTrack) Snap() string {
+	return strings.SplitN(string(s), "=", 2)[0]
 }
 
-// Kernel returns the kernel snap the model uses.
-func (mod *Model) Kernel() string {
-	kernel := mod.HeaderString("kernel")
-	return strings.SplitN(kernel, "=", 2)[0]
-}
-
-// KernelTrack returns the kernel track the model uses.
-func (mod *Model) KernelTrack() string {
-	kernel := mod.HeaderString("kernel")
-	l := strings.SplitN(kernel, "=", 2)
+func (s snapWithTrack) Track() string {
+	l := strings.SplitN(string(s), "=", 2)
 	if len(l) > 1 {
 		return l[1]
 	}
 	return ""
+}
+
+// Gadget returns the gadget snap the model uses.
+func (mod *Model) Gadget() string {
+	return snapWithTrack(mod.HeaderString("gadget")).Snap()
+}
+
+// GadgetTrack returns the gadget track the model uses.
+func (mod *Model) GadgetTrack() string {
+	return snapWithTrack(mod.HeaderString("gadget")).Track()
+}
+
+// Kernel returns the kernel snap the model uses.
+func (mod *Model) Kernel() string {
+	return snapWithTrack(mod.HeaderString("kernel")).Snap()
+}
+
+// KernelTrack returns the kernel track the model uses.
+func (mod *Model) KernelTrack() string {
+	return snapWithTrack(mod.HeaderString("kernel")).Track()
 }
 
 // Base returns the base snap the model uses.
@@ -131,26 +146,26 @@ var _ consistencyChecker = (*Model)(nil)
 // limit model to only lowercase for now
 var validModel = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
 
-func checkKernelHeader(headers map[string]interface{}) error {
-	_, ok := headers["kernel"]
+func checkSnapWithTrackHeader(header string, headers map[string]interface{}) error {
+	_, ok := headers[header]
 	if !ok {
 		return nil
 	}
-	kernel, ok := headers["kernel"].(string)
+	value, ok := headers[header].(string)
 	if !ok {
-		return fmt.Errorf(`"kernel" header must be a string`)
+		return fmt.Errorf(`%q header must be a string`, header)
 	}
-	l := strings.SplitN(kernel, "=", 2)
+	l := strings.SplitN(value, "=", 2)
 	if len(l) == 1 {
 		return nil
 	}
-	kernelTrack := l[1]
-	if strings.Count(kernelTrack, "/") != 0 {
-		return fmt.Errorf(`"kernel" channel selector must be a track name only`)
+	track := l[1]
+	if strings.Count(track, "/") != 0 {
+		return fmt.Errorf(`%q channel selector must be a track name only`, header)
 	}
 	channelRisks := []string{"stable", "candidate", "beta", "edge"}
-	if strutil.ListContains(channelRisks, kernelTrack) {
-		return fmt.Errorf(`"kernel" channel selector must be a track name`)
+	if strutil.ListContains(channelRisks, track) {
+		return fmt.Errorf(`%q channel selector must be a track name`, header)
 	}
 	return nil
 }
@@ -158,9 +173,6 @@ func checkKernelHeader(headers map[string]interface{}) error {
 func checkModel(headers map[string]interface{}) (string, error) {
 	s, err := checkStringMatches(headers, "model", validModel)
 	if err != nil {
-		return "", err
-	}
-	if err := checkKernelHeader(headers); err != nil {
 		return "", err
 	}
 
@@ -217,6 +229,13 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
+	if err := checkSnapWithTrackHeader("kernel", assert.headers); err != nil {
+		return nil, err
+	}
+	if err := checkSnapWithTrackHeader("gadget", assert.headers); err != nil {
+		return nil, err
+	}
+
 	classic, err := checkOptionalBool(assert.headers, "classic")
 	if err != nil {
 		return nil, err
@@ -242,12 +261,6 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if _, err := checker(assert.headers, h); err != nil {
 			return nil, err
 		}
-	}
-
-	// kernel-track is optional but must be a string.
-	_, err = checkOptionalString(assert.headers, "kernel-track")
-	if err != nil {
-		return nil, err
 	}
 
 	// store is optional but must be a string, defaults to the ubuntu store

--- a/image/image.go
+++ b/image/image.go
@@ -295,9 +295,9 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	}
 }
 
-func makeKernelChannel(kernelTrack, defaultChannel string) (string, error) {
-	errPrefix := fmt.Sprintf("cannot use kernel-track %q from model assertion", kernelTrack)
-	kch, err := snap.ParseChannel(kernelTrack, "")
+func makeChannelFromTrack(what, track, defaultChannel string) (string, error) {
+	errPrefix := fmt.Sprintf("cannot use track %q for %s from model assertion", track, what)
+	mch, err := snap.ParseChannel(track, "")
 	if err != nil {
 		return "", fmt.Errorf("%s: %v", errPrefix, err)
 	}
@@ -306,9 +306,9 @@ func makeKernelChannel(kernelTrack, defaultChannel string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("internal error: cannot parse channel %q", defaultChannel)
 		}
-		kch.Risk = dch.Risk
+		mch.Risk = dch.Risk
 	}
-	return kch.Clean().String(), nil
+	return mch.Clean().String(), nil
 }
 
 func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options, local *localInfos) error {
@@ -405,11 +405,18 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 
 		snapChannel := opts.Channel
 		if name == model.Kernel() && model.KernelTrack() != "" {
-			kch, err := makeKernelChannel(model.KernelTrack(), opts.Channel)
+			kch, err := makeChannelFromTrack("kernel", model.KernelTrack(), opts.Channel)
 			if err != nil {
 				return err
 			}
 			snapChannel = kch
+		}
+		if name == model.Gadget() && model.GadgetTrack() != "" {
+			gch, err := makeChannelFromTrack("gadget", model.GadgetTrack(), opts.Channel)
+			if err != nil {
+				return err
+			}
+			snapChannel = gch
 		}
 		dlOpts := &DownloadOptions{
 			TargetDir: snapSeedDir,

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1098,7 +1098,7 @@ func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 	c.Assert(err, ErrorMatches, `cannot use channel: channel name has too many components: x/x/x/x`)
 }
 
-func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
+func (s *imageSuite) TestBootstrapWithKernelAndGadgetTrack(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
 
@@ -1109,7 +1109,7 @@ func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 		"brand-id":     "my-brand",
 		"model":        "my-model",
 		"architecture": "amd64",
-		"gadget":       "pc",
+		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}, nil, "")
@@ -1151,9 +1151,10 @@ func (s *imageSuite) TestBootstrapWithKernelTrack(c *C) {
 		Channel: "18/stable",
 	})
 	c.Check(seed.Snaps[2], DeepEquals, &snap.SeedSnap{
-		Name:   "pc",
-		SnapID: "pc-Id",
-		File:   "pc_1.snap",
+		Name:    "pc",
+		SnapID:  "pc-Id",
+		File:    "pc_1.snap",
+		Channel: "18/stable",
 	})
 }
 


### PR DESCRIPTION
This PR adds support for using track for the gadget in the model
assertion.

Based on https://github.com/snapcore/snapd/pull/5676