### PR TITLE
client: catch and expose logs errors

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -113,6 +113,15 @@ func (client *Client) Logs(names []string, opts LogOptions) (<-chan Log, error) 
 		return nil, err
 	}
 
+	if rsp.StatusCode != 200 {
+		var r response
+		defer rsp.Body.Close()
+		if err := decodeInto(rsp.Body, &r); err != nil {
+			return nil, err
+		}
+		return nil, r.err(client)
+	}
+
 	ch := make(chan Log, 20)
 	go func() {
 		// logs come in application/json-seq, described in RFC7464: it's

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -204,6 +204,14 @@ func (cs *clientSuite) TestClientLogsOpts(c *check.C) {
 	}
 }
 
+func (cs *clientSuite) TestClientLogsNotFound(c *check.C) {
+	cs.rsp = `{"type":"error","status-code":404,"status":"Not Found","result":{"message":"snap \"foo\" not found","kind":"snap-not-found","value":"foo"}}`
+	cs.status = 404
+	actual, err := testClientLogs(cs, c)
+	c.Assert(err, check.ErrorMatches, `snap "foo" not found`)
+	c.Check(actual, check.HasLen, 0)
+}
+
 func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 

--- a/client/client.go
+++ b/client/client.go
@@ -250,17 +250,24 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 	defer rsp.Body.Close()
 
 	if v != nil {
-		dec := json.NewDecoder(rsp.Body)
-		if err := dec.Decode(v); err != nil {
-			r := dec.Buffered()
-			buf, err1 := ioutil.ReadAll(r)
-			if err1 != nil {
-				buf = []byte(fmt.Sprintf("error reading buffered response body: %s", err1))
-			}
-			return fmt.Errorf("cannot decode %q: %s", buf, err)
+		if err := decodeInto(rsp.Body, v); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+func decodeInto(reader io.Reader, v interface{}) error {
+	dec := json.NewDecoder(reader)
+	if err := dec.Decode(v); err != nil {
+		r := dec.Buffered()
+		buf, err1 := ioutil.ReadAll(r)
+		if err1 != nil {
+			buf = []byte(fmt.Sprintf("error reading buffered response body: %s", err1))
+		}
+		return fmt.Errorf("cannot decode %q: %s", buf, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Before, errors from the logs endpoint itself (as opposed to errors
reaching the logs endpoint) were silently ignored.  This fixes that.
