### PR TITLE
osutil,asserts,daemon: support force password change in system-user assertion

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2280,9 +2280,10 @@ func getUserDetailsFromAssertion(st *state.State, email string) (string, *osutil
 
 	gecos := fmt.Sprintf("%s,%s", email, su.Name())
 	opts := &osutil.AddUserOptions{
-		SSHKeys:  su.SSHKeys(),
-		Gecos:    gecos,
-		Password: su.Password(),
+		SSHKeys:             su.SSHKeys(),
+		Gecos:               gecos,
+		Password:            su.Password(),
+		ForcePasswordChange: su.ForcePasswordChange(),
 	}
 	return su.Username(), opts, nil
 }

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -100,7 +100,7 @@ func AddUser(name string, opts *AddUserOptions) error {
 	}
 	if opts.ForcePasswordChange {
 		if opts.Password == "" {
-			return fmt.Errorf("cannot use force password change when no password is provided")
+			return fmt.Errorf("cannot force password change when no password is provided")
 		}
 		cmdStr := []string{
 			"passwd",
@@ -109,7 +109,7 @@ func AddUser(name string, opts *AddUserOptions) error {
 			name,
 		}
 		if output, err := exec.Command(cmdStr[0], cmdStr[1:]...).CombinedOutput(); err != nil {
-			return fmt.Errorf("force password change failed: %s", OutputErr(output, err))
+			return fmt.Errorf("cannot force password change: %s", OutputErr(output, err))
 		}
 	}
 

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -46,6 +46,8 @@ type AddUserOptions struct {
 	SSHKeys    []string
 	// crypt(3) compatible password of the form $id$salt$hash
 	Password string
+	// force a password change by the user on login
+	ForcePasswordChange bool
 }
 
 func AddUser(name string, opts *AddUserOptions) error {
@@ -94,6 +96,20 @@ func AddUser(name string, opts *AddUserOptions) error {
 		}
 		if output, err := exec.Command(cmdStr[0], cmdStr[1:]...).CombinedOutput(); err != nil {
 			return fmt.Errorf("setting password failed: %s", OutputErr(output, err))
+		}
+	}
+	if opts.ForcePasswordChange {
+		if opts.Password == "" {
+			return fmt.Errorf("cannot use force password change when no password is provided")
+		}
+		cmdStr := []string{
+			"passwd",
+			"--expire",
+			// no --extrauser required, see LP: #1562872
+			name,
+		}
+		if output, err := exec.Command(cmdStr[0], cmdStr[1:]...).CombinedOutput(); err != nil {
+			return fmt.Errorf("force password change failed: %s", OutputErr(output, err))
 		}
 	}
 

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -169,6 +169,9 @@ func (s *createUserSuite) TestAddUserWithPasswordForceChange(c *check.C) {
 	c.Check(s.mockAddUser.Calls(), check.DeepEquals, [][]string{
 		{"adduser", "--force-badname", "--gecos", "my gecos", "--disabled-password", "karl.popper"},
 	})
+	c.Check(s.mockUserMod.Calls(), check.DeepEquals, [][]string{
+		{"usermod", "--password", "$6$salt$hash", "karl.popper"},
+	})
 	c.Check(s.mockPasswd.Calls(), check.DeepEquals, [][]string{
 		{"passwd", "--expire", "karl.popper"},
 	})

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -186,7 +186,7 @@ func (s *createUserSuite) TestAddUserPasswordForceChangeUnhappy(c *check.C) {
 		Gecos:               "my gecos",
 		ForcePasswordChange: true,
 	})
-	c.Assert(err, check.ErrorMatches, `cannot use force password change when no password is provided`)
+	c.Assert(err, check.ErrorMatches, `cannot force password change when no password is provided`)
 }
 
 func (s *createUserSuite) TestRealUser(c *check.C) {


### PR DESCRIPTION
This PR adds a new optional `force-password-change: {true,false}` field to the system-user assertion. When set to `true` it will force the user to change the password on first login.

This addresses https://bugs.launchpad.net/snappy/+bug/1774509
