### PR TITLE
snap-confine: make /lib/modules optional

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -642,7 +642,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/var/lib/snapd"},	// to get access to snapd state and seccomp profiles
 			{"/var/tmp"},	// to get access to the other temporary directory
 			{"/run"},	// to get /run with sockets and what not
-			{"/lib/modules"},	// access to the modules of the running kernel
+			{"/lib/modules",.is_optional = true},	// access to the modules of the running kernel
 			{"/usr/src"},	// FIXME: move to SecurityMounts in system-trace interface
 			{"/var/log"},	// FIXME: move to SecurityMounts in log-observe interface
 #ifdef MERGED_USR


### PR DESCRIPTION
This may (or maybe not) fix the current lxd test failure.