### PR TITLE
snap/pack, snap/squashfs: use type to determine mksquashfs args

### DIFF
--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
@@ -334,7 +335,12 @@ func (s *infoSuite) TestReadInfoUnfindable(c *C) {
 }
 
 // makeTestSnap here can also be used to produce broken snaps (differently from snaptest.MakeTestSnapWithFiles)!
-func makeTestSnap(c *C, yaml string) string {
+func makeTestSnap(c *C, snapYaml string) string {
+	var m struct {
+		Type string `yaml:"type"`
+	}
+	yaml.Unmarshal([]byte(snapYaml), &m) // yes, ignore the error
+
 	tmp := c.MkDir()
 	snapSource := filepath.Join(tmp, "snapsrc")
 
@@ -342,12 +348,12 @@ func makeTestSnap(c *C, yaml string) string {
 	c.Assert(err, IsNil)
 
 	// our regular snap.yaml
-	err = ioutil.WriteFile(filepath.Join(snapSource, "meta", "snap.yaml"), []byte(yaml), 0644)
+	err = ioutil.WriteFile(filepath.Join(snapSource, "meta", "snap.yaml"), []byte(snapYaml), 0644)
 	c.Assert(err, IsNil)
 
 	dest := filepath.Join(tmp, "foo.snap")
 	snap := squashfs.New(dest)
-	err = snap.Build(snapSource)
+	err = snap.Build(snapSource, m.Type)
 	c.Assert(err, IsNil)
 
 	return dest

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package squashfs
+
+import (
+	"os"
+	"os/exec"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+var (
+	FromRaw                   = fromRaw
+	NewUnsquashfsStderrWriter = newUnsquashfsStderrWriter
+)
+
+func (s stat) User() string  { return s.user }
+func (s stat) Group() string { return s.group }
+
+func MockLink(newLink func(string, string) error) (restore func()) {
+	oldLink := osLink
+	osLink = newLink
+	return func() {
+		osLink = oldLink
+	}
+}
+
+func MockFromCore(newFromCore func(string, ...string) (*exec.Cmd, error)) (restore func()) {
+	oldFromCore := osutilCommandFromCore
+	osutilCommandFromCore = newFromCore
+	return func() {
+		osutilCommandFromCore = oldFromCore
+	}
+}
+
+func Alike(a, b os.FileInfo, c *check.C, comment check.CommentInterface) {
+	c.Check(a, check.NotNil, comment)
+	c.Check(b, check.NotNil, comment)
+	if a == nil || b == nil {
+		return
+	}
+
+	// the .Name() of the root will be different on non-squashfs things
+	_, asq := a.(*stat)
+	_, bsq := b.(*stat)
+	if !((asq && a.Name() == "/") || (bsq && b.Name() == "/")) {
+		c.Check(a.Name(), check.Equals, b.Name(), comment)
+	}
+
+	c.Check(a.Mode(), check.Equals, b.Mode(), comment)
+	if a.Mode().IsRegular() {
+		c.Check(a.Size(), check.Equals, b.Size(), comment)
+	}
+	am := a.ModTime().UTC().Truncate(time.Minute)
+	bm := b.ModTime().UTC().Truncate(time.Minute)
+	c.Check(am.Equal(bm), check.Equals, true, check.Commentf("%s != %s (%s)", am, bm, comment))
+}


### PR DESCRIPTION
We should be using different args for 'snap pack' than we are doing:

* cores and bases should be built with xattrs
* everything else should be squashed to root
* we should use mksquashfs from core if available

this fixes all that. Also, splits squashfs tests into their own
package (most of the lines in the diff are probably about this tbh).
