### PR TITLE
ifacestate: fix hang when retrying content providers

### DIFF
--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1592,9 +1592,9 @@ plugs:
   default-provider: gtk-common-themes
   target: $SNAP/data-dir/themes
 `
-	fooFname, fooDecl, fooRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
+	calcFname, calcDecl, calcRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
 
-	writeAssertionsToFile("foo.asserts", []asserts.Assertion{devAcct, fooRev, fooDecl})
+	writeAssertionsToFile("calc.asserts", []asserts.Assertion{devAcct, calcRev, calcDecl})
 
 	// put a 2nd firstboot snap into the SnapBlobDir
 	snapYaml = `name: gtk-common-themes
@@ -1606,9 +1606,9 @@ slots:
    read:
     - $SNAP/share/themes/Adawaita
 `
-	barFname, barDecl, barRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(65), "developerid")
+	themesFname, themesDecl, themesRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(65), "developerid")
 
-	writeAssertionsToFile("bar.asserts", []asserts.Assertion{devAcct, barDecl, barRev})
+	writeAssertionsToFile("themes.asserts", []asserts.Assertion{devAcct, themesDecl, themesRev})
 
 	// add a model assertion and its chain
 	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
@@ -1627,7 +1627,7 @@ snaps:
    file: %s
  - name: gtk-common-themes
    file: %s
-`, coreFname, kernelFname, gadgetFname, fooFname, barFname))
+`, coreFname, kernelFname, gadgetFname, calcFname, themesFname))
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -32,6 +32,7 @@ var (
 	ConnectPriv                  = connect
 	GetConns                     = getConns
 	SetConns                     = setConns
+	InSameChangeWaitChain        = inSameChangeWaitChain
 )
 
 func NewConnectOptsWithAutoSet() connectOpts {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -711,14 +711,25 @@ func checkDisconnectConflicts(st *state.State, disconnectingSnap, plugSnap, slot
 	return nil
 }
 
-// inWaitChains returns true if there is a wait chain so that t1
-// is run before needle
-func inWaitChain(t1, needle *state.Task) bool {
-	for _, cand := range t1.HaltTasks() {
-		if inWaitChain(cand, needle) {
+// inSameChangeWaitChains returns true if there is a wait chain so
+// that `startT` is run before `searchT` in the same state.Change.
+func inSameChangeWaitChain(startT, searchT *state.Task) bool {
+	// Trivial case, tasks in different changes (they could in theory
+	// still have cross-change waits but we don't do these today).
+	// In this case, return quickly.
+	if startT.Change() != searchT.Change() {
+		return false
+	}
+	// Do a recursive check if its in the same change
+	return inWaitChainWalker(startT, searchT)
+}
+
+func inWaitChainWalker(startT, searchT *state.Task) bool {
+	for _, cand := range startT.HaltTasks() {
+		if cand == searchT {
 			return true
 		}
-		if cand == needle {
+		if inWaitChainWalker(cand, searchT) {
 			return true
 		}
 	}
@@ -777,7 +788,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 				// Only retry if the task that installs the
 				// content provider is not waiting for us
 				// (or this will just hang forever).
-				if defaultProviders[snapsup.InstanceName()] && !inWaitChain(task, t) {
+				if defaultProviders[snapsup.InstanceName()] && !inSameChangeWaitChain(task, t) {
 					return &state.Retry{After: contentLinkRetryTimeout}
 				}
 			}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -721,15 +721,15 @@ func inSameChangeWaitChain(startT, searchT *state.Task) bool {
 		return false
 	}
 	// Do a recursive check if its in the same change
-	return inWaitChainWalker(startT, searchT)
+	return waitChainSearch(startT, searchT)
 }
 
-func inWaitChainWalker(startT, searchT *state.Task) bool {
+func waitChainSearch(startT, searchT *state.Task) bool {
 	for _, cand := range startT.HaltTasks() {
 		if cand == searchT {
 			return true
 		}
-		if inWaitChainWalker(cand, searchT) {
+		if waitChainSearch(cand, searchT) {
 			return true
 		}
 	}

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type handlersSuite struct{}
+
+var _ = Suite(&handlersSuite{})
+
+func (s *handlersSuite) TestInSameChangeWaitChain(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	// no wait chain (yet)
+	startT := st.NewTask("start", "...start")
+	intermediateT := st.NewTask("intermediateT", "...intermediateT")
+	searchT := st.NewTask("searchT", "...searchT")
+	c.Check(ifacestate.InSameChangeWaitChain(startT, searchT), Equals, false)
+
+	// add (indirect) wait chain
+	searchT.WaitFor(intermediateT)
+	intermediateT.WaitFor(startT)
+	c.Check(ifacestate.InSameChangeWaitChain(startT, searchT), Equals, true)
+}
+
+func (s *handlersSuite) TestInSameChangeWaitChainDifferentChanges(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t1 := st.NewTask("t1", "...")
+	chg1 := st.NewChange("chg1", "...")
+	chg1.AddTask(t1)
+
+	t2 := st.NewTask("t2", "...")
+	chg2 := st.NewChange("chg2", "...")
+	chg2.AddTask(t2)
+
+	// add a cross change wait chain
+	t2.WaitFor(t1)
+	c.Check(ifacestate.InSameChangeWaitChain(t1, t2), Equals, false)
+}


### PR DESCRIPTION
The old code was a bit too naive when checking for content-providers
in auto-connect. It was assuming that when a content provider is
installed in the same change the task that needs the content provider
waiting for that is ok. However this only works if there are no
wait relations between the tasks.

This PR adds a check that ensures that doAutoConnect() does not
hang forever if it finds a content provider install in its
wait chain. In this case the install will just continued and
the content provider auto-connect will DTRT and connect the
interfaces.

This fixes the annoying hang on cosmic that is described in
LP: #1776622.

Fwiw, I tested this (via scp) on a hanging cosmic and this changed fixed it.
We should backport to 2.35 and release there as a new point release.