### PR TITLE
rfc: restore "core" as the API-level host for implicit slots

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -77,7 +77,7 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 func (m *InterfaceManager) selectInterfaceMapper(snaps []*snap.Info) {
 	for _, snapInfo := range snaps {
 		if snapInfo.SnapName() == "snapd" {
-			mapper = &CoreSnapdSystemMapper{}
+			mapper = &CoreSnapdCoreMapper{}
 			break
 		}
 	}
@@ -783,7 +783,7 @@ func (m *CoreSnapdCoreMapper) RemapSnapToResponse(snapName string) string {
 }
 
 // mapper contains the currently active snap mapper.
-var mapper SnapMapper = &CoreCoreSystemMapper{}
+var mapper SnapMapper = &CoreCoreCoreMapper{}
 
 // MockSnapMapper mocks the currently used snap mapper.
 func MockSnapMapper(new SnapMapper) (restore func()) {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -727,6 +727,61 @@ func (m *CoreCoreCoreMapper) RemapSnapFromRequest(snapName string) string {
 	return snapName
 }
 
+// CoreSnapdCoreMapper implements SnapMapper and makes implicit slots appear to
+// be on "core" in the state and in the API while using the "snapd" snap
+// internally in memory.
+//
+type CoreSnapdCoreMapper struct {
+	IdentityMapper // Embedding the identity mapper allows us to cut on boilerplate.
+}
+
+// RemapSnapFromState renames the "core" snap to the "snapd" snap.
+//
+// This allows modern snapd to load an old state that remembers connections
+// between slots on the "core" snap and other snaps. In memory we are actually
+// using "snapd" snap for hosting those slots and this lets us stay compatible.
+func (m *CoreSnapdCoreMapper) RemapSnapFromState(snapName string) string {
+	if snapName == "core" {
+		return "snapd"
+	}
+	return snapName
+}
+
+// RemapSnapToState renames the "snapd" snap to the "core" snap.
+//
+// This allows the state to stay backwards compatible as all the connections
+// seem to refer to the "core" snap, as in pre core{16,18} days where there was
+// only one core snap.
+func (m *CoreSnapdCoreMapper) RemapSnapToState(snapName string) string {
+	if snapName == "snapd" {
+		return "core"
+	}
+	return snapName
+}
+
+// RemapSnapFromRequest renames the "system" snap to the "core" snap.
+//
+// This allows us to accept both legacy "core" and non-legacy "system" name
+// as the snap that holds implicit slots.
+func (m *CoreSnapdCoreMapper) RemapSnapFromRequest(snapName string) string {
+	if snapName == "system" {
+		return "snapd"
+	}
+	return snapName
+}
+
+// RemapSnapToResponse renames the "snapd" snap to the "core" snap.
+//
+// This allows us to make all the implicitly defined slots, that are really
+// associated with the "snapd" snap to seemingly occupy the "core" snap
+// instead. This is done for compatibility with existing software.
+func (m *CoreSnapdCoreMapper) RemapSnapToResponse(snapName string) string {
+	if snapName == "snapd" {
+		return "core"
+	}
+	return snapName
+}
+
 // mapper contains the currently active snap mapper.
 var mapper SnapMapper = &CoreCoreSystemMapper{}
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -709,6 +709,24 @@ func (m *CoreSnapdSystemMapper) RemapSnapToResponse(snapName string) string {
 	return snapName
 }
 
+// CoreCoreCoreMapper implements SnapMapper and makes implicit slots appear to
+// be on "core" in the state and in the API while also using the "core" snap
+// internally in memory.
+type CoreCoreCoreMapper struct {
+	IdentityMapper // Embedding the identity mapper allows us to cut on boilerplate.
+}
+
+// RemapSnapFromRequest renames the "system" snap to the "core" snap.
+//
+// This allows us to accept both legacy "core" and non-legacy "system" name
+// as the snap that holds implicit slots.
+func (m *CoreCoreCoreMapper) RemapSnapFromRequest(snapName string) string {
+	if snapName == "system" {
+		return "core"
+	}
+	return snapName
+}
+
 // mapper contains the currently active snap mapper.
 var mapper SnapMapper = &CoreCoreSystemMapper{}
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -104,6 +104,17 @@ func (s *helpersSuite) TestCoreCoreCoreMapper(c *C) {
 	c.Assert(m.RemapSnapToState("core"), Equals, "core")
 }
 
+func (s *helpersSuite) TestCoreSnapdCoreMapper(c *C) {
+	var m ifacestate.SnapMapper = &ifacestate.CoreSnapdCoreMapper{}
+
+	c.Assert(m.RemapSnapFromRequest("system"), Equals, "snapd")
+	c.Assert(m.RemapSnapFromRequest("core"), Equals, "core")
+	c.Assert(m.RemapSnapToResponse("snapd"), Equals, "core")
+
+	c.Assert(m.RemapSnapFromState("core"), Equals, "snapd")
+	c.Assert(m.RemapSnapToState("snapd"), Equals, "core")
+}
+
 // caseMapper implements SnapMapper to use upper case internally and lower case externally.
 type caseMapper struct{}
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -91,6 +91,19 @@ func (s *helpersSuite) TestCoreSnapdSystemMapper(c *C) {
 	c.Assert(m.RemapSnapToResponse("potato"), Equals, "potato")
 }
 
+func (s *helpersSuite) TestCoreCoreCoreMapper(c *C) {
+	var m ifacestate.SnapMapper = &ifacestate.CoreCoreCoreMapper{}
+
+	// The system snap is a nickname for "core" but only for incoming requests.
+	// Responses are not affected and use "core" for compatibility.
+	c.Assert(m.RemapSnapFromRequest("system"), Equals, "core")
+	c.Assert(m.RemapSnapFromRequest("core"), Equals, "core")
+	c.Assert(m.RemapSnapToResponse("core"), Equals, "core")
+
+	c.Assert(m.RemapSnapFromState("core"), Equals, "core")
+	c.Assert(m.RemapSnapToState("core"), Equals, "core")
+}
+
 // caseMapper implements SnapMapper to use upper case internally and lower case externally.
 type caseMapper struct{}
 

--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -27,7 +27,7 @@ import (
 )
 
 func shouldSnapdHostImplicitSlots(mapper SnapMapper) bool {
-	_, ok := mapper.(*CoreSnapdSystemMapper)
+	_, ok := mapper.(*CoreSnapdCoreMapper)
 	return ok
 }
 


### PR DESCRIPTION
This branch is an request for comments as a possible resolution of https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1791814