### PR TITLE
tests: don't fail interfaces-bluez test if bluez is already installed

### DIFF
--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -11,9 +11,11 @@ environment:
     SNAP_NAME: bluez
 
 execute: |
-    echo "Installing bluez snap from the store ..."
-    expected="(?s)$SNAP_NAME .* from Canonical✓ installed\\n"
-    snap install "$SNAP_NAME" | grep -Pzq "$expected"
+    if ! snap list |grep -Pq "^bluez +" ; then
+        echo "Installing bluez snap from the store ..."
+        expected="(?s)$SNAP_NAME .* from Canonical✓ installed\\n"
+        snap install "$SNAP_NAME" | grep -Pzq "$expected"
+    fi
 
     echo "Connecting bluez snap plugs/slots ..."
     snap connect bluez:client bluez:service

--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -11,7 +11,7 @@ environment:
     SNAP_NAME: bluez
 
 execute: |
-    if ! snap list |grep -Pq "^bluez +" ; then
+    if ! snap list bluez &> /dev/null ; then
         echo "Installing bluez snap from the store ..."
         expected="(?s)$SNAP_NAME .* from Canonical✓ installed\\n"
         snap install "$SNAP_NAME" | grep -Pzq "$expected"


### PR DESCRIPTION
skip installation of the bluez snap in interfaces-bluez spread test if bluez is already installed