### PR TITLE
tests: find snaps just for edge and beta channels

### DIFF
--- a/tests/lib/snaps/test-snapd-just-beta/snap-name
+++ b/tests/lib/snaps/test-snapd-just-beta/snap-name
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "test-snapd-just-beta"

--- a/tests/lib/snaps/test-snapd-just-beta/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-just-beta/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: test-snapd-just-beta
+version: 1.0
+summary: Basic snap published just on beta channel
+description: A basic snap published just on beta channel
+confinement: strict
+grade: stable
+
+apps:
+    snap-name:
+        command: snap-name
+
+parts:
+    copy:
+        plugin: dump
+        source: .

--- a/tests/lib/snaps/test-snapd-just-edge/snap-name
+++ b/tests/lib/snaps/test-snapd-just-edge/snap-name
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "test-snapd-just-edge"

--- a/tests/lib/snaps/test-snapd-just-edge/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-just-edge/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: test-snapd-just-edge
+version: 1.0
+summary: Basic snap published just on edge channel
+description: A basic snap published just on edge channel
+confinement: strict
+grade: stable
+
+apps:
+    snap-name:
+        command: snap-name
+
+parts:
+    copy:
+        plugin: dump
+        source: .

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -54,12 +54,12 @@ execute: |
     MATCH 'cannot install "ubuntu-core", please use "core" instead' < stderr.out
 
     echo "Install a snap that is only available in the edge channel"
-    if snap install test-snapd-only-in-edge 2>stderr.out; then
-        echo "Installing test-snapd-only-in-edge should fail but did not"
+    if snap install test-snapd-just-edge 2>stderr.out; then
+        echo "Installing test-snapd-just-edge should fail but did not"
         exit 1
     fi
-    MATCH 'error: snap "test-snapd-only-in-edge" is not available on stable but' < stderr.out
-    MATCH "snap install --edge test-snapd-only-in-edge" < stderr.out
+    MATCH 'error: snap "test-snapd-just-edge" is not available on stable but' < stderr.out
+    MATCH "snap install --edge test-snapd-just-edge" < stderr.out
 
     echo "Install a snap not available for the given architecture"
     if [ "$(uname -m)" = "x86_64" ]; then

--- a/tests/main/refresh-amend/task.yaml
+++ b/tests/main/refresh-amend/task.yaml
@@ -1,28 +1,28 @@
 summary: Ensure that refresh --amend works
 
 restore: |
-    rm -f test-snapd-only-in-edge_*.snap
+    rm -f test-snapd-just-edge_*.snap
 
 execute: |
     echo "When installing a local snap"
-    snap download --edge test-snapd-only-in-edge
-    snap install --dangerous ./test-snapd-only-in-edge_*.snap
-    snap list |MATCH "test-snapd-only-in-edge.*x1"
+    snap download --edge test-snapd-just-edge
+    snap install --dangerous ./test-snapd-just-edge_*.snap
+    snap list |MATCH "test-snapd-just-edge.*x1"
 
     echo "A normal refresh will not refresh it to the store rev"
-    if snap refresh test-snapd-only-in-edge 2> stderr.out; then
+    if snap refresh test-snapd-just-edge 2> stderr.out; then
         echo "snap refresh should error but did not"
         exit 1
     fi
-    MATCH 'local snap "test-snapd-only-in-edge" is unknown to the store' < stderr.out
+    MATCH 'local snap "test-snapd-just-edge" is unknown to the store' < stderr.out
 
     echo "A refresh with --amend is not enough, the channel needs to be added"
-    if snap refresh --amend test-snapd-only-in-edge 2> stderr.out; then
+    if snap refresh --amend test-snapd-just-edge 2> stderr.out; then
        echo "snap refresh --amend without --edge should error but it did not"
        exit 1
     fi
  
     echo "A refresh with --amend refreshes it to the store revision"
-    snap refresh --edge --amend test-snapd-only-in-edge
+    snap refresh --edge --amend test-snapd-just-edge
     echo "And we have a store revision now"
-    snap info test-snapd-only-in-edge | MATCH "^snap-id:.*[a-zA-Z0-9]+$"
+    snap info test-snapd-just-edge | MATCH "^snap-id:.*[a-zA-Z0-9]+$"

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -62,3 +62,7 @@ execute: |
         echo 'snap find " " returns non user friendly error with whitespace query'
         exit 1
     fi
+
+    echo "List of snaps in edge and beta channels"
+    snap find test-snapd-just- | MATCH "test-snapd-just-edge"
+    snap find test-snapd-just- | MATCH "test-snapd-just-beta"


### PR DESCRIPTION
Changes:
. Using test-snapd-just-{edge,beta} snaps
. Snap test-snapd-only-in-edge replaced (tests udpated)
. searching test updated to search snaps on edge and beta channels
