### PR TITLE
apparmor: add unit test for probeAppArmorParser and simplify code 

### DIFF
--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -159,7 +159,7 @@ var requestedParserFeatures = []apparmorParserFeature{
 func tryParser(rule string) bool {
 	cmd := exec.Command("apparmor_parser", "--preprocess")
 	cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("profile snap-test {\n %s\n}", rule))
-	if _, err := cmd.CombinedOutput(); err != nil {
+	if err := cmd.Run(); err != nil {
 		return false
 	}
 	return true

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -20,8 +20,8 @@
 package release
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -157,27 +157,9 @@ var requestedParserFeatures = []apparmorParserFeature{
 // tryParser will run the parser on the rule to determine if the feature is
 // supported.
 func tryParser(rule string) bool {
-	parser := "apparmor_parser"
-
-	_, err := exec.LookPath(parser)
-	if err != nil {
-		return false
-	}
-
-	cmd := exec.Command(parser, "--preprocess")
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return false
-	}
-
-	go func() {
-		defer stdin.Close()
-		r := fmt.Sprintf("profile snap-test {\n %s\n}", rule)
-		io.WriteString(stdin, r)
-	}()
-
-	_, err = cmd.CombinedOutput()
-	if err != nil {
+	cmd := exec.Command("apparmor_parser", "--preprocess")
+	cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("profile snap-test {\n %s\n}", rule))
+	if _, err := cmd.CombinedOutput(); err != nil {
 		return false
 	}
 	return true

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -20,12 +20,15 @@
 package release_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type apparmorSuite struct{}
@@ -85,4 +88,28 @@ func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 
 	features := release.AppArmorFeatures()
 	c.Check(features, DeepEquals, []string{"network", "policy"})
+}
+
+func (s *apparmorSuite) TestProbeAppArmorParser(c *C) {
+	tmpdir := c.MkDir()
+
+	var testcases = []struct {
+		exit     string
+		features []string
+	}{
+		{"exit 1", []string{}},
+		{"exit 0", []string{"unsafe"}},
+	}
+
+	for _, t := range testcases {
+		mockApparmorParser := testutil.MockCommand(c, "apparmor_parser", fmt.Sprintf("cat > %s/stdin; %s", tmpdir, t.exit))
+		defer mockApparmorParser.Restore()
+
+		features := release.ProbeAppArmorParser()
+		c.Check(features, DeepEquals, t.features)
+		c.Check(mockApparmorParser.Calls(), DeepEquals, [][]string{{"apparmor_parser", "--preprocess"}})
+		inp, err := ioutil.ReadFile(filepath.Join(tmpdir, "stdin"))
+		c.Assert(err, IsNil)
+		c.Check(string(inp), Equals, "profile snap-test {\n change_profile unsafe /**,\n}")
+	}
 }

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -19,7 +19,10 @@
 
 package release
 
-var ReadOSRelease = readOSRelease
+var (
+	ReadOSRelease       = readOSRelease
+	ProbeAppArmorParser = probeAppArmorParser
+)
 
 func MockOSReleasePath(filename string) (restore func()) {
 	old := osReleasePath

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -54,3 +54,8 @@ execute: |
     snap list | MATCH "$CLASSIC_SNAP .*2.0 .*classic"
     snap info "$CLASSIC_SNAP"|MATCH "installed:.* 2.0 .*classic"
     "$CLASSIC_SNAP" | MATCH lala
+
+    if [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
+        echo "Verify we get 'change_profile unsafe' for classic confinement"
+        MATCH "change_profile unsafe" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-classic-confinement.test-snapd-classic-confinement
+    fi


### PR DESCRIPTION
This is a followup on https://github.com/snapcore/snapd/pull/5739 - only 8580132 is new in this PR. 