### PR TITLE
interfaces/apparmor: conditionally add explicit deny rules for ptrace

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -552,7 +552,9 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 					snippet := strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
 					tagSnippets += snippet
 				}
+			}
 
+			if !ignoreSnippets {
 				// For policy with snippets that request
 				// suppression of 'ptrace (trace)' denials, add
 				// the suppression rule unless another

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -419,12 +419,12 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts i
 	// Add profile for each app.
 	for _, appInfo := range snapInfo.Apps {
 		securityTag := appInfo.SecurityTag()
-		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
+		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for each hook.
 	for _, hookInfo := range snapInfo.Hooks {
 		securityTag := hookInfo.SecurityTag()
-		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
+		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for snap-update-ns if we have any apps or hooks.
 	// If we have neither then we don't have any need to create an executing environment.
@@ -482,7 +482,7 @@ func downgradeConfinement() bool {
 	return true
 }
 
-func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
+func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState, spec *Specification) {
 	// Normally we use a specific apparmor template for all snap programs.
 	policy := defaultTemplate
 	ignoreSnippets := false
@@ -552,7 +552,16 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 					snippet := strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
 					tagSnippets += snippet
 				}
+
+				// For policy with snippets that request
+				// suppression of 'ptrace (trace)' denials, add
+				// the suppression rule unless another
+				// interface said it uses them.
+				if spec.suppressPtraceTrace && !spec.usesPtraceTrace {
+					tagSnippets += ptraceTraceDenySnippet
+				}
 			}
+
 			return tagSnippets
 		}
 		return ""

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -559,7 +559,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 				// suppression of 'ptrace (trace)' denials, add
 				// the suppression rule unless another
 				// interface said it uses them.
-				if spec.suppressPtraceTrace && !spec.usesPtraceTrace {
+				if spec.SuppressPtraceTrace() && !spec.UsesPtraceTrace() {
 					tagSnippets += ptraceTraceDenySnippet
 				}
 			}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1634,10 +1634,10 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 	} {
 		s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 			if tc.uses {
-				spec.UsesPtraceTrace()
+				spec.SetUsesPtraceTrace()
 			}
 			if tc.suppress {
-				spec.SuppressPtraceTrace()
+				spec.SetSuppressPtraceTrace()
 			}
 			return nil
 		}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1606,7 +1606,7 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 			suppress: true,
 			expected: false,
 		},
-		// classic with jail, never suppress
+		// classic with jail, only suppress if suppress == true and uses == false
 		{
 			opts:     interfaces.ConfinementOptions{Classic: true, JailMode: true},
 			uses:     false,
@@ -1617,7 +1617,7 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 			opts:     interfaces.ConfinementOptions{Classic: true, JailMode: true},
 			uses:     false,
 			suppress: true,
-			expected: false,
+			expected: true,
 		},
 		{
 			opts:     interfaces.ConfinementOptions{Classic: true, JailMode: true},

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -43,6 +43,20 @@ type Specification struct {
 	// updateNS describe parts of apparmor policy for snap-update-ns executing
 	// on behalf of a given snap.
 	updateNS []string
+
+	// AppArmor deny rules cannot be undone by allow rules which makes
+	// deny rules difficult to work with arbitrary combinations of
+	// interfaces. Sometimes it is useful to suppress noisy denials and
+	// because that can currently only be done with explicit deny rules,
+	// adding explicit deny rules unconditionally makes it difficult for
+	// interfaces to be used in combination. Define the suppressPtraceTrace
+	// to allow an interface to request suppression and define
+	// usesPtraceTrace to omit the explicit deny rules such that:
+	//   if suppressPtraceTrace && !usesPtraceTrace {
+	//       add 'deny ptrace (trace),'
+	//   }
+	suppressPtraceTrace bool
+	usesPtraceTrace     bool
 }
 
 // setScope sets the scope of subsequent AddSnippet family functions.
@@ -476,4 +490,22 @@ func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *sn
 		return iface.AppArmorPermanentSlot(spec, slot)
 	}
 	return nil
+}
+
+// UsesPtraceTrace records when to omit explicit ptrace deny rules
+func (spec *Specification) UsesPtraceTrace() {
+	spec.usesPtraceTrace = true
+}
+
+// SuppressPtraceTrace to request explicit ptrace deny rules
+func (spec *Specification) SuppressPtraceTrace() {
+	spec.suppressPtraceTrace = true
+}
+
+func (spec *Specification) GetUsesPtraceTrace() bool {
+	return spec.usesPtraceTrace
+}
+
+func (spec *Specification) GetSuppressPtraceTrace() bool {
+	return spec.suppressPtraceTrace
 }

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -492,20 +492,20 @@ func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *sn
 	return nil
 }
 
-// UsesPtraceTrace records when to omit explicit ptrace deny rules
-func (spec *Specification) UsesPtraceTrace() {
+// SetUsesPtraceTrace records when to omit explicit ptrace deny rules
+func (spec *Specification) SetUsesPtraceTrace() {
 	spec.usesPtraceTrace = true
 }
 
-// SuppressPtraceTrace to request explicit ptrace deny rules
-func (spec *Specification) SuppressPtraceTrace() {
-	spec.suppressPtraceTrace = true
-}
-
-func (spec *Specification) GetUsesPtraceTrace() bool {
+func (spec *Specification) UsesPtraceTrace() bool {
 	return spec.usesPtraceTrace
 }
 
-func (spec *Specification) GetSuppressPtraceTrace() bool {
+// SetSuppressPtraceTrace to request explicit ptrace deny rules
+func (spec *Specification) SetSuppressPtraceTrace() {
+	spec.suppressPtraceTrace = true
+}
+
+func (spec *Specification) SuppressPtraceTrace() bool {
 	return spec.suppressPtraceTrace
 }

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -539,3 +539,15 @@ func (s *specSuite) TestApparmorOvernameSnippets(c *C) {
 `
 	c.Assert(updateNS[0], Equals, profile)
 }
+
+func (s *specSuite) TestUsesPtraceTrace(c *C) {
+	c.Assert(s.spec.GetUsesPtraceTrace(), Equals, false)
+	s.spec.UsesPtraceTrace()
+	c.Assert(s.spec.GetUsesPtraceTrace(), Equals, true)
+}
+
+func (s *specSuite) TestSuppressPtraceTrace(c *C) {
+	c.Assert(s.spec.GetSuppressPtraceTrace(), Equals, false)
+	s.spec.SuppressPtraceTrace()
+	c.Assert(s.spec.GetSuppressPtraceTrace(), Equals, true)
+}

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -541,13 +541,13 @@ func (s *specSuite) TestApparmorOvernameSnippets(c *C) {
 }
 
 func (s *specSuite) TestUsesPtraceTrace(c *C) {
-	c.Assert(s.spec.GetUsesPtraceTrace(), Equals, false)
-	s.spec.UsesPtraceTrace()
-	c.Assert(s.spec.GetUsesPtraceTrace(), Equals, true)
+	c.Assert(s.spec.UsesPtraceTrace(), Equals, false)
+	s.spec.SetUsesPtraceTrace()
+	c.Assert(s.spec.UsesPtraceTrace(), Equals, true)
 }
 
 func (s *specSuite) TestSuppressPtraceTrace(c *C) {
-	c.Assert(s.spec.GetSuppressPtraceTrace(), Equals, false)
-	s.spec.SuppressPtraceTrace()
-	c.Assert(s.spec.GetSuppressPtraceTrace(), Equals, true)
+	c.Assert(s.spec.SuppressPtraceTrace(), Equals, false)
+	s.spec.SetSuppressPtraceTrace()
+	c.Assert(s.spec.SuppressPtraceTrace(), Equals, true)
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -566,6 +566,19 @@ var overlayRootSnippet = `
   "###UPPERDIR###/{,**/}" r,
 `
 
+var ptraceTraceDenySnippet = `
+# While commands like 'ps', 'ip netns identify <pid>', 'ip netns pids foo', etc
+# trigger a 'ptrace (trace)' denial, they aren't actually tracing other
+# processes. Unfortunately, the kernel overloads trace such that the LSMs are
+# unable to distinguish between tracing other processes and other accesses.
+# ptrace (trace) can be used to break out of the seccomp sandbox unless the
+# kernel has 93e35efb8de45393cf61ed07f7b407629bf698ea (in 4.8+). Until snapd
+# has full ptrace support conditional on kernel support, explicitly deny to
+# silence noisy denials/avoid confusion and accidentally giving away this
+# dangerous access frivolously.
+deny ptrace (trace),
+`
+
 // updateNSTemplate defines the apparmor profile for per-snap snap-update-ns.
 //
 // The per-snap snap-update-ns profiles are composed via a template and

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -106,19 +106,6 @@ owner @{PROC}/@{pid}/mountinfo r,
 deny capability mknod,
 `
 
-const browserSupportConnectedPlugAppArmorWithoutSandbox = `
-# ptrace can be used to break out of the seccomp sandbox, but ps requests
-# 'ptrace (trace)' even though it isn't tracing other processes. Unfortunately,
-# this is due to the kernel overloading trace such that the LSMs are unable to
-# distinguish between tracing other processes and other accesses. We deny the
-# trace here to silence the log.
-# Note: for now, explicitly deny to avoid confusion and accidentally giving
-# away this dangerous access frivolously. We may conditionally deny this in the
-# future. If the kernel has https://lkml.org/lkml/2016/5/26/354 we could also
-# allow this.
-deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**,
-`
-
 const browserSupportConnectedPlugAppArmorWithSandbox = `
 # Leaks installed applications
 # TODO: should this be somewhere else?
@@ -321,7 +308,7 @@ func (iface *browserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	if allowSandbox {
 		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithSandbox)
 	} else {
-		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithoutSandbox)
+		spec.SuppressPtraceTrace()
 	}
 	return nil
 }

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -308,7 +308,7 @@ func (iface *browserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	if allowSandbox {
 		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithSandbox)
 	} else {
-		spec.SuppressPtraceTrace()
+		spec.SetSuppressPtraceTrace()
 	}
 	return nil
 }

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -108,7 +108,6 @@ func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithoutAttrib(c *
 	snippet := apparmorSpec.SnippetForTag("snap.other.app2")
 	c.Assert(string(snippet), testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(string(snippet), Not(testutil.Contains), `capability sys_admin,`)
-	c.Assert(string(snippet), testutil.Contains, `deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
@@ -141,7 +140,6 @@ apps:
 	snippet := apparmorSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
 	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(snippet, Not(testutil.Contains), `capability sys_admin,`)
-	c.Assert(snippet, testutil.Contains, `deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, plug, s.slot)
@@ -173,7 +171,6 @@ apps:
 	snippet := apparmorSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
 	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(snippet, testutil.Contains, `ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
-	c.Assert(snippet, Not(testutil.Contains), `deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, plug, s.slot)

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -55,6 +55,9 @@ type commonInterface struct {
 	connectedSlotKModModules []string
 	permanentPlugKModModules []string
 	permanentSlotKModModules []string
+
+	usesPtraceTrace     bool
+	suppressPtraceTrace bool
 }
 
 // Name returns the interface name.
@@ -86,6 +89,11 @@ func (iface *commonInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 }
 
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if iface.usesPtraceTrace {
+		spec.UsesPtraceTrace()
+	} else if iface.suppressPtraceTrace {
+		spec.SuppressPtraceTrace()
+	}
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)
 	}

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -90,9 +90,9 @@ func (iface *commonInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	if iface.usesPtraceTrace {
-		spec.UsesPtraceTrace()
+		spec.SetUsesPtraceTrace()
 	} else if iface.suppressPtraceTrace {
-		spec.SuppressPtraceTrace()
+		spec.SetSuppressPtraceTrace()
 	}
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -106,11 +106,11 @@ slots:
 		usesPtraceTrace:     false,
 	}
 	spec := &apparmor.Specification{}
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, false)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, false)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 
 	// setting only uses
 	iface = &commonInterface{
@@ -119,11 +119,11 @@ slots:
 		usesPtraceTrace:     true,
 	}
 	spec = &apparmor.Specification{}
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, false)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, true)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, true)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 
 	// setting only suppress
 	iface = &commonInterface{
@@ -132,11 +132,11 @@ slots:
 		usesPtraceTrace:     false,
 	}
 	spec = &apparmor.Specification{}
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, false)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, true)
+	c.Assert(spec.UsesPtraceTrace(), Equals, false)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, true)
 
 	// setting both, only uses is set
 	iface = &commonInterface{
@@ -145,9 +145,9 @@ slots:
 		usesPtraceTrace:     true,
 	}
 	spec = &apparmor.Specification{}
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, false)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
-	c.Assert(spec.GetUsesPtraceTrace(), Equals, true)
-	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.UsesPtraceTrace(), Equals, true)
+	c.Assert(spec.SuppressPtraceTrace(), Equals, false)
 }

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -22,6 +22,7 @@ package builtin
 import (
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -81,4 +82,72 @@ func MockEvalSymlinks(test *testutil.BaseTest, fn func(string) (string, error)) 
 	test.AddCleanup(func() {
 		evalSymlinks = orig
 	})
+}
+
+func (s *commonIfaceSuite) TestSuppressPtraceTrace(c *C) {
+	plug, _ := MockConnectedPlug(c, `
+name: consumer
+version: 0
+apps:
+  app:
+    plugs: [common]
+`, nil, "common")
+	slot, _ := MockConnectedSlot(c, `
+name: producer
+version: 0
+slots:
+  common:
+`, nil, "common")
+
+	// setting nothing
+	iface := &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: false,
+		usesPtraceTrace:     false,
+	}
+	spec := &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+
+	// setting only uses
+	iface = &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: false,
+		usesPtraceTrace:     true,
+	}
+	spec = &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, true)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+
+	// setting only suppress
+	iface = &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: true,
+		usesPtraceTrace:     false,
+	}
+	spec = &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, true)
+
+	// setting both, only uses is set
+	iface = &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: true,
+		usesPtraceTrace:     true,
+	}
+	spec = &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, true)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
 }

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -217,14 +217,9 @@ mount options=(rw, bind) /run/netns/ -> /run/netns/,
 mount options=(rw, bind) / -> /run/netns/*,
 umount /,
 
-# 'ip netns identify <pid>' and 'ip netns pids foo'
+# 'ip netns identify <pid>' and 'ip netns pids foo'. Intenionally omit 'ptrace
+# (trace)' here since ip netns doesn't actually need to trace other processes.
 capability sys_ptrace,
-# FIXME: ptrace can be used to break out of the seccomp sandbox unless the
-# kernel has 93e35efb8de45393cf61ed07f7b407629bf698ea (in 4.8+). Until this is
-# the default in snappy kernels, deny but audit as a reminder to get the
-# kernels patched.
-audit deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.*, # eventually by default
-audit deny ptrace (trace), # for all other peers (process-control or other)
 
 # 'ip netns exec foo /bin/sh'
 mount options=(rw, rslave) /,
@@ -295,6 +290,7 @@ func init() {
 		connectedPlugSecComp:  networkControlConnectedPlugSecComp,
 		connectedPlugUDev:     networkControlConnectedPlugUDev,
 		reservedForOS:         true,
+		suppressPtraceTrace:   true,
 	})
 
 }

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -38,18 +38,9 @@ const systemObserveConnectedPlugAppArmor = `
 # Needed by 'ps'
 @{PROC}/tty/drivers r,
 
-# This ptrace is an information leak
+# This ptrace is an information leak. Intentionlly omit 'ptrace (trace)' here
+# since since ps doesn't actually need to trace other processes.
 ptrace (read),
-
-# ptrace can be used to break out of the seccomp sandbox, but ps requests
-# 'ptrace (trace)' even though it isn't tracing other processes. Unfortunately,
-# this is due to the kernel overloading trace such that the LSMs are unable to
-# distinguish between tracing other processes and other accesses. We deny the
-# trace here to silence the log.
-# Note: for now, explicitly deny to avoid confusion and accidentally giving
-# away this dangerous access frivolously. We may conditionally deny this in the
-# future.
-deny ptrace (trace),
 
 # Other miscellaneous accesses for observing the system
 @{PROC}/modules r,
@@ -130,5 +121,6 @@ func init() {
 		connectedPlugAppArmor: systemObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemObserveConnectedPlugSecComp,
 		reservedForOS:         true,
+		suppressPtraceTrace:   true,
 	})
 }

--- a/tests/main/interfaces-browser-support/task.yaml
+++ b/tests/main/interfaces-browser-support/task.yaml
@@ -106,6 +106,14 @@ execute: |
     fi
 
     if [ "$(snap debug confinement)" = strict ] ; then
+        if [ "$ALLOW_SANDBOX" = "false" ]; then
+            echo "And the policy has the ptrace suppression rule without sandbox"
+            MATCH '^deny ptrace \(trace\),' < /var/lib/snapd/apparmor/profiles/snap.browser-support-consumer.cmd
+        else
+            echo "And the policy has the ptrace suppression rule with sandbox"
+            MATCH '^deny ptrace \(trace\),' < /var/lib/snapd/apparmor/profiles/snap.browser-support-consumer.cmd && echo "Found ptrace rule, but shouldn't have" && exit 1
+        fi
+
         echo "And the resources available with sandbox are not reachable without it"
         if [ "$ALLOW_SANDBOX" = "false" ]; then
             for readable_file in $READABLE_WITH_SANDBOX_FILES; do

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -116,6 +116,9 @@ execute: |
     network-control-consumer.cmd ip netns exec test-ns ip link list | MATCH "veth1"
 
     if [ "$(snap debug confinement)" = strict ] ; then
+        echo "And the policy has the ptrace suppression rule"
+        MATCH '^deny ptrace \(trace\),' < /var/lib/snapd/apparmor/profiles/snap.network-control-consumer.cmd
+
         echo "When the plug is disconnected"
         snap disconnect network-control-consumer:network-control
 

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -44,6 +44,9 @@ execute: |
     fi
 
     if [ "$(snap debug confinement)" = strict ] ; then
+        echo "And the policy has the ptrace suppression rule"
+        MATCH '^deny ptrace \(trace\),' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-system-observe-consumer.consumer
+
         echo "When the plug is disconnected"
         snap disconnect test-snapd-system-observe-consumer:system-observe
 


### PR DESCRIPTION
AppArmor deny rules cannot be undone by allow rules which makes deny
rules difficult to work with arbitrary combinations of interfaces.
Sometimes it is useful to suppress noisy denials and because that can
currently only be done with explicit deny rules, adding explicit deny
rules unconditionally makes it difficult for interfaces to be used in
combination. Define suppressPtraceTrace to allow an interface to request
suppression and define usesPtraceTrace to omit the explict deny rules
such that:
```
  if suppressPtraceTrace && !usesPtraceTrace {
      add 'deny ptrace (trace),'
  }
```
Add UsesPtraceTrace() and SuppressPtraceTrace() that can be called in
the interfaces to set the above and adjust addContent() to use the above
logic to conditionally add a single explicit deny ptrace (trace) rule.

Adjust system-observe and network-observe to suppress via the common
interface and browser-support to use the new SuppressPtraceTrace().

With the above, the policy is equivalent to what was generated before
(except we only have a single explicit denial rather than several when
the above 3 interfaces are all connected at once). Future PRs will
adjust other interfaces to use UsesPtraceTrace() as needed so these
interfaces can still ptrace but continue to use the other interfaces.
