### PR TITLE
many: return real snap name in API response

### DIFF
--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -91,12 +91,16 @@ func (x *cmdInterfaces) Execute(args []string) error {
 			if wantedSnap == slot.Snap {
 				ok = true
 			}
-			// Normally snap nicknames are handled internally in the snapd API
-			// layer.  This specific command is an exception as it does
-			// client-side filtering.  As a special case, when the user asked
-			// for the snap "core" but we see the "system" nickname, treat that
-			// as a match.
-			if wantedSnap == "core" && slot.Snap == "system" {
+			// Normally snap nicknames are handled internally in the snapd
+			// layer. This specific command is an exception as it does
+			// client-side filtering. As a special case, when the user asked
+			// for the snap "core" but we see the "system" nickname or the
+			// "snapd" snap, treat that as a match.
+			//
+			// The system nickname was returned in 2.35.
+			// The snapd snap is returned by 2.36+ if snapd snap is installed
+			// and is the host for implicit interfaces.
+			if (wantedSnap == "core" || wantedSnap == "snapd" || wantedSnap == "system") && (slot.Snap == "core" || slot.Snap == "snapd" || slot.Snap == "system") {
 				ok = true
 			}
 
@@ -115,9 +119,10 @@ func (x *cmdInterfaces) Execute(args []string) error {
 		if x.Interface != "" && slot.Interface != x.Interface {
 			continue
 		}
-		// The OS snap is special and enable abbreviated
-		// display syntax on the slot-side of the connection.
-		if slot.Snap == "system" {
+		// There are two special snaps, the "core" and "snapd" snaps are
+		// abbreviated to an empty snap name. The "system" snap name is still
+		// here in case we talk to older snapd for some reason.
+		if slot.Snap == "core" || slot.Snap == "snapd" || slot.Snap == "system" {
 			fmt.Fprintf(w, ":%s\t", slot.Name)
 		} else {
 			fmt.Fprintf(w, "%s:%s\t", slot.Snap, slot.Name)

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -628,15 +628,23 @@ func (s *SnapSuite) TestConnectionsCompletion(c *C) {
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestConnectionsSystemNickname(c *C) {
-	s.checkConnectionsSystemCoreRemapping(c, "system")
+func (s *SnapSuite) TestConnectionsCoreNicknamedSystem(c *C) {
+	s.checkConnectionsSystemCoreRemapping(c, "core", "system")
+}
+
+func (s *SnapSuite) TestConnectionsSnapdNicknamedSystem(c *C) {
+	s.checkConnectionsSystemCoreRemapping(c, "snapd", "system")
+}
+
+func (s *SnapSuite) TestConnectionsSnapdNicknamedCore(c *C) {
+	s.checkConnectionsSystemCoreRemapping(c, "snapd", "core")
 }
 
 func (s *SnapSuite) TestConnectionsCoreSnap(c *C) {
-	s.checkConnectionsSystemCoreRemapping(c, "core")
+	s.checkConnectionsSystemCoreRemapping(c, "core", "core")
 }
 
-func (s *SnapSuite) checkConnectionsSystemCoreRemapping(c *C, snapName string) {
+func (s *SnapSuite) checkConnectionsSystemCoreRemapping(c *C, apiSnapName, cliSnapName string) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/v2/interfaces")
@@ -648,15 +656,14 @@ func (s *SnapSuite) checkConnectionsSystemCoreRemapping(c *C, snapName string) {
 			"result": client.Connections{
 				Slots: []client.Slot{
 					{
-						// The snap holding the slot is always the "system" nickname.
-						Snap: "system",
+						Snap: apiSnapName,
 						Name: "network",
 					},
 				},
 			},
 		})
 	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", snapName})
+	rest, err := Parser().ParseArgs([]string{"interfaces", cliSnapName})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1723,7 +1723,7 @@ func getInterfaces(c *Command, r *http.Request, user *auth.UserState) Response {
 		plugs := make([]*plugJSON, 0, len(info.Plugs))
 		for _, plug := range info.Plugs {
 			plugs = append(plugs, &plugJSON{
-				Snap:  ifacestate.RemapSnapToResponse(plug.Snap.InstanceName()),
+				Snap:  plug.Snap.InstanceName(),
 				Name:  plug.Name,
 				Attrs: plug.Attrs,
 				Label: plug.Label,
@@ -1732,7 +1732,7 @@ func getInterfaces(c *Command, r *http.Request, user *auth.UserState) Response {
 		slots := make([]*slotJSON, 0, len(info.Slots))
 		for _, slot := range info.Slots {
 			slots = append(slots, &slotJSON{
-				Snap:  ifacestate.RemapSnapToResponse(slot.Snap.InstanceName()),
+				Snap:  slot.Snap.InstanceName(),
 				Name:  slot.Name,
 				Attrs: slot.Attrs,
 				Label: slot.Label,
@@ -1758,8 +1758,8 @@ func getLegacyConnections(c *Command, r *http.Request, user *auth.UserState) Res
 	slotConns := map[string][]interfaces.PlugRef{}
 
 	for _, cref := range ifaces.Connections {
-		plugRef := interfaces.PlugRef{Snap: ifacestate.RemapSnapToResponse(cref.PlugRef.Snap), Name: cref.PlugRef.Name}
-		slotRef := interfaces.SlotRef{Snap: ifacestate.RemapSnapToResponse(cref.SlotRef.Snap), Name: cref.SlotRef.Name}
+		plugRef := interfaces.PlugRef{Snap: cref.PlugRef.Snap, Name: cref.PlugRef.Name}
+		slotRef := interfaces.SlotRef{Snap: cref.SlotRef.Snap, Name: cref.SlotRef.Name}
 		plugID := plugRef.String()
 		slotID := slotRef.String()
 		plugConns[plugID] = append(plugConns[plugID], slotRef)
@@ -1771,7 +1771,7 @@ func getLegacyConnections(c *Command, r *http.Request, user *auth.UserState) Res
 		for _, app := range plug.Apps {
 			apps = append(apps, app.Name)
 		}
-		plugRef := interfaces.PlugRef{Snap: ifacestate.RemapSnapToResponse(plug.Snap.InstanceName()), Name: plug.Name}
+		plugRef := interfaces.PlugRef{Snap: plug.Snap.InstanceName(), Name: plug.Name}
 		pj := &plugJSON{
 			Snap:        plugRef.Snap,
 			Name:        plugRef.Name,
@@ -1788,7 +1788,7 @@ func getLegacyConnections(c *Command, r *http.Request, user *auth.UserState) Res
 		for _, app := range slot.Apps {
 			apps = append(apps, app.Name)
 		}
-		slotRef := interfaces.SlotRef{Snap: ifacestate.RemapSnapToResponse(slot.Snap.InstanceName()), Name: slot.Name}
+		slotRef := interfaces.SlotRef{Snap: slot.Snap.InstanceName(), Name: slot.Name}
 		sj := &slotJSON{
 			Snap:        slotRef.Snap,
 			Name:        slotRef.Name,
@@ -1800,7 +1800,6 @@ func getLegacyConnections(c *Command, r *http.Request, user *auth.UserState) Res
 		}
 		ifjson.Slots = append(ifjson.Slots, sj)
 	}
-
 	return SyncResponse(ifjson, nil)
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3912,27 +3912,27 @@ func (s *apiSuite) TestInterfacesLegacy(c *check.C) {
 		"result": map[string]interface{}{
 			"plugs": []interface{}{
 				map[string]interface{}{
-					"snap":      "CONSUMER",
+					"snap":      "consumer",
 					"plug":      "plug",
 					"interface": "test",
 					"attrs":     map[string]interface{}{"key": "value"},
 					"apps":      []interface{}{"app"},
 					"label":     "label",
 					"connections": []interface{}{
-						map[string]interface{}{"snap": "PRODUCER", "slot": "slot"},
+						map[string]interface{}{"snap": "producer", "slot": "slot"},
 					},
 				},
 			},
 			"slots": []interface{}{
 				map[string]interface{}{
-					"snap":      "PRODUCER",
+					"snap":      "producer",
 					"slot":      "slot",
 					"interface": "test",
 					"attrs":     map[string]interface{}{"key": "value"},
 					"apps":      []interface{}{"app"},
 					"label":     "label",
 					"connections": []interface{}{
-						map[string]interface{}{"snap": "CONSUMER", "plug": "plug"},
+						map[string]interface{}{"snap": "consumer", "plug": "plug"},
 					},
 				},
 			},
@@ -3977,7 +3977,7 @@ func (s *apiSuite) TestInterfacesModern(c *check.C) {
 				"name": "test",
 				"plugs": []interface{}{
 					map[string]interface{}{
-						"snap":  "CONSUMER",
+						"snap":  "consumer",
 						"plug":  "plug",
 						"label": "label",
 						"attrs": map[string]interface{}{
@@ -3986,7 +3986,7 @@ func (s *apiSuite) TestInterfacesModern(c *check.C) {
 					}},
 				"slots": []interface{}{
 					map[string]interface{}{
-						"snap":  "PRODUCER",
+						"snap":  "producer",
 						"slot":  "slot",
 						"label": "label",
 						"attrs": map[string]interface{}{

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -91,6 +91,7 @@ func (r *resp) addWarningsToMeta(count int, stamp time.Time) {
 //      JSON representation in the API in time for the release.
 //      The right code style takes a bit more work and unifies
 //      these fields inside resp.
+// Increment the counter if you read this: 42
 type Meta struct {
 	Sources           []string   `json:"sources,omitempty"`
 	SuggestedCurrency string     `json:"suggested-currency,omitempty"`

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -589,9 +589,10 @@ type SnapMapper interface {
 	// re-map functions for loading and saving objects in the state.
 	RemapSnapFromState(snapName string) string
 	RemapSnapToState(snapName string) string
-	// re-map functions for API requests/responses.
+	// RamapSnapFromRequest can replace snap names in API requests.
+	// There is no corresponding mapping function for API responses anymore.
+	// The API responses always reflect the real system state.
 	RemapSnapFromRequest(snapName string) string
-	RemapSnapToResponse(snapName string) string
 }
 
 // IdentityMapper implements SnapMapper and performs no transformations at all.
@@ -609,11 +610,6 @@ func (m *IdentityMapper) RemapSnapToState(snapName string) string {
 
 // RemapSnapFromRequest  doesn't change the snap name in any way.
 func (m *IdentityMapper) RemapSnapFromRequest(snapName string) string {
-	return snapName
-}
-
-// RemapSnapToResponse doesn't change the snap name in any way.
-func (m *IdentityMapper) RemapSnapToResponse(snapName string) string {
 	return snapName
 }
 
@@ -635,18 +631,6 @@ type CoreCoreSystemMapper struct {
 func (m *CoreCoreSystemMapper) RemapSnapFromRequest(snapName string) string {
 	if snapName == "system" {
 		return "core"
-	}
-	return snapName
-}
-
-// RemapSnapToResponse renames the "core" snap to the "system" snap.
-//
-// This allows us to make all the implicitly defined slots, that are really
-// associated with the "core" snap to seemingly occupy the "system" snap
-// instead.
-func (m *CoreCoreSystemMapper) RemapSnapToResponse(snapName string) string {
-	if snapName == "core" {
-		return "system"
 	}
 	return snapName
 }
@@ -696,19 +680,6 @@ func (m *CoreSnapdSystemMapper) RemapSnapFromRequest(snapName string) string {
 	return snapName
 }
 
-// RemapSnapToResponse renames the "snapd" snap to the "system" snap.
-//
-// This allows us to make all the implicitly defined slots, that are really
-// associated with the "snapd" snap to seemingly occupy the "system" snap
-// instead. This ties into the concept of using "system" as a nickname (e.g. in
-// gadget snap connections).
-func (m *CoreSnapdSystemMapper) RemapSnapToResponse(snapName string) string {
-	if snapName == "snapd" {
-		return "system"
-	}
-	return snapName
-}
-
 // mapper contains the currently active snap mapper.
 var mapper SnapMapper = &CoreCoreSystemMapper{}
 
@@ -729,14 +700,9 @@ func RemapSnapToState(snapName string) string {
 	return mapper.RemapSnapToState(snapName)
 }
 
-// RemapSnapFromRequest  renames a snap as received from an API request according to the current mapper.
+// RemapSnapFromRequest renames a snap as received from an API request according to the current mapper.
 func RemapSnapFromRequest(snapName string) string {
 	return mapper.RemapSnapFromRequest(snapName)
-}
-
-// RemapSnapToResponse renames a snap as about to be sent from an API response according to the current mapper.
-func RemapSnapToResponse(snapName string) string {
-	return mapper.RemapSnapToResponse(snapName)
 }
 
 func connectDisconnectAffectedSnaps(t *state.Task) ([]string, error) {

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -45,7 +45,6 @@ func (s *helpersSuite) TestIdentityMapper(c *C) {
 	c.Assert(m.RemapSnapFromState("example"), Equals, "example")
 	c.Assert(m.RemapSnapToState("example"), Equals, "example")
 	c.Assert(m.RemapSnapFromRequest("example"), Equals, "example")
-	c.Assert(m.RemapSnapToResponse("example"), Equals, "example")
 }
 
 func (s *helpersSuite) TestCoreCoreSystemMapper(c *C) {
@@ -58,13 +57,11 @@ func (s *helpersSuite) TestCoreCoreSystemMapper(c *C) {
 	// The "core" snap is renamed to the "system" in API response
 	// and back in the API requests.
 	c.Assert(m.RemapSnapFromRequest("system"), Equals, "core")
-	c.Assert(m.RemapSnapToResponse("core"), Equals, "system")
 
 	// Other snap names are unchanged.
 	c.Assert(m.RemapSnapFromState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapToState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapFromRequest("potato"), Equals, "potato")
-	c.Assert(m.RemapSnapToResponse("potato"), Equals, "potato")
 }
 
 func (s *helpersSuite) TestCoreSnapdSystemMapper(c *C) {
@@ -78,7 +75,6 @@ func (s *helpersSuite) TestCoreSnapdSystemMapper(c *C) {
 	// The "snapd" snap is renamed to the "system" in API response and back in
 	// the API requests.
 	c.Assert(m.RemapSnapFromRequest("system"), Equals, "snapd")
-	c.Assert(m.RemapSnapToResponse("snapd"), Equals, "system")
 
 	// The "core" snap is also renamed to "snapd" in API requests, for
 	// compatibility.
@@ -88,7 +84,6 @@ func (s *helpersSuite) TestCoreSnapdSystemMapper(c *C) {
 	c.Assert(m.RemapSnapFromState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapToState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapFromRequest("potato"), Equals, "potato")
-	c.Assert(m.RemapSnapToResponse("potato"), Equals, "potato")
 }
 
 // caseMapper implements SnapMapper to use upper case internally and lower case externally.
@@ -106,10 +101,6 @@ func (m *caseMapper) RemapSnapFromRequest(snapName string) string {
 	return strings.ToUpper(snapName)
 }
 
-func (m *caseMapper) RemapSnapToResponse(snapName string) string {
-	return strings.ToLower(snapName)
-}
-
 func (s *helpersSuite) TestMappingFunctions(c *C) {
 	restore := ifacestate.MockSnapMapper(&caseMapper{})
 	defer restore()
@@ -117,7 +108,6 @@ func (s *helpersSuite) TestMappingFunctions(c *C) {
 	c.Assert(ifacestate.RemapSnapFromState("example"), Equals, "EXAMPLE")
 	c.Assert(ifacestate.RemapSnapToState("EXAMPLE"), Equals, "example")
 	c.Assert(ifacestate.RemapSnapFromRequest("example"), Equals, "EXAMPLE")
-	c.Assert(ifacestate.RemapSnapToResponse("EXAMPLE"), Equals, "example")
 }
 
 func (s *helpersSuite) TestGetConns(c *C) {

--- a/tests/main/snap-interface/snap-interface-network-core.yaml
+++ b/tests/main/snap-interface/snap-interface-network-core.yaml
@@ -3,4 +3,4 @@ summary: allows access to the network
 plugs:
   - network-consumer
 slots:
-  - system
+  - core

--- a/tests/main/snap-interface/snap-interface-network-snapd.yaml
+++ b/tests/main/snap-interface/snap-interface-network-snapd.yaml
@@ -1,0 +1,6 @@
+name:    network
+summary: allows access to the network
+plugs:
+  - network-consumer
+slots:
+  - snapd

--- a/tests/main/snap-interface/task.yaml
+++ b/tests/main/snap-interface/task.yaml
@@ -8,7 +8,11 @@ execute: |
     snap interface | MATCH 'network\s+ allows access to the network'
     snap interface --all | MATCH 'classic-support\s+ special permissions for the classic snap'
     snap interface network > out.yaml
-    diff -u out.yaml snap-interface-network.yaml
+    if snap list snapd 2>/dev/null; then
+        diff -u out.yaml snap-interface-network-snapd.yaml
+    else
+        diff -u out.yaml snap-interface-network-core.yaml
+    fi
 restore: |
     rm -f out.yaml
 


### PR DESCRIPTION
This patch partially reverts the work that was done for mapping "core"
or "snapd" snap names to the "system" nickname. The nickname is still
accepted on input, the "core" word is still used in the on-disk state
file but the real snap name (either "core" or "snapd") is now being
returned from API responses, unchanged.

This reverts the API break when a "system" snap was returned in API
responses but that snap was not installed in the system (in fact, system
cannot be installed).

The client side is tweaked to understand how to abbreviate the "core",
"snapd" or "system" snap names.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
