### PR TITLE
spdx: allow Other-Open-Source

### DIFF
--- a/spdx/licenses.go
+++ b/spdx/licenses.go
@@ -484,7 +484,7 @@ var allLicenses = []string{
 
 	// FIXME: non SPDX licenses that the snapstore uses
 	"Proprietary",
-	"Other Open Source",
+	"Other-Open-Source",
 }
 
 // from https://www.google.com/url?q=https://docs.google.com/a/s.sfusd.edu/document/d/1wE_zvLU4c291ACi9wIJmQoE4ltKRW4rzM1TYiIvEVOs/edit?pli%3D1%23heading%3Dh.ruv3yl8g6czd&sa=D&ust=1473291615601000&usg=AFQjCNFyLcPLdEarX1TOesGWxg9Afb57mA

--- a/spdx/parser_test.go
+++ b/spdx/parser_test.go
@@ -44,6 +44,7 @@ func (s *spdxSuite) TestParseHappy(c *C) {
 		"GPL-2.0 AND (BSD-2-Clause OR 0BSD)",
 		"(BSD-2-Clause OR 0BSD) AND GPL-2.0 WITH GCC-exception-3.1",
 		"((GPL-2.0 AND (BSD-2-Clause OR 0BSD)) OR GPL-3.0) ",
+		"Other-Open-Source",
 	} {
 		err := spdx.ValidateLicense(t)
 		c.Check(err, IsNil, Commentf("input: %q", t))


### PR DESCRIPTION
We currently have a "Other Open Source" license in our supported
licenses. This license is not part of spdx and it was added for
store compatibility. However the spaces inside this name will
not work with the spdx parser and it looks also very out of place
with the other licenses.

This PR changes the license to Other-Open-Source so that the
parser can deal with it.  This will allow snaps to set
`license: Other-Open-Source` in their snap.yaml.

We will also make sure that the store is aware of this.

I'm thinking about using `Other-Open-Source` in the license field of the core
and the core18 snaps. Alternatively we could show build a valid spdx string
for core like: `(AFL-2.1 AND AGPL-3.0+ AND Apache-2.0 ... )` which would
include ~100 licenses right now.