### PR TITLE
cmd: use systemdsystemgeneratorsdir, cleanup automake complaints, tweaks

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -245,7 +245,7 @@ snap_confine_snap_confine_SOURCES += \
 	snap-confine/seccomp-support.h
 snap_confine_snap_confine_CFLAGS += $(SECCOMP_CFLAGS)
 if STATIC_LIBSECCOMP
-snap_confine_snap_confine_STATIC += $(shell pkg-config --static --libs libseccomp)
+snap_confine_snap_confine_STATIC += $(shell $(PKG_CONFIG) --static --libs libseccomp)
 else
 snap_confine_snap_confine_extra_libs += $(SECCOMP_LIBS)
 endif  # STATIC_LIBSECCOMP
@@ -254,7 +254,7 @@ endif  # SECCOMP
 if APPARMOR
 snap_confine_snap_confine_CFLAGS += $(APPARMOR_CFLAGS)
 if STATIC_LIBAPPARMOR
-snap_confine_snap_confine_STATIC += $(shell pkg-config --static --libs libapparmor)
+snap_confine_snap_confine_STATIC += $(shell $(PKG_CONFIG) --static --libs libapparmor)
 else
 snap_confine_snap_confine_extra_libs += $(APPARMOR_LIBS)
 endif  # STATIC_LIBAPPARMOR
@@ -398,7 +398,7 @@ snap_discard_ns_snap_discard_ns_STATIC =
 if APPARMOR
 snap_discard_ns_snap_discard_ns_CFLAGS += $(APPARMOR_CFLAGS)
 if STATIC_LIBAPPARMOR
-snap_discard_ns_snap_discard_ns_STATIC += $(shell pkg-config --static --libs libapparmor)
+snap_discard_ns_snap_discard_ns_STATIC += $(shell $(PKG_CONFIG) --static --libs libapparmor)
 else
 snap_discard_ns_snap_discard_ns_LDADD += $(APPARMOR_LIBS)
 endif  # STATIC_LIBAPPARMOR

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -7,9 +7,6 @@ dist_man_MANS =
 noinst_PROGRAMS =
 noinst_LIBRARIES =
 
-# FIXME: get this via something like pkgconf once it is defined there
-SYSTEMD_SYSTEM_ENV_GENERATOR_DIR=/usr/lib/systemd/system-environment-generators
-
 CHECK_CFLAGS = -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes \
 	-Wno-missing-field-initializers -Wno-unused-parameter
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -344,7 +344,11 @@ endif
 ## snap-mgmt
 ##
 
-libexec_PROGRAMS += snap-mgmt/snap-mgmt
+libexec_SCRIPTS = snap-mgmt/snap-mgmt
+
+snap-mgmt/$(am__dirstamp):
+	mkdir -p $$(dirname $@)
+	touch $@
 
 snap-mgmt/snap-mgmt: snap-mgmt/snap-mgmt.sh.in Makefile snap-mgmt/$(am__dirstamp)
 	sed -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),' <$< >$@

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -342,6 +342,7 @@ endif
 ##
 
 libexec_SCRIPTS = snap-mgmt/snap-mgmt
+CLEANFILES += snap-mgmt/$(am__dirstamp) snap-mgmt/snap-mgmt
 
 snap-mgmt/$(am__dirstamp):
 	mkdir -p $$(dirname $@)

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -463,7 +463,8 @@ snap_gdb_shim_snap_gdb_shim_LDADD = libsnap-confine-private.a
 ## snapd-generator
 ##
 
-libexec_PROGRAMS += snapd-generator/snapd-generator
+systemdsystemgeneratordir = $(SYSTEMD_SYSTEM_GENERATOR_DIR)
+systemdsystemgenerator_PROGRAMS = snapd-generator/snapd-generator
 
 snapd_generator_snapd_generator_SOURCES = snapd-generator/main.c
 snapd_generator_snapd_generator_LDADD = libsnap-confine-private.a

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -232,5 +232,9 @@ SYSTEMD_SYSTEM_GENERATOR_DIR="$($PKG_CONFIG --variable=systemdsystemgeneratordir
 AS_IF([test "x$SYSTEMD_SYSTEM_GENERATOR_DIR" = "x"], [SYSTEMD_SYSTEM_GENERATOR_DIR=/lib/systemd/system-generators])
 AC_SUBST(SYSTEMD_SYSTEM_GENERATOR_DIR)
 
+# FIXME: get this via something like pkgconf once it is defined there
+SYSTEMD_SYSTEM_ENV_GENERATOR_DIR="${prefix}/lib/systemd/system-environment-generators"
+AC_SUBST(SYSTEMD_SYSTEM_ENV_GENERATOR_DIR)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -228,5 +228,9 @@ AC_ARG_WITH([host-arch-32bit-triplet],
 AC_SUBST(HOST_ARCH32_TRIPLET)
 AC_DEFINE_UNQUOTED([HOST_ARCH32_TRIPLET], "${HOST_ARCH32_TRIPLET}", [Arch triplet for 32bit libraries])
 
+SYSTEMD_SYSTEM_GENERATOR_DIR="$($PKG_CONFIG --variable=systemdsystemgeneratordir systemd)"
+AS_IF([test "x$SYSTEMD_SYSTEM_GENERATOR_DIR" = "x"], [SYSTEMD_SYSTEM_GENERATOR_DIR=/lib/systemd/system-generators])
+AC_SUBST(SYSTEMD_SYSTEM_GENERATOR_DIR)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -166,9 +166,6 @@ package() {
   install -dm700 "$pkgdir/var/lib/snapd/cache"
 
   make -C cmd install DESTDIR="$pkgdir/"
-  # move snapd-generator to systemd generators
-  install -dm755 "$pkgdir/usr/lib/systemd/system-generators"
-  mv "$pkgdir/usr/lib/snapd/snapd-generator" "$pkgdir/usr/lib/systemd/system-generators/"
 
   # Install man file
   mkdir -p "$pkgdir/usr/share/man/man1"

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -577,8 +577,6 @@ chmod 0755 %{buildroot}%{_sharedstatedir}/snapd/void
 rm -rfv %{buildroot}%{_sysconfdir}/apparmor.d
 # ubuntu-core-launcher is dead
 rm -fv %{buildroot}%{_bindir}/ubuntu-core-launcher
-# Move systemd-generator to the right place
-mv %{buildroot}%{_libexecdir}/snapd/snapd-generator %{buildroot}%{_systemdgeneratordir}
 popd
 
 # Install all systemd and dbus units, and env files

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -281,9 +281,6 @@ install -m 644 -D data/info %{buildroot}%{_libexecdir}/snapd/info
 install -m 644 -D data/completion/snap %{buildroot}%{_datadir}/bash-completion/completions/snap
 install -m 644 -D data/completion/complete.sh %{buildroot}%{_libexecdir}/snapd
 install -m 644 -D data/completion/etelpmoc.sh %{buildroot}%{_libexecdir}/snapd
-# move snapd-generator
-install -m 755 -d %{buildroot}%{_prefix}/lib/systemd/system-generators/
-mv %{buildroot}%{_libexecdir}/snapd/snapd-generator %{buildroot}%{_prefix}/lib/systemd/system-generators/
 
 # Don't ship apparmor helper service when AppArmor is not enabled
 %if ! %{with apparmor}

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -7,7 +7,6 @@ usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapd /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
-usr/lib/snapd/snapd-generator /lib/systemd/system-generators/
 
 # bash completion
 data/completion/snap /usr/share/bash-completion/completions
@@ -36,3 +35,5 @@ usr/lib/snapd/snap-gdb-shim
 
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
+# but system generators end up in lib
+lib/systemd/system-generators

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -7,7 +7,6 @@ usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapd /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
-usr/lib/snapd/snapd-generator /lib/systemd/system-generators/
 
 # bash completion
 data/completion/snap /usr/share/bash-completion/completions
@@ -41,4 +40,5 @@ vendor/github.com/snapcore/squashfuse/src/snapfuse usr/bin
 
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
-
+# but system generators end up in lib
+lib/systemd/system-generators


### PR DESCRIPTION
The main change is discovery and use `systemdsystemgeneratorsdir` to ship snapd-generator. This was quite annoying as each packaging required a fix to move it to the right place. Now it's at the right place to begin with. As usual Ubuntu 14.04 gave some troubles as `systemdsystemgeneratorsdir` was not defined yet in that systemd version, so we default to `lib/systemd/system-generators`.

On top of this, a small tweak to use `$(PKG_CONFIG)` rather than `pkg-config` directly, just in case a path to PKG_CONFIG is overridden or someone is using `pkgconf` without the symlink.

Lastly, fix an annoying warning by `automake` regarding `snap-mgmt`:
```
configure.ac:5: installing './compile'                                                                                                                                                                                                                                                                                                                      
configure.ac:42: installing './config.guess'                                                                                                                                                                                                                                                                                                                
configure.ac:42: installing './config.sub'                                                                                                                                                                                                                                                                                                                  
configure.ac:6: installing './install-sh'                                                                                                                                                                                                                                                                                                                   
configure.ac:6: installing './missing'                                                                                                                                                                                                                                                                                                                      
Makefile.am:350: warning: deprecated feature: target 'snap-mgmt/snap-mgmt' overrides 'snap-mgmt/snap-mgmt$(EXEEXT)'                                                                                                                                                              
Makefile.am:350: change your target to read 'snap-mgmt/snap-mgmt$(EXEEXT)'                                                                                                                                                                                                                                                                                  
/usr/share/automake-1.15/am/program.am: target 'snap-mgmt/snap-mgmt$(EXEEXT)' was defined here                                                                                                                                                                                                                                                              
Makefile.am:5:   while processing program 'snap-mgmt/snap-mgmt'                                                                                                                                                                                                                                                                                             
Makefile.am: installing './depcomp'                                                                                                                                                                                                                                                                                                                         
parallel-tests: installing './test-driver'                    
```
Unfortunately, this required a small workaround for out of the source builds. Apparently, if a `_SCRIPT` is in subdirectory, the directory is not properly created when building outside of source dir.
