### PR TITLE
many: cleanup remaining parallel installs TODOs

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -240,7 +240,6 @@ func (iface *desktopInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 	// Allow mounting document portal
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "  # Mount the document portal\n")
-	// TODO parallel-install: use of proper instance/store name
 	fmt.Fprintf(&buf, "  mount options=(bind) /run/user/[0-9]*/doc/by-app/snap.%s/ -> /run/user/[0-9]*/doc/,\n", plug.Snap().InstanceName())
 	fmt.Fprintf(&buf, "  umount /run/user/[0-9]*/doc/,\n\n")
 	spec.AddUpdateNS(buf.String())

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -230,7 +230,6 @@ func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(downloadConnectedSlotAppArmor, old, new, -1)
 	old = "###PLUG_NAME###"
-	// TODO parallel-install: use of proper instance/store name
 	new = plug.Snap().InstanceName()
 	snippet = strings.Replace(snippet, old, new, -1)
 	spec.AddSnippet(snippet)

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -35,12 +35,11 @@ const UsbMaxInterfaces = 32
 // all the apps bound to a given slot. The result has one of three forms,
 // depending on how apps are bound to the slot:
 //
-// - "snap.$snap.$app" if there is exactly one app bound
-// - "snap.$snap.{$app1,...$appN}" if there are some, but not all, apps bound
-// - "snap.$snap.*" if all apps are bound to the slot
+// - "snap.$snap_instance.$app" if there is exactly one app bound
+// - "snap.$snap_instance.{$app1,...$appN}" if there are some, but not all, apps bound
+// - "snap.$snap_instance.*" if all apps are bound to the slot
 func appLabelExpr(apps map[string]*snap.AppInfo, snap *snap.Info) string {
 	var buf bytes.Buffer
-	// TODO parallel-install: use of proper instance/store name
 	fmt.Fprintf(&buf, `"snap.%s.`, snap.InstanceName())
 	if len(apps) == 1 {
 		for appName := range apps {

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -124,8 +124,7 @@ func (iface *waylandInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 func (iface *waylandInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	if !release.OnClassic {
 		old := "###PLUG_SECURITY_TAGS###"
-		// TODO parallel-install: use of proper instance/store name
-		new := "snap." + plug.Snap().InstanceName() // forms the snap-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
+		new := "snap." + plug.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
 		snippet := strings.Replace(waylandConnectedSlotAppArmor, old, new, -1)
 		spec.AddSnippet(snippet)
 	}

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -273,7 +273,6 @@ func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, flags Flags) e
 	// transition we will end up with not connected interface
 	// connections in the "core" snap. But the transition will
 	// kick in automatically quickly so an extra flag is overkill.
-	// TODO parallel-install: use instance name
 	if snapInfo.InstanceName() == "core" && core.InstanceName() == "ubuntu-core" {
 		return nil
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2233,9 +2233,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	c.Check(snapstate.Installing(s.state), Equals, false)
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
 		macaroon: s.user.StoreMacaroon,
-		// TODO parallel-install: fix once store changes are in place
-		name:   "some-snap",
-		target: filepath.Join(dirs.SnapBlobDir, "some-snap_instance_11.snap"),
+		name:     "some-snap",
+		target:   filepath.Join(dirs.SnapBlobDir, "some-snap_instance_11.snap"),
 	}})
 	c.Check(s.fakeStore.seenPrivacyKeys["privacy-key"], Equals, true, Commentf("salts seen: %v", s.fakeStore.seenPrivacyKeys))
 	expected := fakeOps{

--- a/snap/container.go
+++ b/snap/container.go
@@ -201,7 +201,6 @@ func ValidateContainer(c Container, s *Info, logf func(format string, v ...inter
 
 		if needsrx[path] || mode.IsDir() {
 			if mode.Perm()&0555 != 0555 {
-				// TODO parallel-install: use of proper instance/store name
 				logf("in snap %q: %q should be world-readable and executable, and isn't: %s", s.InstanceName(), path, mode)
 				hasBadModes = true
 			}
@@ -214,21 +213,18 @@ func ValidateContainer(c Container, s *Info, logf func(format string, v ...inter
 				// more than anything else, not worth it IMHO (as I can't
 				// imagine this happening by accident).
 				if mode&(os.ModeDir|os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
-					// TODO parallel-install: use of proper instance/store name
 					logf("in snap %q: %q should be a regular file (or a symlink) and isn't", s.InstanceName(), path)
 					hasBadModes = true
 				}
 			}
 			if needsx[path] || strings.HasPrefix(path, "meta/hooks/") {
 				if mode.Perm()&0111 == 0 {
-					// TODO parallel-install: use of proper instance/store name
 					logf("in snap %q: %q should be executable, and isn't: %s", s.InstanceName(), path, mode)
 					hasBadModes = true
 				}
 			} else {
 				// in needsr, or under meta but not a hook
 				if mode.Perm()&0444 != 0444 {
-					// TODO parallel-install: use of proper instance/store name
 					logf("in snap %q: %q should be world-readable, and isn't: %s", s.InstanceName(), path, mode)
 					hasBadModes = true
 				}
@@ -243,7 +239,6 @@ func ValidateContainer(c Container, s *Info, logf func(format string, v ...inter
 		for _, needs := range []map[string]bool{needsx, needsrx, needsr} {
 			for path := range needs {
 				if !seen[path] {
-					// TODO parallel-install: use of proper instance/store name
 					logf("in snap %q: path %q does not exist", s.InstanceName(), path)
 				}
 			}

--- a/snap/info.go
+++ b/snap/info.go
@@ -444,7 +444,6 @@ func (s *Info) ExpandSnapVariables(path string) string {
 			// inside the mount namespace snap-confine creates and there we will
 			// always have a /snap directory available regardless if the system
 			// we're running on supports this or not.
-			// TODO parallel-install: use of proper instance/store name
 			return filepath.Join(dirs.CoreSnapMountDir, s.SnapName(), s.Revision.String())
 		case "SNAP_DATA":
 			return DataDir(s.SnapName(), s.Revision)

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -93,7 +93,6 @@ func snapEnv(info *snap.Info) map[string]string {
 // used by so many other modules, we run into circular dependencies if it's
 // somewhere more reasonable like the snappy module.
 func basicEnv(info *snap.Info) map[string]string {
-	// TODO parallel-install: use of proper instance/store name
 	return map[string]string{
 		// This uses CoreSnapMountDir because the computed environment
 		// variables are conveyed to the started application process which

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -84,8 +84,6 @@ func ValidateInstanceName(instanceName string) error {
 		return err
 	}
 	if !validInstanceKey.MatchString(instanceKey) {
-		// TODO parallel-install: extend the error message once snap
-		// install help has been updated
 		return fmt.Errorf("invalid instance key: %q", instanceKey)
 	}
 	return nil
@@ -282,8 +280,7 @@ func validateSocketAddrPath(socket *SocketInfo, fieldName string, path string) e
 }
 
 func validateSocketAddrAbstract(socket *SocketInfo, fieldName string, path string) error {
-	// TODO parallel-install: use of proper instance/store name, discuss socket activation in parallel install world
-	prefix := fmt.Sprintf("@snap.%s.", socket.App.Snap.InstanceName())
+	prefix := fmt.Sprintf("@snap.%s.", socket.App.Snap.SnapName())
 	if !strings.HasPrefix(path, prefix) {
 		return fmt.Errorf("socket %q path for %q must be prefixed with %q", socket.Name, fieldName, prefix)
 	}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -280,6 +280,8 @@ func validateSocketAddrPath(socket *SocketInfo, fieldName string, path string) e
 }
 
 func validateSocketAddrAbstract(socket *SocketInfo, fieldName string, path string) error {
+	// this comes from snap declaration, so the prefix can only be the snap
+	// name at this point
 	prefix := fmt.Sprintf("@snap.%s.", socket.App.Snap.SnapName())
 	if !strings.HasPrefix(path, prefix) {
 		return fmt.Errorf("socket %q path for %q must be prefixed with %q", socket.Name, fieldName, prefix)


### PR DESCRIPTION
Cleanup TODOs where usage of InstanceName() vs. SnapName() is clear now.