### PR TITLE
interfaces/hotplug: rename HotplugDeviceKey method to HotplugKey, update test interface

### DIFF
--- a/interfaces/hotplug/spec.go
+++ b/interfaces/hotplug/spec.go
@@ -32,6 +32,11 @@ type Definer interface {
 	HotplugDeviceDetected(di *HotplugDeviceInfo, spec *Specification) error
 }
 
+// HotplugKeyHandler can be implemented by interfaces that need to provide a non-standard key for hotplug devices
+type HotplugKeyHandler interface {
+	HotplugKey(di *HotplugDeviceInfo) (string, error)
+}
+
 // RequestedSlotSpec is a definition of the slot to create in response to hotplug event.
 type RequestedSlotSpec struct {
 	// Name is how the interface wants to name the slot. When left empty,

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -111,7 +111,7 @@ type TestHotplugInterface struct {
 	TestInterface
 
 	// Support for interacting with hotplug subsystem.
-	HotplugDeviceKeyCallback      func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error)
+	HotplugKeyCallback            func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error)
 	HotplugDeviceDetectedCallback func(deviceInfo *hotplug.HotplugDeviceInfo, spec *hotplug.Specification) error
 }
 
@@ -412,9 +412,9 @@ func (t *TestInterface) SystemdPermanentPlug(spec *systemd.Specification, plug *
 
 // Support for interacting with hotplug subsystem.
 
-func (t *TestHotplugInterface) HotplugDeviceKey(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
-	if t.HotplugDeviceKeyCallback != nil {
-		return t.HotplugDeviceKeyCallback(deviceInfo)
+func (t *TestHotplugInterface) HotplugKey(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
+	if t.HotplugKeyCallback != nil {
+		return t.HotplugKeyCallback(deviceInfo)
 	}
 	return "", nil
 }

--- a/interfaces/ifacetest/testiface_test.go
+++ b/interfaces/ifacetest/testiface_test.go
@@ -170,12 +170,12 @@ func (s *TestInterfaceSuite) TestAutoConnect(c *C) {
 	c.Check(iface.AutoConnect(nil, nil), Equals, false)
 }
 
-func (s *TestInterfaceSuite) TestHotplugDeviceKeyError(c *C) {
+func (s *TestInterfaceSuite) TestHotplugKeyError(c *C) {
 	iface := &ifacetest.TestHotplugInterface{
 		TestInterface: ifacetest.TestInterface{
 			InterfaceName: "test",
 		},
-		HotplugDeviceKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
+		HotplugKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
 			return "", fmt.Errorf("error")
 		},
 	}
@@ -183,23 +183,27 @@ func (s *TestInterfaceSuite) TestHotplugDeviceKeyError(c *C) {
 	c.Assert(iface.Name(), Equals, "test")
 
 	dev := &hotplug.HotplugDeviceInfo{}
-	key, err := iface.HotplugDeviceKey(dev)
+	key, err := iface.HotplugKey(dev)
 	c.Assert(err, ErrorMatches, "error")
 	c.Assert(key, Equals, "")
 }
 
-func (s *TestInterfaceSuite) TestHotplugDeviceKeyOK(c *C) {
-	iface := &ifacetest.TestHotplugInterface{
+func (s *TestInterfaceSuite) TestHotplugKeyOK(c *C) {
+	var iface interfaces.Interface
+	iface = &ifacetest.TestHotplugInterface{
 		TestInterface: ifacetest.TestInterface{
 			InterfaceName: "test",
 		},
-		HotplugDeviceKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
+		HotplugKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
 			return "key", nil
 		},
 	}
 
+	hotplugIface, ok := iface.(hotplug.HotplugKeyHandler)
+	c.Assert(ok, Equals, true)
+
 	dev := &hotplug.HotplugDeviceInfo{}
-	key, err := iface.HotplugDeviceKey(dev)
+	key, err := hotplugIface.HotplugKey(dev)
 	c.Assert(err, IsNil)
 	c.Assert(key, Equals, "key")
 }


### PR DESCRIPTION
Rename HotplugDeviceKey method to HotplugKey, added an interface definiton for it and updates test interface accordingly.