### PR TITLE
tests,interfaces: run interfaces-account-control on UC18

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -52,6 +52,9 @@ const accountControlConnectedPlugAppArmor = `
 /etc/default/nss r,
 /etc/pam.d/{,*} r,
 
+# Needed by chpasswd
+/lib/@{multiarch}/security/* ixr,
+
 # Useradd needs netlink
 network netlink raw,
 

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -4,7 +4,7 @@ details: |
     This test makes sure that a snap using the account-control interface
     can handle the user accounts properly.
 
-systems: [ubuntu-core-16-64]
+systems: [ubuntu-core-16-64, ubuntu-core-18-64]
 
 environment:
     TSNAP/ac: account-control-consumer


### PR DESCRIPTION
This also updates the security profile of the accounts-control
interface. The chpasswd program needs to be able to mmap the
pam modules from common-passwd to be able to work.

Based on https://github.com/snapcore/snapd/pull/5784/files