### PR TITLE
interfaces: retain order of inserted security backends

### DIFF
--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -37,6 +37,8 @@ var All []interfaces.SecurityBackend = backends()
 
 func backends() []interfaces.SecurityBackend {
 	all := []interfaces.SecurityBackend{
+		// Because of how the GPIO interface is implemented the systemd backend
+		// must be earlier in the sequence than the apparmor backend.
 		&systemd.Backend{},
 		&seccomp.Backend{},
 		&dbus.Backend{},

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -53,3 +53,23 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 		}
 	}
 }
+
+func (s *backendsSuite) TestEssentialOrdering(c *C) {
+	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	defer restore()
+
+	all := backends.Backends()
+	aaIndex := -1
+	sdIndex := -1
+	for i, backend := range all {
+		switch backend.Name() {
+		case "apparmor":
+			aaIndex = i
+		case "systemd":
+			sdIndex = i
+		}
+	}
+	c.Assert(aaIndex, testutil.IntNotEqual, -1)
+	c.Assert(sdIndex, testutil.IntNotEqual, -1)
+	c.Assert(sdIndex, testutil.IntLessThan, aaIndex)
+}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -43,7 +43,7 @@ type Repository struct {
 	slotPlugs map[*snap.SlotInfo]map[*snap.PlugInfo]*Connection
 	// given a plug and a slot, are they connected?
 	plugSlots map[*snap.PlugInfo]map[*snap.SlotInfo]*Connection
-	backends  map[SecuritySystem]SecurityBackend
+	backends  []SecurityBackend
 }
 
 // NewRepository creates an empty plug repository.
@@ -55,7 +55,6 @@ func NewRepository() *Repository {
 		slots:         make(map[string]map[string]*snap.SlotInfo),
 		slotPlugs:     make(map[*snap.SlotInfo]map[*snap.PlugInfo]*Connection),
 		plugSlots:     make(map[*snap.PlugInfo]map[*snap.SlotInfo]*Connection),
-		backends:      make(map[SecuritySystem]SecurityBackend),
 	}
 
 	return repo
@@ -231,10 +230,12 @@ func (r *Repository) AddBackend(backend SecurityBackend) error {
 	defer r.m.Unlock()
 
 	name := backend.Name()
-	if _, ok := r.backends[name]; ok {
-		return fmt.Errorf("cannot add backend %q, security system name is in use", name)
+	for _, other := range r.backends {
+		if other.Name() == name {
+			return fmt.Errorf("cannot add backend %q, security system name is in use", name)
+		}
 	}
-	r.backends[name] = backend
+	r.backends = append(r.backends, backend)
 	return nil
 }
 
@@ -836,15 +837,13 @@ func (r *Repository) disconnect(plug *snap.PlugInfo, slot *snap.SlotInfo) {
 }
 
 // Backends returns all the security backends.
+// The order is the same as the order in which they were inserted.
 func (r *Repository) Backends() []SecurityBackend {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	result := make([]SecurityBackend, 0, len(r.backends))
-	for _, backend := range r.backends {
-		result = append(result, backend)
-	}
-	sort.Sort(byBackendName(result))
+	result := make([]SecurityBackend, len(r.backends))
+	copy(result, r.backends)
 	return result
 }
 
@@ -884,7 +883,13 @@ func (r *Repository) SnapSpecification(securitySystem SecuritySystem, snapName s
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	backend := r.backends[securitySystem]
+	var backend SecurityBackend
+	for _, b := range r.backends {
+		if b.Name() == securitySystem {
+			backend = b
+			break
+		}
+	}
 	if backend == nil {
 		return nil, fmt.Errorf("cannot handle interfaces of snap %q, security system %q is not known", snapName, securitySystem)
 	}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -222,7 +222,8 @@ func (s *RepositorySuite) TestBackends(c *C) {
 	b2 := &ifacetest.TestSecurityBackend{BackendName: "b2"}
 	c.Assert(s.emptyRepo.AddBackend(b2), IsNil)
 	c.Assert(s.emptyRepo.AddBackend(b1), IsNil)
-	c.Assert(s.emptyRepo.Backends(), DeepEquals, []SecurityBackend{b1, b2})
+	// The order of insertion is retained.
+	c.Assert(s.emptyRepo.Backends(), DeepEquals, []SecurityBackend{b2, b1})
 }
 
 // Tests for Repository.Interface()

--- a/testutil/checkers.go
+++ b/testutil/checkers.go
@@ -300,3 +300,75 @@ func (c *syscallsEqualChecker) Check(params []interface{}, names []string) (resu
 	}
 	return true, ""
 }
+
+type intChecker struct {
+	*check.CheckerInfo
+	rel string
+}
+
+func (checker *intChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	a, ok := params[0].(int)
+	if !ok {
+		return false, "left-hand-side argument must be an int"
+	}
+	b, ok := params[1].(int)
+	if !ok {
+		return false, "right-hand-side argument must be an int"
+	}
+	switch checker.rel {
+	case "<":
+		result = a < b
+	case "<=":
+		result = a <= b
+	case "==":
+		result = a == b
+	case "!=":
+		result = a != b
+	case ">":
+		result = a > b
+	case ">=":
+		result = a >= b
+	default:
+		return false, fmt.Sprintf("unexpected relation %q", checker.rel)
+	}
+	if !result {
+		error = fmt.Sprintf("failed relation %d %s %d", a, checker.rel, b)
+	}
+	return result, error
+}
+
+// IntLessThan checker verifies that one integer is less than other integer.
+//
+// For example:
+//     c.Assert(1, IntLessThan, 2)
+var IntLessThan = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntLessThan", Params: []string{"a", "b"}}, rel: "<"}
+
+// IntLessEqual checker verifies that one integer is less than or equal to other integer.
+//
+// For example:
+//     c.Assert(1, IntLessEqual, 1)
+var IntLessEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntLessEqual", Params: []string{"a", "b"}}, rel: "<="}
+
+// IntEqual checker verifies that one integer is equal to other integer.
+//
+// For example:
+//     c.Assert(1, IntEqual, 1)
+var IntEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntEqual", Params: []string{"a", "b"}}, rel: "=="}
+
+// IntNotEqual checker verifies that one integer is not equal to other integer.
+//
+// For example:
+//     c.Assert(1, IntNotEqual, 2)
+var IntNotEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntNotEqual", Params: []string{"a", "b"}}, rel: "!="}
+
+// IntGreaterThan checker verifies that one integer is greater than other integer.
+//
+// For example:
+//     c.Assert(2, IntGreaterThan, 1)
+var IntGreaterThan = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntGreaterThan", Params: []string{"a", "b"}}, rel: ">"}
+
+// IntGreaterEqual checker verifies that one integer is greater than or equal to other integer.
+//
+// For example:
+//     c.Assert(1, IntGreaterEqual, 2)
+var IntGreaterEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntGreaterEqual", Params: []string{"a", "b"}}, rel: ">="}

--- a/testutil/checkers.go
+++ b/testutil/checkers.go
@@ -332,7 +332,7 @@ func (checker *intChecker) Check(params []interface{}, names []string) (result b
 		return false, fmt.Sprintf("unexpected relation %q", checker.rel)
 	}
 	if !result {
-		error = fmt.Sprintf("failed relation %d %s %d", a, checker.rel, b)
+		error = fmt.Sprintf("relation %d %s %d is not true", a, checker.rel, b)
 	}
 	return result, error
 }

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -388,12 +388,12 @@ func (s *CheckersS) TestIntChecker(c *check.C) {
 	testCheck(c, IntLessThan, false, "right-hand-side argument must be an int", 1, false)
 
 	// Relationship error.
-	testCheck(c, IntLessThan, false, "failed relation 2 < 1", 2, 1)
-	testCheck(c, IntLessEqual, false, "failed relation 2 <= 1", 2, 1)
-	testCheck(c, IntEqual, false, "failed relation 2 == 1", 2, 1)
-	testCheck(c, IntNotEqual, false, "failed relation 2 != 2", 2, 2)
-	testCheck(c, IntGreaterThan, false, "failed relation 1 > 2", 1, 2)
-	testCheck(c, IntGreaterEqual, false, "failed relation 1 >= 2", 1, 2)
+	testCheck(c, IntLessThan, false, "relation 2 < 1 is not true", 2, 1)
+	testCheck(c, IntLessEqual, false, "relation 2 <= 1 is not true", 2, 1)
+	testCheck(c, IntEqual, false, "relation 2 == 1 is not true", 2, 1)
+	testCheck(c, IntNotEqual, false, "relation 2 != 2 is not true", 2, 2)
+	testCheck(c, IntGreaterThan, false, "relation 1 > 2 is not true", 1, 2)
+	testCheck(c, IntGreaterEqual, false, "relation 1 >= 2 is not true", 1, 2)
 
 	// Unexpected relation.
 	unexpected := &intChecker{CheckerInfo: &check.CheckerInfo{Name: "unexpected", Params: []string{"a", "b"}}, rel: "==="}

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -374,3 +374,29 @@ func (s *CheckersS) TestSystemCallSequenceEqual(c *check.C) {
 	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly absent, got only 0 system call(s) but expected 1",
 		[]CallResultError{}, []CallResultError{{C: `foo`}})
 }
+
+func (s *CheckersS) TestIntChecker(c *check.C) {
+	c.Assert(1, IntLessThan, 2)
+	c.Assert(1, IntLessEqual, 1)
+	c.Assert(1, IntEqual, 1)
+	c.Assert(2, IntNotEqual, 1)
+	c.Assert(2, IntGreaterThan, 1)
+	c.Assert(2, IntGreaterEqual, 2)
+
+	// Wrong argument types.
+	testCheck(c, IntLessThan, false, "left-hand-side argument must be an int", false, 1)
+	testCheck(c, IntLessThan, false, "right-hand-side argument must be an int", 1, false)
+
+	// Relationship error.
+	testCheck(c, IntLessThan, false, "failed relation 2 < 1", 2, 1)
+	testCheck(c, IntLessEqual, false, "failed relation 2 <= 1", 2, 1)
+	testCheck(c, IntEqual, false, "failed relation 2 == 1", 2, 1)
+	testCheck(c, IntNotEqual, false, "failed relation 2 != 2", 2, 2)
+	testCheck(c, IntGreaterThan, false, "failed relation 1 > 2", 1, 2)
+	testCheck(c, IntGreaterEqual, false, "failed relation 1 >= 2", 1, 2)
+
+	// Unexpected relation.
+	unexpected := &intChecker{CheckerInfo: &check.CheckerInfo{Name: "unexpected", Params: []string{"a", "b"}}, rel: "==="}
+	testCheck(c, unexpected, false, `unexpected relation "==="`, 1, 2)
+
+}


### PR DESCRIPTION
This patch makes the interface repository retain the order of inserted
security backends. This in turns makes the interface manager respect
that order (as it uses the repository to know about available backends).
This in turn means that the order defined in the interfaces/backends/
package, specifically the All variable there, matters.

The order defined there is:
 - systemd
 - seccomp
 - dbus
 - udev
 - mount
 - kmod
 - apparmor (optionally)

The prior order is essentially the same list, sorted alphabetically:

 - apparmor (optionally)
 - dbus
 - kmod
 - mount
 - seccomp
 - systemd
 - udev

This means that the apparmor module would always go first. This was okay
for most interfaces but unfortunately the gpio interface depends on the
systemd backend (specifically it needs to read a file that only exists
after the systemd backend has completed its task).

Forum: https://forum.snapcraft.io/t/snap-enable-failure/6307/
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>