### PR TITLE
Install snap-failure binary on Fedora

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -464,6 +464,7 @@ sed -e "s:github.com/snapcore/bolt:github.com/boltdb/bolt:g" -i advisor/*.go err
 %gobuild -o bin/snapd $GOFLAGS %{import_path}/cmd/snapd
 %gobuild -o bin/snap $GOFLAGS %{import_path}/cmd/snap
 %gobuild -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
+%gobuild -o bin/snap-failure $GOFLAGS %{import_path}/cmd/snap-failure
 
 # To ensure things work correctly with base snaps,
 # snap-exec and snap-update-ns need to be built statically
@@ -546,6 +547,7 @@ install -d -p %{buildroot}%{_datadir}/selinux/packages
 # Install snap and snapd
 install -p -m 0755 bin/snap %{buildroot}%{_bindir}
 install -p -m 0755 bin/snap-exec %{buildroot}%{_libexecdir}/snapd
+install -p -m 0755 bin/snap-failure %{buildroot}%{_libexecdir}/snapd
 install -p -m 0755 bin/snapctl %{buildroot}%{_bindir}/snapctl
 install -p -m 0755 bin/snapd %{buildroot}%{_libexecdir}/snapd
 install -p -m 0755 bin/snap-update-ns %{buildroot}%{_libexecdir}/snapd
@@ -677,6 +679,7 @@ popd
 %dir %{_libexecdir}/snapd
 %{_libexecdir}/snapd/snapd
 %{_libexecdir}/snapd/snap-exec
+%{_libexecdir}/snapd/snap-failure
 %{_libexecdir}/snapd/info
 %{_libexecdir}/snapd/snap-mgmt
 %{_mandir}/man1/snap.1*


### PR DESCRIPTION
I tried to sign the contributor agreement, but don't know who to specify as Canonical Manager