### PR TITLE
tests/main/layout: cleanup after the test

### DIFF
--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -92,6 +92,6 @@ execute: |
     done
 
 restore:
-    # cleanup after the trespassing bug
+    # cleanup after the trespassing bug, see: https://github.com/snapcore/snapd/pull/4889
     # TODO: remove this once the problem is addressed
     rm -rf /etc/demo /etc/demo.conf /etc/demo.cfg

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -90,3 +90,8 @@ execute: |
         test-snapd-layout.sh -c 'test -w $SNAP/bin-very-weird-place'
         test-snapd-layout.sh -c 'test -w /bin/very-weird-place'
     done
+
+restore:
+    # cleanup after the trespassing bug
+    # TODO: remove this once the problem is addressed
+    rm -rf /etc/demo /etc/demo.conf /etc/demo.cfg


### PR DESCRIPTION
There is a known problem with trespassing the mount namespace. In such situation
some files are left behind in the original rootfs. Make sure we clean up those
files.

