### PR TITLE
ifacestate/hooks: only create interface hook tasks if hooks exist

### DIFF
--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -101,7 +101,8 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 	//  - connect task
 	//  - connect-slot-<slot> hook
 	//  - connect-plug-<plug> hook
-	// The tasks run in sequence (are serialized by WaitFor).
+	// The tasks run in sequence (are serialized by WaitFor). The hooks are optional
+	// and their tasks are not created if not provided by snap.
 	// The prepare- hooks collect attributes via snapctl set.
 	// 'snapctl set' can only modify own attributes (plug's attributes in the *-plug-* hook and
 	// slot's attributes in the *-slot-* hook).
@@ -117,48 +118,72 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 		return nil, &ErrAlreadyConnected{Connection: connRef}
 	}
 
-	plugStatic, slotStatic, err := initialConnectAttributes(st, plugSnap, plugName, slotSnap, slotName)
+	var plugSnapst, slotSnapst snapstate.SnapState
+	if err = snapstate.Get(st, plugSnap, &plugSnapst); err != nil {
+		return nil, err
+	}
+	if err = snapstate.Get(st, slotSnap, &slotSnapst); err != nil {
+		return nil, err
+	}
+	plugSnapInfo, err := plugSnapst.CurrentInfo()
+	if err != nil {
+		return nil, err
+	}
+	slotSnapInfo, err := slotSnapst.CurrentInfo()
 	if err != nil {
 		return nil, err
 	}
 
-	summary := fmt.Sprintf(i18n.G("Connect %s:%s to %s:%s"),
-		plugSnap, plugName, slotSnap, slotName)
+	plugStatic, slotStatic, err := initialConnectAttributes(st, plugSnapInfo, plugSnap, plugName, slotSnapInfo, slotSnap, slotName)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := fmt.Sprintf(i18n.G("Connect %s:%s to %s:%s"), plugSnap, plugName, slotSnap, slotName)
 	connectInterface := st.NewTask("connect", summary)
 
 	initialContext := make(map[string]interface{})
 	initialContext["attrs-task"] = connectInterface.ID()
 
-	plugHookSetup := &hookstate.HookSetup{
-		Snap:     plugSnap,
-		Hook:     "prepare-plug-" + plugName,
-		Optional: true,
-	}
-	undoPrepPlugHookSetup := &hookstate.HookSetup{
-		Snap:        plugSnap,
-		Hook:        "unprepare-plug-" + plugName,
-		Optional:    true,
-		IgnoreError: true,
+	var preparePlugConnection, prepareSlotConnection, connectSlotConnection, connectPlugConnection *state.Task
+
+	preparePlugHookName := fmt.Sprintf("prepare-plug-%s", plugName)
+	if plugSnapInfo.Hooks[preparePlugHookName] != nil {
+		plugHookSetup := &hookstate.HookSetup{
+			Snap:     plugSnap,
+			Hook:     preparePlugHookName,
+			Optional: true,
+		}
+		summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), plugHookSetup.Hook, plugHookSetup.Snap)
+		undoPrepPlugHookSetup := &hookstate.HookSetup{
+			Snap:        plugSnap,
+			Hook:        "unprepare-plug-" + plugName,
+			Optional:    true,
+			IgnoreError: true,
+		}
+		preparePlugConnection = hookstate.HookTaskWithUndo(st, summary, plugHookSetup, undoPrepPlugHookSetup, initialContext)
 	}
 
-	summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), plugHookSetup.Hook, plugHookSetup.Snap)
-	preparePlugConnection := hookstate.HookTaskWithUndo(st, summary, plugHookSetup, undoPrepPlugHookSetup, initialContext)
+	prepareSlotHookName := fmt.Sprintf("prepare-slot-%s", slotName)
+	if slotSnapInfo.Hooks[prepareSlotHookName] != nil {
+		slotHookSetup := &hookstate.HookSetup{
+			Snap:     slotSnap,
+			Hook:     prepareSlotHookName,
+			Optional: true,
+		}
+		undoPrepSlotHookSetup := &hookstate.HookSetup{
+			Snap:        slotSnap,
+			Hook:        "unprepare-slot-" + slotName,
+			Optional:    true,
+			IgnoreError: true,
+		}
 
-	slotHookSetup := &hookstate.HookSetup{
-		Snap:     slotSnap,
-		Hook:     "prepare-slot-" + slotName,
-		Optional: true,
+		summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), slotHookSetup.Hook, slotHookSetup.Snap)
+		prepareSlotConnection = hookstate.HookTaskWithUndo(st, summary, slotHookSetup, undoPrepSlotHookSetup, initialContext)
+		if preparePlugConnection != nil {
+			prepareSlotConnection.WaitFor(preparePlugConnection)
+		}
 	}
-	undoPrepSlotHookSetup := &hookstate.HookSetup{
-		Snap:        slotSnap,
-		Hook:        "unprepare-slot-" + slotName,
-		Optional:    true,
-		IgnoreError: true,
-	}
-
-	summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), slotHookSetup.Hook, slotHookSetup.Snap)
-	prepareSlotConnection := hookstate.HookTaskWithUndo(st, summary, slotHookSetup, undoPrepSlotHookSetup, initialContext)
-	prepareSlotConnection.WaitFor(preparePlugConnection)
 
 	connectInterface.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
 	connectInterface.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
@@ -176,56 +201,73 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 	connectInterface.Set("slot-static", slotStatic)
 	connectInterface.Set("plug-dynamic", emptyDynamicAttrs)
 	connectInterface.Set("slot-dynamic", emptyDynamicAttrs)
-
-	connectInterface.WaitFor(prepareSlotConnection)
-
-	connectSlotHookSetup := &hookstate.HookSetup{
-		Snap:     slotSnap,
-		Hook:     "connect-slot-" + slotName,
-		Optional: true,
-	}
-	undoConnectSlotHookSetup := &hookstate.HookSetup{
-		Snap:        slotSnap,
-		Hook:        "disconnect-slot-" + slotName,
-		Optional:    true,
-		IgnoreError: true,
+	if prepareSlotConnection != nil {
+		connectInterface.WaitFor(prepareSlotConnection)
+	} else {
+		if preparePlugConnection != nil {
+			connectInterface.WaitFor(preparePlugConnection)
+		}
 	}
 
-	summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), connectSlotHookSetup.Hook, connectSlotHookSetup.Snap)
-	connectSlotConnection := hookstate.HookTaskWithUndo(st, summary, connectSlotHookSetup, undoConnectSlotHookSetup, initialContext)
-	connectSlotConnection.WaitFor(connectInterface)
+	connectSlotHookName := fmt.Sprintf("connect-slot-%s", slotName)
+	if slotSnapInfo.Hooks[connectSlotHookName] != nil {
+		connectSlotHookSetup := &hookstate.HookSetup{
+			Snap:     slotSnap,
+			Hook:     connectSlotHookName,
+			Optional: true,
+		}
+		undoConnectSlotHookSetup := &hookstate.HookSetup{
+			Snap:        slotSnap,
+			Hook:        "disconnect-slot-" + slotName,
+			Optional:    true,
+			IgnoreError: true,
+		}
 
-	connectPlugHookSetup := &hookstate.HookSetup{
-		Snap:     plugSnap,
-		Hook:     "connect-plug-" + plugName,
-		Optional: true,
+		summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), connectSlotHookSetup.Hook, connectSlotHookSetup.Snap)
+		connectSlotConnection = hookstate.HookTaskWithUndo(st, summary, connectSlotHookSetup, undoConnectSlotHookSetup, initialContext)
+		connectSlotConnection.WaitFor(connectInterface)
 	}
-	undoConnectPlugHookSetup := &hookstate.HookSetup{
-		Snap:        plugSnap,
-		Hook:        "disconnect-plug-" + plugName,
-		Optional:    true,
-		IgnoreError: true,
+
+	connectPlugHookName := fmt.Sprintf("connect-plug-%s", plugName)
+	if plugSnapInfo.Hooks[connectPlugHookName] != nil {
+		connectPlugHookSetup := &hookstate.HookSetup{
+			Snap:     plugSnap,
+			Hook:     connectPlugHookName,
+			Optional: true,
+		}
+		undoConnectPlugHookSetup := &hookstate.HookSetup{
+			Snap:        plugSnap,
+			Hook:        "disconnect-plug-" + plugName,
+			Optional:    true,
+			IgnoreError: true,
+		}
+
+		summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), connectPlugHookSetup.Hook, connectPlugHookSetup.Snap)
+		connectPlugConnection = hookstate.HookTaskWithUndo(st, summary, connectPlugHookSetup, undoConnectPlugHookSetup, initialContext)
+		if connectSlotConnection != nil {
+			connectPlugConnection.WaitFor(connectSlotConnection)
+		} else {
+			connectPlugConnection.WaitFor(connectInterface)
+		}
 	}
 
-	summary = fmt.Sprintf(i18n.G("Run hook %s of snap %q"), connectPlugHookSetup.Hook, connectPlugHookSetup.Snap)
-	connectPlugConnection := hookstate.HookTaskWithUndo(st, summary, connectPlugHookSetup, undoConnectPlugHookSetup, initialContext)
-	connectPlugConnection.WaitFor(connectSlotConnection)
-
-	return state.NewTaskSet(preparePlugConnection, prepareSlotConnection, connectInterface, connectSlotConnection, connectPlugConnection), nil
+	ts := &state.TaskSet{}
+	for _, t := range []*state.Task{preparePlugConnection, prepareSlotConnection, connectInterface, connectSlotConnection, connectPlugConnection} {
+		if t != nil {
+			ts.AddTask(t)
+		}
+	}
+	return ts, nil
 }
 
-func initialConnectAttributes(st *state.State, plugSnap string, plugName string, slotSnap string, slotName string) (plugStatic, slotStatic map[string]interface{}, err error) {
+func initialConnectAttributes(st *state.State, plugSnapInfo *snap.Info, plugSnap string, plugName string, slotSnapInfo *snap.Info, slotSnap string, slotName string) (plugStatic, slotStatic map[string]interface{}, err error) {
 	var plugSnapst snapstate.SnapState
 
 	if err = snapstate.Get(st, plugSnap, &plugSnapst); err != nil {
 		return nil, nil, err
 	}
-	snapInfo, err := plugSnapst.CurrentInfo()
-	if err != nil {
-		return nil, nil, err
-	}
 
-	plug, ok := snapInfo.Plugs[plugName]
+	plug, ok := plugSnapInfo.Plugs[plugName]
 	if !ok {
 		return nil, nil, fmt.Errorf("snap %q has no plug named %q", plugSnap, plugName)
 	}
@@ -235,16 +277,12 @@ func initialConnectAttributes(st *state.State, plugSnap string, plugName string,
 	if err = snapstate.Get(st, slotSnap, &slotSnapst); err != nil {
 		return nil, nil, err
 	}
-	snapInfo, err = slotSnapst.CurrentInfo()
-	if err != nil {
+
+	if err := addImplicitSlots(st, slotSnapInfo); err != nil {
 		return nil, nil, err
 	}
 
-	if err := addImplicitSlots(st, snapInfo); err != nil {
-		return nil, nil, err
-	}
-
-	slot, ok := snapInfo.Slots[slotName]
+	slot, ok := slotSnapInfo.Slots[slotName]
 	if !ok {
 		return nil, nil, fmt.Errorf("snap %q has no slot named %q", slotSnap, slotName)
 	}

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -102,7 +102,7 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 	//  - connect-slot-<slot> hook
 	//  - connect-plug-<plug> hook
 	// The tasks run in sequence (are serialized by WaitFor). The hooks are optional
-	// and their tasks are not created if not provided by snap.
+	// and their tasks are created when hook exists or is declared in the snap.
 	// The prepare- hooks collect attributes via snapctl set.
 	// 'snapctl set' can only modify own attributes (plug's attributes in the *-plug-* hook and
 	// slot's attributes in the *-slot-* hook).

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -201,6 +201,10 @@ func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, fla
 	connectInterface.Set("slot-static", slotStatic)
 	connectInterface.Set("plug-dynamic", emptyDynamicAttrs)
 	connectInterface.Set("slot-dynamic", emptyDynamicAttrs)
+
+	// The main 'connect' task should wait on prepare-slot- hook or on prepare-plug- hook (whichever is present),
+	// but not on both. While there would be no harm in waiting for both, it's not needed as prepare-slot- will
+	// wait for prepare-plug- anyway, and a simple one-to-one wait dependency makes testing easier.
 	if prepareSlotConnection != nil {
 		connectInterface.WaitFor(prepareSlotConnection)
 	} else {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2217,7 +2217,7 @@ func (ms *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snap
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 
 	tasks := chg.Tasks()
-	connectTask := tasks[len(tasks)-3]
+	connectTask := tasks[len(tasks)-1]
 	c.Assert(connectTask.Kind(), Equals, "connect")
 
 	// verify connect task data


### PR DESCRIPTION
Only create interface hooks tasks if relevant hook exists (i.e. hook file is present, or hook is explicitely listed in snap yaml - the Hooks map has both and is populated by ReadInfo). 

This should slightly reduce execution time as we avoid unneccessary no-op hook tasks which would be ignored by runHook anyway.