### PR TITLE
snapd-env-generator: fix when PATH is empty or unset

### DIFF
--- a/cmd/snapd-env-generator/main.c
+++ b/cmd/snapd-env-generator/main.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 
 	char *path = getenv("PATH");
 	if (path == NULL || sc_streq(path, "")) {
-               printf("PATH=%s\n", snap_bin_dir);
+	       // do nothing, until systemd is fixed, see LP#1791691
                return 0;
         }
 	char buf[PATH_MAX + 1] = { 0 };

--- a/cmd/snapd-env-generator/main.c
+++ b/cmd/snapd-env-generator/main.c
@@ -31,8 +31,10 @@ int main(int argc, char **argv)
 	const char *snap_bin_dir = SNAP_MOUNT_DIR "/bin";
 
 	char *path = getenv("PATH");
-	if (path == NULL)
-		path = "";
+	if (path == NULL || sc_streq(path, "")) {
+               printf("PATH=%s\n", snap_bin_dir);
+               return 0;
+        }
 	char buf[PATH_MAX + 1] = { 0 };
 	strncpy(buf, path, sizeof(buf) - 1);
 	char *s = buf;

--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -35,4 +35,4 @@ execute: |
     [ -z "$(PATH=/bin:/snap/bin:/sbin $SENV)" ] || exit 1
 
     # regression test for LP: #1791691
-    PATH="" $SENV | MATCH '^PATH=/snap/bin$'
+    PATH="" $SENV | MATCH '^$'

--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -33,3 +33,6 @@ execute: |
 
     echo "/snap/bin already part of the PATH should not generate output"
     [ -z "$(PATH=/bin:/snap/bin:/sbin $SENV)" ] || exit 1
+
+    # regression test for LP: #1791691
+    PATH="" $SENV | MATCH '^PATH=/snap/bin$'


### PR DESCRIPTION
When the PATH is empty or unset the generator will generate the
wrong output (PATH=:/snap/bin). This causes havoc. This PR fixes
it by outputing only a PATH=/snap/bin segment that systemd will
correctly piece together.

