### PR TITLE
interfaces/home: don't allow snaps to write to $HOME/bin

### DIFF
--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -75,10 +75,9 @@ owner @{HOME}/snap/ r,
 owner /run/user/[0-9]*/gvfs/{,**} r,
 owner /run/user/[0-9]*/gvfs/*/**  w,
 
-# On some systems HOME/bin is in the default path in ahead of system
-# directories. To prevent snaps from writing arbitrary executables waiting to
-# be launched by the user, deny writes to the directory altogether.
-deny @{HOME}/bin/{,**} w,
+# Disallow writes to the well-known directory included in
+# the user's PATH on several distributions
+deny @{HOME}/bin/{,**} wl,
 `
 
 const homeConnectedPlugAppArmorWithAllRead = `

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -77,7 +77,7 @@ owner /run/user/[0-9]*/gvfs/*/**  w,
 
 # Disallow writes to the well-known directory included in
 # the user's PATH on several distributions
-deny @{HOME}/bin/{,**} wl,
+audit deny @{HOME}/bin/{,**} wl,
 `
 
 const homeConnectedPlugAppArmorWithAllRead = `

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -74,6 +74,11 @@ owner @{HOME}/snap/ r,
 # files; only allow writes to files, not the mount point).
 owner /run/user/[0-9]*/gvfs/{,**} r,
 owner /run/user/[0-9]*/gvfs/*/**  w,
+
+# On some systems HOME/bin is in the default path in ahead of system
+# directories. To prevent snaps from writing arbitrary executables waiting to
+# be launched by the user, deny writes to the directory altogether.
+deny @{HOME}/bin/{,**} w,
 `
 
 const homeConnectedPlugAppArmorWithAllRead = `

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -152,7 +152,7 @@ func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithoutAttrib(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner @{HOME}/ r,`)
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `deny @{HOME}/bin/{,**} w,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `deny @{HOME}/bin/{,**} wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), `# Allow non-owner read`)
 }
 
@@ -173,7 +173,7 @@ apps:
 	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
-	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `deny @{HOME}/bin/{,**} w,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `deny @{HOME}/bin/{,**} wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `# Allow non-owner read`)
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -152,7 +152,7 @@ func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithoutAttrib(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner @{HOME}/ r,`)
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `deny @{HOME}/bin/{,**} wl,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `audit deny @{HOME}/bin/{,**} wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), `# Allow non-owner read`)
 }
 
@@ -173,7 +173,7 @@ apps:
 	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
-	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `deny @{HOME}/bin/{,**} wl,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `audit deny @{HOME}/bin/{,**} wl,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `# Allow non-owner read`)
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -152,6 +152,7 @@ func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithoutAttrib(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `deny @{HOME}/bin/{,**} w,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), `# Allow non-owner read`)
 }
 
@@ -172,6 +173,7 @@ apps:
 	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `deny @{HOME}/bin/{,**} w,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
 	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `# Allow non-owner read`)
 }

--- a/tests/regression/lp-1797556/task.yaml
+++ b/tests/regression/lp-1797556/task.yaml
@@ -12,8 +12,11 @@ restore: |
     su -l -c 'rmdir /home/test/bin/ || true' test
 execute: |
     test -d /home/test/bin
-    test ! -e /home/test/bin/evil
+    test ! -e /home/test/bin/evil-1
+    test ! -e /home/test/bin/evil-2
     if snap debug sandbox-features | grep 'apparmor:.* kernel:file'; then
-        ! su -l -c 'test-snapd-sh.with-home-plug -c touch /home/test/bin/evil' test
+        ! su -l -c 'test-snapd-sh.with-home-plug -c touch /home/test/bin/evil-1' test
+        ! su -l -c 'test-snapd-sh.with-home-plug -c ln /home/test/snap/test-snapd-sh/common/evil-2 /home/test/bin/evil-2' test
     fi
-    test ! -e /home/test/bin/evil
+    test ! -e /home/test/bin/evil-1
+    test ! -e /home/test/bin/evil-2

--- a/tests/regression/lp-1797556/task.yaml
+++ b/tests/regression/lp-1797556/task.yaml
@@ -18,11 +18,11 @@ execute: |
     test -d /home/test/bin
     test ! -e /home/test/bin/evil-1
     test ! -e /home/test/bin/evil-2
-    if snap debug sandbox-features | grep 'apparmor:.* kernel:file'; then
+    if [ "$(snap debug confinement)" = "strict" ]; then
         ! su -l -c 'test-snapd-sh.with-home-plug -c "touch /home/test/bin/evil-1"' test 2>&1 | MATCH '.* Permission denied'
-        dmesg | grep 'apparmor="DENIED" operation="mknod" profile="snap.test-snapd-sh.with-home-plug" name="/home/test/bin/evil-1"'
+        dmesg | grep 'apparmor="DENIED" operation="mknod".* name="/home/test/bin/evil-1"'
         ! su -l -c 'test-snapd-sh.with-home-plug -c "ln /home/test/snap/test-snapd-sh/common/evil-2 /home/test/bin/evil-2"' test 2>&1 | MATCH '.* Permission denied'
-        dmesg | grep 'apparmor="DENIED" operation="link" info="target restricted" error=-13 profile="snap.test-snapd-sh.with-home-plug" name="/home/test/bin/evil-2"'
+        dmesg | grep 'apparmor="DENIED" operation="link".* name="/home/test/bin/evil-2"'
     fi
     test ! -e /home/test/bin/evil-1
     test ! -e /home/test/bin/evil-2

--- a/tests/regression/lp-1797556/task.yaml
+++ b/tests/regression/lp-1797556/task.yaml
@@ -8,15 +8,21 @@ prepare: |
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-sh
     su -l -c 'mkdir -p /home/test/bin/' test
+    su -l -c 'mkdir -p /home/test/snap/test-snapd-sh/common/' test
+    su -l -c 'touch /home/test/snap/test-snapd-sh/common/evil-2' test
+    sysctl -w kernel.printk_ratelimit=0
 restore: |
     su -l -c 'rmdir /home/test/bin/ || true' test
+    sysctl -w kernel.printk_ratelimit=5
 execute: |
     test -d /home/test/bin
     test ! -e /home/test/bin/evil-1
     test ! -e /home/test/bin/evil-2
     if snap debug sandbox-features | grep 'apparmor:.* kernel:file'; then
-        ! su -l -c 'test-snapd-sh.with-home-plug -c touch /home/test/bin/evil-1' test
-        ! su -l -c 'test-snapd-sh.with-home-plug -c ln /home/test/snap/test-snapd-sh/common/evil-2 /home/test/bin/evil-2' test
+        ! su -l -c 'test-snapd-sh.with-home-plug -c "touch /home/test/bin/evil-1"' test 2>&1 | MATCH '.* Permission denied'
+        dmesg | grep 'apparmor="DENIED" operation="mknod" profile="snap.test-snapd-sh.with-home-plug" name="/home/test/bin/evil-1"'
+        ! su -l -c 'test-snapd-sh.with-home-plug -c "ln /home/test/snap/test-snapd-sh/common/evil-2 /home/test/bin/evil-2"' test 2>&1 | MATCH '.* Permission denied'
+        dmesg | grep 'apparmor="DENIED" operation="link" info="target restricted" error=-13 profile="snap.test-snapd-sh.with-home-plug" name="/home/test/bin/evil-2"'
     fi
     test ! -e /home/test/bin/evil-1
     test ! -e /home/test/bin/evil-2

--- a/tests/regression/lp-1797556/task.yaml
+++ b/tests/regression/lp-1797556/task.yaml
@@ -1,0 +1,19 @@
+summary: snaps cannot write to ~/bin
+details: |
+    On some distributions the ~/bin directory is in the default PATH for the
+    user. To avoid hijacking commands and allow sandbox escape, writing to this
+    directory is denied.
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-sh
+    su -l -c 'mkdir -p /home/test/bin/' test
+restore: |
+    su -l -c 'rmdir /home/test/bin/ || true' test
+execute: |
+    test -d /home/test/bin
+    test ! -e /home/test/bin/evil
+    if snap debug sandbox-features | grep 'apparmor:.* kernel:file'; then
+        ! su -l -c 'test-snapd-sh.with-home-plug -c touch /home/test/bin/evil' test
+    fi
+    test ! -e /home/test/bin/evil


### PR DESCRIPTION
The $HOME/bin directory is added to default PATH on some systems. To
prevent sandbox escape in this specific case deny writing to this
directory.

Bug-Link: https://bugs.launchpad.net/snapd/+bug/1797556
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>