### PR TITLE
snapstate: add support for gadget tracks in model assertion

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -73,25 +73,40 @@ func (mod *Model) Architecture() string {
 	return mod.HeaderString("architecture")
 }
 
-// Gadget returns the gadget snap the model uses.
-func (mod *Model) Gadget() string {
-	return mod.HeaderString("gadget")
+// snapWithTrack represents a snap that includes optional track
+// information like `snapName=trackName`
+type snapWithTrack string
+
+func (s snapWithTrack) Snap() string {
+	return strings.SplitN(string(s), "=", 2)[0]
 }
 
-// Kernel returns the kernel snap the model uses.
-func (mod *Model) Kernel() string {
-	kernel := mod.HeaderString("kernel")
-	return strings.SplitN(kernel, "=", 2)[0]
-}
-
-// KernelTrack returns the kernel track the model uses.
-func (mod *Model) KernelTrack() string {
-	kernel := mod.HeaderString("kernel")
-	l := strings.SplitN(kernel, "=", 2)
+func (s snapWithTrack) Track() string {
+	l := strings.SplitN(string(s), "=", 2)
 	if len(l) > 1 {
 		return l[1]
 	}
 	return ""
+}
+
+// Gadget returns the gadget snap the model uses.
+func (mod *Model) Gadget() string {
+	return snapWithTrack(mod.HeaderString("gadget")).Snap()
+}
+
+// GadgetTrack returns the gadget track the model uses.
+func (mod *Model) GadgetTrack() string {
+	return snapWithTrack(mod.HeaderString("gadget")).Track()
+}
+
+// Kernel returns the kernel snap the model uses.
+func (mod *Model) Kernel() string {
+	return snapWithTrack(mod.HeaderString("kernel")).Snap()
+}
+
+// KernelTrack returns the kernel track the model uses.
+func (mod *Model) KernelTrack() string {
+	return snapWithTrack(mod.HeaderString("kernel")).Track()
 }
 
 // Base returns the base snap the model uses.
@@ -131,26 +146,26 @@ var _ consistencyChecker = (*Model)(nil)
 // limit model to only lowercase for now
 var validModel = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
 
-func checkKernelHeader(headers map[string]interface{}) error {
-	_, ok := headers["kernel"]
+func checkSnapWithTrackHeader(header string, headers map[string]interface{}) error {
+	_, ok := headers[header]
 	if !ok {
 		return nil
 	}
-	kernel, ok := headers["kernel"].(string)
+	value, ok := headers[header].(string)
 	if !ok {
-		return fmt.Errorf(`"kernel" header must be a string`)
+		return fmt.Errorf(`%q header must be a string`, header)
 	}
-	l := strings.SplitN(kernel, "=", 2)
+	l := strings.SplitN(value, "=", 2)
 	if len(l) == 1 {
 		return nil
 	}
-	kernelTrack := l[1]
-	if strings.Count(kernelTrack, "/") != 0 {
-		return fmt.Errorf(`"kernel" channel selector must be a track name only`)
+	track := l[1]
+	if strings.Count(track, "/") != 0 {
+		return fmt.Errorf(`%q channel selector must be a track name only`, header)
 	}
 	channelRisks := []string{"stable", "candidate", "beta", "edge"}
-	if strutil.ListContains(channelRisks, kernelTrack) {
-		return fmt.Errorf(`"kernel" channel selector must be a track name`)
+	if strutil.ListContains(channelRisks, track) {
+		return fmt.Errorf(`%q channel selector must be a track name`, header)
 	}
 	return nil
 }
@@ -158,9 +173,6 @@ func checkKernelHeader(headers map[string]interface{}) error {
 func checkModel(headers map[string]interface{}) (string, error) {
 	s, err := checkStringMatches(headers, "model", validModel)
 	if err != nil {
-		return "", err
-	}
-	if err := checkKernelHeader(headers); err != nil {
 		return "", err
 	}
 
@@ -217,6 +229,13 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
+	if err := checkSnapWithTrackHeader("kernel", assert.headers); err != nil {
+		return nil, err
+	}
+	if err := checkSnapWithTrackHeader("gadget", assert.headers); err != nil {
+		return nil, err
+	}
+
 	classic, err := checkOptionalBool(assert.headers, "classic")
 	if err != nil {
 		return nil, err
@@ -242,12 +261,6 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if _, err := checker(assert.headers, h); err != nil {
 			return nil, err
 		}
-	}
-
-	// kernel-track is optional but must be a string.
-	_, err = checkOptionalString(assert.headers, "kernel-track")
-	if err != nil {
-		return nil, err
 	}
 
 	// store is optional but must be a string, defaults to the ubuntu store

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -266,6 +266,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "kernel-id":
 		name = "kernel"
 		typ = snap.TypeKernel
+	case "brand-gadget-id":
+		name = "brand-gadget"
+		typ = snap.TypeGadget
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -155,6 +155,10 @@ func MockModelWithKernelTrack(kernelTrack string) (restore func()) {
 	return mockModel(map[string]string{"kernel": "kernel=" + kernelTrack})
 }
 
+func MockModelWithGadgetTrack(gadgetTrack string) (restore func()) {
+	return mockModel(map[string]string{"gadget": "brand-gadget=" + gadgetTrack})
+}
+
 func MockModel() (restore func()) {
 	return mockModel(nil)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -957,18 +957,23 @@ func canSwitchChannel(st *state.State, snapName, newChannel string) error {
 		return nil
 	}
 
-	if snapName != model.Kernel() {
-		return nil
+	if snapName == model.Kernel() && model.KernelTrack() != "" {
+		nch, err := snap.ParseChannel(newChannel, "")
+		if err != nil {
+			return err
+		}
+		if nch.Track != model.KernelTrack() {
+			return fmt.Errorf("cannot switch from kernel track %q to %q", model.KernelTrack(), nch.String())
+		}
 	}
-	if model.KernelTrack() == "" {
-		return nil
-	}
-	nch, err := snap.ParseChannel(newChannel, "")
-	if err != nil {
-		return err
-	}
-	if nch.Track != model.KernelTrack() {
-		return fmt.Errorf("cannot switch from kernel-track %q to %q", model.KernelTrack(), nch.String())
+	if snapName == model.Gadget() && model.GadgetTrack() != "" {
+		nch, err := snap.ParseChannel(newChannel, "")
+		if err != nil {
+			return err
+		}
+		if nch.Track != model.GadgetTrack() {
+			return fmt.Errorf("cannot switch from gadget track %q to %q", model.GadgetTrack(), nch.String())
+		}
 	}
 
 	return nil

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1214,7 +1214,7 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackForbidden(c *C) {
 	})
 
 	_, err := snapstate.Switch(s.state, "kernel", "new-channel")
-	c.Assert(err, ErrorMatches, `cannot switch from kernel-track "18" to "new-channel/stable"`)
+	c.Assert(err, ErrorMatches, `cannot switch from kernel track "18" to "new-channel/stable"`)
 }
 
 func (s *snapmgrTestSuite) TestSwitchKernelTrackRiskOnlyIsOK(c *C) {
@@ -1232,6 +1232,42 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackRiskOnlyIsOK(c *C) {
 	})
 
 	_, err := snapstate.Switch(s.state, "kernel", "18/beta")
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestSwitchGadgetTrackForbidden(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "brand-gadget", Revision: snap.R(11)},
+		},
+		Channel: "18/stable",
+		Current: snap.R(11),
+		Active:  true,
+	})
+
+	_, err := snapstate.Switch(s.state, "brand-gadget", "new-channel")
+	c.Assert(err, ErrorMatches, `cannot switch from gadget track "18" to "new-channel/stable"`)
+}
+
+func (s *snapmgrTestSuite) TestSwitchGadgetTrackRiskOnlyIsOK(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "brand-gadget", Revision: snap.R(11)},
+		},
+		Channel: "18/stable",
+		Current: snap.R(11),
+		Active:  true,
+	})
+
+	_, err := snapstate.Switch(s.state, "brand-gadget", "18/beta")
 	c.Assert(err, IsNil)
 }
 
@@ -4343,7 +4379,7 @@ func (s *snapmgrTestSuite) TestUpdateKernelTrackChecksSwitchingTracks(c *C) {
 
 	// switching tracks is not ok
 	_, err := snapstate.Update(s.state, "kernel", "new-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `cannot switch from kernel-track "18" to "new-channel/stable"`)
+	c.Assert(err, ErrorMatches, `cannot switch from kernel track "18" to "new-channel/stable"`)
 
 	// no change to the channel is ok
 	_, err = snapstate.Update(s.state, "kernel", "", snap.R(0), s.user.ID, snapstate.Flags{})
@@ -4351,6 +4387,38 @@ func (s *snapmgrTestSuite) TestUpdateKernelTrackChecksSwitchingTracks(c *C) {
 
 	// switching risk level is ok
 	_, err = snapstate.Update(s.state, "kernel", "18/beta", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+}
+
+func (s *snapmgrTestSuite) TestUpdateGadgetTrackChecksSwitchingTracks(c *C) {
+	si := snap.SideInfo{
+		RealName: "brand-gadget",
+		SnapID:   "brand-gadget-id",
+		Revision: snap.R(7),
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Current:  si.Revision,
+		Channel:  "18/stable",
+	})
+
+	// switching tracks is not ok
+	_, err := snapstate.Update(s.state, "brand-gadget", "new-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `cannot switch from gadget track "18" to "new-channel/stable"`)
+
+	// no change to the channel is ok
+	_, err = snapstate.Update(s.state, "brand-gadget", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	// switching risk level is ok
+	_, err = snapstate.Update(s.state, "brand-gadget", "18/beta", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 }
@@ -10243,7 +10311,7 @@ layout:
 	c.Assert(err, IsNil)
 }
 
-func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitch(c *C) {
+func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchKernel(c *C) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
@@ -10270,7 +10338,37 @@ version: 1.0`)
 		Channel:  "some-channel",
 	}
 	_, err := snapstate.InstallPath(s.state, si, someSnap, "some-channel", snapstate.Flags{Required: true})
-	c.Assert(err, ErrorMatches, `cannot switch from kernel-track "18" to "some-channel/stable"`)
+	c.Assert(err, ErrorMatches, `cannot switch from kernel track "18" to "some-channel/stable"`)
+}
+
+func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchGadget(c *C) {
+	// use the real thing for this one
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// snapd cannot be installed unless the model uses a base snap
+	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "brand-gadget", Revision: snap.R(11)},
+		},
+		Channel: "18/stable",
+		Current: snap.R(11),
+		Active:  true,
+	})
+
+	someSnap := makeTestSnap(c, `name: brand-gadget
+version: 1.0`)
+	si := &snap.SideInfo{
+		RealName: "brand-gadget",
+		SnapID:   "brand-gadget-id",
+		Revision: snap.R(42),
+		Channel:  "some-channel",
+	}
+	_, err := snapstate.InstallPath(s.state, si, someSnap, "some-channel", snapstate.Flags{Required: true})
+	c.Assert(err, ErrorMatches, `cannot switch from gadget track "18" to "some-channel/stable"`)
 }
 
 func (s *snapmgrTestSuite) TestInstallLayoutsChecksFeatureFlag(c *C) {


### PR DESCRIPTION
This PR adds the policy bits into the snapstate to ensure that
the track specified in the model assertion for the gadget is
honored.