### PR TITLE
interfaces/apparmor: handle overlayfs snippet for snap-update-ns

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -435,6 +435,9 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		case "###SNAP_INSTANCE_NAME###":
 			return snapInfo.InstanceName()
 		case "###SNIPPETS###":
+			if overlayRoot, _ := isRootWritableOverlay(); overlayRoot != "" {
+				snippets += strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
+			}
 			return snippets
 		}
 		return ""

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1347,6 +1347,8 @@ func (s *backendSuite) TestNFSAndOverlaySnippets(c *C) {
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		c.Check(profile, testutil.FileContains, scenario.overlaySnippet)
 		c.Check(profile, testutil.FileContains, scenario.nfsSnippet)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
+		c.Check(updateNSProfile, testutil.FileContains, scenario.overlaySnippet)
 		s.RemoveSnap(c, snapInfo)
 	}
 }


### PR DESCRIPTION
When running from a live CD which is using overlayfs on the root
filesystem we would get denials from snap-update-ns that tries to
construct content interface connections as appropriate bind mounts.

This is because additional permissions required to support overlayfs
were added to individual application profiles but not to the per-snap
snap-update-ns profile. This is now fixed.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1794953
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
