### PR TITLE
overlord/snapshotstate: store the SnapID in snapshot, block restore if changed

### DIFF
--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -56,6 +56,7 @@ type Snapshot struct {
 	// information about the snap this data is for
 	Snap     string        `json:"snap"`
 	Revision snap.Revision `json:"revision"`
+	SnapID   string        `json:"snap-id,omitempty"`
 	Epoch    snap.Epoch    `json:"epoch,omitempty"`
 	Summary  string        `json:"summary"`
 	Version  string        `json:"version"`

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -162,6 +162,7 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	snapshot := &client.Snapshot{
 		SetID:    id,
 		Snap:     si.InstanceName(),
+		SnapID:   si.SnapID,
 		Revision: si.Revision,
 		Version:  si.Version,
 		Time:     time.Now(),

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -337,6 +337,7 @@ func (s *snapshotSuite) TestList(c *check.C) {
 			Snapshot: client.Snapshot{
 				SetID:    id,
 				Snap:     snapname,
+				SnapID:   "id-for-" + snapname,
 				Version:  "v1.0-" + snapname,
 				Revision: snap.R(int(id)),
 			},
@@ -380,6 +381,7 @@ func (s *snapshotSuite) TestList(c *check.C) {
 				nShots++
 				fn := fmt.Sprintf(fnTpl, snapshot.SetID, snapshot.Snap, snapshot.Version, snapshot.Revision)
 				c.Check(backend.Filename(snapshot), check.Equals, fn, comm)
+				c.Check(snapshot.SnapID, check.Equals, "id-for-"+snapshot.Snap)
 			}
 		}
 		c.Check(nShots, check.Equals, t.numShots)
@@ -441,7 +443,7 @@ func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 	}
 	logger.SimpleSetup()
 
-	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42)}, Version: "v1.33"}
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33"}
 	cfg := map[string]interface{}{"some-setting": false}
 	shID := uint64(12)
 
@@ -449,6 +451,7 @@ func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(shw.SetID, check.Equals, shID)
 	c.Check(shw.Snap, check.Equals, info.InstanceName())
+	c.Check(shw.SnapID, check.Equals, info.SnapID)
 	c.Check(shw.Version, check.Equals, info.Version)
 	c.Check(shw.Revision, check.Equals, info.Revision)
 	c.Check(shw.Conf, check.DeepEquals, cfg)
@@ -458,19 +461,23 @@ func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 	shs, err := backend.List(context.TODO(), 0, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(shs, check.HasLen, 1)
+	c.Assert(shs[0].Snapshots, check.HasLen, 1)
 
 	shr, err := backend.Open(backend.Filename(shw))
 	c.Assert(err, check.IsNil)
 	defer shr.Close()
 
-	c.Check(shr.SetID, check.Equals, shID)
-	c.Check(shr.Snap, check.Equals, info.InstanceName())
-	c.Check(shr.Version, check.Equals, info.Version)
-	c.Check(shr.Revision, check.Equals, info.Revision)
-	c.Check(shr.Conf, check.DeepEquals, cfg)
+	for label, sh := range map[string]*client.Snapshot{"open": &shr.Snapshot, "list": shs[0].Snapshots[0]} {
+		comm := check.Commentf("%q", label)
+		c.Check(sh.SetID, check.Equals, shID, comm)
+		c.Check(sh.Snap, check.Equals, info.InstanceName(), comm)
+		c.Check(sh.SnapID, check.Equals, info.SnapID, comm)
+		c.Check(sh.Version, check.Equals, info.Version, comm)
+		c.Check(sh.Revision, check.Equals, info.Revision, comm)
+		c.Check(sh.Conf, check.DeepEquals, cfg, comm)
+		c.Check(sh.SHA3_384, check.DeepEquals, shw.SHA3_384, comm)
+	}
 	c.Check(shr.Name(), check.Equals, filepath.Join(dirs.SnapshotsDir, "12_hello-snap_v1.33_42.zip"))
-	c.Check(shr.SHA3_384, check.DeepEquals, shw.SHA3_384)
-
 	c.Check(shr.Check(context.TODO(), nil), check.IsNil)
 
 	newroot := c.MkDir()

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -204,7 +204,7 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 
 	for i, snapID := range snapIDs {
 		if snapID == "" {
-			// snapshotted snap was sideloaded, never mind
+			// snapshotted snap was unasserted, never mind
 			continue
 		}
 		snapst, ok := all[snapsFound[i]]
@@ -218,7 +218,7 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 			continue
 		}
 		if sideInfo.SnapID == "" {
-			// current snap is sideloaded, never mind then
+			// current snap is unasserted, never mind then
 			continue
 		}
 		if sideInfo.SnapID != snapID {


### PR DESCRIPTION
This change makes it so that the snap ID is stored in the snapshot,
and if on restore that ID is non-empty, and there is a snap with the
snapshot's snap's name installed that has a non-empty snap ID, and
these two IDs are different, the restore is fails.

This feature was requested at the Brussels sprint, as a minimal
prerequisite to renames (and merges). This then needs to grow to
handle the rename, but at least for now it will do no damage.
