### PR TITLE
overlord/snapshotstate: store epoch in snapshot, check on restore

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -165,6 +165,7 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 		SnapID:   si.SnapID,
 		Revision: si.Revision,
 		Version:  si.Version,
+		Epoch:    si.Epoch,
 		Time:     time.Now(),
 		SHA3_384: make(map[string]string),
 		Size:     0,

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -443,7 +443,8 @@ func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 	}
 	logger.SimpleSetup()
 
-	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33"}
+	epoch := snap.E("42*")
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: *epoch}
 	cfg := map[string]interface{}{"some-setting": false}
 	shID := uint64(12)
 
@@ -453,6 +454,7 @@ func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 	c.Check(shw.Snap, check.Equals, info.InstanceName())
 	c.Check(shw.SnapID, check.Equals, info.SnapID)
 	c.Check(shw.Version, check.Equals, info.Version)
+	c.Check(shw.Epoch, check.DeepEquals, *epoch)
 	c.Check(shw.Revision, check.Equals, info.Revision)
 	c.Check(shw.Conf, check.DeepEquals, cfg)
 	c.Check(backend.Filename(shw), check.Equals, filepath.Join(dirs.SnapshotsDir, "12_hello-snap_v1.33_42.zip"))
@@ -473,6 +475,7 @@ func (s *snapshotSuite) TestHappyRoundtrip(c *check.C) {
 		c.Check(sh.Snap, check.Equals, info.InstanceName(), comm)
 		c.Check(sh.SnapID, check.Equals, info.SnapID, comm)
 		c.Check(sh.Version, check.Equals, info.Version, comm)
+		c.Check(sh.Epoch, check.DeepEquals, *epoch)
 		c.Check(sh.Revision, check.Equals, info.Revision, comm)
 		c.Check(sh.Conf, check.DeepEquals, cfg, comm)
 		c.Check(sh.SHA3_384, check.DeepEquals, shw.SHA3_384, comm)

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -237,10 +237,12 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 				return nil, nil, fmt.Errorf("unexpected error while reading snap info: %v", err)
 			}
 			if !info.Epoch.CanRead(&summary.epoch) {
-				return nil, nil, fmt.Errorf("cannot restore snapshot to incompatible epoch: %s → %s", &summary.epoch, &info.Epoch)
+				const tpl = "cannot restore snapshot for %q: current snap (epoch %s) cannot read snapshot data (epoch %s)"
+				return nil, nil, fmt.Errorf(tpl, summary.snap, &info.Epoch, &summary.epoch)
 			}
 			if summary.snapID != "" && info.SnapID != "" && info.SnapID != summary.snapID {
-				return nil, nil, fmt.Errorf("cannot restore snapshot over id change: %.7s… → %.7s…", summary.snapID, info.SnapID)
+				const tpl = "cannot restore snapshot for %q: current snap (ID %.7s…) does not match snapshot (ID %.7s…)"
+				return nil, nil, fmt.Errorf(tpl, summary.snap, info.SnapID, summary.snapID)
 			}
 		}
 

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -230,30 +230,20 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 	ts = state.NewTaskSet()
 
 	for _, summary := range summaries {
-		if summary.snapID == "" {
-			// snapshotted snap was unasserted, never mind
-			continue
+		if snapst, ok := all[summary.snap]; ok {
+			info, err := snapst.CurrentInfo()
+			if err != nil {
+				// how?
+				return nil, nil, fmt.Errorf("unexpected error while reading snap info: %v", err)
+			}
+			if !info.Epoch.CanRead(&summary.epoch) {
+				return nil, nil, fmt.Errorf("cannot restore snapshot to incompatible epoch: %s → %s", &summary.epoch, &info.Epoch)
+			}
+			if summary.snapID != "" && info.SnapID != "" && info.SnapID != summary.snapID {
+				return nil, nil, fmt.Errorf("cannot restore snapshot over id change: %.7s… → %.7s…", summary.snapID, info.SnapID)
+			}
 		}
-		snapst, ok := all[summary.snap]
-		if !ok {
-			// snap not installed
-			continue
-		}
-		sideInfo := snapst.CurrentSideInfo()
-		if sideInfo == nil {
-			// ... shouldn't happen (but also not installed)
-			continue
-		}
-		if sideInfo.SnapID == "" {
-			// current snap is unasserted, never mind then
-			continue
-		}
-		if sideInfo.SnapID != summary.snapID {
-			return nil, nil, fmt.Errorf("cannot restore snapshot over id change: %.7s… → %.7s…", summary.snapID, sideInfo.SnapID)
-		}
-	}
 
-	for _, summary := range summaries {
 		desc := fmt.Sprintf("Restore data of snap %q from snapshot set #%d", summary.snap, setID)
 		task := st.NewTask("restore-snapshot", desc)
 		snapshot := snapshotSetup{

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -713,11 +713,17 @@ func (snapshotSuite) TestRestoreConflictsWithSnapstate(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer shotfile.Close()
 
+	sideInfo := &snap.SideInfo{RealName: "foo", Revision: snap.R(1)}
 	fakeSnapstateAll := func(*state.State) (map[string]*snapstate.SnapState, error) {
 		return map[string]*snapstate.SnapState{
-			"foo": {Active: true},
+			"foo": {
+				Active:   true,
+				Sequence: []*snap.SideInfo{sideInfo},
+				Current:  sideInfo.Revision,
+			},
 		}, nil
 	}
+	snaptest.MockSnap(c, "{name: foo, version: v1}", sideInfo)
 
 	defer snapshotstate.MockSnapstateAll(fakeSnapstateAll)()
 
@@ -822,6 +828,100 @@ func (snapshotSuite) TestRestoreChecksChangesToSnapID(c *check.C) {
 
 	_, _, err = snapshotstate.Restore(st, 42, nil, nil)
 	c.Assert(err, check.ErrorMatches, `cannot restore snapshot over id change: 0987654… → 1234567…`)
+}
+
+func (snapshotSuite) TestRestoreChecksChangesToEpoch(c *check.C) {
+	shotfile, err := os.Create(filepath.Join(c.MkDir(), "yadda.zip"))
+	c.Assert(err, check.IsNil)
+	defer shotfile.Close()
+
+	sideInfo := &snap.SideInfo{RealName: "a-snap", Revision: snap.R(1)}
+	fakeSnapstateAll := func(*state.State) (map[string]*snapstate.SnapState, error) {
+		return map[string]*snapstate.SnapState{
+			"a-snap": {
+				Active:   true,
+				Sequence: []*snap.SideInfo{sideInfo},
+				Current:  sideInfo.Revision,
+			},
+		}, nil
+	}
+	defer snapshotstate.MockSnapstateAll(fakeSnapstateAll)()
+	snaptest.MockSnap(c, "{name: a-snap, version: v1, epoch: 17}", sideInfo)
+
+	fakeIter := func(_ context.Context, f func(*backend.Reader) error) error {
+		c.Assert(f(&backend.Reader{
+			// not wanted
+			Snapshot: client.Snapshot{
+				SetID: 42,
+				Snap:  "a-snap",
+				Epoch: *snap.E("42"),
+			},
+			File: shotfile,
+		}), check.IsNil)
+
+		return nil
+	}
+	defer snapshotstate.MockBackendIter(fakeIter)()
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	_, _, err = snapshotstate.Restore(st, 42, nil, nil)
+	c.Assert(err, check.ErrorMatches, `cannot restore snapshot to incompatible epoch: 42 → 17`)
+}
+
+func (snapshotSuite) TestRestoreWorksWithCompatibleEpoch(c *check.C) {
+	shotfile, err := os.Create(filepath.Join(c.MkDir(), "yadda.zip"))
+	c.Assert(err, check.IsNil)
+	defer shotfile.Close()
+
+	sideInfo := &snap.SideInfo{RealName: "a-snap", Revision: snap.R(1)}
+	fakeSnapstateAll := func(*state.State) (map[string]*snapstate.SnapState, error) {
+		return map[string]*snapstate.SnapState{
+			"a-snap": {
+				Active:   true,
+				Sequence: []*snap.SideInfo{sideInfo},
+				Current:  sideInfo.Revision,
+			},
+		}, nil
+	}
+	defer snapshotstate.MockSnapstateAll(fakeSnapstateAll)()
+	snaptest.MockSnap(c, "{name: a-snap, version: v1, epoch: {read: [17, 42], write: [42]}}", sideInfo)
+
+	fakeIter := func(_ context.Context, f func(*backend.Reader) error) error {
+		c.Assert(f(&backend.Reader{
+			// not wanted
+			Snapshot: client.Snapshot{
+				SetID: 42,
+				Snap:  "a-snap",
+				Epoch: *snap.E("17"),
+			},
+			File: shotfile,
+		}), check.IsNil)
+
+		return nil
+	}
+	defer snapshotstate.MockBackendIter(fakeIter)()
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	found, taskset, err := snapshotstate.Restore(st, 42, nil, nil)
+	c.Assert(err, check.IsNil)
+	c.Check(found, check.DeepEquals, []string{"a-snap"})
+	tasks := taskset.Tasks()
+	c.Assert(tasks, check.HasLen, 1)
+	c.Check(tasks[0].Kind(), check.Equals, "restore-snapshot")
+	c.Check(tasks[0].Summary(), check.Equals, `Restore data of snap "a-snap" from snapshot set #42`)
+	var snapshot map[string]interface{}
+	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
+	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
+		"set-id":   42.,
+		"snap":     "a-snap",
+		"filename": shotfile.Name(),
+	})
 }
 
 func (snapshotSuite) TestRestore(c *check.C) {

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -827,7 +827,7 @@ func (snapshotSuite) TestRestoreChecksChangesToSnapID(c *check.C) {
 	defer st.Unlock()
 
 	_, _, err = snapshotstate.Restore(st, 42, nil, nil)
-	c.Assert(err, check.ErrorMatches, `cannot restore snapshot over id change: 0987654… → 1234567…`)
+	c.Assert(err, check.ErrorMatches, `cannot restore snapshot for "a-snap": current snap \(ID 1234567…\) does not match snapshot \(ID 0987654…\)`)
 }
 
 func (snapshotSuite) TestRestoreChecksChangesToEpoch(c *check.C) {
@@ -868,7 +868,7 @@ func (snapshotSuite) TestRestoreChecksChangesToEpoch(c *check.C) {
 	defer st.Unlock()
 
 	_, _, err = snapshotstate.Restore(st, 42, nil, nil)
-	c.Assert(err, check.ErrorMatches, `cannot restore snapshot to incompatible epoch: 42 → 17`)
+	c.Assert(err, check.ErrorMatches, `cannot restore snapshot for "a-snap": current snap \(epoch 17\) cannot read snapshot data \(epoch 42\)`)
 }
 
 func (snapshotSuite) TestRestoreWorksWithCompatibleEpoch(c *check.C) {


### PR DESCRIPTION
We weren't storing the snap's epoch in its data's snapshot, and we
weren't checking the current revision could read the restored
data. This change fixes that.