### PR TITLE
client: speedup unit tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,6 +51,7 @@ type clientSuite struct {
 	doCalls int
 	header  http.Header
 	status  int
+	restore func()
 }
 
 var _ = Suite(&clientSuite{})
@@ -70,10 +71,13 @@ func (cs *clientSuite) SetUpTest(c *C) {
 	cs.doCalls = 0
 
 	dirs.SetRootDir(c.MkDir())
+
+	cs.restore = client.MockDoRetry(time.Millisecond, 10*time.Millisecond)
 }
 
 func (cs *clientSuite) TearDownTest(c *C) {
 	os.Unsetenv(client.TestAuthFileEnvKey)
+	cs.restore()
 }
 
 func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {
@@ -99,8 +103,6 @@ func (cs *clientSuite) TestNewPanics(c *C) {
 }
 
 func (cs *clientSuite) TestClientDoReportsErrors(c *C) {
-	restore := client.MockDoRetry(10*time.Millisecond, 100*time.Millisecond)
-	defer restore()
 	cs.err = errors.New("ouchie")
 	err := cs.cli.Do("GET", "/", nil, nil, nil)
 	c.Check(err, ErrorMatches, "cannot communicate with server: ouchie")


### PR DESCRIPTION
Before this change,

    $ go test -count 1 ./client/
    ok  	github.com/snapcore/snapd/client	10.170s

and after,

    $ go test -count 1 ./client/
    ok  	github.com/snapcore/snapd/client	0.101s
