### PR TITLE
tests/main/lxd: pull lxd from candidate; reënable i386

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -2,8 +2,7 @@ summary: Ensure that lxd works
 
 # only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
-# ubuntu-16.04-32: temporarily disable until container detection issues are resolved
-systems: [ubuntu-16.04-64, ubuntu-18*, ubuntu-2*, ubuntu-core-*]
+systems: [ubuntu-16*, ubuntu-18*, ubuntu-2*, ubuntu-core-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro
@@ -48,7 +47,7 @@ execute: |
     }
 
     echo "Install lxd"
-    snap install lxd
+    snap install --candidate lxd
 
     echo "Create a trivial container using the lxd snap"
     wait_for_lxd


### PR DESCRIPTION
We'd disabled the lxd spread test for i386 because the kernel on the gce
image tickled a bug in lxd. That bug is now resolved, and in order to
help catch these bugs earlier, we'll now be pulling lxd from candidate.
