### PR TITLE
cmd/snap: improve UX when removing specific snap revision

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -130,7 +130,11 @@ func (x *cmdRemove) removeOne(opts *client.SnapOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(Stdout, i18n.G("%s removed\n"), name)
+	if opts.Revision != "" {
+		fmt.Fprintf(Stdout, i18n.G("%s (revision %s) removed\n"), name, opts.Revision)
+	} else {
+		fmt.Fprintf(Stdout, i18n.G("%s removed\n"), name)
+	}
 	return nil
 }
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1364,6 +1364,26 @@ func (s *SnapOpSuite) TestRemove(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestRemoveRevision(c *check.C) {
+	s.srv.total = 3
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":   "remove",
+			"revision": "17",
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove", "--revision=17", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(revision 17\) removed`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
 func (s *SnapOpSuite) TestRemoveManyRevision(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove", "--revision=17", "one", "two"})


### PR DESCRIPTION
Currently when doing `snap remove foo --revision=123` prints 'foo removed',
which is not really intuitive as we have not removed the whole snap, but a
single revision instead. Try to improve the UX.
