### PR TITLE
snap: add ByType sorting

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -1075,3 +1075,20 @@ func InstanceName(snapName, instanceKey string) string {
 	}
 	return snapName
 }
+
+// ByType sorts the given slice of snap info by types. The most
+// important types will come first. The "snapd" snap is handled
+// as well.
+type ByType []*Info
+
+func (r ByType) Len() int      { return len(r) }
+func (r ByType) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r ByType) Less(i, j int) bool {
+	if r[i].SideInfo.RealName == "snapd" {
+		return true
+	}
+	if r[j].SideInfo.RealName == "snapd" {
+		return false
+	}
+	return typeOrder[r[i].Type] < typeOrder[r[j].Type]
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1296,3 +1296,38 @@ func (s *infoSuite) TestDirAndFileHelpers(c *C) {
 	c.Check(snap.UserXdgRuntimeDir(12345, "name_instance"), Equals, "/run/user/12345/snap.name_instance")
 	c.Check(snap.UserSnapDir("/home/bob", "name_instance"), Equals, "/home/bob/snap/name_instance")
 }
+
+func (s *infoSuite) TestSortByType(c *C) {
+	infos := []*snap.Info{
+		{SuggestedName: "app1", Type: "app"},
+		{SuggestedName: "os1", Type: "os"},
+		{SuggestedName: "base1", Type: "base"},
+		{SuggestedName: "gadget1", Type: "gadget"},
+		{SuggestedName: "kernel1", Type: "kernel"},
+		{SuggestedName: "app2", Type: "app"},
+		{SuggestedName: "os2", Type: "os"},
+		{SuggestedName: "snapd", Type: "app", SideInfo: snap.SideInfo{
+			RealName: "snapd",
+		}},
+		{SuggestedName: "base2", Type: "base"},
+		{SuggestedName: "gadget2", Type: "gadget"},
+		{SuggestedName: "kernel2", Type: "kernel"},
+	}
+	sort.Stable(snap.ByType(infos))
+
+	c.Check(infos, DeepEquals, []*snap.Info{
+		{SuggestedName: "snapd", Type: "app", SideInfo: snap.SideInfo{
+			RealName: "snapd",
+		}},
+		{SuggestedName: "os1", Type: "os"},
+		{SuggestedName: "os2", Type: "os"},
+		{SuggestedName: "kernel1", Type: "kernel"},
+		{SuggestedName: "kernel2", Type: "kernel"},
+		{SuggestedName: "gadget1", Type: "gadget"},
+		{SuggestedName: "gadget2", Type: "gadget"},
+		{SuggestedName: "base1", Type: "base"},
+		{SuggestedName: "base2", Type: "base"},
+		{SuggestedName: "app1", Type: "app"},
+		{SuggestedName: "app2", Type: "app"},
+	})
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1323,10 +1323,10 @@ func (s *infoSuite) TestSortByType(c *C) {
 		{SuggestedName: "os2", Type: "os"},
 		{SuggestedName: "kernel1", Type: "kernel"},
 		{SuggestedName: "kernel2", Type: "kernel"},
-		{SuggestedName: "gadget1", Type: "gadget"},
-		{SuggestedName: "gadget2", Type: "gadget"},
 		{SuggestedName: "base1", Type: "base"},
 		{SuggestedName: "base2", Type: "base"},
+		{SuggestedName: "gadget1", Type: "gadget"},
+		{SuggestedName: "gadget2", Type: "gadget"},
 		{SuggestedName: "app1", Type: "app"},
 		{SuggestedName: "app2", Type: "app"},
 	})

--- a/snap/types.go
+++ b/snap/types.go
@@ -43,8 +43,8 @@ const (
 // way.
 var typeOrder = map[Type]int{
 	TypeApp:    40,
-	TypeBase:   30,
-	TypeGadget: 20,
+	TypeGadget: 30,
+	TypeBase:   20,
 	TypeKernel: 10,
 	TypeOS:     0,
 }

--- a/snap/types.go
+++ b/snap/types.go
@@ -38,6 +38,17 @@ const (
 	TypeOS Type = "os"
 )
 
+// This is the sort order from least important to most important for
+// types. On e.g. firstboot this will be used to order the snaps this
+// way.
+var typeOrder = map[Type]int{
+	TypeApp:    40,
+	TypeBase:   30,
+	TypeGadget: 20,
+	TypeKernel: 10,
+	TypeOS:     0,
+}
+
 // UnmarshalJSON sets *m to a copy of data.
 func (m *Type) UnmarshalJSON(data []byte) error {
 	var str string


### PR DESCRIPTION
This will be used in the e.g. firstboot code to ensure that snaps
get installed in the right order.
