### PR TITLE
interfaces/many: updates to support k8s worker nodes

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -419,12 +419,12 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts i
 	// Add profile for each app.
 	for _, appInfo := range snapInfo.Apps {
 		securityTag := appInfo.SecurityTag()
-		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
+		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for each hook.
 	for _, hookInfo := range snapInfo.Hooks {
 		securityTag := hookInfo.SecurityTag()
-		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
+		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for snap-update-ns if we have any apps or hooks.
 	// If we have neither then we don't have any need to create an executing environment.
@@ -482,7 +482,7 @@ func downgradeConfinement() bool {
 	return true
 }
 
-func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
+func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState, spec *Specification) {
 	// Normally we use a specific apparmor template for all snap programs.
 	policy := defaultTemplate
 	ignoreSnippets := false
@@ -552,7 +552,16 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 					snippet := strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
 					tagSnippets += snippet
 				}
+
+				// For policy with snippets that request
+				// suppression of 'ptrace (trace)' denials, add
+				// the suppression rule unless another
+				// interface said it uses them.
+				if spec.suppressPtraceTrace && !spec.usesPtraceTrace {
+					tagSnippets += ptraceTraceDenySnippet
+				}
 			}
+
 			return tagSnippets
 		}
 		return ""

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -43,6 +43,20 @@ type Specification struct {
 	// updateNS describe parts of apparmor policy for snap-update-ns executing
 	// on behalf of a given snap.
 	updateNS []string
+
+	// AppArmor deny rules cannot be undone by allow rules which makes
+	// deny rules difficult to work with arbitrary combinations of
+	// interfaces. Sometimes it is useful to suppress noisy denials and
+	// because that can currently only be done with explicit deny rules,
+	// adding explicit deny rules unconditionally makes it difficult for
+	// interfaces to be used in combination. Define the suppressPtraceTrace
+	// to allow an interface to request suppression and define
+	// usesPtraceTrace to omit the explicit deny rules such that:
+	//   if suppressPtraceTrace && !usesPtraceTrace {
+	//       add 'deny ptrace (trace),'
+	//   }
+	suppressPtraceTrace bool
+	usesPtraceTrace     bool
 }
 
 // setScope sets the scope of subsequent AddSnippet family functions.
@@ -476,4 +490,22 @@ func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *sn
 		return iface.AppArmorPermanentSlot(spec, slot)
 	}
 	return nil
+}
+
+// UsesPtraceTrace records when to omit explicit ptrace deny rules
+func (spec *Specification) UsesPtraceTrace() {
+	spec.usesPtraceTrace = true
+}
+
+// SuppressPtraceTrace to request explicit ptrace deny rules
+func (spec *Specification) SuppressPtraceTrace() {
+	spec.suppressPtraceTrace = true
+}
+
+func (spec *Specification) GetUsesPtraceTrace() bool {
+	return spec.usesPtraceTrace
+}
+
+func (spec *Specification) GetSuppressPtraceTrace() bool {
+	return spec.suppressPtraceTrace
 }

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -539,3 +539,15 @@ func (s *specSuite) TestApparmorOvernameSnippets(c *C) {
 `
 	c.Assert(updateNS[0], Equals, profile)
 }
+
+func (s *specSuite) TestUsesPtraceTrace(c *C) {
+	c.Assert(s.spec.GetUsesPtraceTrace(), Equals, false)
+	s.spec.UsesPtraceTrace()
+	c.Assert(s.spec.GetUsesPtraceTrace(), Equals, true)
+}
+
+func (s *specSuite) TestSuppressPtraceTrace(c *C) {
+	c.Assert(s.spec.GetSuppressPtraceTrace(), Equals, false)
+	s.spec.SuppressPtraceTrace()
+	c.Assert(s.spec.GetSuppressPtraceTrace(), Equals, true)
+}

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -566,6 +566,19 @@ var overlayRootSnippet = `
   "###UPPERDIR###/{,**/}" r,
 `
 
+var ptraceTraceDenySnippet = `
+# While commands like 'ps', 'ip netns identify <pid>', 'ip netns pids foo', etc
+# trigger a 'ptrace (trace)' denial, they aren't actually tracing other
+# processes. Unfortunately, the kernel overloads trace such that the LSMs are
+# unable to distinguish between tracing other processes and other accesses.
+# ptrace (trace) can be used to break out of the seccomp sandbox unless the
+# kernel has 93e35efb8de45393cf61ed07f7b407629bf698ea (in 4.8+). Until snapd
+# has full ptrace support conditional on kernel support, explicitly deny to
+# silence noisy denials/avoid confusion and accidentally giving away this
+# dangerous access frivolously.
+deny ptrace (trace),
+`
+
 // updateNSTemplate defines the apparmor profile for per-snap snap-update-ns.
 //
 // The per-snap snap-update-ns profiles are composed via a template and

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -106,19 +106,6 @@ owner @{PROC}/@{pid}/mountinfo r,
 deny capability mknod,
 `
 
-const browserSupportConnectedPlugAppArmorWithoutSandbox = `
-# ptrace can be used to break out of the seccomp sandbox, but ps requests
-# 'ptrace (trace)' even though it isn't tracing other processes. Unfortunately,
-# this is due to the kernel overloading trace such that the LSMs are unable to
-# distinguish between tracing other processes and other accesses. We deny the
-# trace here to silence the log.
-# Note: for now, explicitly deny to avoid confusion and accidentally giving
-# away this dangerous access frivolously. We may conditionally deny this in the
-# future. If the kernel has https://lkml.org/lkml/2016/5/26/354 we could also
-# allow this.
-deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**,
-`
-
 const browserSupportConnectedPlugAppArmorWithSandbox = `
 # Leaks installed applications
 # TODO: should this be somewhere else?
@@ -321,7 +308,7 @@ func (iface *browserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	if allowSandbox {
 		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithSandbox)
 	} else {
-		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithoutSandbox)
+		spec.SuppressPtraceTrace()
 	}
 	return nil
 }

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -108,7 +108,6 @@ func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithoutAttrib(c *
 	snippet := apparmorSpec.SnippetForTag("snap.other.app2")
 	c.Assert(string(snippet), testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(string(snippet), Not(testutil.Contains), `capability sys_admin,`)
-	c.Assert(string(snippet), testutil.Contains, `deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
@@ -141,7 +140,6 @@ apps:
 	snippet := apparmorSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
 	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(snippet, Not(testutil.Contains), `capability sys_admin,`)
-	c.Assert(snippet, testutil.Contains, `deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, plug, s.slot)
@@ -173,7 +171,6 @@ apps:
 	snippet := apparmorSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
 	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(snippet, testutil.Contains, `ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
-	c.Assert(snippet, Not(testutil.Contains), `deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.**`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, plug, s.slot)

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -55,6 +55,9 @@ type commonInterface struct {
 	connectedSlotKModModules []string
 	permanentPlugKModModules []string
 	permanentSlotKModModules []string
+
+	usesPtraceTrace     bool
+	suppressPtraceTrace bool
 }
 
 // Name returns the interface name.
@@ -86,6 +89,11 @@ func (iface *commonInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 }
 
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if iface.usesPtraceTrace {
+		spec.UsesPtraceTrace()
+	} else if iface.suppressPtraceTrace {
+		spec.SuppressPtraceTrace()
+	}
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)
 	}

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -22,6 +22,7 @@ package builtin
 import (
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -81,4 +82,72 @@ func MockEvalSymlinks(test *testutil.BaseTest, fn func(string) (string, error)) 
 	test.AddCleanup(func() {
 		evalSymlinks = orig
 	})
+}
+
+func (s *commonIfaceSuite) TestSuppressPtraceTrace(c *C) {
+	plug, _ := MockConnectedPlug(c, `
+name: consumer
+version: 0
+apps:
+  app:
+    plugs: [common]
+`, nil, "common")
+	slot, _ := MockConnectedSlot(c, `
+name: producer
+version: 0
+slots:
+  common:
+`, nil, "common")
+
+	// setting nothing
+	iface := &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: false,
+		usesPtraceTrace:     false,
+	}
+	spec := &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+
+	// setting only uses
+	iface = &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: false,
+		usesPtraceTrace:     true,
+	}
+	spec = &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, true)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+
+	// setting only suppress
+	iface = &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: true,
+		usesPtraceTrace:     false,
+	}
+	spec = &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, true)
+
+	// setting both, only uses is set
+	iface = &commonInterface{
+		name:                "common",
+		suppressPtraceTrace: true,
+		usesPtraceTrace:     true,
+	}
+	spec = &apparmor.Specification{}
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, false)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.GetUsesPtraceTrace(), Equals, true)
+	c.Assert(spec.GetSuppressPtraceTrace(), Equals, false)
 }

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -40,6 +40,7 @@ const kernelModuleControlConnectedPlugAppArmor = `
 
 capability sys_module,
 @{PROC}/modules r,
+/{,usr/}bin/kmod ixr,
 
 # FIXME: moved to physical-memory-observe (remove this in series 18)
 /dev/mem r,
@@ -49,8 +50,10 @@ capability sys_module,
 # required to verify kernel modules that are loaded.
 capability syslog,
 
-# Allow plug side to read information about loaded kernel modules
+# Allow reading information about loaded kernel modules
 /sys/module/{,**} r,
+/etc/modprobe.d/{,**} r,
+/lib/modprobe.d/{,**} r,
 `
 
 const kernelModuleControlConnectedPlugSecComp = `

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -38,19 +38,19 @@ const kernelModuleControlBaseDeclarationSlots = `
 const kernelModuleControlConnectedPlugAppArmor = `
 # Description: Allow insertion, removal and querying of modules.
 
-  capability sys_module,
-  @{PROC}/modules r,
+capability sys_module,
+@{PROC}/modules r,
 
-  # FIXME: moved to physical-memory-observe (remove this in series 18)
-  /dev/mem r,
+# FIXME: moved to physical-memory-observe (remove this in series 18)
+/dev/mem r,
 
-  # Required to use SYSLOG_ACTION_READ_ALL and SYSLOG_ACTION_SIZE_BUFFER when
-  # /proc/sys/kernel/dmesg_restrict is '1' (syslog(2)). These operations are
-  # required to verify kernel modules that are loaded.
-  capability syslog,
+# Required to use SYSLOG_ACTION_READ_ALL and SYSLOG_ACTION_SIZE_BUFFER when
+# /proc/sys/kernel/dmesg_restrict is '1' (syslog(2)). These operations are
+# required to verify kernel modules that are loaded.
+capability syslog,
 
-  # Allow plug side to read information about loaded kernel modules
-  /sys/module/{,**} r,
+# Allow plug side to read information about loaded kernel modules
+/sys/module/{,**} r,
 `
 
 const kernelModuleControlConnectedPlugSecComp = `

--- a/interfaces/builtin/kernel_module_observe.go
+++ b/interfaces/builtin/kernel_module_observe.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const kernelModuleObserveSummary = `allows querying of kernel modules`
+
+const kernelModuleObserveBaseDeclarationSlots = `
+  kernel-module-observe:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const kernelModuleObserveConnectedPlugAppArmor = `
+# Description: Allow querying of kernel modules.
+/{,usr/}bin/kmod ixr, # seccomp and no SYS_MODULE prevents loading/removing
+@{PROC}/modules r,
+
+# Required to use SYSLOG_ACTION_READ_ALL and SYSLOG_ACTION_SIZE_BUFFER when
+# /proc/sys/kernel/dmesg_restrict is '1' (syslog(2)). These operations are
+# required to verify kernel modules that are loaded.
+capability syslog,
+
+# Allow reading information about loaded kernel modules
+/sys/module/{,**} r,
+/etc/modprobe.d/{,**} r,
+/lib/modprobe.d/{,**} r,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "kernel-module-observe",
+		summary:               kernelModuleObserveSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  kernelModuleObserveBaseDeclarationSlots,
+		connectedPlugAppArmor: kernelModuleObserveConnectedPlugAppArmor,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/kernel_module_observe_test.go
+++ b/interfaces/builtin/kernel_module_observe_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type KernelModuleObserveInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&KernelModuleObserveInterfaceSuite{
+	iface: builtin.MustInterface("kernel-module-observe"),
+})
+
+const kernelmodobsConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [kernel-module-observe]
+`
+
+const kernelmodobsCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  kernel-module-observe:
+`
+
+func (s *KernelModuleObserveInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, kernelmodobsConsumerYaml, nil, "kernel-module-observe")
+	s.slot, s.slotInfo = MockConnectedSlot(c, kernelmodobsCoreYaml, nil, "kernel-module-observe")
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "kernel-module-observe")
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "kernel-module-observe",
+		Interface: "kernel-module-observe",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"kernel-module-observe slots are reserved for the core snap")
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Allow querying of kernel modules")
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows querying of kernel modules`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "kernel-module-observe")
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *KernelModuleObserveInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -26,25 +26,48 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/kmod"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type KubernetesSupportInterfaceSuite struct {
-	iface    interfaces.Interface
-	slotInfo *snap.SlotInfo
-	slot     *interfaces.ConnectedSlot
-	plugInfo *snap.PlugInfo
-	plug     *interfaces.ConnectedPlug
+	iface             interfaces.Interface
+	slotInfo          *snap.SlotInfo
+	slot              *interfaces.ConnectedSlot
+	plugInfo          *snap.PlugInfo
+	plug              *interfaces.ConnectedPlug
+	plugKubeletInfo   *snap.PlugInfo
+	plugKubelet       *interfaces.ConnectedPlug
+	plugKubeproxyInfo *snap.PlugInfo
+	plugKubeproxy     *interfaces.ConnectedPlug
+	plugBadInfo       *snap.PlugInfo
+	plugBad           *interfaces.ConnectedPlug
 }
 
-const k8sMockPlugSnapInfoYaml = `name: other
-version: 1.0
+const k8sMockPlugSnapInfoYaml = `name: kubernetes-support
+version: 0
+plugs:
+  k8s-default:
+    interface: kubernetes-support
+  k8s-kubelet:
+    interface: kubernetes-support
+    flavor: kubelet
+  k8s-kubeproxy:
+    interface: kubernetes-support
+    flavor: kubeproxy
+  k8s-bad:
+    interface: kubernetes-support
+    flavor: bad
 apps:
- app2:
-  command: foo
-  plugs: [kubernetes-support]
+ default:
+  plugs: [k8s-default]
+ kubelet:
+  plugs: [k8s-kubelet]
+ kubeproxy:
+  plugs: [k8s-kubeproxy]
 `
 
 var _ = Suite(&KubernetesSupportInterfaceSuite{
@@ -59,8 +82,18 @@ func (s *KubernetesSupportInterfaceSuite) SetUpTest(c *C) {
 	}
 	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
 	plugSnap := snaptest.MockInfo(c, k8sMockPlugSnapInfoYaml, nil)
-	s.plugInfo = plugSnap.Plugs["kubernetes-support"]
+
+	s.plugInfo = plugSnap.Plugs["k8s-default"]
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+
+	s.plugKubeletInfo = plugSnap.Plugs["k8s-kubelet"]
+	s.plugKubelet = interfaces.NewConnectedPlug(s.plugKubeletInfo, nil, nil)
+
+	s.plugKubeproxyInfo = plugSnap.Plugs["k8s-kubeproxy"]
+	s.plugKubeproxy = interfaces.NewConnectedPlug(s.plugKubeproxyInfo, nil, nil)
+
+	s.plugBadInfo = plugSnap.Plugs["k8s-bad"]
+	s.plugBad = interfaces.NewConnectedPlug(s.plugBadInfo, nil, nil)
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestName(c *C) {
@@ -80,22 +113,120 @@ func (s *KubernetesSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 
 func (s *KubernetesSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugKubeletInfo), IsNil)
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugKubeproxyInfo), IsNil)
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugBadInfo), ErrorMatches, `kubernetes-support plug requires "flavor" to be either "kubelet" or "kubeproxy"`)
 }
 
-func (s *KubernetesSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	kmodSpec := &kmod.Specification{}
-	err := kmodSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+func (s *KubernetesSupportInterfaceSuite) TestKModConnectedPlug(c *C) {
+	// default should have kubeproxy modules
+	spec := &kmod.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(kmodSpec.Modules(), DeepEquals, map[string]bool{
-		"llc": true,
-		"stp": true,
+	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
+		"llc":       true,
+		"stp":       true,
+		"ip_vs_rr":  true,
+		"ip_vs_sh":  true,
+		"ip_vs_wrr": true,
+		"libcrc32c": true,
 	})
 
-	apparmorSpec := &apparmor.Specification{}
-	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	// kubeproxy should have its modules
+	spec = &kmod.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubeproxy, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "# Allow reading the state of modules kubernetes needs\n")
+	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
+		"llc":       true,
+		"stp":       true,
+		"ip_vs_rr":  true,
+		"ip_vs_sh":  true,
+		"ip_vs_wrr": true,
+		"libcrc32c": true,
+	})
+
+	// kubelet shouldn't have anything
+	spec = &kmod.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubelet, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Modules(), DeepEquals, map[string]bool{})
+}
+
+func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
+	// default should have kubeproxy and kubelet rules
+	spec := &apparmor.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.kubernetes-support.default"})
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Common rules for running as a kubernetes node\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow running as the kubelet service\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow running as the kubeproxy service\n")
+
+	// kubeproxy should have only its rules
+	spec = &apparmor.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubeproxy, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.kubernetes-support.kubeproxy"})
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), testutil.Contains, "# Common rules for running as a kubernetes node\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), testutil.Contains, "# Allow running as the kubeproxy service\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), Not(testutil.Contains), "# Allow running as the kubelet service\n")
+
+	// kubelet should have only its rules
+	spec = &apparmor.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubelet, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.kubernetes-support.kubelet"})
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Common rules for running as a kubernetes node\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Allow running as the kubelet service\n")
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), Not(testutil.Contains), "# Allow running as the kubeproxy service\n")
+}
+
+func (s *KubernetesSupportInterfaceSuite) TestSecCompConnectedPlug(c *C) {
+	// default should have kubelet rules
+	spec := &seccomp.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.kubernetes-support.default"})
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow running as the kubelet service\n")
+
+	// kubeproxy should not have any rules
+	spec = &seccomp.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubeproxy, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// kubelet should have only its rules
+	spec = &seccomp.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubelet, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.kubernetes-support.kubelet"})
+	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Allow running as the kubelet service\n")
+}
+
+func (s *KubernetesSupportInterfaceSuite) TestUDevConnectedPlug(c *C) {
+	// default should have kubelet rules
+	spec := &udev.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# kubernetes-support
+KERNEL=="kmsg", TAG+="snap_kubernetes-support_default"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_kubernetes-support_default", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_kubernetes-support_default $devpath $major:$minor"`)
+
+	// kubeproxy should not have any rules
+	spec = &udev.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubeproxy, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 0)
+
+	// kubelet should have only its rules
+	spec = &udev.Specification{}
+	err = spec.AddConnectedPlug(s.iface, s.plugKubelet, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# kubernetes-support
+KERNEL=="kmsg", TAG+="snap_kubernetes-support_kubelet"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_kubernetes-support_kubelet", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_kubernetes-support_kubelet $devpath $major:$minor"`)
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -217,14 +217,9 @@ mount options=(rw, bind) /run/netns/ -> /run/netns/,
 mount options=(rw, bind) / -> /run/netns/*,
 umount /,
 
-# 'ip netns identify <pid>' and 'ip netns pids foo'
+# 'ip netns identify <pid>' and 'ip netns pids foo'. Intenionally omit 'ptrace
+# (trace)' here since ip netns doesn't actually need to trace other processes.
 capability sys_ptrace,
-# FIXME: ptrace can be used to break out of the seccomp sandbox unless the
-# kernel has 93e35efb8de45393cf61ed07f7b407629bf698ea (in 4.8+). Until this is
-# the default in snappy kernels, deny but audit as a reminder to get the
-# kernels patched.
-audit deny ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.*, # eventually by default
-audit deny ptrace (trace), # for all other peers (process-control or other)
 
 # 'ip netns exec foo /bin/sh'
 mount options=(rw, rslave) /,
@@ -295,6 +290,7 @@ func init() {
 		connectedPlugSecComp:  networkControlConnectedPlugSecComp,
 		connectedPlugUDev:     networkControlConnectedPlugUDev,
 		reservedForOS:         true,
+		suppressPtraceTrace:   true,
 	})
 
 }

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -29,7 +29,6 @@ const systemObserveBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/system-observe
 const systemObserveConnectedPlugAppArmor = `
 # Description: Can query system status information. This is restricted because
 # it gives privileged read access to all processes on the system and should
@@ -49,6 +48,9 @@ ptrace (read),
 @{PROC}/diskstats r,
 @{PROC}/kallsyms r,
 @{PROC}/partitions r,
+@{PROC}/sys/kernel/panic r,
+@{PROC}/sys/kernel/panic_on_oops r,
+@{PROC}/sys/vm/panic_on_oom r,
 
 # These are not process-specific (/proc/*/... and /proc/*/task/*/...)
 @{PROC}/*/{,task/,task/*/} r,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -38,18 +38,9 @@ const systemObserveConnectedPlugAppArmor = `
 # Needed by 'ps'
 @{PROC}/tty/drivers r,
 
-# This ptrace is an information leak
+# This ptrace is an information leak. Intentionlly omit 'ptrace (trace)' here
+# since since ps doesn't actually need to trace other processes.
 ptrace (read),
-
-# ptrace can be used to break out of the seccomp sandbox, but ps requests
-# 'ptrace (trace)' even though it isn't tracing other processes. Unfortunately,
-# this is due to the kernel overloading trace such that the LSMs are unable to
-# distinguish between tracing other processes and other accesses. We deny the
-# trace here to silence the log.
-# Note: for now, explicitly deny to avoid confusion and accidentally giving
-# away this dangerous access frivolously. We may conditionally deny this in the
-# future.
-deny ptrace (trace),
 
 # Other miscellaneous accesses for observing the system
 @{PROC}/modules r,
@@ -130,5 +121,6 @@ func init() {
 		connectedPlugAppArmor: systemObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemObserveConnectedPlugSecComp,
 		reservedForOS:         true,
+		suppressPtraceTrace:   true,
 	})
 }

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -143,6 +143,9 @@ apps:
   kernel-module-control:
     command: bin/run
     plugs: [ kernel-module-control ]
+  kernel-module-observe:
+    command: bin/run
+    plugs: [ kernel-module-observe ]
   kubernetes-support:
     command: bin/run
     plugs: [ kubernetes-support ]


### PR DESCRIPTION
* interfaces/kubernetes-support: update to support flavors for worker nodes.
 Refactor the kubernetes-interface to support different flavors of access control via the 'flavor' attribute:
 * kubelet worker node
   * manipulating mounts, etc
   * ptracing containers
   * adjusting panic and panic_on_oops
   * managing kube-pods cgroups
  * kubeproxy workder node
   * managing kube-proxy cgroups
  * default (unspecified): all of the above
 In this manner a kubernetes snap containing many services can more finely tailor accessing for the service (eg, kubeproxy doesn't need to mount)
* interfaces/docker-support: misc access for k8s driving docker
* interfaces/system-observe: allow reading panic, panic_on_oom and panic_on_oops
* add interfaces/kernel-module-observe
* interfaces/kernel-module-control: whitespace changes
* interfaces/kernel-module-control: also allow reading of modprobe.d dirs
* interfaces/firewall-control: various reads/writes for nf. listen on @xtables

Note: this is branched from https://github.com/snapcore/snapd/pull/5980