### PR TITLE
overlord/state: return latest LastAdded time in WarningsSummary

### DIFF
--- a/overlord/state/warning.go
+++ b/overlord/state/warning.go
@@ -261,20 +261,25 @@ func (s *State) PendingWarnings() ([]*Warning, time.Time) {
 }
 
 // WarningsSummary returns the number of warnings that are ready to be
-// shown to the user, and the current timestamp (useful for OKing the
+// shown to the user, and the timestamp of the most recently added
+// warning (useful for silencing the warning alerts, and OKing the
 // returned warnings).
 func (s *State) WarningsSummary() (int, time.Time) {
 	s.reading()
 	now := time.Now().UTC()
+	var last time.Time
 
 	var n int
 	for _, w := range s.warnings {
 		if w.ShowAfter(now) {
 			n++
+			if w.lastAdded.After(last) {
+				last = w.lastAdded
+			}
 		}
 	}
 
-	return n, now
+	return n, last
 }
 
 // UnshowAllWarnings clears the lastShown timestamp from all the

--- a/overlord/state/warning_test.go
+++ b/overlord/state/warning_test.go
@@ -194,6 +194,17 @@ func (stateSuite) TestCheckpoint(c *check.C) {
 	c.Check(fmt.Sprintf("%q", ws), check.Equals, `["hello"]`)
 }
 
+func (stateSuite) TestWarningsSummaryReturnsLastLastAdded(c *check.C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+	t0 := time.Now().Add(-100 * time.Hour)
+	st.AddWarning("hello", t0, never, state.DefaultExpireAfter, state.DefaultRepeatAfter)
+	n, t := st.WarningsSummary()
+	c.Check(n, check.Equals, 1)
+	c.Check(t, check.DeepEquals, t0)
+}
+
 func (stateSuite) TestShowAndOkay(c *check.C) {
 	st := state.New(nil)
 	st.Lock()


### PR DESCRIPTION
Before this change, state's WarningsSummary returned the current
timestamp together with the warnings count. This was fine for then
calling Okay, but useless as a way to filter out the WARNING
footer. This change makes it so that the timestamp returned is the
time the latest showable warning was added, instead.