### PR TITLE
make sure hostnamectl can be used on core too

### DIFF
--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -34,6 +34,9 @@ const hostnameControlConnectedPlugAppArmor = `
 # /{,usr/}bin/hostname ixr, # already allowed by default
 /etc/hostname w,            # read allowed by default
 
+# on core /etc/hostname is a link to /etc/writable/hostname
+/etc/writable/hostname w,
+
 #include <abstractions/dbus-strict>
 /{,usr/}{,s}bin/hostnamectl           ixr,
 


### PR DESCRIPTION
using /usr/bin/hostnamectl from a hook on core gets blocked even with hostname-control connected:

apparmor="DENIED" operation="open" profile="snap.pi-kiosk.hook.prepare-device" name="/etc/writable/hostname" pid=1942 comm="prepare-device" requested_mask="wc" denied_mask="wc" fsuid=0 ouid=0

make /etc/writable/hostname writable too from this interface to fix this bug.