### PR TITLE
overlord/snapstate: fix UpdateMany() to work with parallel instances

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -666,7 +666,7 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 		return nil, nil, err
 	}
 
-	updates, stateByID, ignoreValidation, err := refreshCandidates(ctx, st, names, user, nil)
+	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, user, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -684,7 +684,7 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 	}
 
 	params := func(update *snap.Info) (string, Flags, *SnapState) {
-		snapst := stateByID[update.SnapID]
+		snapst := stateByInstanceName[update.InstanceName()]
 		return snapst.Channel, snapst.Flags, snapst
 
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -753,6 +753,53 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
+func (s *snapmgrTestSuite) TestParallelInstanceUpdateMany(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.parallel-instances", true)
+	tr.Commit()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
+		},
+		Current:     snap.R(3),
+		SnapType:    "app",
+		InstanceKey: "instance",
+	})
+
+	updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0)
+	c.Assert(err, IsNil)
+	c.Assert(tts, HasLen, 2)
+	// task sets order is already stable, but we need to ensure stable ordering
+	// of updates list
+	if updates[0] != "some-snap" {
+		updates[1], updates[0] = updates[0], updates[1]
+	}
+
+	c.Check(updates, DeepEquals, []string{"some-snap", "some-snap_instance"})
+
+	ts := tts[0]
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts, s.state)
+
+	ts = tts[1]
+	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 0, ts, s.state)
+}
+
 func (s *snapmgrTestSuite) TestUpdateManyDevModeConfinementFiltering(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -310,7 +310,7 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, use
 	}
 
 	actionsByUserID := make(map[int][]*store.SnapAction)
-	stateByID := make(map[string]*SnapState, len(snapStates))
+	stateByInstanceName := make(map[string]*SnapState, len(snapStates))
 	ignoreValidation := make(map[string]bool)
 	nCands := 0
 
@@ -330,7 +330,7 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, use
 			return
 		}
 
-		stateByID[installed.SnapID] = snapst
+		stateByInstanceName[installed.InstanceName] = snapst
 
 		if len(names) == 0 {
 			installed.Block = snapst.Block()
@@ -401,5 +401,5 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, use
 		updates = append(updates, updatesForUser...)
 	}
 
-	return updates, stateByID, ignoreValidation, nil
+	return updates, stateByInstanceName, ignoreValidation, nil
 }


### PR DESCRIPTION
Fix `snapstate.UpdateMany()` to not use snap ID indexing in its internal data structures, but rely on instance names instead.

Also, tweak how we sort snaps for updates to ensure that the ordering is stable in the tests.