### PR TITLE
snap: detect layouts vs layout in snap.yaml

### DIFF
--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -54,7 +54,7 @@ type snapYaml struct {
 	Hooks            map[string]hookYaml    `yaml:"hooks,omitempty"`
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
 
-	// typoLayouts "layouts" exists to detect the incorrect plural form of "layout".
+	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
 	TypoLayouts interface{} `yaml:"layouts,omitempty"`
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -53,6 +53,9 @@ type snapYaml struct {
 	Apps             map[string]appYaml     `yaml:"apps,omitempty"`
 	Hooks            map[string]hookYaml    `yaml:"hooks,omitempty"`
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
+
+	// typeLayouts "layouts" exists to detect the incorrect plural form of "layout".
+	TypoLayouts map[string]interface{} `yaml:"layouts,omitempty"`
 }
 
 type appYaml struct {
@@ -182,6 +185,10 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 				User: user, Group: group, Mode: mode,
 			}
 		}
+	}
+
+	if y.TypoLayouts != nil {
+		return nil, fmt.Errorf("incorrect layout definition, please use singular form (layout)")
 	}
 
 	// Rename specific plugs on the core snap.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -54,7 +54,7 @@ type snapYaml struct {
 	Hooks            map[string]hookYaml    `yaml:"hooks,omitempty"`
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
 
-	// typeLayouts "layouts" exists to detect the incorrect plural form of "layout".
+	// typoLayouts "layouts" exists to detect the incorrect plural form of "layout".
 	TypoLayouts map[string]interface{} `yaml:"layouts,omitempty"`
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -188,7 +188,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	}
 
 	if y.TypoLayouts != nil {
-		return nil, fmt.Errorf("incorrect layout definition, please use singular form (layout)")
+		return nil, fmt.Errorf(`cannot use "layouts" (plural), please use singular "layout" instead`)
 	}
 
 	// Rename specific plugs on the core snap.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -55,13 +55,15 @@ type snapYaml struct {
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
 
 	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
-	TypoLayouts layoutsUnmarshalError `yaml:"layouts,omitempty"`
+	TypoLayouts typoDetector `yaml:"layouts,omitempty"`
 }
 
-type layoutsUnmarshalError struct{}
+type typoDetector struct {
+	Hint string
+}
 
-func (*layoutsUnmarshalError) UnmarshalYAML(func(interface{}) error) error {
-	return fmt.Errorf(`cannot use "layouts" (plural), please use singular "layout" instead`)
+func (td *typoDetector) UnmarshalYAML(func(interface{}) error) error {
+	return fmt.Errorf("typo detected: %s", td.Hint)
 }
 
 type appYaml struct {
@@ -125,6 +127,8 @@ type socketsYaml struct {
 // InfoFromSnapYaml creates a new info based on the given snap.yaml data
 func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	var y snapYaml
+	// Customize hints for the typo detector.
+	y.TypoLayouts.Hint = `use singular "layout" instead of plural "layouts"`
 	err := yaml.Unmarshal(yamlData, &y)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse snap.yaml: %s", err)

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -55,7 +55,7 @@ type snapYaml struct {
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
 
 	// typoLayouts "layouts" exists to detect the incorrect plural form of "layout".
-	TypoLayouts map[string]interface{} `yaml:"layouts,omitempty"`
+	TypoLayouts interface{} `yaml:"layouts,omitempty"`
 }
 
 type appYaml struct {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -55,7 +55,13 @@ type snapYaml struct {
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
 
 	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
-	TypoLayouts interface{} `yaml:"layouts,omitempty"`
+	TypoLayouts layoutsUnmarshalError `yaml:"layouts,omitempty"`
+}
+
+type layoutsUnmarshalError struct{}
+
+func (*layoutsUnmarshalError) UnmarshalYAML(func(interface{}) error) error {
+	return fmt.Errorf(`cannot use "layouts" (plural), please use singular "layout" instead`)
 }
 
 type appYaml struct {
@@ -185,10 +191,6 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 				User: user, Group: group, Mode: mode,
 			}
 		}
-	}
-
-	if y.TypoLayouts != nil {
-		return nil, fmt.Errorf(`cannot use "layouts" (plural), please use singular "layout" instead`)
 	}
 
 	// Rename specific plugs on the core snap.

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1702,7 +1702,7 @@ layouts:
     bind: $SNAP/usr/share/foo
 `)
 	info, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, ErrorMatches, `cannot use "layouts" \(plural\), please use singular "layout" instead`)
+	c.Assert(err, ErrorMatches, `cannot parse snap.yaml: cannot use "layouts" \(plural\), please use singular "layout" instead`)
 	c.Assert(info, IsNil)
 }
 

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1702,7 +1702,7 @@ layouts:
     bind: $SNAP/usr/share/foo
 `)
 	info, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, ErrorMatches, "incorrect layout definition, please use singular form \\(layout\\)")
+	c.Assert(err, ErrorMatches, `cannot use "layouts" \(plural\), please use singular "layout" instead`)
 	c.Assert(info, IsNil)
 }
 

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1702,7 +1702,7 @@ layouts:
     bind: $SNAP/usr/share/foo
 `)
 	info, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, ErrorMatches, `cannot parse snap.yaml: cannot use "layouts" \(plural\), please use singular "layout" instead`)
+	c.Assert(err, ErrorMatches, `cannot parse snap.yaml: typo detected: use singular "layout" instead of plural "layouts"`)
 	c.Assert(info, IsNil)
 }
 

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1693,6 +1693,19 @@ layout:
 	})
 }
 
+func (s *YamlSuite) TestLayoutsWithTypo(c *C) {
+	y := []byte(`
+name: foo
+version: 1.0
+layouts:
+  /usr/share/foo:
+    bind: $SNAP/usr/share/foo
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, ErrorMatches, "incorrect layout definition, please use singular form \\(layout\\)")
+	c.Assert(info, IsNil)
+}
+
 func (s *YamlSuite) TestSnapYamlAppTimer(c *C) {
 	y := []byte(`name: wat
 version: 42


### PR DESCRIPTION
This patch adds a check for a typo that people can easily make when
experimenting with snap layouts. The yaml is defined to use the singular
form but there used to be no notification when the plural form was used.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
