### PR TITLE
tests: also run unit/gccgo in 18.04

### DIFF
--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -21,6 +21,7 @@ package main_test
 
 import (
 	"os"
+	"strings"
 	"syscall"
 	"time"
 
@@ -83,5 +84,5 @@ func (s *userdSuite) TestUserd(c *C) {
 	rest, err := snap.Parser().ParseArgs([]string{"userd"})
 	c.Assert(err, IsNil)
 	c.Check(rest, DeepEquals, []string{})
-	c.Check(s.Stdout(), Equals, "Exiting on user defined signal 1.\n")
+	c.Check(strings.ToLower(s.Stdout()), Equals, "exiting on user defined signal 1.\n")
 }

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -541,11 +541,6 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-17.10-64)
                 pkg_linux_image_extra
             ;;
-        ubuntu-18.04-32)
-            echo "
-                gccgo-8
-                "
-            ;;
         ubuntu-18.04-64)
             echo "
                 gccgo-8

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -518,6 +518,7 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-16.04-32)
             echo "
+                gccgo-6
                 evolution-data-server
                 gnome-online-accounts
                 "
@@ -540,8 +541,14 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-17.10-64)
                 pkg_linux_image_extra
             ;;
+        ubuntu-18.04-32)
+            echo "
+                gccgo-8
+                "
+            ;;
         ubuntu-18.04-64)
             echo "
+                gccgo-8
                 evolution-data-server
                 "
             ;;

--- a/tests/unit/gccgo/task.yaml
+++ b/tests/unit/gccgo/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that snapd builds with gccgo
 
 # Only check that gccgo is vaguely happy once.
-systems: [ubuntu-16.04-64]
+systems: [ubuntu-16.04-*, ubuntu-18.04-*]
 
 # Start before anything else as it takes a long time.
 priority: 1000
@@ -12,8 +12,13 @@ warn-timeout: 8m
 kill-timeout: 20m
 
 prepare: |
+    if [ -e /usr/bin/go-8 ]; then
+        goN=/usr/bin/go-8
+    else
+        goN=/usr/bin/go-6
+    fi
     echo Installing gccgo-6 and pretending it is the default go
-    ln -s /usr/bin/go-6 /usr/local/bin/go
+    ln -s "$goN" /usr/local/bin/go
 
 restore: |
     rm -f /usr/local/bin/go

--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -73,7 +73,7 @@ func (s *DBusTest) TearDownSuite(c *C) {
 		err := s.dbusDaemon.Process.Kill()
 		c.Assert(err, IsNil)
 		err = s.dbusDaemon.Wait() // do cleanup
-		c.Assert(err, ErrorMatches, `signal: killed`)
+		c.Assert(err, ErrorMatches, `(?i)signal: killed`)
 	}
 
 }


### PR DESCRIPTION
Without this we were catching some weird gccgoisms only during
pkgbuild tests, which is very late.
