### PR TITLE
allow network_control to also use /sbin/iw

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -109,6 +109,7 @@ network sna,
 /{,usr/}{,s}bin/ip ixr,
 /{,usr/}{,s}bin/ipmaddr ixr,
 /{,usr/}{,s}bin/iptunnel ixr,
+/{,usr/}{,s}bin/iw ixr,
 /{,usr/}{,s}bin/nameif ixr,
 /{,usr/}{,s}bin/netstat ixr,              # -p not supported
 /{,usr/}{,s}bin/nstat ixr,


### PR DESCRIPTION
connecting network-control does not allow managing of wireless devices using the iw tool, this PR adds iw to the allowed binaries in the network-control interfaces.