### PR TITLE
cmd/snap: tweak UX of snap refresh --list

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -629,18 +629,14 @@ func (x *cmdRefresh) Execute([]string) error {
 
 	if x.Time {
 		if x.asksForMode() || x.asksForChannel() {
-			return errors.New(i18n.G("--time does not take mode nor channel flags"))
+			return errors.New(i18n.G("--time does not take mode or channel flags"))
 		}
 		return x.showRefreshTimes()
 	}
 
 	if x.List {
-		if len(x.Positional.Snaps) > 0 {
-			return errors.New(i18n.G("--list does not accept positional arguments"))
-		}
-
-		if x.asksForMode() || x.asksForChannel() {
-			return errors.New(i18n.G("--list does not take mode nor channel flags"))
+		if len(x.Positional.Snaps) > 0 || x.asksForMode() || x.asksForChannel() {
+			return errors.New(i18n.G("--list does not accept additional arguments"))
 		}
 
 		return x.listRefresh()
@@ -936,7 +932,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"revision": i18n.G("Refresh to the given revision, to which you must have developer access"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"list": i18n.G("Show the snaps that would be updated on refresh, but do not perform the refresh"),
+			"list": i18n.G("Show the new versions of snaps that would be updated with the next refresh"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"time": i18n.G("Show auto refresh information but do not perform a refresh"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -635,6 +635,10 @@ func (x *cmdRefresh) Execute([]string) error {
 	}
 
 	if x.List {
+		if len(x.Positional.Snaps) > 0 {
+			return errors.New(i18n.G("--list does not accept positional arguments"))
+		}
+
 		if x.asksForMode() || x.asksForChannel() {
 			return errors.New(i18n.G("--list does not take mode nor channel flags"))
 		}
@@ -932,7 +936,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"revision": i18n.G("Refresh to the given revision, to which you must have developer access"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"list": i18n.G("Show available snaps for refresh but do not perform a refresh"),
+			"list": i18n.G("Show the snaps that would be updated on refresh, but do not perform the refresh"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"time": i18n.G("Show auto refresh information but do not perform a refresh"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -912,10 +912,10 @@ func (s *SnapSuite) TestRefreshListLessOptions(c *check.C) {
 
 	for _, flag := range []string{"--beta", "--channel=potato", "--classic"} {
 		_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list", flag})
-		c.Assert(err, check.ErrorMatches, "--list does not take mode nor channel flags")
+		c.Assert(err, check.ErrorMatches, "--list does not accept additional arguments")
 
 		_, err = snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list", flag, "some-snap"})
-		c.Assert(err, check.ErrorMatches, "--list does not accept positional arguments")
+		c.Assert(err, check.ErrorMatches, "--list does not accept additional arguments")
 	}
 }
 
@@ -1032,12 +1032,6 @@ func (s *SnapSuite) TestRefreshNoTimerNoSchedule(c *check.C) {
 	})
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time"})
 	c.Assert(err, check.ErrorMatches, `internal error: both refresh.timer and refresh.schedule are empty`)
-}
-
-func (s *SnapSuite) TestRefreshListErr(c *check.C) {
-	s.RedirectClientToTestServer(nil)
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list", "--beta"})
-	c.Check(err, check.ErrorMatches, "--list does not take .* flags")
 }
 
 func (s *SnapOpSuite) TestRefreshOne(c *check.C) {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -905,6 +905,20 @@ func (s *SnapOpSuite) TestRevertMissingName(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "the required argument `<snap>` was not provided")
 }
 
+func (s *SnapSuite) TestRefreshListLessOptions(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Fatal("expected to get 0 requests")
+	})
+
+	for _, flag := range []string{"--beta", "--channel=potato", "--classic"} {
+		_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list", flag})
+		c.Assert(err, check.ErrorMatches, "--list does not take mode nor channel flags")
+
+		_, err = snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--list", flag, "some-snap"})
+		c.Assert(err, check.ErrorMatches, "--list does not accept positional arguments")
+	}
+}
+
 func (s *SnapSuite) TestRefreshList(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`snap refresh --list` had a poor description, that misled @basak but
fortunately they told us (thanks!) so now here it is, fixed (I hope).

Also, `snap refresh --list some-snap` would not complain, and just
ignore the extra argument. This too was confusing. This one I 'fixed'
by having it error; I could instead filter, but it's a lot of work
right now.