### PR TITLE
osutil: workaround overlayfs on ubuntu 18.10

### DIFF
--- a/osutil/overlay_linux.go
+++ b/osutil/overlay_linux.go
@@ -69,6 +69,20 @@ func IsRootWritableOverlay() (string, error) {
 					continue
 				}
 
+				if dir == "/media/root-rw/overlay" {
+					// Apparmor doesn't really support overlayfs correctly.
+					// When the root filesystem in a Ubuntu 18.10 server,
+					// ephemeral image, uses overlayfs then the declared
+					// overlayfs upperdir is "/media/root-rw/overlay" but when
+					// apparmor resolves the path the rules look for "/overlay"
+					// for some unknown reason.  As a quick hack to unblock the
+					// Ubuntu 18.10 release, detect this condition and return
+					// the path that apparmor would detect.
+					//
+					// See LP: #1797218 for context.
+					return "/overlay", nil
+				}
+
 				// Make sure trailing slashes are predicatably
 				// missing
 				return dir, nil

--- a/osutil/overlay_linux.go
+++ b/osutil/overlay_linux.go
@@ -70,16 +70,12 @@ func IsRootWritableOverlay() (string, error) {
 				}
 
 				if dir == "/media/root-rw/overlay" {
-					// Apparmor doesn't really support overlayfs correctly.
-					// When the root filesystem in a Ubuntu 18.10 server,
-					// ephemeral image, uses overlayfs then the declared
-					// overlayfs upperdir is "/media/root-rw/overlay" but when
-					// apparmor resolves the path the rules look for "/overlay"
-					// for some unknown reason.  As a quick hack to unblock the
-					// Ubuntu 18.10 release, detect this condition and return
-					// the path that apparmor would detect.
-					//
-					// See LP: #1797218 for context.
+					// On the Ubuntu server ephemeral image, '/' is setup via
+					// overlayroot (on at least 18.10), which uses a combination
+					// of overlayfs and chroot. This differs from the livecd setup
+					// so special case the detection logic to look for the known
+					// upperdir for this configuration, and return the required
+					// path. See LP: #1797218 for details.
 					return "/overlay", nil
 				}
 

--- a/osutil/overlay_linux_test.go
+++ b/osutil/overlay_linux_test.go
@@ -83,6 +83,10 @@ func (s *overlaySuite) TestIsRootWritableOverlay(c *C) {
 		mountinfo: "31 1 0:26 / / rw,relatime shared:1 - overlay overlay rw,lowerdir=//filesystem.squashfs,upperdir=/cow/bad^upper,workdir=/cow/work",
 	}, {
 		mountinfo: "31 1 0:26 / / rw,relatime shared:1 - overlay overlay rw,lowerdir=//filesystem.squashfs,upperdir=/cow/bad\"upper,workdir=/cow/work",
+	}, {
+		// The special cased version for 18.10 server release
+		mountinfo: "28 0 0:24 / / rw,realtime shared:1 - overlay overlayroot rw,lowerdir=/media/root-ro,upperdir=/media/root-rw/overlay,workdir=/media/root-rw/overlay-workdir/_",
+		overlay:   "/overlay",
 	}}
 	for _, tc := range cases {
 		restore := osutil.MockMountInfo(tc.mountinfo)


### PR DESCRIPTION
This patch adds a workaround for apparmor and overlayfs not playing
together on the ephemeral Ubuntu 18.10 server images. On such images
there's an overlayfs mounted over / with the upper directory in
/media/root-rw/overlay. Snapd detects this and generates a directive
with read access to said directory. At runtime we get a denial, however,
one that looks like this:

    [ 1588.858154] audit: type=1400 audit(1539338016.165:576):
    apparmor="DENIED" operation="open" profile="/usr/lib/snapd/snap-confine"
    name="/overlay/" pid=8735 comm="snap-confine"
    profile="/usr/lib/snapd/snap-confine" requested_mask="r"
    denied_mask="r" fsuid=0 ouid=0

As we can see apparmor decided to resolve the path to "/overlay/" (which
notably does not exist in the filesystem at all). The reason for that is
not understood but as a special-case workaround we detect this and
return "/overlay" instead.

Bug-Link: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1797218
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
