### PR TITLE
tests: fix install snaps test by adding link to /snap

### DIFF
--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -86,6 +86,10 @@ restore: |
     systemctl daemon-reload
     systemctl restart snapd.socket
 
+    if [ -L /snap ]; then
+        unlink /snap
+    fi
+
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"

--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -75,6 +75,12 @@ prepare: |
     systemctl daemon-reload
     systemctl restart snapd.socket
 
+    if [ ! -d '/snap' ]; then
+        #shellcheck source=tests/lib/dirs.sh
+        . "$TESTSLIB/dirs.sh"
+        ln -s "$SNAP_MOUNT_DIR" /snap
+    fi
+
 restore: |
     mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
     systemctl daemon-reload


### PR DESCRIPTION
This is to allow installing classic snaps on the install-snapd test. 

Error on https://travis-ci.org/snapcore/spread-cron/builds/422848098#L1463
> snap install micro --stable --classic
error: cannot install "micro": classic confinement requires snaps under /snap or symlink from /snap to /var/lib/snapd/snap
