### PR TITLE
prepare-image-grub-core18: remove image root in restore

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -329,6 +329,9 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 	if osutil.FileExists(dirs.SnapStateFile) {
 		return fmt.Errorf("cannot bootstrap over existing system")
 	}
+	if snaps, _ := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*.snap")); len(snaps) > 0 {
+		return fmt.Errorf("need an empty snap dir in rootdir, got: %v", snaps)
+	}
 
 	// TODO: developer database in home or use snapd (but need
 	// a bit more API there, potential issues when crossing stores/series)

--- a/tests/main/prepare-image-grub-core18/task.yaml
+++ b/tests/main/prepare-image-grub-core18/task.yaml
@@ -9,6 +9,9 @@ environment:
     IMAGE: /tmp/root/image
     GADGET: /tmp/root/gadget
 
+restore: |
+    rm -rf "$ROOT"
+    
 execute: |
     echo Running prepare-image
     su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/ubuntu-core-18-amd64.model $ROOT" test


### PR DESCRIPTION
This will fix the sporadic image issues we see in the tests.