### PR TITLE
overlord: handle sigterm during shutdown better

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -123,5 +123,5 @@ func run() error {
 		// something called Stop()
 	}
 
-	return d.Stop()
+	return d.Stop(ch)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"strings"
@@ -514,7 +515,7 @@ var (
 )
 
 // Stop shuts down the Daemon
-func (d *Daemon) Stop() error {
+func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	d.tomb.Kill(nil)
 
 	d.mu.Lock()
@@ -575,6 +576,12 @@ func (d *Daemon) Stop() error {
 		}
 		// wait for reboot to happen
 		logger.Noticef("Waiting for system reboot")
+		signal.Stop(sigCh)
+		if len(sigCh) > 0 {
+			// a signal arrived in between
+			return nil
+		}
+		close(sigCh)
 		time.Sleep(rebootWaitTimeout)
 		return fmt.Errorf("expected reboot did not happen")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -576,12 +576,12 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		}
 		// wait for reboot to happen
 		logger.Noticef("Waiting for system reboot")
-		signal.Stop(sigCh)
-		if len(sigCh) > 0 {
-			// a signal arrived in between
-			return nil
-		}
 		if sigCh != nil {
+			signal.Stop(sigCh)
+			if len(sigCh) > 0 {
+				// a signal arrived in between
+				return nil
+			}
 			close(sigCh)
 		}
 		time.Sleep(rebootWaitTimeout)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -581,7 +581,9 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 			// a signal arrived in between
 			return nil
 		}
-		close(sigCh)
+		if sigCh != nil {
+			close(sigCh)
+		}
 		time.Sleep(rebootWaitTimeout)
 		return fmt.Errorf("expected reboot did not happen")
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -460,7 +461,8 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	<-snapdDone
 	<-snapDone
 
-	err = d.Stop()
+	ch := make(chan os.Signal, 2)
+	err = d.Stop(ch)
 	c.Check(err, check.IsNil)
 
 	c.Check(s.notified, check.DeepEquals, []string{"READY=1", "STOPPING=1"})
@@ -480,8 +482,9 @@ func (s *daemonSuite) TestRestartWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
+	ch := make(chan os.Signal, 2)
 	d.Start()
-	defer d.Stop()
+	defer d.Stop(ch)
 
 	snapdDone := make(chan struct{})
 	go func() {
@@ -590,8 +593,9 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 		doRespond <- true
 	}()
 
+	ch := make(chan os.Signal, 2)
 	<-responding
-	err = d.Stop()
+	err = d.Stop(ch)
 	doRespond <- false
 	c.Check(err, check.IsNil)
 
@@ -616,8 +620,9 @@ func (s *daemonSuite) TestRestartSystemWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
+	ch := make(chan os.Signal, 2)
 	d.Start()
-	defer d.Stop()
+	defer d.Stop(ch)
 
 	snapdDone := make(chan struct{})
 	go func() {
@@ -681,7 +686,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *check.C) {
 	c.Check(delays, check.HasLen, 1)
 	c.Check(delays[0], check.DeepEquals, rebootWaitTimeout)
 
-	err = d.Stop()
+	err = d.Stop(ch)
 
 	c.Check(err, check.ErrorMatches, "expected reboot did not happen")
 	c.Check(delays, check.HasLen, 2)
@@ -715,4 +720,79 @@ func (s *daemonSuite) TestRebootHelper(c *check.C) {
 
 		cmd.ForgetCalls()
 	}
+}
+
+func makeDaemonListeners(c *check.C, d *Daemon) {
+	snapdL, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, check.IsNil)
+
+	snapL, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, check.IsNil)
+
+	snapdAccept := make(chan struct{})
+	snapdClosed := make(chan struct{})
+	d.snapdListener = &witnessAcceptListener{Listener: snapdL, accept: snapdAccept, closed: snapdClosed}
+
+	snapAccept := make(chan struct{})
+	d.snapListener = &witnessAcceptListener{Listener: snapL, accept: snapAccept}
+}
+
+// This test tests that when the snapd calls a restart of the system
+// a sigterm (from e.g. systemd) is handled when it arrives before
+// stop is fully done.
+func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
+	oldRebootNoticeWait := rebootNoticeWait
+	defer func() {
+		rebootNoticeWait = oldRebootNoticeWait
+	}()
+	rebootNoticeWait = 150 * time.Millisecond
+
+	cmd := testutil.MockCommand(c, "shutdown", "")
+	defer cmd.Restore()
+
+	d := newTestDaemon(c)
+	makeDaemonListeners(c, d)
+	s.markSeeded(d)
+
+	d.Start()
+	d.overlord.State().RequestRestart(state.RestartSystem)
+
+	ch := make(chan os.Signal, 2)
+	go func() { ch <- syscall.SIGTERM }()
+	// stop will check if we got a sigterm in between (which we did)
+	err := d.Stop(ch)
+	c.Assert(err, check.IsNil)
+}
+
+// This test tests that when there is a shutdown we close the sigterm
+// handler so that systemd can kill snapd.
+func (s *daemonSuite) TestRestartShutdown(c *check.C) {
+	oldRebootNoticeWait := rebootNoticeWait
+	oldRebootWaitTimeout := rebootWaitTimeout
+	defer func() {
+		reboot = rebootImpl
+		rebootNoticeWait = oldRebootNoticeWait
+		rebootWaitTimeout = oldRebootWaitTimeout
+	}()
+	rebootWaitTimeout = 100 * time.Millisecond
+	rebootNoticeWait = 150 * time.Millisecond
+
+	cmd := testutil.MockCommand(c, "shutdown", "")
+	defer cmd.Restore()
+
+	d := newTestDaemon(c)
+	makeDaemonListeners(c, d)
+	s.markSeeded(d)
+
+	d.Start()
+	d.overlord.State().RequestRestart(state.RestartSystem)
+
+	sigCh := make(chan os.Signal, 2)
+	// stop (this will timeout but thats not relevant for this test)
+	d.Stop(sigCh)
+
+	// ensure that the sigCh got closed as part of the stop
+	_, chOpen := <-sigCh
+	c.Assert(chOpen, check.Equals, false)
+
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -461,8 +461,7 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	<-snapdDone
 	<-snapDone
 
-	ch := make(chan os.Signal, 2)
-	err = d.Stop(ch)
+	err = d.Stop(nil)
 	c.Check(err, check.IsNil)
 
 	c.Check(s.notified, check.DeepEquals, []string{"READY=1", "STOPPING=1"})
@@ -482,9 +481,8 @@ func (s *daemonSuite) TestRestartWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
-	ch := make(chan os.Signal, 2)
 	d.Start()
-	defer d.Stop(ch)
+	defer d.Stop(nil)
 
 	snapdDone := make(chan struct{})
 	go func() {
@@ -593,9 +591,8 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 		doRespond <- true
 	}()
 
-	ch := make(chan os.Signal, 2)
 	<-responding
-	err = d.Stop(ch)
+	err = d.Stop(nil)
 	doRespond <- false
 	c.Check(err, check.IsNil)
 
@@ -620,9 +617,8 @@ func (s *daemonSuite) TestRestartSystemWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
-	ch := make(chan os.Signal, 2)
 	d.Start()
-	defer d.Stop(ch)
+	defer d.Stop(nil)
 
 	snapdDone := make(chan struct{})
 	go func() {
@@ -686,7 +682,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *check.C) {
 	c.Check(delays, check.HasLen, 1)
 	c.Check(delays[0], check.DeepEquals, rebootWaitTimeout)
 
-	err = d.Stop(ch)
+	err = d.Stop(nil)
 
 	c.Check(err, check.ErrorMatches, "expected reboot did not happen")
 	c.Check(delays, check.HasLen, 2)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -754,7 +754,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
 	d.overlord.State().RequestRestart(state.RestartSystem)
 
 	ch := make(chan os.Signal, 2)
-	go func() { ch <- syscall.SIGTERM }()
+	ch <- syscall.SIGTERM
 	// stop will check if we got a sigterm in between (which we did)
 	err := d.Stop(ch)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
The current snapd reboot hangs in the following scenario:

0. cmd/snapd/main.go runs and sets up a SIGTERM handler
1. snapd refreshes core
2. this triggers daemon:reboot() which will initiate a system shutdown
3. daemon.Start() exits
4. daemon.Stop() runs and waits for a reboot
5. systemd sends a SIGTERM to snapd as part of the reboot process
6. *however* in (4) sigterm is still blocked to systemd waits 1:30min

to fix this we need to stop listening to sigterm in (4). This PR
does that (thanks to Samuele) and adds one test for it. There is
one test missing, i.e. to test that snapd has stopped listening
to sigterm. This is indirect because the test harness seems
to also catch sigterm so we can't just setup a new signal handler
and send sigterm. So we just check if the sigCh got closed.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
