### PR TITLE
client, daemon: support passing of 'unaliased' option when installing from local files

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1424,6 +1424,8 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	flags.RemoveSnapPath = true
 
+	flags.Unaliased = isTrue(form, "unaliased")
+
 	// find the file for the "snap" form field
 	var snapBody multipart.File
 	var origPath string

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6528,6 +6528,28 @@ func (s *apiSuite) TestInstallUnaliased(c *check.C) {
 	c.Check(calledFlags.Unaliased, check.Equals, true)
 }
 
+func (s *apiSuite) TestInstallPathUnaliased(c *check.C) {
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"devmode\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"unaliased\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n"
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	// try a multipart/form-data upload
+	flags := snapstate.Flags{Unaliased: true, RemoveSnapPath: true, DevMode: true}
+	chgSummary := s.sideloadCheck(c, body, head, "local", flags)
+	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
+}
+
 func (s *apiSuite) TestSplitQS(c *check.C) {
 	c.Check(splitQS("foo,bar"), check.DeepEquals, []string{"foo", "bar"})
 	c.Check(splitQS("foo , bar"), check.DeepEquals, []string{"foo", "bar"})


### PR DESCRIPTION
When doing `snap install --unaliased foo_123.snap` the 'unaliased' option was never passed to the daemon and the API code did not handle it.
