### PR TITLE
snap-confine: map /var/lib/extrausers into snaps mount-namespace

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -655,6 +655,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			// compatibility with the first version of base snaps that was
 			// released.
 			{"/mnt",.is_optional = true},	// to support the removable-media interface
+			{"/var/lib/extrausers",.is_optional = true},	// access to UID/GID of extrausers (if available)
 			{},
 		};
 		char rootfs_dir[PATH_MAX] = { 0 };

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -178,6 +178,9 @@
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/run/,
 
+    mount options=(rw rbind) /var/lib/extrausers/ -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+
     mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/modules/ -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
 

--- a/tests/core18/basic/task.yaml
+++ b/tests/core18/basic/task.yaml
@@ -20,3 +20,6 @@ execute: |
         echo "The build-id of snapd must not be empty."
         exit 1
     fi
+
+    echo "Ensure passwd/group is available for snaps"
+    test-snapd-tools-core18.cat /var/lib/extrausers/passwd | MATCH test


### PR DESCRIPTION
Ensure that /var/lib/extrausers is available inside all the snaps
so that snaps can map uid to name. This is important on core18
systems which will not have UID 1000 in /etc/passwd.

Based on https://github.com/snapcore/snapd/pull/5307