### PR TITLE
Skip unsupported architectures for fedora-base-smoke test

### DIFF
--- a/tests/main/fedora-base-smoke/task.yaml
+++ b/tests/main/fedora-base-smoke/task.yaml
@@ -1,11 +1,15 @@
 summary: smoke test for Fedora 29 base snap
-# The hello-fedora snap is not yet available for i386
-systems: [-*-32]
+
+# The hello-fedora snap is just available for amd64 architecture
+systems: [-*-32, -*-arm*, -*-ppc64el, -*-s390x]
+
 # not available on most arches in autopkgtest
 backends: [-autopkgtest]
+
 details: |
   Smoke test for checking if we can run hello-world like application against a
   Fedora 29 base snap correctly.
+
 execute: |
   # This is explicit because fedora29 snap is still in edge.
   snap install --edge fedora29


### PR DESCRIPTION
This is  https://github.com/snapcore/snapd/pull/5640 for 2.35 to fix tests on non amd64 versions.