### PR TITLE
selftest: actually run the kernel version selftest

### DIFF
--- a/selftest/selftest.go
+++ b/selftest/selftest.go
@@ -22,6 +22,7 @@ package selftest
 var checks = []func() error{
 	trySquashfsMount,
 	apparmorUsable,
+	checkKernelVersion,
 }
 
 func Run() error {


### PR DESCRIPTION
The deadcode checker found that the kernel version test was not
used. This PR fixes this.
