### PR TITLE
image: handle errors when downloadedSnapsInfoForBootConfig has no data

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -573,6 +573,9 @@ func setBootvars(downloadedSnapsInfoForBootConfig map[string]*snap.Info, model *
 		bootvar := ""
 
 		info := downloadedSnapsInfoForBootConfig[fn]
+		if info == nil {
+			return fmt.Errorf("cannot get download info for snap %s", fn)
+		}
 		switch info.Type {
 		case snap.TypeOS, snap.TypeBase:
 			bootvar = "snap_core"

--- a/image/image.go
+++ b/image/image.go
@@ -574,7 +574,13 @@ func setBootvars(downloadedSnapsInfoForBootConfig map[string]*snap.Info, model *
 
 		info := downloadedSnapsInfoForBootConfig[fn]
 		if info == nil {
-			return fmt.Errorf("cannot get download info for snap %s", fn)
+			// this should never happen, if it does print some
+			// debug info
+			keys := make([]string, 0, len(downloadedSnapsInfoForBootConfig))
+			for k := range downloadedSnapsInfoForBootConfig {
+				keys = append(keys, k)
+			}
+			return fmt.Errorf("cannot get download info for snap %s, available infos: %v", fn, keys)
 		}
 		switch info.Type {
 		case snap.TypeOS, snap.TypeBase:


### PR DESCRIPTION
Tiny drive-by PR - the current code assumes we always get an info pointer from downloadedSnapsInfoForBootConfig but this may not be the case under some circumstances. Instead of panicing return a proper error.