### PR TITLE
tests: try to build cmd/snap for darwin

### DIFF
--- a/tests/unit/go-darwin/task.yaml
+++ b/tests/unit/go-darwin/task.yaml
@@ -1,0 +1,11 @@
+summary: Build cmd/snap for darwin
+
+prepare: |
+    snap install go --classic
+    mkdir -p /tmp/darwin-build/src/github.com/snapcore
+    cp -ar "$PROJECT_PATH" /tmp/darwin-build/src/github.com/snapcore
+    chown -R test:12345 /tmp/darwin-build/
+    GOPATH=/tmp/darwin-build /snap/bin/go get golang.org/x/sys/unix
+
+execute: |
+    su -l -c "GOOS=darwin PATH=$PATH GOPATH=/tmp/darwin-build /snap/bin/go build -o /dev/null github.com/snapcore/snapd/cmd/snap" test


### PR DESCRIPTION
Currently cmd/snap builds and works* on darwin. This test ensures that
at least it'll continue to build; automation of testing on darwin is
stil TBD.

* snap pack, download, and version work.
