### PR TITLE
overlord: skip testUpdateWithAutoconnectRetry temporarily

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2417,6 +2417,8 @@ apps:
 `
 
 func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeSnapName string) {
+	c.Skip("2018-09-07: test unreliable during PPA builds and under investiation by Pawel")
+
 	snapPath, _ := ms.makeStoreTestSnap(c, someSnapYaml, "40")
 	ms.serveSnap(snapPath, "40")
 


### PR DESCRIPTION
The testUpdateWithAutoconnectRetry test fails during the snapd
package PPA build in ~50% of the builds. What arches fail seems
random. It seems to be a race, the PPA builders tend to be slower
than the developer machines or GCE instances that this test runs
on usually.

Pawel is investigating the issue. Until this issue is resolved
this PR skips the test so that we get reliable snapd builds back.

