### PR TITLE
[RFC] many: use seed-time as salt/seed for generating instance-key in store requests

### DIFF
--- a/cmd/cmd_linux.go
+++ b/cmd/cmd_linux.go
@@ -95,7 +95,7 @@ func coreSupportsReExec(corePath string) bool {
 	// > 0 means our Version is bigger than the version of snapd in core
 	res, err := strutil.VersionCompare(Version, ver[1])
 	if err != nil {
-		logger.Debugf("cannot version compare %q and %q: %s", Version, ver[1], res)
+		logger.Debugf("cannot version compare %q and %q: %v", Version, ver[1], res)
 		return false
 	}
 	if res > 0 {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -312,6 +312,7 @@ func (s *apiBaseSuite) daemon(c *check.C) *Daemon {
 	snapstate.ReplaceStore(st, s)
 	// mark as already seeded
 	st.Set("seeded", true)
+	st.Set("seed-time", time.Now())
 	// registered
 	auth.SetDevice(st, &auth.DeviceState{
 		Brand:  "canonical",

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -22,6 +22,7 @@ package ctlcmd_test
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -137,6 +138,8 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 	defer s.st.Unlock()
 
 	snapstate.ReplaceStore(s.st, &s.fakeStore)
+
+	s.st.Set("seed-time", time.Now())
 
 	// mock installed snaps
 	info1 := snaptest.MockSnap(c, string(testSnapYaml), &snap.SideInfo{

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -168,6 +168,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	st.Lock()
 	defer st.Unlock()
 	st.Set("seeded", true)
+	st.Set("seed-time", time.Now())
 	// registered
 	auth.SetDevice(st, &auth.DeviceState{
 		Brand:  "generic",

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -179,7 +179,7 @@ func (m *autoRefresh) canRefreshRespectingMetered(now, lastRefresh time.Time) (c
 
 	if now.Sub(lastRefresh) >= maxPostponement {
 		// TODO use warnings when the infra becomes available
-		logger.Noticef("Auto refresh disabled while on metered connections, but pending for too long (%s days). Trying to refresh now.", int(maxPostponement.Hours()/24))
+		logger.Noticef("Auto refresh disabled while on metered connections, but pending for too long (%d days). Trying to refresh now.", int(maxPostponement.Hours()/24))
 		return true, nil
 	}
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -51,6 +51,8 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
+
+	s.state.Set("seed-time", time.Now())
 }
 
 func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -87,6 +87,8 @@ func (s *refreshHintsTestSuite) SetUpTest(c *C) {
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
+
+	s.state.Set("seed-time", time.Now())
 }
 
 func (s *refreshHintsTestSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -74,6 +74,8 @@ type snapmgrTestSuite struct {
 	user  *auth.UserState
 	user2 *auth.UserState
 	user3 *auth.UserState
+
+	requestSeed string
 }
 
 func (s *snapmgrTestSuite) settle(c *C) {
@@ -154,7 +156,10 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.user3, err = auth.NewUser(s.state, "username3", "email2@test.com", "", nil)
 	c.Assert(err, IsNil)
 
-	s.state.Set("seed-time", time.Now())
+	now := time.Now()
+	s.state.Set("seed-time", now)
+	// same format as time.Time.MarshalJSON()
+	s.requestSeed = now.Format(time.RFC3339Nano)
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
@@ -2459,6 +2464,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "stable",
 				RefreshedDate:   refreshedDate,
+				RequestSeed:     s.requestSeed,
 			}},
 			userID: 1,
 		},
@@ -2674,6 +2680,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "stable",
 				RefreshedDate:   refreshedDate,
+				RequestSeed:     s.requestSeed,
 			}},
 			userID: 1,
 		},
@@ -3154,9 +3161,9 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 		case "storesvc-snap-action":
 			ir++
 			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
-				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
-				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
-				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1), RequestSeed: s.requestSeed},
+				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2), RequestSeed: s.requestSeed},
+				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5), RequestSeed: s.requestSeed},
 			})
 		case "storesvc-snap-action:action":
 			snapID := op.action.SnapID
@@ -3248,9 +3255,9 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 		case "storesvc-snap-action":
 			ir++
 			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
-				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
-				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
-				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1), RequestSeed: s.requestSeed},
+				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2), RequestSeed: s.requestSeed},
+				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5), RequestSeed: s.requestSeed},
 			})
 		case "storesvc-snap-action:action":
 			snapID := op.action.SnapID
@@ -3353,9 +3360,9 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThro
 		case "storesvc-snap-action":
 			ir++
 			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
-				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
-				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
-				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1), RequestSeed: s.requestSeed},
+				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2), RequestSeed: s.requestSeed},
+				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5), RequestSeed: s.requestSeed},
 			})
 		case "storesvc-snap-action:action":
 			snapID := op.action.SnapID
@@ -3418,6 +3425,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 				SnapID:        "some-snap-id",
 				Revision:      snap.R(7),
 				RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+				RequestSeed:   s.requestSeed,
 			}},
 			userID: 1,
 		},
@@ -3594,6 +3602,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "stable",
 				RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 7),
+				RequestSeed:     s.requestSeed,
 			}},
 			userID: 1,
 		},
@@ -3882,6 +3891,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "other-channel",
 				RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 7),
+				RequestSeed:     s.requestSeed,
 			}},
 			userID: 1,
 		},
@@ -4155,6 +4165,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 			Revision:         snap.R(7),
 			IgnoreValidation: false,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 7),
+			RequestSeed:      s.requestSeed,
 		}},
 		userID: 1,
 	})
@@ -4203,6 +4214,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 			TrackingChannel:  "stable",
 			IgnoreValidation: true,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 11),
+			RequestSeed:      s.requestSeed,
 		}},
 		userID: 1,
 	})
@@ -4255,6 +4267,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 			TrackingChannel:  "stable",
 			IgnoreValidation: true,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 12),
+			RequestSeed:      s.requestSeed,
 		}},
 		userID: 1,
 	})
@@ -4389,6 +4402,7 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 			SnapID:        "some-snap-id",
 			Revision:      snap.R(7),
 			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+			RequestSeed:   s.requestSeed,
 		}},
 		userID: 1,
 	})
@@ -4429,6 +4443,7 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 			SnapID:        "some-snap-id",
 			Revision:      snap.R(7),
 			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+			RequestSeed:   s.requestSeed,
 		}},
 		userID: 1,
 	})
@@ -4469,6 +4484,7 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 			Revision:      snap.R(7),
 			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
 			Block:         []snap.Revision{snap.R(11)},
+			RequestSeed:   s.requestSeed,
 		}},
 		userID: 1,
 	})
@@ -9729,7 +9745,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		{
 			op: "storesvc-snap-action",
 			curSnaps: []store.CurrentSnap{
-				{InstanceName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1), TrackingChannel: "beta", RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
+				{InstanceName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1), TrackingChannel: "beta", RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1), RequestSeed: s.requestSeed},
 			},
 		},
 		{


### PR DESCRIPTION
Built on top of #5761. The changeset uses `seed-time` for salting/seeding the hash when generating `instance-key` for store requests. We also make sure that `seed-time` is populated.
