### PR TITLE
overlord/snapstate: improve cleaup in mount-snap handler

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -621,6 +621,9 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *sna
 	case "gadget":
 		snapType = snap.TypeGadget
 	}
+	if instanceName == "borken-in-setup" {
+		return snapType, fmt.Errorf("cannot install snap %q", instanceName)
+	}
 	return snapType, nil
 }
 


### PR DESCRIPTION
When SetupSnap() fails, the cleanup path would not remove a shared snap
directory if one was created. Unify the cleanup paths in mount snap handler and
make sure to attempt to cleanup the shared directory in all error paths.