### PR TITLE
cmd/snap, tests/main/snap-info: highlight the current channel

### DIFF
--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -417,12 +417,12 @@ description: |
 snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
-channels:                    
-  1/stable:    2.10 (1) 65kB -
-  1/candidate: ↑             
-  1/beta:      ↑             
-  1/edge:      ↑             
-installed:     2.10 (1) 1kB  disabled
+channels:                             
+  1/stable:    2.10 (1) 65kB -        
+  1/candidate: ↑                      
+  1/beta:      ↑                      
+  1/edge:      ↑                      
+installed:     2.10 (1) 1kB  disabled 
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -105,6 +105,7 @@ var colorDescs = mixinDescs{
 
 type escapes struct {
 	green string
+	bold  string
 	end   string
 
 	tick, dash, uparrow string
@@ -112,11 +113,13 @@ type escapes struct {
 
 var (
 	color = escapes{
+		bold:  "\033[1m",
 		green: "\033[32m",
 		end:   "\033[0m",
 	}
 
 	mono = escapes{
+		bold:  "\033[1m",
 		green: "\033[1m",
 		end:   "\033[0m",
 	}

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -37,7 +37,7 @@ def maybe(name, d):
 
 verNotesRx = re.compile(r"^\w\S*\s+-$")
 def verRevNotesRx(s):
-    return re.compile(r"^\w\S*\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$")
+    return re.compile(r"^\w\S*\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + r"(?:\s+<?)?$")
 
 if os.environ['SNAPPY_USE_STAGING_STORE'] == '1':
     snap_ids={


### PR DESCRIPTION
In snap info, highlight the line of the channel map that corresponds
to the currently installed snap. This is done with the use of bold (if
the terminal supports it) and a caret at the end of the line:

here it is with all the escape codes:

    name:      core
    summary:   snapd runtime environment
    publisher: Canonical[32m✓[0m
    contact:   snaps@canonical.com
    license:   unset
    description: |
      The core runtime environment for snapd
    type:         core
    snap-id:      99T7MUlRhtI3U0QFgl5mXXESAiSwt776
    tracking:     beta
    refresh-date: 8 days ago, at 16:04 CEST
    channels:
    [0m  stable:    16-2.35                  (5328) 92MB -    [0m
    [0m  candidate: 16-2.35.2                (5486) 92MB -    [0m
    [1m  beta:      16-2.35.2                (5486) 92MB -    <[0m
    [0m  edge:      16-2.35.2+git947.978cb99 (5537) 92MB -    [0m
    [0minstalled:   16-2.35.2                (5486) 92MB core
