### PR TITLE
spread: put openSUSE to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -85,6 +85,7 @@ backends:
 
             - opensuse-42.3-64:
                 workers: 4
+                manual: true
             - arch-linux-64:
                 workers: 4
 


### PR DESCRIPTION
We get Curl error 52 currently when talking to the opensuse download
server.
