### PR TITLE
snapcraft.yaml: set grade to stable and add type: snapd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,9 +10,8 @@ description: |
 version: set-by-version-script-thxbye
 version-script: |
   ./mkversion.sh --output-only
-grade: devel
-# FIXME: enable once the store was updated
-#type: snapd
+type: snapd
+grade: stable
 
 parts:
   snapd:


### PR DESCRIPTION
Trivial update to the snapcraft.yaml so that we can release 2.36 into candidate and stable. As a drive-by also enables the `type: snapd`.