### PR TITLE
snap: give Epoch a CanRead helper

### DIFF
--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -162,16 +162,8 @@ func (e *Epoch) Validate() error {
 		return &EpochError{Message: epochListNotSorted}
 	}
 
-	// O(𝑚𝑛) instead of O(𝑚log𝑛) for the binary search we could do, but
-	// 𝑚 and 𝑛 <10 per above, so the simple solution is good enough (and if
-	// that alone makes you nervous, know that it is ~2× faster in the
-	// worst case; bisect starts being faster at ~50 entries).
-	for _, r := range e.Read {
-		for _, w := range e.Write {
-			if r == w {
-				return nil
-			}
-		}
+	if intersect(e.Read, e.Write) {
+		return nil
 	}
 	return &EpochError{Message: noEpochIntersection}
 }
@@ -232,7 +224,14 @@ func (e *Epoch) CanRead(other *Epoch) bool {
 		ws = []uint32{0}
 	}
 
-	// see the note above about the O of this vs the allowed lengths of Read and Write
+	return intersect(rs, ws)
+}
+
+func intersect(rs, ws []uint32) bool {
+	// O(𝑚𝑛) instead of O(𝑚log𝑛) for the binary search we could do, but
+	// 𝑚 and 𝑛 < 10, so the simple solution is good enough (and if that
+	// alone makes you nervous, know that it is ~2× faster in the worst
+	// case; bisect starts being faster at ~50 entries).
 	for _, r := range rs {
 		for _, w := range ws {
 			if r == w {

--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -216,13 +216,25 @@ func (e *Epoch) String() string {
 // other one.
 func (e *Epoch) CanRead(other *Epoch) bool {
 	// the intersection between e.Read and other.Write needs to be non-empty
-	// unless they're both empty (happens in tests)
-	if (e == nil || len(e.Read) == 0) && (other == nil || len(other.Write) == 0) {
-		return true
+
+	// normalize (empty epoch should be treated like "0" here)
+	var rs, ws []uint32
+	if e != nil {
+		rs = e.Read
 	}
+	if other != nil {
+		ws = other.Write
+	}
+	if len(rs) == 0 {
+		rs = []uint32{0}
+	}
+	if len(ws) == 0 {
+		ws = []uint32{0}
+	}
+
 	// see the note above about the O of this vs the allowed lengths of Read and Write
-	for _, r := range e.Read {
-		for _, w := range other.Write {
+	for _, r := range rs {
+		for _, w := range ws {
 			if r == w {
 				return true
 			}

--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -212,6 +212,25 @@ func (e *Epoch) String() string {
 	return string(buf)
 }
 
+// CanRead checks whether this epoch can read the data written by the
+// other one.
+func (e *Epoch) CanRead(other *Epoch) bool {
+	// the intersection between e.Read and other.Write needs to be non-empty
+	// unless they're both empty (happens in tests)
+	if (e == nil || len(e.Read) == 0) && (other == nil || len(other.Write) == 0) {
+		return true
+	}
+	// see the note above about the O of this vs the allowed lengths of Read and Write
+	for _, r := range e.Read {
+		for _, w := range other.Write {
+			if r == w {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // EpochError tracks the details of a failed epoch parse or validation.
 type EpochError struct {
 	Message string

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -237,6 +237,7 @@ func (s *epochSuite) TestCanRead(c *check.C) {
 	}{
 		{ab: true, ba: true},                                     // nil should work (for tests!)
 		{a: &snap.Epoch{}, b: &snap.Epoch{}, ab: true, ba: true}, // test for empty epoch
+		{a: snap.E("0"), ab: true, ba: true},                     // hybrid empty / zero
 		{a: snap.E("0"), b: snap.E("1"), ab: false, ba: false},
 		{a: snap.E("0"), b: snap.E("1*"), ab: false, ba: true},
 		{a: snap.E("0"), b: snap.E("2*"), ab: false, ba: false},

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -229,3 +229,33 @@ func (s *epochSuite) TestE(c *check.C) {
 		c.Check(test.e.String(), check.Equals, test.s, check.Commentf(test.s))
 	}
 }
+
+func (s *epochSuite) TestCanRead(c *check.C) {
+	tests := []struct {
+		a, b   *snap.Epoch
+		ab, ba bool
+	}{
+		{ab: true, ba: true},                                     // nil should work (for tests!)
+		{a: &snap.Epoch{}, b: &snap.Epoch{}, ab: true, ba: true}, // test for empty epoch
+		{a: snap.E("0"), b: snap.E("1"), ab: false, ba: false},
+		{a: snap.E("0"), b: snap.E("1*"), ab: false, ba: true},
+		{a: snap.E("0"), b: snap.E("2*"), ab: false, ba: false},
+
+		{
+			a:  &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{2}},
+			b:  &snap.Epoch{Read: []uint32{1, 3, 4}, Write: []uint32{4}},
+			ab: false,
+			ba: false,
+		},
+		{
+			a:  &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{3}},
+			b:  &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{2}},
+			ab: true,
+			ba: true,
+		},
+	}
+	for i, test := range tests {
+		c.Assert(test.a.CanRead(test.b), check.Equals, test.ab, check.Commentf("ab/%d", i))
+		c.Assert(test.b.CanRead(test.a), check.Equals, test.ba, check.Commentf("ba/%d", i))
+	}
+}


### PR DESCRIPTION
The logic behind whether an epoch can read another epoch's data isn't
hard nor error prone, but we might as well have a helper for it.
