### PR TITLE
tests: remove /etc/alternatives from dirs-not-shared-with-hosts

### DIFF
--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -13,18 +13,9 @@ prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
-    # Arch does not use /etc/alternatives
-    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
-        mkdir /etc/alternatives
-    fi
-restore: |
-    # Arch does not use /etc/alternatives
-    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
-        rmdir /etc/alternatives
     fi
 
 environment:
-    DIRECTORY/alternatives: /etc/alternatives
     DIRECTORY/ssl: /etc/ssl
 execute: |
     #shellcheck source=tests/lib/dirs.sh


### PR DESCRIPTION
This is PR #5734 for 2.35
