### PR TITLE
cmd/snap-update-ns: detach BindMount from the Secure type

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -287,7 +287,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
 			// Use Secure.BindMount for bind mounts
 			if flags&syscall.MS_BIND == syscall.MS_BIND {
-				err = sec.BindMount(c.Entry.Name, c.Entry.Dir, uint(flags))
+				err = BindMount(c.Entry.Name, c.Entry.Dir, uint(flags))
 			} else {
 				err = sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","))
 			}

--- a/cmd/snap-update-ns/secure_bindmount.go
+++ b/cmd/snap-update-ns/secure_bindmount.go
@@ -26,7 +26,7 @@ import (
 
 // BindMount performs a bind mount between two absolute paths containing no
 // symlinks.
-func (sec *Secure) BindMount(sourceDir, targetDir string, flags uint) error {
+func BindMount(sourceDir, targetDir string, flags uint) error {
 	// This function only attempts to handle bind mounts. Expanding to other
 	// mounts will require examining do_mount() from fs/namespace.c of the
 	// kernel that called functions (eventually) verify `DCACHE_CANT_MOUNT` is


### PR DESCRIPTION
This continues the removal of the Secure type which is currently de-facto unused.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
