### PR TITLE
ifacestate: fix hang when retrying content providers (2.35)

### DIFF
--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1441,9 +1441,9 @@ plugs:
   default-provider: gtk-common-themes
   target: $SNAP/data-dir/themes
 `
-	fooFname, fooDecl, fooRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
+	calcFname, calcDecl, calcRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
 
-	writeAssertionsToFile("foo.asserts", []asserts.Assertion{devAcct, fooRev, fooDecl})
+	writeAssertionsToFile("calc.asserts", []asserts.Assertion{devAcct, calcRev, calcDecl})
 
 	// put a 2nd firstboot snap into the SnapBlobDir
 	snapYaml = `name: gtk-common-themes
@@ -1455,9 +1455,9 @@ slots:
    read:
     - $SNAP/share/themes/Adawaita
 `
-	barFname, barDecl, barRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(65), "developerid")
+	themesFname, themesDecl, themesRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(65), "developerid")
 
-	writeAssertionsToFile("bar.asserts", []asserts.Assertion{devAcct, barDecl, barRev})
+	writeAssertionsToFile("themes.asserts", []asserts.Assertion{devAcct, themesDecl, themesRev})
 
 	// add a model assertion and its chain
 	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
@@ -1476,7 +1476,7 @@ snaps:
    file: %s
  - name: gtk-common-themes
    file: %s
-`, coreFname, kernelFname, gadgetFname, fooFname, barFname))
+`, coreFname, kernelFname, gadgetFname, calcFname, themesFname))
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1416,3 +1416,102 @@ snaps:
 	c.Assert(err, IsNil)
 	c.Check(seedTime.IsZero(), Equals, false)
 }
+
+func (s *FirstBootTestSuite) TestPopulateFromSeedWrongContentProviderOrder(c *C) {
+	bootloader := boottest.NewMockBootloader("mock", c.MkDir())
+	partition.ForceBootloader(bootloader)
+	defer partition.ForceBootloader(nil)
+	bootloader.SetBootVars(map[string]string{
+		"snap_core":   "core_1.snap",
+		"snap_kernel": "pc-kernel_1.snap",
+	})
+
+	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
+
+	devAcct := assertstest.NewAccount(s.storeSigning, "developer", map[string]interface{}{
+		"account-id": "developerid",
+	}, "")
+
+	// a snap that uses content providers
+	snapYaml := `name: gnome-calculator
+version: 1.0
+plugs:
+ gtk-3-themes:
+  interface: content
+  default-provider: gtk-common-themes
+  target: $SNAP/data-dir/themes
+`
+	fooFname, fooDecl, fooRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
+
+	writeAssertionsToFile("foo.asserts", []asserts.Assertion{devAcct, fooRev, fooDecl})
+
+	// put a 2nd firstboot snap into the SnapBlobDir
+	snapYaml = `name: gtk-common-themes
+version: 1.0
+slots:
+ gtk-3-themes:
+  interface: content
+  source:
+   read:
+    - $SNAP/share/themes/Adawaita
+`
+	barFname, barDecl, barRev := s.makeAssertedSnap(c, snapYaml, nil, snap.R(65), "developerid")
+
+	writeAssertionsToFile("bar.asserts", []asserts.Assertion{devAcct, barDecl, barRev})
+
+	// add a model assertion and its chain
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
+	writeAssertionsToFile("model.asserts", assertsChain)
+
+	// create a seed.yaml
+	content := []byte(fmt.Sprintf(`
+snaps:
+ - name: core
+   file: %s
+ - name: pc-kernel
+   file: %s
+ - name: pc
+   file: %s
+ - name: gnome-calculator
+   file: %s
+ - name: gtk-common-themes
+   file: %s
+`, coreFname, kernelFname, gadgetFname, fooFname, barFname))
+	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	c.Assert(err, IsNil)
+
+	// run the firstboot stuff
+	st := s.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(st)
+	c.Assert(err, IsNil)
+	// use the expected kind otherwise settle with start another one
+	chg := st.NewChange("seed", "run the populate from seed changes")
+	for _, ts := range tsAll {
+		chg.AddAll(ts)
+	}
+	c.Assert(st.Changes(), HasLen, 1)
+
+	// avoid device reg
+	chg1 := st.NewChange("become-operational", "init device")
+	chg1.SetStatus(state.DoingStatus)
+
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(err, IsNil)
+
+	// verify the result
+	var conns map[string]interface{}
+	err = st.Get("conns", &conns)
+	c.Assert(err, IsNil)
+	c.Check(conns, HasLen, 1)
+	conn, hasConn := conns["gnome-calculator:gtk-3-themes gtk-common-themes:gtk-3-themes"]
+	c.Check(hasConn, Equals, true)
+	c.Check(conn.(map[string]interface{})["auto"], Equals, true)
+	c.Check(conn.(map[string]interface{})["interface"], Equals, "content")
+}

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -31,6 +31,7 @@ var (
 	ConnectPriv               = connect
 	GetConns                  = getConns
 	SetConns                  = setConns
+	InSameChangeWaitChain     = inSameChangeWaitChain
 )
 
 func MockRemoveStaleConnections(f func(st *state.State) error) (restore func()) {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -562,15 +562,15 @@ func inSameChangeWaitChain(startT, searchT *state.Task) bool {
 		return false
 	}
 	// Do a recursive check if its in the same change
-	return inWaitChainWalker(startT, searchT)
+	return waitChainSearch(startT, searchT)
 }
 
-func inWaitChainWalker(startT, searchT *state.Task) bool {
+func waitChainSearch(startT, searchT *state.Task) bool {
 	for _, cand := range startT.HaltTasks() {
 		if cand == searchT {
 			return true
 		}
-		if inWaitChainWalker(cand, searchT) {
+		if waitChainSearch(cand, searchT) {
 			return true
 		}
 	}

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type handlersSuite struct{}
+
+var _ = Suite(&handlersSuite{})
+
+func (s *handlersSuite) TestInSameChangeWaitChain(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	// no wait chain (yet)
+	startT := st.NewTask("start", "...start")
+	intermediateT := st.NewTask("intermediateT", "...intermediateT")
+	searchT := st.NewTask("searchT", "...searchT")
+	c.Check(ifacestate.InSameChangeWaitChain(startT, searchT), Equals, false)
+
+	// add (indirect) wait chain
+	searchT.WaitFor(intermediateT)
+	intermediateT.WaitFor(startT)
+	c.Check(ifacestate.InSameChangeWaitChain(startT, searchT), Equals, true)
+}
+
+func (s *handlersSuite) TestInSameChangeWaitChainDifferentChanges(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t1 := st.NewTask("t1", "...")
+	chg1 := st.NewChange("chg1", "...")
+	chg1.AddTask(t1)
+
+	t2 := st.NewTask("t2", "...")
+	chg2 := st.NewChange("chg2", "...")
+	chg2.AddTask(t2)
+
+	// add a cross change wait chain
+	t2.WaitFor(t1)
+	c.Check(ifacestate.InSameChangeWaitChain(t1, t2), Equals, false)
+}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3003,6 +3003,99 @@ slots:
 	c.Check(tConnectPlug.Status(), Equals, state.DoneStatus)
 }
 
+func (s *interfaceManagerSuite) TestAutoconnectForDefaultContentProviderWrongOrderWaitChain(c *C) {
+	restore := ifacestate.MockContentLinkRetryTimeout(5 * time.Millisecond)
+	defer restore()
+
+	s.mockSnap(c, `name: snap-content-plug
+version: 1
+plugs:
+ shared-content-plug:
+  interface: content
+  default-provider: snap-content-slot
+  content: shared-content
+`)
+	s.mockSnap(c, `name: snap-content-slot
+version: 1
+slots:
+ shared-content-slot:
+  interface: content
+  content: shared-content
+`)
+	s.manager(c)
+
+	s.state.Lock()
+
+	supContentPlug := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			Revision: snap.R(1),
+			RealName: "snap-content-plug"},
+	}
+	supContentSlot := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			Revision: snap.R(1),
+			RealName: "snap-content-slot"},
+	}
+	chg := s.state.NewChange("install", "...")
+
+	// Setup a wait chain in the "wrong" order, i.e. pretend we seed
+	// the consumer of the content interface before we seed the producer
+	// (see LP:#1772844) for a real world example of this).
+	tInstPlug := s.state.NewTask("link-snap", "Install snap-content-plug")
+	tInstPlug.Set("snap-setup", supContentPlug)
+	chg.AddTask(tInstPlug)
+
+	tConnectPlug := s.state.NewTask("auto-connect", "...plug")
+	tConnectPlug.Set("snap-setup", supContentPlug)
+	tConnectPlug.WaitFor(tInstPlug)
+	chg.AddTask(tConnectPlug)
+
+	tInstSlot := s.state.NewTask("link-snap", "Install snap-content-slot")
+	tInstSlot.Set("snap-setup", supContentSlot)
+	tInstSlot.WaitFor(tInstPlug)
+	tInstSlot.WaitFor(tConnectPlug)
+	chg.AddTask(tInstSlot)
+
+	tConnectSlot := s.state.NewTask("auto-connect", "...slot")
+	tConnectSlot.Set("snap-setup", supContentSlot)
+	tConnectSlot.WaitFor(tInstPlug)
+	tConnectSlot.WaitFor(tInstSlot)
+	tConnectSlot.WaitFor(tConnectPlug)
+	chg.AddTask(tConnectSlot)
+
+	// pretend plug install was done by snapstate
+	tInstPlug.SetStatus(state.DoneStatus)
+
+	// run the change, this will trigger the auto-connect of the plug
+	s.state.Unlock()
+	for i := 0; i < 5; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	// check that auto-connect did finish and not hang
+	s.state.Lock()
+	c.Check(tConnectPlug.Status(), Equals, state.DoneStatus)
+	c.Check(tInstSlot.Status(), Equals, state.DoStatus)
+	c.Check(tConnectSlot.Status(), Equals, state.DoStatus)
+
+	// pretend snapstate finished installing the slot
+	tInstSlot.SetStatus(state.DoneStatus)
+
+	s.state.Unlock()
+
+	// run again
+	for i := 0; i < 5; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	// and now the slot side auto-connected
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(tConnectSlot.Status(), Equals, state.DoneStatus)
+}
+
 func (s *interfaceManagerSuite) TestSnapsWithSecurityProfiles(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/5803 ported to 2.35

The old code was a bit too naive when checking for content-providers
in auto-connect. It was assuming that when a content provider is
installed in the same change the task that needs the content provider
waiting for that is ok. However this only works if there are no
wait relations between the tasks.

This PR adds a check that ensures that doAutoConnect() does not
hang forever if it finds a content provider install in its
wait chain. In this case the install will just continued and
the content provider auto-connect will DTRT and connect the
interfaces.

This fixes the annoying hang on cosmic that is described in
LP: #1776622.
