### PR TITLE
packaging/arch: sync packaging with AUR

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -75,6 +75,7 @@ build() {
   $gobuild -o $GOPATH/bin/snapctl $GOFLAGS "${_gourl}/cmd/snapctl"
   $gobuild -o $GOPATH/bin/snapd $GOFLAGS "${_gourl}/cmd/snapd"
   $gobuild -o $GOPATH/bin/snap-seccomp $GOFLAGS "${_gourl}/cmd/snap-seccomp"
+  $gobuild -o $GOPATH/bin/snap-failure $GOFLAGS "${_gourl}/cmd/snap-failure"
   # build snap-exec and snap-update-ns completely static for base snaps
   $gobuild_static -o $GOPATH/bin/snap-update-ns $GOFLAGS "${_gourl}/cmd/snap-update-ns"
   $gobuild_static -o $GOPATH/bin/snap-exec $GOFLAGS "${_gourl}/cmd/snap-exec"
@@ -143,6 +144,7 @@ package() {
   install -Dm755 "$GOPATH/bin/snapctl" "$pkgdir/usr/bin/snapctl"
   install -Dm755 "$GOPATH/bin/snapd" "$pkgdir/usr/lib/snapd/snapd"
   install -Dm755 "$GOPATH/bin/snap-seccomp" "$pkgdir/usr/lib/snapd/snap-seccomp"
+  install -Dm755 "$GOPATH/bin/snap-failure" "$pkgdir/usr/lib/snapd/snap-failure"
   install -Dm755 "$GOPATH/bin/snap-update-ns" "$pkgdir/usr/lib/snapd/snap-update-ns"
   install -Dm755 "$GOPATH/bin/snap-exec" "$pkgdir/usr/lib/snapd/snap-exec"
 
@@ -160,6 +162,7 @@ package() {
   install -dm755 "$pkgdir/var/lib/snapd/lib/gl"
   install -dm755 "$pkgdir/var/lib/snapd/lib/gl32"
   install -dm755 "$pkgdir/var/lib/snapd/lib/vulkan"
+  install -dm755 "$pkgdir/var/lib/snapd/lib/glvnd"
   # these dirs have special permissions
   install -dm000 "$pkgdir/var/lib/snapd/void"
   install -dm700 "$pkgdir/var/lib/snapd/cookie"


### PR DESCRIPTION
Sync packaging for Arch Linux with the snapd package from AUR.
