### PR TITLE
snap: validate plug and slot names

### DIFF
--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -305,7 +305,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
 	})
 	defer restore()
 
-	snapInfo := snaptest.MockInfo(c, testConsumerInvalidSlotNameYaml, nil)
+	snapInfo := snaptest.MockInvalidInfo(c, testConsumerInvalidSlotNameYaml, nil)
 	snap.SanitizePlugsSlots(snapInfo)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
 	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS5 \(invalid slot name: "ttyS5"\)`)
@@ -317,7 +317,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 	})
 	defer restore()
 
-	snapInfo := snaptest.MockInfo(c, testConsumerInvalidPlugNameYaml, nil)
+	snapInfo := snaptest.MockInvalidInfo(c, testConsumerInvalidPlugNameYaml, nil)
 	snap.SanitizePlugsSlots(snapInfo)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
 	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS3 \(invalid plug name: "ttyS3"\)`)

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -380,7 +380,12 @@ func Validate(info *Info) error {
 		}
 	}
 
-	// ensure that plug and slot have unique names
+	// Ensure that plugs and slots have appropriate names.
+	if err := plugsSlotsNames(info); err != nil {
+		return err
+	}
+
+	// Ensure that plug and slot have unique names.
 	if err := plugsSlotsUniqueNames(info); err != nil {
 		return err
 	}
@@ -446,6 +451,19 @@ func ValidateLayoutAll(info *Info) error {
 	return nil
 }
 
+func plugsSlotsNames(info *Info) error {
+	for plugName := range info.Plugs {
+		if err := ValidatePlugName(plugName); err != nil {
+			return err
+		}
+	}
+	for slotName := range info.Slots {
+		if err := ValidateSlotName(slotName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func plugsSlotsUniqueNames(info *Info) error {
 	// we could choose the smaller collection if we wanted to optimize this check
 	for plugName := range info.Plugs {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -695,6 +695,32 @@ func (s *ValidateSuite) TestValidateAlias(c *C) {
 	}
 }
 
+func (s *ValidateSuite) TestValidatePlugSlotName(c *C) {
+	const yaml1 = `
+name: invalid-plugs
+version: 1
+plugs:
+  p--lug: null
+`
+	info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml1), nil)
+	c.Assert(err, IsNil)
+	c.Assert(info.Plugs, HasLen, 1)
+	err = Validate(info)
+	c.Assert(err, ErrorMatches, `invalid plug name: "p--lug"`)
+
+	const yaml2 = `
+name: invalid-slots
+version: 1
+slots:
+  s--lot: null
+`
+	info, err = InfoFromSnapYamlWithSideInfo([]byte(yaml2), nil)
+	c.Assert(err, IsNil)
+	c.Assert(info.Slots, HasLen, 1)
+	err = Validate(info)
+	c.Assert(err, ErrorMatches, `invalid slot name: "s--lot"`)
+}
+
 type testConstraint string
 
 func (constraint testConstraint) IsOffLimits(path string) bool {


### PR DESCRIPTION
This patch plugs a hole in snap.yaml validation code. We used to check
the plug and slot names because we used to call repo.AddPlug, and
AddSlot but now we call bulk AddSnap (which is faster and atomic) and it
relies on snap.yaml validation entirely, not doing any more checks. The
problem is that we never validated plug and slot names at that level.

This patch fixes that. From now on invalid plug and slot names will be
rejected early on in the validator, preventing usage of such snaps on
the system.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
