### PR TITLE
osutil, o/snapshotstate, o/sss/backend: quick fixes

### DIFF
--- a/osutil/mkdirallchown.go
+++ b/osutil/mkdirallchown.go
@@ -22,14 +22,22 @@ package osutil
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 
 	"github.com/snapcore/snapd/osutil/sys"
 )
 
+// XXX: we need to come back and fix this; this is a hack to unblock us.
+//      As part of the fixing we should unify with the similar code in
+//      cmd/snap-update-ns/utils.(*Secure).MkdirAll
+var mu sync.Mutex
+
 // MkdirAllChown is like os.MkdirAll but it calls os.Chown on any
 // directories it creates.
 func MkdirAllChown(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
+	mu.Lock()
+	defer mu.Unlock()
 	return mkdirAllChown(filepath.Clean(path), perm, uid, gid)
 }
 

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -436,6 +436,9 @@ func (s *snapshotSuite) TestAddDirToZip(c *check.C) {
 }
 
 func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root")
+	}
 	logger.SimpleSetup()
 
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42)}, Version: "v1.33"}

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -437,7 +437,7 @@ func (s *snapshotSuite) TestAddDirToZip(c *check.C) {
 
 func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("this test cannot run as root")
+		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	logger.SimpleSetup()
 

--- a/overlord/snapshotstate/backend/helpers.go
+++ b/overlord/snapshotstate/backend/helpers.go
@@ -165,10 +165,11 @@ func maybeRunuserCommand(username string, args ...string) *exec.Cmd {
 		// runuser only works for euid 0, and doesn't make sense for root
 		return exec.Command(args[0], args[1:]...)
 	}
-	sudoArgs := make([]string, len(args)+2)
-	copy(sudoArgs[2:], args)
+	sudoArgs := make([]string, len(args)+3)
+	copy(sudoArgs[3:], args)
 	sudoArgs[0] = "-u"
 	sudoArgs[1] = username
+	sudoArgs[2] = "--"
 
 	return exec.Command("runuser", sudoArgs...)
 }

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -488,6 +488,9 @@ func (snapshotSuite) TestSaveOneSnap(c *check.C) {
 }
 
 func (snapshotSuite) TestSaveIntegration(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root")
+	}
 	o := overlord.Mock()
 	st := o.State()
 	st.Lock()
@@ -573,6 +576,9 @@ func (snapshotSuite) TestSaveIntegration(c *check.C) {
 }
 
 func (snapshotSuite) TestSaveIntegrationFails(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root")
+	}
 	o := overlord.Mock()
 	st := o.State()
 	st.Lock()
@@ -815,6 +821,9 @@ func (snapshotSuite) TestRestore(c *check.C) {
 }
 
 func (snapshotSuite) TestRestoreIntegration(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root")
+	}
 	o := overlord.Mock()
 	st := o.State()
 	st.Lock()
@@ -881,6 +890,9 @@ func (snapshotSuite) TestRestoreIntegration(c *check.C) {
 }
 
 func (snapshotSuite) TestRestoreIntegrationFails(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root")
+	}
 	o := overlord.Mock()
 	st := o.State()
 	st.Lock()
@@ -946,11 +958,15 @@ func (snapshotSuite) TestRestoreIntegrationFails(c *check.C) {
 	tasks := change.Tasks()
 	c.Check(tasks, check.HasLen, 3)
 	for _, task := range tasks {
-		c.Check(task.Status(), check.Equals, state.ErrorStatus)
 		if strings.Contains(task.Summary(), `"too-snap"`) {
+			c.Check(task.Status(), check.Equals, state.ErrorStatus)
 			c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR mkdir \S+: permission denied`)
 		} else {
-			c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR context canceled`)
+			if task.Status() == state.ErrorStatus {
+				c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR context canceled`)
+			} else {
+				c.Check(task.Status(), check.Equals, state.UndoneStatus)
+			}
 		}
 	}
 

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -489,7 +489,7 @@ func (snapshotSuite) TestSaveOneSnap(c *check.C) {
 
 func (snapshotSuite) TestSaveIntegration(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("this test cannot run as root")
+		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	o := overlord.Mock()
 	st := o.State()
@@ -577,7 +577,7 @@ func (snapshotSuite) TestSaveIntegration(c *check.C) {
 
 func (snapshotSuite) TestSaveIntegrationFails(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("this test cannot run as root")
+		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	o := overlord.Mock()
 	st := o.State()
@@ -822,7 +822,7 @@ func (snapshotSuite) TestRestore(c *check.C) {
 
 func (snapshotSuite) TestRestoreIntegration(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("this test cannot run as root")
+		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	o := overlord.Mock()
 	st := o.State()
@@ -891,7 +891,7 @@ func (snapshotSuite) TestRestoreIntegration(c *check.C) {
 
 func (snapshotSuite) TestRestoreIntegrationFails(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("this test cannot run as root")
+		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	o := overlord.Mock()
 	st := o.State()
@@ -959,9 +959,15 @@ func (snapshotSuite) TestRestoreIntegrationFails(c *check.C) {
 	c.Check(tasks, check.HasLen, 3)
 	for _, task := range tasks {
 		if strings.Contains(task.Summary(), `"too-snap"`) {
+			// too-snap was set up to fail, should always fail with
+			// 'permission denied' (see the mkdirall w/mode 0 above)
 			c.Check(task.Status(), check.Equals, state.ErrorStatus)
 			c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR mkdir \S+: permission denied`)
 		} else {
+			// the other two might fail (ErrorStatus) if they're
+			// still running when too-snap fails, or they might have
+			// finished and needed to be undone (UndoneStatus); it's
+			// a race, but either is fine.
 			if task.Status() == state.ErrorStatus {
 				c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR context canceled`)
 			} else {


### PR DESCRIPTION
osutil, o/snapshotstate, o/sss/backend: quick fixes

This change addresses a few racy errors that started appearing in
spread once snapshotstate had landed, and some issues that were found
during the debugging of same.

In particular:

* `o/snapshotstate/backend`

  the runuser wrapper had a bug (or runuser has a bug?)  where the -- is
  needed because runuser's option parsing does not stop at he first
  non-option.

* `o/snapshotstate`

  In TestRestoreIntegrationFails sometimes one of the restores actually
  succeeds, and is undone, instead of erroring out.  Also, if running as
  root, don't run the integration tests, as the faking of the user does not
  amuse runuser

* `osutil`

  have a lock so that if one goroutine tries to mkdirallchown /foo/bar, and
  another tries to mkdirallchown /foo/baz, they can't both decide they need
  to make /foo and then have one fail.

  This is hackish, and needs a proper fix, but contention for the lock is
  going to be low and fixing it properly will be tricky. We'll do that
  later.
