### PR TITLE
systemd: do not run "snapd.snap-repair.service.in on firstboot bootstrap

### DIFF
--- a/data/systemd/snapd.snap-repair.service.in
+++ b/data/systemd/snapd.snap-repair.service.in
@@ -9,3 +9,5 @@ Type=oneshot
 ExecStart=@libexecdir@/snapd/snap-repair run
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 Environment=SNAP_REPAIR_FROM_TIMER=1
+# There is no need to start this, the timer will run it
+# X-Snapd-Snap: do-not-start


### PR DESCRIPTION
The snapd.snap-repair.service is run via a timer service. The
unit itself should not be started by snapd when it bootstraps
the system for firstboot. This PR marks the service as such.

This will fix the firstboot problem that we see on the dragonboard
where the snapd snap cannot bootstrap because there is no network
and this makes snap-repair fail.
