### PR TITLE
selftest: detect if apparmor is unusable and error

### DIFF
--- a/selftest/apparmor_lxd.go
+++ b/selftest/apparmor_lxd.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package selftest
+
+import (
+	"fmt"
+	"os"
+)
+
+var apparmorProfilesPath = "/sys/kernel/security/apparmor/profiles"
+
+func apparmorUsable() error {
+	// Check that apparmor is actually usable. In some
+	// configurations of lxd, apparmor looks available when in
+	// reality it isn't. Eg, this can happen when a container runs
+	// unprivileged (eg, root in the container is non-root
+	// outside) and also unconfined (where lxd doesn't set up an
+	// apparmor policy namespace). We can therefore simply check
+	// if /sys/kernel/security/apparmor/profiles is readable (like
+	// aa-status does), and if it isn't, we know we can't manipulate
+	// policy.
+	f, err := os.Open(apparmorProfilesPath)
+	if os.IsPermission(err) {
+		return fmt.Errorf("apparmor detected but insufficient permissions to use it")
+	}
+	if f != nil {
+		f.Close()
+	}
+	return nil
+}

--- a/selftest/selftest.go
+++ b/selftest/selftest.go
@@ -21,6 +21,7 @@ package selftest
 
 var checks = []func() error{
 	trySquashfsMount,
+	apparmorUsable,
 }
 
 func Run() error {

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -28,6 +28,7 @@ restore: |
 
     lxd.lxc stop my-ubuntu --force
     lxd.lxc delete my-ubuntu
+    rm -f conf.yaml 
 
 debug: |
     # shellcheck source=tests/lib/journalctl.sh
@@ -103,3 +104,17 @@ execute: |
     echo "Install lxd-demo server to exercise the lxd interface"
     snap install lxd-demo-server
     snap connect lxd-demo-server:lxd lxd:lxd
+
+    echo "Check that we error in 'unconfined' lxd containers"
+    lxd.lxc config show my-ubuntu > conf.yaml
+    cat <<EOF >> conf.yaml
+    config:
+      raw.lxc: |
+        lxc.apparmor.profile=unconfined
+    EOF
+    lxd.lxc stop --force my-ubuntu
+    lxd.lxc config edit my-ubuntu < conf.yaml
+    lxd.lxc start my-ubuntu
+    # shellcheck disable=SC2016
+    lxd.lxc exec my-ubuntu -- sh -c 'set -x;for i in $(seq 120); do if journalctl -u snapd.service | grep -E "apparmor detected but insufficient permissions to use it"; then break; fi; sleep 1; done'
+    lxd.lxc exec my-ubuntu -- journalctl -u snapd | MATCH "apparmor detected but insufficient permissions to use it"


### PR DESCRIPTION
Under some configuration apparmor may look like its available but
we get permission denied errors when trying to use it. This can
happen on e.g. an lxd container that runs with:

```
raw.lxc: |
  lxc.apparmor.profile=unconfined
```

In this case lxd will not setup apparmor stacking so the container
looks unconfined however lxd will not grant CAP_MAC_ADMIN to the
container (which is quite sensible). But it means that snapd will
not be able to setup any apparmor profiles inside such containers.

When this is detected snapd will refuse to run because we cannot
support this configuration. The host apparmor confinement will
interfere with the container and inside the container we can
not do anything about this. See the unsuccessful PR
https://github.com/snapcore/snapd/pull/5621 for an attempt to support this environment.
