### PR TITLE
cmd/snap: attempt to start the document portal if running with a sess…

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -23,6 +23,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -33,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/godbus/dbus"
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/client"
@@ -548,6 +550,101 @@ func migrateXauthority(info *snap.Info) (string, error) {
 	return targetPath, nil
 }
 
+func activateXdgDocumentPortal(info *snap.Info, snapApp, hook string) error {
+	// Don't do anything for apps or hooks that don't plug the
+	// desktop interface
+	//
+	// NOTE: This check is imperfect because we don't really know
+	// if the interface is connected or not but this is an
+	// acceptable compromise for not having to communicate with
+	// snapd in snap run. In a typical desktop session the
+	// document portal can be in use by many applications, not
+	// just by snaps, so this is at most, pre-emptively using some
+	// extra memory.
+	var plugs map[string]*snap.PlugInfo
+	if hook != "" {
+		plugs = info.Hooks[hook].Plugs
+	} else {
+		_, appName := snap.SplitSnapApp(snapApp)
+		plugs = info.Apps[appName].Plugs
+	}
+	plugsDesktop := false
+	for _, plug := range plugs {
+		if plug.Interface == "desktop" {
+			plugsDesktop = true
+			break
+		}
+	}
+	if !plugsDesktop {
+		return nil
+	}
+
+	u, err := userCurrent()
+	if err != nil {
+		return fmt.Errorf(i18n.G("cannot get the current user: %s"), err)
+	}
+	xdgRuntimeDir := filepath.Join(dirs.XdgRuntimeDirBase, u.Uid)
+
+	// If $XDG_RUNTIME_DIR/doc appears to be a mount point, assume
+	// that the document portal is up and running.
+	expectedMountPoint := filepath.Join(xdgRuntimeDir, "doc")
+	if mounted, err := osutil.IsMounted(expectedMountPoint); err != nil {
+		logger.Noticef("Could not check document portal mount state: %s", err)
+	} else if mounted {
+		return nil
+	}
+
+	// If there is no session bus, our job is done.  We check this
+	// manually to avoid dbus.SessionBus() auto-launching a new
+	// bus.
+	busAddress := osGetenv("DBUS_SESSION_BUS_ADDRESS")
+	if len(busAddress) == 0 {
+		return nil
+	}
+
+	// We've previously tried to start the document portal and
+	// were told the service is unknown: don't bother connecting
+	// to the session bus again.
+	//
+	// As the file is in $XDG_RUNTIME_DIR, it will be cleared over
+	// full logout/login or reboot cycles.
+	portalsUnavailableFile := filepath.Join(xdgRuntimeDir, ".portals-unavailable")
+	if osutil.FileExists(portalsUnavailableFile) {
+		return nil
+	}
+
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return err
+	}
+
+	portal := conn.Object("org.freedesktop.portal.Documents",
+		"/org/freedesktop/portal/documents")
+	var mountPoint []byte
+	if err := portal.Call("org.freedesktop.portal.Documents.GetMountPoint", 0).Store(&mountPoint); err != nil {
+		// It is not considered an error if
+		// xdg-document-portal is not available on the system.
+		if dbusErr, ok := err.(dbus.Error); ok && dbusErr.Name == "org.freedesktop.DBus.Error.ServiceUnknown" {
+			// We ignore errors here: if writing the file
+			// fails, we'll just try connecting to D-Bus
+			// again next time.
+			if err = ioutil.WriteFile(portalsUnavailableFile, []byte(""), 0644); err != nil {
+				logger.Noticef("WARNING: cannot write file at %s: %s", portalsUnavailableFile, err)
+			}
+			return nil
+		}
+		return err
+	}
+
+	// Sanity check to make sure the document portal is exposed
+	// where we think it is.
+	actualMountPoint := strings.TrimRight(string(mountPoint), "\x00")
+	if actualMountPoint != expectedMountPoint {
+		return fmt.Errorf(i18n.G("Expected portal at %#v, got %#v"), expectedMountPoint, actualMountPoint)
+	}
+	return nil
+}
+
 func straceCmd() ([]string, error) {
 	current, err := user.Current()
 	if err != nil {
@@ -729,6 +826,10 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	xauthPath, err := migrateXauthority(info)
 	if err != nil {
 		logger.Noticef("WARNING: cannot copy user Xauthority file: %s", err)
+	}
+
+	if err := activateXdgDocumentPortal(info, snapApp, hook); err != nil {
+		logger.Noticef("WARNING: cannot start document portal: %s", err)
 	}
 
 	cmd := []string{snapConfine}

--- a/osutil/mount_darwin.go
+++ b/osutil/mount_darwin.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+// IsMounted is not implemented on darwin
+func IsMounted(baseDir string) (bool, error) {
+	return false, ErrDarwin
+}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -115,6 +115,13 @@ Requires:       gpg2
 Requires:       openssh
 Requires:       squashfs
 
+# Old versions of xdg-document-portal can expose data belonging to
+# other confied apps.  Older OpenSUSE releases are unlikely to change,
+# so for now limit this to Tumbleweed.
+%if 0%{?suse_version} >= 1550
+Conflicts:      xdg-desktop-portal < 0.11
+%endif
+
 %{?systemd_requires}
 
 # TODO strip the C executables but don't strip the go executables

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -38,6 +38,9 @@ fedora_name_package() {
             printer-driver-cups-pdf)
                 echo "cups-pdf"
                 ;;
+            python3-gi)
+                echo "python3-gobject"
+                ;;
             *)
                 echo "$i"
                 ;;
@@ -70,6 +73,13 @@ opensuse_name_package() {
             printer-driver-cups-pdf)
                 echo "cups-pdf"
                 ;;
+            python3-dbus)
+                # In OpenSUSE Leap 15, this is renamed to python3-dbus-python
+                echo "dbus-1-python3"
+                ;;
+            python3-gi)
+                echo "python3-gobject"
+                ;;
             *)
                 echo "$i"
                 ;;
@@ -94,6 +104,12 @@ arch_name_package() {
             ;;
         man)
             echo "man-db"
+            ;;
+        python3-dbus)
+            echo "python-dbus"
+            ;;
+        python3-gi)
+            echo "python-gobject"
             ;;
         *)
             echo "$1"

--- a/tests/main/document-portal-activation/fake-document-portal.py
+++ b/tests/main/document-portal-activation/fake-document-portal.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+BUS_NAME = "org.freedesktop.portal.Documents"
+OBJECT_PATH = "/org/freedesktop/portal/documents"
+DOC_IFACE = "org.freedesktop.portal.Documents"
+
+class DocPortal(dbus.service.Object):
+    def __init__(self, connection, object_path, logfile, errorfile):
+        super(DocPortal, self).__init__(connection, object_path)
+        self._logfile = logfile
+        self._errorfile = errorfile
+
+    @property
+    def _report_error(self):
+        with open(self._errorfile, 'r') as fp:
+            return 'error' in fp.read()
+
+    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
+                         out_signature="ay")
+    def GetMountPoint(self):
+        with open(self._logfile, "a") as fp:
+            fp.write("GetMountPoint called\n")
+        if self._report_error:
+            raise dbus.DBusException("failure", name=DOC_IFACE + ".Error.Failed")
+        return '/run/user/{}/doc\x00'.format(os.getuid()).encode('ASCII')
+
+def main(argv):
+    logfile, errorfile = argv[1:]
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    main_loop = GLib.MainLoop()
+
+    bus = dbus.SessionBus()
+    # Make sure we quit when the bus shuts down
+    bus.add_signal_receiver(
+        main_loop.quit, signal_name="Disconnected",
+        path="/org/freedesktop/DBus/Local",
+        dbus_interface="org.freedesktop.DBus.Local")
+
+    portal = DocPortal(bus, OBJECT_PATH, logfile, errorfile)
+
+    # Allow other services to assume our bus name
+    bus_name = dbus.service.BusName(
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
+        do_not_queue=True)
+
+    main_loop.run()
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -1,0 +1,98 @@
+summary: Check that the document portal is activated when needed
+description: |
+    In order for xdg-document-portal to securely share files with a
+    confined applications, it must be started prior to setting up the
+    user mount namespace.  This is due to the daemon providing a FUSE
+    file system that needs to be bind mounted in the sandbox.
+
+    With that in mind, we don't want every snap invocation to try and
+    start the document portal.  Only in the following cases:
+
+        - a session bus is running
+        - the snap plugs the "desktop" interface
+
+    Furthermore, we don't want to print an error on systems where
+    xdg-document-portal is not available.
+
+# Disabled on Ubuntu Core because it doesn't provide the "desktop"
+# slot, and Amazon Linux because it doesn't have the required Python 3
+# packages to run the test.
+systems: [ "-ubuntu-core-*", "-amazon-linux-2-*" ]
+
+environment:
+    XDG_RUNTIME_DIR: /run/user/$(id -u)
+
+prepare: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    . "$TESTSLIB"/snaps.sh
+    distro_install_package python3-dbus python3-gi
+    install_local test-snapd-desktop
+    install_local test-snapd-tools
+    rm -f /usr/share/dbus-1/services/fake-document-portal.service
+    mkdir -p "$XDG_RUNTIME_DIR"
+    rm -rf "${XDG_RUNTIME_DIR:?}/*" "${XDG_RUNTIME_DIR:?}/.[!.]*"
+
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    [ -f dbus-launch.pid ] && kill "$(cat dbus-launch.pid)"
+    rm -f dbus-launch.pid
+    rm -f stderr.log doc-portal.log report-error.txt
+    rm -f /usr/share/dbus-1/services/fake-document-portal.service
+    distro_purge_package python3-dbus python3-gi
+    distro_auto_remove_packages
+    rm -rf "${XDG_RUNTIME_DIR:?}/*" "${XDG_RUNTIME_DIR:?}/.[!.]*"
+
+execute: |
+    echo "No output on stderr when running without a session bus"
+    user_data="$HOME/snap/test-snapd-desktop/current"
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+
+    echo "Starting session bus"
+    eval "$(dbus-launch --sh-syntax)"
+    echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
+
+    echo "No output on stderr when running with a session bus, when xdg-document-portal is not present."
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+
+    echo "The absence of the document portal service was recorded"
+    [ -f "$XDG_RUNTIME_DIR/.portals-unavailable" ]
+
+    echo "Make the fake document portal activatable"
+    cat << EOF > /usr/share/dbus-1/services/fake-document-portal.service
+    [D-BUS Service]
+    Name=org.freedesktop.portal.Documents
+    Exec=$(pwd)/fake-document-portal.py $(pwd)/doc-portal.log $(pwd)/report-error.txt
+    EOF
+    : > doc-portal.log
+    : > report-error.txt
+
+    echo "No attempt is made to activate the document portal due to the previous failure"
+    test-snapd-desktop.check-dirs "$user_data"
+    ! MATCH "GetMountPoint called" < doc-portal.log
+
+    echo "Remove the .portals-unavailable file to force a recheck"
+    rm "$XDG_RUNTIME_DIR/.portals-unavailable"
+
+    echo "No output on stderr when running with a session bus and xdg-document-portal is present".
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    MATCH "GetMountPoint called" < doc-portal.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+
+    echo "Putting fake document portal into failure mode"
+    echo "error" > report-error.txt
+    : > doc-portal.log
+
+    echo "Failures from a running xdg-document-portal are reported"
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    MATCH "GetMountPoint called" < doc-portal.log
+    MATCH "WARNING: cannot start document portal: failure" < stderr.log
+
+    echo "Snaps not using the desktop interface will not try to contact the document portal"
+    : > doc-portal.log
+    test-snapd-tools.success 2>stderr.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+    [ "$(wc -c < doc-portal.log)" -eq 0 ]


### PR DESCRIPTION
…ion bus (#5271)

* cmd: attempt to start the document portal if running with a session bus

* tests: add a spread test to verify that document portal activation works

* tests: handle different package names on Fedora, SUSE, and Arch

* tests: changes to fix spread failures on Ubuntu 14.04 and OpenSUSE Leap 42.3

* cmd/snap: changes requested in review

* tests: fix shellcheck warnings

* tests: remove packages installed by test in restore

* tests: more shellcheck fixes

* packaging: conflict with old xdg-desktop-portal on Tumbleweed

* cmd/snap: check whether the app or hook specifically uses the desktop plug.

* cmd/snap: if $XDG_RUNTIME_DIR/doc is a mount point, assume
xdg-document-portal is running.

* tests: disable document-portal-activation spread test on Amazon Linux

Amazon Linux does not ship Python 3 versions of the DBus or GObject
bindings, which this test relies on for the fake document portal
implementation.  It isn't a particularly interesting target for this
feature, so I don't think it is worth spending too much time on.

* cmd/snap: record whether the portal services was available

This means that there should only be one attempt to start the document
portal per user session on systems where xdg-desktop-portal is not
installed.

* cmd/snap: use osutil.IsMounted implementation, and stub out on darwin

* cmd/snap: remove duplicate calculation of $XDG_RUNTIME_DIR

* cmd/snap: rename .snap-portals-unavailable -> .portals-unavailable
