### PR TITLE
snap: use snap.SideInfo in test to fix build with gccgo

### DIFF
--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1337,7 +1337,7 @@ func (s *infoSuite) TestSortByTypeAgain(c *C) {
 	core := &snap.Info{Type: snap.TypeOS}
 	base := &snap.Info{Type: snap.TypeBase}
 	app := &snap.Info{Type: snap.TypeApp}
-	snapd := &snap.Info{SideInfo: snap.SideInfo{RealName: "snapd"}}
+	snapd := &snap.Info{snap.SideInfo: snap.SideInfo{RealName: "snapd"}}
 
 	byType := func(snaps ...*snap.Info) []*snap.Info {
 		sort.Stable(snap.ByType(snaps))

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1337,7 +1337,8 @@ func (s *infoSuite) TestSortByTypeAgain(c *C) {
 	core := &snap.Info{Type: snap.TypeOS}
 	base := &snap.Info{Type: snap.TypeBase}
 	app := &snap.Info{Type: snap.TypeApp}
-	snapd := &snap.Info{snap.SideInfo: snap.SideInfo{RealName: "snapd"}}
+	snapd := &snap.Info{}
+	snapd.SideInfo = snap.SideInfo{RealName: "snapd"}
 
 	byType := func(snaps ...*snap.Info) []*snap.Info {
 		sort.Stable(snap.ByType(snaps))


### PR DESCRIPTION
We currently see build failures on powerpc (which uses gccgo)
because the test is using "SideInfo" instead of "snap.SideInfo".

