### PR TITLE
cmd/snap: commands no longer build their own client

### DIFF
--- a/cmd/snap/cmd_abort.go
+++ b/cmd/snap/cmd_abort.go
@@ -50,14 +50,13 @@ func (x *cmdAbort) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-	id, err := x.GetChangeID(cli)
+	id, err := x.GetChangeID()
 	if err != nil {
 		if err == noChangeFoundOK {
 			return nil
 		}
 		return err
 	}
-	_, err = cli.Abort(id)
+	_, err = x.client.Abort(id)
 	return err
 }

--- a/cmd/snap/cmd_abort_test.go
+++ b/cmd/snap/cmd_abort_test.go
@@ -46,7 +46,7 @@ func (s *SnapSuite) TestAbortLast(c *check.C) {
 			c.Errorf("expected 2 queries, currently on %d", n)
 		}
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"abort", "--last=install"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"abort", "--last=install"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")
@@ -71,13 +71,13 @@ func (s *SnapSuite) TestAbortLastQuestionmark(c *check.C) {
 		}
 	})
 	for i := 0; i < 2; i++ {
-		rest, err := snap.Parser().ParseArgs([]string{"abort", "--last=foobar?"})
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"abort", "--last=foobar?"})
 		c.Assert(err, check.IsNil)
 		c.Assert(rest, check.DeepEquals, []string{})
 		c.Check(s.Stdout(), check.Matches, "")
 		c.Check(s.Stderr(), check.Equals, "")
 
-		_, err = snap.Parser().ParseArgs([]string{"abort", "--last=foobar"})
+		_, err = snap.Parser(snap.Client()).ParseArgs([]string{"abort", "--last=foobar"})
 		if i == 0 {
 			c.Assert(err, check.ErrorMatches, `no changes found`)
 		} else {

--- a/cmd/snap/cmd_ack.go
+++ b/cmd/snap/cmd_ack.go
@@ -23,12 +23,14 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/snapcore/snapd/i18n"
-
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
 )
 
 type cmdAck struct {
+	clientMixin
 	AckOptions struct {
 		AssertionFile flags.Filename
 	} `positional-args:"true" required:"true"`
@@ -57,20 +59,20 @@ func init() {
 	}})
 }
 
-func ackFile(assertFile string) error {
+func ackFile(cli *client.Client, assertFile string) error {
 	assertData, err := ioutil.ReadFile(assertFile)
 	if err != nil {
 		return err
 	}
 
-	return Client().Ack(assertData)
+	return cli.Ack(assertData)
 }
 
 func (x *cmdAck) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	if err := ackFile(string(x.AckOptions.AssertionFile)); err != nil {
+	if err := ackFile(x.client, string(x.AckOptions.AssertionFile)); err != nil {
 		return fmt.Errorf("cannot assert: %v", err)
 	}
 	return nil

--- a/cmd/snap/cmd_advise_test.go
+++ b/cmd/snap/cmd_advise_test.go
@@ -72,7 +72,7 @@ func (s *SnapSuite) TestAdviseCommandHappyText(c *C) {
 	restore := advisor.ReplaceCommandsFinder(mkSillyFinder)
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"advise-snap", "--command", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"advise-snap", "--command", "hello"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, `
@@ -91,7 +91,7 @@ func (s *SnapSuite) TestAdviseCommandHappyJSON(c *C) {
 	restore := advisor.ReplaceCommandsFinder(mkSillyFinder)
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"advise-snap", "--command", "--format=json", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"advise-snap", "--command", "--format=json", "hello"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, `[{"Snap":"hello","Command":"hello"},{"Snap":"hello-wcm","Command":"hello"}]`+"\n")

--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -67,12 +67,11 @@ func (x *cmdAlias) Execute(args []string) error {
 	snapName, appName := snap.SplitSnapApp(string(x.Positionals.SnapApp))
 	alias := x.Positionals.Alias
 
-	cli := Client()
-	id, err := cli.Alias(snapName, appName, alias)
+	id, err := x.client.Alias(snapName, appName, alias)
 	if err != nil {
 		return err
 	}
-	chg, err := x.wait(cli, id)
+	chg, err := x.wait(id)
 	if err != nil {
 		if err == noWait {
 			return nil

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -41,7 +41,7 @@ invoked just using the alias.
           --no-wait     Do not wait for the operation to finish but just print
                         the change id.
 `
-	rest, err := Parser().ParseArgs([]string{"alias", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"alias", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -65,7 +65,7 @@ func (s *SnapSuite) TestAlias(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"alias", "alias-snap.cmd1", "alias1"})
+	rest, err := Parser(Client()).ParseArgs([]string{"alias", "alias-snap.cmd1", "alias1"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, ""+

--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -31,6 +31,7 @@ import (
 )
 
 type cmdAliases struct {
+	clientMixin
 	Positionals struct {
 		Snap installedSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"true"`
@@ -89,7 +90,7 @@ func (x *cmdAliases) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	allStatuses, err := Client().Aliases()
+	allStatuses, err := x.client.Aliases()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -43,7 +43,7 @@ An alias noted as undefined means it was explicitly enabled or disabled but is
 not defined in the current revision of the snap, possibly temporarily (e.g.
 because of a revert). This can cleared with 'snap alias --reset'.
 `
-	rest, err := Parser().ParseArgs([]string{"aliases", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"aliases", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -70,7 +70,7 @@ func (s *SnapSuite) TestAliases(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"aliases"})
+	rest, err := Parser(Client()).ParseArgs([]string{"aliases"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -105,7 +105,7 @@ func (s *SnapSuite) TestAliasesFilterSnap(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"aliases", "foo"})
+	rest, err := Parser(Client()).ParseArgs([]string{"aliases", "foo"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -128,7 +128,7 @@ func (s *SnapSuite) TestAliasesNone(c *C) {
 			"result": map[string]map[string]client.AliasStatus{},
 		})
 	})
-	_, err := Parser().ParseArgs([]string{"aliases"})
+	_, err := Parser(Client()).ParseArgs([]string{"aliases"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "No aliases are currently defined.\n\nUse 'snap help alias' to learn how to create aliases manually.\n")
@@ -149,7 +149,7 @@ func (s *SnapSuite) TestAliasesNoneFilterSnap(c *C) {
 				}},
 		})
 	})
-	_, err := Parser().ParseArgs([]string{"aliases", "not-bar"})
+	_, err := Parser(Client()).ParseArgs([]string{"aliases", "not-bar"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "No aliases are currently defined for snap \"not-bar\".\n\nUse 'snap help alias' to learn how to create aliases manually.\n")

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -127,7 +127,7 @@ func queueFile(src string) error {
 	return osutil.CopyFile(src, dst, osutil.CopyFlagOverwrite)
 }
 
-func autoImportFromSpool() (added int, err error) {
+func autoImportFromSpool(cli *client.Client) (added int, err error) {
 	files, err := ioutil.ReadDir(dirs.SnapAssertsSpoolDir)
 	if os.IsNotExist(err) {
 		return 0, nil
@@ -138,7 +138,7 @@ func autoImportFromSpool() (added int, err error) {
 
 	for _, fi := range files {
 		cand := filepath.Join(dirs.SnapAssertsSpoolDir, fi.Name())
-		if err := ackFile(cand); err != nil {
+		if err := ackFile(cli, cand); err != nil {
 			logger.Noticef("error: cannot import %s: %s", cand, err)
 			continue
 		} else {
@@ -154,7 +154,7 @@ func autoImportFromSpool() (added int, err error) {
 	return added, nil
 }
 
-func autoImportFromAllMounts() (int, error) {
+func autoImportFromAllMounts(cli *client.Client) (int, error) {
 	cands, err := autoImportCandidates()
 	if err != nil {
 		return 0, err
@@ -162,7 +162,7 @@ func autoImportFromAllMounts() (int, error) {
 
 	added := 0
 	for _, cand := range cands {
-		err := ackFile(cand)
+		err := ackFile(cli, cand)
 		// the server is not ready yet
 		if _, ok := err.(client.ConnectionError); ok {
 			logger.Noticef("queuing for later %s", cand)
@@ -214,6 +214,7 @@ func doUmount(mp string) error {
 }
 
 type cmdAutoImport struct {
+	clientMixin
 	Mount []string `long:"mount" arg-name:"<device path>"`
 
 	ForceClassic bool `long:"force-classic"`
@@ -247,9 +248,11 @@ func init() {
 	cmd.hidden = true
 }
 
-func autoAddUsers() error {
+func (x *cmdAutoImport) autoAddUsers() error {
 	cmd := cmdCreateUser{
-		Known: true, Sudoer: true,
+		clientMixin: x.clientMixin,
+		Known:       true,
+		Sudoer:      true,
 	}
 	return cmd.Execute(nil)
 }
@@ -282,18 +285,18 @@ func (x *cmdAutoImport) Execute(args []string) error {
 		defer doUmount(mp)
 	}
 
-	added1, err := autoImportFromSpool()
+	added1, err := autoImportFromSpool(x.client)
 	if err != nil {
 		return err
 	}
 
-	added2, err := autoImportFromAllMounts()
+	added2, err := autoImportFromAllMounts(x.client)
 	if err != nil {
 		return err
 	}
 
 	if added1+added2 > 0 {
-		return autoAddUsers()
+		return x.autoAddUsers()
 	}
 
 	return nil

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -88,7 +88,7 @@ func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"auto-import"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, `created user "foo"`+"\n")
@@ -120,7 +120,7 @@ func (s *SnapSuite) TestAutoImportAssertsNotImportedFromLoop(c *C) {
 	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"auto-import"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
@@ -175,7 +175,7 @@ func (s *SnapSuite) TestAutoImportAssertsHappyNotOnClassic(c *C) {
 	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"auto-import"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
@@ -204,7 +204,7 @@ func (s *SnapSuite) TestAutoImportIntoSpool(c *C) {
 	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"auto-import"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
@@ -261,7 +261,7 @@ func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"auto-import"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, `created user "foo"`+"\n")
@@ -297,6 +297,6 @@ func (s *SnapSuite) TestAutoImportIntoSpoolUnhappyTooBig(c *C) {
 	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
 	defer restore()
 
-	_, err = snap.Parser().ParseArgs([]string{"auto-import"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, ErrorMatches, "cannot queue .*, file size too big: 656384")
 }

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -36,6 +36,7 @@ The buy command buys a snap from the store.
 `)
 
 type cmdBuy struct {
+	clientMixin
 	Positional struct {
 		SnapName remoteSnapName
 	} `positional-args:"yes" required:"yes"`
@@ -56,12 +57,10 @@ func (x *cmdBuy) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	return buySnap(string(x.Positional.SnapName))
+	return buySnap(x.client, string(x.Positional.SnapName))
 }
 
-func buySnap(snapName string) error {
-	cli := Client()
-
+func buySnap(cli *client.Client, snapName string) error {
 	user := cli.LoggedInUser()
 	if user == nil {
 		return fmt.Errorf(i18n.G("You need to be logged in to purchase software. Please run 'snap login' and try again."))
@@ -112,7 +111,7 @@ Once completed, return here and run 'snap buy %s' again.`), snap.Name, snap.Name
 for %s. Press ctrl-c to cancel.`), snap.Name, snap.Publisher.Username, formatPrice(opts.Price, opts.Currency))
 	fmt.Fprint(Stdout, "\n")
 
-	err = requestLogin(user.Email)
+	err = requestLogin(cli, user.Email)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -89,7 +89,7 @@ func (s *BuySnapSuite) TearDownTest(c *check.C) {
 }
 
 func (s *BuySnapSuite) TestBuyHelp(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"buy"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "the required argument `<snap>` was not provided")
 	c.Check(s.Stdout(), check.Equals, "")
@@ -97,13 +97,13 @@ func (s *BuySnapSuite) TestBuyHelp(c *check.C) {
 }
 
 func (s *BuySnapSuite) TestBuyInvalidCharacters(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"buy", "a:b"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "a:b"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "cannot buy snap: invalid characters in name")
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Equals, "")
 
-	_, err = snap.Parser().ParseArgs([]string{"buy", "c*d"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"buy", "c*d"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "cannot buy snap: invalid characters in name")
 	c.Check(s.Stdout(), check.Equals, "")
@@ -161,7 +161,7 @@ func (s *BuySnapSuite) TestBuyFreeSnapFails(c *check.C) {
 	defer mockServer.checkCounts()
 	s.RedirectClientToTestServer(mockServer.serveHttp)
 
-	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "hello"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "cannot buy snap: snap is free")
 	c.Assert(rest, check.DeepEquals, []string{"hello"})
@@ -306,7 +306,7 @@ func (s *BuySnapSuite) TestBuySnapSuccess(c *check.C) {
 	// Confirm the purchase.
 	s.password = "the password"
 
-	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "hello"})
 	c.Check(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
@@ -367,7 +367,7 @@ func (s *BuySnapSuite) TestBuySnapPaymentDeclined(c *check.C) {
 	// Confirm the purchase.
 	s.password = "the password"
 
-	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "hello"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, `Sorry, your payment method has been declined by the issuer. Please review your
 payment details at https://my.ubuntu.com/payment/edit and try again.`)
@@ -404,7 +404,7 @@ func (s *BuySnapSuite) TestBuySnapFailsNoPaymentMethod(c *check.C) {
 	defer mockServer.checkCounts()
 	s.RedirectClientToTestServer(mockServer.serveHttp)
 
-	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "hello"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, `You need to have a payment method associated with your account in order to buy a snap, please visit https://my.ubuntu.com/payment/edit to add one.
 
@@ -439,7 +439,7 @@ func (s *BuySnapSuite) TestBuySnapFailsNotAcceptedTerms(c *check.C) {
 	defer mockServer.checkCounts()
 	s.RedirectClientToTestServer(mockServer.serveHttp)
 
-	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "hello"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, `In order to buy "hello", you need to agree to the latest terms and conditions. Please visit https://my.ubuntu.com/payment/edit to do this.
 
@@ -453,7 +453,7 @@ func (s *BuySnapSuite) TestBuyFailsWithoutLogin(c *check.C) {
 	// We don't login here
 	s.Logout(c)
 
-	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"buy", "hello"})
 	c.Check(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "You need to be logged in to purchase software. Please run 'snap login' and try again.")
 	c.Check(rest, check.DeepEquals, []string{"hello"})

--- a/cmd/snap/cmd_can_manage_refreshes.go
+++ b/cmd/snap/cmd_can_manage_refreshes.go
@@ -25,7 +25,9 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-type cmdCanManageRefreshes struct{}
+type cmdCanManageRefreshes struct {
+	clientMixin
+}
 
 func init() {
 	cmd := addDebugCommand("can-manage-refreshes",
@@ -43,7 +45,7 @@ func (x *cmdCanManageRefreshes) Execute(args []string) error {
 	}
 
 	var resp bool
-	if err := Client().Debug("can-manage-refreshes", nil, &resp); err != nil {
+	if err := x.client.Debug("can-manage-refreshes", nil, &resp); err != nil {
 		return err
 	}
 	fmt.Fprintf(Stdout, "%v\n", resp)

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -41,6 +41,7 @@ change.
 `)
 
 type cmdChanges struct {
+	clientMixin
 	timeMixin
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
@@ -100,8 +101,7 @@ func (c *cmdChanges) Execute(args []string) error {
 		Selector: client.ChangesAll,
 	}
 
-	cli := Client()
-	changes, err := queryChanges(cli, &opts)
+	changes, err := queryChanges(c.client, &opts)
 	if err != nil {
 		return err
 	}
@@ -131,8 +131,7 @@ func (c *cmdChanges) Execute(args []string) error {
 }
 
 func (c *cmdTasks) Execute([]string) error {
-	cli := Client()
-	chid, err := c.GetChangeID(cli)
+	chid, err := c.GetChangeID()
 	if err != nil {
 		if err == noChangeFoundOK {
 			return nil
@@ -140,7 +139,7 @@ func (c *cmdTasks) Execute([]string) error {
 		return err
 	}
 
-	return c.showChange(cli, chid)
+	return c.showChange(chid)
 }
 
 func queryChange(cli *client.Client, chid string) (*client.Change, error) {
@@ -154,8 +153,8 @@ func queryChange(cli *client.Client, chid string) (*client.Change, error) {
 	return chg, nil
 }
 
-func (c *cmdTasks) showChange(cli *client.Client, chid string) error {
-	chg, err := queryChange(cli, chid)
+func (c *cmdTasks) showChange(chid string) error {
+	chg, err := queryChange(c.client, chid)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_changes_test.go
+++ b/cmd/snap/cmd_changes_test.go
@@ -56,13 +56,13 @@ func (s *SnapSuite) TestChangeSimple(c *check.C) {
 	expectedChange := `(?ms)Status +Spawn +Ready +Summary
 Do +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary
 `
-	rest, err := snap.Parser().ParseArgs([]string{"change", "--abs-time", "42"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"change", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, expectedChange)
 	c.Check(s.Stderr(), check.Equals, "")
 
-	rest, err = snap.Parser().ParseArgs([]string{"tasks", "--abs-time", "42"})
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"tasks", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, expectedChange)
@@ -83,7 +83,7 @@ func (s *SnapSuite) TestChangeSimpleRebooting(c *check.C) {
 		n++
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"change", "42"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"change", "42"})
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stderr(), check.Equals, "WARNING: snapd is about to reboot the system\n")
 }
@@ -144,13 +144,13 @@ func (s *SnapSuite) TestTasksLast(c *check.C) {
 	expectedChange := `(?ms)Status +Spawn +Ready +Summary
 Do +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary
 `
-	rest, err := snap.Parser().ParseArgs([]string{"tasks", "--abs-time", "--last=install"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"tasks", "--abs-time", "--last=install"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, expectedChange)
 	c.Check(s.Stderr(), check.Equals, "")
 
-	_, err = snap.Parser().ParseArgs([]string{"tasks", "--abs-time", "--last=foobar"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"tasks", "--abs-time", "--last=foobar"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `no changes of type "foobar" found`)
 }
@@ -171,13 +171,13 @@ func (s *SnapSuite) TestTasksLastQuestionmark(c *check.C) {
 		}
 	})
 	for i := 0; i < 2; i++ {
-		rest, err := snap.Parser().ParseArgs([]string{"tasks", "--last=foobar?"})
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"tasks", "--last=foobar?"})
 		c.Assert(err, check.IsNil)
 		c.Assert(rest, check.DeepEquals, []string{})
 		c.Check(s.Stdout(), check.Matches, "")
 		c.Check(s.Stderr(), check.Equals, "")
 
-		_, err = snap.Parser().ParseArgs([]string{"tasks", "--last=foobar"})
+		_, err = snap.Parser(snap.Client()).ParseArgs([]string{"tasks", "--last=foobar"})
 		if i == 0 {
 			c.Assert(err, check.ErrorMatches, `no changes found`)
 		} else {
@@ -189,11 +189,11 @@ func (s *SnapSuite) TestTasksLastQuestionmark(c *check.C) {
 }
 
 func (s *SnapSuite) TestTasksSyntaxError(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"tasks", "--abs-time", "--last=install", "42"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"tasks", "--abs-time", "--last=install", "42"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `cannot use change ID and type together`)
 
-	_, err = snap.Parser().ParseArgs([]string{"tasks"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"tasks"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `please provide change ID or type with --last=<type>`)
 }
@@ -223,7 +223,7 @@ func (s *SnapSuite) TestChangeProgress(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"change", "--abs-time", "42"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"change", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?ms)Status +Spawn +Ready +Summary

--- a/cmd/snap/cmd_confinement.go
+++ b/cmd/snap/cmd_confinement.go
@@ -33,7 +33,9 @@ The confinement command will print the confinement mode (strict,
 partial or none) the system operates in.
 `)
 
-type cmdConfinement struct{}
+type cmdConfinement struct {
+	clientMixin
+}
 
 func init() {
 	addDebugCommand("confinement", shortConfinementHelp, longConfinementHelp, func() flags.Commander {
@@ -46,8 +48,7 @@ func (cmd cmdConfinement) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-	sysInfo, err := cli.SysInfo()
+	sysInfo, err := cmd.client.SysInfo()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_confinement_test.go
+++ b/cmd/snap/cmd_confinement_test.go
@@ -32,7 +32,7 @@ func (s *SnapSuite) TestConfinement(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"type": "sync", "result": {"confinement": "strict"}}`)
 	})
-	_, err := snap.Parser().ParseArgs([]string{"debug", "confinement"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "confinement"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "strict\n")
 	c.Assert(s.Stderr(), Equals, "")

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -77,13 +77,12 @@ func (x *cmdConnect) Execute(args []string) error {
 		x.Positionals.PlugSpec.Snap = ""
 	}
 
-	cli := Client()
-	id, err := cli.Connect(x.Positionals.PlugSpec.Snap, x.Positionals.PlugSpec.Name, x.Positionals.SlotSpec.Snap, x.Positionals.SlotSpec.Name)
+	id, err := x.client.Connect(x.Positionals.PlugSpec.Snap, x.Positionals.PlugSpec.Name, x.Positionals.SlotSpec.Snap, x.Positionals.SlotSpec.Name)
 	if err != nil {
 		return err
 	}
 
-	if _, err := x.wait(cli, id); err != nil {
+	if _, err := x.wait(id); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -57,7 +57,7 @@ the plug name.
           --no-wait        Do not wait for the operation to finish but just
                            print the change id.
 `
-	rest, err := Parser().ParseArgs([]string{"connect", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"connect", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -90,7 +90,7 @@ func (s *SnapSuite) TestConnectExplicitEverything(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"connect", "producer:plug", "consumer:slot"})
+	rest, err := Parser(Client()).ParseArgs([]string{"connect", "producer:plug", "consumer:slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -123,7 +123,7 @@ func (s *SnapSuite) TestConnectExplicitPlugImplicitSlot(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"connect", "producer:plug", "consumer"})
+	rest, err := Parser(Client()).ParseArgs([]string{"connect", "producer:plug", "consumer"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -156,7 +156,7 @@ func (s *SnapSuite) TestConnectImplicitPlugExplicitSlot(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"connect", "plug", "consumer:slot"})
+	rest, err := Parser(Client()).ParseArgs([]string{"connect", "plug", "consumer:slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -189,7 +189,7 @@ func (s *SnapSuite) TestConnectImplicitPlugImplicitSlot(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"connect", "plug", "consumer"})
+	rest, err := Parser(Client()).ParseArgs([]string{"connect", "plug", "consumer"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -292,7 +292,7 @@ func (s *SnapSuite) TestConnectCompletion(c *C) {
 	defer os.Unsetenv("GO_FLAGS_COMPLETION")
 
 	expected := []flags.Completion{}
-	parser := Parser()
+	parser := Parser(Client())
 	parser.CompletionHandler = func(obtained []flags.Completion) {
 		c.Check(obtained, DeepEquals, expected)
 	}

--- a/cmd/snap/cmd_connectivity_check.go
+++ b/cmd/snap/cmd_connectivity_check.go
@@ -25,7 +25,9 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-type cmdConnectivityCheck struct{}
+type cmdConnectivityCheck struct {
+	clientMixin
+}
 
 func init() {
 	addDebugCommand("connectivity",
@@ -41,13 +43,11 @@ func (x *cmdConnectivityCheck) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-
 	var status struct {
 		Connectivity bool
 		Unreachable  []string
 	}
-	if err := cli.Debug("connectivity", nil, &status); err != nil {
+	if err := x.client.Debug("connectivity", nil, &status); err != nil {
 		return err
 	}
 

--- a/cmd/snap/cmd_connectivity_check_test.go
+++ b/cmd/snap/cmd_connectivity_check_test.go
@@ -47,7 +47,7 @@ func (s *SnapSuite) TestConnectivityHappy(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"debug", "connectivity"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "connectivity"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `Connectivity status:
@@ -74,7 +74,7 @@ func (s *SnapSuite) TestConnectivityUnhappy(c *check.C) {
 
 		n++
 	})
-	_, err := snap.Parser().ParseArgs([]string{"debug", "connectivity"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "connectivity"})
 	c.Assert(err, check.ErrorMatches, "1 servers unreachable")
 	// note that only the unreachable hosts are displayed
 	c.Check(s.Stdout(), check.Equals, `Connectivity status:

--- a/cmd/snap/cmd_create_key_test.go
+++ b/cmd/snap/cmd_create_key_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (s *SnapSuite) TestCreateKeyInvalidCharacters(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"create-key", "a b"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-key", "a b"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "key name \"a b\" is not valid; only ASCII letters, digits, and hyphens are allowed")
 	c.Check(s.Stdout(), Equals, "")

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -38,6 +38,7 @@ An account can be setup at https://login.ubuntu.com.
 `)
 
 type cmdCreateUser struct {
+	clientMixin
 	Positional struct {
 		Email string
 	} `positional-args:"yes"`
@@ -69,8 +70,6 @@ func (x *cmdCreateUser) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-
 	options := client.CreateUserOptions{
 		Email:        x.Positional.Email,
 		Sudoer:       x.Sudoer,
@@ -83,9 +82,9 @@ func (x *cmdCreateUser) Execute(args []string) error {
 	var err error
 
 	if options.Email == "" && options.Known {
-		results, err = cli.CreateUsers([]*client.CreateUserOptions{&options})
+		results, err = x.client.CreateUsers([]*client.CreateUserOptions{&options})
 	} else {
-		result, err = cli.CreateUser(&options)
+		result, err = x.client.CreateUser(&options)
 		if err == nil {
 			results = append(results, result)
 		}

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -71,7 +71,7 @@ func (s *SnapSuite) TestCreateUserNoSudoer(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(makeCreateUserChecker(c, &n, "one@email.com", false, false))
 
-	rest, err := snap.Parser().ParseArgs([]string{"create-user", "one@email.com"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-user", "one@email.com"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
@@ -83,7 +83,7 @@ func (s *SnapSuite) TestCreateUserSudoer(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(makeCreateUserChecker(c, &n, "one@email.com", true, false))
 
-	rest, err := snap.Parser().ParseArgs([]string{"create-user", "--sudoer", "one@email.com"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-user", "--sudoer", "one@email.com"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
@@ -101,7 +101,7 @@ func (s *SnapSuite) TestCreateUserJSON(c *check.C) {
 	}
 	actualResponse := &client.CreateUserResult{}
 
-	rest, err := snap.Parser().ParseArgs([]string{"create-user", "--json", "one@email.com"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-user", "--json", "one@email.com"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
@@ -120,7 +120,7 @@ func (s *SnapSuite) TestCreateUserNoEmailJSON(c *check.C) {
 	}}
 	var actualResponse []*client.CreateUserResult
 
-	rest, err := snap.Parser().ParseArgs([]string{"create-user", "--json", "--known"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-user", "--json", "--known"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
@@ -133,7 +133,7 @@ func (s *SnapSuite) TestCreateUserKnown(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(makeCreateUserChecker(c, &n, "one@email.com", false, true))
 
-	rest, err := snap.Parser().ParseArgs([]string{"create-user", "--known", "one@email.com"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-user", "--known", "one@email.com"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
@@ -143,7 +143,7 @@ func (s *SnapSuite) TestCreateUserKnownNoEmail(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(makeCreateUserChecker(c, &n, "", false, true))
 
-	rest, err := snap.Parser().ParseArgs([]string{"create-user", "--known"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"create-user", "--known"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)

--- a/cmd/snap/cmd_delete_key_test.go
+++ b/cmd/snap/cmd_delete_key_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *SnapKeysSuite) TestDeleteKeyRequiresName(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"delete-key"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"delete-key"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "the required argument `<key-name>` was not provided")
 	c.Check(s.Stdout(), Equals, "")
@@ -36,7 +36,7 @@ func (s *SnapKeysSuite) TestDeleteKeyRequiresName(c *C) {
 }
 
 func (s *SnapKeysSuite) TestDeleteKeyNonexistent(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"delete-key", "nonexistent"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"delete-key", "nonexistent"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot find key named \"nonexistent\" in GPG keyring")
 	c.Check(s.Stdout(), Equals, "")
@@ -44,12 +44,12 @@ func (s *SnapKeysSuite) TestDeleteKeyNonexistent(c *C) {
 }
 
 func (s *SnapKeysSuite) TestDeleteKey(c *C) {
-	rest, err := snap.Parser().ParseArgs([]string{"delete-key", "another"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"delete-key", "another"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
-	_, err = snap.Parser().ParseArgs([]string{"keys", "--json"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"keys", "--json"})
 	c.Assert(err, IsNil)
 	expectedResponse := []snap.Key{
 		{

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -80,8 +80,7 @@ func (x *cmdDisconnect) Execute(args []string) error {
 		return fmt.Errorf("please provide the plug or slot name to disconnect from snap %q", use.Snap)
 	}
 
-	cli := Client()
-	id, err := cli.Disconnect(offer.Snap, offer.Name, use.Snap, use.Name)
+	id, err := x.client.Disconnect(offer.Snap, offer.Name, use.Snap, use.Name)
 	if err != nil {
 		if client.IsInterfacesUnchangedError(err) {
 			fmt.Fprintf(Stdout, i18n.G("No connections to disconnect"))
@@ -91,7 +90,7 @@ func (x *cmdDisconnect) Execute(args []string) error {
 		return err
 	}
 
-	if _, err := x.wait(cli, id); err != nil {
+	if _, err := x.wait(id); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -50,7 +50,7 @@ The snap name may be omitted for the core snap.
           --no-wait        Do not wait for the operation to finish but just
                            print the change id.
 `
-	rest, err := Parser().ParseArgs([]string{"disconnect", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -83,7 +83,7 @@ func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"disconnect", "producer:plug", "consumer:slot"})
+	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "producer:plug", "consumer:slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, "")
@@ -118,7 +118,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"disconnect", "consumer:slot"})
+	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "consumer:slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, "")
@@ -153,7 +153,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnapPlugOrSlot(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"disconnect", "consumer:plug-or-slot"})
+	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "consumer:plug-or-slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, "")
@@ -164,7 +164,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnap(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Fatalf("expected nothing to reach the server")
 	})
-	rest, err := Parser().ParseArgs([]string{"disconnect", "consumer"})
+	rest, err := Parser(Client()).ParseArgs([]string{"disconnect", "consumer"})
 	c.Assert(err, ErrorMatches, `please provide the plug or slot name to disconnect from snap "consumer"`)
 	c.Assert(rest, DeepEquals, []string{"consumer"})
 	c.Assert(s.Stdout(), Equals, "")
@@ -188,7 +188,7 @@ func (s *SnapSuite) TestDisconnectCompletion(c *C) {
 	defer os.Unsetenv("GO_FLAGS_COMPLETION")
 
 	expected := []flags.Completion{}
-	parser := Parser()
+	parser := Parser(Client())
 	parser.CompletionHandler = func(obtained []flags.Completion) {
 		c.Check(obtained, DeepEquals, expected)
 	}

--- a/cmd/snap/cmd_ensure_state_soon.go
+++ b/cmd/snap/cmd_ensure_state_soon.go
@@ -23,7 +23,9 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-type cmdEnsureStateSoon struct{}
+type cmdEnsureStateSoon struct {
+	clientMixin
+}
 
 func init() {
 	cmd := addDebugCommand("ensure-state-soon",
@@ -40,5 +42,5 @@ func (x *cmdEnsureStateSoon) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	return Client().Debug("ensure-state-soon", nil, nil)
+	return x.client.Debug("ensure-state-soon", nil, nil)
 }

--- a/cmd/snap/cmd_ensure_state_soon_test.go
+++ b/cmd/snap/cmd_ensure_state_soon_test.go
@@ -47,7 +47,7 @@ func (s *SnapSuite) TestEnsureStateSoon(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"debug", "ensure-state-soon"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "ensure-state-soon"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")

--- a/cmd/snap/cmd_export_key_test.go
+++ b/cmd/snap/cmd_export_key_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func (s *SnapKeysSuite) TestExportKeyNonexistent(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"export-key", "nonexistent"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"export-key", "nonexistent"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot find key named \"nonexistent\" in GPG keyring")
 	c.Check(s.Stdout(), Equals, "")
@@ -38,7 +38,7 @@ func (s *SnapKeysSuite) TestExportKeyNonexistent(c *C) {
 }
 
 func (s *SnapKeysSuite) TestExportKeyDefault(c *C) {
-	rest, err := snap.Parser().ParseArgs([]string{"export-key"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"export-key"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	pubKey, err := asserts.DecodePublicKey(s.stdout.Bytes())
@@ -48,7 +48,7 @@ func (s *SnapKeysSuite) TestExportKeyDefault(c *C) {
 }
 
 func (s *SnapKeysSuite) TestExportKeyNonDefault(c *C) {
-	rest, err := snap.Parser().ParseArgs([]string{"export-key", "another"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"export-key", "another"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	pubKey, err := asserts.DecodePublicKey(s.stdout.Bytes())
@@ -61,7 +61,7 @@ func (s *SnapKeysSuite) TestExportKeyAccount(c *C) {
 	storeSigning := assertstest.NewStoreStack("canonical", nil)
 	manager := asserts.NewGPGKeypairManager()
 	assertstest.NewAccount(storeSigning, "developer1", nil, "")
-	rest, err := snap.Parser().ParseArgs([]string{"export-key", "another", "--account=developer1"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"export-key", "another", "--account=developer1"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	assertion, err := asserts.Decode(s.stdout.Bytes())

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -137,7 +137,7 @@ func (s *SnapSuite) TestFindSnapName(c *check.C) {
 		n++
 	})
 
-	rest, err := snap.Parser().ParseArgs([]string{"find", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello"})
 
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
@@ -230,7 +230,7 @@ func (s *SnapSuite) TestFindHello(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"find", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
@@ -257,7 +257,7 @@ func (s *SnapSuite) TestFindHelloNarrow(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"find", "--narrow", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--narrow", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
@@ -320,7 +320,7 @@ func (s *SnapSuite) TestFindPriced(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"find", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
@@ -381,7 +381,7 @@ func (s *SnapSuite) TestFindPricedAndBought(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"find", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
@@ -405,7 +405,7 @@ func (s *SnapSuite) TestFindNothingMeansFeaturedSection(c *check.C) {
 		n++
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"find"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"find"})
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(n, check.Equals, 1)
@@ -463,7 +463,7 @@ func (s *SnapSuite) TestFindNetworkTimeoutError(c *check.C) {
 
 		n++
 	})
-	_, err := snap.Parser().ParseArgs([]string{"find", "hello"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello"})
 	c.Assert(err, check.ErrorMatches, `unable to contact snap store`)
 	c.Check(s.Stdout(), check.Equals, "")
 }
@@ -485,7 +485,7 @@ func (s *SnapSuite) TestFindSnapSectionOverview(c *check.C) {
 		n++
 	})
 
-	rest, err := snap.Parser().ParseArgs([]string{"find", "--section"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--section"})
 
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
@@ -517,7 +517,7 @@ func (s *SnapSuite) TestFindSnapInvalidSection(c *check.C) {
 
 		n++
 	})
-	_, err := snap.Parser().ParseArgs([]string{"find", "--section=foobar", "hello"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--section=foobar", "hello"})
 	c.Assert(err, check.ErrorMatches, `No matching section "foobar", use --section to list existing sections`)
 }
 
@@ -548,7 +548,7 @@ func (s *SnapSuite) TestFindSnapNotFoundInSection(c *check.C) {
 		n++
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"find", "--section=foobar", "hello"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--section=foobar", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stderr(), check.Equals, "No matching snaps for \"hello\" in section \"foobar\"\n")
 	c.Check(s.Stdout(), check.Equals, "")
@@ -571,13 +571,13 @@ func (s *SnapSuite) TestFindSnapCachedSection(c *check.C) {
 	os.MkdirAll(path.Dir(dirs.SnapSectionsFile), 0755)
 	ioutil.WriteFile(dirs.SnapSectionsFile, []byte("sec1\nsec2\nsec3"), 0644)
 
-	_, err := snap.Parser().ParseArgs([]string{"find", "--section=foobar", "hello"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--section=foobar", "hello"})
 	c.Logf("stdout: %s", s.Stdout())
 	c.Assert(err, check.ErrorMatches, `No matching section "foobar", use --section to list existing sections`)
 
 	s.ResetStdStreams()
 
-	rest, err := snap.Parser().ParseArgs([]string{"find", "--section"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--section"})
 
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -52,6 +52,7 @@ Nested values may be retrieved via a dotted path:
 `)
 
 type cmdGet struct {
+	clientMixin
 	Positional struct {
 		Snap installedSnapName `required:"yes"`
 		Keys []string
@@ -239,8 +240,7 @@ func (x *cmdGet) Execute(args []string) error {
 	snapName := string(x.Positional.Snap)
 	confKeys := x.Positional.Keys
 
-	cli := Client()
-	conf, err := cli.Conf(snapName, confKeys)
+	conf, err := x.client.Conf(snapName, confKeys)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_get_base_declaration.go
+++ b/cmd/snap/cmd_get_base_declaration.go
@@ -25,7 +25,9 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-type cmdGetBaseDeclaration struct{}
+type cmdGetBaseDeclaration struct {
+	clientMixin
+}
 
 func init() {
 	cmd := addDebugCommand("get-base-declaration",
@@ -44,7 +46,7 @@ func (x *cmdGetBaseDeclaration) Execute(args []string) error {
 	var resp struct {
 		BaseDeclaration string `json:"base-declaration"`
 	}
-	if err := Client().Debug("get-base-declaration", nil, &resp); err != nil {
+	if err := x.client.Debug("get-base-declaration", nil, &resp); err != nil {
 		return err
 	}
 	fmt.Fprintf(Stdout, "%s\n", resp.BaseDeclaration)

--- a/cmd/snap/cmd_get_base_declaration_test.go
+++ b/cmd/snap/cmd_get_base_declaration_test.go
@@ -47,7 +47,7 @@ func (s *SnapSuite) TestGetBaseDeclaration(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"debug", "get-base-declaration"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "get-base-declaration"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "hello\n")

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -112,7 +112,7 @@ func (s *SnapSuite) runTests(cmds []getCmdArgs, c *C) {
 		restore := snapset.MockIsStdinTTY(test.isTerminal)
 		defer restore()
 
-		_, err := snapset.Parser().ParseArgs(strings.Fields(test.args))
+		_, err := snapset.Parser(snapset.Client()).ParseArgs(strings.Fields(test.args))
 		if test.error != "" {
 			c.Check(err, ErrorMatches, test.error)
 		} else {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -40,6 +40,7 @@ import (
 )
 
 type infoCmd struct {
+	clientMixin
 	colorMixin
 	timeMixin
 
@@ -359,8 +360,6 @@ func formatSummary(raw string) string {
 }
 
 func (x *infoCmd) Execute([]string) error {
-	cli := Client()
-
 	termWidth, _ := termSize()
 	termWidth -= 3
 	if termWidth > 100 {
@@ -386,8 +385,8 @@ func (x *infoCmd) Execute([]string) error {
 			noneOK = false
 			continue
 		}
-		remote, resInfo, _ := cli.FindOne(snapName)
-		local, _, _ := cli.Snap(snapName)
+		remote, resInfo, _ := x.client.FindOne(snapName)
+		local, _, _ := x.client.Snap(snapName)
 
 		both := coalesce(local, remote)
 

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -115,7 +115,7 @@ func (s *infoSuite) TestInfoPriced(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
@@ -234,7 +234,7 @@ func (s *infoSuite) TestInfoUnquoted(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
@@ -332,7 +332,7 @@ func (s *infoSuite) TestInfoWithLocalDifferentLicense(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"info", "--abs-time", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "--abs-time", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
@@ -368,7 +368,7 @@ func (s *infoSuite) TestInfoWithLocalNoLicense(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"info", "--abs-time", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "--abs-time", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
@@ -404,7 +404,7 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"info", "--abs-time", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "--abs-time", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
@@ -449,7 +449,7 @@ func (s *infoSuite) TestInfoHumanTimes(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -33,6 +33,7 @@ import (
 )
 
 type cmdInterface struct {
+	clientMixin
 	ShowAttrs   bool `long:"attrs"`
 	ShowAll     bool `long:"all"`
 	Positionals struct {
@@ -70,7 +71,7 @@ func (x *cmdInterface) Execute(args []string) error {
 	if x.Positionals.Interface != "" {
 		// Show one interface in detail.
 		name := string(x.Positionals.Interface)
-		ifaces, err := Client().Interfaces(&client.InterfaceOptions{
+		ifaces, err := x.client.Interfaces(&client.InterfaceOptions{
 			Names: []string{name},
 			Doc:   true,
 			Plugs: true,
@@ -85,7 +86,7 @@ func (x *cmdInterface) Execute(args []string) error {
 		x.showOneInterface(ifaces[0])
 	} else {
 		// Show an overview of available interfaces.
-		ifaces, err := Client().Interfaces(&client.InterfaceOptions{
+		ifaces, err := x.client.Interfaces(&client.InterfaceOptions{
 			Connected: !x.ShowAll,
 		})
 		if err != nil {

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -47,7 +47,7 @@ one connection is shown, or a list of all interfaces if --all is provided.
 [interface command arguments]
   <interface>:           Show details of a specific interface
 `
-	rest, err := Parser().ParseArgs([]string{"interface", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -65,7 +65,7 @@ func (s *SnapSuite) TestInterfaceListEmpty(c *C) {
 			"result": []*client.Interface{},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interface"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface"})
 	c.Assert(err, ErrorMatches, "no interfaces currently connected")
 	c.Assert(rest, DeepEquals, []string{"interface"})
 	c.Assert(s.Stdout(), Equals, "")
@@ -85,7 +85,7 @@ func (s *SnapSuite) TestInterfaceListAllEmpty(c *C) {
 			"result": []*client.Interface{},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interface", "--all"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface", "--all"})
 	c.Assert(err, ErrorMatches, "no interfaces found")
 	c.Assert(rest, DeepEquals, []string{"--all"}) // XXX: feels like a bug in go-flags.
 	c.Assert(s.Stdout(), Equals, "")
@@ -111,7 +111,7 @@ func (s *SnapSuite) TestInterfaceList(c *C) {
 			}},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interface"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -144,7 +144,7 @@ func (s *SnapSuite) TestInterfaceListAll(c *C) {
 			}},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interface", "--all"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface", "--all"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -178,7 +178,7 @@ func (s *SnapSuite) TestInterfaceDetails(c *C) {
 			}},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interface", "network"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface", "network"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -224,7 +224,7 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 			}},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interface", "--attrs", "serial-port"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interface", "--attrs", "serial-port"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -262,7 +262,7 @@ func (s *SnapSuite) TestInterfaceCompletion(c *C) {
 	defer os.Unsetenv("GO_FLAGS_COMPLETION")
 
 	expected := []flags.Completion{}
-	parser := Parser()
+	parser := Parser(Client())
 	parser.CompletionHandler = func(obtained []flags.Completion) {
 		c.Check(obtained, DeepEquals, expected)
 	}

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -28,6 +28,7 @@ import (
 )
 
 type cmdInterfaces struct {
+	clientMixin
 	Interface   string `short:"i"`
 	Positionals struct {
 		Query interfacesSlotOrPlugSpec `skip-help:"true"`
@@ -72,7 +73,7 @@ func (x *cmdInterfaces) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	ifaces, err := Client().Connections()
+	ifaces, err := x.client.Connections()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -50,7 +50,7 @@ func (s *SnapSuite) TestConnectionsZeroSlotsOnePlug(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -81,7 +81,7 @@ func (s *SnapSuite) TestConnectionsZeroPlugsOneSlot(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -132,7 +132,7 @@ func (s *SnapSuite) TestConnectionsOneSlotOnePlug(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -143,7 +143,7 @@ func (s *SnapSuite) TestConnectionsOneSlotOnePlug(c *C) {
 
 	s.SetUpTest(c)
 	// should be the same
-	rest, err = Parser().ParseArgs([]string{"interfaces", "canonical-pi2"})
+	rest, err = Parser(Client()).ParseArgs([]string{"interfaces", "canonical-pi2"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, expectedStdout)
@@ -151,7 +151,7 @@ func (s *SnapSuite) TestConnectionsOneSlotOnePlug(c *C) {
 
 	s.SetUpTest(c)
 	// and the same again
-	rest, err = Parser().ParseArgs([]string{"interfaces", "keyboard-lights"})
+	rest, err = Parser(Client()).ParseArgs([]string{"interfaces", "keyboard-lights"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, expectedStdout)
@@ -189,7 +189,7 @@ func (s *SnapSuite) TestConnectionsTwoPlugs(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -256,7 +256,7 @@ func (s *SnapSuite) TestConnectionsPlugsWithCommonName(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -323,7 +323,7 @@ func (s *SnapSuite) TestConnectionsOsSnapSlots(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -372,7 +372,7 @@ func (s *SnapSuite) TestConnectionsTwoSlotsAndFiltering(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", "-i=serial-port"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces", "-i=serial-port"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -415,7 +415,7 @@ func (s *SnapSuite) TestConnectionsOfSpecificSnap(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", "wake-up-alarm"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces", "wake-up-alarm"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -459,7 +459,7 @@ func (s *SnapSuite) TestConnectionsOfSystemNicknameSnap(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", "system"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces", "system"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -471,7 +471,7 @@ func (s *SnapSuite) TestConnectionsOfSystemNicknameSnap(c *C) {
 	s.ResetStdStreams()
 
 	// when called with system nickname we get the same output
-	rest, err = Parser().ParseArgs([]string{"interfaces", "system"})
+	rest, err = Parser(Client()).ParseArgs([]string{"interfaces", "system"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdoutSystem := "" +
@@ -514,7 +514,7 @@ func (s *SnapSuite) TestConnectionsOfSpecificSnapAndSlot(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", "wake-up-alarm:snooze"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces", "wake-up-alarm:snooze"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -536,7 +536,7 @@ func (s *SnapSuite) TestConnectionsNothingAtAll(c *C) {
 			"result": client.Connections{},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces"})
 	c.Assert(err, ErrorMatches, "no interfaces found")
 	// XXX: not sure why this is returned, I guess that's what happens when a
 	// command Execute returns an error.
@@ -578,7 +578,7 @@ func (s *SnapSuite) TestConnectionsOfSpecificType(c *C) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", "-i", "bool-file"})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces", "-i", "bool-file"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
@@ -607,7 +607,7 @@ func (s *SnapSuite) TestConnectionsCompletion(c *C) {
 	defer os.Unsetenv("GO_FLAGS_COMPLETION")
 
 	expected := []flags.Completion{}
-	parser := Parser()
+	parser := Parser(Client())
 	parser.CompletionHandler = func(obtained []flags.Completion) {
 		c.Check(obtained, DeepEquals, expected)
 	}
@@ -656,7 +656,7 @@ func (s *SnapSuite) checkConnectionsSystemCoreRemapping(c *C, snapName string) {
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", snapName})
+	rest, err := Parser(Client()).ParseArgs([]string{"interfaces", snapName})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +

--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -87,7 +87,7 @@ func (s *SnapKeysSuite) TearDownTest(c *C) {
 }
 
 func (s *SnapKeysSuite) TestKeys(c *C) {
-	rest, err := snap.Parser().ParseArgs([]string{"keys"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"keys"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Matches, `Name +SHA3-384
@@ -102,7 +102,7 @@ func (s *SnapKeysSuite) TestKeysEmptyNoHeader(c *C) {
 	err := os.RemoveAll(s.tempdir)
 	c.Assert(err, IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"keys"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"keys"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "No keys registered, see `snapcraft create-key`")
@@ -110,7 +110,7 @@ func (s *SnapKeysSuite) TestKeysEmptyNoHeader(c *C) {
 }
 
 func (s *SnapKeysSuite) TestKeysJSON(c *C) {
-	rest, err := snap.Parser().ParseArgs([]string{"keys", "--json"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"keys", "--json"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedResponse := []snap.Key{
@@ -132,7 +132,7 @@ func (s *SnapKeysSuite) TestKeysJSON(c *C) {
 func (s *SnapKeysSuite) TestKeysJSONEmpty(c *C) {
 	err := os.RemoveAll(os.Getenv("SNAP_GNUPG_HOME"))
 	c.Assert(err, IsNil)
-	rest, err := snap.Parser().ParseArgs([]string{"keys", "--json"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"keys", "--json"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "[]\n")

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -32,6 +32,7 @@ import (
 )
 
 type cmdKnown struct {
+	clientMixin
 	KnownOptions struct {
 		// XXX: how to get a list of assert types for completion?
 		AssertTypeName assertTypeName `required:"true"`
@@ -112,7 +113,7 @@ func (x *cmdKnown) Execute(args []string) error {
 	if x.Remote {
 		assertions, err = downloadAssertion(string(x.KnownOptions.AssertTypeName), headers)
 	} else {
-		assertions, err = Client().Known(string(x.KnownOptions.AssertTypeName), headers)
+		assertions, err = x.client.Known(string(x.KnownOptions.AssertTypeName), headers)
 	}
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -78,7 +78,7 @@ func (s *SnapSuite) TestKnownRemote(c *check.C) {
 		n++
 	}))
 
-	rest, err := snap.Parser().ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical", "model=pi99"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical", "model=pi99"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, mockModelAssertion)
@@ -86,7 +86,7 @@ func (s *SnapSuite) TestKnownRemote(c *check.C) {
 }
 
 func (s *SnapSuite) TestKnownRemoteMissingPrimaryKey(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical"})
 	c.Assert(err, check.ErrorMatches, `cannot query remote assertion: must provide primary key: model`)
 }
 

--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -42,6 +42,7 @@ indicates that the publisher has been verified.
 `)
 
 type cmdList struct {
+	clientMixin
 	Positional struct {
 		Snaps []installedSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"yes"`
@@ -107,8 +108,7 @@ func (x *cmdList) Execute(args []string) error {
 	}
 
 	names := installedSnapNames(x.Positional.Snaps)
-	cli := Client()
-	snaps, err := cli.List(names, &client.ListOptions{All: x.All})
+	snaps, err := x.client.List(names, &client.ListOptions{All: x.All})
 	if err != nil {
 		if err == client.ErrNoSnapsInstalled {
 			if len(names) == 0 {

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -44,7 +44,7 @@ indicates that the publisher has been verified.
           --unicode=[auto|never|always] Use a little bit of Unicode to improve
                                         legibility. (default: auto)
 `
-	rest, err := snap.Parser().ParseArgs([]string{"list", "--help"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list", "--help"})
 	c.Assert(err.Error(), check.Equals, msg)
 	c.Assert(rest, check.DeepEquals, []string{})
 }
@@ -64,7 +64,7 @@ func (s *SnapSuite) TestList(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"list"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Publisher +Notes
@@ -88,7 +88,7 @@ func (s *SnapSuite) TestListAll(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"list", "--all"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list", "--all"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Publisher +Notes
@@ -111,7 +111,7 @@ func (s *SnapSuite) TestListEmpty(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"list"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")
@@ -132,7 +132,7 @@ func (s *SnapSuite) TestListEmptyWithQuery(c *check.C) {
 
 		n++
 	})
-	_, err := snap.Parser().ParseArgs([]string{"list", "quux"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"list", "quux"})
 	c.Assert(err, check.ErrorMatches, `no matching snaps installed`)
 }
 
@@ -151,7 +151,7 @@ func (s *SnapSuite) TestListWithNoMatchingQuery(c *check.C) {
 
 		n++
 	})
-	_, err := snap.Parser().ParseArgs([]string{"list", "quux"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"list", "quux"})
 	c.Assert(err, check.ErrorMatches, "no matching snaps installed")
 }
 
@@ -170,7 +170,7 @@ func (s *SnapSuite) TestListWithQuery(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"list", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Publisher +Notes
@@ -200,7 +200,7 @@ func (s *SnapSuite) TestListWithNotes(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"list"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?ms)^Name +Version +Rev +Tracking +Publisher +Notes$`)

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -31,6 +31,7 @@ import (
 )
 
 type cmdLogin struct {
+	clientMixin
 	Positional struct {
 		Email string
 	} `positional-args:"yes"`
@@ -64,7 +65,7 @@ func init() {
 		}})
 }
 
-func requestLoginWith2faRetry(email, password string) error {
+func requestLoginWith2faRetry(cli *client.Client, email, password string) error {
 	var otp []byte
 	var err error
 
@@ -74,7 +75,6 @@ func requestLoginWith2faRetry(email, password string) error {
 		i18n.G("Wrong again. Once more: "),
 	}
 
-	cli := Client()
 	reader := bufio.NewReader(nil)
 
 	for i := 0; ; i++ {
@@ -94,7 +94,7 @@ func requestLoginWith2faRetry(email, password string) error {
 	}
 }
 
-func requestLogin(email string) error {
+func requestLogin(cli *client.Client, email string) error {
 	fmt.Fprint(Stdout, fmt.Sprintf(i18n.G("Password of %q: "), email))
 	password, err := ReadPassword(0)
 	fmt.Fprint(Stdout, "\n")
@@ -103,7 +103,7 @@ func requestLogin(email string) error {
 	}
 
 	// strings.TrimSpace needed because we get \r from the pty in the tests
-	return requestLoginWith2faRetry(email, strings.TrimSpace(string(password)))
+	return requestLoginWith2faRetry(cli, email, strings.TrimSpace(string(password)))
 }
 
 func (x *cmdLogin) Execute(args []string) error {
@@ -125,7 +125,7 @@ func (x *cmdLogin) Execute(args []string) error {
 		email = string(in)
 	}
 
-	err := requestLogin(email)
+	err := requestLogin(x.client, email)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_login_test.go
+++ b/cmd/snap/cmd_login_test.go
@@ -54,7 +54,7 @@ func (s *SnapSuite) TestLoginSimple(c *C) {
 
 	// send the password
 	s.password = "some-password\n"
-	rest, err := snap.Parser().ParseArgs([]string{"login", "foo@example.com"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"login", "foo@example.com"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, `Personal information is handled as per our privacy notice at
@@ -76,7 +76,7 @@ func (s *SnapSuite) TestLoginAskEmail(c *C) {
 	// send the password
 	s.password = "some-password"
 
-	rest, err := snap.Parser().ParseArgs([]string{"login"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"login"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	// test slightly ugly, on a real system STDOUT will be:

--- a/cmd/snap/cmd_logout.go
+++ b/cmd/snap/cmd_logout.go
@@ -25,7 +25,9 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-type cmdLogout struct{}
+type cmdLogout struct {
+	clientMixin
+}
 
 var shortLogoutHelp = i18n.G("Log out of snapd and the store")
 
@@ -47,5 +49,5 @@ func (cmd *cmdLogout) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	return Client().Logout()
+	return cmd.client.Logout()
 }

--- a/cmd/snap/cmd_managed.go
+++ b/cmd/snap/cmd_managed.go
@@ -33,7 +33,9 @@ The managed command will print true or false informing whether
 snapd has registered users.
 `)
 
-type cmdIsManaged struct{}
+type cmdIsManaged struct {
+	clientMixin
+}
 
 func init() {
 	cmd := addCommand("managed", shortIsManagedHelp, longIsManagedHelp, func() flags.Commander { return &cmdIsManaged{} }, nil, nil)
@@ -45,7 +47,7 @@ func (cmd cmdIsManaged) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	sysinfo, err := Client().SysInfo()
+	sysinfo, err := cmd.client.SysInfo()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_managed_test.go
+++ b/cmd/snap/cmd_managed_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestManaged(c *C) {
 			fmt.Fprintf(w, `{"type":"sync", "status-code": 200, "result": {"managed":%v}}`, managed)
 		})
 
-		_, err := snap.Parser().ParseArgs([]string{"managed"})
+		_, err := snap.Parser(snap.Client()).ParseArgs([]string{"managed"})
 		c.Assert(err, IsNil)
 		c.Check(s.Stdout(), Equals, fmt.Sprintf("%v\n", managed))
 	}

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestPackCheckSkeletonNoAppFiles(c *check.C) {
 	snapDir := makeSnapDirForPack(c, packSnapYaml)
 
 	// check-skeleton does not fail due to missing files
-	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--check-skeleton", snapDir})
 	c.Assert(err, check.IsNil)
 }
 
@@ -51,7 +51,7 @@ apps:
 `
 	snapDir := makeSnapDirForPack(c, snapYaml)
 
-	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--check-skeleton", snapDir})
 	c.Assert(err, check.ErrorMatches, "snap name cannot be empty")
 }
 
@@ -67,7 +67,7 @@ apps:
 `
 	snapDir := makeSnapDirForPack(c, snapYaml)
 
-	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--check-skeleton", snapDir})
 	c.Assert(err, check.ErrorMatches, `application ("bar" common-id "org.foo.foo" must be unique, already used by application "foo"|"foo" common-id "org.foo.foo" must be unique, already used by application "bar")`)
 }
 
@@ -77,7 +77,7 @@ func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {
 
 	snapDir := makeSnapDirForPack(c, packSnapYaml)
 
-	_, err := snaprun.Parser().ParseArgs([]string{"pack", snapDir, snapDir})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", snapDir, snapDir})
 	c.Assert(err, check.ErrorMatches, ".* snap is unusable due to missing files")
 }
 
@@ -94,7 +94,7 @@ printf "hello world"
 	err = ioutil.WriteFile(filepath.Join(binDir, "hello"), []byte(helloBinContent), 0755)
 	c.Assert(err, check.IsNil)
 
-	_, err = snaprun.Parser().ParseArgs([]string{"pack", snapDir, snapDir})
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", snapDir, snapDir})
 	c.Assert(err, check.IsNil)
 
 	matches, err := filepath.Glob(snapDir + "/hello*.snap")

--- a/cmd/snap/cmd_paths_test.go
+++ b/cmd/snap/cmd_paths_test.go
@@ -33,7 +33,7 @@ func (s *SnapSuite) TestPathsUbuntu(c *C) {
 	defer dirs.SetRootDir("/")
 
 	dirs.SetRootDir("/")
-	_, err := snap.Parser().ParseArgs([]string{"debug", "paths"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
 		"SNAPD_MOUNT=/snap\n"+
@@ -48,7 +48,7 @@ func (s *SnapSuite) TestPathsFedora(c *C) {
 	defer dirs.SetRootDir("/")
 
 	dirs.SetRootDir("/")
-	_, err := snap.Parser().ParseArgs([]string{"debug", "paths"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
 		"SNAPD_MOUNT=/var/lib/snapd/snap\n"+
@@ -63,7 +63,7 @@ func (s *SnapSuite) TestPathsArch(c *C) {
 	defer dirs.SetRootDir("/")
 
 	dirs.SetRootDir("/")
-	_, err := snap.Parser().ParseArgs([]string{"debug", "paths"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
 		"SNAPD_MOUNT=/var/lib/snapd/snap\n"+

--- a/cmd/snap/cmd_prefer.go
+++ b/cmd/snap/cmd_prefer.go
@@ -52,12 +52,11 @@ func (x *cmdPrefer) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-	id, err := cli.Prefer(string(x.Positionals.Snap))
+	id, err := x.client.Prefer(string(x.Positionals.Snap))
 	if err != nil {
 		return err
 	}
-	chg, err := x.wait(cli, id)
+	chg, err := x.wait(id)
 	if err != nil {
 		if err == noWait {
 			return nil

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -40,7 +40,7 @@ to conflicting aliases of other snaps whose aliases will be disabled
           --no-wait  Do not wait for the operation to finish but just print the
                      change id.
 `
-	rest, err := Parser().ParseArgs([]string{"prefer", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"prefer", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -62,7 +62,7 @@ func (s *SnapSuite) TestPrefer(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"prefer", "some-snap"})
+	rest, err := Parser(Client()).ParseArgs([]string{"prefer", "some-snap"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, ""+

--- a/cmd/snap/cmd_repair_repairs_test.go
+++ b/cmd/snap/cmd_repair_repairs_test.go
@@ -45,7 +45,7 @@ func (s *SnapSuite) TestSnapShowRepair(c *C) {
 	mockSnapRepair := mockSnapRepair(c)
 	defer mockSnapRepair.Restore()
 
-	_, err := snap.Parser().ParseArgs([]string{"repair", "canonical-1"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"repair", "canonical-1"})
 	c.Assert(err, IsNil)
 	c.Check(mockSnapRepair.Calls(), DeepEquals, [][]string{
 		{"snap-repair", "show", "canonical-1"},
@@ -59,7 +59,7 @@ func (s *SnapSuite) TestSnapListRepairs(c *C) {
 	mockSnapRepair := mockSnapRepair(c)
 	defer mockSnapRepair.Restore()
 
-	_, err := snap.Parser().ParseArgs([]string{"repairs"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"repairs"})
 	c.Assert(err, IsNil)
 	c.Check(mockSnapRepair.Calls(), DeepEquals, [][]string{
 		{"snap-repair", "list"},

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
@@ -55,6 +56,7 @@ var (
 )
 
 type cmdRun struct {
+	clientMixin
 	Command  string `long:"command" hidden:"yes"`
 	HookName string `long:"hook" hidden:"yes"`
 	Revision string `short:"r" default:"unset" hidden:"yes"`
@@ -93,7 +95,7 @@ and environment.
 		}, nil)
 }
 
-func maybeWaitForSecurityProfileRegeneration() error {
+func maybeWaitForSecurityProfileRegeneration(cli *client.Client) error {
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
 	mismatch, err := interfaces.SystemKeyMismatch()
@@ -126,7 +128,6 @@ func maybeWaitForSecurityProfileRegeneration() error {
 		}
 	}
 
-	cli := Client()
 	for i := 0; i < timeout; i++ {
 		if _, err := cli.SysInfo(); err == nil {
 			return nil
@@ -164,7 +165,7 @@ func (x *cmdRun) Execute(args []string) error {
 		return fmt.Errorf(i18n.G("too many arguments for hook %q: %s"), x.HookName, strings.Join(args, " "))
 	}
 
-	if err := maybeWaitForSecurityProfileRegeneration(); err != nil {
+	if err := maybeWaitForSecurityProfileRegeneration(x.client); err != nil {
 		return err
 	}
 

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -50,27 +50,27 @@ hooks:
 
 func (s *SnapSuite) TestInvalidParameters(c *check.C) {
 	invalidParameters := []string{"run", "--hook=configure", "--command=command-name", "snap-name"}
-	_, err := snaprun.Parser().ParseArgs(invalidParameters)
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*you can only use one of --hook, --command, and --timer.*")
 
 	invalidParameters = []string{"run", "--hook=configure", "--timer=10:00-12:00", "snap-name"}
-	_, err = snaprun.Parser().ParseArgs(invalidParameters)
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*you can only use one of --hook, --command, and --timer.*")
 
 	invalidParameters = []string{"run", "--command=command-name", "--timer=10:00-12:00", "snap-name"}
-	_, err = snaprun.Parser().ParseArgs(invalidParameters)
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*you can only use one of --hook, --command, and --timer.*")
 
 	invalidParameters = []string{"run", "-r=1", "--command=command-name", "snap-name"}
-	_, err = snaprun.Parser().ParseArgs(invalidParameters)
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*-r can only be used with --hook.*")
 
 	invalidParameters = []string{"run", "-r=1", "snap-name"}
-	_, err = snaprun.Parser().ParseArgs(invalidParameters)
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*-r can only be used with --hook.*")
 
 	invalidParameters = []string{"run", "--hook=configure", "foo", "bar", "snap-name"}
-	_, err = snaprun.Parser().ParseArgs(invalidParameters)
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*too many arguments for hook \"configure\": bar.*")
 }
 
@@ -93,10 +93,10 @@ func (s *SnapSuite) TestSnapRunWhenMissingConfine(c *check.C) {
 
 	// and run it!
 	// a regular run will fail
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.ErrorMatches, `.* your core/snapd package`)
 	// a hook run will not fail
-	_, err = snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "snapname"})
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "snapname"})
 	c.Assert(err, check.IsNil)
 
 	// but nothing is run ever
@@ -124,7 +124,7 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -157,7 +157,7 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -193,7 +193,7 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegrationReexeced(c *check.C) {
 		return nil
 	})
 	defer restorer()
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -224,7 +224,7 @@ func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--command=my-command", "snapname.app", "arg1", "arg2"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--command=my-command", "snapname.app", "arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -297,7 +297,7 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 	defer restorer()
 
 	// Run a hook from the active revision
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "snapname"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -329,7 +329,7 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 	defer restorer()
 
 	// Specifically pass "unset" which would use the active version.
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=unset", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=unset", "snapname"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -365,7 +365,7 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 	defer restorer()
 
 	// Run a hook on revision 41
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -389,13 +389,13 @@ func (s *SnapSuite) TestSnapRunHookMissingRevisionIntegration(c *check.C) {
 	defer restorer()
 
 	// Attempt to run a hook on revision 41, which doesn't exist
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
 	c.Assert(err, check.NotNil)
 	c.Check(err, check.ErrorMatches, "cannot find .*")
 }
 
 func (s *SnapSuite) TestSnapRunHookInvalidRevisionIntegration(c *check.C) {
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=invalid", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=invalid", "snapname"})
 	c.Assert(err, check.NotNil)
 	c.Check(err, check.ErrorMatches, "invalid snap revision: \"invalid\"")
 }
@@ -414,23 +414,23 @@ func (s *SnapSuite) TestSnapRunHookMissingHookIntegration(c *check.C) {
 	})
 	defer restorer()
 
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=missing-hook", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=missing-hook", "snapname"})
 	c.Assert(err, check.ErrorMatches, `cannot find hook "missing-hook" in "snapname"`)
 	c.Check(called, check.Equals, false)
 }
 
 func (s *SnapSuite) TestSnapRunErorsForUnknownRunArg(c *check.C) {
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--unknown", "snapname.app", "--arg1", "arg2"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--unknown", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.ErrorMatches, "unknown flag `unknown'")
 }
 
 func (s *SnapSuite) TestSnapRunErorsForMissingApp(c *check.C) {
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "--command=shell"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--command=shell"})
 	c.Assert(err, check.ErrorMatches, "need the application to run as argument")
 }
 
 func (s *SnapSuite) TestSnapRunErorrForUnavailableApp(c *check.C) {
-	_, err := snaprun.Parser().ParseArgs([]string{"run", "not-there"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "not-there"})
 	c.Assert(err, check.ErrorMatches, fmt.Sprintf("cannot find current revision for snap not-there: readlink %s/not-there/current: no such file or directory", dirs.SnapMountDir))
 }
 
@@ -460,7 +460,7 @@ func (s *SnapSuite) TestSnapRunSaneEnvironmentHandling(c *check.C) {
 	defer os.Unsetenv("SNAP_THE_WORLD")
 
 	// and ensure those SNAP_ vars get overridden
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
@@ -515,7 +515,7 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.SnapMountDir, "/core/111", dirs.CoreLibExecDir, "snap-confine"))
@@ -554,7 +554,7 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.SnapMountDir, "/snapd/222", dirs.CoreLibExecDir, "snap-confine"))
@@ -606,7 +606,7 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	})()
 
 	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -729,7 +729,7 @@ echo "stdout output 2"
 	c.Assert(err, check.IsNil)
 
 	// and run it under strace
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "--strace", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
@@ -752,7 +752,7 @@ echo "stdout output 2"
 	sudoCmd.ForgetCalls()
 
 	// try again without filtering
-	rest, err = snaprun.Parser().ParseArgs([]string{"run", "--strace=--raw", "snapname.app", "--arg1", "arg2"})
+	rest, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace=--raw", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
@@ -799,7 +799,7 @@ func (s *SnapSuite) TestSnapRunAppWithStraceOptions(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// and run it under strace
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", `--strace=-tt --raw -o "file with spaces"`, "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--strace=-tt --raw -o "file with spaces"`, "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
@@ -841,7 +841,7 @@ func (s *SnapSuite) TestSnapRunShellIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", "--shell", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--shell", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -881,7 +881,7 @@ func (s *SnapSuite) TestSnapRunAppTimer(c *check.C) {
 	defer restorer()
 
 	// pretend we are outside of timer range
-	rest, err := snaprun.Parser().ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Assert(execCalled, check.Equals, false)
@@ -897,7 +897,7 @@ func (s *SnapSuite) TestSnapRunAppTimer(c *check.C) {
 	defer restorer()
 
 	// and run it under strace
-	_, err = snaprun.Parser().ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "snapname.app", "--arg1", "arg2"})
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(execCalled, check.Equals, true)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))

--- a/cmd/snap/cmd_sandbox_features.go
+++ b/cmd/snap/cmd_sandbox_features.go
@@ -36,6 +36,7 @@ components used by snapd on a given system.
 `)
 
 type cmdSandboxFeatures struct {
+	clientMixin
 	Required []string `long:"required" arg-name:"<backend feature>"`
 }
 
@@ -52,8 +53,7 @@ func (cmd cmdSandboxFeatures) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-	sysInfo, err := cli.SysInfo()
+	sysInfo, err := cmd.client.SysInfo()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_sandbox_features_test.go
+++ b/cmd/snap/cmd_sandbox_features_test.go
@@ -32,7 +32,7 @@ func (s *SnapSuite) TestSandboxFeatures(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"type": "sync", "result": {"sandbox-features": {"apparmor": ["a", "b", "c"], "selinux": ["1", "2", "3"]}}}`)
 	})
-	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox-features"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "sandbox-features"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
 		"apparmor:  a b c\n"+
@@ -44,7 +44,7 @@ func (s *SnapSuite) TestSandboxFeaturesRequired(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"type": "sync", "result": {"sandbox-features": {"apparmor": ["a", "b", "c"], "selinux": ["1", "2", "3"]}}}`)
 	})
-	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox-features", "--required=apparmor:a", "--required=selinux:2"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "sandbox-features", "--required=apparmor:a", "--required=selinux:2"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "")
@@ -54,7 +54,7 @@ func (s *SnapSuite) TestSandboxFeaturesRequiredButMissing(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"type": "sync", "result": {"sandbox-features": {"apparmor": ["a", "b", "c"], "selinux": ["1", "2", "3"]}}}`)
 	})
-	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox-features", "--required=magic:thing"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "sandbox-features", "--required=magic:thing"})
 	c.Assert(err, ErrorMatches, `sandbox feature not available: "magic:thing"`)
 	c.Assert(s.Stdout(), Equals, "")
 	c.Assert(s.Stderr(), Equals, "")

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -30,12 +30,14 @@ import (
 )
 
 type svcStatus struct {
+	clientMixin
 	Positional struct {
 		ServiceNames []serviceName
 	} `positional-args:"yes"`
 }
 
 type svcLogs struct {
+	clientMixin
 	N          string `short:"n" default:"10"`
 	Follow     bool   `short:"f"`
 	Positional struct {
@@ -111,7 +113,7 @@ func (s *svcStatus) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	services, err := Client().Apps(svcNames(s.Positional.ServiceNames), client.AppOptions{Service: true})
+	services, err := s.client.Apps(svcNames(s.Positional.ServiceNames), client.AppOptions{Service: true})
 	if err != nil {
 		return err
 	}
@@ -150,7 +152,7 @@ func (s *svcLogs) Execute(args []string) error {
 		sN = int(n)
 	}
 
-	logs, err := Client().Logs(svcNames(s.Positional.ServiceNames), client.LogOptions{N: sN, Follow: s.Follow})
+	logs, err := s.client.Logs(svcNames(s.Positional.ServiceNames), client.LogOptions{N: sN, Follow: s.Follow})
 	if err != nil {
 		return err
 	}
@@ -174,13 +176,12 @@ func (s *svcStart) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	cli := Client()
 	names := svcNames(s.Positional.ServiceNames)
-	changeID, err := cli.Start(names, client.StartOptions{Enable: s.Enable})
+	changeID, err := s.client.Start(names, client.StartOptions{Enable: s.Enable})
 	if err != nil {
 		return err
 	}
-	if _, err := s.wait(cli, changeID); err != nil {
+	if _, err := s.wait(changeID); err != nil {
 		if err == noWait {
 			return nil
 		}
@@ -204,13 +205,12 @@ func (s *svcStop) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	cli := Client()
 	names := svcNames(s.Positional.ServiceNames)
-	changeID, err := cli.Stop(names, client.StopOptions{Disable: s.Disable})
+	changeID, err := s.client.Stop(names, client.StopOptions{Disable: s.Disable})
 	if err != nil {
 		return err
 	}
-	if _, err := s.wait(cli, changeID); err != nil {
+	if _, err := s.wait(changeID); err != nil {
 		if err == noWait {
 			return nil
 		}
@@ -234,13 +234,12 @@ func (s *svcRestart) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	cli := Client()
 	names := svcNames(s.Positional.ServiceNames)
-	changeID, err := cli.Restart(names, client.RestartOptions{Reload: s.Reload})
+	changeID, err := s.client.Restart(names, client.RestartOptions{Reload: s.Reload})
 	if err != nil {
 		return err
 	}
-	if _, err := s.wait(cli, changeID); err != nil {
+	if _, err := s.wait(changeID); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -83,7 +83,7 @@ func (s *appOpSuite) args(op string, names []string, extra []string, noWait bool
 
 func (s *appOpSuite) testOpNoArgs(c *check.C, op string) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{op})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{op})
 	c.Assert(err, check.ErrorMatches, `.* required argument .* not provided`)
 }
 
@@ -105,7 +105,7 @@ func (s *appOpSuite) testOpErrorResponse(c *check.C, op string, names []string, 
 		n++
 	})
 
-	_, err := snap.Parser().ParseArgs(s.args(op, names, extra, noWait))
+	_, err := snap.Parser(snap.Client()).ParseArgs(s.args(op, names, extra, noWait))
 	c.Assert(err, check.ErrorMatches, "error")
 	c.Check(n, check.Equals, 1)
 }
@@ -135,7 +135,7 @@ func (s *appOpSuite) testOp(c *check.C, op, summary string, names []string, extr
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs(s.args(op, names, extra, noWait))
+	rest, err := snap.Parser(snap.Client()).ParseArgs(s.args(op, names, extra, noWait))
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -83,13 +83,12 @@ func (x *cmdSet) Execute(args []string) error {
 	}
 
 	snapName := string(x.Positional.Snap)
-	cli := Client()
-	id, err := cli.SetConf(snapName, patchValues)
+	id, err := x.client.SetConf(snapName, patchValues)
 	if err != nil {
 		return err
 	}
 
-	if _, err := x.wait(cli, id); err != nil {
+	if _, err := x.wait(id); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -39,7 +39,7 @@ hooks:
 
 func (s *SnapSuite) TestInvalidSetParameters(c *check.C) {
 	invalidParameters := []string{"set", "snap-name", "key", "value"}
-	_, err := snapset.Parser().ParseArgs(invalidParameters)
+	_, err := snapset.Parser(snapset.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*invalid configuration:.*(want key=value).*")
 }
 
@@ -53,7 +53,7 @@ func (s *SnapSuite) TestSnapSetIntegrationString(c *check.C) {
 	s.mockSetConfigServer(c, "value")
 
 	// Set a config value for the active snap
-	_, err := snapset.Parser().ParseArgs([]string{"set", "snapname", "key=value"})
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=value"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -67,7 +67,7 @@ func (s *SnapSuite) TestSnapSetIntegrationNumber(c *check.C) {
 	s.mockSetConfigServer(c, json.Number("1.2"))
 
 	// Set a config value for the active snap
-	_, err := snapset.Parser().ParseArgs([]string{"set", "snapname", "key=1.2"})
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=1.2"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -80,7 +80,7 @@ func (s *SnapSuite) TestSnapSetIntegrationBigInt(c *check.C) {
 	s.mockSetConfigServer(c, json.Number("1234567890"))
 
 	// Set a config value for the active snap
-	_, err := snapset.Parser().ParseArgs([]string{"set", "snapname", "key=1234567890"})
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=1234567890"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -94,7 +94,7 @@ func (s *SnapSuite) TestSnapSetIntegrationJson(c *check.C) {
 	s.mockSetConfigServer(c, map[string]interface{}{"subkey": "value"})
 
 	// Set a config value for the active snap
-	_, err := snapset.Parser().ParseArgs([]string{"set", "snapname", `key={"subkey":"value"}`})
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", `key={"subkey":"value"}`})
 	c.Assert(err, check.IsNil)
 }
 

--- a/cmd/snap/cmd_sign_build_test.go
+++ b/cmd/snap/cmd_sign_build_test.go
@@ -38,7 +38,7 @@ type SnapSignBuildSuite struct {
 var _ = Suite(&SnapSignBuildSuite{})
 
 func (s *SnapSignBuildSuite) TestSignBuildMandatoryFlags(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"sign-build", "foo_1_amd64.snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign-build", "foo_1_amd64.snap"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "the required flags `--developer-id' and `--snap-id' were not specified")
 	c.Check(s.Stdout(), Equals, "")
@@ -46,7 +46,7 @@ func (s *SnapSignBuildSuite) TestSignBuildMandatoryFlags(c *C) {
 }
 
 func (s *SnapSignBuildSuite) TestSignBuildMissingSnap(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"sign-build", "foo_1_amd64.snap", "--developer-id", "dev-id1", "--snap-id", "snap-id-1"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign-build", "foo_1_amd64.snap", "--developer-id", "dev-id1", "--snap-id", "snap-id-1"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot compute snap \"foo_1_amd64.snap\" digest: open foo_1_amd64.snap: no such file or directory")
 	c.Check(s.Stdout(), Equals, "")
@@ -63,7 +63,7 @@ func (s *SnapSignBuildSuite) TestSignBuildMissingKey(c *C) {
 	os.Setenv("SNAP_GNUPG_HOME", tempdir)
 	defer os.Unsetenv("SNAP_GNUPG_HOME")
 
-	_, err := snap.Parser().ParseArgs([]string{"sign-build", snapFilename, "--developer-id", "dev-id1", "--snap-id", "snap-id-1"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign-build", snapFilename, "--developer-id", "dev-id1", "--snap-id", "snap-id-1"})
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot use \"default\" key: cannot find key named \"default\" in GPG keyring")
 	c.Check(s.Stdout(), Equals, "")
@@ -87,7 +87,7 @@ func (s *SnapSignBuildSuite) TestSignBuildWorks(c *C) {
 	os.Setenv("SNAP_GNUPG_HOME", tempdir)
 	defer os.Unsetenv("SNAP_GNUPG_HOME")
 
-	_, err := snap.Parser().ParseArgs([]string{"sign-build", snapFilename, "--developer-id", "dev-id1", "--snap-id", "snap-id-1"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign-build", snapFilename, "--developer-id", "dev-id1", "--snap-id", "snap-id-1"})
 	c.Assert(err, IsNil)
 
 	assertion, err := asserts.Decode([]byte(s.Stdout()))
@@ -122,7 +122,7 @@ func (s *SnapSignBuildSuite) TestSignBuildWorksDevelGrade(c *C) {
 	os.Setenv("SNAP_GNUPG_HOME", tempdir)
 	defer os.Unsetenv("SNAP_GNUPG_HOME")
 
-	_, err := snap.Parser().ParseArgs([]string{"sign-build", snapFilename, "--developer-id", "dev-id1", "--snap-id", "snap-id-1", "--grade", "devel"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign-build", snapFilename, "--developer-id", "dev-id1", "--snap-id", "snap-id-1", "--grade", "devel"})
 	c.Assert(err, IsNil)
 	assertion, err := asserts.Decode([]byte(s.Stdout()))
 	c.Assert(err, IsNil)

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -43,7 +43,7 @@ var statement = []byte(fmt.Sprintf(`{"type": "snap-build",
 func (s *SnapKeysSuite) TestHappyDefaultKey(c *C) {
 	s.stdin.Write(statement)
 
-	rest, err := snap.Parser().ParseArgs([]string{"sign"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 
@@ -55,7 +55,7 @@ func (s *SnapKeysSuite) TestHappyDefaultKey(c *C) {
 func (s *SnapKeysSuite) TestHappyNonDefaultKey(c *C) {
 	s.stdin.Write(statement)
 
-	rest, err := snap.Parser().ParseArgs([]string{"sign", "-k", "another"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "-k", "another"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -195,7 +195,7 @@ func (s *SnapOpSuite) TestInstall(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "candidate", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "candidate", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(candidate\) 1.0 from Bar installed`)
@@ -216,7 +216,7 @@ func (s *SnapOpSuite) TestInstallFromTrack(c *check.C) {
 
 	s.RedirectClientToTestServer(s.srv.handle)
 	// snap install --channel=3.4 means 3.4/stable, this is what we test here
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "3.4", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "3.4", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(3.4/stable\) 1.0 from Bar installed`)
@@ -236,7 +236,7 @@ func (s *SnapOpSuite) TestInstallFromBranch(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "3.4/hotfix-1", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "3.4/hotfix-1", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(3.4/hotfix-1\) 1.0 from Bar installed`)
@@ -257,7 +257,7 @@ func (s *SnapOpSuite) TestInstallDevMode(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "beta", "--devmode", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "beta", "--devmode", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(beta\) 1.0 from Bar installed`)
@@ -276,7 +276,7 @@ func (s *SnapOpSuite) TestInstallClassic(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--classic", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
@@ -295,7 +295,7 @@ func (s *SnapOpSuite) TestInstallUnaliased(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--unaliased", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--unaliased", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
@@ -309,7 +309,7 @@ func (s *SnapOpSuite) TestInstallSnapNotFound(c *check.C) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "snap not found", "value": "foo", "kind": "snap-not-found"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("error: %v\n", err), check.Equals, `error: snap "foo" not found
 `)
@@ -323,7 +323,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailable(c *check.C) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision available as specified", "value": "foo", "kind": "snap-revision-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" not available as specified (see 'snap info foo')
@@ -338,7 +338,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableOnChannel(c *check.C) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision available as specified", "value": "foo", "kind": "snap-revision-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=mytrack", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=mytrack", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" not available on channel "mytrack/stable" (see 'snap info
@@ -354,7 +354,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableAtRevision(c *check.C) 
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "no snap revision available as specified", "value": "foo", "kind": "snap-revision-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--revision=2", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--revision=2", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" revision 2 not available (see 'snap info foo')
@@ -376,7 +376,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackOK(c *ch
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on stable but is available to install on the
@@ -406,7 +406,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackOKPrerel
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--candidate", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--candidate", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on candidate but is available to install on
@@ -434,7 +434,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackOther(c 
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on latest/stable but is available to install
@@ -462,7 +462,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackLatestSt
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=2.0/stable", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=2.0/stable", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on 2.0/stable but is available to install on
@@ -489,7 +489,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelTrackAndRiskO
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=2.0/stable", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=2.0/stable", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on 2.0/stable but other tracks exist.
@@ -514,7 +514,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForArchitectureTrackAnd
 }, "kind": "snap-architecture-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on stable for this architecture (arm64) but
@@ -537,7 +537,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForArchitectureTrackAnd
 }, "kind": "snap-architecture-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=1.0/stable", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=1.0/stable", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: snap "foo" is not available on this architecture (arm64) but exists on
@@ -559,7 +559,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableInvalidChannel(c *check
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=a/b/c/d", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=a/b/c/d", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: requested channel "a/b/c/d" is not valid (see 'snap info foo' for valid
@@ -581,7 +581,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelNonExistingBr
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=stable/baz", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=stable/baz", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: requested a non-existing branch on latest/stable for snap "foo": baz
@@ -602,7 +602,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableForChannelNonExistingBr
 }, "kind": "snap-channel-not-available"}, "status-code": 404}`)
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"install", "--channel=stable/baz", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=stable/baz", "foo"})
 	c.Assert(err, check.NotNil)
 	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
 error: requested a non-existing branch for snap "foo": latest/stable/baz
@@ -666,7 +666,7 @@ func (s *SnapOpSuite) TestInstallPath(c *check.C) {
 	err := ioutil.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
@@ -697,7 +697,7 @@ func (s *SnapOpSuite) TestInstallPathDevMode(c *check.C) {
 	err := ioutil.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--devmode", snapPath})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--devmode", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
@@ -728,7 +728,7 @@ func (s *SnapOpSuite) TestInstallPathClassic(c *check.C) {
 	err := ioutil.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--classic", snapPath})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
@@ -759,7 +759,7 @@ func (s *SnapOpSuite) TestInstallPathDangerous(c *check.C) {
 	err := ioutil.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--dangerous", snapPath})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--dangerous", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
@@ -794,7 +794,7 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 	err := ioutil.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath, "--name", "foo_bar"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", snapPath, "--name", "foo_bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo_bar 1.0 from Bar installed`)
@@ -804,12 +804,12 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 }
 
 func (s *SnapSuite) TestInstallWithInstanceNoPath(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"install", "--name", "foo_bar", "some-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--name", "foo_bar", "some-snap"})
 	c.Assert(err, check.ErrorMatches, "cannot use explicit name when installing from store")
 }
 
 func (s *SnapSuite) TestInstallManyWithInstance(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"install", "--name", "foo_bar", "some-snap-1", "some-snap-2"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--name", "foo_bar", "some-snap-1", "some-snap-2"})
 	c.Assert(err, check.ErrorMatches, "cannot use instance name when installing multiple snaps")
 }
 
@@ -824,7 +824,7 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"revert", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"revert", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	// tracking channel is "" in the test server
@@ -874,7 +874,7 @@ func (s *SnapOpSuite) runRevertTest(c *check.C, opts *client.SnapOptions) {
 		}
 	}
 
-	rest, err := snap.Parser().ParseArgs(cmd)
+	rest, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "foo reverted to 1.0\n")
@@ -900,7 +900,7 @@ func (s *SnapOpSuite) TestRevertClassic(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestRevertMissingName(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"revert"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"revert"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, "the required argument `<snap>` was not provided")
 }
@@ -920,7 +920,7 @@ func (s *SnapSuite) TestRefreshList(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--list"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Publisher +Notes
@@ -945,7 +945,7 @@ func (s *SnapSuite) TestRefreshLegacyTime(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time", "--abs-time"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `schedule: 00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59
@@ -971,7 +971,7 @@ func (s *SnapSuite) TestRefreshTimer(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time", "--abs-time"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `timer: 0:00-24:00/4
@@ -997,7 +997,7 @@ func (s *SnapSuite) TestRefreshHold(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time", "--abs-time"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `timer: 0:00-24:00/4
@@ -1016,13 +1016,13 @@ func (s *SnapSuite) TestRefreshNoTimerNoSchedule(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/system-info")
 		fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"last": "2017-04-25T17:35:00+0200", "next": "2017-04-26T00:58:00+0200"}}}`)
 	})
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--time"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time"})
 	c.Assert(err, check.ErrorMatches, `internal error: both refresh.timer and refresh.schedule are empty`)
 }
 
 func (s *SnapSuite) TestRefreshListErr(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--list", "--beta"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list", "--beta"})
 	c.Check(err, check.ErrorMatches, "--list does not take .* flags")
 }
 
@@ -1035,7 +1035,7 @@ func (s *SnapOpSuite) TestRefreshOne(c *check.C) {
 			"action": "refresh",
 		})
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar refreshed`)
 
@@ -1052,7 +1052,7 @@ func (s *SnapOpSuite) TestRefreshOneSwitchChannel(c *check.C) {
 		})
 		s.srv.channel = "beta"
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--beta", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(beta\) 1.0 from Bar refreshed`)
 }
@@ -1067,7 +1067,7 @@ func (s *SnapOpSuite) TestRefreshOneClassic(c *check.C) {
 			"classic": true,
 		})
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--classic", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--classic", "one"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -1081,7 +1081,7 @@ func (s *SnapOpSuite) TestRefreshOneDevmode(c *check.C) {
 			"devmode": true,
 		})
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--devmode", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--devmode", "one"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -1095,7 +1095,7 @@ func (s *SnapOpSuite) TestRefreshOneJailmode(c *check.C) {
 			"jailmode": true,
 		})
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--jailmode", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--jailmode", "one"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -1109,7 +1109,7 @@ func (s *SnapOpSuite) TestRefreshOneIgnoreValidation(c *check.C) {
 			"ignore-validation": true,
 		})
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--ignore-validation", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--ignore-validation", "one"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -1135,37 +1135,37 @@ func (s *SnapOpSuite) TestRefreshOneRebooting(c *check.C) {
 
 func (s *SnapOpSuite) TestRefreshOneModeErr(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--jailmode", "--devmode", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--jailmode", "--devmode", "one"})
 	c.Assert(err, check.ErrorMatches, `cannot use devmode and jailmode flags together`)
 }
 
 func (s *SnapOpSuite) TestRefreshOneChanErr(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta", "--channel=foo", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--beta", "--channel=foo", "one"})
 	c.Assert(err, check.ErrorMatches, `Please specify a single channel`)
 }
 
 func (s *SnapOpSuite) TestRefreshAllChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--beta"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
 func (s *SnapOpSuite) TestRefreshManyChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta", "one", "two"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--beta", "one", "two"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
 func (s *SnapOpSuite) TestRefreshManyIgnoreValidation(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--ignore-validation", "one", "two"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--ignore-validation", "one", "two"})
 	c.Assert(err, check.ErrorMatches, `a single snap name must be specified when ignoring validation`)
 }
 
 func (s *SnapOpSuite) TestRefreshAllModeFlags(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--devmode"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--devmode"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
@@ -1179,7 +1179,7 @@ func (s *SnapOpSuite) TestRefreshOneAmend(c *check.C) {
 			"amend":  true,
 		})
 	}
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--amend", "one"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--amend", "one"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -1230,7 +1230,7 @@ func (s *SnapOpSuite) runTryTest(c *check.C, opts *client.SnapOptions) {
 		}
 	}
 
-	rest, err := snap.Parser().ParseArgs(cmd)
+	rest, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, fmt.Sprintf(`(?sm).*foo 1.0 mounted from .*%s`, tryDir))
@@ -1271,19 +1271,19 @@ func (s *SnapOpSuite) TestTryNoSnapDirErrors(c *check.C) {
 	})
 
 	cmd := []string{"try", "/"}
-	_, err := snap.Parser().ParseArgs(cmd)
+	_, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 	c.Assert(err, check.ErrorMatches, `"/" does not contain an unpacked snap.
 
 Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
 }
 
 func (s *SnapSuite) TestInstallChannelDuplicationError(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"install", "--edge", "--beta", "some-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--edge", "--beta", "some-snap"})
 	c.Assert(err, check.ErrorMatches, "Please specify a single channel")
 }
 
 func (s *SnapSuite) TestRefreshChannelDuplicationError(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"refresh", "--edge", "--beta", "some-snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--edge", "--beta", "some-snap"})
 	c.Assert(err, check.ErrorMatches, "Please specify a single channel")
 }
 
@@ -1298,7 +1298,7 @@ func (s *SnapOpSuite) TestInstallFromChannel(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"install", "--edge", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--edge", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(edge\) 1.0 from Bar installed`)
@@ -1317,7 +1317,7 @@ func (s *SnapOpSuite) TestEnable(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"enable", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"enable", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo enabled`)
@@ -1336,7 +1336,7 @@ func (s *SnapOpSuite) TestDisable(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"disable", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"disable", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo disabled`)
@@ -1355,7 +1355,7 @@ func (s *SnapOpSuite) TestRemove(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"remove", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo removed`)
@@ -1366,7 +1366,7 @@ func (s *SnapOpSuite) TestRemove(c *check.C) {
 
 func (s *SnapOpSuite) TestRemoveManyRevision(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"remove", "--revision=17", "one", "two"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove", "--revision=17", "one", "two"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify the revision`)
 }
 
@@ -1400,7 +1400,7 @@ func (s *SnapOpSuite) TestRemoveMany(c *check.C) {
 		n++
 	})
 
-	rest, err := snap.Parser().ParseArgs([]string{"remove", "one", "two"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove", "one", "two"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*one removed`)
@@ -1412,13 +1412,13 @@ func (s *SnapOpSuite) TestRemoveMany(c *check.C) {
 
 func (s *SnapOpSuite) TestInstallManyChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"install", "--beta", "one", "two"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--beta", "one", "two"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
 func (s *SnapOpSuite) TestInstallManyMixFileAndStore(c *check.C) {
 	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser().ParseArgs([]string{"install", "store-snap", "./local.snap"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "store-snap", "./local.snap"})
 	c.Assert(err, check.ErrorMatches, `only one snap file can be installed at a time`)
 }
 
@@ -1457,7 +1457,7 @@ func (s *SnapOpSuite) TestInstallMany(c *check.C) {
 		n++
 	})
 
-	rest, err := snap.Parser().ParseArgs([]string{"install", "one", "two"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "one", "two"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	// note that (stable) is omitted
@@ -1469,11 +1469,11 @@ func (s *SnapOpSuite) TestInstallMany(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestInstallZeroEmpty(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"install"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install"})
 	c.Assert(err, check.ErrorMatches, "cannot install zero snaps")
-	_, err = snap.Parser().ParseArgs([]string{"install", ""})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"install", ""})
 	c.Assert(err, check.ErrorMatches, "cannot install snap with empty name")
-	_, err = snap.Parser().ParseArgs([]string{"install", "", "bar"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"install", "", "bar"})
 	c.Assert(err, check.ErrorMatches, "cannot install snap with empty name")
 }
 
@@ -1507,7 +1507,7 @@ func (s *SnapOpSuite) TestNoWait(c *check.C) {
 
 	s.RedirectClientToTestServer(s.srv.handle)
 	for _, cmd := range cmds {
-		rest, err := snap.Parser().ParseArgs(cmd)
+		rest, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 		c.Assert(err, check.IsNil, check.Commentf("%v", cmd))
 		c.Assert(rest, check.DeepEquals, []string{})
 		c.Check(s.Stdout(), check.Matches, "(?sm)42\n")
@@ -1551,7 +1551,7 @@ func (s *SnapOpSuite) TestNoWaitImmediateError(c *check.C) {
 	})
 
 	for _, cmd := range cmds {
-		_, err := snap.Parser().ParseArgs(cmd)
+		_, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 		c.Assert(err, check.ErrorMatches, "failure", check.Commentf("%v", cmd))
 	}
 }
@@ -1601,7 +1601,7 @@ func (s *SnapOpSuite) TestWaitServerError(c *check.C) {
 	})
 
 	for _, cmd := range cmds {
-		_, err := snap.Parser().ParseArgs(cmd)
+		_, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 		c.Assert(err, check.ErrorMatches, "server error", check.Commentf("%v", cmd))
 		// reset
 		n = 0
@@ -1619,7 +1619,7 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser().ParseArgs([]string{"switch", "--beta", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--beta", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" switched to the "beta" channel`)
@@ -1629,12 +1629,12 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchUnhappy(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"switch"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch"})
 	c.Assert(err, check.ErrorMatches, "the required argument `<snap>` was not provided")
 }
 
 func (s *SnapOpSuite) TestSwitchAlsoUnhappy(c *check.C) {
-	_, err := snap.Parser().ParseArgs([]string{"switch", "foo"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "foo"})
 	c.Assert(err, check.ErrorMatches, `missing --channel=<channel-name> parameter`)
 }
 
@@ -1656,6 +1656,6 @@ func (s *SnapOpSuite) TestSnapOpNetworkTimeoutError(c *check.C) {
 	})
 
 	cmd := []string{"install", "hello"}
-	_, err := snap.Parser().ParseArgs(cmd)
+	_, err := snap.Parser(snap.Client()).ParseArgs(cmd)
 	c.Assert(err, check.ErrorMatches, `unable to contact snap store`)
 }

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -53,12 +53,11 @@ func (x *cmdUnalias) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	cli := Client()
-	id, err := cli.Unalias(string(x.Positionals.AliasOrSnap))
+	id, err := x.client.Unalias(string(x.Positionals.AliasOrSnap))
 	if err != nil {
 		return err
 	}
-	chg, err := x.wait(cli, id)
+	chg, err := x.wait(id)
 	if err != nil {
 		if err == noWait {
 			return nil

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -40,7 +40,7 @@ argument is a snap name.
           --no-wait          Do not wait for the operation to finish but just
                              print the change id.
 `
-	rest, err := Parser().ParseArgs([]string{"unalias", "--help"})
+	rest, err := Parser(Client()).ParseArgs([]string{"unalias", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
 }
@@ -63,7 +63,7 @@ func (s *SnapSuite) TestUnalias(c *C) {
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
 	})
-	rest, err := Parser().ParseArgs([]string{"unalias", "alias1"})
+	rest, err := Parser(Client()).ParseArgs([]string{"unalias", "alias1"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, ""+

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -56,7 +56,7 @@ func (s *userdSuite) TearDownTest(c *C) {
 }
 
 func (s *userdSuite) TestUserdBadCommandline(c *C) {
-	_, err := snap.Parser().ParseArgs([]string{"userd", "extra-arg"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd", "extra-arg"})
 	c.Assert(err, ErrorMatches, "too many arguments for command")
 }
 
@@ -81,7 +81,7 @@ func (s *userdSuite) TestUserd(c *C) {
 		c.Fatalf("%s does not appeared on the bus", needle)
 	}()
 
-	rest, err := snap.Parser().ParseArgs([]string{"userd"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd"})
 	c.Assert(err, IsNil)
 	c.Check(rest, DeepEquals, []string{})
 	c.Check(strings.ToLower(s.Stdout()), Equals, "exiting on user defined signal 1.\n")

--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -22,10 +22,11 @@ package main
 import (
 	"fmt"
 
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/i18n"
-
-	"github.com/jessevdk/go-flags"
 )
 
 var shortVersionHelp = i18n.G("Show version details")
@@ -34,7 +35,9 @@ The version command displays the versions of the running client, server,
 and operating system.
 `)
 
-type cmdVersion struct{}
+type cmdVersion struct {
+	clientMixin
+}
 
 func init() {
 	addCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, nil, nil)
@@ -45,12 +48,12 @@ func (cmd cmdVersion) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	printVersions()
+	printVersions(cmd.client)
 	return nil
 }
 
-func printVersions() error {
-	sv := serverVersion()
+func printVersions(cli *client.Client) error {
+	sv := serverVersion(cli)
 	w := tabWriter()
 
 	fmt.Fprintf(w, "snap\t%s\n", cmd.Version)

--- a/cmd/snap/cmd_version_linux.go
+++ b/cmd/snap/cmd_version_linux.go
@@ -24,8 +24,8 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-func serverVersion() *client.ServerVersion {
-	sv, err := Client().ServerVersion()
+func serverVersion(cli *client.Client) *client.ServerVersion {
+	sv, err := cli.ServerVersion()
 
 	if err != nil {
 		sv = &client.ServerVersion{

--- a/cmd/snap/cmd_version_other.go
+++ b/cmd/snap/cmd_version_other.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
-func serverVersion() *client.ServerVersion {
+func serverVersion(*client.Client) *client.ServerVersion {
 	return &client.ServerVersion{
 		Version:       i18n.G("unavailable"),
 		Series:        release.Series,

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -37,7 +37,7 @@ func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 	restore = mockVersion("4.56")
 	defer restore()
 
-	_, err := snap.Parser().ParseArgs([]string{"version"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
 	c.Assert(s.Stderr(), Equals, "")
@@ -52,7 +52,7 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 	restore = mockVersion("4.56")
 	defer restore()
 
-	_, err := snap.Parser().ParseArgs([]string{"version"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
 	c.Assert(s.Stderr(), Equals, "")
@@ -67,7 +67,7 @@ func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
 	restore = mockVersion("4.56")
 	defer restore()
 
-	_, err := snap.Parser().ParseArgs([]string{"version"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\narch    -\n")
 	c.Assert(s.Stderr(), Equals, "")

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -33,6 +33,7 @@ import (
 )
 
 type cmdWait struct {
+	clientMixin
 	Positional struct {
 		Snap installedSnapName `required:"yes"`
 		Key  string
@@ -135,9 +136,8 @@ The same is true of the laugh.`)
 		return fmt.Errorf("the required argument `<key>` was not provided")
 	}
 
-	cli := Client()
 	for {
-		conf, err := cli.Conf(snapName, []string{confKey})
+		conf, err := x.client.Conf(snapName, []string{confKey})
 		if err != nil && !isNoOption(err) {
 			return err
 		}

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -43,7 +43,7 @@ func (s *SnapSuite) TestCmdWaitHappy(c *C) {
 		n++
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"wait", "system", "seed.loaded"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"wait", "system", "seed.loaded"})
 	c.Assert(err, IsNil)
 
 	// ensure we retried a bit but make the check not overly precise
@@ -59,7 +59,7 @@ func (s *SnapSuite) TestCmdWaitMissingConfKey(c *C) {
 		n++
 	})
 
-	_, err := snap.Parser().ParseArgs([]string{"wait", "snapName"})
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"wait", "snapName"})
 	c.Assert(err, ErrorMatches, "the required argument `<key>` was not provided")
 
 	c.Check(n, Equals, 0)
@@ -161,7 +161,7 @@ func (s *SnapSuite) TestCmdWaitIntegration(c *C) {
 			testValueCh <- "42"
 		}
 
-		_, err := snap.Parser().ParseArgs([]string{"wait", "system", "test.value"})
+		_, err := snap.Parser(snap.Client()).ParseArgs([]string{"wait", "system", "test.value"})
 		c.Assert(err, IsNil)
 		if t.willWait {
 			// we waited once, then got a non-wait value

--- a/cmd/snap/cmd_watch.go
+++ b/cmd/snap/cmd_watch.go
@@ -43,8 +43,7 @@ func (x *cmdWatch) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	cli := Client()
-	id, err := x.GetChangeID(cli)
+	id, err := x.GetChangeID()
 	if err != nil {
 		if err == noChangeFoundOK {
 			return nil
@@ -54,7 +53,9 @@ func (x *cmdWatch) Execute(args []string) error {
 
 	// this is the only valid use of wait without a waitMixin (ie
 	// without --no-wait), so we fake it here.
-	_, err = waitMixin{skipAbort: true}.wait(cli, id)
+	wmx := &waitMixin{skipAbort: true}
+	wmx.client = x.client
+	_, err = wmx.wait(id)
 
 	return err
 }

--- a/cmd/snap/cmd_watch_test.go
+++ b/cmd/snap/cmd_watch_test.go
@@ -66,7 +66,7 @@ func (s *SnapSuite) TestCmdWatch(c *C) {
 		}
 	})
 
-	rest, err := snap.Parser().ParseArgs([]string{"watch", "two"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"watch", "two"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(n, Equals, 3)
@@ -104,7 +104,7 @@ func (s *SnapSuite) TestWatchLast(c *C) {
 			c.Errorf("expected 4 queries, currently on %d", n)
 		}
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"watch", "--last=install"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"watch", "--last=install"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(n, Equals, 4)
@@ -134,13 +134,13 @@ func (s *SnapSuite) TestWatchLastQuestionmark(c *C) {
 		}
 	})
 	for i := 0; i < 2; i++ {
-		rest, err := snap.Parser().ParseArgs([]string{"watch", "--last=foobar?"})
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"watch", "--last=foobar?"})
 		c.Assert(err, IsNil)
 		c.Assert(rest, DeepEquals, []string{})
 		c.Check(s.Stdout(), Matches, "")
 		c.Check(s.Stderr(), Equals, "")
 
-		_, err = snap.Parser().ParseArgs([]string{"watch", "--last=foobar"})
+		_, err = snap.Parser(snap.Client()).ParseArgs([]string{"watch", "--last=foobar"})
 		if i == 0 {
 			c.Assert(err, ErrorMatches, `no changes found`)
 		} else {

--- a/cmd/snap/cmd_whoami.go
+++ b/cmd/snap/cmd_whoami.go
@@ -32,7 +32,9 @@ var longWhoAmIHelp = i18n.G(`
 The whoami command prints the email the user is logged in with.
 `)
 
-type cmdWhoAmI struct{}
+type cmdWhoAmI struct {
+	clientMixin
+}
 
 func init() {
 	addCommand("whoami", shortWhoAmIHelp, longWhoAmIHelp, func() flags.Commander { return &cmdWhoAmI{} }, nil, nil)
@@ -43,7 +45,7 @@ func (cmd cmdWhoAmI) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	email, err := Client().WhoAmI()
+	email, err := cmd.client.WhoAmI()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -36,7 +36,7 @@ import (
 type installedSnapName string
 
 func (s installedSnapName) Complete(match string) []flags.Completion {
-	snaps, err := Client().List(nil, nil)
+	snaps, err := mkClient().List(nil, nil)
 	if err != nil {
 		return nil
 	}
@@ -103,7 +103,7 @@ func (s remoteSnapName) Complete(match string) []flags.Completion {
 	if len(match) < 3 {
 		return nil
 	}
-	snaps, _, err := Client().Find(&client.FindOptions{
+	snaps, _, err := mkClient().Find(&client.FindOptions{
 		Prefix: true,
 		Query:  match,
 	})
@@ -147,7 +147,7 @@ func (s anySnapName) Complete(match string) []flags.Completion {
 type changeID string
 
 func (s changeID) Complete(match string) []flags.Completion {
-	changes, err := Client().Changes(&client.ChangesOptions{Selector: client.ChangesAll})
+	changes, err := mkClient().Changes(&client.ChangesOptions{Selector: client.ChangesAll})
 	if err != nil {
 		return nil
 	}
@@ -165,7 +165,7 @@ func (s changeID) Complete(match string) []flags.Completion {
 type assertTypeName string
 
 func (n assertTypeName) Complete(match string) []flags.Completion {
-	cli := Client()
+	cli := mkClient()
 	names, err := cli.AssertionTypes()
 	if err != nil {
 		return nil
@@ -295,7 +295,7 @@ func (spec *interfaceSpec) Complete(match string) []flags.Completion {
 	parts := strings.SplitN(match, ":", 2)
 
 	// Ask snapd about available interfaces.
-	ifaces, err := Client().Connections()
+	ifaces, err := mkClient().Connections()
 	if err != nil {
 		return nil
 	}
@@ -386,7 +386,7 @@ func (spec *interfaceSpec) Complete(match string) []flags.Completion {
 type interfaceName string
 
 func (s interfaceName) Complete(match string) []flags.Completion {
-	ifaces, err := Client().Interfaces(nil)
+	ifaces, err := mkClient().Interfaces(nil)
 	if err != nil {
 		return nil
 	}
@@ -404,7 +404,7 @@ func (s interfaceName) Complete(match string) []flags.Completion {
 type appName string
 
 func (s appName) Complete(match string) []flags.Completion {
-	cli := Client()
+	cli := mkClient()
 	apps, err := cli.Apps(nil, client.AppOptions{})
 	if err != nil {
 		return nil
@@ -428,7 +428,7 @@ func (s appName) Complete(match string) []flags.Completion {
 type serviceName string
 
 func (s serviceName) Complete(match string) []flags.Completion {
-	cli := Client()
+	cli := mkClient()
 	apps, err := cli.Apps(nil, client.AppOptions{Service: true})
 	if err != nil {
 		return nil
@@ -453,7 +453,7 @@ func (s serviceName) Complete(match string) []flags.Completion {
 type aliasOrSnap string
 
 func (s aliasOrSnap) Complete(match string) []flags.Completion {
-	aliases, err := Client().Aliases()
+	aliases, err := mkClient().Aliases()
 	if err != nil {
 		return nil
 	}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -33,6 +33,8 @@ import (
 var RunMain = run
 
 var (
+	Client = mkClient
+
 	CreateUserDataDirs = createUserDataDirs
 	ResolveApp         = resolveApp
 	IsReexeced         = isReexeced
@@ -185,7 +187,9 @@ func MockWaitConfTimeout(d time.Duration) (restore func()) {
 }
 
 func Wait(cli *client.Client, id string) (*client.Change, error) {
-	return waitMixin{}.wait(cli, id)
+	wmx := waitMixin{}
+	wmx.client = cli
+	return wmx.wait(id)
 }
 
 func ColorMixin(cmode, umode string) colorMixin {

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -28,6 +28,7 @@ import (
 )
 
 type changeIDMixin struct {
+	clientMixin
 	LastChangeType string `long:"last"`
 	Positional     struct {
 		ID changeID `positional-arg-name:"<id>"`
@@ -48,7 +49,7 @@ var changeIDMixinArgDesc = []argDesc{{
 // should not be user-visible, but keep it clear and polite because mistakes happen
 var noChangeFoundOK = errors.New("no change found but that's ok")
 
-func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
+func (l *changeIDMixin) GetChangeID() (string, error) {
 	if l.Positional.ID == "" && l.LastChangeType == "" {
 		return "", fmt.Errorf(i18n.G("please provide change ID or type with --last=<type>"))
 	}
@@ -61,6 +62,7 @@ func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
 		return string(l.Positional.ID), nil
 	}
 
+	cli := l.client
 	// note that at this point we know l.LastChangeType != ""
 	kind := l.LastChangeType
 	optional := false

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -161,12 +161,24 @@ func lintArg(cmdName, optName, desc, origDesc string) {
 	}
 }
 
+type clientSetter interface {
+	setClient(*client.Client)
+}
+
+type clientMixin struct {
+	client *client.Client
+}
+
+func (ch *clientMixin) setClient(cli *client.Client) {
+	ch.client = cli
+}
+
 // Parser creates and populates a fresh parser.
 // Since commands have local state a fresh parser is required to isolate tests
 // from each other.
-func Parser() *flags.Parser {
+func Parser(cli *client.Client) *flags.Parser {
 	optionsData.Version = func() {
-		printVersions()
+		printVersions(cli)
 		panic(&exitStatus{0})
 	}
 	parser := flags.NewParser(&optionsData, flags.PassDoubleDash|flags.PassAfterNonOption)
@@ -191,6 +203,9 @@ snaps on the system. Start with 'snap list' to see installed snaps.`)
 	// Add all regular commands
 	for _, c := range commands {
 		obj := c.builder()
+		if x, ok := obj.(clientSetter); ok {
+			x.setClient(cli)
+		}
 		if x, ok := obj.(parserSetter); ok {
 			x.setParser(parser)
 		}
@@ -246,7 +261,11 @@ snaps on the system. Start with 'snap list' to see installed snaps.`)
 	}
 	// Add all the sub-commands of the debug command
 	for _, c := range debugCommands {
-		cmd, err := debugCommand.AddCommand(c.name, c.shortHelp, strings.TrimSpace(c.longHelp), c.builder())
+		obj := c.builder()
+		if x, ok := obj.(clientSetter); ok {
+			x.setClient(cli)
+		}
+		cmd, err := debugCommand.AddCommand(c.name, c.shortHelp, strings.TrimSpace(c.longHelp), obj)
 		if err != nil {
 			logger.Panicf("cannot add debug command %q: %v", c.name, err)
 		}
@@ -299,7 +318,8 @@ var ClientConfig = client.Config{
 }
 
 // Client returns a new client using ClientConfig as configuration.
-func Client() *client.Client {
+// commands should (in general) not use this, and instead use clientMixin.
+func mkClient() *client.Client {
 	cli := client.New(&ClientConfig)
 	if runtime.GOOS != "linux" {
 		cli.Hijack(func(*http.Request) (*http.Response, error) {
@@ -366,6 +386,7 @@ func main() {
 			os.Exit(46)
 		}
 		cmd := &cmdRun{}
+		cmd.client = mkClient()
 		args := []string{snapApp}
 		args = append(args, os.Args[1:]...)
 		// this will call syscall.Exec() so it does not return
@@ -414,7 +435,8 @@ var wrongDashes = string([]rune{
 })
 
 func run() error {
-	parser := Parser()
+	cli := mkClient()
+	parser := Parser(cli)
 	_, err := parser.Parse()
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok {

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -37,6 +37,7 @@ var (
 )
 
 type waitMixin struct {
+	clientMixin
 	NoWait    bool `long:"no-wait"`
 	skipAbort bool
 }
@@ -47,11 +48,12 @@ var waitDescs = mixinDescs{
 
 var noWait = errors.New("no wait for op")
 
-func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error) {
+func (wmx waitMixin) wait(id string) (*client.Change, error) {
 	if wmx.NoWait {
 		fmt.Fprintf(Stdout, "%s\n", id)
 		return nil, noWait
 	}
+	cli := wmx.client
 	// Intercept sigint
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, os.Interrupt)
@@ -61,8 +63,7 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		if sig == nil || wmx.skipAbort {
 			return
 		}
-		cli := Client()
-		_, err := cli.Abort(id)
+		_, err := wmx.client.Abort(id)
 		if err != nil {
 			fmt.Fprintf(Stderr, err.Error()+"\n")
 		}


### PR DESCRIPTION
Before this change, any command needing to talk to snapd would
instantiate a *client.Client and use that. With this, the client is
instantiated by run(), and passed to the commands (in a slightly
convoluted way, because flags is the one invoking the commands).
