### PR TITLE
tests: cherry-pick test fixes from master for 2.35

### DIFF
--- a/overlord/devicestate/crypto.go
+++ b/overlord/devicestate/crypto.go
@@ -45,7 +45,7 @@ func generateRSAKey(keyLength int) (*rsa.PrivateKey, error) {
 
 	rsaKeyFile := filepath.Join(tempDir, "rsa.key")
 
-	cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", strconv.Itoa(keyLength), "-N", "", "-f", rsaKeyFile)
+	cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", strconv.Itoa(keyLength), "-N", "", "-f", rsaKeyFile, "-m", "PEM")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, osutil.OutputErr(out, err)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -560,7 +560,7 @@ pkg_dependencies_ubuntu_classic(){
 
 pkg_linux_image_extra(){
     if apt-cache policy "linux-image-extra-$(uname -r)" >/dev/null 2>&1; then
-        echo "linuximage-extra-$(uname -r)"
+        echo "linux-image-extra-$(uname -r)"
     elif apt-cache policy "linux-image-extra-$(uname -r | cut -d- -f1)" >/dev/null 2>&1; then
         echo "linux-image-extra-$(uname -r | cut -d- -f1)"
     else

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -559,14 +559,14 @@ pkg_dependencies_ubuntu_classic(){
 }
 
 pkg_linux_image_extra(){
-    if apt-cache policy "linux-image-extra-$(uname -r)" >/dev/null 2>&1; then
+    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
+    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
         echo "linux-image-extra-$(uname -r)"
-    elif apt-cache policy "linux-image-extra-$(uname -r | cut -d- -f1)" >/dev/null 2>&1; then
-        echo "linux-image-extra-$(uname -r | cut -d- -f1)"
-    else
-        echo "cannot find a matching kernel modules package"
-        exit 1
+        return
     fi
+
+    kernel_version="$(uname -r | cut -d- -f1)"
+    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
 }
 
 pkg_dependencies_ubuntu_core(){

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -558,15 +558,17 @@ pkg_dependencies_ubuntu_classic(){
     esac
 }
 
-pkg_linux_image_extra(){
-    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
-    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
-        echo "linux-image-extra-$(uname -r)"
-        return
+pkg_linux_image_extra (){
+    if apt-cache show "linux-image-extra-$(uname -r)" > /dev/null 2>&1; then
+        echo "linux-image-extra-$(uname -r)";
+    else
+        if apt-cache show "linux-modules-extra-$(uname -r)" > /dev/null 2>&1; then
+            echo "linux-modules-extra-$(uname -r)";
+        else
+            echo "cannot find a matching kernel modules package";
+            exit 1;
+        fi;
     fi
-
-    kernel_version="$(uname -r | cut -d- -f1)"
-    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
 }
 
 pkg_dependencies_ubuntu_core(){

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -559,14 +559,14 @@ pkg_dependencies_ubuntu_classic(){
 }
 
 pkg_linux_image_extra(){
-    if apt-cache policy "linux-image-extra-$(uname -r)" >/dev/null 2>&1; then
-        echo "linuximage-extra-$(uname -r)"
-    elif apt-cache policy "linux-image-extra-$(uname -r | cut -d- -f1)" >/dev/null 2>&1; then
-        echo "linux-image-extra-$(uname -r | cut -d- -f1)"
-    else
-        echo "cannot find a matching kernel modules package"
-        exit 1
+    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
+    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
+        echo "linux-image-extra-$(uname -r)"
+        return
     fi
+
+    kernel_version="$(uname -r | cut -d '-' -f1)"
+    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
 }
 
 pkg_dependencies_ubuntu_core(){

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -559,7 +559,7 @@ pkg_dependencies_ubuntu_classic(){
 }
 
 pkg_linux_image_extra(){
-    available_pkgs=$(apt-cache policy linux-image-extra-*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
+    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
     if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
         echo "linux-image-extra-$(uname -r)"
         return

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -513,16 +513,14 @@ pkg_dependencies_ubuntu_classic(){
 
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*)
-            echo "
-                linux-image-extra-$(uname -r)
-                "
+                pkg_linux_image_extra
             ;;
         ubuntu-16.04-32)
             echo "
                 evolution-data-server
                 gnome-online-accounts
-                linux-image-extra-$(uname -r)
                 "
+                pkg_linux_image_extra
             ;;
         ubuntu-16.04-64)
             echo "
@@ -531,17 +529,15 @@ pkg_dependencies_ubuntu_classic(){
                 gnome-online-accounts
                 kpartx
                 libvirt-bin
-                linux-image-extra-$(uname -r)
                 nfs-kernel-server
                 qemu
                 x11-utils
                 xvfb
                 "
+                pkg_linux_image_extra
             ;;
         ubuntu-17.10-64)
-            echo "
-                linux-image-extra-4.13.0-16-generic
-                "
+                pkg_linux_image_extra
             ;;
         ubuntu-18.04-64)
             echo "
@@ -562,11 +558,22 @@ pkg_dependencies_ubuntu_classic(){
     esac
 }
 
+pkg_linux_image_extra(){
+    available_pkgs=$(apt-cache policy linux-image-extra-*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
+    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
+        echo "linux-image-extra-$(uname -r)"
+        return
+    fi
+
+    kernel_version="$(uname -r | cut -d '-' -f1)"
+    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
+}
+
 pkg_dependencies_ubuntu_core(){
     echo "
-        linux-image-extra-$(uname -r)
         pollinate
         "
+        pkg_linux_image_extra
 }
 
 pkg_dependencies_fedora(){

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -559,14 +559,14 @@ pkg_dependencies_ubuntu_classic(){
 }
 
 pkg_linux_image_extra(){
-    available_pkgs=$(apt-cache policy linux-image-extra-.*-generic | grep -E 'linux-image-extra-.*:' | tr -d :)
-    if echo "$available_pkgs" | grep -q "linux-image-extra-$(uname -r)"; then
-        echo "linux-image-extra-$(uname -r)"
-        return
+    if apt-cache policy "linux-image-extra-$(uname -r)" >/dev/null 2>&1; then
+        echo "linuximage-extra-$(uname -r)"
+    elif apt-cache policy "linux-image-extra-$(uname -r | cut -d- -f1)" >/dev/null 2>&1; then
+        echo "linux-image-extra-$(uname -r | cut -d- -f1)"
+    else
+        echo "cannot find a matching kernel modules package"
+        exit 1
     fi
-
-    kernel_version="$(uname -r | cut -d '-' -f1)"
-    echo "$available_pkgs" | grep -E "linux-image-extra-${kernel_version}.*" | head -n1
 }
 
 pkg_dependencies_ubuntu_core(){

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -13,7 +13,6 @@ prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
-    fi
 
 environment:
     DIRECTORY/ssl: /etc/ssl

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -13,18 +13,9 @@ prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
-    # Arch does not use /etc/alternatives
-    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
-        mkdir /etc/alternatives
-    fi
-restore: |
-    # Arch does not use /etc/alternatives
-    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
-        rmdir /etc/alternatives
     fi
 
 environment:
-    DIRECTORY/alternatives: /etc/alternatives
     DIRECTORY/ssl: /etc/ssl
 execute: |
     #shellcheck source=tests/lib/dirs.sh


### PR DESCRIPTION
This cherry-picks a bunch of test fixes from master back into 2.35 to ensure the tests run cleanly.