### PR TITLE
interfaces/apparmor: report apparmor support level and policy

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -581,6 +581,10 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxFeatures returns the list of apparmor features supported by the kernel.
 func (b *Backend) SandboxFeatures() []string {
+	if release.AppArmorLevel() == release.NoAppArmor {
+		return nil
+	}
+
 	features := kernelFeatures()
 	tags := make([]string, 0, len(features))
 	for _, feature := range features {
@@ -588,5 +592,18 @@ func (b *Backend) SandboxFeatures() []string {
 		// allow us to introduce our own tags later.
 		tags = append(tags, "kernel:"+feature)
 	}
+
+	level := "full"
+	policy := "default"
+	if release.AppArmorLevel() == release.PartialAppArmor {
+		level = "partial"
+
+		if downgradeConfinement() {
+			policy = "downgraded"
+		}
+	}
+	tags = append(tags, fmt.Sprintf("support-level:%s", level))
+	tags = append(tags, fmt.Sprintf("policy:%s", policy))
+
 	return tags
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1404,10 +1404,30 @@ func (s *backendSuite) TestNsProfile(c *C) {
 }
 
 func (s *backendSuite) TestSandboxFeatures(c *C) {
-	restore := apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
+	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	defer restore()
+	restore = apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
-	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar"})
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "support-level:full", "policy:default"})
+}
+
+func (s *backendSuite) TestSandboxFeaturesPartial(c *C) {
+	restore := release.MockAppArmorLevel(release.PartialAppArmor)
+	defer restore()
+	restore = release.MockReleaseInfo(&release.OS{ID: "opensuse-tumbleweed"})
+	defer restore()
+	restore = osutil.MockKernelVersion("4.16.10-1-default")
+	defer restore()
+	restore = apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
+	defer restore()
+
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "support-level:partial", "policy:default"})
+
+	restore = osutil.MockKernelVersion("4.14.1-default")
+	defer restore()
+
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "support-level:partial", "policy:downgraded"})
 }
 
 func (s *backendSuite) TestParallelInstanceSetupSnapUpdateNS(c *C) {


### PR DESCRIPTION
Extend sandbox features returned by the AppArmor backend with supported AppArmor
level and whether the policy is downgraded or not.

Make `snap debug sandbox-features` output slightly more helpful when debugging.
