### PR TITLE
snapstate: only report errors if there is an actual error 

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -252,7 +252,7 @@ func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error
 		return "", err
 	}
 	if err := db.MarkReported(dupSig); err != nil {
-		logger.Noticef("cannot mark %s as reported", oopsID)
+		logger.Noticef("cannot mark %s as reported: %s", oopsID, err)
 	}
 
 	return oopsID, nil

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -383,7 +383,17 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 		extra["UbuntuCoreTransitionCount"] = strconv.Itoa(ubuntuCoreTransitionCount)
 	}
 
-	if !settings.ProblemReportsDisabled(st) {
+	// Only report and error if there is an actual error in the change,
+	// we could undo things because the user canceled the change.
+	isErr := func() bool {
+		for _, tt := range t.Change().Tasks() {
+			if tt.Status() == state.ErrorStatus {
+				return true
+			}
+		}
+		return false
+	}
+	if isErr() && !settings.ProblemReportsDisabled(st) {
 		st.Unlock()
 		oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, strings.Join(logMsg, "\n"), strings.Join(dupSig, "\n"), extra)
 		st.Lock()

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -385,15 +385,14 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// Only report and error if there is an actual error in the change,
 	// we could undo things because the user canceled the change.
-	isErr := func() bool {
-		for _, tt := range t.Change().Tasks() {
-			if tt.Status() == state.ErrorStatus {
-				return true
-			}
+	var isErr bool
+	for _, tt := range t.Change().Tasks() {
+		if tt.Status() == state.ErrorStatus {
+			isErr = true
+			break
 		}
-		return false
 	}
-	if isErr() && !settings.ProblemReportsDisabled(st) {
+	if isErr && !settings.ProblemReportsDisabled(st) {
 		st.Unlock()
 		oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, strings.Join(logMsg, "\n"), strings.Join(dupSig, "\n"), extra)
 		st.Lock()


### PR DESCRIPTION
The code in the undo handler was too naive. It would report errors
even if the change was aborted and not actually errored. This PR
fixes this and only report real errors.