### PR TITLE
tests: refactor for nested suite and tests fixed

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -46,14 +46,22 @@ create_nested_core_vm(){
     esac
 
     # create ubuntu-core image
+    EXTRA_SNAPS=""
+    if [ -d "${PWD}/extra-snaps" ] && [ "$(ls -l ${PWD}/extra-snaps/*.snap | wc -l)" -gt 0 ]; then
+        EXTRA_SNAPS="--extra-snaps ${PWD}/extra-snaps/*.snap"
+    fi
+    /snap/bin/ubuntu-image --image-size 3G "$TESTSLIB/assertions/nested-${NESTED_ARCH}.model" --channel "$CORE_CHANNEL" --output ubuntu-core.img "$EXTRA_SNAPS"
     mkdir -p /tmp/work-dir
-    /snap/bin/ubuntu-image --image-size 3G "$TESTSLIB/assertions/nested-${NESTED_ARCH}.model" --channel "$CORE_CHANNEL" --output ubuntu-core.img
     mv ubuntu-core.img /tmp/work-dir
 
     create_assertions_disk
     start_nested_vm
-    wait_for_ssh
-    prepare_ssh
+    if wait_for_ssh; then
+        prepare_ssh
+    else
+        echo "ssh not stablished, exiting..."
+        exit 1
+    fi
 }
 
 start_nested_vm(){

--- a/tests/nested/core-revert/task.yaml
+++ b/tests/nested/core-revert/task.yaml
@@ -34,8 +34,6 @@ execute: |
 
     cd "$SPREAD_PATH"
     execute_remote "sudo snap install network-manager"
-    execute_remote "sudo snap install bluez"
-    execute_remote "sudo bluez.bluetoothctl -a"
     execute_remote "snap aliases" | MATCH "nmcli"
 
     # configure network-manager to take over the connection control on next reboot
@@ -45,14 +43,19 @@ execute: |
     execute_remote "snap info core" | MATCH "tracking: +${CORE_CHANNEL}"
     execute_remote "sudo snap refresh --${CORE_REFRESH_CHANNEL} core" || true
 
-    wait_for_ssh
+    if ! wait_for_ssh; then
+        echo "ssh not stablished, exiting..."
+        exit 1
+    fi
 
-    while ! execute_remote "snap changes" | MATCH "Done.*Refresh \"core\" snap from \"${CORE_REFRESH_CHANNEL}\" channel"; do sleep 1 ; done
+    while ! execute_remote "snap changes" | MATCH "Done.*Refresh \"core\" snap from \"${CORE_REFRESH_CHANNEL}\" channel"; do
+        sleep 1
+    done
     execute_remote "snap info core" | MATCH "tracking: +${CORE_REFRESH_CHANNEL}"
     # make sure network-manager is on charge of eth0
     execute_remote "nmcli c" | MATCH eth0
     execute_remote "nmcli d" | MATCH "eth0 +ethernet +connected"
-    execute_remote "sudo bluez.bluetoothctl -a"
+
     # sanity check, no refresh should be done here but the command shouldn't fail
     execute_remote "sudo snap refresh"
 
@@ -60,13 +63,16 @@ execute: |
 
     execute_remote "sudo snap revert core" || true
 
-    wait_for_ssh
+    if ! wait_for_ssh; then
+        echo "ssh not stablished, exiting..."
+        exit 1
+    fi
 
     while ! execute_remote "snap changes" | MATCH "Done.*Revert \"core\" snap"; do sleep 1 ; done
     execute_remote "snap aliases" | MATCH "nmcli"
     execute_remote "snap info core" | MATCH "tracking: +${CORE_REFRESH_CHANNEL}"
     execute_remote "ifconfig" | MATCH eth0
-    execute_remote "sudo bluez.bluetoothctl -a"
+    #execute_remote "sudo bluez.bluetoothctl -a"
     # this currently fails, refresh from the old version conflicts with aliases
     # execute_remote "sudo snap refresh"
 

--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -3,53 +3,22 @@ summary: create ubuntu-core image and execute the suite in a nested qemu instanc
 systems: [ubuntu-16.04-64, ubuntu-16.04-32]
 
 prepare: |
-    # FIXME: until https://github.com/snapcore/snapd/pull/3263 is available from
-    # the archive we need to build snapd from branch so that it can be used by
-    # ubuntu-image
-
-    # first, remove snapd, in the prepare stage of the nested suite ubuntu-image is installed,
-    # before building snapd from the branch we check that the core is not present
-    apt remove -y --purge snapd
-
-    . "$TESTSLIB/prepare.sh"
-    prepare_classic
-    prepare_each_classic
-
-    snap install --classic --beta ubuntu-image
-
-    # determine arch related vars
-    case "$NESTED_ARCH" in
-    amd64)
-        QEMU="$(which qemu-system-x86_64)"
-        ;;
-    i386)
-        QEMU="$(which qemu-system-i386)"
-        ;;
-    *)
-        echo "unsupported architecture"
-        exit 1
-        ;;
-    esac
-
-    # create ubuntu-core image
-    mkdir -p /tmp/work-dir
-
+    # download core and save it as extra snap
+    mkdir -p extra-snaps
     snap download core
-    /snap/bin/ubuntu-image --image-size 3G "$TESTSLIB/assertions/nested-${NESTED_ARCH}.model" --channel "$CORE_CHANNEL" --output ubuntu-core.img --extra-snaps core_*.snap
-    mv ubuntu-core.img /tmp/work-dir
+    mv core_*.snap extra-snaps/
 
     . "$TESTSLIB/nested.sh"
-    create_assertions_disk
-    start_nested_vm
+    create_nested_core_vm
 
 restore: |
+    rm -rf extra-snaps
+
     . "$TESTSLIB/nested.sh"
     destroy_nested_core_vm
 
 execute: |
     . "$TESTSLIB/nested.sh"
-    wait_for_ssh
-    prepare_ssh
 
     echo "Wait for first boot to be done"
     while ! execute_remote "snap changes" | MATCH "Done.*Initialize system state"; do sleep 1; done


### PR DESCRIPTION
This is the first part of the refactor, then there is a change to make those tests run on core 18 as well.
