### PR TITLE
interfaces: include invalid type in Attr error

### DIFF
--- a/interfaces/connection.go
+++ b/interfaces/connection.go
@@ -95,7 +95,7 @@ func getAttribute(snapName string, ifaceName string, staticAttrs map[string]inte
 	}
 
 	if reflect.TypeOf(v) != rt.Elem() {
-		return fmt.Errorf("snap %q has interface %q with invalid value type for %q attribute", snapName, ifaceName, path)
+		return fmt.Errorf("snap %q has interface %q with invalid value type %q for %q attribute", snapName, ifaceName, reflect.TypeOf(v), path)
 	}
 	rv := reflect.ValueOf(val)
 	rv.Elem().Set(reflect.ValueOf(v))

--- a/interfaces/connection_test.go
+++ b/interfaces/connection_test.go
@@ -94,7 +94,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *C) {
 	c.Assert(val, Equals, "value")
 
 	c.Assert(slot.StaticAttr("unknown", &val), ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.StaticAttr("attr", &intVal), ErrorMatches, `snap "producer" has interface "interface" with invalid value type for "attr" attribute`)
+	c.Check(slot.StaticAttr("attr", &intVal), ErrorMatches, `snap "producer" has interface "interface" with invalid value type "string" for "attr" attribute`)
 	c.Check(slot.StaticAttr("attr", val), ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over slot.Attrs
@@ -132,7 +132,7 @@ func (s *connSuite) TestStaticPlugAttrs(c *C) {
 	c.Assert(val, Equals, "value")
 
 	c.Assert(plug.StaticAttr("unknown", &val), ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.StaticAttr("attr", &intVal), ErrorMatches, `snap "consumer" has interface "interface" with invalid value type for "attr" attribute`)
+	c.Check(plug.StaticAttr("attr", &intVal), ErrorMatches, `snap "consumer" has interface "interface" with invalid value type "string" for "attr" attribute`)
 	c.Check(plug.StaticAttr("attr", val), ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over plug.Attrs
@@ -169,7 +169,7 @@ func (s *connSuite) TestDynamicSlotAttrs(c *C) {
 	c.Assert(num, Equals, int64(222))
 
 	c.Check(slot.Attr("unknown", &strVal), ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.Attr("foo", &intVal), ErrorMatches, `snap "producer" has interface "interface" with invalid value type for "foo" attribute`)
+	c.Check(slot.Attr("foo", &intVal), ErrorMatches, `snap "producer" has interface "interface" with invalid value type "string" for "foo" attribute`)
 	c.Check(slot.Attr("number", intVal), ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
 }
 
@@ -291,7 +291,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *C) {
 	c.Assert(num, Equals, int64(222))
 
 	c.Check(plug.Attr("unknown", &strVal), ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.Attr("foo", &intVal), ErrorMatches, `snap "consumer" has interface "interface" with invalid value type for "foo" attribute`)
+	c.Check(plug.Attr("foo", &intVal), ErrorMatches, `snap "consumer" has interface "interface" with invalid value type "string" for "foo" attribute`)
 	c.Check(plug.Attr("number", intVal), ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
 }
 


### PR DESCRIPTION
We got a bugreport about seeding failing with 2.36~pre1 - the
errors reads:

    2018-10-11T07:22:04Z ERROR cannot setup apparmor for snap "edge-connect": cannot obtain apparmor specification for snap "edge-connect": snap "gadget" has interface "gpio" with invalid value type for "number" attribute
    2018-10-11T07:22:07Z ERROR cannot obtain apparmor specification for snap "edge-connect": snap "gadget" has interface "gpio" with invalid value type for "number" attribute

Unfortunately the error includes no information about what type Attr()
got. So this PR changes the error to include this information:

    snap "gadget" has interface "gpio" with invalid value type "some-type" for "number" attribute

With this the issue should be easier to resolve.
