### PR TITLE
store: gracefully handle unexpected errors in 'action' response

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -2293,6 +2293,12 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			} else {
 				if cur := curSnaps[res.InstanceKey]; cur != nil {
 					a := refreshes[res.InstanceKey]
+					if a == nil {
+						// got an error for a snap that was not part of an 'action'
+						otherErrors = append(otherErrors, translateSnapActionError("", "", res.Error.Code, fmt.Sprintf("snap %q: %s", cur.InstanceName, res.Error.Message), nil))
+						logger.Debugf("unexpected error for snap %q, instance key %v: %v %v", cur.InstanceName, res.InstanceKey, res.Error.Code, res.Error.Message)
+						continue
+					}
 					channel := a.Channel
 					if channel == "" && a.Revision.Unset() {
 						channel = cur.TrackingChannel


### PR DESCRIPTION
Having a number of parallel instances of some snap installed in the system and
trying to install another snap, I hit a problem where store would include an
unexpected error in the 'action' response for a snap that was not part of the
'install' action. The error was about duplicate instance of the same snap in
request 'context'.

With the following request:
```
{
    "context": [
        {
            "snap-id": "7Q1OfI5JLwQMvR4LXoToCw1srmPjnu7z",
            "instance-key": "7Q1OfI5JLwQMvR4LXoToCw1srmPjnu7z",
            ...
        },
        {
            "snap-id": "7Q1OfI5JLwQMvR4LXoToCw1srmPjnu7z",
            "instance-key": "7Q1OfI5JLwQMvR4LXoToCw1srmPjnu7z:d3ZayHx_juNBYOCHyKqGCggvrQN-rSGgFeOYyIJOScw",
            ...
        },
        {
            "snap-id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
            "instance-key": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
            ...
        },
        {
            "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
            "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
            ...
        }
    ],
    "actions": [
        {
            "action": "install",
            "instance-key": "install-1",
            "name": "ohmygiraffe",
            "channel": "stable"
        }
    ],
    ...
}
```
The actual error reported in the response was:
```
   {
       "error": {
           "code": "duplicated-snap",
           "message": "The Snap is present more than once in the request."
       },
       "instance-key": "7Q1OfI5JLwQMvR4LXoToCw1srmPjnu7z:d3ZayHx_juNBYOCHyKqGCggvrQN-rSGgFeOYyIJOScw",
       "name": null,
       "result": "error",
       "snap": null,
       "snap-id": "7Q1OfI5JLwQMvR4LXoToCw1srmPjnu7z"
   }
```
Try to gracefully handle such errors.

