### PR TITLE
snap: only show "next" refresh time if its after the hold time

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -592,12 +592,14 @@ func (x *cmdRefresh) showRefreshTimes() error {
 		fmt.Fprintf(Stdout, "hold: %s\n", x.fmtTime(hold))
 	}
 	// only show "next" if its after "hold" to not confuse users
-	if hold.IsZero() || next.After(hold) {
-		if !next.IsZero() {
-			fmt.Fprintf(Stdout, "next: %s\n", x.fmtTime(next))
+	if !next.IsZero() {
+		if next.Before(hold) {
+			fmt.Fprintf(Stdout, "next: %s (but held)\n", x.fmtTime(next))
 		} else {
-			fmt.Fprintf(Stdout, "next: n/a\n")
+			fmt.Fprintf(Stdout, "next: %s\n", x.fmtTime(next))
 		}
+	} else {
+		fmt.Fprintf(Stdout, "next: n/a\n")
 	}
 	return nil
 }

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -593,7 +593,9 @@ func (x *cmdRefresh) showRefreshTimes() error {
 	}
 	// only show "next" if its after "hold" to not confuse users
 	if !next.IsZero() {
-		if next.Before(hold) {
+		// Snapstate checks for holdTime.After(limitTime) so we need
+		// to check for before or equal here to be fully correct.
+		if next.Before(hold) || next.Equal(hold) {
 			fmt.Fprintf(Stdout, "next: %s (but held)\n", x.fmtTime(next))
 		} else {
 			fmt.Fprintf(Stdout, "next: %s\n", x.fmtTime(next))

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1003,6 +1003,7 @@ func (s *SnapSuite) TestRefreshHold(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `timer: 0:00-24:00/4
 last: 2017-04-25T17:35:00+02:00
 hold: 2017-04-28T00:00:00+02:00
+next: 2017-04-26T00:58:00+02:00 (but held)
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1003,7 +1003,6 @@ func (s *SnapSuite) TestRefreshHold(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `timer: 0:00-24:00/4
 last: 2017-04-25T17:35:00+02:00
 hold: 2017-04-28T00:00:00+02:00
-next: 2017-04-26T00:58:00+02:00
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit


### PR DESCRIPTION
We got a bugreport that the the output of `snap refresh --time`
is confusing when the "core.refresh.hold" option is used. The
issue here is that "next" may display a time before the hold
time set by the user. The reason is that the internal next
will always be calculated and then when its about to run we
check against the hold time. But this is something internal
so an easy fix to avoid confusion is to simply hide "next"
if its before "hold".

See https://forum.snapcraft.io/t/7230