### PR TITLE
tests/main/parallel-install-local: rename from *-sideload, extend to run snaps

### DIFF
--- a/tests/main/parallel-install-local/task.yaml
+++ b/tests/main/parallel-install-local/task.yaml
@@ -7,7 +7,7 @@ execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
 
-    echo "Sideload the regular snap"
+    echo "Install the regular snap"
     install_local test-snapd-tools
 
     #shellcheck source=tests/lib/dirs.sh
@@ -19,7 +19,7 @@ execute: |
     snap set system experimental.parallel-instances=true
 
     for instance in foo longname; do
-        echo "Sideload same snap as different instance named test-snapd-tools_$instance"
+        echo "Install snap instance named test-snapd-tools_$instance"
         expected="^test-snapd-tools_$instance 1.0 installed\$"
         install_local_as test-snapd-tools "test-snapd-tools_$instance" | MATCH "$expected"
 

--- a/tests/main/parallel-install-local/task.yaml
+++ b/tests/main/parallel-install-local/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks parallel installation of snaps from local files
 
-restore:
+restore: |
     snap set system experimental.parallel-instances=null
 
 execute: |

--- a/tests/main/parallel-install-sideload/task.yaml
+++ b/tests/main/parallel-install-sideload/task.yaml
@@ -1,4 +1,7 @@
-summary: Checks for parallel installation of sideloaded snaps
+summary: Checks parallel installation of snaps from local files
+
+restore:
+    snap set system experimental.parallel-instances=null
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh
@@ -22,10 +25,12 @@ execute: |
 
         test -d "$SNAP_MOUNT_DIR/test-snapd-tools_$instance/x1"
 
-        # TODO parallel-install: this is expected to fail until the remaining
-        # bits land
-        ! su -l -c "test-snapd-tools_$instance.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
-        # MATCH "hello user data from test-snapd-tools_$instance" < "/home/test/snap/test-snapd-tools_$instance/x1/data"
+        #shellcheck disable=SC2016
+        "test-snapd-tools_$instance.cmd" sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
+        MATCH "hello data from test-snapd-tools_$instance" < "/var/snap/test-snapd-tools_$instance/x1/data"
+
+        su -l -c "test-snapd-tools_$instance.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
+        MATCH "hello user data from test-snapd-tools_$instance" < "/home/test/snap/test-snapd-tools_$instance/x1/data"
     done
 
     echo "All snaps are listed"
@@ -38,5 +43,3 @@ execute: |
     test -d "$SNAP_MOUNT_DIR/test-snapd-tools_longname/x1"
     test -d "$SNAP_MOUNT_DIR/test-snapd-tools/x1"
 
-restore:
-    snap set system experimental.parallel-instances=null


### PR DESCRIPTION
Extend the test to run installed snaps. Remove use of 'sideload' and rename the test.
