### PR TITLE
cmd: refactor IPC and lifecycle of the helper process

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -61,8 +61,8 @@ fmt: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
 # The hack target helps devlopers work on snap-confine on their live system by
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack
-hack: snap-confine/snap-confine snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp
-	sudo install -D -m 6755 snap-confine/snap-confine $(DESTDIR)$(libexecdir)/snap-confine
+hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp
+	sudo install -D -m 6755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
 	sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine.real
 	sudo install -d -m 755 $(DESTDIR)/var/lib/snapd/apparmor/snap-confine/
 	sudo apparmor_parser -r snap-confine/snap-confine.apparmor

--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -80,7 +80,6 @@ static void test_sc_alloc_mount_ns(void)
 	g_assert_cmpint(group->pipe_fd[0], ==, -1);
 	g_assert_cmpint(group->pipe_fd[1], ==, -1);
 	g_assert_cmpint(group->child, ==, 0);
-	g_assert_cmpint(group->should_populate, ==, false);
 	g_assert_null(group->name);
 }
 
@@ -102,7 +101,6 @@ static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name)
 	g_assert_cmpint(group->pipe_fd[0], ==, -1);
 	g_assert_cmpint(group->pipe_fd[1], ==, -1);
 	g_assert_cmpint(group->child, ==, 0);
-	g_assert_cmpint(group->should_populate, ==, false);
 	g_assert_cmpstr(group->name, ==, group_name);
 	return group;
 }

--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -77,7 +77,8 @@ static void test_sc_alloc_mount_ns(void)
 	g_test_queue_free(group);
 	g_assert_nonnull(group);
 	g_assert_cmpint(group->dir_fd, ==, -1);
-	g_assert_cmpint(group->event_fd, ==, -1);
+	g_assert_cmpint(group->pipe_fd[0], ==, -1);
+	g_assert_cmpint(group->pipe_fd[1], ==, -1);
 	g_assert_cmpint(group->child, ==, 0);
 	g_assert_cmpint(group->should_populate, ==, false);
 	g_assert_null(group->name);
@@ -98,7 +99,8 @@ static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name)
 	// Check if the returned group data looks okay
 	g_assert_nonnull(group);
 	g_assert_cmpint(group->dir_fd, !=, -1);
-	g_assert_cmpint(group->event_fd, ==, -1);
+	g_assert_cmpint(group->pipe_fd[0], ==, -1);
+	g_assert_cmpint(group->pipe_fd[1], ==, -1);
 	g_assert_cmpint(group->child, ==, 0);
 	g_assert_cmpint(group->should_populate, ==, false);
 	g_assert_cmpstr(group->name, ==, group_name);

--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -77,8 +77,10 @@ static void test_sc_alloc_mount_ns(void)
 	g_test_queue_free(group);
 	g_assert_nonnull(group);
 	g_assert_cmpint(group->dir_fd, ==, -1);
-	g_assert_cmpint(group->pipe_fd[0], ==, -1);
-	g_assert_cmpint(group->pipe_fd[1], ==, -1);
+	g_assert_cmpint(group->pipe_master[0], ==, -1);
+	g_assert_cmpint(group->pipe_master[1], ==, -1);
+	g_assert_cmpint(group->pipe_helper[0], ==, -1);
+	g_assert_cmpint(group->pipe_helper[1], ==, -1);
 	g_assert_cmpint(group->child, ==, 0);
 	g_assert_null(group->name);
 }
@@ -98,8 +100,10 @@ static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name)
 	// Check if the returned group data looks okay
 	g_assert_nonnull(group);
 	g_assert_cmpint(group->dir_fd, !=, -1);
-	g_assert_cmpint(group->pipe_fd[0], ==, -1);
-	g_assert_cmpint(group->pipe_fd[1], ==, -1);
+	g_assert_cmpint(group->pipe_master[0], ==, -1);
+	g_assert_cmpint(group->pipe_master[1], ==, -1);
+	g_assert_cmpint(group->pipe_helper[0], ==, -1);
+	g_assert_cmpint(group->pipe_helper[1], ==, -1);
 	g_assert_cmpint(group->child, ==, 0);
 	g_assert_cmpstr(group->name, ==, group_name);
 	return group;

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -680,6 +680,10 @@ static void sc_wait_for_capture_helper(struct sc_mount_ns *group)
 void sc_preserve_populated_mount_ns(struct sc_mount_ns *group)
 {
 	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_NS);
+}
+
+void sc_wait_for_helper(struct sc_mount_ns *group)
+{
 	sc_message_capture_helper(group, HELPER_CMD_EXIT);
 	sc_wait_for_capture_helper(group);
 }

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -73,6 +73,11 @@ static const char *sc_ns_dir = SC_NS_DIR;
  **/
 #define SC_NS_MNT_FILE ".mnt"
 
+enum {
+	HELPER_CMD_EXIT,
+	HELPER_CMD_CAPTURE_NS,
+};
+
 /**
  * Read /proc/self/mountinfo and check if /run/snapd/ns is a private bind mount.
  *
@@ -174,9 +179,9 @@ struct sc_mount_ns {
 	// Descriptor to the namespace group control directory.  This descriptor is
 	// opened with O_PATH|O_DIRECTORY so it's only used for openat() calls.
 	int dir_fd;
-	// Descriptor to an eventfd that is used to notify the child that it can
-	// now complete its job and exit.
-	int event_fd;
+	// Descriptor for a pair for a pipe file descriptors (read end, write end)
+	// that snap-confine uses to send messages to the helper process.
+	int pipe_fd[2];
 	// Identifier of the child process that is used during the one-time (per
 	// group) initialization and capture process.
 	pid_t child;
@@ -191,7 +196,8 @@ static struct sc_mount_ns *sc_alloc_mount_ns(void)
 		die("cannot allocate memory for sc_mount_ns");
 	}
 	group->dir_fd = -1;
-	group->event_fd = -1;
+	group->pipe_fd[0] = -1;
+	group->pipe_fd[1] = -1;
 	// Redundant with calloc but some functions check for the non-zero value so
 	// I'd like to keep this explicit in the code.
 	group->child = 0;
@@ -221,7 +227,8 @@ struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
 void sc_close_mount_ns(struct sc_mount_ns *group)
 {
 	sc_cleanup_close(&group->dir_fd);
-	sc_cleanup_close(&group->event_fd);
+	sc_cleanup_close(&group->pipe_fd[0]);
+	sc_cleanup_close(&group->pipe_fd[1]);
 	free(group->name);
 	free(group);
 }
@@ -444,6 +451,11 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 	return EAGAIN;
 }
 
+static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
+			pid_t parent);
+static void helper_exit(void);
+static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent);
+
 int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 			       struct sc_apparmor *apparmor,
 			       const char *base_snap_name,
@@ -518,81 +530,28 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 		}
 		return 0;
 	}
-	// Create a new namespace and ask the caller to populate it.
-	// For rationale of forking see this:
-	// https://lists.linuxfoundation.org/pipermail/containers/2013-August/033386.html
-	//
-	// The eventfd created here is used to synchronize the child and the parent
-	// processes. It effectively tells the child to perform the capture
-	// operation.
-	group->event_fd = eventfd(0, EFD_CLOEXEC);
-	if (group->event_fd < 0) {
-		die("cannot create eventfd");
+	// Create a pipe for sending commands to the helper process.
+	if (pipe2(group->pipe_fd, O_CLOEXEC | O_DIRECT) < 0) {
+		die("cannot create pipes for commanding the helper process");
 	}
-	debug("forking support process for mount namespace capture");
+	// Create a new namespace and ask the caller to populate it.
+
 	// Store the PID of the "parent" process. This done instead of calls to
 	// getppid() because then we can reliably track the PID of the parent even
 	// if the child process is re-parented.
 	pid_t parent = getpid();
-	// Glibc defines pid as a signed 32bit integer. There's no standard way to
-	// print pid's portably so this is the best we can do.
+
+	// For rationale of forking see this:
+	// https://lists.linuxfoundation.org/pipermail/containers/2013-August/033386.html
 	pid_t pid = fork();
 	if (pid < 0) {
-		die("cannot fork support process for mount namespace capture");
+		die("cannot fork helper process for mount namespace capture");
 	}
 	if (pid == 0) {
-		// This is the child process which will capture the mount namespace.
-		//
-		// It will do so by bind-mounting the SC_NS_MNT_FILE after the parent
-		// process calls unshare() and finishes setting up the namespace
-		// completely.
-		// Change the hat to a sub-profile that has limited permissions
-		// necessary to accomplish the capture of the mount namespace.
-		sc_maybe_aa_change_hat(apparmor,
-				       "mount-namespace-capture-helper", 0);
-		// Configure the child to die as soon as the parent dies. In an odd
-		// case where the parent is killed then we don't want to complete our
-		// task or wait for anything.
-		if (prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0) < 0) {
-			die("cannot set parent process death notification signal to SIGINT");
-		}
-		// Check that parent process is still alive. If this is the case then
-		// we can *almost* reliably rely on the PR_SET_PDEATHSIG signal to wake
-		// us up from eventfd_read() below. In the rare case that the PID numbers
-		// overflow and the now-dead parent PID is recycled we will still hang
-		// forever on the read from eventfd below.
-		if (kill(parent, 0) < 0) {
-			switch (errno) {
-			case ESRCH:
-				debug("parent process has terminated");
-				abort();
-			default:
-				die("cannot confirm that parent process is alive");
-				break;
-			}
-		}
-		if (fchdir(group->dir_fd) < 0) {
-			die("cannot move to directory with preserved namespaces");
-		}
-		eventfd_t value = 0;
-		sc_enable_sanity_timeout();
-		if (eventfd_read(group->event_fd, &value) < 0) {
-			die("cannot read expected data from eventfd");
-		}
-		sc_disable_sanity_timeout();
-		char src[PATH_MAX] = { 0 };
-		char dst[PATH_MAX] = { 0 };
-		sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt",
-				 (int)parent);
-		sc_must_snprintf(dst, sizeof dst, "%s%s", group->name,
-				 SC_NS_MNT_FILE);
-		if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
-			die("cannot preserve mount namespace of process %d as %s", (int)parent, dst);
-		}
-		debug("mount namespace of process %d preserved as %s",
-		      (int)parent, dst);
-		exit(0);
+		helper_main(group, apparmor, parent);
 	} else {
+		// Glibc defines pid as a signed 32bit integer. There's no standard way to
+		// print pid's portably so this is the best we can do.
 		debug("forked support process %d", (int)pid);
 		group->child = pid;
 		// Unshare the mount namespace and set a flag instructing the caller that
@@ -606,37 +565,123 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 	return 0;
 }
 
-bool sc_should_populate_mount_ns(struct sc_mount_ns * group)
+static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
+			pid_t parent)
+{
+	// This is the child process which will capture the mount namespace.
+	//
+	// It will do so by bind-mounting the SC_NS_MNT_FILE after the parent
+	// process calls unshare() and finishes setting up the namespace
+	// completely.
+	// Change the hat to a sub-profile that has limited permissions
+	// necessary to accomplish the capture of the mount namespace.
+	sc_maybe_aa_change_hat(apparmor, "mount-namespace-capture-helper", 0);
+	// Configure the child to die as soon as the parent dies. In an odd
+	// case where the parent is killed then we don't want to complete our
+	// task or wait for anything.
+	if (prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0) < 0) {
+		die("cannot set parent process death notification signal to SIGINT");
+	}
+	// Check that parent process is still alive. If this is the case then we
+	// can *almost* reliably rely on the PR_SET_PDEATHSIG signal to wake us up
+	// from read(2) below. In the rare case that the PID numbers overflow and
+	// the now-dead parent PID is recycled we will still hang forever on the
+	// read from the pipe below.
+	if (kill(parent, 0) < 0) {
+		switch (errno) {
+		case ESRCH:
+			debug("parent process has terminated");
+			abort();
+		default:
+			die("cannot confirm that parent process is alive");
+			break;
+		}
+	}
+	if (fchdir(group->dir_fd) < 0) {
+		die("cannot move to directory with preserved namespaces");
+	}
+	int command = -1;
+	for (;;) {
+		debug("helper process waiting for command");
+		sc_enable_sanity_timeout();
+		if (read(group->pipe_fd[0], &command, sizeof command) < 0) {
+			die("cannot read command from the pipe");
+		}
+		sc_disable_sanity_timeout();
+		debug("helper process received command %d", command);
+		switch (command) {
+		case HELPER_CMD_EXIT:
+			helper_exit();
+			break;
+		case HELPER_CMD_CAPTURE_NS:
+			helper_capture_ns(group, parent);
+			break;
+		}
+	}
+}
+
+static void helper_exit(void)
+{
+	debug("helper process exiting");
+	exit(0);
+}
+
+static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
+{
+	char src[PATH_MAX] = { 0 };
+	char dst[PATH_MAX] = { 0 };
+
+	debug("capturing per-snap mount namespace");
+	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
+	sc_must_snprintf(dst, sizeof dst, "%s%s", group->name, SC_NS_MNT_FILE);
+	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
+		die("cannot preserve mount namespace of process %d as %s",
+		    (int)parent, dst);
+	}
+	debug("mount namespace of process %d preserved as %s",
+	      (int)parent, dst);
+}
+
+bool sc_should_populate_mount_ns(struct sc_mount_ns *group)
 {
 	return group->should_populate;
 }
 
-void sc_preserve_populated_mount_ns(struct sc_mount_ns *group)
+static void sc_message_capture_helper(struct sc_mount_ns *group, int command_id)
 {
 	if (group->child == 0) {
-		die("precondition failed: we don't have a support process for mount namespace capture");
+		die("precondition failed: we don't have a helper process");
 	}
-	if (group->event_fd < 0) {
-		die("precondition failed: we don't have an eventfd for mount namespace capture");
+	if (group->pipe_fd[1] < 0) {
+		die("precondition failed: we don't have an pipe");
 	}
-	debug
-	    ("asking support process for mount namespace capture (pid: %d) to perform the capture",
-	     group->child);
-	if (eventfd_write(group->event_fd, 1) < 0) {
-		die("cannot write eventfd");
+	debug("sending command %d to helper process (pid: %d)",
+	      command_id, group->child);
+	if (write(group->pipe_fd[1], &command_id, sizeof command_id) < 0) {
+		die("cannot send command %d to helper process", command_id);
 	}
-	debug
-	    ("waiting for the support process for mount namespace capture to exit");
+}
+
+static void sc_wait_for_capture_helper(struct sc_mount_ns *group)
+{
+	debug("waiting for the helper process to exit");
 	int status = 0;
 	errno = 0;
 	if (waitpid(group->child, &status, 0) < 0) {
-		die("cannot wait for the support process for mount namespace capture");
+		die("cannot wait for the helper process");
 	}
 	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		die("support process for mount namespace capture exited abnormally");
+		die("helper process exited abnormally");
 	}
-	debug("support process for mount namespace capture exited normally");
+	debug("helper process exited normally");
 	group->child = 0;
+}
+
+void sc_preserve_populated_mount_ns(struct sc_mount_ns *group)
+{
+	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_NS);
+	sc_message_capture_helper(group, HELPER_CMD_EXIT);
+	sc_wait_for_capture_helper(group);
 }
 
 void sc_discard_preserved_mount_ns(struct sc_mount_ns *group)

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -224,6 +224,9 @@ struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
 
 void sc_close_mount_ns(struct sc_mount_ns *group)
 {
+	if (group->child != 0) {
+		sc_wait_for_helper(group);
+	}
 	sc_cleanup_close(&group->dir_fd);
 	sc_cleanup_close(&group->pipe_fd[0]);
 	sc_cleanup_close(&group->pipe_fd[1]);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -678,7 +678,7 @@ static void sc_message_capture_helper(struct sc_mount_ns *group, int command_id)
 	if (write(group->pipe_master[1], &command_id, sizeof command_id) < 0) {
 		die("cannot send command %d to helper process", command_id);
 	}
-	debug("waiting for response from helper\n");
+	debug("waiting for response from helper");
 	if (read(group->pipe_helper[0], &ack, sizeof ack) < 0) {
 		die("cannot receive ack from helper process");
 	}

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -92,26 +92,20 @@ struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
 void sc_close_mount_ns(struct sc_mount_ns *group);
 
 /**
- * Join the mount namespace associated with this group if one exists.
+ * Join a preserved mount namespace if one exists.
  *
  * Technically the function opens /run/snapd/ns/${group_name}.mnt and tries to
  * use setns() with the obtained file descriptor. If the call succeeds then the
  * function returns and subsequent call to sc_should_populate_mount_ns() will
  * return false.
  *
- * If the call fails then an eventfd is constructed and a support process is
- * forked. The child process waits until data is written to the eventfd (this
- * can be done by calling sc_preserve_populated_mount_ns()). In the meantime
- * the parent process unshares the mount namespace and sets a flag so that
- * sc_should_populate_mount_ns() returns true.
- *
- * @returns 0 on success and EAGAIN if the namespace was stale and needs
- * to be re-made.
+ * If the preserved mount namespace does not exist or exists but is stale and
+ * was discarded and returns ESRCH. If the mount namespace was joined the
+ * function returns zero.
  **/
-int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
-			       struct sc_apparmor *apparmor,
-			       const char *base_snap_name,
-			       const char *snap_name);
+int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
+			 *apparmor, const char *base_snap_name,
+			 const char *snap_name);
 
 /**
  * Check if the namespace needs to be populated.
@@ -123,17 +117,26 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 bool sc_should_populate_mount_ns(struct sc_mount_ns *group);
 
 /**
+ * Fork off a helper process for mount namespace capture.
+ *
+ * This function forks the helper process. It needs to be paired with
+ * sc_wait_for_helper which instructs the helper to shut down and waits for
+ * that to happen.
+ *
+ * For rationale for forking and using a helper process please see
+ * https://lists.linuxfoundation.org/pipermail/containers/2013-August/033386.html
+ **/
+void sc_fork_helper(struct sc_mount_ns *group, struct sc_apparmor *apparmor);
+
+/**
  * Preserve prepared namespace group.
  *
  * This function signals the child support process for namespace capture to
- * perform the capture. It must be called after the call to
- * sc_create_or_join_mount_ns() and only when sc_should_populate_mount_ns()
- * returns true.
+ * perform the capture.
  *
- * Technically this function writes to an eventfd that causes the child process
- * to wake up, bind mount /proc/$ppid/ns/mnt to /run/snapd/ns/${group_name}.mnt
- * and then exit. The parent process (the caller) then collects the child
- * process and returns.
+ * Technically this function writes to pipe that causes the child process to
+ * wake up and bind mount /proc/$ppid/ns/mnt to
+ * /run/snapd/ns/${group_name}.mnt.
  *
  * The helper process will wait for subsequent commands. Please call
  * sc_wait_for_helper() to terminate it.
@@ -144,7 +147,7 @@ void sc_preserve_populated_mount_ns(struct sc_mount_ns *group);
  * Ask the helper process to terminate and wait for it to finish.
  *
  * This function asks the helper process to exit by writing an appropriate
- * command to the eventfd used for the inter process communication between the
+ * command to the pipe used for the inter process communication between the
  * main snap-confine process and the helper and then waits for the process to
  * terminate cleanly.
  **/

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -126,7 +126,7 @@ bool sc_should_populate_mount_ns(struct sc_mount_ns *group);
  * Preserve prepared namespace group.
  *
  * This function signals the child support process for namespace capture to
- * perform the capture and shut down. It must be called after the call to
+ * perform the capture. It must be called after the call to
  * sc_create_or_join_mount_ns() and only when sc_should_populate_mount_ns()
  * returns true.
  *
@@ -134,8 +134,21 @@ bool sc_should_populate_mount_ns(struct sc_mount_ns *group);
  * to wake up, bind mount /proc/$ppid/ns/mnt to /run/snapd/ns/${group_name}.mnt
  * and then exit. The parent process (the caller) then collects the child
  * process and returns.
+ *
+ * The helper process will wait for subsequent commands. Please call
+ * sc_wait_for_helper() to terminate it.
  **/
 void sc_preserve_populated_mount_ns(struct sc_mount_ns *group);
+
+/**
+ * Ask the helper process to terminate and wait for it to finish.
+ *
+ * This function asks the helper process to exit by writing an appropriate
+ * command to the eventfd used for the inter process communication between the
+ * main snap-confine process and the helper and then waits for the process to
+ * terminate cleanly.
+ **/
+void sc_wait_for_helper(struct sc_mount_ns *group);
 
 /**
  * Discard the preserved namespace group.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -251,6 +251,10 @@ int main(int argc, char **argv)
 						     base_snap_name,
 						     snap_instance);
 				sc_preserve_populated_mount_ns(group);
+				/* TODO: once the helper process lifecycle is separated from
+				 * the need to construct a mount namespace move this call to
+				 * after sc_setup_user_mounts() below. */
+				sc_wait_for_helper(group);
 			}
 			sc_close_mount_ns(group);
 			// older versions of snap-confine created incorrect

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -254,12 +254,9 @@ int main(int argc, char **argv)
 						     base_snap_name,
 						     snap_instance);
 
-				/* Preserve the mount namespace and ask the helper to terminate. */
+				/* Preserve the mount namespace. */
 				sc_preserve_populated_mount_ns(group);
-				sc_wait_for_helper(group);
 			}
-
-			sc_close_mount_ns(group);
 
 			/* Older versions of snap-confine created incorrect 777 permissions
 			   for /var/lib and we need to fixup for systems that had their NS
@@ -290,6 +287,7 @@ int main(int argc, char **argv)
 
 			sc_setup_user_mounts(&apparmor, snap_update_ns_fd,
 					     snap_instance);
+			sc_close_mount_ns(group);
 
 			// Reset path as we cannot rely on the path from the host OS to
 			// make sense. The classic distribution may use any PATH that makes

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -20,6 +20,7 @@
 
 #include <errno.h>
 #include <glob.h>
+#include <sched.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -231,36 +232,38 @@ int main(int argc, char **argv)
 			      snap_instance);
 			struct sc_mount_ns *group = NULL;
 			group = sc_open_mount_ns(snap_instance, 0);
-			if (sc_create_or_join_mount_ns(group, &apparmor,
-						       base_snap_name,
-						       snap_instance) ==
-			    EAGAIN) {
-				// If the namespace was stale and was discarded we just need to
-				// try again. Since this is done with the per-snap lock held
-				// there are no races here.
-				if (sc_create_or_join_mount_ns(group, &apparmor,
-							       base_snap_name,
-							       snap_instance) ==
-				    EAGAIN) {
-					die("unexpectedly the namespace needs to be discarded again");
+			int retval = sc_join_preserved_ns(group, &apparmor,
+							  base_snap_name,
+							  snap_instance);
+			if (retval == ESRCH) {
+				/* Stale mount namespace discarded or no mount namespace to
+				   join. We need to construct a new mount namespace ourselves.
+				   To capture it we will need a helper process so make one. */
+				sc_fork_helper(group, &apparmor);
+
+				/* Create and Populate the mount namespace. This performs all
+				   of the bootstrapping mounts, pivots into the new root
+				   filesystem and applies the per-snap mount profile using
+				   snap-update-ns. */
+				debug("unsharing the mount namespace");
+				if (unshare(CLONE_NEWNS) < 0) {
+					die("cannot unshare the mount namespace");
 				}
-			}
-			if (sc_should_populate_mount_ns(group)) {
 				sc_populate_mount_ns(&apparmor,
 						     snap_update_ns_fd,
 						     base_snap_name,
 						     snap_instance);
+
+				/* Preserve the mount namespace and ask the helper to terminate. */
 				sc_preserve_populated_mount_ns(group);
-				/* TODO: once the helper process lifecycle is separated from
-				 * the need to construct a mount namespace move this call to
-				 * after sc_setup_user_mounts() below. */
 				sc_wait_for_helper(group);
 			}
+
 			sc_close_mount_ns(group);
-			// older versions of snap-confine created incorrect
-			// 777 permissions for /var/lib and we need to fixup
-			// for systems that had their NS created with an
-			// old version
+
+			/* Older versions of snap-confine created incorrect 777 permissions
+			   for /var/lib and we need to fixup for systems that had their NS
+			   created with an old version. */
 			sc_maybe_fixup_permissions();
 			sc_maybe_fixup_udev();
 


### PR DESCRIPTION
This branch makes the helper process used by snap confine for the capture of
mount namespace more flexible. It can now be started and commanded separately
from the rest of the process, whereas in the past is was fused with a call that
also switched or created namespaces. It can now execute numbered commands,
namely exit and capture, not just capture and exit together.

From the system point of view the only observable change is that we are now
using a pipe instead of en eventfd to interact with the helper. There is no
breaking or risky change induced by this branch.

Those changes allow the helper to be later re-used to capture the mount
namespace created for each user running snap applications on the system. Which
will be done in subsequent patches that also start using the temporary feature
flag file for the experimental per-user mount namespaces.

As a reviewer you may find this post handy:
https://forum.snapcraft.io/t/snapd-2-36-snap-confine-logic-walkthrough/7843

This now includes revised messages from https://github.com/snapcore/snapd/pull/6004

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
