### PR TITLE
interfaces/network-setup-control: allow calling netplan generate/apply

### DIFF
--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -34,6 +34,9 @@ const networkSetupControlConnectedPlugAppArmor = `
 
 /etc/netplan/{,**} rw,
 /etc/network/{,**} rw,
+
+# allow "netplan generate" and "netplan apply" after changing the config
+/{,usr/}{,s}bin/netplan ixr,
 `
 
 func init() {


### PR DESCRIPTION
network_setup_control allows writing and changing the netplan configuration but the only way to make actual use of it is to also connect the shutdown interface and trigger a reboot. 

The "netplan generate" and "netplan apply" commands should be allowed in this interface to be able to avoid the extra interface connection for shutdown and to avoid an unneeded reboot for a simple network setup change.