### PR TITLE
store: speedup unit tests

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -73,6 +73,14 @@ func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	})
 }
 
+func MockConnCheckStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
+	originalConnCheckStrategy := connCheckStrategy
+	connCheckStrategy = strategy
+	t.AddCleanup(func() {
+		connCheckStrategy = originalConnCheckStrategy
+	})
+}
+
 func (cm *CacheManager) CacheDir() string {
 	return cm.cacheDir
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -5942,6 +5942,11 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 }
 
 func (s *storeTestSuite) TestConnectivityCheckUnhappy(c *C) {
+	store.MockConnCheckStrategy(&s.BaseTest, retry.LimitCount(3, retry.Exponential{
+		Initial: time.Millisecond,
+		Factor:  1.3,
+	}))
+
 	seenPaths := make(map[string]int, 2)
 	var mockServerURL *url.URL
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Before this change,

    $ go test -count 1 ./store
    ok  	github.com/snapcore/snapd/store	11.921s

and after,

    $ go test -count 1 ./store
    ok  	github.com/snapcore/snapd/store	0.633s
