### PR TITLE
tests: run account-control test with different bases

### DIFF
--- a/tests/lib/snaps/account-control-consumer-core18/bin/chpasswd
+++ b/tests/lib/snaps/account-control-consumer-core18/bin/chpasswd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/chpasswd "$@"

--- a/tests/lib/snaps/account-control-consumer-core18/bin/deluser
+++ b/tests/lib/snaps/account-control-consumer-core18/bin/deluser
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/deluser "$@"

--- a/tests/lib/snaps/account-control-consumer-core18/bin/useradd
+++ b/tests/lib/snaps/account-control-consumer-core18/bin/useradd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/useradd "$@"

--- a/tests/lib/snaps/account-control-consumer-core18/meta/snap.yaml
+++ b/tests/lib/snaps/account-control-consumer-core18/meta/snap.yaml
@@ -1,0 +1,16 @@
+name: account-control-consumer-core18
+version: 1.0
+summary: Basic account-control consumer snap
+description: A basic snap declaring a plug on a account-control slot
+base: core18
+
+apps:
+  useradd:
+    command: bin/useradd
+    plugs: [account-control]
+  deluser:
+    command: bin/deluser
+    plugs: [account-control]
+  chpasswd:
+    command: bin/chpasswd
+    plugs: [account-control]

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -6,14 +6,18 @@ details: |
 
 systems: [ubuntu-core-16-64]
 
+environment:
+    TSNAP/ac: account-control-consumer
+    TSNAP/accore18: account-control-consumer-core18
+
 prepare: |
     echo "Given a snap declaring a plug on account-control is installed"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local account-control-consumer
+    install_local "$TSNAP"
 
     echo "And the account-control plug is connected"
-    snap connect account-control-consumer:account-control
+    snap connect "$TSNAP":account-control
 
 restore: |
     echo "Ensure alice is gone from the system"
@@ -25,8 +29,8 @@ execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
-    "$SNAP_MOUNT_DIR"/bin/account-control-consumer.useradd --extrausers alice
-    echo alice:password | "$SNAP_MOUNT_DIR"/bin/account-control-consumer.chpasswd
+    "$SNAP_MOUNT_DIR"/bin/"$TSNAP".useradd --extrausers alice
+    echo alice:password | "$SNAP_MOUNT_DIR"/bin/"$TSNAP".chpasswd
 
     # User deletion is unsupported yet on Core: https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1659534
-    # $SNAP_MOUNT_DIR/bin/account-control-consumer.userdel --extrausers alice
+    # $SNAP_MOUNT_DIR/bin/"$TSNAP".userdel --extrausers alice


### PR DESCRIPTION
We got a bugreport that the account control interface is not working
correctly when used on UC16 with a snap that uses "base: core18".

To ensure this is working the interfaces-account-control test is
extended to test an account-control-consumer when it comes from
a different base (core18 in the test).



Thanks to Ian Johnson for the report.

