### PR TITLE
cmd/snap: bring back 'snap version'

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -22,7 +22,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/i18n"
 
@@ -51,16 +50,7 @@ func (cmd cmdVersion) Execute(args []string) error {
 }
 
 func printVersions() error {
-	sv, err := Client().ServerVersion()
-	if err != nil {
-		sv = &client.ServerVersion{
-			Version:     i18n.G("unavailable"),
-			Series:      "-",
-			OSID:        "-",
-			OSVersionID: "-",
-		}
-	}
-
+	sv := serverVersion()
 	w := tabWriter()
 
 	fmt.Fprintf(w, "snap\t%s\n", cmd.Version)
@@ -77,5 +67,5 @@ func printVersions() error {
 	}
 	w.Flush()
 
-	return err
+	return nil
 }

--- a/cmd/snap/cmd_version_linux.go
+++ b/cmd/snap/cmd_version_linux.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+)
+
+func serverVersion() *client.ServerVersion {
+	sv, err := Client().ServerVersion()
+
+	if err != nil {
+		sv = &client.ServerVersion{
+			Version:     i18n.G("unavailable"),
+			Series:      "-",
+			OSID:        "-",
+			OSVersionID: "-",
+		}
+	}
+	return sv
+}

--- a/cmd/snap/cmd_version_other.go
+++ b/cmd/snap/cmd_version_other.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !linux
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
+)
+
+func serverVersion() *client.ServerVersion {
+	return &client.ServerVersion{
+		Version:       i18n.G("unavailable"),
+		Series:        release.Series,
+		OSID:          runtime.GOOS,
+		OnClassic:     true,
+		KernelVersion: fmt.Sprintf("%s (%s)", osutil.KernelVersion(), runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
With the changes introduced in 97ecb36cde81129f8c690988d7e3fab5aa2ea1de
`snap version` would print an error message, just like any other command
that tried to talk to snapd itself:

    $ snap version
    Interacting with snapd is not yet supported on darwin.
    This command has been left available for documentation purposes only.

this is unfortunate, as we actually could use this output to help users. So
this change brings it back:

    $ snap version
    snap     2.34+git209.g9c5287393.dirty
    snapd    unavailable
    series   16
    CP/M-86  -
    kernel   2.11 (386)
