### PR TITLE
interfaces/tests: use TestInterface instead of a custom local helper

### DIFF
--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -25,7 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	. "github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/hotplug"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -2408,25 +2407,11 @@ func (s *RepositorySuite) TestConnectWithStaticAttrs(c *C) {
 	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, slotAttrs)
 }
 
-type hotplugTestInterface struct{ InterfaceName string }
-
-func (h *hotplugTestInterface) Name() string {
-	return h.InterfaceName
-}
-
-func (h *hotplugTestInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
-	return true
-}
-
-func (h *hotplugTestInterface) HotplugDeviceDetected(di *hotplug.HotplugDeviceInfo, spec *hotplug.Specification) error {
-	return nil
-}
-
 func (s *RepositorySuite) TestAllHotplugInterfaces(c *C) {
 	repo := NewRepository()
 	c.Assert(repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface1"}), IsNil)
-	c.Assert(repo.AddInterface(&hotplugTestInterface{InterfaceName: "iface2"}), IsNil)
-	c.Assert(repo.AddInterface(&hotplugTestInterface{InterfaceName: "iface3"}), IsNil)
+	c.Assert(repo.AddInterface(&ifacetest.TestHotplugInterface{TestInterface: ifacetest.TestInterface{InterfaceName: "iface2"}}), IsNil)
+	c.Assert(repo.AddInterface(&ifacetest.TestHotplugInterface{TestInterface: ifacetest.TestInterface{InterfaceName: "iface3"}}), IsNil)
 
 	hi := repo.AllHotplugInterfaces()
 	c.Assert(hi, HasLen, 2)


### PR DESCRIPTION
Use TestInterface for AllHotplugInterfaces test, instead of a custom dummy interface (which was introduced early, and later I enhanced our general TestInterface for hotplug testing).
