### PR TITLE
interfaces/builtin: avahi interface update

### DIFF
--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -45,6 +45,10 @@ const avahiObserveBaseDeclarationSlots = `
 const avahiObservePermanentSlotAppArmor = `
 network netlink,
 
+# Allow access to deamon to create socket
+/{,var/}run/avahi-daemon/  w,
+/{,var/}run/avahi-daemon/{pid,socket} rw,
+
 # Description: Allow operating as the avahi service. This gives
 # privileged access to the system.
 #include <abstractions/dbus-strict>
@@ -231,6 +235,8 @@ const avahiObservePermanentSlotDBus = `
 const avahiObserveConnectedPlugAppArmor = `
 # Description: allows domain, record, service, and service type browsing
 # as well as address, host and service resolving
+
+/{,var/}run/avahi-daemon/socket rw,
 
 #include <abstractions/dbus-strict>
 dbus (send)


### PR DESCRIPTION
Avahi behaves differently on core and classic systems. Socket is created in different location on classic  system deployed by deb package and on core by avahi snap.

Additionally client, depending on way it talks to daemon, needs to sometimes connect socket dir interface. However there is no alternative to this on classic system, when system does not expose content interface for socket directory.
Instead give avahi-daemon permission to create socked in the same place it does it on classic system


Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?