### PR TITLE
wrappers: do not depend on network.taget in socket units, tweak generated units

### DIFF
--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -27,6 +27,7 @@ import (
 var (
 	// services
 	GenerateSnapServiceFile = generateSnapServiceFile
+	GenerateSnapSocketFiles = generateSnapSocketFiles
 	GenerateSnapTimerFile   = generateSnapTimerFile
 
 	// desktop

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -492,18 +492,19 @@ WantedBy={{.ServicesTarget}}
 
 func genServiceSocketFile(appInfo *snap.AppInfo, socketName string) []byte {
 	socketTemplate := `[Unit]
-# Auto-generated, DO NO EDIT
+# Auto-generated, DO NOT EDIT
 Description=Socket {{.SocketName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
 Requires={{.MountUnit}}
-Wants={{.PrerequisiteTarget}}
-After={{.MountUnit}} {{.PrerequisiteTarget}}
+After={{.MountUnit}}
 X-Snappy=yes
 
 [Socket]
 Service={{.ServiceFileName}}
 FileDescriptorName={{.SocketInfo.Name}}
 ListenStream={{.ListenStream}}
-{{if .SocketInfo.SocketMode}}SocketMode={{.SocketInfo.SocketMode | printf "%04o"}}{{end}}
+{{- if .SocketInfo.SocketMode}}
+SocketMode={{.SocketInfo.SocketMode | printf "%04o"}}
+{{- end}}
 
 [Install]
 WantedBy={{.SocketsTarget}}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -515,23 +515,21 @@ WantedBy={{.SocketsTarget}}
 	socket := appInfo.Sockets[socketName]
 	listenStream := renderListenStream(socket)
 	wrapperData := struct {
-		App                *snap.AppInfo
-		ServiceFileName    string
-		PrerequisiteTarget string
-		SocketsTarget      string
-		MountUnit          string
-		SocketName         string
-		SocketInfo         *snap.SocketInfo
-		ListenStream       string
+		App             *snap.AppInfo
+		ServiceFileName string
+		SocketsTarget   string
+		MountUnit       string
+		SocketName      string
+		SocketInfo      *snap.SocketInfo
+		ListenStream    string
 	}{
-		App:                appInfo,
-		ServiceFileName:    filepath.Base(appInfo.ServiceFile()),
-		SocketsTarget:      systemd.SocketsTarget,
-		PrerequisiteTarget: systemd.PrerequisiteTarget,
-		MountUnit:          filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir())),
-		SocketName:         socketName,
-		SocketInfo:         socket,
-		ListenStream:       listenStream,
+		App:             appInfo,
+		ServiceFileName: filepath.Base(appInfo.ServiceFile()),
+		SocketsTarget:   systemd.SocketsTarget,
+		MountUnit:       filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir())),
+		SocketName:      socketName,
+		SocketInfo:      socket,
+		ListenStream:    listenStream,
 	}
 
 	if err := t.Execute(&templateOut, wrapperData); err != nil {


### PR DESCRIPTION
Depending on network.target (which is currently used as PrerequisiteTarget) may
lead to dependncy cycles, see https://forum.snapcraft.io/t/7666 for details.
Socket units should depend on mount unit only.

While at it, tweak the generated unit files to not leave empty lines and extend
tests to verify contents of generated socket unit files.