### PR TITLE
cmd/snap-update-ns: separate OpenPath from the Secure struct

### DIFF
--- a/cmd/snap-update-ns/secure_bindmount.go
+++ b/cmd/snap-update-ns/secure_bindmount.go
@@ -43,12 +43,12 @@ func (sec *Secure) BindMount(sourceDir, targetDir string, flags uint) error {
 
 	// Step 1: acquire file descriptors representing the source and destination
 	// directories, ensuring no symlinks are followed.
-	sourceFd, err := sec.OpenPath(sourceDir)
+	sourceFd, err := OpenPath(sourceDir)
 	if err != nil {
 		return err
 	}
 	defer sysClose(sourceFd)
-	targetFd, err := sec.OpenPath(targetDir)
+	targetFd, err := OpenPath(targetDir)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (sec *Secure) BindMount(sourceDir, targetDir string, flags uint) error {
 	if flags&syscall.MS_RDONLY != 0 {
 		// We need to look up the target directory a second time, because
 		// targetFd refers to the path shadowed by the mount point.
-		mountFd, err := sec.OpenPath(targetDir)
+		mountFd, err := OpenPath(targetDir)
 		if err != nil {
 			// FIXME: the mount occurred, but the user moved the target
 			// somewhere

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -159,7 +159,7 @@ func (sec *Secure) CheckTrespassing(dirFd int, dirName string, name string) erro
 //
 // The file descriptor is opened using the O_PATH, O_NOFOLLOW,
 // and O_CLOEXEC flags.
-func (sec *Secure) OpenPath(path string) (int, error) {
+func OpenPath(path string) (int, error) {
 	iter, err := strutil.NewPathIterator(path)
 	if err != nil {
 		return -1, fmt.Errorf("cannot open path: %s", err)

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -717,7 +717,7 @@ func (s *utilsSuite) TestCleanTrailingSlash(c *C) {
 func (s *utilsSuite) TestSecureOpenPath(c *C) {
 	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
 	s.sys.InsertFstatResult("fstat 5 <ptr>", stat)
-	fd, err := s.sec.OpenPath("/foo/bar")
+	fd, err := update.OpenPath("/foo/bar")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 5)
@@ -734,7 +734,7 @@ func (s *utilsSuite) TestSecureOpenPath(c *C) {
 func (s *utilsSuite) TestSecureOpenPathSingleSegment(c *C) {
 	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
 	s.sys.InsertFstatResult("fstat 4 <ptr>", stat)
-	fd, err := s.sec.OpenPath("/foo")
+	fd, err := update.OpenPath("/foo")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 4)
@@ -749,7 +749,7 @@ func (s *utilsSuite) TestSecureOpenPathSingleSegment(c *C) {
 func (s *utilsSuite) TestSecureOpenPathRoot(c *C) {
 	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
 	s.sys.InsertFstatResult("fstat 3 <ptr>", stat)
-	fd, err := s.sec.OpenPath("/")
+	fd, err := update.OpenPath("/")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 3)
@@ -911,7 +911,7 @@ func (s *realSystemSuite) TestSecureOpenPathDirectory(c *C) {
 	path := filepath.Join(c.MkDir(), "test")
 	c.Assert(os.Mkdir(path, 0755), IsNil)
 
-	fd, err := s.sec.OpenPath(path)
+	fd, err := update.OpenPath(path)
 	c.Assert(err, IsNil)
 	defer syscall.Close(fd)
 
@@ -927,7 +927,7 @@ func (s *realSystemSuite) TestSecureOpenPathDirectory(c *C) {
 }
 
 func (s *realSystemSuite) TestSecureOpenPathRelativePath(c *C) {
-	fd, err := s.sec.OpenPath("relative/path")
+	fd, err := update.OpenPath("relative/path")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "path .* is not absolute")
 }
@@ -937,15 +937,15 @@ func (s *realSystemSuite) TestSecureOpenPathUncleanPath(c *C) {
 	path := filepath.Join(base, "test")
 	c.Assert(os.Mkdir(path, 0755), IsNil)
 
-	fd, err := s.sec.OpenPath(base + "//test")
+	fd, err := update.OpenPath(base + "//test")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `cannot open path: cannot iterate over unclean path ".*//test"`)
 
-	fd, err = s.sec.OpenPath(base + "/./test")
+	fd, err = update.OpenPath(base + "/./test")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `cannot open path: cannot iterate over unclean path ".*/./test"`)
 
-	fd, err = s.sec.OpenPath(base + "/test/../test")
+	fd, err = update.OpenPath(base + "/test/../test")
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `cannot open path: cannot iterate over unclean path ".*/test/../test"`)
 }
@@ -954,7 +954,7 @@ func (s *realSystemSuite) TestSecureOpenPathFile(c *C) {
 	path := filepath.Join(c.MkDir(), "file.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("hello"), 0644), IsNil)
 
-	fd, err := s.sec.OpenPath(path)
+	fd, err := update.OpenPath(path)
 	c.Assert(err, IsNil)
 	defer syscall.Close(fd)
 
@@ -968,7 +968,7 @@ func (s *realSystemSuite) TestSecureOpenPathFile(c *C) {
 func (s *realSystemSuite) TestSecureOpenPathNotFound(c *C) {
 	path := filepath.Join(c.MkDir(), "test")
 
-	fd, err := s.sec.OpenPath(path)
+	fd, err := update.OpenPath(path)
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "no such file or directory")
 }
@@ -981,7 +981,7 @@ func (s *realSystemSuite) TestSecureOpenPathSymlink(c *C) {
 	symlink := filepath.Join(base, "symlink")
 	c.Assert(os.Symlink(dir, symlink), IsNil)
 
-	fd, err := s.sec.OpenPath(symlink)
+	fd, err := update.OpenPath(symlink)
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, `".*" is a symbolic link`)
 }
@@ -998,7 +998,7 @@ func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {
 	c.Assert(os.Symlink(dir, symlink), IsNil)
 	c.Assert(os.Mkdir(path, 0755), IsNil)
 
-	fd, err := s.sec.OpenPath(symlinkedPath)
+	fd, err := update.OpenPath(symlinkedPath)
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "not a directory")
 }


### PR DESCRIPTION
The OpenPath function doesn't need to use the Secure type so let's
detach it. This operation will be followed up by detaching of remaining
helpers from said structure.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
