### PR TITLE
overlord: don't make become-operational interfere with user requests (2.35)

### DIFF
--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -114,6 +114,14 @@ func CheckChangeConflictMany(st *state.State, snapNames []string, ignoreChangeID
 		if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
 			continue
 		}
+		if chg.Kind() == "become-operational" {
+			// become-operational will be retried until success
+			// and on its own just runs a hook on gadget:
+			// do not make it interfere with user requests
+			// TODO: consider a use vs change modeling of
+			// conflicts
+			continue
+		}
 
 		snaps, err := affectedSnaps(task)
 		if err != nil {


### PR DESCRIPTION
It might be running at any time, contains only a run-hook and will retry anyway itself if it encounters issues.
