### PR TITLE
cmd/snap: add a bunch of TRANSLATORS notes (and a little more i18n)

### DIFF
--- a/cmd/snap/cmd_ack.go
+++ b/cmd/snap/cmd_ack.go
@@ -54,7 +54,7 @@ func init() {
 	}, nil, []argDesc{{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		name: i18n.G("<assertion file>"),
-		// TRANSLATORS: This should probably not start with a lowercase letter.
+		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Assertion file"),
 	}})
 }

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -80,7 +80,6 @@ func outputAdviseExactText(command string, result []advisor.Command) error {
 	fmt.Fprintf(Stdout, i18n.G("Command %q not found, but can be installed with:\n"), command)
 	fmt.Fprintf(Stdout, "\n")
 	for _, snap := range result {
-		// TRANSLATORS: %s is a snap name
 		fmt.Fprintf(Stdout, "sudo snap install %s\n", snap.Snap)
 	}
 	fmt.Fprintf(Stdout, "\n")

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -61,24 +61,30 @@ func init() {
 	cmd := addCommand("advise-snap", shortAdviseSnapHelp, longAdviseSnapHelp, func() flags.Commander {
 		return &cmdAdviseSnap{}
 	}, map[string]string{
-		"command":  i18n.G("Advise on snaps that provide the given command"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"command": i18n.G("Advise on snaps that provide the given command"),
+		// TRANSLATORS: This should not start with a lowercase letter.
 		"from-apt": i18n.G("Advise will talk to apt via an apt hook"),
-		"format":   i18n.G("Use the given output format"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"format": i18n.G("Use the given output format"),
 	}, []argDesc{
-		{name: "<command or pkg>"},
+		// TRANSLATORS: This needs to be wrapped in <>s.
+		{name: i18n.G("<command or pkg>")},
 	})
 	cmd.hidden = true
 }
 
 func outputAdviseExactText(command string, result []advisor.Command) error {
 	fmt.Fprintf(Stdout, "\n")
+	// TRANSLATORS: %q is a command name (like "gimp" or "loimpress")
 	fmt.Fprintf(Stdout, i18n.G("Command %q not found, but can be installed with:\n"), command)
 	fmt.Fprintf(Stdout, "\n")
 	for _, snap := range result {
+		// TRANSLATORS: %s is a snap name
 		fmt.Fprintf(Stdout, "sudo snap install %s\n", snap.Snap)
 	}
 	fmt.Fprintf(Stdout, "\n")
-	fmt.Fprintf(Stdout, "See 'snap info <snap name>' for additional versions.\n")
+	fmt.Fprintln(Stdout, i18n.G("See 'snap info <snap name>' for additional versions."))
 	fmt.Fprintf(Stdout, "\n")
 	return nil
 }
@@ -88,10 +94,10 @@ func outputAdviseMisspellText(command string, result []advisor.Command) error {
 	fmt.Fprintf(Stdout, i18n.G("Command %q not found, did you mean:\n"), command)
 	fmt.Fprintf(Stdout, "\n")
 	for _, snap := range result {
-		fmt.Fprintf(Stdout, " command %q from snap %q\n", snap.Command, snap.Snap)
+		fmt.Fprintf(Stdout, i18n.G(" command %q from snap %q\n"), snap.Command, snap.Snap)
 	}
 	fmt.Fprintf(Stdout, "\n")
-	fmt.Fprintf(Stdout, "See 'snap info <snap name>' for additional versions.\n")
+	fmt.Fprintln(Stdout, i18n.G("See 'snap info <snap name>' for additional versions."))
 	fmt.Fprintf(Stdout, "\n")
 	return nil
 }

--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -113,6 +113,6 @@ func printChangedAliases(w io.Writer, label string, changed []*changedAlias) {
 	fmt.Fprintf(w, "%s:\n", label)
 	for _, a := range changed {
 		// TRANSLATORS: the first %s is a snap command (e.g. "hello-world.echo"), the second is the alias
-		fmt.Fprintf(w, "\t- %s as %s\n", snap.JoinSnapApp(a.Snap, a.App), a.Alias)
+		fmt.Fprintf(w, i18n.G("\t- %s as %s\n"), snap.JoinSnapApp(a.Snap, a.App), a.Alias)
 	}
 }

--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -98,9 +98,11 @@ func showAliasChanges(chg *client.Change) error {
 	}
 	w := tabwriter.NewWriter(Stdout, 2, 2, 1, ' ', 0)
 	if len(added) != 0 {
+		// TRANSLATORS: this is used to introduce a list of aliases that were added
 		printChangedAliases(w, i18n.G("Added"), added)
 	}
 	if len(removed) != 0 {
+		// TRANSLATORS: this is used to introduce a list of aliases that were removed
 		printChangedAliases(w, i18n.G("Removed"), removed)
 	}
 	w.Flush()
@@ -110,6 +112,7 @@ func showAliasChanges(chg *client.Change) error {
 func printChangedAliases(w io.Writer, label string, changed []*changedAlias) {
 	fmt.Fprintf(w, "%s:\n", label)
 	for _, a := range changed {
+		// TRANSLATORS: the first %s is a snap command (e.g. "hello-world.echo"), the second is the alias
 		fmt.Fprintf(w, "\t- %s as %s\n", snap.JoinSnapApp(a.Snap, a.App), a.Alias)
 	}
 }

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -242,7 +242,9 @@ func init() {
 		func() flags.Commander {
 			return &cmdAutoImport{}
 		}, map[string]string{
-			"mount":         i18n.G("Temporarily mount device before inspecting"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"mount": i18n.G("Temporarily mount device before inspecting"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"force-classic": i18n.G("Force import on classic systems"),
 		}, nil)
 	cmd.hidden = true

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -47,7 +47,7 @@ func init() {
 		return &cmdBuy{}
 	}, map[string]string{}, []argDesc{{
 		name: "<snap>",
-		// TRANSLATORS: This should probably not start with a lowercase letter.
+		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Snap name"),
 	}})
 }

--- a/cmd/snap/cmd_create_key.go
+++ b/cmd/snap/cmd_create_key.go
@@ -48,7 +48,7 @@ used for signing assertions.
 		}, nil, []argDesc{{
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<key-name>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to create; defaults to 'default'"),
 		}})
 	cmd.hidden = true

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -52,14 +52,18 @@ type cmdCreateUser struct {
 func init() {
 	cmd := addCommand("create-user", shortCreateUserHelp, longCreateUserHelp, func() flags.Commander { return &cmdCreateUser{} },
 		map[string]string{
-			"json":          i18n.G("Output results in JSON format"),
-			"sudoer":        i18n.G("Grant sudo access to the created user"),
-			"known":         i18n.G("Use known assertions for user creation"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"json": i18n.G("Output results in JSON format"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"sudoer": i18n.G("Grant sudo access to the created user"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"known": i18n.G("Use known assertions for user creation"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"force-managed": i18n.G("Force adding the user, even if the device is already managed"),
 		}, []argDesc{{
 			// TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
 			name: i18n.G("<email>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+			// TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 			desc: i18n.G("An email of a user on login.ubuntu.com"),
 		}})
 	cmd.hidden = true

--- a/cmd/snap/cmd_delete_key.go
+++ b/cmd/snap/cmd_delete_key.go
@@ -44,7 +44,7 @@ the given name.
 		}, nil, []argDesc{{
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<key-name>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to delete"),
 		}})
 	cmd.hidden = true

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -56,7 +56,7 @@ func init() {
 		"revision": i18n.G("Download the given revision of a snap, to which you must have developer access"),
 	}), []argDesc{{
 		name: "<snap>",
-		// TRANSLATORS: This should probably not start with a lowercase letter.
+		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Snap name"),
 	}})
 }

--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -50,7 +50,7 @@ imported by other systems.
 		}, []argDesc{{
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<key-name>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to export"),
 		}})
 	cmd.hidden = true

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -164,8 +164,11 @@ func init() {
 	addCommand("find", shortFindHelp, longFindHelp, func() flags.Commander {
 		return &cmdFind{}
 	}, colorDescs.also(map[string]string{
+		// TRANSLATORS: This should not start with a lowercase letter.
 		"private": i18n.G("Search private snaps"),
-		"narrow":  i18n.G("Only search for snaps in “stable”"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"narrow": i18n.G("Only search for snaps in “stable”"),
+		// TRANSLATORS: This should not start with a lowercase letter.
 		"section": i18n.G("Restrict the search to a given section"),
 	}), []argDesc{{
 		// TRANSLATORS: This needs to be wrapped in <>s.

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -66,19 +66,22 @@ type cmdGet struct {
 func init() {
 	addCommand("get", shortGetHelp, longGetHelp, func() flags.Commander { return &cmdGet{} },
 		map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"d": i18n.G("Always return document, even with single key"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"l": i18n.G("Always return list, even with single key"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"t": i18n.G("Strict typing with nulls and quoted strings"),
 		}, []argDesc{
 			{
 				name: "<snap>",
-				// TRANSLATORS: This should probably not start with a lowercase letter.
+				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The snap whose conf is being requested"),
 			},
 			{
 				// TRANSLATORS: This needs to be wrapped in <>s.
 				name: i18n.G("<key>"),
-				// TRANSLATORS: This should probably not start with a lowercase letter.
+				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("Key of interest within the configuration"),
 			},
 		})

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -70,7 +70,10 @@ type cmdHelp struct {
 
 func init() {
 	addCommand("help", shortHelpHelp, longHelpHelp, func() flags.Commander { return &cmdHelp{} },
-		map[string]string{"man": i18n.G("Generate the manpage")}, nil)
+		map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"man": i18n.G("Generate the manpage"),
+		}, nil)
 }
 
 func (cmd *cmdHelp) setParser(parser *flags.Parser) {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -67,6 +67,7 @@ func init() {
 		func() flags.Commander {
 			return &infoCmd{}
 		}, colorDescs.also(timeDescs).also(map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"verbose": i18n.G("Include more details on the snap (expanded notes, base, etc.)"),
 		}), nil)
 }

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -53,12 +53,14 @@ func init() {
 	addCommand("interface", shortInterfaceHelp, longInterfaceHelp, func() flags.Commander {
 		return &cmdInterface{}
 	}, map[string]string{
+		// TRANSLATORS: This should not start with a lowercase letter.
 		"attrs": i18n.G("Show interface attributes"),
-		"all":   i18n.G("Include unused interfaces"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"all": i18n.G("Include unused interfaces"),
 	}, []argDesc{{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		name: i18n.G("<interface>"),
-		// TRANSLATORS: This should probably not start with a lowercase letter.
+		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Show details of a specific interface"),
 	}})
 }

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -59,11 +59,12 @@ func init() {
 	addCommand("interfaces", shortInterfacesHelp, longInterfacesHelp, func() flags.Commander {
 		return &cmdInterfaces{}
 	}, map[string]string{
+		// TRANSLATORS: This should not start with a lowercase letter.
 		"i": i18n.G("Constrain listing to specific interfaces"),
 	}, []argDesc{{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		name: i18n.G("<snap>:<slot or plug>"),
-		// TRANSLATORS: This should probably not start with a lowercase letter.
+		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Constrain listing to a specific snap or snap:name"),
 	}})
 }

--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -42,7 +42,10 @@ assertions.
 `),
 		func() flags.Commander {
 			return &cmdKeys{}
-		}, map[string]string{"json": i18n.G("Output results in JSON format")}, nil)
+		}, map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"json": i18n.G("Output results in JSON format"),
+		}, nil)
 	cmd.hidden = true
 }
 

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -56,12 +56,12 @@ func init() {
 		{
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<assertion type>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Assertion type name"),
 		}, {
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<header filter>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Constrain listing to those matching header=value"),
 		},
 	})

--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -54,6 +54,7 @@ type cmdList struct {
 func init() {
 	addCommand("list", shortListHelp, longListHelp, func() flags.Commander { return &cmdList{} },
 		colorDescs.also(map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"all": i18n.G("Show all revisions"),
 		}), nil)
 }

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -60,7 +60,7 @@ func init() {
 		}, nil, []argDesc{{
 			// TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
 			name: i18n.G("<email>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 			desc: i18n.G("The login.ubuntu.com email to login as"),
 		}})
 }

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -58,6 +58,7 @@ func init() {
 		func() flags.Commander {
 			return &packCmd{}
 		}, map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"check-skeleton": i18n.G("Validate snap-dir metadata only"),
 		}, nil)
 }

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -49,9 +49,9 @@ core device images.
 			return &cmdPrepareImage{}
 		}, map[string]string{
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"extra-snaps": "Extra snaps to be installed",
+			"extra-snaps": i18n.G("Extra snaps to be installed"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"channel": "The channel to use",
+			"channel": i18n.G("The channel to use"),
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to be wrapped in <>s.

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -48,18 +48,20 @@ core device images.
 		func() flags.Commander {
 			return &cmdPrepareImage{}
 		}, map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"extra-snaps": "Extra snaps to be installed",
-			"channel":     "The channel to use",
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"channel": "The channel to use",
 		}, []argDesc{
 			{
 				// TRANSLATORS: This needs to be wrapped in <>s.
 				name: i18n.G("<model-assertion>"),
-				// TRANSLATORS: This should probably not start with a lowercase letter.
+				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The model assertion name"),
 			}, {
 				// TRANSLATORS: This needs to be wrapped in <>s.
 				name: i18n.G("<root-dir>"),
-				// TRANSLATORS: This should probably not start with a lowercase letter.
+				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The output directory"),
 			},
 		})

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -84,12 +84,19 @@ and environment.
 		func() flags.Commander {
 			return &cmdRun{}
 		}, map[string]string{
-			"command":    i18n.G("Alternative command to run"),
-			"hook":       i18n.G("Hook to run"),
-			"r":          i18n.G("Use a specific snap revision when running hook"),
-			"shell":      i18n.G("Run a shell instead of the command (useful for debugging)"),
-			"strace":     i18n.G("Run the command under strace (useful for debugging). Extra strace options can be specified as well here. Pass --raw to strace early snap helpers."),
-			"gdb":        i18n.G("Run the command with gdb"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"command": i18n.G("Alternative command to run"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"hook": i18n.G("Hook to run"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"r": i18n.G("Use a specific snap revision when running hook"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"shell": i18n.G("Run a shell instead of the command (useful for debugging)"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"strace": i18n.G("Run the command under strace (useful for debugging). Extra strace options can be specified as well here. Pass --raw to strace early snap helpers."),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"gdb": i18n.G("Run the command with gdb"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"timer":      i18n.G("Run as a timer service with given schedule"),
 			"parser-ran": "",
 		}, nil)

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -77,25 +77,31 @@ func init() {
 	argdescs := []argDesc{{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		name: i18n.G("<service>"),
+		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("A service specification, which can be just a snap name (for all services in the snap), or <snap>.<app> for a single service."),
 	}}
 	addCommand("services", shortServicesHelp, longServicesHelp, func() flags.Commander { return &svcStatus{} }, nil, argdescs)
 	addCommand("logs", shortLogsHelp, longLogsHelp, func() flags.Commander { return &svcLogs{} },
 		map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"n": i18n.G("Show only the given number of lines, or 'all'."),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"f": i18n.G("Wait for new lines and print them as they come in."),
 		}, argdescs)
 
 	addCommand("start", shortStartHelp, longStartHelp, func() flags.Commander { return &svcStart{} },
 		waitDescs.also(map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"enable": i18n.G("As well as starting the service now, arrange for it to be started on boot."),
 		}), argdescs)
 	addCommand("stop", shortStopHelp, longStopHelp, func() flags.Commander { return &svcStop{} },
 		waitDescs.also(map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"disable": i18n.G("As well as stopping the service now, arrange for it to no longer be started on boot."),
 		}), argdescs)
 	addCommand("restart", shortRestartHelp, longRestartHelp, func() flags.Commander { return &svcRestart{} },
 		waitDescs.also(map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"reload": i18n.G("If the service has a reload command, use it instead of restarting."),
 		}), argdescs)
 }

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -55,12 +55,12 @@ func init() {
 	addCommand("set", shortSetHelp, longSetHelp, func() flags.Commander { return &cmdSet{} }, waitDescs, []argDesc{
 		{
 			name: "<snap>",
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("The snap to configure (e.g. hello-world)"),
 		}, {
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<conf value>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Configuration value (key=value)"),
 		},
 	})

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -44,7 +44,10 @@ type cmdSign struct {
 func init() {
 	cmd := addCommand("sign", shortSignHelp, longSignHelp, func() flags.Commander {
 		return &cmdSign{}
-	}, map[string]string{"k": i18n.G("Name of the key to use, otherwise use the default key")}, nil)
+	}, map[string]string{
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"k": i18n.G("Name of the key to use, otherwise use the default key"),
+	}, nil)
 	cmd.hidden = true
 }
 

--- a/cmd/snap/cmd_sign_build.go
+++ b/cmd/snap/cmd_sign_build.go
@@ -56,14 +56,18 @@ func init() {
 		func() flags.Commander {
 			return &cmdSignBuild{}
 		}, map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"developer-id": i18n.G("Identifier of the signer"),
-			"snap-id":      i18n.G("Identifier of the snap package associated with the build"),
-			"k":            i18n.G("Name of the GnuPG key to use (defaults to 'default' as key name)"),
-			"grade":        i18n.G("Grade states the build quality of the snap (defaults to 'stable')"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"snap-id": i18n.G("Identifier of the snap package associated with the build"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"k": i18n.G("Name of the GnuPG key to use (defaults to 'default' as key name)"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"grade": i18n.G("Grade states the build quality of the snap (defaults to 'stable')"),
 		}, []argDesc{{
 			// TRANSLATORS: This needs to be wrapped in <>s.
 			name: i18n.G("<filename>"),
-			// TRANSLATORS: This should probably not start with a lowercase letter.
+			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Filename of the snap you want to assert a build for"),
 		}})
 	cmd.hidden = true

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -211,11 +211,16 @@ func (mxd mixinDescs) also(m map[string]string) mixinDescs {
 }
 
 var channelDescs = mixinDescs{
-	"channel":   i18n.G("Use this channel instead of stable"),
-	"beta":      i18n.G("Install from the beta channel"),
-	"edge":      i18n.G("Install from the edge channel"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
+	"channel": i18n.G("Use this channel instead of stable"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
+	"beta": i18n.G("Install from the beta channel"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
+	"edge": i18n.G("Install from the edge channel"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
 	"candidate": i18n.G("Install from the candidate channel"),
-	"stable":    i18n.G("Install from the stable channel"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
+	"stable": i18n.G("Install from the stable channel"),
 }
 
 func (mx *channelMixin) setChannelFromCommandline() error {
@@ -301,8 +306,11 @@ type modeMixin struct {
 }
 
 var modeDescs = mixinDescs{
-	"classic":  i18n.G("Put snap in classic mode and disable security confinement"),
-	"devmode":  i18n.G("Put snap in development mode and disable security confinement"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
+	"classic": i18n.G("Put snap in classic mode and disable security confinement"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
+	"devmode": i18n.G("Put snap in development mode and disable security confinement"),
+	// TRANSLATORS: this should start with an upper case character (if they exist)
 	"jailmode": i18n.G("Put snap in enforced confinement mode"),
 }
 
@@ -900,28 +908,42 @@ func (x cmdSwitch) Execute(args []string) error {
 
 func init() {
 	addCommand("remove", shortRemoveHelp, longRemoveHelp, func() flags.Commander { return &cmdRemove{} },
-		waitDescs.also(map[string]string{"revision": i18n.G("Remove only the given revision")}), nil)
+		waitDescs.also(map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"revision": i18n.G("Remove only the given revision"),
+		}), nil)
 	addCommand("install", shortInstallHelp, longInstallHelp, func() flags.Commander { return &cmdInstall{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(map[string]string{
-			"revision":        i18n.G("Install the given revision of a snap, to which you must have developer access"),
-			"dangerous":       i18n.G("Install the given snap file even if there are no pre-acknowledged signatures for it, meaning it was not verified and could be dangerous (--devmode implies this)"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"revision": i18n.G("Install the given revision of a snap, to which you must have developer access"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"dangerous": i18n.G("Install the given snap file even if there are no pre-acknowledged signatures for it, meaning it was not verified and could be dangerous (--devmode implies this)"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"force-dangerous": i18n.G("Alias for --dangerous (DEPRECATED)"),
-			"unaliased":       i18n.G("Install the given snap without enabling its automatic aliases"),
-			"name":            i18n.G("Install the snap file under given snap name"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"unaliased": i18n.G("Install the given snap without enabling its automatic aliases"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"name": i18n.G("Install the snap file under given snap name"),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{
-			"amend":             i18n.G("Allow refresh attempt on snap unknown to the store"),
-			"revision":          i18n.G("Refresh to the given revision, to which you must have developer access"),
-			"list":              i18n.G("Show available snaps for refresh but do not perform a refresh"),
-			"time":              i18n.G("Show auto refresh information but do not perform a refresh"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"amend": i18n.G("Allow refresh attempt on snap unknown to the store"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"revision": i18n.G("Refresh to the given revision, to which you must have developer access"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"list": i18n.G("Show available snaps for refresh but do not perform a refresh"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"time": i18n.G("Show auto refresh information but do not perform a refresh"),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"ignore-validation": i18n.G("Ignore validation by other snaps blocking the refresh"),
 		}), nil)
 	addCommand("try", shortTryHelp, longTryHelp, func() flags.Commander { return &cmdTry{} }, waitDescs.also(modeDescs), nil)
 	addCommand("enable", shortEnableHelp, longEnableHelp, func() flags.Commander { return &cmdEnable{} }, waitDescs, nil)
 	addCommand("disable", shortDisableHelp, longDisableHelp, func() flags.Commander { return &cmdDisable{} }, waitDescs, nil)
 	addCommand("revert", shortRevertHelp, longRevertHelp, func() flags.Commander { return &cmdRevert{} }, waitDescs.also(modeDescs).also(map[string]string{
-		"revision": "Revert to the given revision",
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"revision": i18n.G("Revert to the given revision"),
 	}), nil)
 	addCommand("switch", shortSwitchHelp, longSwitchHelp, func() flags.Commander { return &cmdSwitch{} }, waitDescs.also(channelDescs), nil)
 }

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -49,6 +49,7 @@ func init() {
 		func() flags.Commander {
 			return &cmdUserd{}
 		}, map[string]string{
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"autostart": i18n.G("Autostart user applications"),
 		}, nil)
 	cmd.hidden = true

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -49,12 +49,12 @@ func init() {
 		}, nil, []argDesc{
 			{
 				name: "<snap>",
-				// TRANSLATORS: This should probably not start with a lowercase letter.
+				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The snap for which configuration will be checked"),
 			}, {
 				// TRANSLATORS: This needs to be wrapped in <>s.
 				name: i18n.G("<key>"),
-				// TRANSLATORS: This should probably not start with a lowercase letter.
+				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("Key of interest within the configuration"),
 			},
 		})

--- a/cmd/snap/cmd_warnings.go
+++ b/cmd/snap/cmd_warnings.go
@@ -65,7 +65,9 @@ sufficient time has passed.
 
 func init() {
 	addCommand("warnings", shortWarningsHelp, longWarningsHelp, func() flags.Commander { return &cmdWarnings{} }, timeDescs.also(map[string]string{
-		"all":     i18n.G("Show all warnings"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"all": i18n.G("Show all warnings"),
+		// TRANSLATORS: This should not start with a lowercase letter.
 		"verbose": i18n.G("Show more information"),
 	}), nil)
 	addCommand("okay", shortOkayHelp, longOkayHelp, func() flags.Commander { return &cmdOkay{} }, nil, nil)

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -99,7 +99,9 @@ func colorTable(mode string) escapes {
 }
 
 var colorDescs = mixinDescs{
-	"color":   i18n.G("Use a little bit of color to highlight some things."),
+	// TRANSLATORS: This should not start with a lowercase letter.
+	"color": i18n.G("Use a little bit of color to highlight some things."),
+	// TRANSLATORS: This should not start with a lowercase letter.
 	"unicode": i18n.G("Use a little bit of Unicode to improve legibility."),
 }
 

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -36,13 +36,14 @@ type changeIDMixin struct {
 }
 
 var changeIDMixinOptDesc = mixinDescs{
+	// TRANSLATORS: This should not start with a lowercase letter.
 	"last": i18n.G("Select last change of given type (install, refresh, remove, try, auto-refresh, etc.). A question mark at the end of the type means to do nothing (instead of returning an error) if no change of the given type is found. Note the question mark could need protecting from the shell."),
 }
 
 var changeIDMixinArgDesc = []argDesc{{
 	// TRANSLATORS: This needs to be wrapped in <>s.
 	name: i18n.G("<change-id>"),
-	// TRANSLATORS: This should probably not start with a lowercase letter.
+	// TRANSLATORS: This should not start with a lowercase letter.
 	desc: i18n.G("Change ID"),
 }}
 

--- a/cmd/snap/times.go
+++ b/cmd/snap/times.go
@@ -33,6 +33,7 @@ type timeMixin struct {
 }
 
 var timeDescs = mixinDescs{
+	// TRANSLATORS: This should not start with a lowercase letter.
 	"abs-time": i18n.G("Display absolute times (in RFC 3339 format). Otherwise, display relative times up to 60 days, then YYYY-MM-DD."),
 }
 

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -43,6 +43,7 @@ type waitMixin struct {
 }
 
 var waitDescs = mixinDescs{
+	// TRANSLATORS: This should not start with a lowercase letter.
 	"no-wait": i18n.G("Do not wait for the operation to finish but just print the change id."),
 }
 


### PR DESCRIPTION
All option descriptions were missing a TRANSLATORS note about not
starting the description with lowercase; I've added that. I've also
removed the ambiguous "probably" from the existing note on argument
descriptions, and clarified it in the two cases where the probability
was relevant.

Also, and opportunistically (and only at first because this PR got too
big), I added some i18n.G's that were missing.

I recommend you read this diff with the "ignore whitespace" option turned on.