### PR TITLE
tests: initial setup for testing current branch on nested vm and hotplug management

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -595,9 +595,11 @@ suites:
         # Test cases are not yet ported to Fedora/openSUSE that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
-        systems: [-fedora-*, -opensuse-*, -amazon-*]
+        systems: [-fedora-*, -opensuse-*, -amazon-*, -arch-*]
         environment:
+            NESTED_TYPE: "$(HOST: echo ${SPREAD_NESTED_TYPE:-core})"
             NESTED_ARCH: "$(HOST: echo ${SPREAD_NESTED_ARCH:-amd64})"
+            NESTED_SYSTEM: "$(HOST: echo ${SPREAD_NESTED_SYSTEM:-xenial})"
             CORE_REFRESH_CHANNEL: "$(HOST: echo ${SPREAD_CORE_REFRESH_CHANNEL:-candidate})"
         halt-timeout: 2h
         kill-timeout: 2h
@@ -607,11 +609,19 @@ suites:
             . "$TESTSLIB"/pkgdb.sh
             distro_update_package_db
             distro_install_package snapd qemu genisoimage sshpass
-            snap install --classic --beta ubuntu-image
+            if [ "$NESTED_TYPE" = "core" ]; then
+                snap install --classic --beta ubuntu-image
+            else
+                distro_install_package qemu-kvm cloud-image-utils
+            fi
         restore: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
             distro_purge_package qemu genisoimage sshpass
-            snap remove ubuntu-image
+            if [ "$NESTED_TYPE" = "core" ]; then
+                snap remove ubuntu-image
+            else
+                distro_purge_package qemu-kvm cloud-image-utils
+            fi
 
 # vim:ts=4:sw=4:et

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -37,10 +37,10 @@ create_assertions_disk(){
 get_qemu_for_nested_vm(){
     case "$NESTED_ARCH" in
     amd64)
-        echo "$(command -v qemu-system-x86_64)"
+        command -v qemu-system-x86_64
         ;;
     i386)
-        echo "$(command -v qemu-system-i386)"
+        command -v qemu-system-i386
         ;;
     *)
         echo "unsupported architecture"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -152,10 +152,10 @@ copy_remote(){
     sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$*" user1@localhost:~
 }
 
-add_chardev(){
+add_file_chardev(){
     CHARDEV_ID=$1
-    CHARDEV_PORT=$2
-    echo "chardev-add socket,id=$CHARDEV_ID,port=$CHARDEV_PORT,server,host=localhost,nowait" | nc -q 0 127.0.0.1 "$MON_PORT"
+    CHARDEV_PATH=$2
+    echo "chardev-add file,id=$CHARDEV_ID,path=$CHARDEV_PATH" | nc -q 0 127.0.0.1 "$MON_PORT"
     echo "chardev added"
 }
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -152,10 +152,10 @@ copy_remote(){
     sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$*" user1@localhost:~
 }
 
-add_file_chardev(){
+add_tty_chardev(){
     CHARDEV_ID=$1
     CHARDEV_PATH=$2
-    echo "chardev-add file,id=$CHARDEV_ID,path=$CHARDEV_PATH" | nc -q 0 127.0.0.1 "$MON_PORT"
+    echo "chardev-add tty,path=$CHARDEV_PATH,id=$CHARDEV_ID" | nc -q 0 127.0.0.1 "$MON_PORT"
     echo "chardev added"
 }
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -3,6 +3,10 @@
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB"/systemd.sh
 
+WORK_DIR=/tmp/work-dir
+SSH_PORT=8022
+MON_PORT=8888
+
 wait_for_ssh(){
     retry=150
     while ! execute_remote true; do
@@ -30,20 +34,40 @@ create_assertions_disk(){
     umount /mnt/assertions && rm -rf /mnt/assertions
 }
 
-create_nested_core_vm(){
-    # determine arch related vars
+get_qemu_for_nested_vm(){
     case "$NESTED_ARCH" in
     amd64)
-        QEMU="$(command -v qemu-system-x86_64)"
+        echo "$(command -v qemu-system-x86_64)"
         ;;
     i386)
-        QEMU="$(command -v qemu-system-i386)"
+        echo "$(command -v qemu-system-i386)"
         ;;
     *)
         echo "unsupported architecture"
         exit 1
         ;;
     esac
+}
+
+get_image_url_for_nested_vm(){
+    case "$NESTED_SYSTEM" in
+    xenial|trusty)
+        echo "https://cloud-images.ubuntu.com/${NESTED_SYSTEM}/current/${NESTED_SYSTEM}-server-cloudimg-${NESTED_ARCH}-disk1.img"
+        ;;
+    bionic)
+        echo "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-${NESTED_ARCH}.img"
+        ;;
+    *)
+        echo "unsupported system"
+        exit 1
+        ;;
+    esac
+
+}
+
+create_nested_core_vm(){
+    # determine arch related vars
+    QEMU=$(get_qemu_for_nested_vm)
 
     # create ubuntu-core image
     EXTRA_SNAPS=""
@@ -51,11 +75,11 @@ create_nested_core_vm(){
         EXTRA_SNAPS="--extra-snaps ${PWD}/extra-snaps/*.snap"
     fi
     /snap/bin/ubuntu-image --image-size 3G "$TESTSLIB/assertions/nested-${NESTED_ARCH}.model" --channel "$CORE_CHANNEL" --output ubuntu-core.img "$EXTRA_SNAPS"
-    mkdir -p /tmp/work-dir
-    mv ubuntu-core.img /tmp/work-dir
+    mkdir -p "$WORK_DIR"
+    mv ubuntu-core.img "$WORK_DIR"
 
     create_assertions_disk
-    start_nested_vm
+    start_nested_core_vm
     if wait_for_ssh; then
         prepare_ssh
     else
@@ -64,18 +88,82 @@ create_nested_core_vm(){
     fi
 }
 
-start_nested_vm(){
-    systemd_create_and_start_unit nested-vm "${QEMU} -m 2048 -nographic -net nic,model=virtio -net user,hostfwd=tcp::8022-:22 -drive file=/tmp/work-dir/ubuntu-core.img,if=virtio,cache=none,format=raw -drive file=${PWD}/assertions.disk,if=virtio,cache=none,format=raw"
+start_nested_core_vm(){
+    systemd_create_and_start_unit nested-vm "${QEMU} -m 2048 -nographic -net nic,model=virtio -net user,hostfwd=tcp::$SSH_PORT-:22 -drive file=$WORK_DIR/ubuntu-core.img,if=virtio,cache=none,format=raw -drive file=${PWD}/assertions.disk,if=virtio,cache=none,format=raw -monitor tcp:127.0.0.1:$MON_PORT,server,nowait -usb"
     if ! wait_for_ssh; then
         systemctl restart nested-vm
     fi
 }
 
-destroy_nested_core_vm(){
+create_nested_classic_vm(){
+    mkdir -p "$WORK_DIR"
+
+    # Get the cloud image
+    IMAGE_URL=$(get_image_url_for_nested_vm)
+    wget -P "$WORK_DIR" "$IMAGE_URL"
+    IMAGE=$(ls $WORK_DIR/*.img)
+
+    # Prepare the cloud-init configuration
+    cat <<EOF > "$WORK_DIR/seed"
+#cloud-config
+  ssh_pwauth: True
+  users:
+   - name: user1
+     sudo: ALL=(ALL) NOPASSWD:ALL
+     shell: /bin/bash
+  chpasswd:
+   list: |
+    user1:ubuntu
+   expire: False
+EOF
+    cloud-localds -H "$(hostname)" "$WORK_DIR/seed.img" "$WORK_DIR/seed"
+
+    # Start the vm
+    start_nested_classic_vm "$IMAGE"
+}
+
+start_nested_classic_vm(){
+    IMAGE=$1
+    QEMU=$(get_qemu_for_nested_vm)
+
+    systemd_create_and_start_unit nested-vm "${QEMU} -m 2048 -nographic -net nic,model=virtio -net user,hostfwd=tcp::$SSH_PORT-:22 -hda $IMAGE -hdb $WORK_DIR/seed.img -monitor tcp:127.0.0.1:$MON_PORT,server,nowait -usb"
+    wait_for_ssh
+}
+
+destroy_nested_vm(){
     systemd_stop_and_destroy_unit nested-vm
-    rm -rf /tmp/work-dir
+    rm -rf "$WORK_DIR"
 }
 
 execute_remote(){
-    sshpass -p ubuntu ssh -p 8022 -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost "$*"
-}   
+    sshpass -p ubuntu ssh -p "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost "$*"
+}
+
+copy_remote(){
+    sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$*" user1@localhost:~
+}
+
+add_usb_tablet_device(){
+    DEVICE_NAME=$1
+    echo "device_add usb-tablet,port=1,id=$DEVICE_NAME" | nc -q 0 127.0.0.1 "$MON_PORT"
+    echo "device added"
+}
+
+add_usb_hub_device(){
+    DEVICE_NAME=$1
+    echo "device_add usb-hub,port=2,id=$DEVICE_NAME" | nc -q 0 127.0.0.1 "$MON_PORT"
+    echo "device added"
+}
+
+add_usb_drive_device(){
+    DEVICE_NAME=$1
+    DEVICE_DRIVE=$2
+    echo "device_add usb-storage,port=2.4,drive=$DEVICE_DRIVE,id=$DEVICE_NAME" | nc -q 0 127.0.0.1 "$MON_PORT"
+    echo "device added"
+}
+
+del_device(){
+    DEVICE_NAME=$1
+    echo "device_del $DEVICE_NAME" | nc -q 0 127.0.0.1 "$MON_PORT"
+    echo "device deleted"
+}

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -107,6 +107,7 @@ create_nested_classic_vm(){
     IMAGE_URL=$(get_image_url_for_nested_vm)
     wget -P "$WORK_DIR" "$IMAGE_URL"
     IMAGE=$(ls $WORK_DIR/*.img)
+    test "$(echo "$IMAGE" | wc -l)" = "1"
 
     # Prepare the cloud-init configuration
     cat <<EOF > "$WORK_DIR/seed"

--- a/tests/nested/core-revert/task.yaml
+++ b/tests/nested/core-revert/task.yaml
@@ -12,7 +12,7 @@ prepare: |
 restore: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    destroy_nested_core_vm
+    destroy_nested_vm
 
 debug: |
     systemctl stop nested-vm || true

--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -17,7 +17,7 @@ restore: |
 
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    destroy_nested_core_vm
+    destroy_nested_vm
 
 execute: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -25,7 +25,20 @@ execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
-    add_chardev my-chardev 9022
+    if execute_remote "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+        echo "Usb serial already registered, exiting..."
+        exit 1
+    fi
+
+    add_file_chardev my-chardev my-test-file
     add_usb_serial_device my-usb-serial my-chardev
+
+    execute_remote "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"
+
     del_device my-usb-serial
     remove_chardev my-chardev
+
+    if execute_remote "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+        echo "Usb serial should not be registered anymore, exiting..."
+        exit 1
+    fi

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -13,6 +13,7 @@ prepare: |
     copy_remote "${GOHOME}"/snapd_*.deb
     execute_remote 'sudo apt update'
     execute_remote 'sudo apt install -y ./snapd_*.deb'
+    #shellcheck disable=SC2016
     execute_remote 'sudo apt install -y linux-image-extra-$(uname -r) || sudo apt install -y linux-modules-extra-$(uname -r)'
 
 restore: |

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -11,10 +11,9 @@ prepare: |
     . "$TESTSLIB/nested.sh"
     create_nested_classic_vm
     copy_remote "${GOHOME}"/snapd_*.deb
+    execute_remote 'sudo apt update'
     execute_remote 'sudo apt install -y ./snapd_*.deb'
     execute_remote 'sudo apt install -y linux-image-extra-$(uname -r)'
-    execute_remote 'sudo reboot' || true
-    wait_for_ssh
 
 restore: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -13,7 +13,7 @@ prepare: |
     copy_remote "${GOHOME}"/snapd_*.deb
     execute_remote 'sudo apt update'
     execute_remote 'sudo apt install -y ./snapd_*.deb'
-    execute_remote 'sudo apt install -y linux-image-extra-$(uname -r)'
+    execute_remote 'sudo apt install -y linux-image-extra-$(uname -r) || sudo apt install -y linux-modules-extra-$(uname -r)'
 
 restore: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -11,7 +11,10 @@ prepare: |
     . "$TESTSLIB/nested.sh"
     create_nested_classic_vm
     copy_remote "${GOHOME}"/snapd_*.deb
-    execute_remote "sudo apt install -y ./snapd_*.deb"
+    execute_remote 'sudo apt install -y ./snapd_*.deb'
+    execute_remote 'sudo apt install -y linux-image-extra-$(uname -r)'
+    execute_remote 'sudo reboot' || true
+    wait_for_ssh
 
 restore: |
     #shellcheck source=tests/lib/nested.sh
@@ -19,7 +22,11 @@ restore: |
     destroy_nested_vm
 
     "$TESTSLIB"/prepare-restore.sh --restore-suite-each
-    "$TESTSLIB"/prepare-restore.sh --restore-suite    
+    "$TESTSLIB"/prepare-restore.sh --restore-suite
+
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    distro_install_package snapd
 
 execute: |
     #shellcheck source=tests/lib/nested.sh
@@ -30,10 +37,11 @@ execute: |
         exit 1
     fi
 
-    add_file_chardev my-chardev my-test-file
+    add_tty_chardev my-chardev /dev/tty5
     add_usb_serial_device my-usb-serial my-chardev
 
     execute_remote "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"
+    execute_remote 'ls /dev/tty*' | MATCH "ttyUSB0"
 
     del_device my-usb-serial
     remove_chardev my-chardev

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -25,5 +25,7 @@ execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
-    add_usb_tablet_device my-tablet
-    del_device my-tablet
+    add_chardev my-chardev 9022
+    add_usb_serial_device my-usb-serial my-chardev
+    del_device my-usb-serial
+    remove_chardev my-chardev

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -11,7 +11,7 @@ prepare: |
     . "$TESTSLIB/nested.sh"
     create_nested_classic_vm
     copy_remote "${GOHOME}"/snapd_*.deb
-    execute_remote "sudo dpkg -i snapd_*.deb"
+    execute_remote "sudo apt install -y ./snapd_*.deb"
 
 restore: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/hot-plug/task.yaml
+++ b/tests/nested/hot-plug/task.yaml
@@ -1,0 +1,29 @@
+summary: create ubuntu classic image, install snapd and test hot plug feature
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+
+prepare: |
+
+    "$TESTSLIB"/prepare-restore.sh --prepare-suite
+    "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+    create_nested_classic_vm
+    copy_remote "${GOHOME}"/snapd_*.deb
+    execute_remote "sudo dpkg -i snapd_*.deb"
+
+restore: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+    destroy_nested_vm
+
+    "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+    "$TESTSLIB"/prepare-restore.sh --restore-suite    
+
+execute: |
+    #shellcheck source=tests/lib/nested.sh
+    . "$TESTSLIB/nested.sh"
+
+    add_usb_tablet_device my-tablet
+    del_device my-tablet

--- a/tests/nested/image-build/task.yaml
+++ b/tests/nested/image-build/task.yaml
@@ -10,7 +10,7 @@ prepare: |
 restore: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    destroy_nested_core_vm
+    destroy_nested_vm
 
 execute: |
     cd "$SPREAD_PATH"


### PR DESCRIPTION
This change contains:
. Support for testing current branch on nested vm by
. Support for classic environments on nested vm
. Refector on nested helper
. Initial support for hotplug on qemu
. New test which should be completed with the hotplug test and build
and deploy snapd to the nested vm

See the next link with all the commands which can be used in the qemu
monitor including the add-usb command. Link:
https://paste.ubuntu.com/p/h9mH2JfPzt/

Test this running:

SPREAD_NESTED_TYPE=classic SPREAD_NESTED_ARCH=amd64
SPREAD_NESTED_SYSTEM=xenial spread -debug
google:ubuntu-16.04-64:tests/nested/hot-plug

SPREAD_NESTED_TYPE=classic SPREAD_NESTED_ARCH=amd64
SPREAD_NESTED_SYSTEM=bionic spread -debug
google:ubuntu-18.04-64:tests/nested/hot-plug

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
