### PR TITLE
cmd/snap-confine: switch to validation of SNAP_INSTANCE_NAME

### DIFF
--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -33,11 +33,11 @@ execute: |
     # NOTE: This has to run as the test user because the protection is only
     # active if user gains elevated permissions as a result of using setuid
     # root snap-confine.
-    if su test -c "sh -c \"SNAP_NAME=test-snapd-tools $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>/dev/null\""; then
+    if su test -c "sh -c \"SNAP_NAME=test-snapd-tools SNAP_INSTANCE_NAME=test-snapd-tools $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>/dev/null\""; then
         echo "snap-confine didn't refuse to run!"
         exit 1
     fi
-    su test -c "sh -c \"SNAP_NAME=test-snapd-tools $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"
+    su test -c "sh -c \"SNAP_NAME=test-snapd-tools SNAP_INSTANCE_NAME=test-snapd-tools $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"
 debug: |
     ls -ld "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine" || true
     ls -ld "$SNAP_MOUNT_DIR/ubuntu-core/current/usr/lib/snapd/snap-confine" || true


### PR DESCRIPTION
SNAP_INSTANCE_NAME is now set for all snaps, regardless of them using instance
key. For backward compatibility SNAP_NAME is still set, but should have no use
outside of snap runtime environment. For reference, given a snap foo_bar,
SNAP_INSTANCE_NAME=foo_bar, SNAP_NAME=foo. Instance-key less snaps have both
vars set to the same value.

Switch to the new variable, employ corresponding name validation.

