### PR TITLE
tests/main/snap-env: extend to cover parallel installations of snaps

### DIFF
--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -1,63 +1,85 @@
 summary: inspect all the set environment variables prefixed with SNAP_ and XDG_
 
+environment:
+    NAME: test-snapd-tools
+    INSTANCE_KEY:
+    NAME/parallel: test-snapd-tools_foo
+    INSTANCE_KEY/parallel: foo
+
 prepare: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-tools
+
+    if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
+        snap set system experimental.parallel-instances=true
+    fi
+    # shellcheck disable=SC2153
+    install_local_as test-snapd-tools "$NAME"
 
 restore: |
     rm -f ./*.snap
     rm -f ./*-vars.txt
+
+    if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
+        snap set system experimental.parallel-instances=null
+    fi
 
 debug: |
     cat ./*-vars.txt
 
 execute: |
     echo "Collect SNAP and XDG environment variables"
-    test-snapd-tools.env | grep -E '^SNAP_' | sort > snap-vars.txt
-    test-snapd-tools.env | grep -E '^XDG_' | sort > xdg-vars.txt
-    test-snapd-tools.env | grep -E '^EXTRA_' | sort > extra-vars.txt
+    "$NAME".env | grep -E '^SNAP_' | sort > snap-vars.txt
+    "$NAME".env | grep -E '^XDG_' | sort > xdg-vars.txt
+    "$NAME".env | grep -E '^EXTRA_' | sort > extra-vars.txt
 
     echo "Collect PATH and HOME environment variables"
-    test-snapd-tools.env | grep -E '^(SNAP|PATH|HOME)=' | sort > misc-vars.txt
+    "$NAME".env | grep -E '^(SNAP|PATH|HOME)=' | sort > misc-vars.txt
 
     echo "Ensure that SNAP environment variables are what we expect"
     MATCH '^SNAP_ARCH=(amd64|i386|arm64|armhf|ppc64el|s390x)$'            < snap-vars.txt
+    # parallel-installs: global snap directories are remapped to $SNAP_NAME
     MATCH '^SNAP_COMMON=/var/snap/test-snapd-tools/common$'               < snap-vars.txt
     MATCH '^SNAP_DATA=/var/snap/test-snapd-tools/x1$'                     < snap-vars.txt
     MATCH '^SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void$' < snap-vars.txt
-    MATCH '^SNAP_NAME=test-snapd-tools$'                                  < snap-vars.txt
     # XXX: probably not something we ought to test
     # egrep -q '^SNAP_REEXEC=0$' snap-vars.txt
     MATCH '^SNAP_REVISION=x1$'                                            < snap-vars.txt
-    MATCH '^SNAP_USER_COMMON=/root/snap/test-snapd-tools/common$'         < snap-vars.txt
-    MATCH '^SNAP_USER_DATA=/root/snap/test-snapd-tools/x1$'               < snap-vars.txt
+    # parallel-installs: user directories are instance specific
+    MATCH "^SNAP_USER_COMMON=/root/snap/$NAME/common$"                    < snap-vars.txt
+    MATCH "^SNAP_USER_DATA=/root/snap/$NAME/x1$"                          < snap-vars.txt
     MATCH '^SNAP_VERSION=1.0$'                                            < snap-vars.txt
-    CTX=$(cat /var/lib/snapd/cookie/snap.test-snapd-tools)
+    CTX=$(cat "/var/lib/snapd/cookie/snap.$NAME")
     MATCH "^SNAP_COOKIE=$CTX"                                             < snap-vars.txt
     MATCH "^SNAP_CONTEXT=$CTX"                                            < snap-vars.txt
-    # TODO parallel-install: install snap with instance key and verify variables
-    MATCH '^SNAP_INSTANCE_NAME=test-snapd-tools$'                         < snap-vars.txt
-    MATCH '^SNAP_INSTANCE_KEY=$'                                          < snap-vars.txt
+    # parallel-installs: $SNAP_NAME is always _the_ snap name
+    MATCH '^SNAP_NAME=test-snapd-tools$'                                  < snap-vars.txt
+    # parallel-install: name of a particular instance
+    MATCH "^SNAP_INSTANCE_NAME=$NAME$"                                    < snap-vars.txt
+    # parallel-installs: empty if none is set
+    MATCH "^SNAP_INSTANCE_KEY=$INSTANCE_KEY$"                             < snap-vars.txt
     test "$(wc -l < snap-vars.txt)" -eq 14
 
     echo "Enure that XDG environment variables are what we expect"
-    MATCH '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$'  < xdg-vars.txt
+    # parallel-installs: xdg directory is instance specific
+    MATCH "^XDG_RUNTIME_DIR=/run/user/0/snap.$NAME$"  < xdg-vars.txt
     test "$(wc -l < xdg-vars.txt)" -ge 1
 
     echo "Enure that EXTRA environment variables are what we expect"
     MATCH '^EXTRA_GLOBAL=extra-global'                             < extra-vars.txt
     MATCH '^EXTRA_LOCAL=extra-local'                               < extra-vars.txt
     MATCH '^EXTRA_LOCAL_NESTED=extra-global-nested'                < extra-vars.txt
-    MATCH "^EXTRA_CACHE_DIR=$HOME/snap/test-snapd-tools/x1/.cache" < extra-vars.txt
+    MATCH "^EXTRA_CACHE_DIR=$HOME/snap/$NAME/x1/.cache"            < extra-vars.txt
     MATCH '^EXTRA_LOCAL_PATH=/snap/test-snapd-tools/x1/bin:/snap/test-snapd-tools/x1/usr/bin:/usr/bin' < extra-vars.txt
     test "$(wc -l < extra-vars.txt)" -eq 5
 
     echo "Ensure that TMPDIR is not passed through to a confined snap"
-    TMPDIR=/foobar test-snapd-tools.env | grep -qv ^TMPDIR=
+    TMPDIR=/foobar "$NAME".env | grep -qv ^TMPDIR=
 
     echo "Ensure that SNAP, PATH and HOME are what we expect"
+    # parallel-installs: $SNAP is remapped to appear under $SNAP_NAME
     MATCH "^SNAP=/snap/test-snapd-tools/x1$"                                                                < misc-vars.txt
     MATCH '^PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games$' < misc-vars.txt
-    MATCH '^HOME=/root/snap/test-snapd-tools/x1$'                                                           < misc-vars.txt
+    # parallel-installs: $HOME is set to instance specific path
+    MATCH "^HOME=/root/snap/$NAME/x1$"                                                                      < misc-vars.txt
     test "$(wc -l < misc-vars.txt)" -eq 3

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -1,8 +1,8 @@
 summary: inspect all the set environment variables prefixed with SNAP_ and XDG_
 
 environment:
-    NAME: test-snapd-tools
-    INSTANCE_KEY:
+    NAME/regular: test-snapd-tools
+    INSTANCE_KEY/regular:
     NAME/parallel: test-snapd-tools_foo
     INSTANCE_KEY/parallel: foo
 


### PR DESCRIPTION
Now that we can run parallel installed snaps, add parallel installs variant of the test.

