### PR TITLE
tests/main/lxd: run ubuntu-16.04 only on 64 bit variant

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -2,7 +2,8 @@ summary: Ensure that lxd works
 
 # only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
-systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*, ubuntu-core-*]
+# ubuntu-16.04-32: temporarily disable until container detection issues are resolved
+systems: [ubuntu-16.04-64, ubuntu-18*, ubuntu-2*, ubuntu-core-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro


### PR DESCRIPTION
Temporarily limit Ubuntu 16.04 systems running this test to 64 bit variant only.
Workaround breakage in ubuntu:16.04:i386 containers which is still being
investigated.
