### PR TITLE
cmd: remove --skip-command-chain from snap run and snap-exec

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -39,9 +39,8 @@ var syscallExec = syscall.Exec
 
 // commandline args
 var opts struct {
-	Command          string `long:"command" description:"use a different command like {stop,post-stop} from the app"`
-	SkipCommandChain bool   `long:"skip-command-chain" description:"do not run command chain"`
-	Hook             string `long:"hook" description:"hook to run" hidden:"yes"`
+	Command string `long:"command" description:"use a different command like {stop,post-stop} from the app"`
+	Hook    string `long:"hook" description:"hook to run" hidden:"yes"`
 }
 
 func init() {
@@ -90,10 +89,10 @@ func run() error {
 
 	// Now actually handle the dispatching
 	if opts.Hook != "" {
-		return execHook(snapApp, revision, opts.Hook, opts.SkipCommandChain)
+		return execHook(snapApp, revision, opts.Hook)
 	}
 
-	return execApp(snapApp, revision, opts.Command, extraArgs, opts.SkipCommandChain)
+	return execApp(snapApp, revision, opts.Command, extraArgs)
 }
 
 const defaultShell = "/bin/bash"
@@ -151,7 +150,7 @@ func expandEnvCmdArgs(args []string, env map[string]string) []string {
 	return cmdArgs
 }
 
-func execApp(snapApp, revision, command string, args []string, skipCommandChain bool) error {
+func execApp(snapApp, revision, command string, args []string) error {
 	rev, err := snap.ParseRevision(revision)
 	if err != nil {
 		return fmt.Errorf("cannot parse revision %q: %s", revision, err)
@@ -213,9 +212,7 @@ func execApp(snapApp, revision, command string, args []string, skipCommandChain 
 	fullCmd = append(fullCmd, cmdArgs...)
 	fullCmd = append(fullCmd, args...)
 
-	if !skipCommandChain {
-		fullCmd = append(absoluteCommandChain(app.Snap, app.CommandChain), fullCmd...)
-	}
+	fullCmd = append(absoluteCommandChain(app.Snap, app.CommandChain), fullCmd...)
 
 	if err := syscallExec(fullCmd[0], fullCmd, env); err != nil {
 		return fmt.Errorf("cannot exec %q: %s", fullCmd[0], err)
@@ -224,7 +221,7 @@ func execApp(snapApp, revision, command string, args []string, skipCommandChain 
 	return nil
 }
 
-func execHook(snapName, revision, hookName string, skipCommandChain bool) error {
+func execHook(snapName, revision, hookName string) error {
 	rev, err := snap.ParseRevision(revision)
 	if err != nil {
 		return err
@@ -246,9 +243,6 @@ func execHook(snapName, revision, hookName string, skipCommandChain bool) error 
 	env := append(os.Environ(), osutil.SubstituteEnv(hook.Env())...)
 
 	// run the hook
-	cmd := []string{filepath.Join(hook.Snap.HooksDir(), hook.Name)}
-	if !skipCommandChain {
-		cmd = append(absoluteCommandChain(hook.Snap, hook.CommandChain), cmd...)
-	}
+	cmd := append(absoluteCommandChain(hook.Snap, hook.CommandChain), filepath.Join(hook.Snap.HooksDir(), hook.Name))
 	return syscallExec(cmd[0], cmd, env)
 }

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -158,7 +158,7 @@ func (s *snapExecSuite) TestSnapExecAppIntegration(c *C) {
 	defer restore()
 
 	// launch and verify its run the right way
-	err := snapExec.ExecApp("snapname.app", "42", "stop", []string{"arg1", "arg2"}, false)
+	err := snapExec.ExecApp("snapname.app", "42", "stop", []string{"arg1", "arg2"})
 	c.Assert(err, IsNil)
 	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/stop-app", dirs.SnapMountDir))
 	c.Check(execArgs, DeepEquals, []string{execArgv0, "arg1", "arg2"})
@@ -189,30 +189,23 @@ func (s *snapExecSuite) TestSnapExecAppCommandChainIntegration(c *C) {
 	post_stop_path := fmt.Sprintf("%s/snapname/42/post-stop-app2", dirs.SnapMountDir)
 
 	for _, t := range []struct {
-		cmd              string
-		args             []string
-		skipCommandChain bool
-		expected         []string
+		cmd      string
+		args     []string
+		expected []string
 	}{
 		// Normal command
 		{expected: []string{chain1_path, chain2_path, app_path}},
-		{skipCommandChain: true, expected: []string{app_path}},
 		{args: []string{"arg1", "arg2"}, expected: []string{chain1_path, chain2_path, app_path, "arg1", "arg2"}},
-		{args: []string{"arg1", "arg2"}, skipCommandChain: true, expected: []string{app_path, "arg1", "arg2"}},
 
 		// Stop command
 		{cmd: "stop", expected: []string{chain1_path, chain2_path, stop_path}},
-		{cmd: "stop", skipCommandChain: true, expected: []string{stop_path}},
 		{cmd: "stop", args: []string{"arg1", "arg2"}, expected: []string{chain1_path, chain2_path, stop_path, "arg1", "arg2"}},
-		{cmd: "stop", args: []string{"arg1", "arg2"}, skipCommandChain: true, expected: []string{stop_path, "arg1", "arg2"}},
 
 		// Post-stop command
 		{cmd: "post-stop", expected: []string{chain1_path, chain2_path, post_stop_path}},
-		{cmd: "post-stop", skipCommandChain: true, expected: []string{post_stop_path}},
 		{cmd: "post-stop", args: []string{"arg1", "arg2"}, expected: []string{chain1_path, chain2_path, post_stop_path, "arg1", "arg2"}},
-		{cmd: "post-stop", args: []string{"arg1", "arg2"}, skipCommandChain: true, expected: []string{post_stop_path, "arg1", "arg2"}},
 	} {
-		err := snapExec.ExecApp("snapname.app2", "42", t.cmd, t.args, t.skipCommandChain)
+		err := snapExec.ExecApp("snapname.app2", "42", t.cmd, t.args)
 		c.Assert(err, IsNil)
 		c.Check(execArgv0, Equals, t.expected[0])
 		c.Check(execArgs, DeepEquals, t.expected)
@@ -235,7 +228,7 @@ func (s *snapExecSuite) TestSnapExecHookIntegration(c *C) {
 	defer restore()
 
 	// launch and verify it ran correctly
-	err := snapExec.ExecHook("snapname", "42", "configure", false)
+	err := snapExec.ExecHook("snapname", "42", "configure")
 	c.Assert(err, IsNil)
 	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/meta/hooks/configure", dirs.SnapMountDir))
 	c.Check(execArgs, DeepEquals, []string{execArgv0})
@@ -260,18 +253,10 @@ func (s *snapExecSuite) TestSnapExecHookCommandChainIntegration(c *C) {
 	chain2_path := fmt.Sprintf("%s/snapname/42/chain2", dirs.SnapMountDir)
 	hook_path := fmt.Sprintf("%s/snapname/42/meta/hooks/configure", dirs.SnapMountDir)
 
-	for _, t := range []struct {
-		skipCommandChain bool
-		expected         []string
-	}{
-		{expected: []string{chain1_path, chain2_path, hook_path}},
-		{skipCommandChain: true, expected: []string{hook_path}},
-	} {
-		err := snapExec.ExecHook("snapname", "42", "configure", t.skipCommandChain)
-		c.Assert(err, IsNil)
-		c.Check(execArgv0, Equals, t.expected[0])
-		c.Check(execArgs, DeepEquals, t.expected)
-	}
+	err := snapExec.ExecHook("snapname", "42", "configure")
+	c.Assert(err, IsNil)
+	c.Check(execArgv0, Equals, chain1_path)
+	c.Check(execArgs, DeepEquals, []string{chain1_path, chain2_path, hook_path})
 }
 
 func (s *snapExecSuite) TestSnapExecHookMissingHookIntegration(c *C) {
@@ -280,7 +265,7 @@ func (s *snapExecSuite) TestSnapExecHookMissingHookIntegration(c *C) {
 		Revision: snap.R("42"),
 	})
 
-	err := snapExec.ExecHook("snapname", "42", "missing-hook", false)
+	err := snapExec.ExecHook("snapname", "42", "missing-hook")
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "cannot find hook \"missing-hook\" in \"snapname\"")
 }
@@ -403,25 +388,19 @@ func (s *snapExecSuite) TestSnapExecShellIntegration(c *C) {
 	defer restore()
 
 	// launch and verify its run the right way
-	err := snapExec.ExecApp("snapname.app", "42", "shell", []string{"-c", "echo foo"}, false)
+	err := snapExec.ExecApp("snapname.app", "42", "shell", []string{"-c", "echo foo"})
 	c.Assert(err, IsNil)
 	c.Check(execArgv0, Equals, "/bin/bash")
 	c.Check(execArgs, DeepEquals, []string{execArgv0, "-c", "echo foo"})
 	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path/lib")
 
 	// launch and verify shell still runs the command chain
-	err = snapExec.ExecApp("snapname.app2", "42", "shell", []string{"-c", "echo foo"}, false)
+	err = snapExec.ExecApp("snapname.app2", "42", "shell", []string{"-c", "echo foo"})
 	c.Assert(err, IsNil)
 	chain1 := fmt.Sprintf("%s/snapname/42/chain1", dirs.SnapMountDir)
 	chain2 := fmt.Sprintf("%s/snapname/42/chain2", dirs.SnapMountDir)
 	c.Check(execArgv0, Equals, chain1)
 	c.Check(execArgs, DeepEquals, []string{chain1, chain2, "/bin/bash", "-c", "echo foo"})
-
-	// also verify that it supports skipping the command chain
-	err = snapExec.ExecApp("snapname.app2", "42", "shell", []string{"-c", "echo foo"}, true)
-	c.Assert(err, IsNil)
-	c.Check(execArgv0, Equals, "/bin/bash")
-	c.Check(execArgs, DeepEquals, []string{execArgv0, "-c", "echo foo"})
 }
 
 func (s *snapExecSuite) TestSnapExecAppIntegrationWithVars(c *C) {
@@ -446,7 +425,7 @@ func (s *snapExecSuite) TestSnapExecAppIntegrationWithVars(c *C) {
 	defer os.Unsetenv("SNAP_DATA")
 
 	// launch and verify its run the right way
-	err := snapExec.ExecApp("snapname.app", "42", "", []string{"user-arg1"}, false)
+	err := snapExec.ExecApp("snapname.app", "42", "", []string{"user-arg1"})
 	c.Assert(err, IsNil)
 	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/run-app", dirs.SnapMountDir))
 	c.Check(execArgs, DeepEquals, []string{execArgv0, "cmd-arg1", "/var/snap/snapname/42", "user-arg1"})

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -55,11 +55,10 @@ var (
 )
 
 type cmdRun struct {
-	Command          string `long:"command" hidden:"yes"`
-	HookName         string `long:"hook" hidden:"yes"`
-	Revision         string `short:"r" default:"unset" hidden:"yes"`
-	Shell            bool   `long:"shell" `
-	SkipCommandChain bool   `long:"skip-command-chain"`
+	Command  string `long:"command" hidden:"yes"`
+	HookName string `long:"hook" hidden:"yes"`
+	Revision string `short:"r" default:"unset" hidden:"yes"`
+	Shell    bool   `long:"shell" `
 
 	// This options is both a selector (use or don't use strace) and it
 	// can also carry extra options for strace. This is why there is
@@ -83,15 +82,14 @@ and environment.
 		func() flags.Commander {
 			return &cmdRun{}
 		}, map[string]string{
-			"command":            i18n.G("Alternative command to run"),
-			"hook":               i18n.G("Hook to run"),
-			"r":                  i18n.G("Use a specific snap revision when running hook"),
-			"shell":              i18n.G("Run a shell instead of the command (useful for debugging)"),
-			"skip-command-chain": i18n.G("Do not run the command chain (useful for debugging)"),
-			"strace":             i18n.G("Run the command under strace (useful for debugging). Extra strace options can be specified as well here. Pass --raw to strace early snap helpers."),
-			"gdb":                i18n.G("Run the command with gdb"),
-			"timer":              i18n.G("Run as a timer service with given schedule"),
-			"parser-ran":         "",
+			"command":    i18n.G("Alternative command to run"),
+			"hook":       i18n.G("Hook to run"),
+			"r":          i18n.G("Use a specific snap revision when running hook"),
+			"shell":      i18n.G("Run a shell instead of the command (useful for debugging)"),
+			"strace":     i18n.G("Run the command under strace (useful for debugging). Extra strace options can be specified as well here. Pass --raw to strace early snap helpers."),
+			"gdb":        i18n.G("Run the command with gdb"),
+			"timer":      i18n.G("Run as a timer service with given schedule"),
+			"parser-ran": "",
 		}, nil)
 }
 
@@ -760,9 +758,6 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	}
 	if x.Command != "" {
 		cmd = append(cmd, "--command="+x.Command)
-	}
-	if x.SkipCommandChain {
-		cmd = append(cmd, "--skip-command-chain")
 	}
 
 	if hook != "" {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -136,39 +136,6 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
 }
 
-func (s *SnapSuite) TestSnapRunAppIntegrationSkipCommandChain(c *check.C) {
-	defer mockSnapConfine(dirs.DistroLibExecDir)()
-
-	// mock installed snap
-	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{
-		Revision: snap.R("x2"),
-	})
-
-	// redirect exec
-	execArg0 := ""
-	execArgs := []string{}
-	execEnv := []string{}
-	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
-		execArg0 = arg0
-		execArgs = args
-		execEnv = envv
-		return nil
-	})
-	defer restorer()
-
-	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "--skip-command-chain", "snapname.app", "--arg1", "arg2"})
-	c.Assert(err, check.IsNil)
-	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
-	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
-		"snap.snapname.app",
-		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
-		"--skip-command-chain", "snapname.app", "--arg1", "arg2"})
-	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
-}
-
 func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
@@ -338,38 +305,6 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 		"snap.snapname.hook.configure",
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
-	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
-}
-
-func (s *SnapSuite) TestSnapRunHookIntegrationSkipCommandChain(c *check.C) {
-	defer mockSnapConfine(dirs.DistroLibExecDir)()
-
-	// mock installed snap
-	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{
-		Revision: snap.R(42),
-	})
-
-	// redirect exec
-	execArg0 := ""
-	execArgs := []string{}
-	execEnv := []string{}
-	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
-		execArg0 = arg0
-		execArgs = args
-		execEnv = envv
-		return nil
-	})
-	defer restorer()
-
-	// Run a hook from the active revision
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--skip-command-chain", "--hook=configure", "snapname"})
-	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
-	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
-		"snap.snapname.hook.configure",
-		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
-		"--skip-command-chain", "--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
 

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -30,17 +30,3 @@ execute: |
     env="$(snap run --shell command-chain.hello -c 'env')"
     echo "$env" | MATCH '^CHAIN_1_RAN=1$'
     echo "$env" | MATCH '^CHAIN_2_RAN=1$'
-
-    echo "Also ensure that 'snap run' supports skipping the command chain"
-    [ "$(snap run --skip-command-chain command-chain.hello)" = "hello" ]
-    [ "$(snap run --shell --skip-command-chain command-chain.hello -c 'echo "shell"')" = "shell" ]
-    env="$(snap run --shell --skip-command-chain command-chain.hello -c 'env')"
-    echo "$env" | MATCH -v '^CHAIN_1_RAN=1$'
-    echo "$env" | MATCH -v '^CHAIN_2_RAN=1$'
-
-    echo "Ensure that 'snap run' supports skipping the command chain for hooks as well"
-    rm -f "$BREADCRUMB"
-    snap run --skip-command-chain --hook configure command-chain
-    [ "$(cat "$BREADCRUMB")" = "configure" ]
-    MATCH -v '^CHAIN_1_RAN=1$' < "$ENVDUMP"
-    MATCH -v '^CHAIN_2_RAN=1$' < "$ENVDUMP"


### PR DESCRIPTION
Done by request, see [forum topic](https://forum.snapcraft.io/t/6112/9) for more details.