### PR TITLE
selftest: rename selftest.Run() to sanity.Check()

### DIFF
--- a/cmd/snapd/export_test.go
+++ b/cmd/snapd/export_test.go
@@ -27,11 +27,11 @@ var (
 	Run = run
 )
 
-func MockSelftestRun(f func() error) (restore func()) {
-	oldSelftestRun := selftestRun
-	selftestRun = f
+func MockSanityCheck(f func() error) (restore func()) {
+	oldSanityCheck := sanityCheck
+	sanityCheck = f
 	return func() {
-		selftestRun = oldSelftestRun
+		sanityCheck = oldSanityCheck
 	}
 }
 

--- a/cmd/snapd/main_test.go
+++ b/cmd/snapd/main_test.go
@@ -54,15 +54,15 @@ func (s *snapdSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(s.tmpdir)
 }
 
-func (s *snapdSuite) TestSelftestFailGoesIntoDegradedMode(c *C) {
+func (s *snapdSuite) TestSanityFailGoesIntoDegradedMode(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	selftestErr := fmt.Errorf("foo failed")
-	selftestWasRun := 0
-	restore = snapd.MockSelftestRun(func() error {
-		selftestWasRun += 1
-		return selftestErr
+	sanityErr := fmt.Errorf("foo failed")
+	sanityCheckWasRun := 0
+	restore = snapd.MockSanityCheck(func() error {
+		sanityCheckWasRun += 1
+		return sanityErr
 	})
 	defer restore()
 
@@ -77,11 +77,11 @@ func (s *snapdSuite) TestSelftestFailGoesIntoDegradedMode(c *C) {
 	}()
 	time.Sleep(100 * time.Millisecond)
 
-	// verify that talking to the daemon yields the selftest error
+	// verify that talking to the daemon yields the sanity error
 	// message
 	cli := client.New(nil)
 	_, err := cli.Abort("123")
-	c.Check(selftestWasRun >= 1, Equals, true)
+	c.Check(sanityCheckWasRun >= 1, Equals, true)
 	c.Check(err, ErrorMatches, "system does not fully support snapd: foo failed")
 	c.Check(logbuf.String(), testutil.Contains, "system does not fully support snapd: foo failed")
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -367,8 +367,8 @@ func (d *Daemon) Init() error {
 // as readonlyOK.
 //
 // This is useful to report errors to the client when the daemon
-// cannot work because e.g. a selftest failed or the system is out of
-// diskspace.
+// cannot work because e.g. a sanity check failed or the system is out
+// of diskspace.
 //
 // When the system is fine again calling "DegradedMode(nil)" is enough
 // to put the daemon into full operation again.

--- a/sanity/apparmor_lxd.go
+++ b/sanity/apparmor_lxd.go
@@ -17,7 +17,7 @@
  *
  */
 
-package selftest
+package sanity
 
 import (
 	"fmt"

--- a/sanity/apparmor_lxd_test.go
+++ b/sanity/apparmor_lxd_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package selftest_test
+package sanity_test
 
 import (
 	"os"
@@ -25,16 +25,16 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/selftest"
+	"github.com/snapcore/snapd/sanity"
 )
 
-func (s *selftestSuite) TestCheckApparmorUsable(c *C) {
+func (s *sanitySuite) TestCheckApparmorUsable(c *C) {
 	epermProfilePath := filepath.Join(c.MkDir(), "profiles")
-	restore := selftest.MockAppArmorProfilesPath(epermProfilePath)
+	restore := sanity.MockAppArmorProfilesPath(epermProfilePath)
 	defer restore()
 	err := os.Chmod(filepath.Dir(epermProfilePath), 0444)
 	c.Assert(err, IsNil)
 
-	err = selftest.CheckApparmorUsable()
+	err = sanity.CheckApparmorUsable()
 	c.Check(err, ErrorMatches, "apparmor detected but insufficient permissions to use it")
 }

--- a/sanity/check.go
+++ b/sanity/check.go
@@ -17,11 +17,11 @@
  *
  */
 
-package selftest
+package sanity
 
 var checks []func() error
 
-func Run() error {
+func Check() error {
 	for _, f := range checks {
 		if err := f(); err != nil {
 			return err

--- a/sanity/check_test.go
+++ b/sanity/check_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package selftest_test
+package sanity_test
 
 import (
 	"go/ast"
@@ -32,17 +32,17 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/selftest"
+	"github.com/snapcore/snapd/sanity"
 )
 
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
-type selftestSuite struct{}
+type sanitySuite struct{}
 
-var _ = Suite(&selftestSuite{})
+var _ = Suite(&sanitySuite{})
 
-func (s *selftestSuite) TestRunHappy(c *C) {
+func (s *sanitySuite) TestRunHappy(c *C) {
 	var happyChecks []func() error
 	var happyCheckRan int
 
@@ -51,15 +51,15 @@ func (s *selftestSuite) TestRunHappy(c *C) {
 		return nil
 	})
 
-	restore := selftest.MockChecks(happyChecks)
+	restore := sanity.MockChecks(happyChecks)
 	defer restore()
 
-	err := selftest.Run()
+	err := sanity.Check()
 	c.Check(err, IsNil)
 	c.Check(happyCheckRan, Equals, 1)
 }
 
-func (s *selftestSuite) TestRunNotHappy(c *C) {
+func (s *sanitySuite) TestRunNotHappy(c *C) {
 	var unhappyChecks []func() error
 	var unhappyCheckRan int
 
@@ -68,25 +68,25 @@ func (s *selftestSuite) TestRunNotHappy(c *C) {
 		return nil
 	})
 
-	restore := selftest.MockChecks(unhappyChecks)
+	restore := sanity.MockChecks(unhappyChecks)
 	defer restore()
 
-	err := selftest.Run()
+	err := sanity.Check()
 	c.Check(err, IsNil)
 	c.Check(unhappyCheckRan, Equals, 1)
 }
 
-func (s *selftestSuite) TestUnexportedChecks(c *C) {
-	// collect what funcs we run in selftest.Check
+func (s *sanitySuite) TestUnexportedChecks(c *C) {
+	// collect what funcs we run in sanity.Check
 	var runCheckers []string
-	v := reflect.ValueOf(selftest.Checks())
+	v := reflect.ValueOf(sanity.Checks())
 	for i := 0; i < v.Len(); i++ {
 		v := v.Index(i)
 		fname := runtime.FuncForPC(v.Pointer()).Name()
 		pos := strings.LastIndexByte(fname, '.')
 		checker := fname[pos+1:]
 		if !strings.HasPrefix(checker, "check") {
-			c.Fatalf(`%q in selftest.Checks does not have "check" prefix`, checker)
+			c.Fatalf(`%q in sanity.Checks does not have "check" prefix`, checker)
 		}
 		runCheckers = append(runCheckers, checker)
 	}

--- a/sanity/export_test.go
+++ b/sanity/export_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package selftest
+package sanity
 
 var (
 	CheckSquashfsMount  = checkSquashfsMount

--- a/sanity/squashfs.go
+++ b/sanity/squashfs.go
@@ -17,7 +17,7 @@
  *
  */
 
-package selftest
+package sanity
 
 import (
 	"bytes"
@@ -69,13 +69,13 @@ bAEA+f+YuAAQAAA=
 `)
 
 func checkSquashfsMount() error {
-	tmpSquashfsFile, err := ioutil.TempFile("", "selftest-squashfs-")
+	tmpSquashfsFile, err := ioutil.TempFile("", "sanity-squashfs-")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(tmpSquashfsFile.Name())
 
-	tmpMountDir, err := ioutil.TempDir("", "selftest-mountpoint-")
+	tmpMountDir, err := ioutil.TempDir("", "sanity-mountpoint-")
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func checkSquashfsMount() error {
 	defer func() {
 		if output, err := exec.Command("umount", tmpMountDir).CombinedOutput(); err != nil {
 			// os.RemoveAll(tmpMountDir) will fail here if umount fails
-			logger.Noticef("cannot unmount selftest squashfs image: %v", osutil.OutputErr(output, err))
+			logger.Noticef("cannot unmount sanity check squashfs image: %v", osutil.OutputErr(output, err))
 		}
 	}()
 

--- a/sanity/squashfs_test.go
+++ b/sanity/squashfs_test.go
@@ -17,17 +17,17 @@
  *
  */
 
-package selftest_test
+package sanity_test
 
 import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil/squashfs"
-	"github.com/snapcore/snapd/selftest"
+	"github.com/snapcore/snapd/sanity"
 	"github.com/snapcore/snapd/testutil"
 )
 
-func (s *selftestSuite) TestCheckSquashfsMountHappy(c *C) {
+func (s *sanitySuite) TestCheckSquashfsMountHappy(c *C) {
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
@@ -38,7 +38,7 @@ func (s *selftestSuite) TestCheckSquashfsMountHappy(c *C) {
 	mockUmount := testutil.MockCommand(c, "umount", "")
 	defer mockUmount.Restore()
 
-	err := selftest.CheckSquashfsMount()
+	err := sanity.CheckSquashfsMount()
 	c.Check(err, IsNil)
 
 	c.Check(mockMount.Calls(), HasLen, 1)
@@ -54,7 +54,7 @@ func (s *selftestSuite) TestCheckSquashfsMountHappy(c *C) {
 	})
 }
 
-func (s *selftestSuite) TestCheckSquashfsMountNotHappy(c *C) {
+func (s *sanitySuite) TestCheckSquashfsMountNotHappy(c *C) {
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
@@ -64,7 +64,7 @@ func (s *selftestSuite) TestCheckSquashfsMountNotHappy(c *C) {
 	mockUmount := testutil.MockCommand(c, "umount", "")
 	defer mockUmount.Restore()
 
-	err := selftest.CheckSquashfsMount()
+	err := sanity.CheckSquashfsMount()
 	c.Check(err, ErrorMatches, "cannot mount squashfs image using.*")
 
 	c.Check(mockMount.Calls(), HasLen, 1)
@@ -77,7 +77,7 @@ func (s *selftestSuite) TestCheckSquashfsMountNotHappy(c *C) {
 	})
 }
 
-func (s *selftestSuite) TestCheckSquashfsMountWrongContent(c *C) {
+func (s *sanitySuite) TestCheckSquashfsMountWrongContent(c *C) {
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
@@ -87,7 +87,7 @@ func (s *selftestSuite) TestCheckSquashfsMountWrongContent(c *C) {
 	mockUmount := testutil.MockCommand(c, "umount", "")
 	defer mockUmount.Restore()
 
-	err := selftest.CheckSquashfsMount()
+	err := sanity.CheckSquashfsMount()
 	c.Check(err, ErrorMatches, `unexpected squashfs canary content: "wrong content\\n"`)
 
 	c.Check(mockMount.Calls(), HasLen, 1)

--- a/sanity/version.go
+++ b/sanity/version.go
@@ -17,7 +17,7 @@
  *
  */
 
-package selftest
+package sanity
 
 import (
 	"fmt"

--- a/sanity/version_test.go
+++ b/sanity/version_test.go
@@ -17,21 +17,21 @@
  *
  */
 
-package selftest_test
+package sanity_test
 
 import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/selftest"
+	"github.com/snapcore/snapd/sanity"
 )
 
 type versionSuite struct{}
 
 var _ = Suite(&versionSuite{})
 
-func (s *selftestSuite) TestFreshInstallOfSnapdOnTrusty(c *C) {
+func (s *sanitySuite) TestFreshInstallOfSnapdOnTrusty(c *C) {
 	// Mock an Ubuntu 14.04 system running a 3.13.0 kernel
 	restore := release.MockOnClassic(true)
 	defer restore()
@@ -41,11 +41,11 @@ func (s *selftestSuite) TestFreshInstallOfSnapdOnTrusty(c *C) {
 	defer restore()
 
 	// Check for the given advice.
-	err := selftest.CheckKernelVersion()
+	err := sanity.CheckKernelVersion()
 	c.Assert(err, ErrorMatches, "you need to reboot into a 4.4 kernel to start using snapd")
 }
 
-func (s *selftestSuite) TestRebootedOnTrusty(c *C) {
+func (s *sanitySuite) TestRebootedOnTrusty(c *C) {
 	// Mock an Ubuntu 14.04 system running a 4.4.0 kernel
 	restore := release.MockOnClassic(true)
 	defer restore()
@@ -55,6 +55,6 @@ func (s *selftestSuite) TestRebootedOnTrusty(c *C) {
 	defer restore()
 
 	// Check for the given advice.
-	err := selftest.CheckKernelVersion()
+	err := sanity.CheckKernelVersion()
 	c.Assert(err, IsNil)
 }

--- a/tests/main/sanitycheck/task.yaml
+++ b/tests/main/sanitycheck/task.yaml
@@ -1,7 +1,7 @@
-summary: Ensure that the selftest works
+summary: Ensure that the sanity check works
 
 prepare: |
-    echo "Break mounting so that the selftest of a squashfs mount fails"
+    echo "Break mounting so that the sanity check of a squashfs mount fails"
     mount -o bind /bin/false /bin/mount
 
 restore: |
@@ -10,7 +10,7 @@ restore: |
     systemctl restart snapd
 
 execute: |
-    echo "Restart snapd so that the selftest runs"
+    echo "Restart snapd so that the sanity check runs"
     systemctl restart snapd
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
@@ -23,11 +23,11 @@ execute: |
         sleep 1
     done
 
-    echo "Ensure selftest error is reported in the journal"
+    echo "Ensure sanity check error is reported in the journal"
     journalctl -u snapd | MATCH "system does not fully support snapd: cannot mount squashfs image"
 
     echo "Ensure GET commands still work"
     snap list | MATCH core
     
-    echo "Ensure snap commands reply with selftest error"
+    echo "Ensure snap commands reply with sanity check error"
     snap install test-snapd-tools 2>&1 | MATCH "system does not fully support snapd: cannot mount squashfs image"


### PR DESCRIPTION
During one of the recent reviews @niemeyer pointed out that the selftest name is poorly choose because its really about the environment that snapd runs in, not so much about a self-test of snapd.

I renamed the function from "selftest.Run()" to "sanity.Check()" now. Better ideas for names welcome of course :)