### PR TITLE
daemon, snapstate: consistent snap list [--all] output with broken snaps

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1537,20 +1537,25 @@ func (s *apiSuite) TestSnapsInfoAll(c *check.C) {
 	s.mkInstalledInState(c, d, "local", "foo", "v2", snap.R(2), false, "")
 	s.mkInstalledInState(c, d, "local", "foo", "v3", snap.R(3), true, "")
 	s.mkInstalledInState(c, d, "local_foo", "foo", "v4", snap.R(4), true, "")
+	brokenInfo := s.mkInstalledInState(c, d, "local_bar", "foo", "v5", snap.R(5), true, "")
+	// make sure local_bar is 'broken'
+	err := os.Remove(filepath.Join(brokenInfo.MountDir(), "meta", "snap.yaml"))
+	c.Assert(err, check.IsNil)
 
 	expectedHappy := map[string]bool{
 		"local":     true,
 		"local_foo": true,
+		"local_bar": true,
 	}
 	for _, t := range []struct {
 		q        string
 		numSnaps int
 		typ      ResponseType
 	}{
-		{"?select=enabled", 2, "sync"},
-		{`?select=`, 2, "sync"},
-		{"", 2, "sync"},
-		{"?select=all", 4, "sync"},
+		{"?select=enabled", 3, "sync"},
+		{`?select=`, 3, "sync"},
+		{"", 3, "sync"},
+		{"?select=all", 5, "sync"},
 		{"?select=invalid-field", 0, "error"},
 	} {
 		c.Logf("trying: %v", t)

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -130,7 +130,15 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 			for _, seq := range snapst.Sequence {
 				info, err = snap.ReadInfo(name, seq)
 				if err != nil {
-					break
+					// single revision may be broken
+					_, instanceKey := snap.SplitInstanceName(name)
+					info = &snap.Info{
+						SideInfo:    *seq,
+						InstanceKey: instanceKey,
+						Broken:      err.Error(),
+					}
+					// clear the error
+					err = nil
 				}
 				publisher, err = publisherAccount(st, info)
 				aboutThis = append(aboutThis, aboutSnap{info, snapst, publisher})

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -244,9 +244,11 @@ func readInfo(name string, si *snap.SideInfo, flags int) (*snap.Info, error) {
 		logger.Noticef("cannot read snap info of snap %q at revision %s: %s", name, si.Revision, err)
 	}
 	if bse, ok := err.(snap.BrokenSnapError); ok {
+		_, instanceKey := snap.SplitInstanceName(name)
 		info := &snap.Info{
 			SuggestedName: name,
 			Broken:        bse.Broken(),
+			InstanceKey:   instanceKey,
 		}
 		info.Apps = snap.GuessAppsForBroken(info)
 		if si != nil {


### PR DESCRIPTION

daemon: always generate a snap info for broken snaps when listing all

When calling `snap list`, snaps that are broken will appear with a `broken` note
in the notes column like this:
```
$ snap list
Name               Version   Rev   Tracking  Publisher     Notes
core               16-2.35   5328  stable    canonical✓    core
hello-world_foo              27    stable    canonical✓    broken
```
However, when calling `snap list --all`, the client would get an error instead:
```
$ snap list --all
error: cannot list local snaps! cannot find installed snap "hello-world_foo" at revision 27:
       missing file /var/lib/snapd/snap/hello-world_foo/27/meta/snap.yaml
```
The ensures that we get consistent error case output for the listing of all
snaps.

