### PR TITLE
wrappers: remove Wants=network-online.target

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -131,7 +131,7 @@ const (
 	ServicesTarget = "multi-user.target"
 
 	// the target prerequisite for systemd units we generate
-	PrerequisiteTarget = "network-online.target"
+	PrerequisiteTarget = "network.target"
 
 	// the default target for systemd socket units that we generate
 	SocketsTarget = "sockets.target"

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -46,8 +46,8 @@ const expectedServiceFmt = `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network-online.target
-After=%s-snap-44.mount network-online.target
+Wants=network.target
+After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]
@@ -80,8 +80,8 @@ var (
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application xkcd-webserver.xkcd-webserver
 Requires=%s-xkcd\x2dwebserver-44.mount
-Wants=network-online.target
-After=%s-xkcd\x2dwebserver-44.mount network-online.target
+Wants=network.target
+After=%s-xkcd\x2dwebserver-44.mount network.target
 X-Snappy=yes
 
 [Service]
@@ -280,8 +280,8 @@ func (s *servicesWrapperGenSuite) TestServiceAfterBefore(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network-online.target
-After=%s-snap-44.mount network-online.target snap.snap.bar.service snap.snap.zed.service
+Wants=network.target
+After=%s-snap-44.mount network.target snap.snap.bar.service snap.snap.zed.service
 Before=snap.snap.foo.service
 X-Snappy=yes
 
@@ -404,8 +404,8 @@ func (s *servicesWrapperGenSuite) TestServiceTimerServiceUnit(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network-online.target
-After=%s-snap-44.mount network-online.target
+Wants=network.target
+After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]
@@ -564,8 +564,8 @@ func (s *servicesWrapperGenSuite) TestKillModeSig(c *C) {
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
-Wants=network-online.target
-After=%s-snap-44.mount network-online.target
+Wants=network.target
+After=%s-snap-44.mount network.target
 X-Snappy=yes
 
 [Service]


### PR DESCRIPTION
When generating units we always and unconditionally pull in
Wants=network-online.target currently. However as reported in

    https://forum.snapcraft.io/t/6063

this will slow down service startup by 2 minutes if any of the
network interfaces is not ready. Instead this PR changes it to
the network.target which is less strict and only means that the
systems network stack is up (and conversely that services should
be stopped before the network is stopped).

Note that this change exiting behaviour and might break existing
snaps. However arguable those are already broken because the
network may go up and down so network-online is not a good
gurantee for something that the software itself should deal
with.
