### PR TITLE
cmd/snap: handle "snap interfaces core" better

### DIFF
--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -91,6 +91,14 @@ func (x *cmdInterfaces) Execute(args []string) error {
 			if wantedSnap == slot.Snap {
 				ok = true
 			}
+			// Normally snap nicknames are handled internally in the snapd API
+			// layer.  This specific command is an exception as it does
+			// client-side filtering.  As a special case, when the user asked
+			// for the snap "core" but we see the "system" nickname, treat that
+			// as a match.
+			if wantedSnap == "core" && slot.Snap == "system" {
+				ok = true
+			}
 
 			for i := 0; i < len(slot.Connections) && !ok; i++ {
 				if wantedSnap == slot.Connections[i].Snap {

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -627,3 +627,41 @@ func (s *SnapSuite) TestConnectionsCompletion(c *C) {
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "")
 }
+
+func (s *SnapSuite) TestConnectionsSystemNickname(c *C) {
+	s.checkConnectionsSystemCoreRemapping(c, "system")
+}
+
+func (s *SnapSuite) TestConnectionsCoreSnap(c *C) {
+	s.checkConnectionsSystemCoreRemapping(c, "core")
+}
+
+func (s *SnapSuite) checkConnectionsSystemCoreRemapping(c *C, snapName string) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v2/interfaces")
+		body, err := ioutil.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type": "sync",
+			"result": client.Connections{
+				Slots: []client.Slot{
+					{
+						// The snap holding the slot is always the "system" nickname.
+						Snap: "system",
+						Name: "network",
+					},
+				},
+			},
+		})
+	})
+	rest, err := Parser().ParseArgs([]string{"interfaces", snapName})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	expectedStdout := "" +
+		"Slot      Plug\n" +
+		":network  -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}

--- a/tests/main/interfaces-cli/task.yaml
+++ b/tests/main/interfaces-cli/task.yaml
@@ -23,3 +23,8 @@ execute: |
     echo "When the interfaces list is restricted by slot and snap"
     echo "Then only the requested slots are shown"
     snap interfaces -i "$PLUG" "$SNAP_NAME" | grep -Pzq "$expected"
+
+    echo "Implicit slots are exposed by a snap holding the nickname 'system'"
+    echo "but for compatibility they can also be listed when asking for 'core'"
+    snap interfaces -i network system | MATCH '^:network .*'
+    snap interfaces -i network core | MATCH '^:network .*'


### PR DESCRIPTION
The legacy "snap interfaces" command does client side filtering and thus
doesn't benefit from the server-side nickname/remapping created when the
core18 snap was introduced. With the introduction of the re-mapping
logic implicit slots are provided by various snaps that are always
exposed, on the API layer, under the "system" nickname.

The re-mapping is done server side so various commands like "connect"
and "disconnect" work perfectly fine with both old and new names. The
"snap interfaes" (plural) command is the exception as it was doing all
of the filtering locally.

This patch adds a tiny special case that allows matching "system"
nickname when the user has requested the "core" snap.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
