### PR TITLE
client, cmd/snap: on !linux, exit when the client tries to Do something

### DIFF
--- a/client/client_other.go
+++ b/client/client_other.go
@@ -1,0 +1,26 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !linux
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+// SetDoer sets the client's doer to the given one
+func (client *Client) SetDoer(d doer) {
+	client.doer = d
+}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -295,17 +294,6 @@ var ClientConfig = client.Config{
 	Socket: dirs.SnapdSocket,
 	// Allow interactivity if we have a terminal
 	Interactive: isStdinTTY,
-}
-
-// Client returns a new client using ClientConfig as configuration.
-func Client() *client.Client {
-	if runtime.GOOS != "linux" {
-		fmt.Fprintf(Stderr, i18n.G(`Interacting with snapd is not yet supported on %s.
-This command has been left available for documentation purposes only.
-`), runtime.GOOS)
-		os.Exit(1)
-	}
-	return client.New(&ClientConfig)
 }
 
 func init() {

--- a/cmd/snap/main_linux.go
+++ b/cmd/snap/main_linux.go
@@ -1,0 +1,29 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/client"
+)
+
+// Client returns a new client using ClientConfig as configuration.
+func Client() *client.Client {
+	return client.New(&ClientConfig)
+}

--- a/cmd/snap/main_other.go
+++ b/cmd/snap/main_other.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !linux
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+)
+
+type otherDoer struct{}
+
+func (otherDoer) Do(*http.Request) (*http.Response, error) {
+	fmt.Fprintf(Stderr, i18n.G(`Interacting with snapd is not yet supported on %s.
+This command has been left available for documentation purposes only.
+`), runtime.GOOS)
+	os.Exit(1)
+	panic("execution continued past call to exit")
+}
+
+// Client returns a new client using ClientConfig as configuration.
+func Client() *client.Client {
+	cli := client.New(&ClientConfig)
+	cli.SetDoer(otherDoer{})
+	return cli
+}


### PR DESCRIPTION
Before this change snap client on non-linux would exit with a warning
when trying to instantiate a client.Client object inside a command. As
we need to move towards instantiating client before running the
commands parser and passing that client in to the command, this
approach proves problematic. This change makes it so that only when
trying to talk to the network does the non-linux client bail out.