### PR TITLE
 snap-confine: map /var/lib/extrausers into snaps mount-namespace 

### DIFF
--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -275,6 +275,50 @@ static void test_sc_do_umount(gconstpointer snap_debug)
 	}
 }
 
+static bool missing_mount(struct sc_fault_state *state, void *ptr)
+{
+	errno = ENOENT;
+	return true;
+}
+
+static void test_sc_do_optional_mount_missing(void)
+{
+	sc_break("mount", missing_mount);
+	bool ok = sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
+	g_assert_false(ok);
+	sc_reset_faults();
+}
+
+static void test_sc_do_optional_mount_failure(gconstpointer snap_debug)
+{
+	if (g_test_subprocess()) {
+		sc_break("mount", broken_mount);
+		if (GPOINTER_TO_INT(snap_debug) == 1) {
+			g_setenv("SNAP_CONFINE_DEBUG", "1", true);
+		}
+		(void)sc_do_optional_mount("/foo", "/bar", "ext4", MS_RDONLY,
+					   NULL);
+
+		g_test_message("expected sc_do_mount not to return");
+		sc_reset_faults();
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	if (GPOINTER_TO_INT(snap_debug) == 0) {
+		g_test_trap_assert_stderr
+		    ("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+	} else {
+		/* with snap_debug the debug output hides the actual mount commands *but*
+		 * they are still shown if there was an error
+		 */
+		g_test_trap_assert_stderr
+		    ("DEBUG: performing operation: (disabled) use debug build to see details\n"
+		     "cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+	}
+}
+
 static void __attribute__ ((constructor)) init(void)
 {
 	g_test_add_func("/mount/sc_mount_opt2str", test_sc_mount_opt2str);
@@ -288,4 +332,12 @@ static void __attribute__ ((constructor)) init(void)
 			     GINT_TO_POINTER(1), test_sc_do_mount);
 	g_test_add_data_func("/mount/sc_do_umount_with_debug",
 			     GINT_TO_POINTER(1), test_sc_do_umount);
+	g_test_add_func("/mount/sc_do_optional_mount_missing",
+			test_sc_do_optional_mount_missing);
+	g_test_add_data_func("/mount/sc_do_optional_mount_failure",
+			     GINT_TO_POINTER(0),
+			     test_sc_do_optional_mount_failure);
+	g_test_add_data_func("/mount/sc_do_optional_mount_failure_with_debug",
+			     GINT_TO_POINTER(1),
+			     test_sc_do_optional_mount_failure);
 }

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -256,9 +256,10 @@ static const char *use_debug_build =
     "(disabled) use debug build to see details";
 #endif
 
-void sc_do_mount(const char *source, const char *target,
-		 const char *fs_type, unsigned long mountflags,
-		 const void *data)
+static bool sc_do_mount_ex(const char *source, const char *target,
+			   const char *fs_type,
+			   unsigned long mountflags, const void *data,
+			   bool optional)
 {
 	char buf[10000] = { 0 };
 	const char *mount_cmd = NULL;
@@ -274,9 +275,11 @@ void sc_do_mount(const char *source, const char *target,
 	}
 	if (sc_faulty("mount", NULL)
 	    || mount(source, target, fs_type, mountflags, data) < 0) {
-		// Save errno as ensure can clobber it.
 		int saved_errno = errno;
-
+		if (optional && saved_errno == ENOENT) {
+			// The special-cased value that is allowed to fail.
+			return false;
+		}
 		// Drop privileges so that we can compute our nice error message
 		// without risking an attack on one of the string functions there.
 		sc_privs_drop();
@@ -288,6 +291,21 @@ void sc_do_mount(const char *source, const char *target,
 		errno = saved_errno;
 		die("cannot perform operation: %s", mount_cmd);
 	}
+	return true;
+}
+
+void sc_do_mount(const char *source, const char *target,
+		 const char *fs_type, unsigned long mountflags,
+		 const void *data)
+{
+	(void)sc_do_mount_ex(source, target, fs_type, mountflags, data, false);
+}
+
+bool sc_do_optional_mount(const char *source, const char *target,
+			  const char *fs_type, unsigned long mountflags,
+			  const void *data)
+{
+	return sc_do_mount_ex(source, target, fs_type, mountflags, data, true);
 }
 
 void sc_do_umount(const char *target, int flags)

--- a/cmd/libsnap-confine-private/mount-opt.h
+++ b/cmd/libsnap-confine-private/mount-opt.h
@@ -18,6 +18,7 @@
 #ifndef SNAP_CONFINE_MOUNT_OPT_H
 #define SNAP_CONFINE_MOUNT_OPT_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /**
@@ -66,6 +67,19 @@ const char *sc_umount_cmd(char *buf, size_t buf_size, const char *target,
 void sc_do_mount(const char *source, const char *target,
 		 const char *fs_type, unsigned long mountflags,
 		 const void *data);
+
+/**
+ * A thin wrapper around mount(2) with logging and error checks.
+ *
+ * This variant is allowed to silently fail when mount fails with ENOENT.
+ * That is, it can be used to perform mount operations and if either the source
+ * or the destination is not present, carry on as if nothing had happened.
+ *
+ * The return value indicates if the operation was successful or not.
+ **/
+bool sc_do_optional_mount(const char *source, const char *target,
+			  const char *fs_type, unsigned long mountflags,
+			  const void *data);
 
 /**
  * A thin wrapper around umount(2) with logging and error checks.

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -202,6 +202,9 @@ struct sc_mount {
 	// Alternate path defines the rbind mount "alternative" of path.
 	// It exists so that we can make /media on systems that use /run/media.
 	const char *altpath;
+	// Optional mount points are not processed unless the source and
+	// destination both exist.
+	bool is_optional;
 };
 
 struct sc_mount_config {
@@ -301,7 +304,17 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		}
 		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
 				 mnt->path);
-		sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
+		if (mnt->is_optional) {
+			bool ok = sc_do_optional_mount(mnt->path, dst, NULL,
+						       MS_REC | MS_BIND, NULL);
+			if (!ok) {
+				// If we cannot mount it, just continue.
+				continue;
+			}
+		} else {
+			sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND,
+				    NULL);
+		}
 		if (!mnt->is_bidirectional) {
 			// Mount events will only propagate inwards to the namespace. This
 			// way the running application cannot alter any global state apart
@@ -638,6 +651,10 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/media", true},	// access to the users removable devices
 #endif				// MERGED_USR
 			{"/run/netns", true},	// access to the 'ip netns' network namespaces
+			// The /mnt directory is optional in base snaps to ensure backwards
+			// compatibility with the first version of base snaps that was
+			// released.
+			{"/mnt",.is_optional = true},	// to support the removable-media interface
 			{},
 		};
 		char rootfs_dir[PATH_MAX] = { 0 };

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -655,6 +655,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			// compatibility with the first version of base snaps that was
 			// released.
 			{"/mnt",.is_optional = true},	// to support the removable-media interface
+			{"/var/lib/extrausers",.is_optional = true},	// access to UID/GID of extrausers (if available)
 			{},
 		};
 		char rootfs_dir[PATH_MAX] = { 0 };

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -187,6 +187,9 @@
     mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/usr/src/,
 
+    mount options=(rw rbind) /mnt/ -> /tmp/snap.rootfs_*/mnt/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/mnt/,
+
     # allow making host snap-exec available inside base snaps
     mount options=(rw bind) @LIBEXECDIR@/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -178,6 +178,9 @@
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/run/,
 
+    mount options=(rw rbind) /var/lib/extrausers/ -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+
     mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/modules/ -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
 

--- a/interfaces/builtin/removable_media.go
+++ b/interfaces/builtin/removable_media.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -42,6 +42,11 @@ const removableMediaConnectedPlugAppArmor = `
 # Mount points could be in /run/media/<user>/* or /media/<user>/*
 /{,run/}media/*/ r,
 /{,run/}media/*/** rwk,
+
+# Allow read-only access to /mnt to enumerate items.
+/mnt/ r,
+# Allow write access to anything under /mnt
+/mnt/** rwk,
 `
 
 func init() {

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -87,6 +87,7 @@ func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.other"})
 	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.other"), testutil.Contains, "/{,run/}media/*/ r")
+	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.other"), testutil.Contains, "/mnt/** rwk,")
 }
 
 func (s *RemovableMediaInterfaceSuite) TestInterfaces(c *C) {

--- a/tests/core18/basic/task.yaml
+++ b/tests/core18/basic/task.yaml
@@ -20,3 +20,6 @@ execute: |
         echo "The build-id of snapd must not be empty."
         exit 1
     fi
+
+    echo "Ensure passwd/group is available for snaps"
+    test-snapd-tools-core18.cat /var/lib/extrausers/passwd | MATCH test

--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -22,6 +22,10 @@ prepare: |
     mkdir -p /run/media/testdir
     touch /run/media/testdir/testfile
 
+    echo "Mount a filesystem in /tmp/testing and put some data there"
+    mkdir -p /mnt/testing/
+    mount -t tmpfs none /mnt/testing
+    echo canary > /mnt/testing/data
 
 restore: |
     rm -f call.error
@@ -36,6 +40,9 @@ restore: |
     if [ -f /run/media/fake ]; then
         rm -rf /run/media/
     fi
+
+    umount /mnt/testing
+    rmdir /mnt/testing || true # in case the user had /mnt/testing
 
 execute: |
     echo "The interface is not connected by default"
@@ -56,6 +63,11 @@ execute: |
     test-snapd-removable-media.sh -c "ls /run/media/testdir"
     test-snapd-removable-media.sh -c "echo test >> /run/media/testdir/testfile"
 
+    echo "And the snap has read-write access to /mnt/testing/data"
+    test-snapd-removable-media.sh -c 'cat /mnt/testing/data' | MATCH canary
+    test-snapd-removable-media.sh -c 'echo modified > /mnt/testing/data'
+    MATCH modified < /mnt/testing/data
+
     if [ "$(snap debug confinement)" = partial ]; then
         exit 0
     fi
@@ -69,3 +81,8 @@ execute: |
         exit 1
     fi
     MATCH "Permission denied" < call.error
+
+    echo "Then /mnt/testing/data is no longer readable"
+    if test-snapd-removable-media.sh -c 'cat /mnt/testing/data'; then
+        echo "/mnt/testing/data should no longer be readable" && exit 1
+    fi


### PR DESCRIPTION
This is #5692 and its prerequisite commit for 2.35. This fixes a bug that field engineering reported.