### PR TITLE
image: fix incorrect error when using local bases

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -86,6 +86,17 @@ func (li *localInfos) Info(name string) *snap.Info {
 	return nil
 }
 
+// hasName returns true if the given "snapName" is found within the
+// list of snap names or paths.
+func (li *localInfos) hasName(snaps []string, snapName string) bool {
+	for _, snapNameOrPath := range snaps {
+		if li.Name(snapNameOrPath) == snapName {
+			return true
+		}
+	}
+	return false
+}
+
 func localSnaps(tsto *ToolingStore, opts *Options) (*localInfos, error) {
 	local := make(map[string]*snap.Info)
 	nameToPath := make(map[string]string)
@@ -443,7 +454,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		if info.Type == snap.TypeGadget && info.Base != model.Base() {
 			return fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, model.Base())
 		}
-		if info.Base != "" && !strutil.ListContains(snaps, info.Base) {
+		if info.Base != "" && !local.hasName(snaps, info.Base) {
 			return fmt.Errorf("cannot add snap %q without also adding its base %q explicitly", name, info.Base)
 		}
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1458,6 +1458,77 @@ func (s *imageSuite) TestBootstrapGadgetBaseModelBaseMismatch(c *C) {
 	c.Assert(err, ErrorMatches, `cannot use gadget snap because its base "" is different from model base "core18"`)
 }
 
+func (s *imageSuite) TestBootstrapToRootDirSnapReqBase(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":         "16",
+		"authority-id":   "my-brand",
+		"brand-id":       "my-brand",
+		"model":          "my-model",
+		"architecture":   "amd64",
+		"gadget":         "pc",
+		"kernel":         "pc-kernel",
+		"required-snaps": []interface{}{"snap-req-other-base"},
+		"timestamp":      time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	model := rawmodel.(*asserts.Model)
+	rootdir := filepath.Join(c.MkDir(), "imageroot")
+	gadgetUnpackDir := c.MkDir()
+	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
+		"core":                "canonical",
+		"pc":                  "canonical",
+		"pc-kernel":           "canonical",
+		"snap-req-other-base": "canonical",
+	})
+	opts := &image.Options{
+		RootDir:         rootdir,
+		GadgetUnpackDir: gadgetUnpackDir,
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, IsNil)
+	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
+	c.Assert(err, ErrorMatches, `cannot add snap "snap-req-other-base" without also adding its base "other-base" explicitly`)
+}
+
+func (s *imageSuite) TestBootstrapToRootDirSnapReqBaseFromLocal(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":         "16",
+		"authority-id":   "my-brand",
+		"brand-id":       "my-brand",
+		"model":          "my-model",
+		"architecture":   "amd64",
+		"gadget":         "pc",
+		"kernel":         "pc-kernel",
+		"required-snaps": []interface{}{"snap-req-other-base"},
+		"timestamp":      time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	model := rawmodel.(*asserts.Model)
+	rootdir := filepath.Join(c.MkDir(), "imageroot")
+	gadgetUnpackDir := c.MkDir()
+	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
+		"core":                "canonical",
+		"pc":                  "canonical",
+		"pc-kernel":           "canonical",
+		"snap-req-other-base": "canonical",
+		"other-base":          "canonical",
+	})
+	bfn := s.downloadedSnaps["other-base"]
+	opts := &image.Options{
+		RootDir:         rootdir,
+		GadgetUnpackDir: gadgetUnpackDir,
+		Snaps:           []string{bfn},
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, IsNil)
+	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
+	c.Assert(err, IsNil)
+}
+
 type toolingAuthContextSuite struct {
 	ac auth.AuthContext
 }


### PR DESCRIPTION
The image code has a check that ensures that no snaps are added
without their coresponding bases. However there is a bug in that
check where it incorrectly errors if the base is added via the
--extra-snaps commandline. This PR fixes this bug and adds the
missing tests.

Thanks to @sil2100