### PR TITLE
overlord/devicestate: use OpenSSL's PEM format when generating keys

### DIFF
--- a/overlord/devicestate/crypto.go
+++ b/overlord/devicestate/crypto.go
@@ -45,7 +45,7 @@ func generateRSAKey(keyLength int) (*rsa.PrivateKey, error) {
 
 	rsaKeyFile := filepath.Join(tempDir, "rsa.key")
 
-	cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", strconv.Itoa(keyLength), "-N", "", "-f", rsaKeyFile)
+	cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", strconv.Itoa(keyLength), "-N", "", "-f", rsaKeyFile, "-m", "PEM")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, osutil.OutputErr(out, err)


### PR DESCRIPTION
OpenSSH 7.8 release changed the default format of generated private keys to its
own, replacing OpenSSL PEM format which we relied upon. Pass '.. -m PEM' to use
the PEM format. See https://lwn.net/Articles/763444/ for details.

