### PR TITLE
image: improve validation of extra snaps

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -100,28 +100,34 @@ func localSnaps(tsto *ToolingStore, opts *Options) (*localInfos, error) {
 	local := make(map[string]*snap.Info)
 	nameToPath := make(map[string]string)
 	for _, snapName := range opts.Snaps {
-		if strings.HasSuffix(snapName, ".snap") && osutil.FileExists(snapName) {
-			snapFile, err := snap.Open(snapName)
-			if err != nil {
-				return nil, err
-			}
-			info, err := snap.ReadInfoFromSnapFile(snapFile, nil)
-			if err != nil {
-				return nil, err
-			}
-			// local snap gets local revision
-			info.Revision = snap.R(-1)
-			nameToPath[info.InstanceName()] = snapName
-			local[snapName] = info
+		if !strings.HasSuffix(snapName, ".snap") {
+			continue
+		}
 
-			si, err := snapasserts.DeriveSideInfo(snapName, tsto)
-			if err != nil && !asserts.IsNotFound(err) {
-				return nil, err
-			}
-			if err == nil {
-				info.SnapID = si.SnapID
-				info.Revision = si.Revision
-			}
+		if !osutil.FileExists(snapName) {
+			return nil, fmt.Errorf("local snap %s not found", snapName)
+		}
+
+		snapFile, err := snap.Open(snapName)
+		if err != nil {
+			return nil, err
+		}
+		info, err := snap.ReadInfoFromSnapFile(snapFile, nil)
+		if err != nil {
+			return nil, err
+		}
+		// local snap gets local revision
+		info.Revision = snap.R(-1)
+		nameToPath[info.InstanceName()] = snapName
+		local[snapName] = info
+
+		si, err := snapasserts.DeriveSideInfo(snapName, tsto)
+		if err != nil && !asserts.IsNotFound(err) {
+			return nil, err
+		}
+		if err == nil {
+			info.SnapID = si.SnapID
+			info.Revision = si.Revision
 		}
 	}
 	return &localInfos{
@@ -130,11 +136,14 @@ func localSnaps(tsto *ToolingStore, opts *Options) (*localInfos, error) {
 	}, nil
 }
 
-func validateNoParallelSnapInstances(snaps []string) error {
+func validateSnapNames(snaps []string) error {
 	for _, snapName := range snaps {
-		_, instanceKey := snap.SplitInstanceName(snapName)
-		if instanceKey != "" {
+		if _, instanceKey := snap.SplitInstanceName(snapName); instanceKey != "" {
+			// be specific about this error
 			return fmt.Errorf("cannot use snap %q, parallel snap instances are unsupported", snapName)
+		}
+		if err := snap.ValidateName(snapName); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -149,7 +158,7 @@ func validateNonLocalSnaps(snaps []string) error {
 			nonLocalSnaps = append(nonLocalSnaps, snapName)
 		}
 	}
-	return validateNoParallelSnapInstances(nonLocalSnaps)
+	return validateSnapNames(nonLocalSnaps)
 }
 
 func Prepare(opts *Options) error {
@@ -220,8 +229,12 @@ func decodeModelAssertion(opts *Options) (*asserts.Model, error) {
 	}
 
 	modelSnaps := modela.RequiredSnaps()
-	modelSnaps = append(modelSnaps, modela.Kernel(), modela.Gadget(), modela.Base())
-	if err := validateNoParallelSnapInstances(modelSnaps); err != nil {
+	modelSnaps = append(modelSnaps, modela.Kernel(), modela.Gadget())
+	if modela.Base() != "" {
+		// base is optional
+		modelSnaps = append(modelSnaps, modela.Base())
+	}
+	if err := validateSnapNames(modelSnaps); err != nil {
 		return nil, err
 	}
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1164,6 +1164,18 @@ func (s *imageSuite) TestNoLocalParallelSnapInstances(c *C) {
 	c.Assert(err, ErrorMatches, `cannot use snap "foo_instance", parallel snap instances are unsupported`)
 }
 
+func (s *imageSuite) TestNoInvalidSnapNames(c *C) {
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		ModelFile: fn,
+		Snaps:     []string{"foo.invalid.name"},
+	})
+	c.Assert(err, ErrorMatches, `invalid snap name: "foo.invalid.name"`)
+}
+
 func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
 	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
@@ -1661,6 +1673,15 @@ func (s *imageSuite) TestBootstrapToRootDirMissingContentProvider(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(s.stderr.String(), Equals, `WARNING: the default content provider "gtk-common-themes" requested by snap "snap-req-content-provider" is not getting installed.`)
+}
+
+func (s *imageSuite) TestMissingLocalSnaps(c *C) {
+	opts := &image.Options{
+		Snaps: []string{"i-am-missing.snap"},
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, ErrorMatches, "local snap i-am-missing.snap not found")
+	c.Assert(local, IsNil)
 }
 
 type toolingAuthContextSuite struct {


### PR DESCRIPTION
When extra snap is a local file, the path must exist, this should be enough to
catch typos.

On the other hand, should snap be grabbed from the store, it must have a valid
snap name. Again, this should catch typos that make the name 'invalid'.
