### PR TITLE
snapcraft: do not use --dirty in mkversion (because LP:#1662388)

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -41,7 +41,9 @@ fi
 if [ -z "$v" ]; then
     # Let's try to derive the version from git..
     if command -v git >/dev/null; then
-        v="$(git describe --dirty --always | sed -e 's/-/+git/;y/-/./' )"
+        # not using "--dirty" here until the following bug is fixed:
+        # https://bugs.launchpad.net/snapcraft/+bug/1662388
+        v="$(git describe --always | sed -e 's/-/+git/;y/-/./' )"
         o=git
     fi
 fi


### PR DESCRIPTION
When running the snapd snap and using `snap version` the output
will currently show a version string with ".dirty" appended.

The reason for this is that snapcraft modifies the git tree
during building, see:
 https://bugs.launchpad.net/snapcraft/+bug/1662388

Until this bug is fixed we will need to generate the version
without the --dirty flag.
