### PR TITLE
snap: detect layouts vs layout in snap.yaml (#5869)

### DIFF
--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -53,6 +53,17 @@ type snapYaml struct {
 	Apps             map[string]appYaml     `yaml:"apps,omitempty"`
 	Hooks            map[string]hookYaml    `yaml:"hooks,omitempty"`
 	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
+
+	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
+	TypoLayouts typoDetector `yaml:"layouts,omitempty"`
+}
+
+type typoDetector struct {
+	Hint string
+}
+
+func (td *typoDetector) UnmarshalYAML(func(interface{}) error) error {
+	return fmt.Errorf("typo detected: %s", td.Hint)
 }
 
 type appYaml struct {
@@ -116,6 +127,8 @@ type socketsYaml struct {
 // InfoFromSnapYaml creates a new info based on the given snap.yaml data
 func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	var y snapYaml
+	// Customize hints for the typo detector.
+	y.TypoLayouts.Hint = `use singular "layout" instead of plural "layouts"`
 	err := yaml.Unmarshal(yamlData, &y)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse snap.yaml: %s", err)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1693,6 +1693,19 @@ layout:
 	})
 }
 
+func (s *YamlSuite) TestLayoutsWithTypo(c *C) {
+	y := []byte(`
+name: foo
+version: 1.0
+layouts:
+  /usr/share/foo:
+    bind: $SNAP/usr/share/foo
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, ErrorMatches, `cannot parse snap.yaml: typo detected: use singular "layout" instead of plural "layouts"`)
+	c.Assert(info, IsNil)
+}
+
 func (s *YamlSuite) TestSnapYamlAppTimer(c *C) {
 	y := []byte(`name: wat
 version: 42


### PR DESCRIPTION
* snap: detect layouts vs layout in snap.yaml

This patch adds a check for a typo that people can easily make when
experimenting with snap layouts. The yaml is defined to use the singular
form but there used to be no notification when the plural form was used.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

* snap: fix typo in a typo

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

* snap: simplify typo type

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

* snap: tweak error wording

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

* snap: tweak type documentation

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

* snap: tweak error handling

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

* snap: generalize the typo detector

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>