### PR TITLE
interfaces/modem-manager: allow access to more USB strings

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -67,7 +67,7 @@ capability sys_admin,
 
 # For {mbim,qmi}-proxy
 unix (bind, listen) type=stream addr="@{mbim,qmi}-proxy",
-/sys/devices/**/usb**/descriptors r,
+/sys/devices/**/usb**/{descriptors,manufacturer,product} r,
 # See https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net-qmi
 /sys/devices/**/net/*/qmi/* rw,
 


### PR DESCRIPTION
Allow access to manufacturer and product USB strings.