### PR TITLE
install: don't start disabled services

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -308,9 +308,8 @@ func (s *systemd) IsEnabled(serviceName string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	// note that "systemctl is-enabled <name>" returns exit code 1 for disabled services
-	// as well as outputting "disabled\n", so we need to cast the error, and
-	// also trim the whitespace from the output to check the command output
+	// "systemctl is-enabled <name>" prints `disabled\n` to stderr and returns exit code 1
+	// for disabled services
 	sysdErr, ok := err.(*Error)
 	if ok && sysdErr.exitCode == 1 && strings.TrimSpace(string(sysdErr.msg)) == "disabled" {
 		return false, nil

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -130,6 +130,7 @@ type Systemd interface {
 	Kill(service, signal, who string) error
 	Restart(service string, timeout time.Duration) error
 	Status(services ...string) ([]*ServiceStatus, error)
+	IsEnabled(service string) (bool, error)
 	LogReader(services []string, n int, follow bool) (io.ReadCloser, error)
 	WriteMountUnitFile(name, revision, what, where, fstype string) (string, error)
 	Mask(service string) error
@@ -299,6 +300,22 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 	}
 
 	return sts, nil
+}
+
+// IsEnabled checkes whether the given service is enabled
+func (s *systemd) IsEnabled(serviceName string) (bool, error) {
+	_, err := systemctlCmd("--root", s.rootDir, "is-enabled", serviceName)
+	if err == nil {
+		return true, nil
+	}
+	// note that "systemctl is-enabled <name>" returns exit code 1 for disabled services
+	// as well as outputting "disabled\n", so we need to cast the error, and
+	// also trim the whitespace from the output to check the command output
+	sysdErr, ok := err.(*Error)
+	if ok && sysdErr.exitCode == 1 && strings.TrimSpace(string(sysdErr.msg)) == "disabled" {
+		return false, nil
+	}
+	return false, err
 }
 
 // Stop the given service, and wait until it has stopped.

--- a/tests/lib/snaps/test-snapd-svcs-disable-install-hook/bin/forking.sh
+++ b/tests/lib/snaps/test-snapd-svcs-disable-install-hook/bin/forking.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sleep 60 &

--- a/tests/lib/snaps/test-snapd-svcs-disable-install-hook/bin/simple.sh
+++ b/tests/lib/snaps/test-snapd-svcs-disable-install-hook/bin/simple.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sleep 60

--- a/tests/lib/snaps/test-snapd-svcs-disable-install-hook/meta/hooks/install
+++ b/tests/lib/snaps/test-snapd-svcs-disable-install-hook/meta/hooks/install
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for service in simple forking; do
+    echo "Disabling $service service from install hook"
+    snapctl stop --disable "test-snapd-svcs-disable-install-hook.$service"
+done

--- a/tests/lib/snaps/test-snapd-svcs-disable-install-hook/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-svcs-disable-install-hook/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-svcs-disable-install-hook
+version: 1.0
+apps:
+    simple:
+        daemon: simple
+        command: bin/simple.sh
+    forking:
+        daemon: forking
+        command: bin/forking.sh

--- a/tests/main/svcs-disable-install-hook/task.yaml
+++ b/tests/main/svcs-disable-install-hook/task.yaml
@@ -1,0 +1,11 @@
+summary: Check that `snapctl stop --disable` actually stops services on install
+
+execute: |
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-svcs-disable-install-hook
+
+    for service in simple forking; do
+        echo "Verify that the $service service isn't running"
+        snap services | MATCH "test-snapd-svcs-disable-install-hook\\.$service\\s+disabled\\s+inactive"
+    done

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -130,7 +130,18 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 		}(app)
 
 		if len(app.Sockets) == 0 && app.Timer == nil {
-			services = append(services, app.ServiceName())
+			// check if the service is disabled, if so don't start it up
+			// this could happen for example if the service was disabled in
+			// the install hook by snapctl or if the service was disabled in
+			// the previous installation
+			isEnabled, err := sysd.IsEnabled(app.ServiceName())
+			if err != nil {
+				return err
+			}
+
+			if isEnabled {
+				services = append(services, app.ServiceName())
+			}
 		}
 
 		for _, socket := range app.Sockets {
@@ -156,7 +167,6 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 				return err
 			}
 		}
-
 	}
 
 	if len(services) > 0 {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -226,7 +226,45 @@ func (s *servicesTestSuite) TestStartServices(c *C) {
 	err := wrappers.StartServices(info.Services(), nil)
 	c.Assert(err, IsNil)
 
-	c.Assert(s.sysdLog, DeepEquals, [][]string{{"start", filepath.Base(svcFile)}})
+	c.Assert(s.sysdLog, DeepEquals, [][]string{
+		{"--root", s.tempdir, "is-enabled", filepath.Base(svcFile)},
+		{"start", filepath.Base(svcFile)},
+	})
+}
+
+func (s *servicesTestSuite) TestNoStartDisabledServices(c *C) {
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
+
+	s.systemctlRestorer()
+	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
+	if [ "$1" = "--root" ]; then
+	    shift 2
+	fi
+	
+	case "$1" in
+	    is-enabled)
+	        if [ "$2" = "snap.hello-snap.svc1.service" ]; then
+	            echo "disabled"
+	            exit 1
+	        else
+	            echo "unexpected call $*"
+	            exit 2
+	        fi
+	        ;;
+	    *)
+	        echo "unexpected call $*"
+	        exit 2
+	esac
+	`)
+	defer r.Restore()
+
+	err := wrappers.StartServices(info.Services(), nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(r.Calls(), DeepEquals, [][]string{
+		{"systemctl", "--root", s.tempdir, "is-enabled", filepath.Base(svcFile)},
+	})
 }
 
 func (s *servicesTestSuite) TestAddSnapMultiServicesFailCreateCleanup(c *C) {
@@ -434,8 +472,10 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 
 	err := wrappers.StartServices(info.Services(), nil)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 5, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 7, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
+		{"--root", s.tempdir, "is-enabled", svc1Name},
+		{"--root", s.tempdir, "is-enabled", svc2Name},
 		{"start", svc1Name, svc2Name}, // one of the services fails
 		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
@@ -486,8 +526,9 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	err := wrappers.StartServices(apps, nil)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 16, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 17, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
+		{"--root", s.tempdir, "is-enabled", svc1Name},
 		{"--root", s.tempdir, "enable", svc2SocketName},
 		{"start", svc2SocketName},
 		{"--root", s.tempdir, "enable", svc3SocketName},
@@ -727,8 +768,9 @@ func (s *servicesTestSuite) TestStartSnapTimerEnableStart(c *C) {
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"]}
 	err := wrappers.StartServices(apps, nil)
 	c.Assert(err, IsNil)
-	c.Assert(s.sysdLog, HasLen, 3, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
+	c.Assert(s.sysdLog, HasLen, 4, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
 	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "is-enabled", svc1Name},
 		{"--root", dirs.GlobalRootDir, "enable", svc2Timer},
 		{"start", svc2Timer},
 		{"start", svc1Name},
@@ -761,8 +803,9 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"]}
 	err := wrappers.StartServices(apps, nil)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 9, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "is-enabled", svc1Name},
 		{"--root", dirs.GlobalRootDir, "enable", svc2Timer},
 		{"start", svc2Timer}, // this call fails
 		{"stop", svc2Timer},


### PR DESCRIPTION
Note that this PR intends to only fix a specific subset of the issue with service startup during install; that is services that are disabled in the install hook, etc. and do *not* have sockets or timers. 
How to handle sockets or timers is still not yet clear, so we would like to just fix this specific bug, which is clearly wrong. There is a forum topic open to discuss the larger situation with sockets and timers here: https://forum.snapcraft.io/t/how-to-manage-services-with-sockets-timers/7904

Also note that there is basically no regression potential here, because we don't currently check services when installing at all, and as such all services are unconditionally installed. 

Ping @bboozzoo 