### PR TITLE
ifacestate: retry on "discard-snap" in autoconnect conflict check

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -652,7 +652,7 @@ func checkAutoconnectConflicts(st *state.State, plugSnap, slotSnap string) error
 		}
 
 		// other snap that affects us because of plug or slot
-		if k == "unlink-snap" || k == "link-snap" || k == "setup-profiles" {
+		if k == "unlink-snap" || k == "link-snap" || k == "setup-profiles" || k == "discard-snap" {
 			// if snap is getting removed, we will retry but the snap will be gone and auto-connect becomes no-op
 			// if snap is getting installed/refreshed - temporary conflict, retry later
 			return &state.Retry{After: connectRetryTimeout}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -546,6 +546,14 @@ func (s *interfaceManagerSuite) TestAutoconnectConflictOnUnlink(c *C) {
 	s.testRetryError(c, err)
 }
 
+func (s *interfaceManagerSuite) TestAutoconnectConflictOnDiscardSnap(c *C) {
+	s.state.Lock()
+	task := s.state.NewTask("discard-snap", "")
+	s.state.Unlock()
+	err := s.createAutoconnectChange(c, task)
+	s.testRetryError(c, err)
+}
+
 func (s *interfaceManagerSuite) TestAutoconnectConflictOnLink(c *C) {
 	s.state.Lock()
 	task := s.state.NewTask("link-snap", "")


### PR DESCRIPTION
In the conflict checking code we wait (i.e. retry) for "unlink-snap" task of the other snap to finish, but this is not enough - we should actually wait for "discard-snap"as doDiscardSnap removes the snap from snapstate (if it was the last installed revision). Not waiting for discard-snap means we have a small window between unlink-snap and discard-snap where autoconnect might conclude it's ok to create connect tasks and hooks desptite the fact that the other snap is being removed. If such window is hit, we get the following test failure caused by interface hooks (hooks were created by doAutoConnect handler after unlink-snap of "other-snap", but before "discard-snap", the hooks then failed after "discard-snap" removed the snap from snapstate:
```
managers_test.go:2530:
    c.Check(chg.Err(), IsNil)
... value *state.changeError = &state.changeError{errors:[]state.taskError{state.taskError{task:"Run hook prepare-plug-media-hub of snap \"other-snap\"", error:"cannot find \"other-snap\" snap"}
```

Note, waiting on "discard-snaps" means we also wait on "remove-profiles" (which we should wait for anyway as it disconnects the snap from repo).