### PR TITLE
cmd/snap-update-ns: don't trespass on host filesystem in /etc and other places

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -104,13 +104,14 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	// TODO: re-factor this, if possible, with inspection and preemptive
 	// creation after the current release ships. This should be possible but
 	// will affect tests heavily (churn, not safe before release).
+	rs := nil
 	switch kind {
 	case "":
-		err = sec.MkdirAll(path, mode, uid, gid)
+		err = MkdirAll(path, mode, uid, gid, rs)
 	case "file":
-		err = sec.MkfileAll(path, mode, uid, gid)
+		err = MkfileAll(path, mode, uid, gid, rs)
 	case "symlink":
-		err = sec.MksymlinkAll(path, mode, uid, gid, c.Entry.XSnapdSymlink())
+		err = MksymlinkAll(path, mode, uid, gid, c.Entry.XSnapdSymlink(), rs)
 	}
 	if needsMimic, mimicPath := mimicRequired(err); needsMimic && pokeHoles {
 		// If the error can be recovered by using a writable mimic

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -291,7 +291,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
 			// Use Secure.BindMount for bind mounts
 			if flags&syscall.MS_BIND == syscall.MS_BIND {
-				err = sec.BindMount(c.Entry.Name, c.Entry.Dir, uint(flags))
+				err = BindMount(c.Entry.Name, c.Entry.Dir, uint(flags))
 			} else {
 				err = sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","))
 			}

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -64,7 +64,7 @@ func (c Change) String() string {
 }
 
 // changePerform is Change.Perform that can be mocked for testing.
-var changePerform func(*Change, *Secure) ([]*Change, error)
+var changePerform func(*Change, *Assumptions) ([]*Change, error)
 
 // mimicRequired provides information if an error warrants a writable mimic.
 //
@@ -81,7 +81,7 @@ func mimicRequired(err error) (needsMimic bool, path string) {
 	return false, ""
 }
 
-func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change, error) {
+func (c *Change) createPath(path string, pokeHoles bool, as *Assumptions) ([]*Change, error) {
 	// If we've been asked to create a missing path, and the mount
 	// entry uses the ignore-missing option, return an error.
 	if c.Entry.XSnapdIgnoreMissing() {
@@ -107,7 +107,7 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	// TODO: re-factor this, if possible, with inspection and preemptive
 	// creation after the current release ships. This should be possible but
 	// will affect tests heavily (churn, not safe before release).
-	rs := sec.RestrictionsFor(path)
+	rs := as.RestrictionsFor(path)
 	switch kind {
 	case "":
 		err = MkdirAll(path, mode, uid, gid, rs)
@@ -119,19 +119,19 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	if needsMimic, mimicPath := mimicRequired(err); needsMimic && pokeHoles {
 		// If the error can be recovered by using a writable mimic
 		// then construct one and try again.
-		changes, err = createWritableMimic(mimicPath, path, sec)
+		changes, err = createWritableMimic(mimicPath, path, as)
 		if err != nil {
 			err = fmt.Errorf("cannot create writable mimic over %q: %s", mimicPath, err)
 		} else {
 			// Try once again. Note that we care *just* about the error. We have already
 			// performed the hole poking and thus additional changes must be nil.
-			_, err = c.createPath(path, false, sec)
+			_, err = c.createPath(path, false, as)
 		}
 	}
 	return changes, err
 }
 
-func (c *Change) ensureTarget(sec *Secure) ([]*Change, error) {
+func (c *Change) ensureTarget(as *Assumptions) ([]*Change, error) {
 	var changes []*Change
 
 	kind := c.Entry.XSnapdKind()
@@ -160,13 +160,13 @@ func (c *Change) ensureTarget(sec *Secure) ([]*Change, error) {
 		case "symlink":
 			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 				// Create path verifies the symlink or fails if it is not what we wanted.
-				_, err = c.createPath(path, false, sec)
+				_, err = c.createPath(path, false, as)
 			} else {
 				err = fmt.Errorf("cannot create symlink in %q: existing file in the way", path)
 			}
 		}
 	} else if os.IsNotExist(err) {
-		changes, err = c.createPath(path, true, sec)
+		changes, err = c.createPath(path, true, as)
 	} else {
 		// If we cannot inspect the element let's just bail out.
 		err = fmt.Errorf("cannot inspect %q: %v", path, err)
@@ -174,7 +174,7 @@ func (c *Change) ensureTarget(sec *Secure) ([]*Change, error) {
 	return changes, err
 }
 
-func (c *Change) ensureSource(sec *Secure) ([]*Change, error) {
+func (c *Change) ensureSource(as *Assumptions) ([]*Change, error) {
 	var changes []*Change
 
 	// We only have to do ensure bind mount source exists.
@@ -215,7 +215,7 @@ func (c *Change) ensureSource(sec *Secure) ([]*Change, error) {
 		// snap they apply to. As such they are useless for content sharing but
 		// very much useful to layouts.
 		pokeHoles := c.Entry.XSnapdOrigin() == "layout"
-		changes, err = c.createPath(path, pokeHoles, sec)
+		changes, err = c.createPath(path, pokeHoles, as)
 	} else {
 		// If we cannot inspect the element let's just bail out.
 		err = fmt.Errorf("cannot inspect %q: %v", path, err)
@@ -225,7 +225,7 @@ func (c *Change) ensureSource(sec *Secure) ([]*Change, error) {
 }
 
 // changePerformImpl is the real implementation of Change.Perform
-func changePerformImpl(c *Change, sec *Secure) (changes []*Change, err error) {
+func changePerformImpl(c *Change, as *Assumptions) (changes []*Change, err error) {
 	if c.Action == Mount {
 		var changesSource, changesTarget []*Change
 		// We may be asked to bind mount a file, bind mount a directory, mount
@@ -236,7 +236,7 @@ func changePerformImpl(c *Change, sec *Secure) (changes []*Change, err error) {
 		// As a result of this ensure call we may need to make the medium writable
 		// and that's why we may return more changes as a result of performing this
 		// one.
-		changesTarget, err = c.ensureTarget(sec)
+		changesTarget, err = c.ensureTarget(as)
 		// NOTE: we are collecting changes even if things fail. This is so that
 		// upper layers can perform undo correctly.
 		changes = append(changes, changesTarget...)
@@ -250,7 +250,7 @@ func changePerformImpl(c *Change, sec *Secure) (changes []*Change, err error) {
 		// This property holds as long as we don't interact with locations that
 		// are under the control of regular (non-snap) processes that are not
 		// suspended and may be racing with us.
-		changesSource, err = c.ensureSource(sec)
+		changesSource, err = c.ensureSource(as)
 		// NOTE: we are collecting changes even if things fail. This is so that
 		// upper layers can perform undo correctly.
 		changes = append(changes, changesSource...)
@@ -260,7 +260,7 @@ func changePerformImpl(c *Change, sec *Secure) (changes []*Change, err error) {
 	}
 
 	// Perform the underlying mount / unmount / unlink call.
-	err = c.lowLevelPerform(sec)
+	err = c.lowLevelPerform(as)
 	return changes, err
 }
 
@@ -274,12 +274,12 @@ func init() {
 //
 // Perform may synthesize *additional* changes that were necessary to perform
 // this change (such as mounted tmpfs or overlayfs).
-func (c *Change) Perform(sec *Secure) ([]*Change, error) {
-	return changePerform(c, sec)
+func (c *Change) Perform(as *Assumptions) ([]*Change, error) {
+	return changePerform(c, as)
 }
 
 // lowLevelPerform is simple bridge from Change to mount / unmount syscall.
-func (c *Change) lowLevelPerform(sec *Secure) error {
+func (c *Change) lowLevelPerform(as *Assumptions) error {
 	var err error
 	switch c.Action {
 	case Mount:
@@ -297,7 +297,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 			}
 			logger.Debugf("mount %q %q %q %d %q (error: %v)", c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","), err)
 			if err == nil {
-				sec.AddChange(c)
+				as.AddChange(c)
 			}
 		}
 		return err
@@ -314,7 +314,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 			}
 			err = sysUnmount(c.Entry.Dir, flags)
 			if err == nil {
-				sec.AddChange(c)
+				as.AddChange(c)
 			}
 			logger.Debugf("umount %q (error: %v)", c.Entry.Dir, err)
 		}

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -74,6 +74,9 @@ func mimicRequired(err error) (needsMimic bool, path string) {
 	case *ReadOnlyFsError:
 		rofsErr := err.(*ReadOnlyFsError)
 		return true, rofsErr.Path
+	case *TrespassingError:
+		tErr := err.(*TrespassingError)
+		return true, tErr.ViolatedPath
 	}
 	return false, ""
 }
@@ -104,7 +107,7 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	// TODO: re-factor this, if possible, with inspection and preemptive
 	// creation after the current release ships. This should be possible but
 	// will affect tests heavily (churn, not safe before release).
-	rs := nil
+	rs := sec.RestrictionsFor(path)
 	switch kind {
 	case "":
 		err = MkdirAll(path, mode, uid, gid, rs)

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -293,6 +293,9 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 				err = sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","))
 			}
 			logger.Debugf("mount %q %q %q %d %q (error: %v)", c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","), err)
+			if err == nil {
+				sec.AddChange(c)
+			}
 		}
 		return err
 	case Unmount:
@@ -307,6 +310,9 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 				flags |= syscall.MNT_DETACH
 			}
 			err = sysUnmount(c.Entry.Dir, flags)
+			if err == nil {
+				sec.AddChange(c)
+			}
 			logger.Debugf("umount %q (error: %v)", c.Entry.Dir, err)
 		}
 		return err

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -286,7 +286,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 		kind := c.Entry.XSnapdKind()
 		switch kind {
 		case "symlink":
-			// symlinks are handled in createInode directly, nothing to do here.
+			// symlinks are handled in createPath directly, nothing to do here.
 		case "", "file":
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
 			// Use Secure.BindMount for bind mounts

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -353,6 +353,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithError(c *C) {
 
 // Change.Perform wants to mount a filesystem but the mount point isn't there.
 func (s *changeSuite) TestPerformFilesystemMountWithoutMountPoint(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "device", Dir: "/target", Type: "type"}}
 	synth, err := chg.Perform(s.sec)
@@ -372,6 +373,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPoint(c *C) {
 
 // Change.Perform wants to create a filesystem but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointWithErrors(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "target" 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "device", Dir: "/target", Type: "type"}}
@@ -388,6 +390,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointWithErrors(c *C
 
 // Change.Perform wants to mount a filesystem but the mount point isn't there and the parent is read-only.
 func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/rofs/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, syscall.ENOENT, nil) // works on 2nd try
@@ -478,6 +481,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 
 // Change.Perform wants to mount a filesystem but the mount point isn't there and the parent is read-only and mimic fails during planning.
 func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBaseErrorWhilePlanning(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/rofs/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, syscall.ENOENT)
@@ -513,6 +517,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 
 // Change.Perform wants to mount a filesystem but the mount point isn't there and the parent is read-only and mimic fails during execution.
 func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBaseErrorWhileExecuting(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/rofs/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, syscall.ENOENT)
@@ -725,6 +730,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithError(c *C) {
 
 // Change.Perform wants to bind mount a directory but the mount point isn't there.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPoint(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir)
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
@@ -758,6 +764,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPoint(c *C) {
 
 // Change.Perform wants to bind mount a directory but the mount source isn't there.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSource(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/source"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
 	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
@@ -791,6 +798,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSource(c *C) {
 
 // Change.Perform wants to create a directory bind mount but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointWithErrors(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "target" 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
@@ -807,6 +815,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointWithErrors(c
 
 // Change.Perform wants to create a directory bind mount but the mount source isn't there and cannot be created.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceWithErrors(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/source"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "source" 0755`, errTesting)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
@@ -825,6 +834,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceWithErrors(
 
 // Change.Perform wants to bind mount a directory but the mount point isn't there and the parent is read-only.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyBase(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/rofs/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, syscall.ENOENT, nil) // works on 2nd try
@@ -932,6 +942,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 
 // Change.Perform wants to bind mount a directory but the mount source isn't there and the parent is read-only.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnlyBase(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertOsLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
 	s.sys.InsertFault(`lstat "/rofs/source"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
@@ -956,6 +967,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnly
 
 // Change.Perform wants to bind mount a directory but the mount source isn't there and the parent is read-only but this is for a layout.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnlyBaseForLayout(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
 	s.sys.InsertFault(`lstat "/rofs/source"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
@@ -1219,6 +1231,7 @@ func (s *changeSuite) TestPerformFileBindMountWithError(c *C) {
 
 // Change.Perform wants to bind mount a file but the mount point isn't there.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountPoint(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile)
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
@@ -1251,6 +1264,7 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPoint(c *C) {
 
 // Change.Perform wants to create a directory bind mount but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountPointWithErrors(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
@@ -1267,6 +1281,7 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointWithErrors(c *C) 
 
 // Change.Perform wants to bind mount a file but the mount source isn't there.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountSource(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/source"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoFile)
 	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
@@ -1299,6 +1314,7 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountSource(c *C) {
 
 // Change.Perform wants to create a file bind mount but the mount source isn't there and cannot be created.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountSourceWithErrors(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/source"`, syscall.ENOENT)
 	s.sys.InsertFault(`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, errTesting)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoFile)
@@ -1317,6 +1333,7 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountSourceWithErrors(c *C)
 
 // Change.Perform wants to bind mount a file but the mount point isn't there and the parent is read-only.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/rofs/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, syscall.EROFS, nil) // works on 2nd try
@@ -1541,6 +1558,7 @@ func (s *changeSuite) TestPerformCreateSymlinkNameLstatError(c *C) {
 
 // Change.Perform wants to create a symlink.
 func (s *changeSuite) TestPerformCreateSymlink(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/name"`, syscall.ENOENT)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform(s.sec)
@@ -1556,6 +1574,7 @@ func (s *changeSuite) TestPerformCreateSymlink(c *C) {
 
 // Change.Perform wants to create a symlink but it fails.
 func (s *changeSuite) TestPerformCreateSymlinkWithError(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/name"`, syscall.ENOENT)
 	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
@@ -1584,6 +1603,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithNoTargetError(c *C) {
 
 // Change.Perform wants to create a symlink but the base directory isn't there.
 func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDir(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/base/name"`, syscall.ENOENT)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/base/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform(s.sec)
@@ -1603,6 +1623,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDir(c *C) {
 
 // Change.Perform wants to create a symlink but the base directory isn't there and cannot be created.
 func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirWithErrors(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/base/name"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "base" 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/base/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
@@ -1619,6 +1640,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirWithErrors(c *C) {
 
 // Change.Perform wants to create a symlink but the base directory isn't there and the parent is read-only.
 func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertFault(`lstat "/rofs/name"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`symlinkat "/oldname" 4 "name"`, syscall.EROFS, nil) // works on 2nd try
@@ -1716,6 +1738,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithFileInTheWay(c *C) {
 
 // Change.Perform wants to create a symlink but a correct symlink is already present.
 func (s *changeSuite) TestPerformCreateSymlinkWithGoodSymlinkPresent(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertOsLstatResult(`lstat "/name"`, testutil.FileInfoSymlink)
 	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, syscall.EEXIST)
 	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Mode: syscall.S_IFLNK})
@@ -1738,6 +1761,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithGoodSymlinkPresent(c *C) {
 
 // Change.Perform wants to create a symlink but a incorrect symlink is already present.
 func (s *changeSuite) TestPerformCreateSymlinkWithBadSymlinkPresent(c *C) {
+	defer s.sec.MockUnrestrictedPrefixes("/")() // Treat test path as unrestricted.
 	s.sys.InsertOsLstatResult(`lstat "/name"`, testutil.FileInfoSymlink)
 	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, syscall.EEXIST)
 	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Mode: syscall.S_IFLNK})

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -142,7 +142,7 @@ func FreezerCgroupDir() string {
 	return freezerCgroupDir
 }
 
-func MockChangePerform(f func(chg *Change, sec *Secure) ([]*Change, error)) func() {
+func MockChangePerform(f func(chg *Change, as *Assumptions) ([]*Change, error)) func() {
 	origChangePerform := changePerform
 	changePerform = f
 	return func() {

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -151,6 +151,10 @@ func computeAndSaveChanges(snapName string, sec *Secure) error {
 		return fmt.Errorf("cannot load current mount profile of snap %q: %s", snapName, err)
 	}
 	debugShowProfile(currentBefore, "current mount profile (before applying changes)")
+	// Synthesize mount changes that were applied before for the purpose of the tmpfs detector.
+	for _, entry := range currentBefore.Entries {
+		sec.AddChange(&Change{Action: Mount, Entry: entry})
+	}
 
 	currentAfter, err := applyProfile(snapName, currentBefore, desired, sec)
 	if err != nil {

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -128,9 +128,28 @@ func applyFstab(snapName string, fromSnapConfine bool) error {
 		thawSnapProcesses(opts.Positionals.SnapName)
 	}()
 
-	// TODO: configure the secure helper and inform it about directories that
-	// can be created without trespassing.
+	// Allow creating directories related to this snap name.
+	//
+	// Note that we allow /var/snap instead of /var/snap/$SNAP_NAME because
+	// content interface connections can readily create missing mount points on
+	// both sides of the interface connection.
+	//
+	// We scope /snap/$SNAP_NAME because only one side of the connection can be
+	// created, as snaps are read-only, the mimic construction will kick-in and
+	// create the missing directory but this directory is only visible from the
+	// snap that we are operating on (either plug or slot side, the point is,
+	// the mount point is not universally visible).
+	//
+	// /snap/$SNAP_NAME needs to be there as the code that creates such mount
+	// points must traverse writable host filesystem that contains /snap/*/ and
+	// normally such access is off-limits. This approach allows /snap/foo
+	// without allowing /snap/bin, for example.
+
+	// TODO: Handle /home/*/snap/* when we do per-user mount namespaces and
+	// allow defining layout items that refer to SNAP_USER_DATA and
+	// SNAP_USER_COMMON.
 	sec := &Secure{}
+	sec.AddUnrestrictedPrefixes("/tmp", "/var/snap", "/snap/"+snapName)
 	return computeAndSaveChanges(snapName, sec)
 }
 

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -40,7 +40,7 @@ func Test(t *testing.T) { TestingT(t) }
 
 type mainSuite struct {
 	testutil.BaseTest
-	sec *update.Secure
+	as  *update.Assumptions
 	log *bytes.Buffer
 }
 
@@ -48,7 +48,7 @@ var _ = Suite(&mainSuite{})
 
 func (s *mainSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.sec = &update.Secure{}
+	s.as = &update.Assumptions{}
 	buf, restore := logger.MockLogger()
 	s.BaseTest.AddCleanup(restore)
 	s.log = buf
@@ -58,7 +58,7 @@ func (s *mainSuite) TestComputeAndSaveChanges(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		return nil, nil
 	})
 	defer restore()
@@ -79,7 +79,7 @@ func (s *mainSuite) TestComputeAndSaveChanges(c *C) {
 	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	err = update.ComputeAndSaveChanges(snapName, s.sec)
+	err = update.ComputeAndSaveChanges(snapName, s.as)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -114,7 +114,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	// represented here. The changes have only one goal: tell
 	// snap-update-ns how the mimic can be undone in case it is no longer
 	// needed.
-	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		// The change that we were asked to perform is to create a bind mount
 		// from within the snap to /usr/share/mysnap.
 		c.Assert(chg, DeepEquals, &update.Change{
@@ -146,7 +146,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	c.Assert(update.ComputeAndSaveChanges(snapName, s.sec), IsNil)
+	c.Assert(update.ComputeAndSaveChanges(snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -180,7 +180,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		n++
 		switch n {
 		case 0:
@@ -223,7 +223,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	c.Assert(update.ComputeAndSaveChanges(snapName, s.sec), IsNil)
+	c.Assert(update.ComputeAndSaveChanges(snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -245,7 +245,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		n++
 		switch n {
 		case 0:
@@ -265,7 +265,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	c.Assert(update.ComputeAndSaveChanges(snapName, s.sec), ErrorMatches, "testing")
+	c.Assert(update.ComputeAndSaveChanges(snapName, s.as), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -287,7 +287,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		n++
 		switch n {
 		case 0:
@@ -308,7 +308,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	defer restore()
 
 	// The error was ignored, and no mount was recorded in the profile
-	c.Assert(update.ComputeAndSaveChanges(snapName, s.sec), IsNil)
+	c.Assert(update.ComputeAndSaveChanges(snapName, s.as), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -318,7 +318,7 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	defer dirs.SetRootDir("/")
 
 	var changes []update.Change
-	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
 		changes = append(changes, *chg)
 		return nil, nil
 	})

--- a/cmd/snap-update-ns/secure.go
+++ b/cmd/snap-update-ns/secure.go
@@ -1,0 +1,184 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// Secure is a helper for making filesystem operations free from certain kinds of attacks.
+type Secure struct {
+	unrestrictedPrefixes []string
+	pastChanges          []*Change
+}
+
+// AddUnrestrictedPrefixes adds a list of directories where writing is allowed
+// even if it would hit the real host filesystem (or transit through the host
+// filesystem). This is intended to be used with certain well-known locations
+// such as /tmp, $SNAP_DATA and $SNAP.
+func (sec *Secure) AddUnrestrictedPrefixes(prefixes ...string) {
+	for _, prefix := range prefixes {
+		sec.unrestrictedPrefixes = append(sec.unrestrictedPrefixes, filepath.Clean(prefix)+"/")
+	}
+}
+
+// MockUnrestrictedPrefixes replaces the set of path prefixes without any restrictions.
+func (sec *Secure) MockUnrestrictedPrefixes(prefixes ...string) (restore func()) {
+	old := sec.unrestrictedPrefixes
+	sec.unrestrictedPrefixes = prefixes
+	return func() {
+		sec.unrestrictedPrefixes = old
+	}
+}
+
+// AddChange records the fact that a change was applied to the system.
+func (sec *Secure) AddChange(change *Change) {
+	sec.pastChanges = append(sec.pastChanges, change)
+}
+
+// isRestricted returns true if a path follows restricted writing scheme.
+//
+// Writing to a restricted path results in step-by-step validation of each
+// directory, starting from the root of the file system. Unless writing is
+// allowed a mimic must be constructed to ensure that writes are not visible in
+// undesired locations of the host filesystem.
+//
+// Provided path is the full, absolute path of the entity that needs to be
+// created (directory, file or symbolic link).
+func (sec *Secure) isRestricted(path string) bool {
+	// Anything rooted at one of the unrestricted prefixes is not restricted.
+	// Those are for things like /var/snap/, for example.
+	for _, prefix := range sec.unrestrictedPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return false
+		}
+	}
+	// All other paths are restricted
+	return true
+}
+
+// canWriteToDirectory returns true if writing to a given directory is allowed.
+//
+// Writing is allowed in one of thee cases:
+// 1) The directory is in one of the explicitly permitted locations.
+//    This is the strongest permission as it explicitly allows writing to
+//    places that may show up on the host, one of the examples being $SNAP_DATA.
+// 2) The directory is on a read-only filesystem.
+// 3) The directory is on a tmpfs created by snapd.
+func (sec *Secure) canWriteToDirectory(dirFd int, dirName string) (bool, error) {
+	if !sec.isRestricted(dirName) {
+		return true, nil
+	}
+	var fsData syscall.Statfs_t
+	if err := sysFstatfs(dirFd, &fsData); err != nil {
+		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
+	}
+	// Writing to read only directories is allowed because EROFS is handled
+	// by each of the writing helpers already.
+	if ok := IsReadOnly(dirFd, dirName, &fsData); ok {
+		return true, nil
+	}
+	// Writing to a trusted tmpfs is allowed because those are not leaking to
+	// the host.
+	if ok := IsSnapdCreatedPrivateTmpfs(dirFd, dirName, &fsData, sec.pastChanges); ok {
+		return true, nil
+	}
+	// If writing is not not allowed by one of the three rules above then it is
+	// disallowed.
+	return false, nil
+}
+
+// Restrictions contains meta-data of a compound write operation.
+//
+// This structure helps various functions that write to the filesystem to keep
+// track of the ultimate destination across several calls (e.g. the function
+// that creates a file needs to call helpers to create subsequent directories).
+// Keeping track of the desired path aids in constructing useful error messages.
+//
+// In addition the context keeps track of the restricted write mode flag which
+// is based on the full path of the desired object being constructed. This allows
+// various write helpers to avoid trespassing on host filesystem in places that
+// are not expected to be written to by snapd (e.g. outside of $SNAP_DATA).
+type Restrictions struct {
+	sec         *Secure
+	desiredPath string
+	restricted  bool
+}
+
+// RestrictionsFor computes restrictions for the desired path.
+func (sec *Secure) RestrictionsFor(desiredPath string) *Restrictions {
+	if sec.isRestricted(desiredPath) {
+		return &Restrictions{sec: sec, desiredPath: desiredPath, restricted: true}
+	}
+	return nil
+}
+
+// TrespassingError is an error when filesystem operation would affect the host.
+type TrespassingError struct {
+	ViolatedPath string
+	DesiredPath  string
+}
+
+// Error returns a formatted error message.
+func (e *TrespassingError) Error() string {
+	return fmt.Sprintf("cannot write to %q because it would affect the host in %q", e.DesiredPath, e.ViolatedPath)
+}
+
+// Check verifies if writing to a directory would trespass on the host.
+//
+// The check is only performed in restricted mode. If the check fails a
+// TrespassingError is returned.
+func (rs *Restrictions) Check(dirFd int, dirName string) error {
+	if rs == nil || !rs.restricted {
+		return nil
+	}
+	// In restricted mode check the directory before attempting to write to it.
+	ok, err := rs.sec.canWriteToDirectory(dirFd, dirName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if dirName == "/" {
+			// If writing to / is not allowed then we are in a tough spot
+			// because we cannot construct a writable mimic over /. This
+			// should never happen in normal circumstances because the root
+			// filesystem is some kind of base snap.
+			return fmt.Errorf("cannot recover from trespassing over /")
+		}
+		// If writing is not allowed then report a trespassing error.
+		// FIXME: we don't know the desired path here so the error is mildly unhelpful.
+		return &TrespassingError{ViolatedPath: dirName, DesiredPath: rs.desiredPath}
+	}
+	return nil
+}
+
+// LiftRestrictions lifts write restrictions for the desired path.
+//
+// This function should be called when, as subsequent components of a path are
+// either discovered or created, the conditions for using restricted mode are
+// no longer true.
+func (rs *Restrictions) LiftRestrictions() {
+	if rs != nil {
+		rs.restricted = false
+	}
+}

--- a/cmd/snap-update-ns/secure.go
+++ b/cmd/snap-update-ns/secure.go
@@ -166,7 +166,6 @@ func (rs *Restrictions) Check(dirFd int, dirName string) error {
 			return fmt.Errorf("cannot recover from trespassing over /")
 		}
 		// If writing is not allowed then report a trespassing error.
-		// FIXME: we don't know the desired path here so the error is mildly unhelpful.
 		return &TrespassingError{ViolatedPath: dirName, DesiredPath: rs.desiredPath}
 	}
 	return nil

--- a/cmd/snap-update-ns/secure_bindmount.go
+++ b/cmd/snap-update-ns/secure_bindmount.go
@@ -26,7 +26,7 @@ import (
 
 // BindMount performs a bind mount between two absolute paths containing no
 // symlinks.
-func (sec *Secure) BindMount(sourceDir, targetDir string, flags uint) error {
+func BindMount(sourceDir, targetDir string, flags uint) error {
 	// This function only attempts to handle bind mounts. Expanding to other
 	// mounts will require examining do_mount() from fs/namespace.c of the
 	// kernel that called functions (eventually) verify `DCACHE_CANT_MOUNT` is

--- a/cmd/snap-update-ns/secure_bindmount.go
+++ b/cmd/snap-update-ns/secure_bindmount.go
@@ -43,12 +43,12 @@ func (sec *Secure) BindMount(sourceDir, targetDir string, flags uint) error {
 
 	// Step 1: acquire file descriptors representing the source and destination
 	// directories, ensuring no symlinks are followed.
-	sourceFd, err := sec.OpenPath(sourceDir)
+	sourceFd, err := OpenPath(sourceDir)
 	if err != nil {
 		return err
 	}
 	defer sysClose(sourceFd)
-	targetFd, err := sec.OpenPath(targetDir)
+	targetFd, err := OpenPath(targetDir)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (sec *Secure) BindMount(sourceDir, targetDir string, flags uint) error {
 	if flags&syscall.MS_RDONLY != 0 {
 		// We need to look up the target directory a second time, because
 		// targetFd refers to the path shadowed by the mount point.
-		mountFd, err := sec.OpenPath(targetDir)
+		mountFd, err := OpenPath(targetDir)
 		if err != nil {
 			// FIXME: the mount occurred, but the user moved the target
 			// somewhere

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -73,21 +73,17 @@ var (
 //
 // Directories are read only when they reside on file systems mounted in read
 // only mode or when the underlying file system itself is inherently read only.
-func IsReadOnly(dirFd int, dirName string) (bool, error) {
-	var fsData syscall.Statfs_t
-	if err := sysFstatfs(dirFd, &fsData); err != nil {
-		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
-	}
+func IsReadOnly(dirFd int, dirName string, fsData *syscall.Statfs_t) bool {
 	// If something is mounted with f_flags & ST_RDONLY then is read-only.
 	if fsData.Flags&StReadOnly == StReadOnly {
-		return true, nil
+		return true
 	}
 	// If something is a known read-only file-system then it is safe.
 	// Older copies of snapd were not mounting squashfs as read only.
 	if fsData.Type == SquashfsMagic {
-		return true, nil
+		return true
 	}
-	return false, nil
+	return false
 }
 
 // IsSnapdCreatedPrivateTmpfs returns true if a directory is a tmpfs mounted by snapd.
@@ -97,14 +93,10 @@ func IsReadOnly(dirFd int, dirName string) (bool, error) {
 // the mount namespace. A directory is trusted if it is a tmpfs that was
 // mounted by snap-confine or snapd-update-ns. Note that sub-directories of a
 // trusted tmpfs are not considered trusted by this function.
-func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (bool, error) {
-	var fsData syscall.Statfs_t
-	if err := sysFstatfs(dirFd, &fsData); err != nil {
-		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
-	}
+func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, fsData *syscall.Statfs_t, changes []*Change) bool {
 	// If something is not a tmpfs it cannot be the trusted tmpfs we are looking for.
 	if fsData.Type != TmpfsMagic {
-		return false, nil
+		return false
 	}
 	// Any of the past changes that mounted a tmpfs exactly at the directory we
 	// are inspecting is considered as trusted. This is conservative because it
@@ -119,7 +111,7 @@ func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (b
 	for i := len(changes) - 1; i >= 0; i-- {
 		change := changes[i]
 		if change.Entry.Type == "tmpfs" && change.Entry.Dir == dirName {
-			return change.Action == Mount, nil
+			return change.Action == Mount
 		}
 	}
 	// TODO: As a special exception, assume that a tmpfs over /var/lib is
@@ -127,7 +119,7 @@ func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (b
 	// a particular behavior of LXD.  Once the quirk is migrated to a mount
 	// profile (or removed entirely if no longer necessary) the following code
 	// fragment can go away.
-	return dirName == "/var/lib", nil
+	return dirName == "/var/lib"
 }
 
 // ReadOnlyFsError is an error encapsulating encountered EROFS.

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -619,10 +619,10 @@ type FatalError struct {
 // In the event of a failure the undo plan is executed and an error is
 // returned. If the undo plan fails the function returns a FatalError as it
 // cannot fix the system from an inconsistent state.
-func execWritableMimic(plan []*Change, sec *Secure) ([]*Change, error) {
+func execWritableMimic(plan []*Change, as *Assumptions) ([]*Change, error) {
 	undoChanges := make([]*Change, 0, len(plan)-2)
 	for i, change := range plan {
-		if _, err := changePerform(change, sec); err != nil {
+		if _, err := changePerform(change, as); err != nil {
 			// Drat, we failed! Let's undo everything according to our own undo
 			// plan, by following it in reverse order.
 
@@ -645,7 +645,7 @@ func execWritableMimic(plan []*Change, sec *Secure) ([]*Change, error) {
 				if recoveryUndoChange.Entry.OptBool("rbind") {
 					recoveryUndoChange.Entry.Options = append(recoveryUndoChange.Entry.Options, osutil.XSnapdDetach())
 				}
-				if _, err2 := changePerform(recoveryUndoChange, sec); err2 != nil {
+				if _, err2 := changePerform(recoveryUndoChange, as); err2 != nil {
 					// Drat, we failed when trying to recover from an error.
 					// We cannot do anything at this stage.
 					return nil, &FatalError{error: fmt.Errorf("cannot undo change %q while recovering from earlier error %v: %v", recoveryUndoChange, err, err2)}
@@ -693,12 +693,12 @@ func execWritableMimic(plan []*Change, sec *Secure) ([]*Change, error) {
 	return undoChanges, nil
 }
 
-func createWritableMimic(dir, neededBy string, sec *Secure) ([]*Change, error) {
+func createWritableMimic(dir, neededBy string, as *Assumptions) ([]*Change, error) {
 	plan, err := planWritableMimic(dir, neededBy)
 	if err != nil {
 		return nil, err
 	}
-	changes, err := execWritableMimic(plan, sec)
+	changes, err := execWritableMimic(plan, as)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -151,7 +151,7 @@ func (sec *Secure) CheckTrespassing(dirFd int, dirName string, name string) erro
 //
 // The file descriptor is opened using the O_PATH, O_NOFOLLOW,
 // and O_CLOEXEC flags.
-func (sec *Secure) OpenPath(path string) (int, error) {
+func OpenPath(path string) (int, error) {
 	iter, err := strutil.NewPathIterator(path)
 	if err != nil {
 		return -1, fmt.Errorf("cannot open path: %s", err)

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -229,6 +229,7 @@ func MkDir(dirFd int, dirName string, name string, perm os.FileMode, uid sys.Use
 		return -1, err
 	}
 
+	made := true
 	const openFlags = syscall.O_NOFOLLOW | syscall.O_CLOEXEC | syscall.O_DIRECTORY
 
 	if err := sysMkdirat(dirFd, name, uint32(perm.Perm())); err != nil {
@@ -281,6 +282,7 @@ func MkFile(dirFd int, dirName string, name string, perm os.FileMode, uid sys.Us
 		return err
 	}
 
+	made := true
 	// NOTE: Tests don't show O_RDONLY as has a value of 0 and is not
 	// translated to textual form. It is added here for explicitness.
 	const openFlags = syscall.O_NOFOLLOW | syscall.O_CLOEXEC | syscall.O_RDONLY

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -181,10 +181,10 @@ func OpenPath(path string) (int, error) {
 }
 
 // MkPrefix creates all the missing directories in a given base path and
-// returns the file descriptor to the leaf directory. This function is a base
-// for secure variants of mkdir, touch and symlink. None of the traversed
-// directories can be symbolic links.
-func (sec *Secure) MkPrefix(base string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) (int, error) {
+// returns the file descriptor to the leaf directory as well as the restricted
+// flag. This function is a base for secure variants of mkdir, touch and
+// symlink. None of the traversed directories can be symbolic links.
+func MkPrefix(base string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, rs *Restrictions) (int, error) {
 	iter, err := strutil.NewPathIterator(base)
 	if err != nil {
 		// TODO: Reword the error and adjust the tests.
@@ -205,7 +205,7 @@ func (sec *Secure) MkPrefix(base string, perm os.FileMode, uid sys.UserID, gid s
 		// Keep closing the previous descriptor as we go, so that we have the
 		// last one handy from the MkDir below.
 		defer sysClose(fd)
-		fd, err = sec.MkDir(fd, iter.CurrentBase(), iter.CurrentCleanName(), perm, uid, gid)
+		fd, err = MkDir(fd, iter.CurrentBase(), iter.CurrentCleanName(), perm, uid, gid, rs)
 		if err != nil {
 			return -1, err
 		}
@@ -220,8 +220,7 @@ func (sec *Secure) MkPrefix(base string, perm os.FileMode, uid sys.UserID, gid s
 // convenience). This function is meant to be used to construct subsequent
 // elements of some path. The return value contains the newly created file
 // descriptor for the new directory or -1 on error.
-func (sec *Secure) MkDir(dirFd int, dirName string, name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) (int, error) {
-	made := true
+func MkDir(dirFd int, dirName string, name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, rs *Restrictions) (int, error) {
 
 	const openFlags = syscall.O_NOFOLLOW | syscall.O_CLOEXEC | syscall.O_DIRECTORY
 
@@ -257,11 +256,10 @@ func (sec *Secure) MkDir(dirFd int, dirName string, name string, perm os.FileMod
 // MkFile creates a file with a given name.
 //
 // The directory is represented with a file descriptor and its name (for
-// convenience). This function is meant to be used to create the leaf file as a
-// preparation for a mount point. Existing files are reused without errors.
+// convenience). This function is meant to be used to create the leaf file as
+// a preparation for a mount point. Existing files are reused without errors.
 // Newly created files have the specified mode and ownership.
-func (sec *Secure) MkFile(dirFd int, dirName string, name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
-	made := true
+func MkFile(dirFd int, dirName string, name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, rs *Restrictions) error {
 
 	// NOTE: Tests don't show O_RDONLY as has a value of 0 and is not
 	// translated to textual form. It is added here for explicitness.
@@ -307,7 +305,7 @@ func (sec *Secure) MkFile(dirFd int, dirName string, name string, perm os.FileMo
 // The directory is represented with a file descriptor and its name (for
 // convenience). This function is meant to be used to create the leaf symlink.
 // Existing and identical symlinks are reused without errors.
-func (sec *Secure) MkSymlink(dirFd int, dirName string, name string, oldname string) error {
+func MkSymlink(dirFd int, dirName string, name string, oldname string, rs *Restrictions) error {
 	// Create the final path segment as a symlink.
 	// TODO: don't write links outside of tmpfs or $SNAP_{,USER_}{DATA,COMMON}
 	if err := sysSymlinkat(oldname, dirFd, name); err != nil {
@@ -364,7 +362,7 @@ func (sec *Secure) MkSymlink(dirFd int, dirName string, name string, oldname str
 // The uid and gid are used for the fchown(2) system call which is performed
 // after each segment is created and opened. The special value -1 may be used
 // to request that ownership is not changed.
-func (sec *Secure) MkdirAll(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
+func MkdirAll(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, rs *Restrictions) error {
 	if path != filepath.Clean(path) {
 		// TODO: Reword the error and adjust the tests.
 		return fmt.Errorf("cannot split unclean path %q", path)
@@ -378,7 +376,7 @@ func (sec *Secure) MkdirAll(path string, perm os.FileMode, uid sys.UserID, gid s
 	base = filepath.Clean(base) // Needed to chomp the trailing slash.
 
 	// Create the prefix.
-	dirFd, err := sec.MkPrefix(base, perm, uid, gid)
+	dirFd, err := MkPrefix(base, perm, uid, gid, rs)
 	if err != nil {
 		return err
 	}
@@ -386,7 +384,7 @@ func (sec *Secure) MkdirAll(path string, perm os.FileMode, uid sys.UserID, gid s
 
 	if name != "" {
 		// Create the leaf as a directory.
-		leafFd, err := sec.MkDir(dirFd, base, name, perm, uid, gid)
+		leafFd, err := MkDir(dirFd, base, name, perm, uid, gid, rs)
 		if err != nil {
 			return err
 		}
@@ -401,7 +399,7 @@ func (sec *Secure) MkdirAll(path string, perm os.FileMode, uid sys.UserID, gid s
 // This function is like MkdirAll but it creates an empty file instead of
 // a directory for the final path component. Each created directory component
 // is chowned to the desired user and group.
-func (sec *Secure) MkfileAll(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
+func MkfileAll(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, rs *Restrictions) error {
 	if path != filepath.Clean(path) {
 		// TODO: Reword the error and adjust the tests.
 		return fmt.Errorf("cannot split unclean path %q", path)
@@ -419,7 +417,7 @@ func (sec *Secure) MkfileAll(path string, perm os.FileMode, uid sys.UserID, gid 
 	base = filepath.Clean(base) // Needed to chomp the trailing slash.
 
 	// Create the prefix.
-	dirFd, err := sec.MkPrefix(base, perm, uid, gid)
+	dirFd, err := MkPrefix(base, perm, uid, gid, rs)
 	if err != nil {
 		return err
 	}
@@ -427,13 +425,13 @@ func (sec *Secure) MkfileAll(path string, perm os.FileMode, uid sys.UserID, gid 
 
 	if name != "" {
 		// Create the leaf as a file.
-		err = sec.MkFile(dirFd, base, name, perm, uid, gid)
+		err = MkFile(dirFd, base, name, perm, uid, gid, rs)
 	}
 	return err
 }
 
 // MksymlinkAll is a secure implementation of "ln -s".
-func (sec *Secure) MksymlinkAll(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, oldname string) error {
+func MksymlinkAll(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, oldname string, rs *Restrictions) error {
 	if path != filepath.Clean(path) {
 		// TODO: Reword the error and adjust the tests.
 		return fmt.Errorf("cannot split unclean path %q", path)
@@ -455,7 +453,7 @@ func (sec *Secure) MksymlinkAll(path string, perm os.FileMode, uid sys.UserID, g
 	base = filepath.Clean(base) // Needed to chomp the trailing slash.
 
 	// Create the prefix.
-	dirFd, err := sec.MkPrefix(base, perm, uid, gid)
+	dirFd, err := MkPrefix(base, perm, uid, gid, rs)
 	if err != nil {
 		return err
 	}
@@ -463,7 +461,7 @@ func (sec *Secure) MksymlinkAll(path string, perm os.FileMode, uid sys.UserID, g
 
 	if name != "" {
 		// Create the leaf as a symlink.
-		err = sec.MkSymlink(dirFd, base, name, oldname)
+		err = MkSymlink(dirFd, base, name, oldname, rs)
 	}
 	return err
 }

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -131,21 +131,6 @@ func (e *ReadOnlyFsError) Error() string {
 	return fmt.Sprintf("cannot operate on read-only filesystem at %s", e.Path)
 }
 
-// Secure is a helper for making filesystem operations free from certain kinds of attacks.
-type Secure struct{}
-
-// CheckTrespassing inspects if a filesystem operation on the given path
-// segment would trespass on the host.
-//
-// The idea of trespassing is so that we do not attempt to create a
-// directory, a file or a symlink in a directory that is usually beyond
-// control of snap applications. We are perfectly comfortable with creating
-// things in $SNAP_DATA or in /tmp but we don't want to do so in /etc or in
-// other sensitive places.
-func (sec *Secure) CheckTrespassing(dirFd int, dirName string, name string) error {
-	return nil
-}
-
 // OpenPath creates a path file descriptor for the given
 // path, making sure no components are symbolic links.
 //

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -757,151 +757,110 @@ func (s *utilsSuite) TestSecureOpenPathRoot(c *C) {
 	})
 }
 
-func (s *utilsSuite) TestIsReadOnlyFstatfsError(c *C) {
-	path := "/some/path"
-	s.sys.InsertFault("fstatfs 3 <ptr>", errTesting)
-	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
-	c.Assert(err, IsNil)
-	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, ErrorMatches, `cannot fstatfs "/some/path": testing`)
-	c.Assert(result, Equals, false)
-}
-
 func (s *utilsSuite) TestIsReadOnlySquashfsMountedRo(c *C) {
-	statfs := syscall.Statfs_t{Type: update.SquashfsMagic, Flags: update.StReadOnly}
+	statfs := &syscall.Statfs_t{Type: update.SquashfsMagic, Flags: update.StReadOnly}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, IsNil)
+	result := update.IsReadOnly(fd, path, statfs)
 	c.Assert(result, Equals, true)
 }
 
 func (s *utilsSuite) TestIsReadOnlySquashfsMountedRw(c *C) {
-	statfs := syscall.Statfs_t{Type: update.SquashfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.SquashfsMagic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, IsNil)
+	result := update.IsReadOnly(fd, path, statfs)
 	c.Assert(result, Equals, true)
 }
 
 func (s *utilsSuite) TestIsReadOnlyExt4MountedRw(c *C) {
-	statfs := syscall.Statfs_t{Type: update.Ext4Magic}
+	statfs := &syscall.Statfs_t{Type: update.Ext4Magic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, false)
-}
-
-func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsFstatfsError(c *C) {
-	// fstatfs errors are handled and propagated.
-	path := "/some/path"
-	s.sys.InsertFault("fstatfs 3 <ptr>", errTesting)
-	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
-	c.Assert(err, IsNil)
-	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, ErrorMatches, `cannot fstatfs "/some/path": testing`)
+	result := update.IsReadOnly(fd, path, statfs)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsNotATmpfs(c *C) {
 	// An ext4 (which is not a tmpfs) is not a private tmpfs.
-	statfs := syscall.Statfs_t{Type: update.Ext4Magic}
+	statfs := &syscall.Statfs_t{Type: update.Ext4Magic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, IsNil)
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, nil)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsNotTrusted(c *C) {
 	// A tmpfs is not private if it doesn't come from a change we made.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, IsNil)
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, nil)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsViaChanges(c *C) {
 	// A tmpfs is private because it was mounted by snap-update-ns.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 
 	// A tmpfs was mounted in the past so it is private.
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, []*update.Change{
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, true)
 
 	// A tmpfs was mounted but then it was unmounted so it is not private anymore.
-	result, err = update.IsSnapdCreatedPrivateTmpfs(fd, path, []*update.Change{
+	result = update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, false)
 
 	// Finally, after the mounting and unmounting the tmpfs was mounted again.
-	result, err = update.IsSnapdCreatedPrivateTmpfs(fd, path, []*update.Change{
+	result = update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, true)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsDeeper(c *C) {
 	// A tmpfs is not private beyond the exact mount point from a change.
 	// That is, sub-directories of a private tmpfs are not recognized as private.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	fd, err := s.sys.Open("/some/path/below", syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, "/some/path/below", []*update.Change{
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, "/some/path/below", statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/some/path", Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsViaVarLib(c *C) {
 	// A tmpfs in /var/lib is private because it is a special
 	// quirk applied by snap-confine, without having a change record.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	path := "/var/lib"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, IsNil)
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, nil)
 	c.Assert(result, Equals, true)
 }
 

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -715,7 +715,7 @@ func (s *utilsSuite) TestCleanTrailingSlash(c *C) {
 func (s *utilsSuite) TestSecureOpenPath(c *C) {
 	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
 	s.sys.InsertFstatResult("fstat 5 <ptr>", stat)
-	fd, err := s.sec.OpenPath("/foo/bar")
+	fd, err := update.OpenPath("/foo/bar")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 5)
@@ -732,7 +732,7 @@ func (s *utilsSuite) TestSecureOpenPath(c *C) {
 func (s *utilsSuite) TestSecureOpenPathSingleSegment(c *C) {
 	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
 	s.sys.InsertFstatResult("fstat 4 <ptr>", stat)
-	fd, err := s.sec.OpenPath("/foo")
+	fd, err := update.OpenPath("/foo")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 4)
@@ -747,7 +747,7 @@ func (s *utilsSuite) TestSecureOpenPathSingleSegment(c *C) {
 func (s *utilsSuite) TestSecureOpenPathRoot(c *C) {
 	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
 	s.sys.InsertFstatResult("fstat 3 <ptr>", stat)
-	fd, err := s.sec.OpenPath("/")
+	fd, err := update.OpenPath("/")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 3)
@@ -868,7 +868,7 @@ func (s *realSystemSuite) TestSecureOpenPathDirectory(c *C) {
 	path := filepath.Join(c.MkDir(), "test")
 	c.Assert(os.Mkdir(path, 0755), IsNil)
 
-	fd, err := s.sec.OpenPath(path)
+	fd, err := update.OpenPath(path)
 	c.Assert(err, IsNil)
 	defer syscall.Close(fd)
 
@@ -884,7 +884,7 @@ func (s *realSystemSuite) TestSecureOpenPathDirectory(c *C) {
 }
 
 func (s *realSystemSuite) TestSecureOpenPathRelativePath(c *C) {
-	fd, err := s.sec.OpenPath("relative/path")
+	fd, err := update.OpenPath("relative/path")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "path .* is not absolute")
 }
@@ -894,15 +894,15 @@ func (s *realSystemSuite) TestSecureOpenPathUncleanPath(c *C) {
 	path := filepath.Join(base, "test")
 	c.Assert(os.Mkdir(path, 0755), IsNil)
 
-	fd, err := s.sec.OpenPath(base + "//test")
+	fd, err := update.OpenPath(base + "//test")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `cannot open path: cannot iterate over unclean path ".*//test"`)
 
-	fd, err = s.sec.OpenPath(base + "/./test")
+	fd, err = update.OpenPath(base + "/./test")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `cannot open path: cannot iterate over unclean path ".*/./test"`)
 
-	fd, err = s.sec.OpenPath(base + "/test/../test")
+	fd, err = update.OpenPath(base + "/test/../test")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `cannot open path: cannot iterate over unclean path ".*/test/../test"`)
 }
@@ -911,7 +911,7 @@ func (s *realSystemSuite) TestSecureOpenPathFile(c *C) {
 	path := filepath.Join(c.MkDir(), "file.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello"), 0644), IsNil)
 
-	fd, err := s.sec.OpenPath(path)
+	fd, err := update.OpenPath(path)
 	c.Assert(err, IsNil)
 	defer syscall.Close(fd)
 
@@ -925,7 +925,7 @@ func (s *realSystemSuite) TestSecureOpenPathFile(c *C) {
 func (s *realSystemSuite) TestSecureOpenPathNotFound(c *C) {
 	path := filepath.Join(c.MkDir(), "test")
 
-	fd, err := s.sec.OpenPath(path)
+	fd, err := update.OpenPath(path)
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "no such file or directory")
 }
@@ -938,7 +938,7 @@ func (s *realSystemSuite) TestSecureOpenPathSymlink(c *C) {
 	symlink := filepath.Join(base, "symlink")
 	c.Assert(os.Symlink(dir, symlink), IsNil)
 
-	fd, err := s.sec.OpenPath(symlink)
+	fd, err := update.OpenPath(symlink)
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `".*" is a symbolic link`)
 }
@@ -955,7 +955,7 @@ func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {
 	c.Assert(os.Symlink(dir, symlink), IsNil)
 	c.Assert(os.Mkdir(path, 0755), IsNil)
 
-	fd, err := s.sec.OpenPath(symlinkedPath)
+	fd, err := update.OpenPath(symlinkedPath)
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "not a directory")
 }

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -426,6 +426,7 @@ var _ = Suite(&realSystemSuite{})
 
 func (s *realSystemSuite) SetUpTest(c *C) {
 	s.sec = &update.Secure{}
+	s.sec.AddUnrestrictedPrefixes("/tmp")
 }
 
 // Check that we can actually create directories.

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -87,8 +87,6 @@ func (s *utilsSuite) TestSecureMkdirAllLevel0(c *C) {
 
 // Ensure that we can create a directory in the top-level directory.
 func (s *utilsSuite) TestSecureMkdirAllLevel1(c *C) {
-	os.Setenv("SNAPD_DEBUG", "1")
-	defer os.Unsetenv("SNAPD_DEBUG")
 	c.Assert(s.sec.MkdirAll("/path", 0755, 123, 456), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -64,21 +64,21 @@ func (s *utilsSuite) TearDownTest(c *C) {
 
 // Ensure that we reject unclean paths.
 func (s *utilsSuite) TestSecureMkdirAllUnclean(c *C) {
-	err := s.sec.MkdirAll("/unclean//path", 0755, 123, 456)
+	err := update.MkdirAll("/unclean//path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot split unclean path .*`)
 	c.Assert(s.sys.RCalls(), HasLen, 0)
 }
 
 // Ensure that we refuse to create a directory with an relative path.
 func (s *utilsSuite) TestSecureMkdirAllRelative(c *C) {
-	err := s.sec.MkdirAll("rel/path", 0755, 123, 456)
+	err := update.MkdirAll("rel/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot create directory with relative path: "rel/path"`)
 	c.Assert(s.sys.RCalls(), HasLen, 0)
 }
 
 // Ensure that we can "create the root directory.
 func (s *utilsSuite) TestSecureMkdirAllLevel0(c *C) {
-	c.Assert(s.sec.MkdirAll("/", 0755, 123, 456), IsNil)
+	c.Assert(update.MkdirAll("/", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `close 3`},
@@ -87,7 +87,7 @@ func (s *utilsSuite) TestSecureMkdirAllLevel0(c *C) {
 
 // Ensure that we can create a directory in the top-level directory.
 func (s *utilsSuite) TestSecureMkdirAllLevel1(c *C) {
-	c.Assert(s.sec.MkdirAll("/path", 0755, 123, 456), IsNil)
+	c.Assert(update.MkdirAll("/path", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "path" 0755`},
@@ -100,7 +100,7 @@ func (s *utilsSuite) TestSecureMkdirAllLevel1(c *C) {
 
 // Ensure that we can create a directory two levels from the top-level directory.
 func (s *utilsSuite) TestSecureMkdirAllLevel2(c *C) {
-	c.Assert(s.sec.MkdirAll("/path/to", 0755, 123, 456), IsNil)
+	c.Assert(update.MkdirAll("/path/to", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "path" 0755`},
@@ -117,7 +117,7 @@ func (s *utilsSuite) TestSecureMkdirAllLevel2(c *C) {
 
 // Ensure that we can create a directory three levels from the top-level directory.
 func (s *utilsSuite) TestSecureMkdirAllLevel3(c *C) {
-	c.Assert(s.sec.MkdirAll("/path/to/something", 0755, 123, 456), IsNil)
+	c.Assert(update.MkdirAll("/path/to/something", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "path" 0755`},
@@ -140,7 +140,7 @@ func (s *utilsSuite) TestSecureMkdirAllLevel3(c *C) {
 func (s *utilsSuite) TestSecureMkdirAllROFS(c *C) {
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST) // just realistic
 	s.sys.InsertFault(`mkdirat 4 "path" 0755`, syscall.EROFS)
-	err := s.sec.MkdirAll("/rofs/path", 0755, 123, 456)
+	err := update.MkdirAll("/rofs/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot operate on read-only filesystem at /rofs`)
 	c.Assert(err.(*update.ReadOnlyFsError).Path, Equals, "/rofs")
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
@@ -157,7 +157,7 @@ func (s *utilsSuite) TestSecureMkdirAllROFS(c *C) {
 func (s *utilsSuite) TestSecureMkdirAllExistingDirsDontChown(c *C) {
 	s.sys.InsertFault(`mkdirat 3 "abs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`mkdirat 4 "path" 0755`, syscall.EEXIST)
-	err := s.sec.MkdirAll("/abs/path", 0755, 123, 456)
+	err := update.MkdirAll("/abs/path", 0755, 123, 456, nil)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -174,7 +174,7 @@ func (s *utilsSuite) TestSecureMkdirAllExistingDirsDontChown(c *C) {
 // Ensure that we we close everything when mkdirat fails.
 func (s *utilsSuite) TestSecureMkdirAllMkdiratError(c *C) {
 	s.sys.InsertFault(`mkdirat 3 "abs" 0755`, errTesting)
-	err := s.sec.MkdirAll("/abs", 0755, 123, 456)
+	err := update.MkdirAll("/abs", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot create directory "/abs": testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -186,7 +186,7 @@ func (s *utilsSuite) TestSecureMkdirAllMkdiratError(c *C) {
 // Ensure that we we close everything when fchown fails.
 func (s *utilsSuite) TestSecureMkdirAllFchownError(c *C) {
 	s.sys.InsertFault(`fchown 4 123 456`, errTesting)
-	err := s.sec.MkdirAll("/path", 0755, 123, 456)
+	err := update.MkdirAll("/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot chown directory "/path" to 123.456: testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -201,7 +201,7 @@ func (s *utilsSuite) TestSecureMkdirAllFchownError(c *C) {
 // Check error path when we cannot open root directory.
 func (s *utilsSuite) TestSecureMkdirAllOpenRootError(c *C) {
 	s.sys.InsertFault(`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, errTesting)
-	err := s.sec.MkdirAll("/abs/path", 0755, 123, 456)
+	err := update.MkdirAll("/abs/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, "cannot open root directory: testing")
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, E: errTesting},
@@ -211,7 +211,7 @@ func (s *utilsSuite) TestSecureMkdirAllOpenRootError(c *C) {
 // Check error path when we cannot open non-root directory.
 func (s *utilsSuite) TestSecureMkdirAllOpenError(c *C) {
 	s.sys.InsertFault(`openat 3 "abs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, errTesting)
-	err := s.sec.MkdirAll("/abs/path", 0755, 123, 456)
+	err := update.MkdirAll("/abs/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot open directory "/abs": testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -436,7 +436,7 @@ func (s *realSystemSuite) TestSecureMkdirAllForReal(c *C) {
 	// Create d (which already exists) with mode 0777 (but c.MkDir() used 0700
 	// internally and since we are not creating the directory we should not be
 	// changing that.
-	c.Assert(s.sec.MkdirAll(d, 0777, sys.FlagID, sys.FlagID), IsNil)
+	c.Assert(update.MkdirAll(d, 0777, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err := os.Stat(d)
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)
@@ -446,7 +446,7 @@ func (s *realSystemSuite) TestSecureMkdirAllForReal(c *C) {
 	// check that it was applied. Note that default umask 022 is subtracted so
 	// effective directory has different permissions.
 	d1 := filepath.Join(d, "subdir")
-	c.Assert(s.sec.MkdirAll(d1, 0707, sys.FlagID, sys.FlagID), IsNil)
+	c.Assert(update.MkdirAll(d1, 0707, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err = os.Stat(d1)
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)
@@ -455,7 +455,7 @@ func (s *realSystemSuite) TestSecureMkdirAllForReal(c *C) {
 	// Create d2, which is a deeper subdirectory, with another distinct mode
 	// and check that it was applied.
 	d2 := filepath.Join(d, "subdir/subdir/subdir")
-	c.Assert(s.sec.MkdirAll(d2, 0750, sys.FlagID, sys.FlagID), IsNil)
+	c.Assert(update.MkdirAll(d2, 0750, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err = os.Stat(d2)
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)
@@ -466,28 +466,28 @@ func (s *realSystemSuite) TestSecureMkdirAllForReal(c *C) {
 
 // Ensure that we reject unclean paths.
 func (s *utilsSuite) TestSecureMkfileAllUnclean(c *C) {
-	err := s.sec.MkfileAll("/unclean//path", 0755, 123, 456)
+	err := update.MkfileAll("/unclean//path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot split unclean path .*`)
 	c.Assert(s.sys.RCalls(), HasLen, 0)
 }
 
 // Ensure that we refuse to create a file with an relative path.
 func (s *utilsSuite) TestSecureMkfileAllRelative(c *C) {
-	err := s.sec.MkfileAll("rel/path", 0755, 123, 456)
+	err := update.MkfileAll("rel/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot create file with relative path: "rel/path"`)
 	c.Assert(s.sys.RCalls(), HasLen, 0)
 }
 
 // Ensure that we refuse creating the root directory as a file.
 func (s *utilsSuite) TestSecureMkfileAllLevel0(c *C) {
-	err := s.sec.MkfileAll("/", 0755, 123, 456)
+	err := update.MkfileAll("/", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot create non-file path: "/"`)
 	c.Assert(s.sys.RCalls(), HasLen, 0)
 }
 
 // Ensure that we can create a file in the top-level directory.
 func (s *utilsSuite) TestSecureMkfileAllLevel1(c *C) {
-	c.Assert(s.sec.MkfileAll("/path", 0755, 123, 456), IsNil)
+	c.Assert(update.MkfileAll("/path", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `openat 3 "path" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, R: 4},
@@ -499,7 +499,7 @@ func (s *utilsSuite) TestSecureMkfileAllLevel1(c *C) {
 
 // Ensure that we can create a file two levels from the top-level directory.
 func (s *utilsSuite) TestSecureMkfileAllLevel2(c *C) {
-	c.Assert(s.sec.MkfileAll("/path/to", 0755, 123, 456), IsNil)
+	c.Assert(update.MkfileAll("/path/to", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "path" 0755`},
@@ -515,7 +515,7 @@ func (s *utilsSuite) TestSecureMkfileAllLevel2(c *C) {
 
 // Ensure that we can create a file three levels from the top-level directory.
 func (s *utilsSuite) TestSecureMkfileAllLevel3(c *C) {
-	c.Assert(s.sec.MkfileAll("/path/to/something", 0755, 123, 456), IsNil)
+	c.Assert(update.MkfileAll("/path/to/something", 0755, 123, 456, nil), IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "path" 0755`},
@@ -537,7 +537,7 @@ func (s *utilsSuite) TestSecureMkfileAllLevel3(c *C) {
 func (s *utilsSuite) TestSecureMkfileAllROFS(c *C) {
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST) // just realistic
 	s.sys.InsertFault(`openat 4 "path" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, syscall.EROFS)
-	err := s.sec.MkfileAll("/rofs/path", 0755, 123, 456)
+	err := update.MkfileAll("/rofs/path", 0755, 123, 456, nil)
 	c.Check(err, ErrorMatches, `cannot operate on read-only filesystem at /rofs`)
 	c.Assert(err.(*update.ReadOnlyFsError).Path, Equals, "/rofs")
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
@@ -554,7 +554,7 @@ func (s *utilsSuite) TestSecureMkfileAllROFS(c *C) {
 func (s *utilsSuite) TestSecureMkfileAllExistingDirsDontChown(c *C) {
 	s.sys.InsertFault(`mkdirat 3 "abs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 4 "path" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, syscall.EEXIST)
-	err := s.sec.MkfileAll("/abs/path", 0755, 123, 456)
+	err := update.MkfileAll("/abs/path", 0755, 123, 456, nil)
 	c.Check(err, IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -572,7 +572,7 @@ func (s *utilsSuite) TestSecureMkfileAllExistingDirsDontChown(c *C) {
 func (s *utilsSuite) TestSecureMkfileAllOpenat2ndError(c *C) {
 	s.sys.InsertFault(`openat 3 "abs" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 3 "abs" O_NOFOLLOW|O_CLOEXEC 0`, errTesting)
-	err := s.sec.MkfileAll("/abs", 0755, 123, 456)
+	err := update.MkfileAll("/abs", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot open file "/abs": testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -585,7 +585,7 @@ func (s *utilsSuite) TestSecureMkfileAllOpenat2ndError(c *C) {
 // Ensure that we we close everything when openat (non-exclusive) fails.
 func (s *utilsSuite) TestSecureMkfileAllOpenatError(c *C) {
 	s.sys.InsertFault(`openat 3 "abs" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, errTesting)
-	err := s.sec.MkfileAll("/abs", 0755, 123, 456)
+	err := update.MkfileAll("/abs", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot open file "/abs": testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -597,7 +597,7 @@ func (s *utilsSuite) TestSecureMkfileAllOpenatError(c *C) {
 // Ensure that we we close everything when fchown fails.
 func (s *utilsSuite) TestSecureMkfileAllFchownError(c *C) {
 	s.sys.InsertFault(`fchown 4 123 456`, errTesting)
-	err := s.sec.MkfileAll("/path", 0755, 123, 456)
+	err := update.MkfileAll("/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot chown file "/path" to 123.456: testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -611,7 +611,7 @@ func (s *utilsSuite) TestSecureMkfileAllFchownError(c *C) {
 // Check error path when we cannot open root directory.
 func (s *utilsSuite) TestSecureMkfileAllOpenRootError(c *C) {
 	s.sys.InsertFault(`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, errTesting)
-	err := s.sec.MkfileAll("/abs/path", 0755, 123, 456)
+	err := update.MkfileAll("/abs/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, "cannot open root directory: testing")
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, E: errTesting},
@@ -621,7 +621,7 @@ func (s *utilsSuite) TestSecureMkfileAllOpenRootError(c *C) {
 // Check error path when we cannot open non-root directory.
 func (s *utilsSuite) TestSecureMkfileAllOpenError(c *C) {
 	s.sys.InsertFault(`openat 3 "abs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, errTesting)
-	err := s.sec.MkfileAll("/abs/path", 0755, 123, 456)
+	err := update.MkfileAll("/abs/path", 0755, 123, 456, nil)
 	c.Assert(err, ErrorMatches, `cannot open directory "/abs": testing`)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -640,7 +640,7 @@ func (s *realSystemSuite) TestSecureMkfileAllForReal(c *C) {
 	// check that it was applied. Note that default umask 022 is subtracted so
 	// effective directory has different permissions.
 	f1 := filepath.Join(d, "file")
-	c.Assert(s.sec.MkfileAll(f1, 0707, sys.FlagID, sys.FlagID), IsNil)
+	c.Assert(update.MkfileAll(f1, 0707, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err := os.Stat(f1)
 	c.Assert(err, IsNil)
 	c.Check(fi.Mode().IsRegular(), Equals, true)
@@ -649,7 +649,7 @@ func (s *realSystemSuite) TestSecureMkfileAllForReal(c *C) {
 	// Create f2, which is a deeper subdirectory, with another distinct mode
 	// and check that it was applied.
 	f2 := filepath.Join(d, "subdir/subdir/file")
-	c.Assert(s.sec.MkfileAll(f2, 0750, sys.FlagID, sys.FlagID), IsNil)
+	c.Assert(update.MkfileAll(f2, 0750, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err = os.Stat(f2)
 	c.Assert(err, IsNil)
 	c.Check(fi.Mode().IsRegular(), Equals, true)
@@ -664,7 +664,7 @@ func (s *realSystemSuite) TestSecureMksymlinkAllForReal(c *C) {
 	// Create symlink f1 that points to "oldname" and check that it
 	// is correct. Note that symlink permissions are always set to 0777
 	f1 := filepath.Join(d, "symlink")
-	err := s.sec.MksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname")
+	err := update.MksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname", nil)
 	c.Assert(err, IsNil)
 	fi, err := os.Lstat(f1)
 	c.Assert(err, IsNil)
@@ -676,28 +676,28 @@ func (s *realSystemSuite) TestSecureMksymlinkAllForReal(c *C) {
 	c.Check(target, Equals, "oldname")
 
 	// Create an identical symlink to see that it doesn't fail.
-	err = s.sec.MksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname")
+	err = update.MksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname", nil)
 	c.Assert(err, IsNil)
 
 	// Create a different symlink and see that it fails now
-	err = s.sec.MksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "other")
+	err = update.MksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "other", nil)
 	c.Assert(err, ErrorMatches, `cannot create symbolic link ".*/symlink": existing symbolic link in the way`)
 
 	// Create an file and check that it clashes with a symlink we attempt to create.
 	f2 := filepath.Join(d, "file")
-	err = s.sec.MkfileAll(f2, 0755, sys.FlagID, sys.FlagID)
+	err = update.MkfileAll(f2, 0755, sys.FlagID, sys.FlagID, nil)
 	c.Assert(err, IsNil)
-	err = s.sec.MksymlinkAll(f2, 0755, sys.FlagID, sys.FlagID, "oldname")
+	err = update.MksymlinkAll(f2, 0755, sys.FlagID, sys.FlagID, "oldname", nil)
 	c.Assert(err, ErrorMatches, `cannot create symbolic link ".*/file": existing file in the way`)
 
 	// Create an file and check that it clashes with a symlink we attempt to create.
 	f3 := filepath.Join(d, "dir")
-	err = s.sec.MkdirAll(f3, 0755, sys.FlagID, sys.FlagID)
+	err = update.MkdirAll(f3, 0755, sys.FlagID, sys.FlagID, nil)
 	c.Assert(err, IsNil)
-	err = s.sec.MksymlinkAll(f3, 0755, sys.FlagID, sys.FlagID, "oldname")
+	err = update.MksymlinkAll(f3, 0755, sys.FlagID, sys.FlagID, "oldname", nil)
 	c.Assert(err, ErrorMatches, `cannot create symbolic link ".*/dir": existing file in the way`)
 
-	err = s.sec.MksymlinkAll("/", 0755, sys.FlagID, sys.FlagID, "oldname")
+	err = update.MksymlinkAll("/", 0755, sys.FlagID, sys.FlagID, "oldname", nil)
 	c.Assert(err, ErrorMatches, `cannot create non-file path: "/"`)
 }
 

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -536,10 +536,10 @@ func (s *utilsSuite) TestSecureMkfileAllLevel3(c *C) {
 
 // Ensure that we can detect read only filesystems.
 func (s *utilsSuite) TestSecureMkfileAllROFS(c *C) {
-	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST) // just realistic
+	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 4 "path" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, syscall.EROFS)
 	err := update.MkfileAll("/rofs/path", 0755, 123, 456, nil)
-	c.Check(err, ErrorMatches, `cannot operate on read-only filesystem at /rofs`)
+	c.Assert(err, ErrorMatches, `cannot operate on read-only filesystem at /rofs`)
 	c.Assert(err.(*update.ReadOnlyFsError).Path, Equals, "/rofs")
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
@@ -556,7 +556,7 @@ func (s *utilsSuite) TestSecureMkfileAllExistingDirsDontChown(c *C) {
 	s.sys.InsertFault(`mkdirat 3 "abs" 0755`, syscall.EEXIST)
 	s.sys.InsertFault(`openat 4 "path" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, syscall.EEXIST)
 	err := update.MkfileAll("/abs/path", 0755, 123, 456, nil)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "abs" 0755`, E: syscall.EEXIST},

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -33,7 +33,6 @@ execute: |
         test-snapd-layout.sh -c "true"
 
         echo "layout declarations are honored"
-
         test-snapd-layout.sh -c "test -d /etc/demo"
         test-snapd-layout.sh -c "test -f /etc/demo.conf"
         test-snapd-layout.sh -c "test -h /etc/demo.cfg"
@@ -60,6 +59,15 @@ execute: |
         [ "$(test-snapd-layout.sh -c "stat /var/spool/rsyslog -c '%a'")" = "700" ]
         [ "$(test-snapd-layout.sh -c "stat /var/spool/rsyslog -c '%u'")" = "108" ]
         [ "$(test-snapd-layout.sh -c "stat /var/spool/rsyslog -c '%g'")" = "4" ]
+
+        echo "layout declarations didn't leak to the host"
+        test ! -e /etc/demo
+        test ! -e /etc/demo.conf
+        test ! -e /etc/demo.cfg
+        test ! -e /usr/share/demo
+        test ! -e /var/lib/demo
+        test ! -e /var/cache/demo
+        test ! -e /opt/demo
 
         echo "layout locations pointing to SNAP_DATA and SNAP_COMMON are writable"
         echo "and the writes go to the right place in the backing store"
@@ -95,8 +103,3 @@ execute: |
         test-snapd-layout.sh -c 'test -w $SNAP/bin-very-weird-place'
         test-snapd-layout.sh -c 'test -w /bin/very-weird-place'
     done
-
-restore:
-    # cleanup after the trespassing bug, see: https://github.com/snapcore/snapd/pull/4889
-    # TODO: remove this once the problem is addressed
-    rm -rf /etc/demo /etc/demo.conf /etc/demo.cfg


### PR DESCRIPTION
This large branch changes the snap-update-ns command to check for
_trespassing_, that is the act of writing in unexpected places to the host
filesystem. Before this bug is fixed trespassing would manifest itself as empty
files, empty directories or symlinks in places that are shared with the host,
typically `/etc`.

To combat this issue we're employing writable mimics, that is, privately
mounted tpmfs-es that contain the orignal content of a given directory created
using a set of bind mounts.

To know when we should construct a writable mimic we now keep track of
Restrictions structure, as a re-factored extension to the existing Secure
structure. While Secure keeps track of global state (set of tmpfs-es that were
mounted, set of white-listed paths where restrictions don't apply, such as
$SNAP_DATA) the Restrictions type keeps track of _local_ state of a single write operation.

It is possible that as we progress through some path we are constructing, we
will discover a tmpfs that as mounted by snapd (and we have records to confirm
that). If we manage to succesfully create a new directory on such privately
shared tmpfs filesystem we know that subsequent writes will stay private to the
mount namespace we operate on. This allows us to LiftRestrictions and carry
on creating things as we please.

There are some more tests that we can write (I have some on my home machine
that I haven't pushed here) but I wanted to do a first round of public review
after a few rounds of review with mborzecki.

NOTE: We know of several shortcomings but those are not new and are somewhat
special cases of a special case alreday. I will be addressing them separately
on top of this PR.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
