### PR TITLE
daemon: make error responders not printf when called with 1 argument

### DIFF
--- a/daemon/response.go
+++ b/daemon/response.go
@@ -226,8 +226,11 @@ func AsyncResponse(result map[string]interface{}, meta *Meta) Response {
 // makeErrorResponder builds an errorResponder from the given error status.
 func makeErrorResponder(status int) errorResponder {
 	return func(format string, v ...interface{}) Response {
-		res := &errorResult{
-			Message: fmt.Sprintf(format, v...),
+		res := &errorResult{}
+		if len(v) == 0 {
+			res.Message = format
+		} else {
+			res.Message = fmt.Sprintf(format, v...)
 		}
 		if status == 401 {
 			res.Kind = errorKindLoginRequired


### PR DESCRIPTION
Before this change, doing e.g. `InternalError(err.Error())` was a bug:
the error responder would call sprintf on the args, meaning that any
percent sign in the error message would explode into an angry (and
confusing) MISSING in the error message.

In the past I'd caught instances of this bug and fixed the caller.  In
retrospect this was a bad idea, as we now again have instances of the
bug. This change fixes it in the responder: if called with a single
argument, don't call Sprintf. Tadaaaa. No more bug.
