### PR TITLE
cmd/snap-update-ns: remove empty placeholders used for mounting

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -308,15 +308,69 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			err = osRemove(c.Entry.Dir)
 			logger.Debugf("remove %q (error: %v)", c.Entry.Dir, err)
 		case "", "file":
+			// Detach the mount point instead of unmounting it if requested.
 			flags := umountNoFollow
 			if c.Entry.XSnapdDetach() {
 				flags |= syscall.MNT_DETACH
 			}
+
+			// Perform the raw unmount operation.
 			err = sysUnmount(c.Entry.Dir, flags)
 			if err == nil {
 				as.AddChange(c)
 			}
 			logger.Debugf("umount %q (error: %v)", c.Entry.Dir, err)
+			if err != nil {
+				return err
+			}
+
+			// Open a path of the file we are considering the removal of.
+			path := c.Entry.Dir
+			var fd int
+			fd, err = OpenPath(path)
+			if err != nil {
+				return err
+			}
+			defer sysClose(fd)
+
+			// Don't attempt to remove anything from squashfs.
+			var statfsBuf syscall.Statfs_t
+			err = sysFstatfs(fd, &statfsBuf)
+			if err != nil {
+				return err
+			}
+			if statfsBuf.Type == SquashfsMagic {
+				return nil
+			}
+
+			if kind == "file" {
+				// Don't attempt to remove non-empty files since they cannot be
+				// the placeholders we created.
+				var statBuf syscall.Stat_t
+				err = sysFstat(fd, &statBuf)
+				if err != nil {
+					return err
+				}
+				if statBuf.Size != 0 {
+					return nil
+				}
+			}
+
+			// Remove the file or directory while using the full path. There's
+			// no way to avoid a race here since there's no way to unlink a
+			// file solely by file descriptor.
+			err = osRemove(path)
+			// Unpack the low-level error that osRemove wraps into PathError.
+			if packed, ok := err.(*os.PathError); ok {
+				err = packed.Err
+			}
+			// If we were removing a directory but it was not empty then just
+			// ignore the error. This is the equivalent of the non-empty file
+			// check we do above. See rmdir(2) for explanation why we accept
+			// more than one errno value.
+			if kind == "" && (err == syscall.ENOTEMPTY || err == syscall.EEXIST) {
+				return nil
+			}
 		}
 		return err
 	case Keep:

--- a/tests/main/interfaces-content-mkdir-writable/task.yaml
+++ b/tests/main/interfaces-content-mkdir-writable/task.yaml
@@ -84,16 +84,10 @@ execute: |
     test-snapd-content-advanced-plug.sh -c "$(printf 'test -f $%s/target/canary' "$VAR")"
 
     # Without discarding the namespace disconnect the content interface. This
-    # should undo the bind mounts but keep the directories around. The canary
-    # file is thus no longer accessible but all the directories are in place
-    # because we never remove them explicitly.
+    # should undo the bind mounts and remove the placeholder files and
+    # directories.
     snap disconnect "$PLUG" "$SLOT"
-
-    if [ "$VAR" != "SNAP" ]; then
-        test-snapd-content-advanced-plug.sh -c "$(printf 'test -d $%s/target' "$VAR")"
-    else
-        test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -d $%s/target' "$VAR")"
-    fi
+    test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -d $%s/target' "$VAR")"
     test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -e $%s/target/canary' "$VAR")"
     test-snapd-content-advanced-slot.sh -c "$(printf 'test -d $%s/source' "$VAR")"
     test-snapd-content-advanced-slot.sh -c "$(printf 'test -e $%s/source/canary' "$VAR")"

--- a/tests/main/layout-symlink-bind-revert/task.yaml
+++ b/tests/main/layout-symlink-bind-revert/task.yaml
@@ -20,5 +20,5 @@ execute: |
     app 2>&1 | MATCH '/snap/app/x2/bin/app: 2: /snap/app/x2/bin/app: /opt/runtime/runner: not found'
 
     echo "The broken application is reverted"
-    snap revert app 2>&1 | MATCH 'cannot update snap namespace: cannot create symlink in "/opt/runtime": existing file in the way'
-    app 2>&1 | MATCH '/snap/app/x2/bin/app: 2: /snap/app/x2/bin/app: /opt/runtime/runner: not found'
+    snap revert app 2>&1 | MATCH 'app reverted to 1'
+    app 2>&1 | MATCH "RUNTIME: Hello from the app"


### PR DESCRIPTION
This patch fixes an edge case where a mount namespace cannot be updated
because of leftover empty placeholder files or directories that
interfere with the subsequent operation, e.g. construction of a symlink
or directory (while a placeholder file exists).

When a mount change is undone, empty files and empty directories that
inhabit file systems other than squashfs are removed. This is imperfect
because we don't know if we had actually created a file but since we
measure it as empty the compromise is acceptable.

The spread test that was introduced prior to the fix is updated to show
the correct operation of revert now. The spread test for content
interface connection is tweaked to reflect the fact that we remove
unused placeholders now.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
