### PR TITLE
interfaces/apparmor: do not downgrade confinement on arch with linux-hardened 4.17.4+

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -446,6 +446,29 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	}
 }
 
+func downgradeConfinement() bool {
+	kver := osutil.KernelVersion()
+	switch {
+	case release.DistroLike("opensuse-tumbleweed"):
+		if cmp, _ := strutil.VersionCompare(kver, "4.16"); cmp >= 0 {
+			// As a special exception, for openSUSE Tumbleweed which ships Linux
+			// 4.16, do not downgrade the confinement template.
+			return false
+		}
+	case release.DistroLike("arch"):
+		if !strings.HasSuffix(kver, "-hardened") {
+			// how did we get here anyway?
+			return true
+		}
+		if cmp, _ := strutil.VersionCompare(kver, "4.17.4"); cmp >= 0 {
+			// linux-hardened 4.17.4+ has apparmor enabled
+			return false
+		}
+	}
+
+	return true
+}
+
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
 	// Normally we use a specific apparmor template for all snap programs.
 	policy := defaultTemplate
@@ -467,10 +490,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 		// so the meaning of the template would change across kernel
 		// versions and we have not validated that the current template
 		// is operational on older kernels.
-		if cmp, _ := strutil.VersionCompare(osutil.KernelVersion(), "4.16"); cmp >= 0 && release.DistroLike("opensuse-tumbleweed") {
-			// As a special exception, for openSUSE Tumbleweed which ships Linux
-			// 4.16, do not downgrade the confinement template.
-		} else {
+		if downgradeConfinement() {
 			policy = classicTemplate
 			ignoreSnippets = true
 		}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -456,16 +456,15 @@ func downgradeConfinement() bool {
 			return false
 		}
 	case release.DistroLike("arch"):
-		if !strings.HasSuffix(kver, "-hardened") {
-			// how did we get here anyway?
-			return true
-		}
-		if cmp, _ := strutil.VersionCompare(kver, "4.17.4"); cmp >= 0 {
-			// linux-hardened 4.17.4+ has apparmor enabled
-			return false
+		if strings.HasSuffix(kver, "-hardened") {
+			if cmp, _ := strutil.VersionCompare(kver, "4.17.4"); cmp >= 0 {
+				// The linux-hardened 4.17.4+ package has
+				// apparmor enabled, do not downgrade the
+				// confinement template.
+				return false
+			}
 		}
 	}
-
 	return true
 }
 

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1376,7 +1376,7 @@ func (s *backendSuite) TestDowngradeConfinement(c *C) {
 		{"arch", "4.18.5-arch1-1-ARCH", true},
 		{"arch", "4.17.4-hardened", false},
 		{"arch", "4.17.4-1-ARCH", true},
-		{"arch", "4.18.6-arch1-1-ARCH", false},
+		{"arch", "4.18.6-arch1-1-ARCH", true},
 	} {
 		c.Logf("trying: %+v", tc)
 		restore := release.MockReleaseInfo(&release.OS{ID: tc.distro})

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -30,6 +30,7 @@ var (
 	NsProfile                  = nsProfile
 	ProfileGlobs               = profileGlobs
 	SnapConfineFromSnapProfile = snapConfineFromSnapProfile
+	DowngradeConfinement       = downgradeConfinement
 )
 
 // MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS


### PR DESCRIPTION
The `linux-hardened` kernel available from `community` repo has AppArmor enabled.
Since it's a recent kernel, there should be no need to downgrade confinement.