### PR TITLE
cmd/snap-update-ns: re-factor pair of helpers to call fstatfs once

### DIFF
--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -73,21 +73,17 @@ var (
 //
 // Directories are read only when they reside on file systems mounted in read
 // only mode or when the underlying file system itself is inherently read only.
-func IsReadOnly(dirFd int, dirName string) (bool, error) {
-	var fsData syscall.Statfs_t
-	if err := sysFstatfs(dirFd, &fsData); err != nil {
-		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
-	}
+func IsReadOnly(dirFd int, dirName string, fsData *syscall.Statfs_t) bool {
 	// If something is mounted with f_flags & ST_RDONLY then is read-only.
 	if fsData.Flags&StReadOnly == StReadOnly {
-		return true, nil
+		return true
 	}
 	// If something is a known read-only file-system then it is safe.
 	// Older copies of snapd were not mounting squashfs as read only.
 	if fsData.Type == SquashfsMagic {
-		return true, nil
+		return true
 	}
-	return false, nil
+	return false
 }
 
 // IsSnapdCreatedPrivateTmpfs returns true if a directory is a tmpfs mounted by snapd.
@@ -97,14 +93,10 @@ func IsReadOnly(dirFd int, dirName string) (bool, error) {
 // the mount namespace. A directory is trusted if it is a tmpfs that was
 // mounted by snap-confine or snapd-update-ns. Note that sub-directories of a
 // trusted tmpfs are not considered trusted by this function.
-func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (bool, error) {
-	var fsData syscall.Statfs_t
-	if err := sysFstatfs(dirFd, &fsData); err != nil {
-		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
-	}
+func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, fsData *syscall.Statfs_t, changes []*Change) bool {
 	// If something is not a tmpfs it cannot be the trusted tmpfs we are looking for.
 	if fsData.Type != TmpfsMagic {
-		return false, nil
+		return false
 	}
 	// Any of the past changes that mounted a tmpfs exactly at the directory we
 	// are inspecting is considered as trusted. This is conservative because it
@@ -119,7 +111,7 @@ func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (b
 	for i := len(changes) - 1; i >= 0; i-- {
 		change := changes[i]
 		if change.Entry.Type == "tmpfs" && change.Entry.Dir == dirName {
-			return change.Action == Mount, nil
+			return change.Action == Mount
 		}
 	}
 	// TODO: As a special exception, assume that a tmpfs over /var/lib is
@@ -127,7 +119,7 @@ func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (b
 	// a particular behavior of LXD.  Once the quirk is migrated to a mount
 	// profile (or removed entirely if no longer necessary) the following code
 	// fragment can go away.
-	return dirName == "/var/lib", nil
+	return dirName == "/var/lib"
 }
 
 // ReadOnlyFsError is an error encapsulating encountered EROFS.

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -759,151 +759,110 @@ func (s *utilsSuite) TestSecureOpenPathRoot(c *C) {
 	})
 }
 
-func (s *utilsSuite) TestIsReadOnlyFstatfsError(c *C) {
-	path := "/some/path"
-	s.sys.InsertFault("fstatfs 3 <ptr>", errTesting)
-	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
-	c.Assert(err, IsNil)
-	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, ErrorMatches, `cannot fstatfs "/some/path": testing`)
-	c.Assert(result, Equals, false)
-}
-
 func (s *utilsSuite) TestIsReadOnlySquashfsMountedRo(c *C) {
-	statfs := syscall.Statfs_t{Type: update.SquashfsMagic, Flags: update.StReadOnly}
+	statfs := &syscall.Statfs_t{Type: update.SquashfsMagic, Flags: update.StReadOnly}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, IsNil)
+	result := update.IsReadOnly(fd, path, statfs)
 	c.Assert(result, Equals, true)
 }
 
 func (s *utilsSuite) TestIsReadOnlySquashfsMountedRw(c *C) {
-	statfs := syscall.Statfs_t{Type: update.SquashfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.SquashfsMagic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, IsNil)
+	result := update.IsReadOnly(fd, path, statfs)
 	c.Assert(result, Equals, true)
 }
 
 func (s *utilsSuite) TestIsReadOnlyExt4MountedRw(c *C) {
-	statfs := syscall.Statfs_t{Type: update.Ext4Magic}
+	statfs := &syscall.Statfs_t{Type: update.Ext4Magic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsReadOnly(fd, path)
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, false)
-}
-
-func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsFstatfsError(c *C) {
-	// fstatfs errors are handled and propagated.
-	path := "/some/path"
-	s.sys.InsertFault("fstatfs 3 <ptr>", errTesting)
-	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
-	c.Assert(err, IsNil)
-	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, ErrorMatches, `cannot fstatfs "/some/path": testing`)
+	result := update.IsReadOnly(fd, path, statfs)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsNotATmpfs(c *C) {
 	// An ext4 (which is not a tmpfs) is not a private tmpfs.
-	statfs := syscall.Statfs_t{Type: update.Ext4Magic}
+	statfs := &syscall.Statfs_t{Type: update.Ext4Magic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, IsNil)
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, nil)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsNotTrusted(c *C) {
 	// A tmpfs is not private if it doesn't come from a change we made.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, IsNil)
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, nil)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsViaChanges(c *C) {
 	// A tmpfs is private because it was mounted by snap-update-ns.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	path := "/some/path"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 
 	// A tmpfs was mounted in the past so it is private.
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, []*update.Change{
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, true)
 
 	// A tmpfs was mounted but then it was unmounted so it is not private anymore.
-	result, err = update.IsSnapdCreatedPrivateTmpfs(fd, path, []*update.Change{
+	result = update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, false)
 
 	// Finally, after the mounting and unmounting the tmpfs was mounted again.
-	result, err = update.IsSnapdCreatedPrivateTmpfs(fd, path, []*update.Change{
+	result = update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, true)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsDeeper(c *C) {
 	// A tmpfs is not private beyond the exact mount point from a change.
 	// That is, sub-directories of a private tmpfs are not recognized as private.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	fd, err := s.sys.Open("/some/path/below", syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, "/some/path/below", []*update.Change{
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, "/some/path/below", statfs, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/some/path", Type: "tmpfs"}},
 	})
-	c.Assert(err, IsNil)
 	c.Assert(result, Equals, false)
 }
 
 func (s *utilsSuite) TestIsSnapdCreatedPrivateTmpfsViaVarLib(c *C) {
 	// A tmpfs in /var/lib is private because it is a special
 	// quirk applied by snap-confine, without having a change record.
-	statfs := syscall.Statfs_t{Type: update.TmpfsMagic}
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
 	path := "/var/lib"
-	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
 	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
-	result, err := update.IsSnapdCreatedPrivateTmpfs(fd, path, nil)
-	c.Assert(err, IsNil)
+	result := update.IsSnapdCreatedPrivateTmpfs(fd, path, statfs, nil)
 	c.Assert(result, Equals, true)
 }
 


### PR DESCRIPTION
This patch changes IsReadOnly and IsSnapdCreatedPrivateTmpfs to accept
a syscall.Statfs_t buffer and delegate the call that populates the
buffer to the upcoming helper that combines the two. I did this after
noticing a pattern of repeated fstatfs, on the same file descriptor,
inside tests that would exercise this code path. This lets use save
one of the calls.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
