### PR TITLE
interfaces/builtin: add gpio-keys interface for accessing events

### DIFF
--- a/interfaces/builtin/gpio_keys.go
+++ b/interfaces/builtin/gpio_keys.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/udev"
+)
+
+const gpioKeysSummary = `allows access to gpio keys events`
+
+const gpioKeysBaseDeclarationSlots = `
+  gpio-keys:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const gpioKeysConnectedPlugAppArmor = `
+# Description: Allow reading and writing events to gpio keys devices
+
+#
+# evdev-based interface
+#
+
+# /dev/input/event* is unfortunately not namespaced and includes all input
+# devices, including keyboards and mice, which allows input sniffing and
+# injection. Until we have inode tagging of devices, we use a glob rule here
+# and rely on udev tagging to only add evdev devices to the snap's device
+# cgroup that are marked with ENV{ID_PATH}=="platform-gpio-keys". As such,
+# even though AppArmor allows all evdev, the device cgroup does not.
+/dev/input/event[0-9]* rw,
+
+# Allow reading for supported event reports for all input devices. See
+# https://www.kernel.org/doc/Documentation/input/event-codes.txt
+# FIXME: this is a very minor information leak and snapd should instead query
+# udev for the specific accesses associated with the above devices.
+/sys/devices/**/input[0-9]*/capabilities/* r,
+`
+
+// Add the gpio keys devices. They come up with ENV{ID_PATH} set to
+// "platform-gpio-keys" value.
+//
+// Because of the unconditional /dev/input/event[0-9]* AppArmor rule, we need
+// to ensure that the device cgroup is in effect even when there are no
+// gpio keys present so that we don't give away all input to the snap.
+var gpioKeysConnectedPlugUDev = []string{
+	`KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_PATH}=="platform-gpio-keys"`,
+}
+
+type gpioKeysInterface struct {
+	commonInterface
+}
+
+func (iface *gpioKeysInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.TriggerSubsystem("input")
+	return iface.commonInterface.UDevConnectedPlug(spec, plug, slot)
+}
+
+func init() {
+	registerIface(&gpioKeysInterface{commonInterface{
+		name:                  "gpio-keys",
+		summary:               gpioKeysSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  gpioKeysBaseDeclarationSlots,
+		connectedPlugAppArmor: gpioKeysConnectedPlugAppArmor,
+		connectedPlugUDev:     gpioKeysConnectedPlugUDev,
+		reservedForOS:         true,
+	}})
+}

--- a/interfaces/builtin/gpio_keys_test.go
+++ b/interfaces/builtin/gpio_keys_test.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type GpioKeysInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&GpioKeysInterfaceSuite{
+	iface: builtin.MustInterface("gpio-keys"),
+})
+
+const gpioKeysConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [gpio-keys]
+`
+
+const gpioKeysCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  gpio-keys:
+`
+
+func (s *GpioKeysInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, gpioKeysConsumerYaml, nil, "gpio-keys")
+	s.slot, s.slotInfo = MockConnectedSlot(c, gpioKeysCoreYaml, nil, "gpio-keys")
+}
+
+func (s *GpioKeysInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "gpio-keys")
+}
+
+func (s *GpioKeysInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "gpio-keys",
+		Interface: "gpio-keys",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"gpio-keys slots are reserved for the core snap")
+}
+
+func (s *GpioKeysInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *GpioKeysInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 1)
+	c.Assert(spec.Snippets(), testutil.Contains, `# gpio-keys
+KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_PATH}=="platform-gpio-keys", TAG+="snap_consumer_app"`)
+	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input"})
+}
+
+func (s *GpioKeysInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to gpio keys events`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "gpio-keys")
+}
+
+func (s *GpioKeysInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *GpioKeysInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}


### PR DESCRIPTION
This new interface makes possible to read events coming from GPIO keys
such as some sort of buttons available on devices. The purpose is to
allow events to be captured by snaps that can trigger actions based on
them.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
