### PR TITLE
 cmd: support re-exec into the "snapd" snap 

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,13 +42,13 @@ import (
 const reExecKey = "SNAP_REEXEC"
 
 var (
-	// newCore is the place to look for the core snap; everything in this
-	// location will be new enough to re-exec into.
-	newCore = "/snap/core/current"
+	// snapdSnap is the place to look for the snapd snap; we will re-exec
+	// here
+	snapdSnap = "/snap/snapd/current"
 
-	// oldCore is the previous location of the core snap. Only things
-	// newer than minOldRevno will be ok to re-exec into.
-	oldCore = "/snap/ubuntu-core/current"
+	// coreSnap is the place to look for the core snap; we will re-exec
+	// here if there is no snapd snap
+	coreSnap = "/snap/core/current"
 
 	// selfExe is the path to a symlink pointing to the current executable
 	selfExe = "/proc/self/exe"
@@ -147,9 +147,9 @@ func mustUnsetenv(key string) {
 	}
 }
 
-// ExecInCoreSnap makes sure you're executing the binary that ships in
-// the core snap.
-func ExecInCoreSnap() {
+// ExecInSnapdOrCoreSnap makes sure you're executing the binary that ships in
+// the snapd/core snap.
+func ExecInSnapdOrCoreSnap() {
 	// Which executable are we?
 	exe, err := os.Readlink(selfExe)
 	if err != nil {
@@ -185,11 +185,11 @@ func ExecInCoreSnap() {
 	}
 
 	// Is this executable in the core snap too?
-	corePath := newCore
-	full := filepath.Join(newCore, exe)
+	corePath := snapdSnap
+	full := filepath.Join(snapdSnap, exe)
 	if !osutil.FileExists(full) {
-		corePath = oldCore
-		full = filepath.Join(oldCore, exe)
+		corePath = coreSnap
+		full = filepath.Join(coreSnap, exe)
 		if !osutil.FileExists(full) {
 			return
 		}

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -24,14 +24,14 @@ var (
 	CoreSupportsReExec   = coreSupportsReExec
 )
 
-func MockCorePaths(newOldCore, newNewCore string) func() {
-	oldOldCore := oldCore
-	oldNewCore := newCore
-	newCore = newNewCore
-	oldCore = newOldCore
+func MockCoreSnapdPaths(newCoreSnap, newSnapdSnap string) func() {
+	oldOldCore := coreSnap
+	oldNewCore := snapdSnap
+	snapdSnap = newSnapdSnap
+	coreSnap = newCoreSnap
 	return func() {
-		newCore = oldNewCore
-		oldCore = oldOldCore
+		snapdSnap = oldNewCore
+		coreSnap = oldOldCore
 	}
 }
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -320,7 +320,7 @@ func resolveApp(snapApp string) (string, error) {
 }
 
 func main() {
-	cmd.ExecInCoreSnap()
+	cmd.ExecInSnapdOrCoreSnap()
 
 	// check for magic symlink to /usr/bin/snap:
 	// 1. symlink from command-not-found to /usr/bin/snap: run c-n-f

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func main() {
-	cmd.ExecInCoreSnap()
+	cmd.ExecInSnapdOrCoreSnap()
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -22,6 +22,7 @@ package configcore
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
@@ -57,6 +58,7 @@ var supportedConfigurations = map[string]bool{
 	"core.experimental.layouts":            true,
 	"core.experimental.parallel-instances": true,
 	"core.experimental.hotplug":            true,
+	"core.experimental.snapd-snap":         true,
 }
 
 func validateBoolFlag(tr Conf, flag string) error {
@@ -74,14 +76,13 @@ func validateBoolFlag(tr Conf, flag string) error {
 }
 
 func validateExperimentalSettings(tr Conf) error {
-	if err := validateBoolFlag(tr, "experimental.layouts"); err != nil {
-		return err
-	}
-	if err := validateBoolFlag(tr, "experimental.parallel-instances"); err != nil {
-		return err
-	}
-	if err := validateBoolFlag(tr, "experimental.hotplug"); err != nil {
-		return err
+	for k := range supportedConfigurations {
+		if !strings.HasPrefix(k, "core.experimental.") {
+			continue
+		}
+		if err := validateBoolFlag(tr, strings.TrimPrefix(k, "core.")); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -119,6 +119,7 @@ func (r *runCfgSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
 		"experimental.layouts":            "foo",
 		"experimental.parallel-instances": "foo",
 		"experimental.hotplug":            "foo",
+		"experimental.snapd-snap":         "foo",
 	} {
 		conf := &mockConf{
 			state: r.state,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -67,9 +67,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			return nil, err
 		}
 		if model == nil || model.Base() == "" {
-			var experimentalAllowSnapd bool
 			tr := config.NewTransaction(st)
-			err := tr.Get("core", "experimental.snapd-snap", &experimentalAllowSnapd)
+			experimentalAllowSnapd, err := getFeatureFlagBool(tr, "experimental.snapd-snap")
 			if err != nil && !config.IsNoOption(err) {
 				return nil, err
 			}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -67,7 +67,15 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			return nil, err
 		}
 		if model == nil || model.Base() == "" {
-			return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
+			var experimentalAllowSnapd bool
+			tr := config.NewTransaction(st)
+			err := tr.Get("core", "experimental.snapd-snap", &experimentalAllowSnapd)
+			if err != nil && !config.IsNoOption(err) {
+				return nil, err
+			}
+			if !experimentalAllowSnapd {
+				return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
+			}
 		}
 	}
 	if snapst.IsInstalled() && !snapst.Active {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -11562,6 +11562,18 @@ func (s *snapmgrTestSuite) TestNoSnapdSnapOnSystemsWithoutBase(c *C) {
 	c.Assert(err, ErrorMatches, "cannot install snapd snap on a model without a base snap yet")
 }
 
+func (s *snapmgrTestSuite) TestNoSnapdSnapOnSystemsWithoutBaseButOption(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.snapd-snap", true)
+	tr.Commit()
+
+	_, err := snapstate.Install(s.state, "snapd", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
 func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/tests/main/snapd-reexec-snapd-snap/task.yaml
+++ b/tests/main/snapd-reexec-snapd-snap/task.yaml
@@ -1,0 +1,26 @@
+summary: Test that snapd reexecs itself into the snapd snap
+
+# Disable for Fedora, openSUSE and Arch as re-exec is not support there yet
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*]
+
+restore: |
+    umount /snap/snapd/current/usr/lib/snapd/info || true
+
+execute: |
+    if [ "${SNAP_REEXEC:-}" = "0" ]; then
+        echo "skipping test when SNAP_REEXEC is disabled"
+        exit 0
+    fi
+
+    echo "Enable installing the snapd snap"
+    snap set core experimental.snapd-snap=true
+    snap install --edge snapd
+    # We need to pretend the version of snapd in the snapd snap is the same
+    # as the installed one so that it re-execs. We use a higher version in
+    # the local snap and "tweak" the core snap to get re-exec but this will
+    # only work with core re-exec not snapd-reexec.
+    mount -o bind /usr/lib/snapd/info /snap/snapd/current/usr/lib/snapd/info
+
+    echo "Ensure we re-exec by default"
+    /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH 'DEBUG: restarting into "/snap/snapd/current/usr/bin/snap"'
+


### PR DESCRIPTION
It also removes support to re-exec into the ubuntu-core snap
because there is no reason for us to ever re-exec into it (it
will always be older than the current code).

Based on  #5709
