### PR TITLE
overlord/snapstate: verify SnapState name matches instance key

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1854,6 +1854,11 @@ func NumSnaps(st *state.State) (int, error) {
 
 // Set sets the SnapState of the given snap, overwriting any earlier state.
 func Set(st *state.State, name string, snapst *SnapState) {
+	if snapst != nil {
+		if _, key := snap.SplitInstanceName(name); key != snapst.InstanceKey {
+			panic(fmt.Sprintf("internal error: instance key %q and snap %q do not match", snapst.InstanceKey, name))
+		}
+	}
 	var snaps map[string]*json.RawMessage
 	err := st.Get("snaps", &snaps)
 	if err != nil && err != state.ErrNoState {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -259,6 +259,33 @@ func (s *snapmgrTestSuite) TestCleanSnapStateGet(c *C) {
 	})
 }
 
+func (s *snapmgrTestSuite) TestSnapstateSetInstanceKeyMismatch(c *C) {
+	c.Assert(func() {
+		// no instance key in SnapState{}
+		snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
+			Active: true,
+			Sequence: []*snap.SideInfo{
+				{RealName: "some-snap", Revision: snap.R(1)},
+			},
+			Current:  snap.R(1),
+			SnapType: "app",
+		})
+	}, Panics, `internal error: instance key "" and snap "some-snap_instance" do not match`)
+
+	c.Assert(func() {
+		// no instance key in name
+		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+			Active: true,
+			Sequence: []*snap.SideInfo{
+				{RealName: "some-snap", Revision: snap.R(1)},
+			},
+			Current:     snap.R(1),
+			SnapType:    "app",
+			InstanceKey: "instance",
+		})
+	}, Panics, `internal error: instance key "instance" and snap "some-snap" do not match`)
+}
+
 func (s *snapmgrTestSuite) TestStore(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
Verify that instance key matches the name passed to snapstate.Set() and panic
otherwise.

This should make the tests a bit easier to handle and allow catching error sooner.