### PR TITLE
overlord: don't make become-operational interfere with user requests

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -477,6 +477,26 @@ func (s *interfaceManagerSuite) TestConnectDoesConflict(c *C) {
 	c.Assert(err, ErrorMatches, `snap "consumer" has "other-connect" change in progress`)
 }
 
+func (s *interfaceManagerSuite) TestConnectBecomeOperationalNoConflict(c *C) {
+	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("become-operational", "...")
+	hooksup := &hookstate.HookSetup{
+		Snap: "producer",
+		Hook: "prepare-device",
+	}
+	t := hookstate.HookTask(s.state, "prep", hooksup, nil)
+	chg.AddTask(t)
+
+	_, err := ifacestate.Connect(s.state, "consumer", "plug", "producer", "slot")
+	c.Assert(err, IsNil)
+}
+
 func (s *interfaceManagerSuite) TestAutoconnectDoesntConflictOnInstallingDifferentSnap(c *C) {
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -114,6 +114,14 @@ func CheckChangeConflictMany(st *state.State, snapNames []string, ignoreChangeID
 		if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
 			continue
 		}
+		if chg.Kind() == "become-operational" {
+			// become-operational will be retried until success
+			// and on its own just runs a hook on gadget:
+			// do not make it interfere with user requests
+			// TODO: consider a use vs change modeling of
+			// conflicts
+			continue
+		}
 
 		snaps, err := affectedSnaps(task)
 		if err != nil {


### PR DESCRIPTION
It might be running at any time, contains only a run-hook and will retry anyway it itself encounters issues.
