### PR TITLE
many: fetch the device store assertion together and in the context of interpreting snap-declarations

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -143,3 +143,13 @@ func FetchSnapDeclaration(f asserts.Fetcher, snapID string) error {
 
 	return f.Fetch(ref)
 }
+
+// FetchStore fetches the store assertion and its prerequisites for the given store id using the given fetcher.
+func FetchStore(f asserts.Fetcher, storeID string) error {
+	ref := &asserts.Ref{
+		Type:       asserts.StoreType,
+		PrimaryKey: []string{storeID},
+	}
+
+	return f.Fetch(ref)
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -925,7 +925,7 @@ var (
 	snapstateRevert            = snapstate.Revert
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 
-	assertstateRefreshAssertions = assertstate.RefreshAssertions
+	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
 )
 
 func ensureStateSoonImpl(st *state.State) {
@@ -960,7 +960,7 @@ func modeFlags(devMode, jailMode, classic bool) (snapstate.Flags, error) {
 
 func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly
-	if err := assertstateRefreshAssertions(st, nil, inst.userID); err != nil {
+	if err := assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
 		return nil, err
 	}
 
@@ -1015,14 +1015,6 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 			return nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
 		}
 	}
-
-	// refresh store assertion to have current information to interpret
-	// snap declarations
-	opts := assertstate.RefreshAssertionsOptions{Store: true}
-	if err := assertstateRefreshAssertions(st, &opts, inst.userID); err != nil {
-		return nil, err
-	}
-
 	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID)
 	if err != nil {
 		return nil, err
@@ -1057,13 +1049,6 @@ func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskS
 		return "", nil, err
 	}
 
-	// refresh store assertion to have current information to interpret
-	// snap declarations
-	opts := assertstate.RefreshAssertionsOptions{Store: true}
-	if err = assertstateRefreshAssertions(st, &opts, inst.userID); err != nil {
-		return "", nil, err
-	}
-
 	logger.Noticef("Installing snap %q revision %s", inst.Snaps[0], inst.Revision)
 
 	tset, err := snapstateInstall(st, inst.Snaps[0], inst.Channel, inst.Revision, inst.userID, flags)
@@ -1092,7 +1077,7 @@ func snapUpdate(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	}
 
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can
-	if err = assertstateRefreshAssertions(st, nil, inst.userID); err != nil {
+	if err = assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
 		return "", nil, err
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3709,6 +3709,32 @@ func (s *apiSuite) TestInstallLeaveOld(c *check.C) {
 	c.Check(err, check.IsNil)
 }
 
+func (s *apiSuite) TestInstall(c *check.C) {
+	var calledName string
+
+	snapstateInstall = func(s *state.State, name, channel string, revision snap.Revision, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
+		calledName = name
+
+		t := s.NewTask("fake-install-snap", "Doing a fake install")
+		return state.NewTaskSet(t), nil
+	}
+
+	d := s.daemon(c)
+	inst := &snapInstruction{
+		Action: "install",
+		// Install the snap in developer mode
+		DevMode: true,
+		Snaps:   []string{"fake"},
+	}
+
+	st := d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	_, _, err := inst.dispatch()(inst, st)
+	c.Check(err, check.IsNil)
+	c.Check(calledName, check.Equals, "fake")
+}
+
 func (s *apiSuite) TestInstallDevMode(c *check.C) {
 	var calledFlags snapstate.Flags
 

--- a/image/image.go
+++ b/image/image.go
@@ -377,6 +377,8 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		}
 	}
 
+	// XXX: fetch device store assertion (and prereqs) if available
+
 	// put snaps in place
 	if err := os.MkdirAll(dirs.SnapBlobDir, 0755); err != nil {
 		return err

--- a/image/image.go
+++ b/image/image.go
@@ -377,8 +377,6 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		}
 	}
 
-	// XXX: fetch device store assertion (and prereqs) if available
-
 	// put snaps in place
 	if err := os.MkdirAll(dirs.SnapBlobDir, 0755); err != nil {
 		return err
@@ -540,6 +538,8 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 	if len(locals) > 0 {
 		fmt.Fprintf(Stderr, "WARNING: %s were installed from local snaps disconnected from a store and cannot be refreshed subsequently!\n", strutil.Quoted(locals))
 	}
+
+	// TODO: fetch device store assertion (and prereqs) if available
 
 	for _, aRef := range f.addedRefs {
 		var afn string

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -82,8 +82,9 @@ func DB(s *state.State) asserts.RODatabase {
 
 // doValidateSnap fetches the relevant assertions for the snap being installed and cross checks them with the snap.
 func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
-	t.State().Lock()
-	defer t.State().Unlock()
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
 
 	snapsup, err := snapstate.TaskSnapSetup(t)
 	if err != nil {
@@ -95,11 +96,29 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// XXX: try to fetch the device store assertion if available at least
-	// once per overall change
+	modelAs, err := snapstate.Model(st)
+	if err != nil {
+		return err
+	}
 
-	err = doFetch(t.State(), snapsup.UserID, func(f asserts.Fetcher) error {
-		return snapasserts.FetchSnapAssertions(f, sha3_384)
+	err = doFetch(st, snapsup.UserID, func(f asserts.Fetcher) error {
+		if err := snapasserts.FetchSnapAssertions(f, sha3_384); err != nil {
+			return err
+		}
+
+		// fetch store assertion if available
+		if modelAs.Store() != "" {
+			err := snapasserts.FetchStore(f, modelAs.Store())
+			if notFound, ok := err.(*asserts.NotFoundError); ok {
+				if notFound.Type != asserts.StoreType {
+					return err
+				}
+			} else if err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 	if notFound, ok := err.(*asserts.NotFoundError); ok {
 		if notFound.Type == asserts.SnapRevisionType {
@@ -112,7 +131,7 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	db := DB(t.State())
+	db := DB(st)
 	err = snapasserts.CrossCheck(snapsup.InstanceName(), sha3_384, snapSize, snapsup.SideInfo, db)
 	if err != nil {
 		// TODO: trigger a global sanity check

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -95,6 +95,9 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// XXX: try to fetch the device store assertion if available at least
+	// once per overall change
+
 	err = doFetch(t.State(), snapsup.UserID, func(f asserts.Fetcher) error {
 		return snapasserts.FetchSnapAssertions(f, sha3_384)
 	})

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -138,7 +138,7 @@ func findError(format string, ref *asserts.Ref, err error) error {
 
 // RefreshSnapDeclarations refetches all the current snap declarations and their prerequisites.
 func RefreshSnapDeclarations(s *state.State, userID int) error {
-	modelAs, err := snapstate.ModelPastSeed(s)
+	modelAs, err := snapstate.ModelPastSeeding(s)
 	if err != nil {
 		return err
 	}

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -106,9 +106,13 @@ func validateProxyStore(tr Conf) error {
 	st := tr.State()
 	st.Lock()
 	defer st.Unlock()
-	_, err = assertstate.Store(st, proxyStore)
+
+	store, err := assertstate.Store(st, proxyStore)
 	if asserts.IsNotFound(err) {
 		return fmt.Errorf("cannot set proxy.store to %q without a matching store assertion", proxyStore)
+	}
+	if err == nil && store.URL() == nil {
+		return fmt.Errorf("cannot set proxy.store to %q with a matching store assertion with url unset", proxyStore)
 	}
 	return err
 }

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -291,6 +291,11 @@ func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
 	dc, err := ioutil.ReadDir(assertSeedDir)
 	if release.OnClassic && os.IsNotExist(err) {
 		// on classic seeding is optional
+		// set the fallback model
+		err := setClassicFallbackModel(st, device)
+		if err != nil {
+			return nil, err
+		}
 		return nil, errNothingToDo
 	}
 	if err != nil {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -159,6 +159,24 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st)
 	c.Assert(err, IsNil)
 	checkTrivialSeeding(c, tsAll)
+
+	// already set the fallback model
+
+	// verify that the model was added
+	db := assertstate.DB(st)
+	as, err := db.Find(asserts.ModelType, map[string]string{
+		"series":   "16",
+		"brand-id": "generic",
+		"model":    "generic-classic",
+	})
+	c.Assert(err, IsNil)
+	_, ok := as.(*asserts.Model)
+	c.Check(ok, Equals, true)
+
+	ds, err := auth.Device(st)
+	c.Assert(err, IsNil)
+	c.Check(ds.Brand, Equals, "generic")
+	c.Check(ds.Model, Equals, "generic-classic")
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -27,6 +27,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -175,11 +177,16 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 	s.mockContext, err = hookstate.NewContext(task, task.State(), setup, s.mockHandler, "")
 	c.Assert(err, IsNil)
 
+	s.st.Set("seeded", true)
 	s.st.Set("refresh-privacy-key", "privacy-key")
+	snapstate.Model = func(*state.State) (*asserts.Model, error) {
+		return sysdb.GenericClassicModel(), nil
+	}
 }
 
 func (s *servicectlSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
+	snapstate.Model = nil
 }
 
 func (s *servicectlSuite) TestStopCommand(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -169,6 +169,8 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	defer st.Unlock()
 	st.Set("seeded", true)
 	// registered
+	err = assertstate.Add(st, sysdb.GenericClassicModel())
+	c.Assert(err, IsNil)
 	auth.SetDevice(st, &auth.DeviceState{
 		Brand:  "generic",
 		Model:  "generic-classic",
@@ -1836,7 +1838,7 @@ apps:
 	ms.serveSnap(fooPath, "15")
 
 	// refresh all
-	err = assertstate.RefreshSnapDeclarations(st, 0)
+	err = assertstate.RefreshAssertions(st, nil, 0)
 	c.Assert(err, IsNil)
 
 	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, 0, nil)
@@ -2362,7 +2364,7 @@ version: @VERSION@`
 	c.Assert(repo.AddSnap(coreInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshSnapDeclarations(st, 0)
+	err := assertstate.RefreshAssertions(st, nil, 0)
 	c.Assert(err, IsNil)
 
 	updates, tts, err := snapstate.UpdateMany(context.TODO(), st, []string{"core", "some-snap", "other-snap"}, 0, nil)
@@ -2462,7 +2464,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	c.Assert(repo.AddSnap(otherInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshSnapDeclarations(st, 0)
+	err := assertstate.RefreshAssertions(st, nil, 0)
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Update(st, updateSnapName, "stable", snap.R(0), 0, snapstate.Flags{})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1838,7 +1838,7 @@ apps:
 	ms.serveSnap(fooPath, "15")
 
 	// refresh all
-	err = assertstate.RefreshAssertions(st, nil, 0)
+	err = assertstate.RefreshSnapDeclarations(st, 0)
 	c.Assert(err, IsNil)
 
 	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, 0, nil)
@@ -2364,7 +2364,7 @@ version: @VERSION@`
 	c.Assert(repo.AddSnap(coreInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshAssertions(st, nil, 0)
+	err := assertstate.RefreshSnapDeclarations(st, 0)
 	c.Assert(err, IsNil)
 
 	updates, tts, err := snapstate.UpdateMany(context.TODO(), st, []string{"core", "some-snap", "other-snap"}, 0, nil)
@@ -2464,7 +2464,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	c.Assert(repo.AddSnap(otherInfo), IsNil)
 
 	// refresh all
-	err := assertstate.RefreshAssertions(st, nil, 0)
+	err := assertstate.RefreshSnapDeclarations(st, 0)
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Update(st, updateSnapName, "stable", snap.R(0), 0, snapstate.Flags{})

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -100,13 +100,16 @@ func (s *autoRefreshTestSuite) SetUpTest(c *C) {
 	}
 	snapstate.IsOnMeteredConnection = func() (bool, error) { return false, nil }
 
+	s.state.Set("seeded", true)
 	s.state.Set("seed-time", time.Now())
 	s.state.Set("refresh-privacy-key", "privacy-key")
+	snapstate.SetDefaultModel()
 }
 
 func (s *autoRefreshTestSuite) TearDownTest(c *C) {
 	snapstate.CanAutoRefresh = nil
 	snapstate.AutoAliases = nil
+	snapstate.Model = nil
 	dirs.SetRootDir("")
 }
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -30,7 +30,6 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
@@ -45,11 +44,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
-)
-
-// hook setup by devicestate
-var (
-	Model func(st *state.State) (*asserts.Model, error)
 )
 
 // TaskSnapSetup returns the SnapSetup with task params hold by or referred to by the the task.

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -52,7 +52,14 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
 
+	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "privacy-key")
+	snapstate.SetDefaultModel()
+}
+
+func (s *prereqSuite) TearDownTest(c *C) {
+	s.reset()
+	snapstate.Model = nil
 }
 
 func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -609,7 +609,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 	}
 
 	// need to have a model set before trying to talk the store
-	if _, err := ModelPastSeed(st); err != nil {
+	if _, err := ModelPastSeeding(st); err != nil {
 		return nil, err
 	}
 
@@ -687,7 +687,7 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 	}
 
 	// need to have a model set before trying to talk the store
-	if _, err := ModelPastSeed(st); err != nil {
+	if _, err := ModelPastSeeding(st); err != nil {
 		return nil, nil, err
 	}
 
@@ -1067,7 +1067,7 @@ func Update(st *state.State, name, channel string, revision snap.Revision, userI
 	}
 
 	// need to have a model set before trying to talk the store
-	if _, err := ModelPastSeed(st); err != nil {
+	if _, err := ModelPastSeeding(st); err != nil {
 		return nil, err
 	}
 
@@ -2076,11 +2076,11 @@ var (
 	Model func(st *state.State) (*asserts.Model, error)
 )
 
-// ModelPastSeed returns the device model assertion if available and
+// ModelPastSeeding returns the device model assertion if available and
 // the device is seeded, at that point the device store is known
 // and seeding done. Otherwise it returns a ChangeConflictError
 // about being too early.
-func ModelPastSeed(st *state.State) (*asserts.Model, error) {
+func ModelPastSeeding(st *state.State) (*asserts.Model, error) {
 	var seeded bool
 	err := st.Get("seeded", &seeded)
 	if err != nil && err != state.ErrNoState {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -608,6 +608,11 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		return nil, &snap.AlreadyInstalledError{Snap: name}
 	}
 
+	// need to have a model set before trying to talk the store
+	if _, err := ModelPastSeed(st); err != nil {
+		return nil, err
+	}
+
 	info, err := installInfo(st, name, channel, revision, userID)
 	if err != nil {
 		return nil, err
@@ -678,6 +683,11 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 	}
 	user, err := userFromUserID(st, userID)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	// need to have a model set before trying to talk the store
+	if _, err := ModelPastSeed(st); err != nil {
 		return nil, nil, err
 	}
 
@@ -1054,6 +1064,11 @@ func Update(st *state.State, name, channel string, revision snap.Revision, userI
 	//        until we know what we want to do
 	if !snapst.Active {
 		return nil, fmt.Errorf("refreshing disabled snap %q not supported", name)
+	}
+
+	// need to have a model set before trying to talk the store
+	if _, err := ModelPastSeed(st); err != nil {
+		return nil, err
 	}
 
 	if err := canSwitchChannel(st, name, channel); err != nil {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -154,7 +154,9 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.user3, err = auth.NewUser(s.state, "username3", "email2@test.com", "", nil)
 	c.Assert(err, IsNil)
 
+	s.state.Set("seeded", true)
 	s.state.Set("seed-time", time.Now())
+	snapstate.SetDefaultModel()
 
 	s.state.Set("refresh-privacy-key", "privacy-key")
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
@@ -168,9 +170,6 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.state.Unlock()
 
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
-		return nil, nil
-	}
-	snapstate.Model = func(*state.State) (*asserts.Model, error) {
 		return nil, nil
 	}
 }
@@ -736,6 +735,24 @@ func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
 
 	verifyUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts, s.state)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyTooEarly(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", nil)
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	_, _, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0, nil)
+	c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{})
+	c.Assert(err, ErrorMatches, `too early for operation, device not yet seeded or device model not acknowledged`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
@@ -1550,6 +1567,17 @@ func (s *snapmgrTestSuite) TestInstallRevision(c *C) {
 	c.Check(snapsup.Revision(), Equals, snap.R(7))
 }
 
+func (s *snapmgrTestSuite) TestInstallTooEarly(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", nil)
+
+	_, err := snapstate.Install(s.state, "some-snap", "some-channel", snap.R(0), 0, snapstate.Flags{})
+	c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{})
+	c.Assert(err, ErrorMatches, `too early for operation, device not yet seeded or device model not acknowledged`)
+}
+
 func (s *snapmgrTestSuite) TestInstallConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1907,6 +1935,24 @@ func (s *snapmgrTestSuite) TestUpdateChannelFallback(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapsup.Channel, Equals, "edge")
+}
+
+func (s *snapmgrTestSuite) TestUpdateTooEarly(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", nil)
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{})
+	c.Assert(err, ErrorMatches, `too early for operation, device not yet seeded or device model not acknowledged`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateConflict(c *C) {
@@ -8031,10 +8077,14 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesAtSeedPolicy(c *C) {
 	// special policy only on classic
 	r := release.MockOnClassic(true)
 	defer r()
+	// set at not seeded yet
+	st := s.state
+	st.Lock()
+	st.Set("seeded", nil)
+	st.Unlock()
 
 	s.snapmgr.Ensure()
 
-	st := s.state
 	st.Lock()
 	defer st.Unlock()
 
@@ -8056,7 +8106,6 @@ func (s *snapmgrTestSuite) verifyRefreshLast(c *C) {
 
 func makeTestRefreshConfig(st *state.State) {
 	// avoid special at seed policy
-	st.Set("seeded", true)
 	now := time.Now()
 	st.Set("last-refresh", time.Date(2009, 8, 13, 8, 0, 5, 0, now.Location()))
 
@@ -8419,7 +8468,6 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesWithUpdateStoreError(c *C) {
 	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
 
 	// avoid special at seed policy
-	s.state.Set("seeded", true)
 	s.state.Set("last-refresh", time.Time{})
 	autoRefreshAssertionsCalled := 0
 	restore := mockAutoRefreshAssertions(func(st *state.State, userID int) error {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12531,12 +12531,12 @@ func (s *modelPastSeedSuite) TestTooEarly(c *C) {
 	}
 
 	// not seeded, no model assertion
-	_, err := snapstate.ModelPastSeed(s.st)
+	_, err := snapstate.ModelPastSeeding(s.st)
 	c.Assert(err, DeepEquals, expectedErr)
 
 	// seeded, no model assertion
 	s.st.Set("seeded", true)
-	_, err = snapstate.ModelPastSeed(s.st)
+	_, err = snapstate.ModelPastSeeding(s.st)
 	c.Assert(err, DeepEquals, expectedErr)
 }
 
@@ -12549,7 +12549,7 @@ func (s *modelPastSeedSuite) TestReady(c *C) {
 
 	snapstate.SetDefaultModel()
 
-	modelAs, err := snapstate.ModelPastSeed(s.st)
+	modelAs, err := snapstate.ModelPastSeeding(s.st)
 	c.Assert(err, IsNil)
 	c.Check(modelAs.Model(), Equals, "baz-3000")
 }

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -230,6 +230,9 @@ prepare_classic() {
 
     # Snapshot the state including core.
     if ! is_snapd_state_saved; then
+        # need to be seeded to proceed with snap install
+        # also make sure the captured state is seeded
+        snap wait system seed.loaded
         # Pre-cache a few heavy snaps so that they can be installed by tests
         # quickly. This relies on a behavior of snapd where .partial files are
         # used for resuming downloads.
@@ -290,6 +293,9 @@ setup_reflash_magic() {
     distro_install_package kpartx busybox-static
     distro_install_local_package "$GOHOME"/snapd_*.deb
     distro_clean_package_cache
+
+    # need to be seeded to proceed with snap install
+    snap wait system seed.loaded
 
     # we cannot use "names.sh" here because no snaps are installed yet
     core_name="core"

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -27,6 +27,9 @@ execute: |
     distro_purge_package snapd
     distro_install_build_snapd
 
+    # need to be seeded to allow snap install
+    snap wait system seed.loaded
+
     snap download "--${CORE_CHANNEL}" ubuntu-core
     snap ack ./ubuntu-core_*.assert
     snap install ./ubuntu-core_*.snap

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -47,6 +47,9 @@ execute: |
     distro_purge_package snapd
     distro_install_build_snapd
 
+    # need to be seeded to allow snap install
+    snap wait system seed.loaded
+
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the
     # current time to prevent the ubuntu-core transition before the test snap is
     # installed

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -24,6 +24,7 @@ prepare: |
     systemd_stop_units snapd.service
     rm -f /var/lib/snapd/state.json
     systemctl start snapd
+    snap wait system seed.loaded
 
 execute: |
     echo "When a snap declaring a content sharing plug is installed"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -84,6 +84,7 @@ execute: |
     fi
     lxd.lxc exec my-ubuntu -- systemctl daemon-reload
     lxd.lxc exec my-ubuntu -- systemctl restart snapd.service
+    lxd.lxc exec my-ubuntu -- snap wait system seed.loaded
     lxd.lxc exec my-ubuntu -- cat /etc/environment
 
     # FIXME: ensure that the kernel running is recent enough, this

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -35,6 +35,9 @@ execute: |
         systemctl enable snapd.socket
     fi
 
+    # need to be seeded to allow snap install
+    snap wait system seed.loaded
+
     prevsnapdver=$(snap --version|grep "snapd ")
 
     if [[ "$SPREAD_SYSTEM" = debian-* ]] ; then

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -36,7 +36,9 @@ execute: |
     fi
 
     # need to be seeded to allow snap install
-    snap wait system seed.loaded
+    if ! snap wait 2>&1|MATCH "unknown command" ; then
+        snap wait system seed.loaded
+    fi
 
     prevsnapdver=$(snap --version|grep "snapd ")
 


### PR DESCRIPTION
Also for consistency make sure we are seeded and we have a model before allowing install/refresh operations, reporting otherwise a conflict error about being too early/in conflict with device setting up.

TODO:  (for follow up) make sure prepare-image also fetches the device store assertion if available