### PR TITLE
snap/squashfs: improve error message from Build on mksquashfs failure

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -313,10 +313,11 @@ func (s *Snap) Build(buildDir string) error {
 			"-no-fragments",
 			"-no-progress",
 		).CombinedOutput()
-		if err == nil {
-			return nil
+		if err != nil {
+			return fmt.Errorf("mksquashfs call failed: %s", osutil.OutputErr(output, err))
 		}
-		return fmt.Errorf("mksquashfs call failed: %s", osutil.OutputErr(output, err))
+
+		return nil
 	})
 }
 

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -304,7 +304,7 @@ func (s *Snap) Build(buildDir string) error {
 	}
 
 	return osutil.ChDir(buildDir, func() error {
-		return exec.Command(
+		output, err := exec.Command(
 			"mksquashfs",
 			".", fullSnapPath,
 			"-noappend",
@@ -312,7 +312,11 @@ func (s *Snap) Build(buildDir string) error {
 			"-no-xattrs",
 			"-no-fragments",
 			"-no-progress",
-		).Run()
+		).CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		return fmt.Errorf("mksquashfs call failed: %s", osutil.OutputErr(output, err))
 	})
 }
 


### PR DESCRIPTION
Without this change:

    $ snap pack test-snapd-complexion/
    error: cannot pack "test-snapd-complexion/": exit status 1

With this change:

    $ snap pack test-snapd-complexion/
    error: cannot pack "test-snapd-complexion/": mksquashfs call failed:
    -----
    mksquashfs: Compressor "xz" is not supported!
    mksquashfs: Compressors available:
            gzip (default)
    -----
