### PR TITLE
interfaces: updates for default, screen-inhibit-control, tpm, {hardware,system,network}-observe

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -220,6 +220,7 @@
     # pivot_root preparation and execution
     mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
     mount options=(rw private) -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+    # pivot_root mediation in AppArmor is not complete. See LP: #1791711
     pivot_root,
     # cleanup
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -55,6 +55,7 @@ var defaultTemplate = `
   /etc/ld.so.preload r,
 
   # The base abstraction doesn't yet have this
+  /etc/sysconfig/clock r,
   /lib/terminfo/** rk,
   /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -136,6 +136,8 @@ var defaultTemplate = `
   /{,usr/}bin/cpio ixr,
   /{,usr/}bin/cut ixr,
   /{,usr/}bin/date ixr,
+  /{,usr/}bin/dbus-daemon ixr,
+  /{,usr/}bin/dbus-run-session ixr,
   /{,usr/}bin/dbus-send ixr,
   /{,usr/}bin/dd ixr,
   /{,usr/}bin/diff{,3} ixr,
@@ -347,6 +349,7 @@ var defaultTemplate = `
   /sys/devices/virtual/tty/{console,tty*}/active r,
   /sys/fs/cgroup/memory/memory.limit_in_bytes r,
   /sys/fs/cgroup/memory/snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,
+  /sys/module/apparmor/parameters/enabled r,
   /{,usr/}lib/ r,
 
   # Reads of oom_adj and oom_score_adj are safe
@@ -422,6 +425,7 @@ var defaultTemplate = `
 
   # Allow apps from the same package to communicate with each other via an
   # abstract or anonymous socket
+  unix (bind, listen) addr="@snap.@{SNAP_INSTANCE_NAME}.**",
   unix peer=(label=snap.@{SNAP_INSTANCE_NAME}.*),
 
   # Allow apps from the same package to communicate with each other via DBus.

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -37,6 +37,9 @@ const hardwareObserveConnectedPlugAppArmor = `
 # used by lscpu and 'lspci -A intel-conf1/intel-conf2'
 capability sys_rawio,
 
+# see loaded kernel modules
+@{PROC}/modules r,
+
 # used by lspci
 capability sys_admin,
 /etc/modprobe.d/{,*} r,

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -64,6 +64,9 @@ dbus send
 
 #include <abstractions/ssl_certs>
 
+# see loaded kernel modules
+@{PROC}/modules r,
+
 @{PROC}/@{pid}/net/ r,
 @{PROC}/@{pid}/net/** r,
 

--- a/interfaces/builtin/password_manager_service.go
+++ b/interfaces/builtin/password_manager_service.go
@@ -64,7 +64,7 @@ dbus (receive, send)
     peer=(label=unconfined),
 
 # KWallet's client API is still in use in KDE/Plasma. It's DBus API relies upon
-# member data for access to its 'folders' and 'entries' and is therefore does
+# member data for access to its 'folders' and 'entries' and it therefore does
 # not allow for application isolation via AppArmor. For details, see:
 # - https://cgit.kde.org/kdelibs.git/tree/kdeui/util/kwallet.h?h=v4.14.33
 #

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -68,7 +68,7 @@ dbus (send)
 dbus (send)
     bus=session
     path=/{,org/freedesktop/,org/gnome/}ScreenSaver
-    interface=org.freedesktop.ScreenSaver
+    interface=org.{freedesktop,gnome}.ScreenSaver
     member={Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),
 

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -52,6 +52,7 @@ ptrace (read),
 deny ptrace (trace),
 
 # Other miscellaneous accesses for observing the system
+@{PROC}/modules r,
 @{PROC}/stat r,
 @{PROC}/vmstat r,
 @{PROC}/diskstats r,

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -30,11 +30,11 @@ const tpmBaseDeclarationSlots = `
 `
 
 const tpmConnectedPlugAppArmor = `
-# Description: for those who need to talk to the system TPM chip over /dev/tpm0
-# and kernel TPM resource manager /dev/tpmrm0 (4.12+)
+# Description: for those who need to talk to the system TPM chip over
+# /dev/tpm[0-9]* and kernel TPM resource manager /dev/tpmrm[0-0]* (4.12+)
 
-/dev/tpm0 rw,
-/dev/tpmrm0 rw,
+/dev/tpm[0-9]* rw,
+/dev/tpmrm[0-9]* rw,
 `
 
 var tpmConnectedPlugUDev = []string{

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -84,7 +84,7 @@ func (s *TpmInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/tpm0")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/tpm[0-9]*")
 }
 
 func (s *TpmInterfaceSuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
* interfaces/default: allow read of /etc/sysconfig/clock
* interfaces/screen-inhibit-control: also allow interface="org.gnome.ScreenSaver"
* interfaces/{hardware,system,network}-observe: allow reading /proc/modules
* snap-confine.apparmor.in: add bug reference for pivot_root
* interfaces/password-manager-service: fix typo in comment
* interfaces/tpm: fix apparmor rules to match what is allowed by udev
* interfaces/default: allow snaps to use/create DBus private buses (see commit message for more detail

References:
* https://forum.snapcraft.io/t/hiri-wont-start/7075
* https://forum.snapcraft.io/t/what-interface-i-need-to-run-lsmod/7441/3
* https://forum.snapcraft.io/t/how-to-use-dbus-run-session-on-ubuntu-core/7077/2