### PR TITLE
image: warn on missing default-providers

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -471,8 +471,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 			return fmt.Errorf("cannot add snap %q without also adding its base %q explicitly", name, info.Base)
 		}
 		// warn about missing default providers
-		dps := neededDefaultProviders(info)
-		for _, dp := range dps {
+		for _, dp := range neededDefaultProviders(info) {
 			if !local.hasName(snaps, dp) {
 				fmt.Fprintf(Stderr, "WARNING: the %q default content provider %q is not getting installed.", info.InstanceName(), dp)
 			}

--- a/image/image.go
+++ b/image/image.go
@@ -473,7 +473,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		// warn about missing default providers
 		for _, dp := range neededDefaultProviders(info) {
 			if !local.hasName(snaps, dp) {
-				fmt.Fprintf(Stderr, "WARNING: the %q default content provider %q is not getting installed.", info.InstanceName(), dp)
+				fmt.Fprintf(Stderr, "WARNING: the default content provider %q requested by snap %q is not getting installed.", dp, info.InstanceName())
 			}
 		}
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1576,7 +1576,7 @@ func (s *imageSuite) TestBootstrapToRootDirMissingContentProvider(c *C) {
 	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
 	c.Assert(err, IsNil)
 
-	c.Check(s.stderr.String(), Equals, `WARNING: the "snap-req-content-provider" default content provider "gtk-common-themes" is not getting installed.`)
+	c.Check(s.stderr.String(), Equals, `WARNING: the default content provider "gtk-common-themes" requested by snap "snap-req-content-provider" is not getting installed.`)
 }
 
 type toolingAuthContextSuite struct {


### PR DESCRIPTION
This PR warns about missing default-providers on the image when
snaps are added that use the content interface. It is only a
warning because the default-provider field is just a suggestion
what snap should provide this functionality.
