### PR TITLE
tests: use lxd's waitready instead of polling lxd socket

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -43,15 +43,12 @@ execute: |
         exit
     fi
 
-    wait_for_lxd(){
-        while ! printf 'GET / HTTP/1.0\n\n' | nc -U /var/snap/lxd/common/lxd/unix.socket | MATCH '200 OK'; do sleep 1; done
-    }
-
     echo "Install lxd"
     snap install --candidate lxd
 
     echo "Create a trivial container using the lxd snap"
-    wait_for_lxd
+    snap set lxd waitready.timeout=240
+    lxd waitready
     lxd init --auto
 
     echo "Setting up proxy for lxc"


### PR DESCRIPTION
The lxd spread test uses polling around lxd's unit socket to check whether it's ready. This PR tries to change to to use `lxd waitready`.

The waitready timeout is configurable and 600 secs by default (see https://github.com/lxc/lxd-pkg-snap/pull/7), I changed it to 2 minutes in the test.

Let's see if the change is ok for all the systems we test lxd on.