### PR TITLE
cmd/snap-update-ns: better detection of snapd-made tmpfs

### DIFF
--- a/cmd/snap-update-ns/trespassing.go
+++ b/cmd/snap-update-ns/trespassing.go
@@ -34,6 +34,12 @@ import (
 type Assumptions struct {
 	unrestrictedPaths []string
 	pastChanges       []*Change
+
+	// verifiedDevices represents the set of devices that are verified as a tmpfs
+	// that was mounted by snapd. Those are only discovered on-demand. The
+	// major:minor number is packed into one uint64 as in syscall.Stat_t.Dev
+	// field.
+	verifiedDevices map[uint64]bool
 }
 
 // AddUnrestrictedPaths adds a list of directories where writing is allowed
@@ -91,14 +97,27 @@ func (as *Assumptions) canWriteToDirectory(dirFd int, dirName string) (bool, err
 	if err := sysFstatfs(dirFd, &fsData); err != nil {
 		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
 	}
+	var fileData syscall.Stat_t
+	if err := sysFstat(dirFd, &fileData); err != nil {
+		return false, fmt.Errorf("cannot fstat %q: %s", dirName, err)
+	}
 	// Writing to read only directories is allowed because EROFS is handled
 	// by each of the writing helpers already.
 	if ok := isReadOnly(dirName, &fsData); ok {
 		return true, nil
 	}
 	// Writing to a trusted tmpfs is allowed because those are not leaking to
-	// the host.
-	if ok := isPrivateTmpfsCreatedBySnapd(dirName, &fsData, as.pastChanges); ok {
+	// the host. Also, each time we find a good tmpfs we explicitly remember the device major/minor,
+	if as.verifiedDevices[fileData.Dev] {
+		return true, nil
+	}
+	if ok := isPrivateTmpfsCreatedBySnapd(dirName, &fsData, &fileData, as.pastChanges); ok {
+		if as.verifiedDevices == nil {
+			as.verifiedDevices = make(map[uint64]bool)
+		}
+		if fileData.Dev != 0 {
+			as.verifiedDevices[fileData.Dev] = true
+		}
 		return true, nil
 	}
 	// If writing is not not allowed by one of the three rules above then it is
@@ -201,7 +220,7 @@ func isReadOnly(dirName string, fsData *syscall.Statfs_t) bool {
 // to the mount namespace. A directory is trusted if it is a tmpfs that was
 // mounted by snap-confine or snapd-update-ns. Note that sub-directories of a
 // trusted tmpfs are not considered trusted by this function.
-func isPrivateTmpfsCreatedBySnapd(dirName string, fsData *syscall.Statfs_t, changes []*Change) bool {
+func isPrivateTmpfsCreatedBySnapd(dirName string, fsData *syscall.Statfs_t, fileData *syscall.Stat_t, changes []*Change) bool {
 	// If something is not a tmpfs it cannot be the trusted tmpfs we are looking for.
 	if fsData.Type != TmpfsMagic {
 		return false

--- a/cmd/snap-update-ns/trespassing.go
+++ b/cmd/snap-update-ns/trespassing.go
@@ -115,6 +115,9 @@ func (as *Assumptions) canWriteToDirectory(dirFd int, dirName string) (bool, err
 		if as.verifiedDevices == nil {
 			as.verifiedDevices = make(map[uint64]bool)
 		}
+		// Don't record 0:0 as those are all to easy to add in tests and would
+		// skew tests using zero-initialized structures. Real device numbers
+		// are not zero either so this is not a test-only conditional.
 		if fileData.Dev != 0 {
 			as.verifiedDevices[fileData.Dev] = true
 		}

--- a/cmd/snap-update-ns/trespassing_test.go
+++ b/cmd/snap-update-ns/trespassing_test.go
@@ -126,7 +126,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryTmpfs(c *C) {
 	c.Assert(ok, Equals, false)
 }
 
-// We allowed allowed to write to tmpfs that was mounted by snapd.
+// We are allowed to write to tmpfs that was mounted by snapd.
 func (s *trespassingSuite) TestCanWriteToDirectoryTmpfsMountedBySnapd(c *C) {
 	a := &update.Assumptions{}
 
@@ -147,7 +147,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryTmpfsMountedBySnapd(c *C) {
 	c.Assert(ok, Equals, true)
 }
 
-// We allowed allowed to write to directory beneath a tmpfs that was mounted by snapd.
+// We are allowed to write to directory beneath a tmpfs that was mounted by snapd.
 func (s *trespassingSuite) TestCanWriteToDirectoryUnderTmpfsMountedBySnapd(c *C) {
 	a := &update.Assumptions{}
 
@@ -183,7 +183,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryUnderTmpfsMountedBySnapd(c *C)
 	c.Assert(ok, Equals, true)
 }
 
-// We allowed allowed to write to directory which is a bind mount of something, beneath a tmpfs that was mounted by snapd.
+// We are allowed to write to directory which is a bind mount of something, beneath a tmpfs that was mounted by snapd.
 func (s *trespassingSuite) TestCanWriteToDirectoryUnderReboundTmpfsMountedBySnapd(c *C) {
 	a := &update.Assumptions{}
 
@@ -220,7 +220,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryUnderReboundTmpfsMountedBySnap
 	c.Assert(ok, Equals, false)
 }
 
-// We allowed allowed to write to an unrestricted path.
+// We are allowed to write to an unrestricted path.
 func (s *trespassingSuite) TestCanWriteToDirectoryUnrestricted(c *C) {
 	a := &update.Assumptions{}
 

--- a/cmd/snap-update-ns/trespassing_test.go
+++ b/cmd/snap-update-ns/trespassing_test.go
@@ -85,6 +85,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryWritableExt4(c *C) {
 	defer s.sys.Close(fd)
 
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.Ext4Magic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	ok, err := a.CanWriteToDirectory(fd, path)
 	c.Assert(err, IsNil)
@@ -101,6 +102,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryReadOnlyExt4(c *C) {
 	defer s.sys.Close(fd)
 
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.Ext4Magic, Flags: update.StReadOnly})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	ok, err := a.CanWriteToDirectory(fd, path)
 	c.Assert(err, IsNil)
@@ -117,6 +119,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryTmpfs(c *C) {
 	defer s.sys.Close(fd)
 
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.TmpfsMagic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	ok, err := a.CanWriteToDirectory(fd, path)
 	c.Assert(err, IsNil)
@@ -133,6 +136,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryTmpfsMountedBySnapd(c *C) {
 	defer s.sys.Close(fd)
 
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.TmpfsMagic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	a.AddChange(&update.Change{
 		Action: update.Mount,
@@ -141,6 +145,79 @@ func (s *trespassingSuite) TestCanWriteToDirectoryTmpfsMountedBySnapd(c *C) {
 	ok, err := a.CanWriteToDirectory(fd, path)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
+}
+
+// We allowed allowed to write to directory beneath a tmpfs that was mounted by snapd.
+func (s *trespassingSuite) TestCanWriteToDirectoryUnderTmpfsMountedBySnapd(c *C) {
+	a := &update.Assumptions{}
+
+	fd, err := s.sys.Open("/etc", syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd)
+
+	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.TmpfsMagic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{Dev: 0x42})
+
+	a.AddChange(&update.Change{
+		Action: update.Mount,
+		Entry:  osutil.MountEntry{Type: "tmpfs", Dir: "/etc"}})
+
+	ok, err := a.CanWriteToDirectory(fd, "/etc")
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	// Now we have primed the assumption state with knowledge of 0x42 device as
+	// a verified tmpfs.  We can now exploit it by trying to write to
+	// /etc/conf.d and seeing that is allowed even though /etc/conf.d itself is
+	// not a mount point representing tmpfs.
+
+	fd2, err := s.sys.Open("/etc/conf.d", syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd2)
+
+	s.sys.InsertFstatfsResult(`fstatfs 4 <ptr>`, syscall.Statfs_t{Type: update.TmpfsMagic})
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Dev: 0x42})
+
+	ok, err = a.CanWriteToDirectory(fd2, "/etc/conf.d")
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+}
+
+// We allowed allowed to write to directory which is a bind mount of something, beneath a tmpfs that was mounted by snapd.
+func (s *trespassingSuite) TestCanWriteToDirectoryUnderReboundTmpfsMountedBySnapd(c *C) {
+	a := &update.Assumptions{}
+
+	fd, err := s.sys.Open("/etc", syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	c.Assert(fd, Equals, 3)
+	defer s.sys.Close(fd)
+
+	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.TmpfsMagic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{Dev: 0x42})
+
+	a.AddChange(&update.Change{
+		Action: update.Mount,
+		Entry:  osutil.MountEntry{Type: "tmpfs", Dir: "/etc"}})
+
+	ok, err := a.CanWriteToDirectory(fd, "/etc")
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+
+	// Now we have primed the assumption state with knowledge of 0x42 device as
+	// a verified tmpfs. Unlike in the test above though the directory
+	// /etc/conf.d is a bind mount from another tmpfs that we know nothing
+	// about.
+	fd2, err := s.sys.Open("/etc/conf.d", syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	c.Assert(fd2, Equals, 4)
+	defer s.sys.Close(fd2)
+
+	s.sys.InsertFstatfsResult(`fstatfs 4 <ptr>`, syscall.Statfs_t{Type: update.TmpfsMagic})
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Dev: 0xdeadbeef})
+
+	ok, err = a.CanWriteToDirectory(fd2, "/etc/conf.d")
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, false)
 }
 
 // We allowed allowed to write to an unrestricted path.
@@ -153,6 +230,7 @@ func (s *trespassingSuite) TestCanWriteToDirectoryUnrestricted(c *C) {
 	defer s.sys.Close(fd)
 
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.Ext4Magic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	a.AddUnrestrictedPaths(path)
 
@@ -161,8 +239,8 @@ func (s *trespassingSuite) TestCanWriteToDirectoryUnrestricted(c *C) {
 	c.Assert(ok, Equals, true)
 }
 
-// Errors are propagated to the caller.
-func (s *trespassingSuite) TestCanWriteToDirectoryErrors(c *C) {
+// Errors from fstatfs are propagated to the caller.
+func (s *trespassingSuite) TestCanWriteToDirectoryErrorsFstatfs(c *C) {
 	a := &update.Assumptions{}
 
 	path := "/etc"
@@ -174,6 +252,23 @@ func (s *trespassingSuite) TestCanWriteToDirectoryErrors(c *C) {
 
 	ok, err := a.CanWriteToDirectory(fd, path)
 	c.Assert(err, ErrorMatches, `cannot fstatfs "/etc": testing`)
+	c.Assert(ok, Equals, false)
+}
+
+// Errors from fstat are propagated to the caller.
+func (s *trespassingSuite) TestCanWriteToDirectoryErrorsFstat(c *C) {
+	a := &update.Assumptions{}
+
+	path := "/etc"
+	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd)
+
+	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{})
+	s.sys.InsertFault(`fstat 3 <ptr>`, errTesting)
+
+	ok, err := a.CanWriteToDirectory(fd, path)
+	c.Assert(err, ErrorMatches, `cannot fstat "/etc": testing`)
 	c.Assert(ok, Equals, false)
 }
 
@@ -190,6 +285,7 @@ func (s *trespassingSuite) TestRestrictionsForEtc(c *C) {
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.Ext4Magic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	// Check reports trespassing error, restrictions may be lifted though.
 	err = rs.Check(fd, "/etc")
@@ -242,6 +338,7 @@ func (s *trespassingSuite) TestRestrictionsForRootfsEntries(c *C) {
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	s.sys.InsertFstatfsResult(`fstatfs 3 <ptr>`, syscall.Statfs_t{Type: update.Ext4Magic})
+	s.sys.InsertFstatResult(`fstat 3 <ptr>`, syscall.Stat_t{})
 
 	// Nil restrictions have working Check and Lift methods.
 	c.Assert(rs.Check(fd, "/"), ErrorMatches, `cannot recover from trespassing over /`)
@@ -276,7 +373,8 @@ func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdNotATmpfs(c *C) {
 	path := "/some/path"
 	// An ext4 (which is not a tmpfs) is not a private tmpfs.
 	statfs := &syscall.Statfs_t{Type: update.Ext4Magic}
-	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, nil)
+	stat := &syscall.Stat_t{}
+	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, nil)
 	c.Assert(result, Equals, false)
 }
 
@@ -284,7 +382,8 @@ func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdNotTrusted(c *C) {
 	path := "/some/path"
 	// A tmpfs is not private if it doesn't come from a change we made.
 	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
-	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, nil)
+	stat := &syscall.Stat_t{}
+	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, nil)
 	c.Assert(result, Equals, false)
 }
 
@@ -292,22 +391,23 @@ func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdViaChanges(c *C) {
 	path := "/some/path"
 	// A tmpfs is private because it was mounted by snap-update-ns.
 	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
+	stat := &syscall.Stat_t{}
 
 	// A tmpfs was mounted in the past so it is private.
-	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, []*update.Change{
+	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
 	c.Assert(result, Equals, true)
 
 	// A tmpfs was mounted but then it was unmounted so it is not private anymore.
-	result = update.IsPrivateTmpfsCreatedBySnapd(path, statfs, []*update.Change{
+	result = update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 	})
 	c.Assert(result, Equals, false)
 
 	// Finally, after the mounting and unmounting the tmpfs was mounted again.
-	result = update.IsPrivateTmpfsCreatedBySnapd(path, statfs, []*update.Change{
+	result = update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: path, Type: "tmpfs"}},
@@ -320,7 +420,8 @@ func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdDeeper(c *C) {
 	// A tmpfs is not private beyond the exact mount point from a change.
 	// That is, sub-directories of a private tmpfs are not recognized as private.
 	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
-	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, []*update.Change{
+	stat := &syscall.Stat_t{}
+	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, []*update.Change{
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/some/path", Type: "tmpfs"}},
 	})
 	c.Assert(result, Equals, false)
@@ -331,6 +432,7 @@ func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdViaVarLib(c *C) {
 	// A tmpfs in /var/lib is private because it is a special
 	// quirk applied by snap-confine, without having a change record.
 	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
-	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, nil)
+	stat := &syscall.Stat_t{}
+	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, nil)
 	c.Assert(result, Equals, true)
 }

--- a/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
@@ -30,3 +30,8 @@ layout:
   # Layout can refer to non-existing source path.
   /bin/very/weird/place:
     bind: $SNAP/bin/very/weird/place
+  # Layout can safely construct a path as a sibling of a mimic entry of another
+  # layout item. Here we take advantage of the improved tmpfs detection and
+  # tracking logic in snap-update-ns.
+  /bin/other/weird/place:
+    bind: $SNAP

--- a/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
@@ -30,8 +30,10 @@ layout:
   # Layout can refer to non-existing source path.
   /bin/very/weird/place:
     bind: $SNAP/bin/very/weird/place
-  # Layout can safely construct a path as a sibling of a mimic entry of another
-  # layout item. Here we take advantage of the improved tmpfs detection and
-  # tracking logic in snap-update-ns.
-  /bin/other/weird/place:
-    bind: $SNAP
+  # Layout can safely construct a path underneath a mimic established by
+  # another layout item. Here a writable mimic of /bin is established and both
+  # of the layout items using it can write to deeply nested entires therein
+  # (not directly under the tmpfs mount point). This takes advantage of the
+  # improved tmpfs detection and tracking logic in snap-update-ns.
+  /bin/very/weird/space:
+    bind: $SNAP/bin/very/weird/space


### PR DESCRIPTION
This patch extends the conservative logic for determining if a directory
can be safely written to because as a snapd-made tmpfs. The initial
logic was only accepting the mount point that corresponds to an entry
in the current mount profile, that is, direct proof correlation between
a tmpfs in the system and a tmpfs mount directive as given by snapd.

This works fine for cases where we mount tmpfs over a directory, e.g.
/bin and subsequently create files or directories as entries directly
underneath. It also works in cases where we create a brand new
directory, for example /bin/foo/ and then populate it with files or more
directories. This second case is not directly allowed by the trespassing
tmpfs detector. It only works because the detector is switched off as
soon as, while creating an object such as /bin/foo/bar we noticed that
we created foo as a new directory. This proves that foo was not an
existing bind mount and that it was created on a tmpfs substrate and
thus inhabits the same tmpfs.

This logic was too restrictive though, when /bin/foo/ already existed
and we attempted to create /bin/foo/froz. In such case the old logic
would allow writes to /bin (because it matches a tmpfs mount point) but
would not allow the write in /bin/foo to be attempted because it was not
inspecting /bin/foo nor trying to correlate that to /bin itself in any
way.

With the new change as we discover that /bin is a tmpfs that snapd
instructed to mount (perhaps sometime in the past when old copy of snapd
ran) we collect the major:minor and store it for the duration of the
snap-update-ns process.

When we subsequently determine trespassing safety of /bin/foo we keep
allowing writes for as long as the major:minor numbers can be traced to
a tmpfs that we visited and verified in the past. This removes the
conservative restriction while keeping the tmpfs verification strict. It
is strict in the sense that unknown tmpfs that is mounted by another
party (e.g. part of the classic distribution partitioning scheme) is not
considered safe to write. This way we still guarantee that writes do not
leak to the initial mount namespace.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
