### PR TITLE
snapcraft.yaml: add workaround for LP:#1791871

### DIFF
--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -17,12 +17,18 @@ import os
 
 import snapcraft
 
-# cowboy baby, see https://bugs.launchpad.net/snapcraft/+bug/1772584
+# cowboy baby :(
+# see https://bugs.launchpad.net/snapcraft/+bug/1772584
+# and https://bugs.launchpad.net/snapcraft/+bug/1791871
 def patch_snapcraft():
     import snapcraft.internal.common
+    import snapcraft.internal.sources._local
     # very hacky but gets the job done for now, right now
     # SNAPCRAFT_FILES is only used to know what to exclude
     snapcraft.internal.common.SNAPCRAFT_FILES.remove("snap")
+        def _patched_check(self, target):
+            return False
+    snapcraft.internal.sources._local.Local._check = _patched_check
 patch_snapcraft()
 
 

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -20,14 +20,18 @@ import snapcraft
 # cowboy baby :(
 # see https://bugs.launchpad.net/snapcraft/+bug/1772584
 # and https://bugs.launchpad.net/snapcraft/+bug/1791871
+#
+# This will be fixed by snapcraft - the agreement is that they
+# will look for a .snap/ directory with "snapcraft" in it and
+# use that when available.
 def patch_snapcraft():
     import snapcraft.internal.common
     import snapcraft.internal.sources._local
     # very hacky but gets the job done for now, right now
     # SNAPCRAFT_FILES is only used to know what to exclude
     snapcraft.internal.common.SNAPCRAFT_FILES.remove("snap")
-        def _patched_check(self, target):
-            return False
+    def _patched_check(self, target):
+        return False
     snapcraft.internal.sources._local.Local._check = _patched_check
 patch_snapcraft()
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,7 +19,6 @@ parts:
     # FIXME: this should probably go upstream
     plugin: x-builddeb
     source: .
-    source-type: git
 
 # Note that this snap is unusual in that it has no "apps" section.
 #

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,6 +19,7 @@ parts:
     # FIXME: this should probably go upstream
     plugin: x-builddeb
     source: .
+    source-type: git
 
 # Note that this snap is unusual in that it has no "apps" section.
 #


### PR DESCRIPTION
The snapcraft building currently fails with a strange error. This
is probably bug https://bugs.launchpad.net/snapcraft/+bug/1791871

This PR adds a workaround for this.

