### PR TITLE
snapshotstate: restore to current revision

### DIFF
--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -174,10 +174,10 @@ type Logf func(format string, args ...interface{})
 
 // Restore the data from the snapshot.
 //
-// If successful this will replace the existing data (for the revision in the
-// snapshot) with that contained in the snapshot.  It keeps track of the old
-// data in the task so it can be undone (or cleaned up).
-func (r *Reader) Restore(ctx context.Context, usernames []string, logf Logf) (rs *RestoreState, e error) {
+// If successful this will replace the existing data (for the given revision,
+// or the one in the snapshot) with that contained in the snapshot. It keeps
+// track of the old data in the task so it can be undone (or cleaned up).
+func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames []string, logf Logf) (rs *RestoreState, e error) {
 	rs = &RestoreState{}
 	defer func() {
 		if e != nil {
@@ -192,6 +192,11 @@ func (r *Reader) Restore(ctx context.Context, usernames []string, logf Logf) (rs
 	si := snap.MinimalPlaceInfo(r.Snap, r.Revision)
 	hasher := crypto.SHA3_384.New()
 	var sz sizer
+
+	var curdir string
+	if !current.Unset() {
+		curdir = current.String()
+	}
 
 	for entry := range r.SHA3_384 {
 		if err := ctx.Err(); err != nil {
@@ -317,7 +322,14 @@ func (r *Reader) Restore(ctx context.Context, usernames []string, logf Logf) (rs
 				r.Name(), entry, expectedHash, actualHash)
 		}
 
-		// TODO: something with Config
+		if curdir != "" && curdir != revdir {
+			// rename it in tempdir
+			// this is where we assume the current revision can read the snapshot revision's data
+			if err := os.Rename(filepath.Join(tempdir, revdir), filepath.Join(tempdir, curdir)); err != nil {
+				return rs, err
+			}
+			revdir = curdir
+		}
 
 		for _, dir := range []string{"common", revdir} {
 			source := filepath.Join(tempdir, dir)

--- a/overlord/snapshotstate/export_test.go
+++ b/overlord/snapshotstate/export_test.go
@@ -114,7 +114,7 @@ func MockBackendOpen(f func(string) (*backend.Reader, error)) (restore func()) {
 	}
 }
 
-func MockBackendRestore(f func(*backend.Reader, context.Context, []string, backend.Logf) (*backend.RestoreState, error)) (restore func()) {
+func MockBackendRestore(f func(*backend.Reader, context.Context, snap.Revision, []string, backend.Logf) (*backend.RestoreState, error)) (restore func()) {
 	old := backendRestore
 	backendRestore = f
 	return func() {

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -83,10 +83,11 @@ func (SnapshotManager) affectedSnaps(t *state.Task) ([]string, error) {
 }
 
 type snapshotSetup struct {
-	SetID    uint64   `json:"set-id"`
-	Snap     string   `json:"snap"`
-	Users    []string `json:"users,omitempty"`
-	Filename string   `json:"filename,omitempty"`
+	SetID    uint64        `json:"set-id"`
+	Snap     string        `json:"snap"`
+	Users    []string      `json:"users,omitempty"`
+	Filename string        `json:"filename,omitempty"`
+	Current  snap.Revision `json:"current"`
 }
 
 func filename(setID uint64, si *snap.Info) string {
@@ -178,7 +179,7 @@ func doRestore(task *state.Task, tomb *tomb.Tomb) error {
 	}
 	defer reader.Close()
 
-	restoreState, err := backendRestore(reader, tomb.Context(nil), snapshot.Users, task.Logf)
+	restoreState, err := backendRestore(reader, tomb.Context(nil), snapshot.Current, snapshot.Users, task.Logf)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -276,7 +276,7 @@ func (rs *readerSuite) SetUpTest(c *check.C) {
 			rs.calls = append(rs.calls, "open")
 			return &backend.Reader{}, nil
 		}),
-		snapshotstate.MockBackendRestore(func(*backend.Reader, context.Context, []string, backend.Logf) (*backend.RestoreState, error) {
+		snapshotstate.MockBackendRestore(func(*backend.Reader, context.Context, snap.Revision, []string, backend.Logf) (*backend.RestoreState, error) {
 			rs.calls = append(rs.calls, "restore")
 			return &backend.RestoreState{}, nil
 		}),
@@ -313,7 +313,7 @@ func (rs *readerSuite) TestDoRestore(c *check.C) {
 			Snapshot: client.Snapshot{Conf: map[string]interface{}{"hello": "there"}},
 		}, nil
 	})()
-	defer snapshotstate.MockBackendRestore(func(_ *backend.Reader, _ context.Context, users []string, _ backend.Logf) (*backend.RestoreState, error) {
+	defer snapshotstate.MockBackendRestore(func(_ *backend.Reader, _ context.Context, _ snap.Revision, users []string, _ backend.Logf) (*backend.RestoreState, error) {
 		rs.calls = append(rs.calls, "restore")
 		c.Check(users, check.DeepEquals, []string{"a-user", "b-user"})
 		return &backend.RestoreState{}, nil
@@ -396,7 +396,7 @@ func (rs *readerSuite) TestDoRestoreFailsUnserialisableSnapshotConfigError(c *ch
 }
 
 func (rs *readerSuite) TestDoRestoreFailsOnRestoreError(c *check.C) {
-	defer snapshotstate.MockBackendRestore(func(*backend.Reader, context.Context, []string, backend.Logf) (*backend.RestoreState, error) {
+	defer snapshotstate.MockBackendRestore(func(*backend.Reader, context.Context, snap.Revision, []string, backend.Logf) (*backend.RestoreState, error) {
 		rs.calls = append(rs.calls, "restore")
 		return nil, errors.New("bzzt")
 	})()

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -230,6 +230,7 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 	ts = state.NewTaskSet()
 
 	for _, summary := range summaries {
+		var current snap.Revision
 		if snapst, ok := all[summary.snap]; ok {
 			info, err := snapst.CurrentInfo()
 			if err != nil {
@@ -244,6 +245,7 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 				const tpl = "cannot restore snapshot for %q: current snap (ID %.7s…) does not match snapshot (ID %.7s…)"
 				return nil, nil, fmt.Errorf(tpl, summary.snap, info.SnapID, summary.snapID)
 			}
+			current = snapst.Current
 		}
 
 		desc := fmt.Sprintf("Restore data of snap %q from snapshot set #%d", summary.snap, setID)
@@ -253,6 +255,7 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 			Snap:     summary.snap,
 			Users:    users,
 			Filename: summary.filename,
+			Current:  current,
 		}
 		task.Set("snapshot-setup", &snapshot)
 		// see the note about snapshots not using lanes, above.

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -482,9 +482,10 @@ func (snapshotSuite) TestSaveOneSnap(c *check.C) {
 	var snapshot map[string]interface{}
 	c.Check(tasks[0].Get("snapshot-setup", &snapshot), check.IsNil)
 	c.Check(snapshot, check.DeepEquals, map[string]interface{}{
-		"set-id": 1.,
-		"snap":   "a-snap",
-		"users":  []interface{}{"a-user"},
+		"set-id":  1.,
+		"snap":    "a-snap",
+		"users":   []interface{}{"a-user"},
+		"current": "unset",
 	})
 }
 
@@ -921,6 +922,7 @@ func (snapshotSuite) TestRestoreWorksWithCompatibleEpoch(c *check.C) {
 		"set-id":   42.,
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
+		"current":  "1",
 	})
 }
 
@@ -957,6 +959,7 @@ func (snapshotSuite) TestRestore(c *check.C) {
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
 		"users":    []interface{}{"a-user"},
+		"current":  "unset",
 	})
 }
 
@@ -1210,6 +1213,7 @@ func (snapshotSuite) TestCheck(c *check.C) {
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
 		"users":    []interface{}{"a-user"},
+		"current":  "unset",
 	})
 }
 
@@ -1322,5 +1326,6 @@ func (snapshotSuite) TestForget(c *check.C) {
 		"set-id":   42.,
 		"snap":     "a-snap",
 		"filename": shotfile.Name(),
+		"current":  "unset",
 	})
 }


### PR DESCRIPTION
Without this change, snapshots restore to the same revision they were
taken from. With the epoch check done in #5903 we can now safely
restore to the current revision, as wanted.
