### PR TITLE
systemd, wrappers: speed up wrappers unit tests

### DIFF
--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -21,23 +21,11 @@ package systemd
 
 import (
 	"io"
-	"time"
 )
 
 var (
 	Jctl = jctl
 )
-
-func MockStopDelays(checkDelay, notifyDelay time.Duration) func() {
-	oldCheckDelay := stopCheckDelay
-	oldNotifyDelay := stopNotifyDelay
-	stopCheckDelay = checkDelay
-	stopNotifyDelay = notifyDelay
-	return func() {
-		stopCheckDelay = oldCheckDelay
-		stopNotifyDelay = oldNotifyDelay
-	}
-}
 
 func MockOsGetenv(f func(string) string) func() {
 	oldOsGetenv := osGetenv

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -69,6 +69,19 @@ func MockSystemctl(f func(args ...string) ([]byte, error)) func() {
 	}
 }
 
+// MockStopDelays is used from tests so that Stop can be less
+// forgiving there.
+func MockStopDelays(checkDelay, notifyDelay time.Duration) func() {
+	oldCheckDelay := stopCheckDelay
+	oldNotifyDelay := stopNotifyDelay
+	stopCheckDelay = checkDelay
+	stopNotifyDelay = notifyDelay
+	return func() {
+		stopCheckDelay = oldCheckDelay
+		stopNotifyDelay = oldNotifyDelay
+	}
+}
+
 func Available() error {
 	_, err := systemctlCmd("--version")
 	return err


### PR DESCRIPTION
Doing this meant exposing systemd.MockStopDelays, so calls to
systemd.Stop wouldn't be too slow.

Before this change,

    $ go test -count 1 ./wrappers/
    ok  	github.com/snapcore/snapd/wrappers	10.076s

and after,

    $ go test -count 1 ./wrappers/
    ok  	github.com/snapcore/snapd/wrappers	0.174s
