### PR TITLE
snap, wrappers: support restart-delay, generate RestartSec=<value> in service units

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -720,6 +720,7 @@ type AppInfo struct {
 	ReloadCommand   string
 	PostStopCommand string
 	RestartCond     RestartCondition
+	RestartDelay    timeout.Timeout
 	Completer       string
 	RefreshMode     string
 	StopMode        StopModeType

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -83,9 +83,10 @@ type appYaml struct {
 	RefreshMode     string          `yaml:"refresh-mode,omitempty"`
 	StopMode        StopModeType    `yaml:"stop-mode,omitempty"`
 
-	RestartCond RestartCondition `yaml:"restart-condition,omitempty"`
-	SlotNames   []string         `yaml:"slots,omitempty"`
-	PlugNames   []string         `yaml:"plugs,omitempty"`
+	RestartCond  RestartCondition `yaml:"restart-condition,omitempty"`
+	RestartDelay timeout.Timeout  `yaml:"restart-delay,omitempty"`
+	SlotNames    []string         `yaml:"slots,omitempty"`
+	PlugNames    []string         `yaml:"plugs,omitempty"`
 
 	BusName  string `yaml:"bus-name,omitempty"`
 	CommonID string `yaml:"common-id,omitempty"`
@@ -321,6 +322,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			ReloadCommand:   yApp.ReloadCommand,
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
+			RestartDelay:    yApp.RestartDelay,
 			BusName:         yApp.BusName,
 			CommonID:        yApp.CommonID,
 			Environment:     yApp.Environment,

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1792,3 +1792,19 @@ hooks:
 	hook := info.Hooks["configure"]
 	c.Check(hook.CommandChain, DeepEquals, []string{"hookchain1", "hookchain2"})
 }
+
+func (s *YamlSuite) TestSnapYamlRestartDelay(c *C) {
+	yAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+  command: bin/foo
+  daemon: simple
+  restart-delay: 12s
+`)
+	info, err := snap.InfoFromSnapYaml(yAutostart)
+	c.Assert(err, IsNil)
+	app := info.Apps["foo"]
+	c.Assert(app, NotNil)
+	c.Check(app.RestartDelay, Equals, timeout.Timeout(12*time.Second))
+}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -623,7 +623,7 @@ func validateAppRestart(app *AppInfo) error {
 
 	if app.RestartDelay != 0 {
 		if !app.IsService() {
-			return fmt.Errorf("cannot define restart-delay for application %q as it's not a service", app.Name)
+			return fmt.Errorf("application %q must be a service to define restart-delay", app.Name)
 		}
 
 		if app.RestartDelay < 0 {
@@ -633,7 +633,7 @@ func validateAppRestart(app *AppInfo) error {
 
 	if app.RestartCond != "" {
 		if !app.IsService() {
-			return fmt.Errorf("cannot define restart-condition for application %q as it's not a service", app.Name)
+			return fmt.Errorf("application %q must be a service to define restart-condition", app.Name)
 		}
 	}
 	return nil

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -614,6 +614,31 @@ func validateAppTimer(app *AppInfo) error {
 	return nil
 }
 
+func validateAppRestart(app *AppInfo) error {
+	// app.RestartCond value is validated when unmarshalling
+
+	if app.RestartDelay == 0 && app.RestartCond == "" {
+		return nil
+	}
+
+	if app.RestartDelay != 0 {
+		if !app.IsService() {
+			return fmt.Errorf("cannot define restart-delay for application %q as it's not a service", app.Name)
+		}
+
+		if app.RestartDelay < 0 {
+			return fmt.Errorf("cannot use a negative restart-delay for application %q", app.Name)
+		}
+	}
+
+	if app.RestartCond != "" {
+		if !app.IsService() {
+			return fmt.Errorf("cannot define restart-condition for application %q as it's not a service", app.Name)
+		}
+	}
+	return nil
+}
+
 // appContentWhitelist is the whitelist of legal chars in the "apps"
 // section of snap.yaml. Do not allow any of [',",`] here or snap-exec
 // will get confused. chainContentWhitelist is the same, but for the
@@ -678,6 +703,9 @@ func ValidateApp(app *AppInfo) error {
 		}
 	}
 
+	if err := validateAppRestart(app); err != nil {
+		return err
+	}
 	if err := validateAppOrderNames(app, app.Before); err != nil {
 		return err
 	}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1543,11 +1543,11 @@ apps:
 	}, {
 		name: "foo restart-delay but not a service",
 		desc: fooDelayNotADaemon,
-		err:  `cannot define restart-delay for application "foo" as it's not a service`,
+		err:  `application "foo" must be a service to define restart-delay`,
 	}, {
 		name: "foo restart-delay but not a service",
 		desc: fooConditionNotADaemon,
-		err:  `cannot define restart-condition for application "foo" as it's not a service`,
+		err:  `application "foo" must be a service to define restart-condition`,
 	}, {
 		name: "negative restart-delay",
 		desc: fooNegativeDelay,

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1486,3 +1486,84 @@ version: 1.0
 		c.Check(err, ErrorMatches, fmt.Sprintf("invalid instance key: %q", s))
 	}
 }
+
+func (s *ValidateSuite) TestValidateAppRestart(c *C) {
+	meta := []byte(`
+name: foo
+version: 1.0
+`)
+	fooAllGood := []byte(`
+apps:
+  foo:
+    daemon: simple
+    restart-condition: on-abort
+    restart-delay: 12s
+`)
+	fooAllGoodDefault := []byte(`
+apps:
+  foo:
+    daemon: simple
+`)
+	fooAllGoodJustDelay := []byte(`
+apps:
+  foo:
+    daemon: simple
+    restart-delay: 12s
+`)
+	fooConditionNotADaemon := []byte(`
+apps:
+  foo:
+    restart-condition: on-abort
+`)
+	fooDelayNotADaemon := []byte(`
+apps:
+  foo:
+    restart-delay: 12s
+`)
+	fooNegativeDelay := []byte(`
+apps:
+  foo:
+    daemon: simple
+    restart-delay: -12s
+`)
+
+	tcs := []struct {
+		name string
+		desc []byte
+		err  string
+	}{{
+		name: "foo all good",
+		desc: fooAllGood,
+	}, {
+		name: "foo all good with default values",
+		desc: fooAllGoodDefault,
+	}, {
+		name: "foo all good with restart-delay only",
+		desc: fooAllGoodJustDelay,
+	}, {
+		name: "foo restart-delay but not a service",
+		desc: fooDelayNotADaemon,
+		err:  `cannot define restart-delay for application "foo" as it's not a service`,
+	}, {
+		name: "foo restart-delay but not a service",
+		desc: fooConditionNotADaemon,
+		err:  `cannot define restart-condition for application "foo" as it's not a service`,
+	}, {
+		name: "negative restart-delay",
+		desc: fooNegativeDelay,
+		err:  `cannot use a negative restart-delay for application "foo"`,
+	}}
+	for _, tc := range tcs {
+		c.Logf("trying %q", tc.name)
+		info, err := InfoFromSnapYaml(append(meta, tc.desc...))
+		c.Assert(err, IsNil)
+		c.Assert(info, NotNil)
+
+		err = Validate(info)
+		if tc.err != "" {
+			c.Assert(err, ErrorMatches, tc.err)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -389,6 +389,9 @@ X-Snappy=yes
 ExecStart={{.App.LauncherCommand}}
 SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
 Restart={{.Restart}}
+{{- if .App.RestartDelay}}
+RestartSec={{.App.RestartDelay.Seconds}}
+{{- end}}
 WorkingDirectory={{.App.Snap.DataDir}}
 {{- if .App.StopCommand}}
 ExecStop={{.App.LauncherStopCommand}}


### PR DESCRIPTION
This was asked for in the forum https://forum.snapcraft.io/t/expose-a-more-consistent-subset-of-systemds-service-directives/2268/52

It is possible to control the delay systemd applies between service restarts. The snap YAML looks like this:
```
name: foo
version: 1.0
apps:
  foo:
    daemon: simple
    restart-delay: 12s
```

(cc @kyrofa )