### PR TITLE
overlord/assertstate: propagate TaskSnapSetup error

### DIFF
--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -87,7 +87,7 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	snapsup, err := snapstate.TaskSnapSetup(t)
 	if err != nil {
-		return nil
+		return fmt.Errorf("internal error: cannot obtain snap setup: %s", err)
 	}
 
 	sha3_384, snapSize, err := asserts.SnapFileSHA3_384(snapsup.SnapPath)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -455,6 +455,22 @@ func (s *assertMgrSuite) TestValidateSnap(c *C) {
 	c.Check(snapRev.(*asserts.SnapRevision).SnapRevision(), Equals, 10)
 }
 
+func (s *assertMgrSuite) TestValidateSnapMissingSnapSetup(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("install", "...")
+	t := s.state.NewTask("validate-snap", "Fetch and check snap assertions")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	c.Assert(chg.Err(), ErrorMatches, `(?s).*internal error: cannot obtain snap setup: no state entry for key.*`)
+}
+
 func (s *assertMgrSuite) TestValidateSnapNotFound(c *C) {
 	tempdir := c.MkDir()
 	snapPath := filepath.Join(tempdir, "foo.snap")


### PR DESCRIPTION
I've accidently found a typo in assertmgr where an error from TaskSnapSetup wouldn't be propagated. This PR fixes it.
