### PR TITLE
snap/snapenv: drop some instance specific variables, use instance-specific ones for user locations

### DIFF
--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -101,10 +101,10 @@ func basicEnv(info *snap.Info) map[string]string {
 		// always mounted on /snap OR it is a classically confined snap where
 		// /snap is a part of the distribution package.
 		//
-		// NOTE for parallel-installs the mount namespace setup is
-		// making the environment of each snap instance appear as if
-		// it's the only snap, i.e. SNAP paths point to the same
-		// locations within the mount namespace
+		// For parallel-installs the mount namespace setup is making the
+		// environment of each snap instance appear as if it's the only
+		// snap, i.e. SNAP paths point to the same locations within the
+		// mount namespace
 		"SNAP":               filepath.Join(dirs.CoreSnapMountDir, info.SnapName(), info.Revision.String()),
 		"SNAP_COMMON":        snap.CommonDataDir(info.SnapName()),
 		"SNAP_DATA":          snap.DataDir(info.SnapName(), info.Revision),
@@ -125,10 +125,8 @@ func basicEnv(info *snap.Info) map[string]string {
 // used by so many other modules, we run into circular dependencies if it's
 // somewhere more reasonable like the snappy module.
 func userEnv(info *snap.Info, home string) map[string]string {
-	// TODO parallel-install: we do not have a way to make the mounts from
-	// instance-specific to snap-specific directories at user controlled
-	// location completely safe, make sure we use instance-specific
-	// directories always
+	// To keep things simple the user variables always point to the
+	// instance-specific directories.
 	result := map[string]string{
 		"SNAP_USER_COMMON": info.UserCommonDataDir(home),
 		"SNAP_USER_DATA":   info.UserDataDir(home),

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -105,17 +105,15 @@ func basicEnv(info *snap.Info) map[string]string {
 		// the environment of each snap instance appear as if it's the
 		// only snap, i.e. SNAP paths point to the same locations within
 		// the mount namespace
-		"SNAP":                 filepath.Join(dirs.CoreSnapMountDir, info.SnapName(), info.Revision.String()),
-		"SNAP_COMMON":          snap.CommonDataDir(info.SnapName()),
-		"SNAP_DATA":            snap.DataDir(info.SnapName(), info.Revision),
-		"SNAP_NAME":            info.SnapName(),
-		"SNAP_INSTANCE":        filepath.Join(dirs.CoreSnapMountDir, info.InstanceName(), info.Revision.String()),
-		"SNAP_INSTANCE_NAME":   info.InstanceName(),
-		"SNAP_INSTANCE_COMMON": info.CommonDataDir(),
-		"SNAP_INSTANCE_DATA":   info.DataDir(),
-		"SNAP_VERSION":         info.Version,
-		"SNAP_REVISION":        info.Revision.String(),
-		"SNAP_ARCH":            arch.UbuntuArchitecture(),
+		"SNAP":               filepath.Join(dirs.CoreSnapMountDir, info.SnapName(), info.Revision.String()),
+		"SNAP_COMMON":        snap.CommonDataDir(info.SnapName()),
+		"SNAP_DATA":          snap.DataDir(info.SnapName(), info.Revision),
+		"SNAP_NAME":          info.SnapName(),
+		"SNAP_INSTANCE_NAME": info.InstanceName(),
+		"SNAP_INSTANCE_KEY":  info.InstanceKey,
+		"SNAP_VERSION":       info.Version,
+		"SNAP_REVISION":      info.Revision.String(),
+		"SNAP_ARCH":          arch.UbuntuArchitecture(),
 		// see https://github.com/snapcore/snapd/pull/2732#pullrequestreview-18827193
 		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
 		"SNAP_REEXEC":       os.Getenv("SNAP_REEXEC"),
@@ -127,17 +125,18 @@ func basicEnv(info *snap.Info) map[string]string {
 // used by so many other modules, we run into circular dependencies if it's
 // somewhere more reasonable like the snappy module.
 func userEnv(info *snap.Info, home string) map[string]string {
-	// TODO parallel-install: use of proper instance/store name
+	// TODO parallel-install: we do not have a way to make the mounts from
+	// instance-specific to snap-specific directories at user controlled
+	// location completely safe, make sure we use instance-specific
+	// directories always
 	result := map[string]string{
-		"SNAP_USER_COMMON":          snap.UserCommonDataDir(home, info.SnapName()),
-		"SNAP_USER_DATA":            snap.UserDataDir(home, info.SnapName(), info.Revision),
-		"SNAP_INSTANCE_USER_COMMON": info.UserCommonDataDir(home),
-		"SNAP_INSTANCE_USER_DATA":   info.UserDataDir(home),
-		"XDG_RUNTIME_DIR":           info.UserXdgRuntimeDir(sys.Geteuid()),
+		"SNAP_USER_COMMON": info.UserCommonDataDir(home),
+		"SNAP_USER_DATA":   info.UserDataDir(home),
+		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(sys.Geteuid()),
 	}
 	// For non-classic snaps, we set HOME but on classic allow snaps to see real HOME
 	if !info.NeedsClassic() {
-		result["HOME"] = snap.UserDataDir(home, info.SnapName(), info.Revision)
+		result["HOME"] = info.UserDataDir(home)
 	}
 	return result
 }

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -101,10 +101,10 @@ func basicEnv(info *snap.Info) map[string]string {
 		// always mounted on /snap OR it is a classically confined snap where
 		// /snap is a part of the distribution package.
 		//
-		// NOTE for parallel-installs snap-confine takes care of making
-		// the environment of each snap instance appear as if it's the
-		// only snap, i.e. SNAP paths point to the same locations within
-		// the mount namespace
+		// NOTE for parallel-installs the mount namespace setup is
+		// making the environment of each snap instance appear as if
+		// it's the only snap, i.e. SNAP paths point to the same
+		// locations within the mount namespace
 		"SNAP":               filepath.Join(dirs.CoreSnapMountDir, info.SnapName(), info.Revision.String()),
 		"SNAP_COMMON":        snap.CommonDataDir(info.SnapName()),
 		"SNAP_DATA":          snap.DataDir(info.SnapName(), info.Revision),

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -187,14 +187,14 @@ func (s *HTestSuite) TestParallelInstallSnapRunSnapExecEnv(c *C) {
 			"SNAP_REVISION":      "42",
 			"SNAP_VERSION":       "1.0",
 
-			// NOTE: those are mapped by mount namespace setup
+			// Those are mapped to snap-specific directories by
+			// mount namespace setup
 			"SNAP":        fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_COMMON": "/var/snap/snapname/common",
 			"SNAP_DATA":   "/var/snap/snapname/42",
 
-			// NOTE: currently we cannot do the user bind mounts in
-			// a secure way, thus the instance-specific user's data
-			// directories are not mapped to snap-specific ones
+			// User's data directories are not mapped to
+			// snap-specific ones
 			"SNAP_USER_COMMON": fmt.Sprintf("%s/snap/snapname_foo/common", usr.HomeDir),
 			"SNAP_USER_DATA":   fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
 			"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -81,19 +81,17 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	env := basicEnv(mockSnapInfo)
 
 	c.Assert(env, DeepEquals, map[string]string{
-		"SNAP":                 fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
-		"SNAP_ARCH":            arch.UbuntuArchitecture(),
-		"SNAP_COMMON":          "/var/snap/foo/common",
-		"SNAP_DATA":            "/var/snap/foo/17",
-		"SNAP_LIBRARY_PATH":    "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
-		"SNAP_NAME":            "foo",
-		"SNAP_INSTANCE":        fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
-		"SNAP_INSTANCE_NAME":   "foo",
-		"SNAP_INSTANCE_COMMON": "/var/snap/foo/common",
-		"SNAP_INSTANCE_DATA":   "/var/snap/foo/17",
-		"SNAP_REEXEC":          "",
-		"SNAP_REVISION":        "17",
-		"SNAP_VERSION":         "1.0",
+		"SNAP":               fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
+		"SNAP_ARCH":          arch.UbuntuArchitecture(),
+		"SNAP_COMMON":        "/var/snap/foo/common",
+		"SNAP_DATA":          "/var/snap/foo/17",
+		"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+		"SNAP_NAME":          "foo",
+		"SNAP_INSTANCE_NAME": "foo",
+		"SNAP_INSTANCE_KEY":  "",
+		"SNAP_REEXEC":        "",
+		"SNAP_REVISION":      "17",
+		"SNAP_VERSION":       "1.0",
 	})
 
 }
@@ -102,12 +100,10 @@ func (ts *HTestSuite) TestUser(c *C) {
 	env := userEnv(mockSnapInfo, "/root")
 
 	c.Assert(env, DeepEquals, map[string]string{
-		"HOME":                      "/root/snap/foo/17",
-		"SNAP_USER_COMMON":          "/root/snap/foo/common",
-		"SNAP_USER_DATA":            "/root/snap/foo/17",
-		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo/common",
-		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
+		"HOME":             "/root/snap/foo/17",
+		"SNAP_USER_COMMON": "/root/snap/foo/common",
+		"SNAP_USER_DATA":   "/root/snap/foo/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
 	})
 }
 
@@ -116,11 +112,9 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 
 	c.Assert(env, DeepEquals, map[string]string{
 		// NOTE HOME Is absent! we no longer override it
-		"SNAP_USER_COMMON":          "/root/snap/foo/common",
-		"SNAP_USER_DATA":            "/root/snap/foo/17",
-		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo/common",
-		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
+		"SNAP_USER_COMMON": "/root/snap/foo/common",
+		"SNAP_USER_DATA":   "/root/snap/foo/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
 	})
 }
 
@@ -142,25 +136,21 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":                      fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP":                      fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
-			"SNAP_ARCH":                 arch.UbuntuArchitecture(),
-			"SNAP_COMMON":               "/var/snap/snapname/common",
-			"SNAP_DATA":                 "/var/snap/snapname/42",
-			"SNAP_LIBRARY_PATH":         "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
-			"SNAP_NAME":                 "snapname",
-			"SNAP_INSTANCE":             fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
-			"SNAP_INSTANCE_NAME":        "snapname",
-			"SNAP_INSTANCE_COMMON":      "/var/snap/snapname/common",
-			"SNAP_INSTANCE_DATA":        "/var/snap/snapname/42",
-			"SNAP_REEXEC":               "",
-			"SNAP_REVISION":             "42",
-			"SNAP_USER_COMMON":          fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_USER_DATA":            fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP_INSTANCE_USER_COMMON": fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_INSTANCE_USER_DATA":   fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP_VERSION":              "1.0",
-			"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
+			"HOME":               fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP":               fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_ARCH":          arch.UbuntuArchitecture(),
+			"SNAP_COMMON":        "/var/snap/snapname/common",
+			"SNAP_DATA":          "/var/snap/snapname/42",
+			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+			"SNAP_NAME":          "snapname",
+			"SNAP_INSTANCE_NAME": "snapname",
+			"SNAP_INSTANCE_KEY":  "",
+			"SNAP_REEXEC":        "",
+			"SNAP_REVISION":      "42",
+			"SNAP_USER_COMMON":   fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
+			"SNAP_USER_DATA":     fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP_VERSION":       "1.0",
+			"XDG_RUNTIME_DIR":    fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
 		})
 	}
 }
@@ -186,25 +176,21 @@ func (s *HTestSuite) TestParallelInstallSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":                      fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP":                      fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
-			"SNAP_ARCH":                 arch.UbuntuArchitecture(),
-			"SNAP_COMMON":               "/var/snap/snapname/common",
-			"SNAP_DATA":                 "/var/snap/snapname/42",
-			"SNAP_LIBRARY_PATH":         "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
-			"SNAP_NAME":                 "snapname",
-			"SNAP_INSTANCE":             fmt.Sprintf("%s/snapname_foo/42", dirs.CoreSnapMountDir),
-			"SNAP_INSTANCE_NAME":        "snapname_foo",
-			"SNAP_INSTANCE_COMMON":      "/var/snap/snapname_foo/common",
-			"SNAP_INSTANCE_DATA":        "/var/snap/snapname_foo/42",
-			"SNAP_REEXEC":               "",
-			"SNAP_REVISION":             "42",
-			"SNAP_USER_COMMON":          fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_USER_DATA":            fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP_INSTANCE_USER_COMMON": fmt.Sprintf("%s/snap/snapname_foo/common", usr.HomeDir),
-			"SNAP_INSTANCE_USER_DATA":   fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
-			"SNAP_VERSION":              "1.0",
-			"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),
+			"HOME":               fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
+			"SNAP":               fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_ARCH":          arch.UbuntuArchitecture(),
+			"SNAP_COMMON":        "/var/snap/snapname/common",
+			"SNAP_DATA":          "/var/snap/snapname/42",
+			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+			"SNAP_NAME":          "snapname",
+			"SNAP_INSTANCE_NAME": "snapname_foo",
+			"SNAP_INSTANCE_KEY":  "foo",
+			"SNAP_REEXEC":        "",
+			"SNAP_REVISION":      "42",
+			"SNAP_USER_COMMON":   fmt.Sprintf("%s/snap/snapname_foo/common", usr.HomeDir),
+			"SNAP_USER_DATA":     fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
+			"XDG_RUNTIME_DIR":    fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),
+			"SNAP_VERSION":       "1.0",
 		})
 	}
 }
@@ -215,12 +201,10 @@ func (ts *HTestSuite) TestParallelInstallUser(c *C) {
 	env := userEnv(&info, "/root")
 
 	c.Assert(env, DeepEquals, map[string]string{
-		"HOME":                      "/root/snap/foo/17",
-		"SNAP_USER_COMMON":          "/root/snap/foo/common",
-		"SNAP_USER_DATA":            "/root/snap/foo/17",
-		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo_bar/common",
-		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo_bar/17",
-		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
+		"HOME":             "/root/snap/foo_bar/17",
+		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
+		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
 	})
 }
 
@@ -231,11 +215,9 @@ func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
 
 	c.Assert(env, DeepEquals, map[string]string{
 		// NOTE HOME Is absent! we no longer override it
-		"SNAP_USER_COMMON":          "/root/snap/foo/common",
-		"SNAP_USER_DATA":            "/root/snap/foo/17",
-		"SNAP_INSTANCE_USER_COMMON": "/root/snap/foo_bar/common",
-		"SNAP_INSTANCE_USER_DATA":   "/root/snap/foo_bar/17",
-		"XDG_RUNTIME_DIR":           fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
+		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
+		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
 	})
 }
 

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -136,21 +136,23 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":               fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP":               fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_ARCH":          arch.UbuntuArchitecture(),
-			"SNAP_COMMON":        "/var/snap/snapname/common",
-			"SNAP_DATA":          "/var/snap/snapname/42",
 			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
 			"SNAP_NAME":          "snapname",
 			"SNAP_INSTANCE_NAME": "snapname",
 			"SNAP_INSTANCE_KEY":  "",
 			"SNAP_REEXEC":        "",
 			"SNAP_REVISION":      "42",
-			"SNAP_USER_COMMON":   fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_USER_DATA":     fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
 			"SNAP_VERSION":       "1.0",
-			"XDG_RUNTIME_DIR":    fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
+
+			"SNAP":        fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_COMMON": "/var/snap/snapname/common",
+			"SNAP_DATA":   "/var/snap/snapname/42",
+
+			"SNAP_USER_COMMON": fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
+			"SNAP_USER_DATA":   fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.snapname", sys.Geteuid()),
+			"HOME":             fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
 		})
 	}
 }
@@ -176,21 +178,27 @@ func (s *HTestSuite) TestParallelInstallSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":               fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
-			"SNAP":               fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_ARCH":          arch.UbuntuArchitecture(),
-			"SNAP_COMMON":        "/var/snap/snapname/common",
-			"SNAP_DATA":          "/var/snap/snapname/42",
 			"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
 			"SNAP_NAME":          "snapname",
 			"SNAP_INSTANCE_NAME": "snapname_foo",
 			"SNAP_INSTANCE_KEY":  "foo",
 			"SNAP_REEXEC":        "",
 			"SNAP_REVISION":      "42",
-			"SNAP_USER_COMMON":   fmt.Sprintf("%s/snap/snapname_foo/common", usr.HomeDir),
-			"SNAP_USER_DATA":     fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
-			"XDG_RUNTIME_DIR":    fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),
 			"SNAP_VERSION":       "1.0",
+
+			// NOTE: those are mapped by mount namespace setup
+			"SNAP":        fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
+			"SNAP_COMMON": "/var/snap/snapname/common",
+			"SNAP_DATA":   "/var/snap/snapname/42",
+
+			// NOTE: currently we cannot do the user bind mounts in
+			// a secure way, thus the instance-specific user's data
+			// directories are not mapped to snap-specific ones
+			"SNAP_USER_COMMON": fmt.Sprintf("%s/snap/snapname_foo/common", usr.HomeDir),
+			"SNAP_USER_DATA":   fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
+			"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.snapname_foo", sys.Geteuid()),
+			"HOME":             fmt.Sprintf("%s/snap/snapname_foo/42", usr.HomeDir),
 		})
 	}
 }

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -38,11 +38,8 @@ execute: |
     MATCH "^SNAP_CONTEXT=$CTX"                                            < snap-vars.txt
     # TODO parallel-install: install snap with instance key and verify variables
     MATCH '^SNAP_INSTANCE_NAME=test-snapd-tools$'                         < snap-vars.txt
-    MATCH '^SNAP_INSTANCE_COMMON=/var/snap/test-snapd-tools/common$'      < snap-vars.txt
-    MATCH '^SNAP_INSTANCE_DATA=/var/snap/test-snapd-tools/x1$'            < snap-vars.txt
-    MATCH '^SNAP_INSTANCE_USER_COMMON=/root/snap/test-snapd-tools/common$' < snap-vars.txt
-    MATCH '^SNAP_INSTANCE_USER_DATA=/root/snap/test-snapd-tools/x1$'      < snap-vars.txt
-    test "$(wc -l < snap-vars.txt)" -eq 18
+    MATCH '^SNAP_INSTANCE_KEY=$'                                          < snap-vars.txt
+    test "$(wc -l < snap-vars.txt)" -eq 14
 
     echo "Enure that XDG environment variables are what we expect"
     MATCH '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$'  < xdg-vars.txt


### PR DESCRIPTION
Per yesterday's discussion with @niemeyer 

Drop the following environment variables:
    - `SNAP_INSTANCE`
    - `SNAP_INSTANCE_DATA`
    - `SNAP_INSTANCE_COMMON`
    - `SNAP_INSTANCE_USER_DATA`
    - `SNAP_INSTANCE_USER_COMMON`
    
Add `SNAP_INSTANCE_KEY`, which is always set, even if snap was installed without
instance key.
    
Make sure that `SNAP_USER_{COMMON,DATA}` use instance specific directories, as we
currently have no way of making the mounts with user controlled locations.