### PR TITLE
release, interfaces: make snapd degrade gracefully when AppArmor userspace tooling is unavailable

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -116,7 +116,9 @@ func generateSystemKey() (*systemKey, error) {
 	sk.BuildID = buildID
 
 	// Add apparmor-features (which is already sorted)
-	sk.AppArmorFeatures = release.AppArmorFeatures()
+	if release.AppArmorLevel() != release.NoAppArmor {
+		sk.AppArmorFeatures = release.AppArmorFeatures()
+	}
 
 	// Add if home is using NFS, if so we need to have a different
 	// security profile and if this changes we need to change our

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -99,6 +99,7 @@ var (
 		"ptrace",
 		"signal",
 	}
+	apparmorUserspaceExists = apparmorUserspaceExistsImpl
 )
 
 // isDirectoy is like osutil.IsDirectory but we cannot import this
@@ -111,7 +112,7 @@ func isDirectory(path string) bool {
 	return stat.IsDir()
 }
 
-func apparmorUserspaceExists() bool {
+func apparmorUserspaceExistsImpl() bool {
 	_, err := exec.LookPath("apparmor_parser")
 
 	return err == nil

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -26,7 +26,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/testutil"
 )
 
 type apparmorSuite struct{}
@@ -54,6 +53,8 @@ func (s *apparmorSuite) TestProbeAppArmorNoAppArmorParser(c *C) {
 	fakeSysPath := c.MkDir()
 	restore := release.MockAppArmorFeaturesSysPath(fakeSysPath)
 	defer restore()
+	restore = release.MockAppArmorUserspaceExists(false)
+	defer restore()
 
 	level, summary := release.ProbeAppArmor()
 	c.Check(level, Equals, release.NoAppArmor)
@@ -64,8 +65,8 @@ func (s *apparmorSuite) TestProbeAppArmorPartialAppArmor(c *C) {
 	fakeSysPath := c.MkDir()
 	restore := release.MockAppArmorFeaturesSysPath(fakeSysPath)
 	defer restore()
-	cmd := testutil.MockCommand(c, "apparmor_parser", "true")
-	defer cmd.Restore()
+	restore = release.MockAppArmorUserspaceExists(true)
+	defer restore()
 
 	level, summary := release.ProbeAppArmor()
 	c.Check(level, Equals, release.PartialAppArmor)
@@ -76,8 +77,8 @@ func (s *apparmorSuite) TestProbeAppArmorFullAppArmor(c *C) {
 	fakeSysPath := c.MkDir()
 	restore := release.MockAppArmorFeaturesSysPath(fakeSysPath)
 	defer restore()
-	cmd := testutil.MockCommand(c, "apparmor_parser", "true")
-	defer cmd.Restore()
+	restore = release.MockAppArmorUserspaceExists(true)
+	defer restore()
 
 	for _, feature := range release.RequiredAppArmorFeatures {
 		err := os.Mkdir(filepath.Join(fakeSysPath, feature), 0755)

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -32,6 +32,16 @@ func MockOSReleasePath(filename string) (restore func()) {
 	}
 }
 
+func MockAppArmorUserspaceExists(exists bool) (restore func()) {
+	old := apparmorUserspaceExists
+	apparmorUserspaceExists = func() bool {
+		return exists
+	}
+	return func() {
+		apparmorUserspaceExists = old
+	}
+}
+
 var (
 	ProbeAppArmor            = probeAppArmor
 	RequiredAppArmorFeatures = requiredAppArmorFeatures

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -32,14 +32,6 @@ func MockOSReleasePath(filename string) (restore func()) {
 	}
 }
 
-func MockAppArmorFeaturesSysPath(path string) (restorer func()) {
-	old := appArmorFeaturesSysPath
-	appArmorFeaturesSysPath = path
-	return func() {
-		appArmorFeaturesSysPath = old
-	}
-}
-
 var (
 	ProbeAppArmor            = probeAppArmor
 	RequiredAppArmorFeatures = requiredAppArmorFeatures


### PR DESCRIPTION
This is an attempt to make snapd fail gracefully when the host system has AppArmor support in the kernel, but the userspace tooling is not present. Namely when `apparmor_parser` is unavaialble, do not fail hard, preventing installation/removal of snaps. Instead, degrade AppArmor support level to NoAppArmor and work with that.
