### PR TITLE
cmd: put our manpages in section 8

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -186,8 +186,8 @@ decode-mount-opts/decode-mount-opts$(EXEEXT): LIBS += -Wl,-Bstatic $(decode_moun
 
 libexec_PROGRAMS += snap-confine/snap-confine
 if HAVE_RST2MAN
-dist_man_MANS += snap-confine/snap-confine.1
-CLEANFILES += snap-confine/snap-confine.1
+dist_man_MANS += snap-confine/snap-confine.8
+CLEANFILES += snap-confine/snap-confine.8
 endif
 EXTRA_DIST += snap-confine/snap-confine.rst
 EXTRA_DIST += snap-confine/snap-confine.apparmor.in
@@ -312,8 +312,7 @@ snap-confine/unit-tests$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_confine_unit_tests
 endif  # WITH_UNIT_TESTS
 
 if HAVE_RST2MAN
-snap-confine/%.1: snap-confine/%.rst
-	mkdir -p snap-confine
+%.8: %.rst
 	$(HAVE_RST2MAN) $^ > $@
 endif
 
@@ -389,8 +388,8 @@ install-exec-local::
 
 libexec_PROGRAMS += snap-discard-ns/snap-discard-ns
 if HAVE_RST2MAN
-dist_man_MANS += snap-discard-ns/snap-discard-ns.5
-CLEANFILES += snap-discard-ns/snap-discard-ns.5
+dist_man_MANS += snap-discard-ns/snap-discard-ns.8
+CLEANFILES += snap-discard-ns/snap-discard-ns.8
 endif
 EXTRA_DIST += snap-discard-ns/snap-discard-ns.rst
 
@@ -426,12 +425,6 @@ snap-discard-ns/snap-discard-ns$(EXEEXT): $(snap_discard_ns_snap_discard_ns_OBJE
 	$(AM_V_CCLD)$(snap_discard_ns_snap_discard_ns_LINK) $(snap_discard_ns_snap_discard_ns_OBJECTS) $(snap_discard_ns_snap_discard_ns_LDADD) $(LIBS)
 
 snap-discard-ns/snap-discard-ns$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_discard_ns_snap_discard_ns_STATIC) -Wl,-Bdynamic -pthread
-
-if HAVE_RST2MAN
-snap-discard-ns/%.5: snap-discard-ns/%.rst
-	mkdir -p snap-discard-ns
-	$(HAVE_RST2MAN) $^ > $@
-endif
 
 ##
 ## system-shutdown
@@ -491,12 +484,8 @@ snapd_env_generator_snapd_env_generator_LDADD = libsnap-confine-private.a
 EXTRA_DIST += snapd-env-generator/snapd-env-generator.rst
 
 if HAVE_RST2MAN
-snapd-env-generator/%.7: snapd-env-generator/%.rst
-	mkdir -p snapd-env-generator
-	$(HAVE_RST2MAN) $^ > $@
-
-dist_man_MANS += snapd-env-generator/snapd-env-generator.7
-CLEANFILES += snapd-env-generator/snapd-env-generator.7
+dist_man_MANS += snapd-env-generator/snapd-env-generator.8
+CLEANFILES += snapd-env-generator/snapd-env-generator.8
 endif
 
 ##

--- a/cmd/snap-confine/snap-confine.rst
+++ b/cmd/snap-confine/snap-confine.rst
@@ -10,7 +10,7 @@ internal tool for confining snappy applications
 :Date:   2017-09-18
 :Copyright: Canonical Ltd.
 :Version: 2.28
-:Manual section: 1
+:Manual section: 8
 :Manual group: snappy
 
 SYNOPSIS

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -154,3 +154,14 @@ func (s *SnapSuite) TestHelpCategories(c *check.C) {
 		}
 	}
 }
+
+func (s *SnapSuite) TestManpageInSection8(c *check.C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "help", "--man"}
+
+	err := snap.RunMain()
+	c.Assert(err, check.IsNil)
+
+	c.Check(s.Stdout(), check.Matches, `\.TH snap 8 (?s).*`)
+}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -172,8 +172,8 @@ package() {
   make -C cmd install DESTDIR="$pkgdir/"
 
   # Install man file
-  mkdir -p "$pkgdir/usr/share/man/man1"
-  "$srcdir/go/bin/snap" help --man > "$pkgdir/usr/share/man/man1/snap.1"
+  mkdir -p "$pkgdir/usr/share/man/man8"
+  "$srcdir/go/bin/snap" help --man > "$pkgdir/usr/share/man/man8/snap.8"
 
   # Install the "info" data file with snapd version
   install -m 644 -D "$srcdir/go/src/${_gourl}/data/info" \

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -518,7 +518,7 @@ popd
 %install
 install -d -p %{buildroot}%{_bindir}
 install -d -p %{buildroot}%{_libexecdir}/snapd
-install -d -p %{buildroot}%{_mandir}/man1
+install -d -p %{buildroot}%{_mandir}/man8
 install -d -p %{buildroot}%{_environmentdir}
 install -d -p %{buildroot}%{_systemdgeneratordir}
 install -d -p %{buildroot}%{_unitdir}
@@ -561,8 +561,8 @@ install -p -m 0644 data/selinux/snappy.if %{buildroot}%{_datadir}/selinux/devel/
 install -p -m 0644 data/selinux/snappy.pp.bz2 %{buildroot}%{_datadir}/selinux/packages
 %endif
 
-# Install snap(1) man page
-bin/snap help --man > %{buildroot}%{_mandir}/man1/snap.1
+# Install snap(8) man page
+bin/snap help --man > %{buildroot}%{_mandir}/man8/snap.8
 
 # Install the "info" data file with snapd version
 install -m 644 -D data/info %{buildroot}%{_libexecdir}/snapd/info
@@ -683,13 +683,13 @@ popd
 %{_libexecdir}/snapd/snap-failure
 %{_libexecdir}/snapd/info
 %{_libexecdir}/snapd/snap-mgmt
-%{_mandir}/man1/snap.1*
+%{_mandir}/man8/snap.8*
 %{_datadir}/bash-completion/completions/snap
 %{_libexecdir}/snapd/complete.sh
 %{_libexecdir}/snapd/etelpmoc.sh
 %{_libexecdir}/snapd/snapd.run-from-snap
 %{_sysconfdir}/profile.d/snapd.sh
-%{_mandir}/man7/snapd-env-generator.7*
+%{_mandir}/man8/snapd-env-generator.8*
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.service
 %{_unitdir}/snapd.autoimport.service
@@ -738,8 +738,8 @@ popd
 %{_libexecdir}/snapd/snap-seccomp
 %{_libexecdir}/snapd/snap-update-ns
 %{_libexecdir}/snapd/system-shutdown
-%{_mandir}/man1/snap-confine.1*
-%{_mandir}/man5/snap-discard-ns.5*
+%{_mandir}/man8/snap-confine.8*
+%{_mandir}/man8/snap-discard-ns.8*
 %{_systemdgeneratordir}/snapd-generator
 %attr(0000,root,root) %{_sharedstatedir}/snapd/void
 

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -237,8 +237,8 @@ ln -s %{_libexecdir}/snapd/snapctl  %{buildroot}%{_bindir}/snapctl
                       SNAP_MOUNT_DIR=%{snap_mount_dir}
 
 # Generate and install man page for snap command
-install -m 755 -d %{buildroot}%{_mandir}/man1
-%{buildroot}%{_bindir}/snap help --man >  %{buildroot}%{_mandir}/man1/snap.1
+install -m 755 -d %{buildroot}%{_mandir}/man8
+%{buildroot}%{_bindir}/snap help --man >  %{buildroot}%{_mandir}/man8/snap.8
 
 # TODO: enable gosrc
 # TODO: enable gofilelist
@@ -363,9 +363,9 @@ fi
 %dir %{_datadir}/polkit-1
 %dir %{_datadir}/polkit-1/actions
 %verify(not user group mode) %attr(06755,root,root) %{_libexecdir}/snapd/snap-confine
-%{_mandir}/man1/snap-confine.1.*
-%{_mandir}/man5/snap-discard-ns.5.*
-%{_mandir}/man7/snapd-env-generator.7*
+%{_mandir}/man8/snap-confine.8*
+%{_mandir}/man8/snap-discard-ns.8*
+%{_mandir}/man8/snapd-env-generator.8*
 %{_unitdir}/snapd.service
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.seeded.service
@@ -397,7 +397,7 @@ fi
 %{_libexecdir}/snapd/complete.sh
 %{_libexecdir}/snapd/etelpmoc.sh
 %{_prefix}/lib/systemd/system-generators/snapd-generator
-%{_mandir}/man1/snap.1.*
+%{_mandir}/man8/snap.8*
 %{_datadir}/dbus-1/services/io.snapcraft.Launcher.service
 %{_datadir}/dbus-1/services/io.snapcraft.Settings.service
 %{_datadir}/polkit-1/actions/io.snapcraft.snapd.policy


### PR DESCRIPTION
I hadn't realised, but our manpages are a mess.

We currently ship four manpages: `snap(1)`, `snap-confine(1)`,
`snap-env-generator(7)`, and `snap-discard-ns(5)`.

* Section 5 is where file formats are described, like `fstab(5)` or
  `passwd(5)`. `snap-discard-ns` is a program that can only be run as
  root; it goes in section 8.

* Section 7 is where generators in the abstract are described, in
  `systemd.generator(7)`. The generators themselves go in section 8,
  like `systemd-fstab-generator(8)`. So `snap-env-generator` goes in
  section 8.

* I always thought we shipped `snap(8)`: in `debian/rules`, I added
  the rule to create `snap.8`, and then shipped that. I didn't notice
  that `go-flags` wrote it as `snap(1)`, and of course the content
  wins over the filename. My rationale here is that `snap` is like
  `apt(8)`, `ifconfig(8)`, `mount(8)`, ...: users can use them to
  query things, but to modify the system state they need to be admins.

* `snap-confine` is setuid root, and so users _can_ run it, but it's
  not meant for users to run it directly. Just thinking of a system
  administrator running `snap-confine` directly is a stretch. Even so,
  I'm not sure: is it more like `gtk-query-immodule(1)`, or more like
  `ssh-keysign(8)`? I'd put it in section 8, but I can see arguments
  for it to stay in section 1.

So: in this PR, I move all our manpages to section 8. Bring it.
