### PR TITLE
tests: avoid removing core snap on reset

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -104,7 +104,7 @@ reset_all_snap() {
     for snap in "$SNAP_MOUNT_DIR"/*; do
         snap="${snap:6}"
         case "$snap" in
-            "bin" | "$gadget_name" | "$kernel_name" | "$core_name" | README)
+            "bin" | "$gadget_name" | "$kernel_name" | "$core_name" | "core" | README)
                 ;;
             *)
                 # make sure snapd is running before we attempt to remove snaps, in case a test stopped it


### PR DESCRIPTION
This change is done to avoid removing the core snap, which is removed on
the reset script on ubuntu-core-18* systems.

This is making slow the the tests which are installing snaps depending
on the core snap, such as test-snapd-tools.

An example, the test install-closed-channel test is taking 12 seconds on
ubuntu-core-16 and 90 seconds on ubuntu-core-18 running in a local vm.
