### PR TITLE
osutils: unit tests speedup; introduce «run-checks --short-unit».

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
         - ./get-deps.sh
       script:
         - ./run-checks --static
-        - ./run-checks --unit
+        - ./run-checks --short-unit
     - stage: quick
       go: 1.10
       name: OSX build and minimal runtime sanity check

--- a/osutil/context_test.go
+++ b/osutil/context_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+	"testing"
 	"time"
 
 	"golang.org/x/net/context"
@@ -74,6 +75,10 @@ func (ctxSuite) TestRun(c *check.C) {
 }
 
 func (ctxSuite) TestRunRace(c *check.C) {
+	if testing.Short() {
+		c.Skip("skippinng non-short test")
+	}
+
 	// first, time how long /bin/false takes
 	t0 := time.Now()
 	cmderr := exec.Command("/bin/false").Run()

--- a/osutil/flock_test.go
+++ b/osutil/flock_test.go
@@ -134,7 +134,7 @@ func (s *flockSuite) TestLockUnlockNonblockingWorks(c *C) {
 		if osutil.FileExists(lockPath) {
 			break
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Millisecond)
 	}
 
 	lock, err := osutil.NewFileLock(lockPath)

--- a/run-checks
+++ b/run-checks
@@ -29,6 +29,8 @@ fi
 export GOPATH="${GOPATH:-$(realpath "$(dirname "$0")"/../../../../)}"
 export PATH="$PATH:${GOPATH%%:*}/bin"
 
+short=
+
 STATIC=
 UNIT=
 SPREAD=
@@ -45,6 +47,10 @@ case "${1:-all}" in
         ;;
     --unit)
         UNIT=1
+        ;;
+    --short-unit)
+        UNIT=1
+        short=1
         ;;
     --spread)
         SPREAD=1
@@ -216,30 +222,34 @@ fi
 if [ "$UNIT" = 1 ]; then
     ./get-deps.sh
 
-    # Prepare the coverage output profile.
-    rm -rf .coverage
-    mkdir .coverage
-    echo "mode: $COVERMODE" > .coverage/coverage.out
-
     echo Building
     go build -v github.com/snapcore/snapd/...
 
     # tests
     echo Running tests from "$PWD"
-    if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
-        # shellcheck disable=SC2046
-        $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+    if [ "$short" = 1 ]; then
+            # shellcheck disable=SC2046
+            $goctest -short -v $(go list ./... | grep -v '/vendor/' )
     else
-        for pkg in $(go list ./... | grep -v '/vendor/' ); do
-            go test -i "$pkg"
-            $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
-            append_coverage .coverage/profile.out
-        done
-    fi
+        # Prepare the coverage output profile.
+        rm -rf .coverage
+        mkdir .coverage
+        echo "mode: $COVERMODE" > .coverage/coverage.out
 
-    # upload to codecov.io if on travis
-    if [ "${TRAVIS_BUILD_NUMBER:-}" ]; then
-        curl -s https://codecov.io/bash | bash /dev/stdin -f .coverage/coverage.out
+        if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
+            # shellcheck disable=SC2046
+            $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+        else
+            for pkg in $(go list ./... | grep -v '/vendor/' ); do
+                go test -i "$pkg"
+                $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
+                append_coverage .coverage/profile.out
+            done
+        fi
+        # upload to codecov.io if on travis
+        if [ "${TRAVIS_BUILD_NUMBER:-}" ]; then
+            curl -s https://codecov.io/bash | bash /dev/stdin -f .coverage/coverage.out
+        fi
     fi
 fi
 


### PR DESCRIPTION
In trying to speed up the `osutils` unit tests I found that a
particular test was problematic, as there wasn't a good way of making
it consistently quicker (on my machine it takes between .2s and 40s).

So instead I skip that test if `testing.Short()`, and added a
`--short-unit` option to `run-checks` that runs `go test -short`.
While I was at it I made the short unit test not run with `-coverage`,
which also speeds it up. And of course, the travis "quick" unit test
run is now a `--short-unit`.

So now,

    $ go test -count 10 ./osutil
    ok  	github.com/snapcore/snapd/osutil	118.122s
    $ go test -short -count 10 ./osutil
    ok  	github.com/snapcore/snapd/osutil	5.910s

(I did also shave ~.1s off one other test, FWIW, but it's not one that
runs in travis anyway).