### PR TITLE
cmd/snap: speed up unit tests

### DIFF
--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 
 	. "gopkg.in/check.v1"
 
@@ -60,6 +61,9 @@ done
 `)
 
 func (s *SnapKeysSuite) SetUpTest(c *C) {
+	if testing.Short() && s.GnupgCmd == "/usr/bin/gpg2" {
+		c.Skip("gpg2 does not do short tests")
+	}
 	s.BaseSnapSuite.SetUpTest(c)
 
 	s.tempdir = c.MkDir()

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -69,16 +69,15 @@ func (s *userdSuite) TestUserd(c *C) {
 		}()
 
 		needle := "io.snapcraft.Launcher"
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 100; i++ {
 			for _, objName := range s.SessionBus.Names() {
 				if objName == needle {
 					return
 				}
-				time.Sleep(1 * time.Second)
 			}
-
+			time.Sleep(10 * time.Millisecond)
 		}
-		c.Fatalf("%s does not appeared on the bus", needle)
+		c.Fatalf("%s has not appeared on the bus", needle)
 	}()
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd"})

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -69,7 +69,7 @@ func (s *userdSuite) TestUserd(c *C) {
 		}()
 
 		needle := "io.snapcraft.Launcher"
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 1000; i++ {
 			for _, objName := range s.SessionBus.Names() {
 				if objName == needle {
 					return

--- a/cmd/snap/cmd_watch_test.go
+++ b/cmd/snap/cmd_watch_test.go
@@ -44,6 +44,7 @@ func (s *SnapSuite) TestCmdWatch(c *C) {
 	meter := &progresstest.Meter{}
 	defer progress.MockMeter(meter)()
 	defer snap.MockMaxGoneTime(time.Millisecond)()
+	defer snap.MockPollTime(time.Millisecond)()
 
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +80,7 @@ func (s *SnapSuite) TestWatchLast(c *C) {
 	meter := &progresstest.Meter{}
 	defer progress.MockMeter(meter)()
 	defer snap.MockMaxGoneTime(time.Millisecond)()
+	defer snap.MockPollTime(time.Millisecond)()
 
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
cmd/snap started at nearly 13s, but most of that is because ssh2 is
slow to start up. I was able to shave a couple of seconds elsewhere
though. And I tagged the ssh2 tests as not-short.

Before:

    $ go test -count 1 ./cmd/snap
    ok  	github.com/snapcore/snapd/cmd/snap	13.868s

and then,

    $ go test -count 1 ./cmd/snap
    ok  	github.com/snapcore/snapd/cmd/snap	11.470s
    $ go test -short -count 1 ./cmd/snap
    ok  	github.com/snapcore/snapd/cmd/snap	1.251s
