### PR TITLE
overlord: add chg.Err() in testUpdateWithAutoconnectRetry

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2511,6 +2511,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	st.Lock()
 	c.Assert(err, IsNil)
 
+	c.Check(chg.Err(), IsNil)
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// check connections


### PR DESCRIPTION
We are currently seeing build failures in the edge PPA with
the following error:
```
FAIL: managers_test.go:2522: mgrsSuite.TestUpdateWithAutoconnectRetrySlotSide

managers_test.go:2523:
    ms.testUpdateWithAutoconnectRetry(c, "some-snap", "other-snap")
managers_test.go:2514:
    c.Assert(chg.Status(), Equals, state.DoneStatus)
... obtained state.Status = 9 ("Error")
... expected state.Status = 4 ("Done")
```
This happens quite frequently but seems to be dependent on the
environment, i.e. it is not reproducible when run locally outside
of the sbuild environment.
