### PR TITLE
spread-shellcheck: fix interleaved error messages, tweaks

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -66,9 +66,10 @@ class ShellcheckRunError(Exception):
 
 
 class ShellcheckError(Exception):
-    def __init__(self):
+    def __init__(self, path):
         super().__init__()
         self.sectionerrors = {}
+        self.path = path
 
     def addfailure(self, section, error):
         self.sectionerrors[section] = error
@@ -110,7 +111,6 @@ def checksection(data):
                             shell=True)
     stdout, _ = proc.communicate(input=data.encode('utf-8'), timeout=10)
     if proc.returncode != 0:
-        logging.debug('shellcheck failed')
         raise ShellcheckRunError(stdout)
 
 
@@ -119,29 +119,26 @@ def checkfile(path):
     with open(path) as inf:
         data = yaml.load(inf)
 
-    errors = ShellcheckError()
+    errors = ShellcheckError(path)
 
     for section in SECTIONS:
         if section not in data:
             continue
 
         try:
-            logging.debug("checking section %s", section)
+            logging.debug("%s: checking section %s", path, section)
             checksection(data[section])
         except ShellcheckRunError as serr:
-            logging.debug("%s: shellcheck failed in section '%s'",
-                          path, section)
             errors.addfailure(section, serr.stderr.decode('utf-8'))
 
     if path.endswith('spread.yaml') and 'suites' in data:
         # check suites
         for suite in data['suites'].keys():
-            logging.debug('checking suite %s', suite)
             for section in SECTIONS:
                 if section not in data['suites'][suite]:
                     continue
                 try:
-                    logging.debug("checking section %s", section)
+                    logging.debug("%s (suite %s): checking section %s", path, suite, section)
                     checksection(data['suites'][suite][section])
                 except ShellcheckRunError as serr:
                     errors.addfailure('suites/' + suite + '/' + section,
@@ -166,19 +163,24 @@ def checkpath(loc, max_workers):
         locations = [loc]
 
     failed = []
-    def check1path(entry):
+
+    def check1path(path):
         try:
-            checkfile(entry)
-        except ShellcheckError as serr:
-            logging.error(('shellcheck failed for file %s in sections: '
-                           '%s; error log follows'),
-                          entry, ', '.join(serr.sectionerrors.keys()))
-            for section, error in serr.sectionerrors.items():
-                logging.error("%s: section '%s':\n%s", entry, section, error)
-            failed.append(entry)
+            checkfile(path)
+        except ShellcheckError as err:
+            return err
+        return None
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        executor.map(check1path, locations)
+        for serr in executor.map(check1path, locations):
+            if not isinstance(serr, ShellcheckError):
+                continue
+            logging.error(('shellcheck failed for file %s in sections: '
+                           '%s; error log follows'),
+                          serr.path, ', '.join(serr.sectionerrors.keys()))
+            for section, error in serr.sectionerrors.items():
+                logging.error("%s: section '%s':\n%s", serr.path, section, error)
+            failed.append(serr.path)
 
     if failed:
         raise ShellcheckFailures(failures=failed)

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -173,7 +173,7 @@ def checkpath(loc, max_workers):
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for serr in executor.map(check1path, locations):
-            if not isinstance(serr, ShellcheckError):
+            if serr is None:
                 continue
             logging.error(('shellcheck failed for file %s in sections: '
                            '%s; error log follows'),


### PR DESCRIPTION
When shellcheck identifies erorrs in many files, the error log will be
interleaved as the logging is happening from inside of the helper ran by a
thread pool executor. Tweak the code so that the helpers return the error
instead of doing the logging directly.

Minor logging cleanup.


