### PR TITLE
overlord/snapshotstate: chown the tempdir

### DIFF
--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -268,10 +268,15 @@ func (r *Reader) Restore(ctx context.Context, usernames []string, logf Logf) (rs
 			return rs, fmt.Errorf("Cannot restore snapshot into %q: not a directory.", parent)
 		}
 
+		// TODO: have something more atomic in osutil
 		tempdir, err := ioutil.TempDir(parent, ".snapshot")
 		if err != nil {
 			return rs, err
 		}
+		if err := sys.ChownPath(tempdir, uid, gid); err != nil {
+			return rs, err
+		}
+
 		// one way or another we want tempdir gone
 		defer func() {
 			if err := os.RemoveAll(tempdir); err != nil {


### PR DESCRIPTION
Without this change, restoring snapshots of user data fail because the
tempdir into which snapd unpacks the user's data is not owned by the
user (and the restore is run as the user).

Integrating this thing is fun, did I mention?
