### PR TITLE
wrappers: fix snap services order in tests

### DIFF
--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -720,7 +720,9 @@ func (s *servicesTestSuite) TestStartSnapTimerEnableStart(c *C) {
   timer: 10:00-12:00
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.StartServices(info.Services(), nil)
+	// fix the apps order to make the test stable
+	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"]}
+	err := wrappers.StartServices(apps, nil)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 3, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
 	c.Check(s.sysdLog, DeepEquals, [][]string{


### PR DESCRIPTION
info.Services() returns a list of services built from underlying .Apps map. Map
iteration order is 'undefined' (or somewhat random). Meaning it's possible that
the services will happen to be iterated opposite order than assumed.

With changes from #5777 the test would fail every other run on my machine.