### PR TITLE
overlord,store: support proxy settings internally too

### DIFF
--- a/httputil/client.go
+++ b/httputil/client.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type ClientOpts struct {
+	Timeout    time.Duration
+	TLSConfig  *tls.Config
+	MayLogBody bool
+	Proxy      func(*http.Request) (*url.URL, error)
+}
+
+// NewHTTPCLient returns a new http.Client with a LoggedTransport, a
+// Timeout and preservation of range requests across redirects
+func NewHTTPClient(opts *ClientOpts) *http.Client {
+	if opts == nil {
+		opts = &ClientOpts{}
+	}
+
+	transport := newDefaultTransport()
+	transport.TLSClientConfig = opts.TLSConfig
+	if opts.Proxy != nil {
+		transport.Proxy = opts.Proxy
+	}
+
+	return &http.Client{
+		Transport: &LoggedTransport{
+			Transport: transport,
+			Key:       "SNAPD_DEBUG_HTTP",
+			body:      opts.MayLogBody,
+		},
+		Timeout:       opts.Timeout,
+		CheckRedirect: checkRedirect,
+	}
+}

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -34,7 +34,7 @@ var _ = check.Suite(&clientSuite{})
 
 func mustParse(c *check.C, rawurl string) *url.URL {
 	url, err := url.Parse("http://some-proxy:3128")
-	c.Check(err, check.IsNil)
+	c.Assert(err, check.IsNil)
 	return url
 }
 

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -1,0 +1,62 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httputil_test
+
+import (
+	"net/http"
+	"net/url"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/httputil"
+)
+
+type clientSuite struct{}
+
+var _ = check.Suite(&clientSuite{})
+
+func mustParse(c *check.C, rawurl string) *url.URL {
+	url, err := url.Parse("http://some-proxy:3128")
+	c.Check(err, check.IsNil)
+	return url
+}
+
+type proxyProvider struct {
+	proxy *url.URL
+}
+
+func (p *proxyProvider) proxyCallback(*http.Request) (*url.URL, error) {
+	return p.proxy, nil
+}
+
+func (s *clientSuite) TestClientOptsWithProxy(c *check.C) {
+	pp := proxyProvider{proxy: mustParse(c, "http://some-proxy:3128")}
+	cli := httputil.NewHTTPClient(&httputil.ClientOpts{
+		Proxy: pp.proxyCallback,
+	})
+	c.Assert(cli, check.NotNil)
+
+	trans := cli.Transport.(*httputil.LoggedTransport).Transport.(*http.Transport)
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	c.Check(err, check.IsNil)
+	url, err := trans.Proxy(req)
+	c.Check(err, check.IsNil)
+	c.Check(url.String(), check.Equals, "http://some-proxy:3128")
+}

--- a/httputil/logger.go
+++ b/httputil/logger.go
@@ -20,13 +20,11 @@
 package httputil
 
 import (
-	"crypto/tls"
 	"errors"
 	"net/http"
 	"net/http/httputil"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/snapcore/snapd/logger"
 )
@@ -86,33 +84,6 @@ func (tr *LoggedTransport) getFlags() debugflag {
 	}
 
 	return debugflag(flags)
-}
-
-type ClientOpts struct {
-	Timeout    time.Duration
-	TLSConfig  *tls.Config
-	MayLogBody bool
-}
-
-// NewHTTPCLient returns a new http.Client with a LoggedTransport, a
-// Timeout and preservation of range requests across redirects
-func NewHTTPClient(opts *ClientOpts) *http.Client {
-	if opts == nil {
-		opts = &ClientOpts{}
-	}
-
-	transport := newDefaultTransport()
-	transport.TLSClientConfig = opts.TLSConfig
-
-	return &http.Client{
-		Transport: &LoggedTransport{
-			Transport: transport,
-			Key:       "SNAPD_DEBUG_HTTP",
-			body:      opts.MayLogBody,
-		},
-		Timeout:       opts.Timeout,
-		CheckRedirect: checkRedirect,
-	}
 }
 
 func checkRedirect(req *http.Request, via []*http.Request) error {

--- a/overlord/configstate/proxyconf/proxy.go
+++ b/overlord/configstate/proxyconf/proxy.go
@@ -54,5 +54,4 @@ func (p *ProxySettings) Conf(req *http.Request) (*url.URL, error) {
 		return nil, err
 	}
 	return url, nil
-
 }

--- a/overlord/configstate/proxyconf/proxy.go
+++ b/overlord/configstate/proxyconf/proxy.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package proxyconf
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type ProxySettings struct {
+	st *state.State
+}
+
+func New(st *state.State) *ProxySettings {
+	return &ProxySettings{st: st}
+}
+
+func (p *ProxySettings) Conf(req *http.Request) (*url.URL, error) {
+	p.st.Lock()
+	tr := config.NewTransaction(p.st)
+	p.st.Unlock()
+
+	var proxy string
+	err := tr.Get("core", fmt.Sprintf("proxy.%s", req.URL.Scheme), &proxy)
+	if proxy == "" || config.IsNoOption(err) {
+		return http.ProxyFromEnvironment(req)
+	}
+	if err != nil {
+		return nil, err
+	}
+	url, err := url.Parse(proxy)
+	if err != nil {
+		return nil, err
+	}
+	return url, nil
+
+}

--- a/overlord/configstate/proxyconf/proxy_test.go
+++ b/overlord/configstate/proxyconf/proxy_test.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package proxyconf_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/proxyconf"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestT(t *testing.T) { TestingT(t) }
+
+type proxyconfSuite struct{}
+
+var _ = Suite(&proxyconfSuite{})
+
+func (s *proxyconfSuite) TestProxySettingsNoSetting(c *C) {
+	st := state.New(nil)
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	c.Assert(err, IsNil)
+
+	expected, err := http.ProxyFromEnvironment(req)
+	c.Assert(err, IsNil)
+
+	proxyConf := proxyconf.New(st)
+	proxy, err := proxyConf.Conf(req)
+	c.Assert(err, IsNil)
+	c.Check(proxy, DeepEquals, expected)
+}
+
+func (s *proxyconfSuite) TestProxySettings(c *C) {
+	st := state.New(nil)
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	tr := config.NewTransaction(st)
+	tr.Set("core", "proxy.http", "http://some-proxy:3128")
+	tr.Commit()
+	st.Unlock()
+
+	proxyConf := proxyconf.New(st)
+	proxy, err := proxyConf.Conf(req)
+	c.Assert(err, IsNil)
+	c.Check(proxy, DeepEquals, &url.URL{
+		Scheme: "http",
+		Host:   "some-proxy:3128",
+	})
+}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/cmdstate"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/proxyconf"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -150,8 +151,11 @@ func New() (*Overlord, error) {
 	s.Lock()
 	defer s.Unlock()
 	// setting up the store
+	proxyConf := proxyconf.New(s)
 	authContext := auth.NewAuthContext(s, o.deviceMgr)
-	sto := storeNew(nil, authContext)
+	cfg := store.DefaultConfig()
+	cfg.Proxy = proxyConf.Conf
+	sto := storeNew(cfg, authContext)
 	sto.SetCacheDownloads(defaultCachedDownloads)
 
 	snapstate.ReplaceStore(s, sto)

--- a/store/store.go
+++ b/store/store.go
@@ -110,6 +110,9 @@ type Config struct {
 
 	// CacheDownloads is the number of downloads that should be cached
 	CacheDownloads int
+
+	// Callback what (http) Proxy to use when talking to the store
+	Proxy func(*http.Request) (*url.URL, error)
 }
 
 // setBaseURL updates the store API's base URL in the Config. Must not be used
@@ -154,6 +157,7 @@ type Store struct {
 	suggestedCurrency string
 
 	cacher downloadCache
+	proxy  func(*http.Request) (*url.URL, error)
 }
 
 func respToError(resp *http.Response, msg string) error {
@@ -346,10 +350,12 @@ func New(cfg *Config, authContext auth.AuthContext) *Store {
 		infoFields:      infoFields,
 		authContext:     authContext,
 		deltaFormat:     deltaFormat,
+		proxy:           cfg.Proxy,
 
 		client: httputil.NewHTTPClient(&httputil.ClientOpts{
 			Timeout:    10 * time.Second,
 			MayLogBody: true,
+			Proxy:      cfg.Proxy,
 		}),
 	}
 	store.SetCacheDownloads(cfg.CacheDownloads)
@@ -1225,6 +1231,7 @@ func (s *Store) WriteCatalogs(ctx context.Context, names io.Writer, adder SnapAd
 	client := httputil.NewHTTPClient(&httputil.ClientOpts{
 		MayLogBody: false,
 		Timeout:    10 * time.Second,
+		Proxy:      s.proxy,
 	})
 	doRequest := func() (*http.Response, error) {
 		return s.doRequest(ctx, client, reqOptions, nil)
@@ -1485,7 +1492,7 @@ var download = func(ctx context.Context, name, sha3_384, downloadURL string, use
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		var resp *http.Response
-		resp, finalErr = s.doRequest(ctx, httputil.NewHTTPClient(nil), reqOptions, user)
+		resp, finalErr = s.doRequest(ctx, httputil.NewHTTPClient(&httputil.ClientOpts{Proxy: s.proxy}), reqOptions, user)
 
 		if cancelled(ctx) {
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())

--- a/store/store.go
+++ b/store/store.go
@@ -111,7 +111,7 @@ type Config struct {
 	// CacheDownloads is the number of downloads that should be cached
 	CacheDownloads int
 
-	// Callback what (http) Proxy to use when talking to the store
+	// Proxy returns the HTTP proxy to use when talking to the store
 	Proxy func(*http.Request) (*url.URL, error)
 }
 

--- a/tests/main/proxy/task.yaml
+++ b/tests/main/proxy/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that the core.proxy.* settings are honored
 
+# Limited to ubuntu 18.04 because the squid there is well tested. We
+# could add a squid (or custom go proxy) snap instead and run
+# everywhere.
 systems: [ubuntu-18.04-64]
 
 restore: |
@@ -7,6 +10,7 @@ restore: |
     apt autoremove --purge -y squid
 
 prepare: |
+    # ensure we start from a clean state
     rm -rf /var/log/squid/*
     apt install -y squid
 
@@ -23,6 +27,6 @@ execute: |
         if grep api.snapcraft.io /var/log/squid/access.log; then
             break
         fi
-        sleep 1h
+        sleep 1
     done
     MATCH "CONNECT api.snapcraft.io" < /var/log/squid/access.log

--- a/tests/main/proxy/task.yaml
+++ b/tests/main/proxy/task.yaml
@@ -1,0 +1,28 @@
+summary: Ensure that the core.proxy.* settings are honored
+
+systems: [ubuntu-18.04-64]
+
+restore: |
+    snap set core proxy.https=
+    apt autoremove --purge -y squid
+
+prepare: |
+    rm -rf /var/log/squid/*
+    apt install -y squid
+
+execute: |
+    echo "Setup proxy config"
+    snap set core proxy.https=http://localhost:3128
+
+    echo "Check that the commands go through the proxy"
+    snap find test-snapd-tools | MATCH test-snapd-tools
+
+    # ensure squid wrote the access.log
+    systemctl restart squid
+    for _ in $(seq 10); do
+        if grep api.snapcraft.io /var/log/squid/access.log; then
+            break
+        fi
+        sleep 1h
+    done
+    MATCH "CONNECT api.snapcraft.io" < /var/log/squid/access.log


### PR DESCRIPTION
This PR adds support to read the proxy settings from the core config. 

There is some more work in devicestate (which creates its own httputil.NewHTTPClient). If this looks reasonable so far I will attack devicestate.