### PR TITLE
spdx: remove "Other Open Source" from the support licenses

### DIFF
--- a/spdx/licenses.go
+++ b/spdx/licenses.go
@@ -484,7 +484,6 @@ var allLicenses = []string{
 
 	// FIXME: non SPDX licenses that the snapstore uses
 	"Proprietary",
-	"Other Open Source",
 }
 
 // from https://www.google.com/url?q=https://docs.google.com/a/s.sfusd.edu/document/d/1wE_zvLU4c291ACi9wIJmQoE4ltKRW4rzM1TYiIvEVOs/edit?pli%3D1%23heading%3Dh.ruv3yl8g6czd&sa=D&ust=1473291615601000&usg=AFQjCNFyLcPLdEarX1TOesGWxg9Afb57mA


### PR DESCRIPTION
This license is not part of spdx and was only added for backward
compatibility. But given that we will use "unset" for unknown
licenses the backward compatibility is not required.

It was pointed out in https://github.com/snapcore/snapd/pull/5691 that
we do not need/want this non-spdx license - so this PR removes it.