### PR TITLE
vendor, cmd/snap: refactor to accommodate the new less buggy go-flags

### DIFF
--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -38,8 +38,8 @@ Once this manual alias is setup the respective application command can be
 invoked just using the alias.
 
 [alias command options]
-          --no-wait     Do not wait for the operation to finish but just print
-                        the change id.
+      --no-wait       Do not wait for the operation to finish but just print
+                      the change id.
 `
 	s.testSubCommandHelp(c, "alias", msg)
 }

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -54,8 +54,8 @@ Connects the provided plug to the slot in the core snap with a name matching
 the plug name.
 
 [connect command options]
-          --no-wait        Do not wait for the operation to finish but just
-                           print the change id.
+      --no-wait          Do not wait for the operation to finish but just print
+                         the change id.
 `
 	s.testSubCommandHelp(c, "connect", msg)
 }

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -47,8 +47,8 @@ Disconnects everything from the provided plug or slot.
 The snap name may be omitted for the core snap.
 
 [disconnect command options]
-          --no-wait        Do not wait for the operation to finish but just
-                           print the change id.
+      --no-wait          Do not wait for the operation to finish but just print
+                         the change id.
 `
 	s.testSubCommandHelp(c, "disconnect", msg)
 }

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -41,11 +41,11 @@ If no interface name is provided, a list of interface names with at least
 one connection is shown, or a list of all interfaces if --all is provided.
 
 [interface command options]
-          --attrs        Show interface attributes
-          --all          Include unused interfaces
+      --attrs          Show interface attributes
+      --all            Include unused interfaces
 
 [interface command arguments]
-  <interface>:           Show details of a specific interface
+  <interface>:         Show details of a specific interface
 `
 	s.testSubCommandHelp(c, "interface", msg)
 }

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -38,11 +38,11 @@ A green check mark (given color and unicode support) after a publisher name
 indicates that the publisher has been verified.
 
 [list command options]
-          --all                         Show all revisions
-          --color=[auto|never|always]   Use a little bit of color to highlight
-                                        some things. (default: auto)
-          --unicode=[auto|never|always] Use a little bit of Unicode to improve
-                                        legibility. (default: auto)
+      --all                           Show all revisions
+      --color=[auto|never|always]     Use a little bit of color to highlight
+                                      some things. (default: auto)
+      --unicode=[auto|never|always]   Use a little bit of Unicode to improve
+                                      legibility. (default: auto)
 `
 	s.testSubCommandHelp(c, "list", msg)
 }

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -37,8 +37,8 @@ to conflicting aliases of other snaps whose aliases will be disabled
 (or removed, for manual ones).
 
 [prefer command options]
-          --no-wait  Do not wait for the operation to finish but just print the
-                     change id.
+      --no-wait    Do not wait for the operation to finish but just print the
+                   change id.
 `
 	s.testSubCommandHelp(c, "prefer", msg)
 }

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -49,27 +49,27 @@ hooks:
 `)
 
 func (s *SnapSuite) TestInvalidParameters(c *check.C) {
-	invalidParameters := []string{"run", "--hook=configure", "--command=command-name", "snap-name"}
+	invalidParameters := []string{"run", "--hook=configure", "--command=command-name", "--", "snap-name"}
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*you can only use one of --hook, --command, and --timer.*")
 
-	invalidParameters = []string{"run", "--hook=configure", "--timer=10:00-12:00", "snap-name"}
+	invalidParameters = []string{"run", "--hook=configure", "--timer=10:00-12:00", "--", "snap-name"}
 	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*you can only use one of --hook, --command, and --timer.*")
 
-	invalidParameters = []string{"run", "--command=command-name", "--timer=10:00-12:00", "snap-name"}
+	invalidParameters = []string{"run", "--command=command-name", "--timer=10:00-12:00", "--", "snap-name"}
 	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*you can only use one of --hook, --command, and --timer.*")
 
-	invalidParameters = []string{"run", "-r=1", "--command=command-name", "snap-name"}
+	invalidParameters = []string{"run", "-r=1", "--command=command-name", "--", "snap-name"}
 	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*-r can only be used with --hook.*")
 
-	invalidParameters = []string{"run", "-r=1", "snap-name"}
+	invalidParameters = []string{"run", "-r=1", "--", "snap-name"}
 	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*-r can only be used with --hook.*")
 
-	invalidParameters = []string{"run", "--hook=configure", "foo", "bar", "snap-name"}
+	invalidParameters = []string{"run", "--hook=configure", "--", "foo", "bar", "snap-name"}
 	_, err = snaprun.Parser(snaprun.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*too many arguments for hook \"configure\": bar.*")
 }
@@ -93,10 +93,10 @@ func (s *SnapSuite) TestSnapRunWhenMissingConfine(c *check.C) {
 
 	// and run it!
 	// a regular run will fail
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.ErrorMatches, `.* your core/snapd package`)
 	// a hook run will not fail
-	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "snapname"})
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "--", "snapname"})
 	c.Assert(err, check.IsNil)
 
 	// but nothing is run ever
@@ -124,7 +124,7 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -157,7 +157,7 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -193,7 +193,7 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegrationReexeced(c *check.C) {
 		return nil
 	})
 	defer restorer()
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -224,7 +224,7 @@ func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--command=my-command", "snapname.app", "arg1", "arg2"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--command=my-command", "--", "snapname.app", "arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -297,7 +297,7 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 	defer restorer()
 
 	// Run a hook from the active revision
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "--", "snapname"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -329,7 +329,7 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 	defer restorer()
 
 	// Specifically pass "unset" which would use the active version.
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=unset", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=unset", "--", "snapname"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -365,7 +365,7 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 	defer restorer()
 
 	// Run a hook on revision 41
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=41", "--", "snapname"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -389,13 +389,13 @@ func (s *SnapSuite) TestSnapRunHookMissingRevisionIntegration(c *check.C) {
 	defer restorer()
 
 	// Attempt to run a hook on revision 41, which doesn't exist
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=41", "--", "snapname"})
 	c.Assert(err, check.NotNil)
 	c.Check(err, check.ErrorMatches, "cannot find .*")
 }
 
 func (s *SnapSuite) TestSnapRunHookInvalidRevisionIntegration(c *check.C) {
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=invalid", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "-r=invalid", "--", "snapname"})
 	c.Assert(err, check.NotNil)
 	c.Check(err, check.ErrorMatches, "invalid snap revision: \"invalid\"")
 }
@@ -414,13 +414,13 @@ func (s *SnapSuite) TestSnapRunHookMissingHookIntegration(c *check.C) {
 	})
 	defer restorer()
 
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=missing-hook", "snapname"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=missing-hook", "--", "snapname"})
 	c.Assert(err, check.ErrorMatches, `cannot find hook "missing-hook" in "snapname"`)
 	c.Check(called, check.Equals, false)
 }
 
 func (s *SnapSuite) TestSnapRunErorsForUnknownRunArg(c *check.C) {
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--unknown", "snapname.app", "--arg1", "arg2"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--unknown", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.ErrorMatches, "unknown flag `unknown'")
 }
 
@@ -430,7 +430,7 @@ func (s *SnapSuite) TestSnapRunErorsForMissingApp(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunErorrForUnavailableApp(c *check.C) {
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "not-there"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "not-there"})
 	c.Assert(err, check.ErrorMatches, fmt.Sprintf("cannot find current revision for snap not-there: readlink %s/not-there/current: no such file or directory", dirs.SnapMountDir))
 }
 
@@ -460,7 +460,7 @@ func (s *SnapSuite) TestSnapRunSaneEnvironmentHandling(c *check.C) {
 	defer os.Unsetenv("SNAP_THE_WORLD")
 
 	// and ensure those SNAP_ vars get overridden
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
@@ -515,7 +515,7 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.SnapMountDir, "/core/111", dirs.CoreLibExecDir, "snap-confine"))
@@ -554,7 +554,7 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.SnapMountDir, "/snapd/222", dirs.CoreLibExecDir, "snap-confine"))
@@ -606,7 +606,7 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	})()
 
 	// and run it!
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "snapname.app"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -729,7 +729,7 @@ echo "stdout output 2"
 	c.Assert(err, check.IsNil)
 
 	// and run it under strace
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
@@ -752,7 +752,7 @@ echo "stdout output 2"
 	sudoCmd.ForgetCalls()
 
 	// try again without filtering
-	rest, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace=--raw", "snapname.app", "--arg1", "arg2"})
+	rest, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--strace=--raw", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
@@ -799,7 +799,7 @@ func (s *SnapSuite) TestSnapRunAppWithStraceOptions(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// and run it under strace
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--strace=-tt --raw -o "file with spaces"`, "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--strace=-tt --raw -o "file with spaces"`, "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
@@ -841,7 +841,7 @@ func (s *SnapSuite) TestSnapRunShellIntegration(c *check.C) {
 	defer restorer()
 
 	// and run it!
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--shell", "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--shell", "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
@@ -881,7 +881,7 @@ func (s *SnapSuite) TestSnapRunAppTimer(c *check.C) {
 	defer restorer()
 
 	// pretend we are outside of timer range
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "snapname.app", "--arg1", "arg2"})
+	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
 	c.Assert(execCalled, check.Equals, false)
@@ -897,7 +897,7 @@ func (s *SnapSuite) TestSnapRunAppTimer(c *check.C) {
 	defer restorer()
 
 	// and run it under strace
-	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "snapname.app", "--arg1", "arg2"})
+	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", `--timer="mon,10:00~12:00,,fri,13:00"`, "--", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(execCalled, check.Equals, true)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -795,8 +795,8 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", snapPath, "--name", "foo_bar"})
-	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
+	c.Assert(err, check.IsNil)
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo_bar 1.0 from Bar installed`)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -37,8 +37,8 @@ alias, or disables all aliases of a snap, including manual ones, if the
 argument is a snap name.
 
 [unalias command options]
-          --no-wait          Do not wait for the operation to finish but just
-                             print the change id.
+      --no-wait            Do not wait for the operation to finish but just
+                           print the change id.
 `
 	s.testSubCommandHelp(c, "unalias", msg)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -35,7 +35,7 @@ var RunMain = run
 var (
 	Client = mkClient
 
-	PatchForSnapRun = patchForSnapRun
+	FirstNonOptionIsRun = firstNonOptionIsRun
 
 	CreateUserDataDirs = createUserDataDirs
 	ResolveApp         = resolveApp

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -35,6 +35,8 @@ var RunMain = run
 var (
 	Client = mkClient
 
+	PatchForSnapRun = patchForSnapRun
+
 	CreateUserDataDirs = createUserDataDirs
 	ResolveApp         = resolveApp
 	IsReexeced         = isReexeced

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -297,32 +297,34 @@ func (s *SnapSuite) TestResolveApp(c *C) {
 	c.Check(err, NotNil)
 }
 
-func (s *SnapSuite) TestPatchForSnapRun(c *C) {
-	type T struct{ given, expected string }
-	ts := []T{
-		// these shouldn't change at all
-		{"", ""},
-		{"snap verb --flag arg", "snap verb --flag arg"},
-		{"snap verb arg --flag", "snap verb arg --flag"},
-		{"snap -g verb --flag arg", "snap -g verb --flag arg"},
-		{"snap -g verb arg --flag", "snap -g verb arg --flag"},
-
-		// snap run, but no non-options?
-		{"snap --global run --flag", "snap --global run --flag"},
-
-		// basic snap run usage
-		{"snap run --flag arg", "snap run --flag -- arg"},
-		{"snap run arg --flag", "snap run -- arg --flag"},
-		{"snap -g run --flag arg", "snap -g run --flag -- arg"},
-		{"snap -g run arg --flag", "snap -g run -- arg --flag"},
-
-		// user-provided "--"
-		{"snap -g run --flag -- arg", "snap -g run --flag -- arg"},
-		{"snap -g run -- --flag arg", "snap -g run -- --flag arg"},    // this one would result in an error either way
-		{"snap -g run arg -- --flag", "snap -g run -- arg -- --flag"}, // in this one the user-provided -- is for arg, not for us
+func (s *SnapSuite) TestFirstNonOptionIsRun(c *C) {
+	osArgs := os.Args
+	defer func() {
+		os.Args = osArgs
+	}()
+	for _, negative := range []string{
+		"",
+		"snap",
+		"snap verb",
+		"snap verb --flag arg",
+		"snap verb arg --flag",
+		"snap --global verb --flag arg",
+	} {
+		os.Args = strings.Fields(negative)
+		c.Check(snap.FirstNonOptionIsRun(), Equals, false)
 	}
-	for _, t := range ts {
-		out := snap.PatchForSnapRun(strings.Fields(t.given))
-		c.Check(strings.Join(out, " "), Equals, t.expected, Commentf(t.expected))
+
+	for _, positive := range []string{
+		"snap run",
+		"snap run --flag",
+		"snap run --flag arg",
+		"snap run arg --flag",
+		"snap --global run",
+		"snap --global run --flag",
+		"snap --global run --flag arg",
+		"snap --global run arg --flag",
+	} {
+		os.Args = strings.Fields(positive)
+		c.Check(snap.FirstNonOptionIsRun(), Equals, true)
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,8 +39,8 @@
 		{
 			"checksumSHA1": "GcYF2BhpiQkshVVXxHPS/Oq491c=",
 			"path": "github.com/jessevdk/go-flags",
-			"revision": "e7ac6cd8efdaaad25ca45e5394ead835b6b1e19f",
-			"revisionTime": "2018-09-27T08:01:41Z"
+			"revision": "7309ec74f752d05ce2c62b8fd5755c4a2e3913cb",
+			"revisionTime": "2018-09-27T14:32:58Z"
 		},
 		{
 			"checksumSHA1": "dqtKfXGotqkiYaS328PpWeusig8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -37,10 +37,10 @@
 			"revisionTime": "2016-03-17T21:34:30Z"
 		},
 		{
-			"checksumSHA1": "Ihm00CfTHuuTYXgXJkgH7TFP0L4=",
+			"checksumSHA1": "GcYF2BhpiQkshVVXxHPS/Oq491c=",
 			"path": "github.com/jessevdk/go-flags",
-			"revision": "96dc06278ce32a0e9d957d590bb987c81ee66407",
-			"revisionTime": "2017-07-20T12:40:56Z"
+			"revision": "e7ac6cd8efdaaad25ca45e5394ead835b6b1e19f",
+			"revisionTime": "2018-09-27T08:01:41Z"
 		},
 		{
 			"checksumSHA1": "dqtKfXGotqkiYaS328PpWeusig8=",


### PR DESCRIPTION
go-flags on master has some fixes to manpage generation that are
interesting for us. In particular, the paragraphs following a command
with only hidden options were not dedented properly, and included a
spurious "Usage:" line, making it very messy and hard to find the
following command:

```
   help
       Show help about a command

       The help command displays information about snap commands.

       Usage: snap [OPTIONS] help [help-OPTIONS]

          info
              Show detailed information about snaps
```

would now render properly as

```
   help
       Show help about a command

       The help command displays information about snap commands.

   info
       Show detailed information about snaps
```

as well as some the alignment of options in help output no longer
leaving space for hidden options.

However, another bug fixed by this revision is that the
`PassAfterNonOption` flag now performs as advertised, meaning that
`snap install foo --classic` and `snap install --classic foo` are
different, if that flag is used. This is bad for us because we want
the fexibility it used to provide, but we also need this behaviour for
`snap run`.

That is, everywhere except in `snap run` we want options that come
after arguments to be treated as options, but in `snap run`,
anything that comes after the snap name argument we want to pass
through.

The `PassDoubleDash` flag would let us do that, by simply including a
`"--"` before the snap name. Unfortunately if we switch to requiring
this, it will break people who might be running `snap run` by hand and
dependend on the old behaviour.

~~This commit drops our use of `PassAfterNonOption`, and tweaks
`os.Args` to add a `"--"` before the snapname in `snap run` calls, if
the user hasn't added it themself.~~

This commit only adds `PassAfterNonOption` when we're trying to run `snap run`.

HTH, HAND.
