### PR TITLE
apparmor: create SnapAppArmorDir in setupSnapConfineReexec

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -226,15 +226,16 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 //
 // Additionally it will cleanup stale apparmor profiles it created.
 func setupSnapConfineReexec(info *snap.Info) error {
-	err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755)
-	if err != nil {
+	if err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755); err != nil {
 		return fmt.Errorf("cannot create snap-confine policy directory: %s", err)
 	}
-
 	dir, glob, content, err := snapConfineFromSnapProfile(info)
 	cache := dirs.AppArmorCacheDir
 	if err != nil {
 		return fmt.Errorf("cannot compute snap-confine profile: %s", err)
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create snap-confine directory %q: %s", dir, err)
 	}
 
 	changed, removed, errEnsure := osutil.EnsureDirState(dir, glob, content)

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -33,6 +33,7 @@ var (
 	DowngradeConfinement       = downgradeConfinement
 	LoadProfiles               = loadProfiles
 	UnloadProfiles             = unloadProfiles
+	SetupSnapConfineReexec     = setupSnapConfineReexec
 )
 
 // MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS


### PR DESCRIPTION
The dirs.SnapAppArmorDir may not yet be available on a core18
system when snapd is run for the first time. This PR ensures it
gets created and it also updates the tests to not mock more dirs
than really available.

This fixes a first-boot race observed on the pi3 on UC18.