### PR TITLE
cmd/libsnap: add functions for handling facts

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -82,6 +82,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/cleanup-funcs.h \
 	libsnap-confine-private/error.c \
 	libsnap-confine-private/error.h \
+	libsnap-confine-private/facts.c \
+	libsnap-confine-private/facts.h \
 	libsnap-confine-private/fault-injection.c \
 	libsnap-confine-private/fault-injection.h \
 	libsnap-confine-private/locking.c \
@@ -112,6 +114,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/classic-test.c \
 	libsnap-confine-private/cleanup-funcs-test.c \
 	libsnap-confine-private/error-test.c \
+	libsnap-confine-private/facts-test.c \
 	libsnap-confine-private/fault-injection-test.c \
 	libsnap-confine-private/locking-test.c \
 	libsnap-confine-private/mount-opt-test.c \
@@ -120,8 +123,8 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/secure-getenv-test.c \
 	libsnap-confine-private/snap-test.c \
 	libsnap-confine-private/string-utils-test.c \
-	libsnap-confine-private/test-utils.c \
 	libsnap-confine-private/test-utils-test.c \
+	libsnap-confine-private/test-utils.c \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "facts.h"
+#include "facts.c"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <glib.h>
+
+static void remove_file(gpointer * fname)
+{
+	chmod((const char *)fname, 0644);
+	unlink((const char *)fname);
+}
+
+static void test_sc_load_facts(void)
+{
+	const char *fname = "facts.test";
+	char *facts = NULL;
+
+	g_test_queue_destroy((GDestroyNotify) remove_file, (gpointer) fname);
+
+	/* The facts file can be missing. */
+	unlink(fname);
+	facts = sc_load_facts(fname);
+	g_test_queue_free((gpointer) facts);
+	g_assert_cmpstr(facts, ==, NULL);
+
+	/* The facts file can be empty. */
+	g_file_set_contents(fname, "", -1, NULL);
+	facts = sc_load_facts(fname);
+	g_test_queue_free((gpointer) facts);
+	g_assert_cmpstr(facts, ==, "");
+
+	/* The facts file can have reasonable contents. */
+	g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);
+	facts = sc_load_facts(fname);
+	g_test_queue_free((gpointer) facts);
+	g_assert_cmpstr(facts, ==, "key=value\nfoo=bar\n");
+}
+
+static void test_sc_load_facts__too_big(void)
+{
+	const char *fname = "facts.test";
+
+	g_test_queue_destroy((GDestroyNotify) remove_file, (gpointer) fname);
+
+	if (g_test_subprocess()) {
+		/* The facts file cannot be larger than 16KB */
+		char buf[16 * 1024];
+		memset(buf, 'x', sizeof buf);
+		g_file_set_contents(fname, buf, -1, NULL);
+		(void)sc_load_facts(fname);
+		g_test_message("expected sc_load_facts not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("cannot load facts larger than 16KB\n");
+}
+
+static void test_sc_load_facts__cannot_open(void)
+{
+	const char *fname = "facts.test";
+
+	g_test_queue_destroy((GDestroyNotify) remove_file, (gpointer) fname);
+
+	if (g_test_subprocess()) {
+		g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);
+		chmod(fname, 0000);
+		(void)sc_load_facts(fname);
+		g_test_message("expected sc_load_facts not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot open facts file facts.test: Permission denied\n");
+}
+
+static void test_sc_query_fact(void)
+{
+	const char *facts = "f1=1\nf2=22\nf3=333\n";
+
+	/* Searching in and for various NULL or empty things. */
+	g_assert_cmpuint(sc_query_fact(NULL, NULL, NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("name=value", NULL, NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact(NULL, "name", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact(NULL, "", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("", NULL, NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("", "", NULL, 0), ==, 0);
+
+	/* Querying for value size. */
+	g_assert_cmpuint(sc_query_fact("name=value\n", "name", NULL, 0), ==, 6);
+	g_assert_cmpuint(sc_query_fact("name=value", "name", NULL, 0), ==, 6);
+	g_assert_cmpuint(sc_query_fact("name=\n", "name", NULL, 0), ==, 1);
+	g_assert_cmpuint(sc_query_fact("name=", "name", NULL, 0), ==, 1);
+	g_assert_cmpuint(sc_query_fact("\n", "name", NULL, 0), ==, 0);
+
+	g_assert_cmpuint(sc_query_fact(facts, "f1", NULL, 0), ==, 1 + 1);
+	g_assert_cmpuint(sc_query_fact(facts, "f2", NULL, 0), ==, 2 + 1);
+	g_assert_cmpuint(sc_query_fact(facts, "f3", NULL, 0), ==, 3 + 1);
+
+	/* Searching without success */
+	g_assert_cmpuint(sc_query_fact("name", "nam", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("name=", "nam", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("namevalue=", "nam", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("name", "name=", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("name=", "name=", NULL, 0), ==, 0);
+	g_assert_cmpuint(sc_query_fact("namevalue=", "name=", NULL, 0), ==, 0);
+
+	char buf1[1], buf2[2];
+	size_t n;
+
+	/* The value is "1" but we have 0 bytes! */
+	memset(buf1, 0777, sizeof buf1);
+	n = sc_query_fact(facts, "f1", buf1, 0);
+	g_assert_cmpuint(n, ==, 1 + 1);
+
+	/* The value is "1" but we have space for just "". */
+	memset(buf1, 0777, sizeof buf1);
+	n = sc_query_fact(facts, "f1", buf1, sizeof buf1);
+	g_assert_cmpuint(n, ==, 1 + 1);
+	g_assert_cmpstr(buf1, ==, "");
+
+	/* The value is "22" but we have space for just "2". */
+	memset(buf2, 0777, sizeof buf2);
+	n = sc_query_fact(facts, "f2", buf2, sizeof buf2);
+	g_assert_cmpuint(n, ==, 2 + 1);
+	g_assert_cmpstr(buf2, ==, "2");
+
+	char buf[16];
+
+	/* Retrieval of values */
+	memset(buf, 0777, sizeof buf);
+	n = sc_query_fact(facts, "f1", buf, sizeof buf);
+	g_assert_cmpuint(n, ==, 1 + 1);
+	g_assert_cmpstr(buf, ==, "1");
+
+	memset(buf, 0777, sizeof buf);
+	n = sc_query_fact(facts, "f2", buf, sizeof buf);
+	g_assert_cmpuint(n, ==, 2 + 1);
+	g_assert_cmpstr(buf, ==, "22");
+
+	memset(buf, 0777, sizeof buf);
+	n = sc_query_fact(facts, "f3", buf, sizeof buf);
+	g_assert_cmpuint(n, ==, 3 + 1);
+	g_assert_cmpstr(buf, ==, "333");
+}
+
+static void test_sc_get_bool_fact(void)
+{
+	g_assert_false(sc_get_bool_fact("layouts=banana", "layouts", false));
+	g_assert_false(sc_get_bool_fact("layouts=", "layouts", false));
+	g_assert_false(sc_get_bool_fact("layouts=false", "layouts", false));
+	g_assert_true(sc_get_bool_fact("layouts=true", "layouts", true));
+	g_assert_true(sc_get_bool_fact("hotplug=true", "layouts", true));
+}
+
+static void __attribute__ ((constructor)) init(void)
+{
+	g_test_add_func("/facts/load", test_sc_load_facts);
+	g_test_add_func("/facts/load::2big", test_sc_load_facts__too_big);
+	g_test_add_func("/facts/load::cannot-open",
+			test_sc_load_facts__cannot_open);
+	g_test_add_func("/facts/query", test_sc_query_fact);
+	g_test_add_func("/facts/get_bool", test_sc_get_bool_fact);
+}

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -35,25 +35,25 @@ static void test_sc_load_facts(void)
 	const char *fname = "facts.test";
 	char *facts = NULL;
 
-	g_test_queue_destroy(remove_file, fname);
+	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	/* The facts file can be missing. */
 	unlink(fname);
 	facts = sc_load_facts(fname);
-	g_test_queue_free(facts);
+	g_test_queue_free((gpointer) facts);
 	g_assert_cmpstr(facts, ==, NULL);
 
 	/* The facts file can be empty. */
 	g_assert_true(g_file_set_contents(fname, "", -1, NULL));
 	facts = sc_load_facts(fname);
-	g_test_queue_free(facts);
+	g_test_queue_free((gpointer) facts);
 	g_assert_cmpstr(facts, ==, "");
 
 	/* The facts file can have reasonable contents. */
 	g_assert_true(g_file_set_contents
 		      (fname, "key=value\nfoo=bar\n", -1, NULL));
 	facts = sc_load_facts(fname);
-	g_test_queue_free(facts);
+	g_test_queue_free((gpointer) facts);
 	g_assert_cmpstr(facts, ==, "key=value\nfoo=bar\n");
 }
 
@@ -61,7 +61,7 @@ static void test_sc_load_facts__too_big(void)
 {
 	const char *fname = "facts.test";
 
-	g_test_queue_destroy(remove_file, fname);
+	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	if (g_test_subprocess()) {
 		/* The facts file cannot be larger than 16KB */
@@ -82,7 +82,7 @@ static void test_sc_load_facts__cannot_open(void)
 {
 	const char *fname = "facts.test";
 
-	g_test_queue_destroy(remove_file, fname);
+	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	if (g_test_subprocess()) {
 		g_assert_true(g_file_set_contents

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -80,8 +80,12 @@ static void test_sc_load_facts__too_big(void)
 
 static void test_sc_load_facts__cannot_open(void)
 {
-	const char *fname = "facts.test";
+	if (getegid() == 0 || getgid() == 0) {
+		g_test_skip("this test cannot run as root");
+		return;
+	}
 
+	const char *fname = "facts.test";
 	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	if (g_test_subprocess()) {

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -35,24 +35,24 @@ static void test_sc_load_facts(void)
 	const char *fname = "facts.test";
 	char *facts = NULL;
 
-	g_test_queue_destroy(remove_file, (gpointer) fname);
+	g_test_queue_destroy(remove_file, fname);
 
 	/* The facts file can be missing. */
 	unlink(fname);
 	facts = sc_load_facts(fname);
-	g_test_queue_free((gpointer) facts);
+	g_test_queue_free(facts);
 	g_assert_cmpstr(facts, ==, NULL);
 
 	/* The facts file can be empty. */
 	g_file_set_contents(fname, "", -1, NULL);
 	facts = sc_load_facts(fname);
-	g_test_queue_free((gpointer) facts);
+	g_test_queue_free(facts);
 	g_assert_cmpstr(facts, ==, "");
 
 	/* The facts file can have reasonable contents. */
 	g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);
 	facts = sc_load_facts(fname);
-	g_test_queue_free((gpointer) facts);
+	g_test_queue_free(facts);
 	g_assert_cmpstr(facts, ==, "key=value\nfoo=bar\n");
 }
 
@@ -60,7 +60,7 @@ static void test_sc_load_facts__too_big(void)
 {
 	const char *fname = "facts.test";
 
-	g_test_queue_destroy(remove_file, (gpointer) fname);
+	g_test_queue_destroy(remove_file, fname);
 
 	if (g_test_subprocess()) {
 		/* The facts file cannot be larger than 16KB */
@@ -81,7 +81,7 @@ static void test_sc_load_facts__cannot_open(void)
 {
 	const char *fname = "facts.test";
 
-	g_test_queue_destroy(remove_file, (gpointer) fname);
+	g_test_queue_destroy(remove_file, fname);
 
 	if (g_test_subprocess()) {
 		g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -26,8 +26,10 @@
 static void remove_file(gpointer data)
 {
 	const char *fname = (const char *)data;
-	g_assert_cmpint(chmod(fname, 0644), ==, 0);
-	g_assert_cmpint(unlink(fname), ==, 0);
+	if (access(fname, F_OK) == 0) {
+		g_assert_cmpint(chmod(fname, 0644), ==, 0);
+		g_assert_cmpint(unlink(fname), ==, 0);
+	}
 }
 
 static void test_sc_load_facts(void)

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -26,8 +26,8 @@
 static void remove_file(gpointer data)
 {
 	const char *fname = (const char *)data;
-	chmod(fname, 0644);
-	unlink(fname);
+	g_assert_cmpint(chmod(fname, 0644), ==, 0);
+	g_assert_cmpint(unlink(fname), ==, 0);
 }
 
 static void test_sc_load_facts(void)

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -44,13 +44,14 @@ static void test_sc_load_facts(void)
 	g_assert_cmpstr(facts, ==, NULL);
 
 	/* The facts file can be empty. */
-	g_file_set_contents(fname, "", -1, NULL);
+	g_assert_true(g_file_set_contents(fname, "", -1, NULL));
 	facts = sc_load_facts(fname);
 	g_test_queue_free(facts);
 	g_assert_cmpstr(facts, ==, "");
 
 	/* The facts file can have reasonable contents. */
-	g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);
+	g_assert_true(g_file_set_contents
+		      (fname, "key=value\nfoo=bar\n", -1, NULL));
 	facts = sc_load_facts(fname);
 	g_test_queue_free(facts);
 	g_assert_cmpstr(facts, ==, "key=value\nfoo=bar\n");
@@ -66,7 +67,7 @@ static void test_sc_load_facts__too_big(void)
 		/* The facts file cannot be larger than 16KB */
 		char buf[16 * 1024];
 		memset(buf, 'x', sizeof buf);
-		g_file_set_contents(fname, buf, -1, NULL);
+		g_assert_true(g_file_set_contents(fname, buf, -1, NULL));
 		(void)sc_load_facts(fname);
 		g_test_message("expected sc_load_facts not to return");
 		g_test_fail();
@@ -84,7 +85,8 @@ static void test_sc_load_facts__cannot_open(void)
 	g_test_queue_destroy(remove_file, fname);
 
 	if (g_test_subprocess()) {
-		g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);
+		g_assert_true(g_file_set_contents
+			      (fname, "key=value\nfoo=bar\n", -1, NULL));
 		chmod(fname, 0000);
 		(void)sc_load_facts(fname);
 		g_test_message("expected sc_load_facts not to return");

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -23,7 +23,7 @@
 
 #include <glib.h>
 
-static void remove_file(gpointer * fname)
+static void remove_file(gpointer fname)
 {
 	chmod((const char *)fname, 0644);
 	unlink((const char *)fname);
@@ -34,7 +34,7 @@ static void test_sc_load_facts(void)
 	const char *fname = "facts.test";
 	char *facts = NULL;
 
-	g_test_queue_destroy((GDestroyNotify) remove_file, (gpointer) fname);
+	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	/* The facts file can be missing. */
 	unlink(fname);
@@ -59,7 +59,7 @@ static void test_sc_load_facts__too_big(void)
 {
 	const char *fname = "facts.test";
 
-	g_test_queue_destroy((GDestroyNotify) remove_file, (gpointer) fname);
+	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	if (g_test_subprocess()) {
 		/* The facts file cannot be larger than 16KB */
@@ -80,7 +80,7 @@ static void test_sc_load_facts__cannot_open(void)
 {
 	const char *fname = "facts.test";
 
-	g_test_queue_destroy((GDestroyNotify) remove_file, (gpointer) fname);
+	g_test_queue_destroy(remove_file, (gpointer) fname);
 
 	if (g_test_subprocess()) {
 		g_file_set_contents(fname, "key=value\nfoo=bar\n", -1, NULL);

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -65,7 +65,7 @@ static void test_sc_load_facts__too_big(void)
 
 	if (g_test_subprocess()) {
 		/* The facts file cannot be larger than 16KB */
-		char buf[16 * 1024];
+		char buf[16 * 1024 + 1];
 		memset(buf, 'x', sizeof buf);
 		g_assert_true(g_file_set_contents(fname, buf, -1, NULL));
 		(void)sc_load_facts(fname);

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -101,7 +101,7 @@ static void test_sc_load_facts__cannot_open(void)
 
 static void test_sc_query_fact(void)
 {
-	const char *facts = "f1=1\nf2=22\nf3=333\n";
+	const char *facts = "f0=\nf1=1\nf2=22\nf3=333\n";
 
 	/* Searching in and for various NULL or empty things. */
 	g_assert_cmpuint(sc_query_fact(NULL, NULL, NULL, 0), ==, 0);
@@ -118,6 +118,7 @@ static void test_sc_query_fact(void)
 	g_assert_cmpuint(sc_query_fact("name=", "name", NULL, 0), ==, 1);
 	g_assert_cmpuint(sc_query_fact("\n", "name", NULL, 0), ==, 0);
 
+	g_assert_cmpuint(sc_query_fact(facts, "f0", NULL, 0), ==, 0 + 1);
 	g_assert_cmpuint(sc_query_fact(facts, "f1", NULL, 0), ==, 1 + 1);
 	g_assert_cmpuint(sc_query_fact(facts, "f2", NULL, 0), ==, 2 + 1);
 	g_assert_cmpuint(sc_query_fact(facts, "f3", NULL, 0), ==, 3 + 1);
@@ -153,6 +154,11 @@ static void test_sc_query_fact(void)
 	char buf[16];
 
 	/* Retrieval of values */
+	memset(buf, 0777, sizeof buf);
+	n = sc_query_fact(facts, "f0", buf, sizeof buf);
+	g_assert_cmpuint(n, ==, 0 + 1);
+	g_assert_cmpstr(buf, ==, "");
+
 	memset(buf, 0777, sizeof buf);
 	n = sc_query_fact(facts, "f1", buf, sizeof buf);
 	g_assert_cmpuint(n, ==, 1 + 1);

--- a/cmd/libsnap-confine-private/facts-test.c
+++ b/cmd/libsnap-confine-private/facts-test.c
@@ -23,10 +23,11 @@
 
 #include <glib.h>
 
-static void remove_file(gpointer fname)
+static void remove_file(gpointer data)
 {
-	chmod((const char *)fname, 0644);
-	unlink((const char *)fname);
+	const char *fname = (const char *)data;
+	chmod(fname, 0644);
+	unlink(fname);
 }
 
 static void test_sc_load_facts(void)

--- a/cmd/libsnap-confine-private/facts.c
+++ b/cmd/libsnap-confine-private/facts.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "facts.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cleanup-funcs.h"
+#include "string-utils.h"
+#include "utils.h"
+
+char *sc_load_facts(const char *fname)
+{
+	FILE *f __attribute__ ((cleanup(sc_cleanup_file))) = NULL;
+	char *buf_copy;
+	size_t nread;
+	char buf[16 * 1024 + 1];
+
+	f = fopen(fname, "rt");
+	if (f == NULL) {
+		if (errno == ENOENT) {
+			return NULL;
+		}
+		die("cannot open facts file %s", fname);
+	}
+
+	nread = fread(buf, 1, sizeof buf, f);
+	if (!feof(f)) {
+		die("cannot load facts larger than 16KB");
+	}
+
+	buf_copy = malloc(nread + 1);
+	if (buf_copy == NULL) {
+		die("cannot allocate memory for facts");
+	}
+
+	memcpy(buf_copy, buf, nread);
+	buf_copy[nread] = '\0';
+	return buf_copy;
+}
+
+size_t sc_query_fact(const char *facts, const char *name, char *buf, size_t n)
+{
+	const char *f_start, *f_end, *f_value_start, *f_next;
+	size_t f_len, f_value_len, name_len;
+
+	if (name == NULL || *name == '\0') {
+		return 0;
+	}
+	name_len = strlen(name);
+
+	/* Advance from one fact to the next. Each loop finds the next fact. */
+	for (f_start = facts; f_start != NULL; f_start = f_next) {
+		/* Facts are delimited with newlines, the last newline is optional. */
+		f_next = strchr(f_start, '\n');
+		if (f_next != NULL) {
+			f_end = f_next;
+			/* Step over the newline to look at the next fact. */
+			f_next += 1;
+		} else {
+			f_end = f_start + strlen(f_start);
+			/* f_next remains null, last iteration */
+		}
+		f_len = f_end - f_start;
+
+		if (f_len < name_len + 1) {
+			/* Skip entries shorter than "${name}=" */
+			continue;
+		}
+		if ((strncmp(f_start, name, name_len) != 0)
+		    || f_start[name_len] != '=') {
+			/* Skip entries not starting with "${name}=" */
+			continue;
+		}
+		/* The value starts just after "${name}=" */
+		f_value_start = &f_start[name_len + 1];
+		/* The length includes the terminating '\0' we wish to insert. */
+		f_value_len = f_end - f_value_start + 1;
+
+		if (buf != NULL && n > 0) {
+			if (f_value_len < n) {
+				/* Copy complete fact. */
+				memcpy(buf, f_value_start, f_value_len);
+				buf[f_value_len - 1] = '\0';
+			} else {
+				/* Copy truncated fact. */
+				memcpy(buf, f_value_start, n);
+				buf[n - 1] = '\0';
+			}
+		}
+
+		/* Return the number of bytes needed to represent the value. */
+		return f_value_len;
+	}
+	return 0;
+}
+
+bool sc_get_bool_fact(const char *facts, const char *name, bool default_value)
+{
+	/* Sufficient to represent "true" and "false" and the terminator. */
+	char value[6];
+
+	if (sc_query_fact(facts, name, value, sizeof value) > 0) {
+		if (sc_streq(value, "true")) {
+			return true;
+		}
+		if (sc_streq(value, "false")) {
+			return false;
+		}
+	}
+	return default_value;
+}

--- a/cmd/libsnap-confine-private/facts.c
+++ b/cmd/libsnap-confine-private/facts.c
@@ -28,7 +28,7 @@
 
 char *sc_load_facts(const char *fname)
 {
-	FILE *f __attribute__ ((cleanup(sc_cleanup_file))) = NULL;
+	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
 	char *buf_copy;
 	size_t nread;
 	char buf[16 * 1024 + 1];

--- a/cmd/libsnap-confine-private/facts.c
+++ b/cmd/libsnap-confine-private/facts.c
@@ -91,17 +91,19 @@ size_t sc_query_fact(const char *facts, const char *name, char *buf, size_t n)
 		}
 		/* The value starts just after "${name}=" */
 		f_value_start = &f_start[name_len + 1];
-		/* The length includes the terminating '\0' we wish to insert. */
+		/* The length includes the terminating '\0' we wish to insert.
+		 * This also the value is never really empty so we can safely
+		 * subtract one from this value in memcpy call below. */
 		f_value_len = f_end - f_value_start + 1;
 
 		if (buf != NULL && n > 0) {
 			if (f_value_len < n) {
 				/* Copy complete fact. */
-				memcpy(buf, f_value_start, f_value_len);
+				memcpy(buf, f_value_start, f_value_len - 1);
 				buf[f_value_len - 1] = '\0';
 			} else {
 				/* Copy truncated fact. */
-				memcpy(buf, f_value_start, n);
+				memcpy(buf, f_value_start, n - 1);
 				buf[n - 1] = '\0';
 			}
 		}

--- a/cmd/libsnap-confine-private/facts.c
+++ b/cmd/libsnap-confine-private/facts.c
@@ -66,7 +66,7 @@ size_t sc_query_fact(const char *facts, const char *name, char *buf, size_t n)
 	}
 	name_len = strlen(name);
 
-	/* Advance from one fact to the next. Each loop finds the next fact. */
+	/* Advance from one fact to the next. Each iteration finds the next fact. */
 	for (f_start = facts; f_start != NULL; f_start = f_next) {
 		/* Facts are delimited with newlines, the last newline is optional. */
 		f_next = strchr(f_start, '\n');

--- a/cmd/libsnap-confine-private/facts.h
+++ b/cmd/libsnap-confine-private/facts.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_FACTS_H
+#define SNAP_CONFINE_FACTS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Facts are stored as multi-line strings using key=value syntax */
+
+/**
+ * Directory where facts are stored by snapd.
+ *
+ * The directory *may* be absent.
+**/
+#define SC_FACT_DIR "/var/lib/snapd/facts"
+
+/**
+ * Load facts from a given file.
+ *
+ * The file must contain key=value facts, one per line. The file may be absent,
+ * it is equivalent to an empty file. Facts are limited to, at most, 16KB of
+ * data.
+ *
+ * The return value must by released by calling free(3).
+ **/
+char *sc_load_facts(const char *fname);
+
+/** 
+ * Find, and possibly copy, a fact with the given name.
+ *
+ * The return value is always the number of bytes needed to represent the
+ * fact, including the terminating '\0' character or 0 if the fact was not
+ * found.
+ *
+ * If a non-empty buffer is provided then up to n bytes of the fact are stored
+ * in the buffer. At all times the buffer is terminated with the '\0'
+ * character.
+**/
+size_t sc_query_fact(const char *facts, const char *name, char *buf, size_t n);
+
+/**
+ * Find the value of a boolean fact with a default value.
+ *
+ * The return value is the boolean interpretation of the fact with the given
+ * name or the default_value if the fact was not available or was not the string
+ * "true" or "false".
+**/
+bool sc_get_bool_fact(const char *facts, const char *name, bool default_value);
+
+#endif


### PR DESCRIPTION
This patch adds a set of functions for loading and examining facts.
Those can be used from snap-confine to control access to experimental
features.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
