### PR TITLE
snapstate: refactor tests to use SetModel*

### DIFF
--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -85,12 +85,13 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
-	snapstate.MockModel()
+	snapstate.SetDefaultModel()
 }
 
 func (bs *bootedSuite) TearDownTest(c *C) {
 	bs.BaseTest.TearDownTest(c)
 	snapstate.AutoAliases = nil
+	snapstate.Model = nil
 	release.MockOnClassic(true)
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
@@ -344,8 +345,7 @@ func (bs *bootedSuite) TestWaitRestartCore(c *C) {
 }
 
 func (bs *bootedSuite) TestWaitRestartBootableBase(c *C) {
-	restore := snapstate.MockModelWithBase("core18")
-	defer restore()
+	snapstate.SetModelWithBase("core18")
 
 	st := bs.state
 	st.Lock()

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -141,25 +141,23 @@ func MockIsOnMeteredConnection(mock func() (bool, error)) func() {
 	}
 }
 
-func MockModelWithBase(baseName string) (restore func()) {
-	return mockModel(map[string]string{"base": baseName})
+func SetModelWithBase(baseName string) {
+	setModel(map[string]string{"base": baseName})
 }
 
-func MockModelWithKernelTrack(kernelTrack string) (restore func()) {
-	return mockModel(map[string]string{"kernel": "kernel=" + kernelTrack})
+func SetModelWithKernelTrack(kernelTrack string) {
+	setModel(map[string]string{"kernel": "kernel=" + kernelTrack})
 }
 
-func MockModelWithGadgetTrack(gadgetTrack string) (restore func()) {
-	return mockModel(map[string]string{"gadget": "brand-gadget=" + gadgetTrack})
+func SetModelWithGadgetTrack(gadgetTrack string) {
+	setModel(map[string]string{"gadget": "brand-gadget=" + gadgetTrack})
 }
 
-func MockModel() (restore func()) {
-	return mockModel(nil)
+func SetDefaultModel() {
+	setModel(nil)
 }
 
-func mockModel(override map[string]string) (restore func()) {
-	oldModel := Model
-
+func setModel(override map[string]string) {
 	model := map[string]interface{}{
 		"type":              "model",
 		"authority-id":      "brand",
@@ -183,8 +181,5 @@ func mockModel(override map[string]string) (restore func()) {
 
 	Model = func(*state.State) (*asserts.Model, error) {
 		return a.(*asserts.Model), nil
-	}
-	return func() {
-		Model = oldModel
 	}
 }

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -64,7 +64,12 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 
 	s.setup(c, s.stateBackend)
 
-	snapstate.MockModel()
+	snapstate.SetDefaultModel()
+}
+
+func (s *linkSnapSuite) TearDownTest(c *C) {
+	s.baseHandlerSuite.TearDownTest(c)
+	snapstate.Model = nil
 }
 
 func checkHasCookieForSnap(c *C, st *state.State, snapName string) {
@@ -385,8 +390,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnCoreWithBase(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = snapstate.MockModelWithBase("core18")
-	defer restore()
+	snapstate.SetModelWithBase("core18")
 
 	s.state.Lock()
 	si := &snap.SideInfo{

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -178,6 +178,7 @@ func (s *snapmgrTestSuite) TearDownTest(c *C) {
 	snapstate.ValidateRefreshes = nil
 	snapstate.AutoAliases = nil
 	snapstate.CanAutoRefresh = nil
+	snapstate.Model = nil
 }
 
 type ForeignTaskTracker interface {
@@ -998,7 +999,7 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC16(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
-	snapstate.MockModelWithBase("core18")
+	snapstate.SetModelWithBase("core18")
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1264,7 +1265,7 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackForbidden(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.MockModelWithKernelTrack("18")
+	snapstate.SetModelWithKernelTrack("18")
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{RealName: "kernel", Revision: snap.R(11)},
@@ -1282,7 +1283,7 @@ func (s *snapmgrTestSuite) TestSwitchKernelTrackRiskOnlyIsOK(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.MockModelWithKernelTrack("18")
+	snapstate.SetModelWithKernelTrack("18")
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{RealName: "kernel", Revision: snap.R(11)},
@@ -1300,7 +1301,7 @@ func (s *snapmgrTestSuite) TestSwitchGadgetTrackForbidden(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.SetModelWithGadgetTrack("18")
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{RealName: "brand-gadget", Revision: snap.R(11)},
@@ -1318,7 +1319,7 @@ func (s *snapmgrTestSuite) TestSwitchGadgetTrackRiskOnlyIsOK(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.SetModelWithGadgetTrack("18")
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{RealName: "brand-gadget", Revision: snap.R(11)},
@@ -4843,7 +4844,7 @@ func (s *snapmgrTestSuite) TestUpdateKernelTrackChecksSwitchingTracks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.MockModelWithKernelTrack("18")
+	snapstate.SetModelWithKernelTrack("18")
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
@@ -4875,7 +4876,7 @@ func (s *snapmgrTestSuite) TestUpdateGadgetTrackChecksSwitchingTracks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.SetModelWithGadgetTrack("18")
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
@@ -8641,7 +8642,7 @@ var _ = Suite(&canRemoveSuite{})
 func (s *canRemoveSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.st = state.New(nil)
-	snapstate.MockModel()
+	snapstate.SetDefaultModel()
 }
 
 func (s *canRemoveSuite) TearDownTest(c *C) {
@@ -8686,7 +8687,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseIsOk(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	snapstate.MockModelWithBase("core18")
+	snapstate.SetModelWithBase("core18")
 	os := &snap.Info{
 		Type: snap.TypeOS,
 	}
@@ -8699,7 +8700,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUse(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	snapstate.MockModelWithBase("core18")
+	snapstate.SetModelWithBase("core18")
 
 	// pretend we have a snap installed that has no base (which means
 	// it needs core)
@@ -11274,7 +11275,7 @@ func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchKernel(c *C) 
 	defer s.state.Unlock()
 
 	// snapd cannot be installed unless the model uses a base snap
-	snapstate.MockModelWithKernelTrack("18")
+	snapstate.SetModelWithKernelTrack("18")
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{RealName: "kernel", Revision: snap.R(11)},
@@ -11304,7 +11305,7 @@ func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchGadget(c *C) 
 	defer s.state.Unlock()
 
 	// snapd cannot be installed unless the model uses a base snap
-	snapstate.MockModelWithGadgetTrack("18")
+	snapstate.SetModelWithGadgetTrack("18")
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{RealName: "brand-gadget", Revision: snap.R(11)},
@@ -11641,8 +11642,7 @@ func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
 	defer s.state.Unlock()
 
 	// snapd cannot be installed unless the model uses a base snap
-	restore := snapstate.MockModelWithBase("core18")
-	defer restore()
+	snapstate.SetModelWithBase("core18")
 
 	// but snapd do not for install
 	ts, err := snapstate.Install(s.state, "snapd", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})


### PR DESCRIPTION
To make things clearer the model setting in the tests is now done
via a SetModel* helper instead of a MockModel*. This is cleaner
because there is no default snapstate.Model() set (it is `nil`).
