### PR TITLE
cmd: rename ns_group to mount_ns

### DIFF
--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -70,10 +70,10 @@ static const char *sc_test_use_fake_ns_dir(void)
 
 // Check that allocating a namespace group sets up internal data structures to
 // safe values.
-static void test_sc_alloc_ns_group(void)
+static void test_sc_alloc_mount_ns(void)
 {
-	struct sc_ns_group *group = NULL;
-	group = sc_alloc_ns_group();
+	struct sc_mount_ns *group = NULL;
+	group = sc_alloc_mount_ns();
 	g_test_queue_free(group);
 	g_assert_nonnull(group);
 	g_assert_cmpint(group->dir_fd, ==, -1);
@@ -86,15 +86,15 @@ static void test_sc_alloc_ns_group(void)
 // Initialize a namespace group.
 //
 // The group is automatically destroyed at the end of the test.
-static struct sc_ns_group *sc_test_open_ns_group(const char *group_name)
+static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name)
 {
 	// Initialize a namespace group
-	struct sc_ns_group *group = NULL;
+	struct sc_mount_ns *group = NULL;
 	if (group_name == NULL) {
 		group_name = "test-group";
 	}
-	group = sc_open_ns_group(group_name, 0);
-	g_test_queue_destroy((GDestroyNotify) sc_close_ns_group, group);
+	group = sc_open_mount_ns(group_name, 0);
+	g_test_queue_destroy((GDestroyNotify) sc_close_mount_ns, group);
 	// Check if the returned group data looks okay
 	g_assert_nonnull(group);
 	g_assert_cmpint(group->dir_fd, !=, -1);
@@ -107,21 +107,21 @@ static struct sc_ns_group *sc_test_open_ns_group(const char *group_name)
 
 // Check that initializing a namespace group creates the appropriate
 // filesystem structure.
-static void test_sc_open_ns_group(void)
+static void test_sc_open_mount_ns(void)
 {
 	const char *ns_dir = sc_test_use_fake_ns_dir();
-	sc_test_open_ns_group(NULL);
+	sc_test_open_mount_ns(NULL);
 	// Check that the group directory exists
 	g_assert_true(g_file_test
 		      (ns_dir, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR));
 }
 
-static void test_sc_open_ns_group_graceful(void)
+static void test_sc_open_mount_ns_graceful(void)
 {
 	sc_set_ns_dir("/nonexistent");
 	g_test_queue_destroy((GDestroyNotify) sc_set_ns_dir, SC_NS_DIR);
-	struct sc_ns_group *group =
-	    sc_open_ns_group("foo", SC_NS_FAIL_GRACEFULLY);
+	struct sc_mount_ns *group =
+	    sc_open_mount_ns("foo", SC_NS_FAIL_GRACEFULLY);
 	g_assert_null(group);
 }
 
@@ -130,7 +130,7 @@ static void unmount_dir(void *dir)
 	umount(dir);
 }
 
-static void test_sc_is_ns_group_dir_private(void)
+static void test_sc_is_mount_ns_dir_private(void)
 {
 	if (geteuid() != 0) {
 		g_test_skip("this test needs to run as root");
@@ -141,7 +141,7 @@ static void test_sc_is_ns_group_dir_private(void)
 
 	if (g_test_subprocess()) {
 		// The temporary directory should not be private initially
-		g_assert_false(sc_is_ns_group_dir_private());
+		g_assert_false(sc_is_mount_ns_dir_private());
 
 		/// do what "mount --bind /foo /foo; mount --make-private /foo" does.
 		int err;
@@ -151,14 +151,14 @@ static void test_sc_is_ns_group_dir_private(void)
 		g_assert_cmpint(err, ==, 0);
 
 		// The temporary directory should now be private
-		g_assert_true(sc_is_ns_group_dir_private());
+		g_assert_true(sc_is_mount_ns_dir_private());
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, G_TEST_SUBPROCESS_INHERIT_STDERR);
 	g_test_trap_assert_passed();
 }
 
-static void test_sc_initialize_ns_groups(void)
+static void test_sc_initialize_mount_ns(void)
 {
 	if (geteuid() != 0) {
 		g_test_skip("this test needs to run as root");
@@ -169,9 +169,9 @@ static void test_sc_initialize_ns_groups(void)
 	g_test_queue_destroy(unmount_dir, (char *)ns_dir);
 	if (g_test_subprocess()) {
 		// Initialize namespace groups using a fake directory.
-		sc_initialize_ns_groups();
+		sc_initialize_mount_ns();
 		// Check that the fake directory is now a private mount.
-		g_assert_true(sc_is_ns_group_dir_private());
+		g_assert_true(sc_is_mount_ns_dir_private());
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, G_TEST_SUBPROCESS_INHERIT_STDERR);
@@ -206,13 +206,13 @@ static void test_nsfs_fs_id(void)
 
 static void __attribute__ ((constructor)) init(void)
 {
-	g_test_add_func("/ns/sc_alloc_ns_group", test_sc_alloc_ns_group);
-	g_test_add_func("/ns/sc_open_ns_group", test_sc_open_ns_group);
-	g_test_add_func("/ns/sc_open_ns_group/graceful",
-			test_sc_open_ns_group_graceful);
+	g_test_add_func("/ns/sc_alloc_mount_ns", test_sc_alloc_mount_ns);
+	g_test_add_func("/ns/sc_open_mount_ns", test_sc_open_mount_ns);
+	g_test_add_func("/ns/sc_open_mount_ns/graceful",
+			test_sc_open_mount_ns_graceful);
 	g_test_add_func("/ns/nsfs_fs_id", test_nsfs_fs_id);
-	g_test_add_func("/system/ns/sc_is_ns_group_dir_private",
-			test_sc_is_ns_group_dir_private);
-	g_test_add_func("/system/ns/sc_initialize_ns_groups",
-			test_sc_initialize_ns_groups);
+	g_test_add_func("/system/ns/sc_is_mount_ns_dir_private",
+			test_sc_is_mount_ns_dir_private);
+	g_test_add_func("/system/ns/sc_initialize_mount_ns",
+			test_sc_initialize_mount_ns);
 }

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -79,7 +79,7 @@ static const char *sc_ns_dir = SC_NS_DIR;
  * We do this because /run/snapd/ns cannot be shared with any other peers as per:
  * https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
  **/
-static bool sc_is_ns_group_dir_private(void)
+static bool sc_is_mount_ns_dir_private(void)
 {
 	struct sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	info = sc_parse_mountinfo(NULL);
@@ -157,13 +157,13 @@ void sc_reassociate_with_pid1_mount_ns(void)
 	}
 }
 
-void sc_initialize_ns_groups(void)
+void sc_initialize_mount_ns(void)
 {
 	debug("creating namespace group directory %s", sc_ns_dir);
 	if (sc_nonfatal_mkpath(sc_ns_dir, 0755) < 0) {
 		die("cannot create namespace group directory %s", sc_ns_dir);
 	}
-	if (!sc_is_ns_group_dir_private()) {
+	if (!sc_is_mount_ns_dir_private()) {
 		debug
 		    ("bind mounting the namespace group directory over itself");
 		if (mount(sc_ns_dir, sc_ns_dir, NULL, MS_BIND | MS_REC, NULL) <
@@ -181,7 +181,7 @@ void sc_initialize_ns_groups(void)
 	}
 }
 
-struct sc_ns_group {
+struct sc_mount_ns {
 	// Name of the namespace group ($SNAP_NAME).
 	char *name;
 	// Descriptor to the namespace group control directory.  This descriptor is
@@ -197,9 +197,9 @@ struct sc_ns_group {
 	bool should_populate;
 };
 
-static struct sc_ns_group *sc_alloc_ns_group(void)
+static struct sc_mount_ns *sc_alloc_mount_ns(void)
 {
-	struct sc_ns_group *group = calloc(1, sizeof *group);
+	struct sc_mount_ns *group = calloc(1, sizeof *group);
 	if (group == NULL) {
 		die("cannot allocate memory for namespace group");
 	}
@@ -211,10 +211,10 @@ static struct sc_ns_group *sc_alloc_ns_group(void)
 	return group;
 }
 
-struct sc_ns_group *sc_open_ns_group(const char *group_name,
+struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
 				     const unsigned flags)
 {
-	struct sc_ns_group *group = sc_alloc_ns_group();
+	struct sc_mount_ns *group = sc_alloc_mount_ns();
 	debug("opening namespace group directory %s", sc_ns_dir);
 	group->dir_fd =
 	    open(sc_ns_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
@@ -232,7 +232,7 @@ struct sc_ns_group *sc_open_ns_group(const char *group_name,
 	return group;
 }
 
-void sc_close_ns_group(struct sc_ns_group *group)
+void sc_close_mount_ns(struct sc_mount_ns *group)
 {
 	debug("releasing resources associated with namespace group %s",
 	      group->name);
@@ -467,7 +467,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 	return EAGAIN;
 }
 
-int sc_create_or_join_ns_group(struct sc_ns_group *group,
+int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 			       struct sc_apparmor *apparmor,
 			       const char *base_snap_name,
 			       const char *snap_name)
@@ -481,7 +481,7 @@ int sc_create_or_join_ns_group(struct sc_ns_group *group,
 	// doesn't have to be a mounted namespace.
 	//
 	// If the mounted namespace is discarded with
-	// sc_discard_preserved_ns_group() it will revert to a regular file.  If
+	// sc_discard_preserved_mount_ns() it will revert to a regular file.  If
 	// snap-confine is killed for whatever reason after the file is created but
 	// before the file is bind-mounted it will also be a regular file.
 	mnt_fd = openat(group->dir_fd, mnt_fname,
@@ -647,12 +647,12 @@ int sc_create_or_join_ns_group(struct sc_ns_group *group,
 	return 0;
 }
 
-bool sc_should_populate_ns_group(struct sc_ns_group * group)
+bool sc_should_populate_mount_ns(struct sc_mount_ns * group)
 {
 	return group->should_populate;
 }
 
-void sc_preserve_populated_ns_group(struct sc_ns_group *group)
+void sc_preserve_populated_mount_ns(struct sc_mount_ns *group)
 {
 	if (group->child == 0) {
 		die("precondition failed: we don't have a support process for mount namespace capture");
@@ -680,7 +680,7 @@ void sc_preserve_populated_ns_group(struct sc_ns_group *group)
 	group->child = 0;
 }
 
-void sc_discard_preserved_ns_group(struct sc_ns_group *group)
+void sc_discard_preserved_mount_ns(struct sc_mount_ns *group)
 {
 	// Remember the current working directory
 	int old_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
 			debug("ensuring that snap mount directory is shared");
 			sc_ensure_shared_snap_mount();
 			debug("unsharing snap namespace directory");
-			sc_initialize_ns_groups();
+			sc_initialize_mount_ns();
 			sc_unlock(global_lock_fd);
 
 			// Find and open snap-update-ns from the same
@@ -229,30 +229,30 @@ int main(int argc, char **argv)
 			int snap_lock_fd = sc_lock_snap(snap_instance);
 			debug("initializing mount namespace: %s",
 			      snap_instance);
-			struct sc_ns_group *group = NULL;
-			group = sc_open_ns_group(snap_instance, 0);
-			if (sc_create_or_join_ns_group(group, &apparmor,
+			struct sc_mount_ns *group = NULL;
+			group = sc_open_mount_ns(snap_instance, 0);
+			if (sc_create_or_join_mount_ns(group, &apparmor,
 						       base_snap_name,
 						       snap_instance) ==
 			    EAGAIN) {
 				// If the namespace was stale and was discarded we just need to
 				// try again. Since this is done with the per-snap lock held
 				// there are no races here.
-				if (sc_create_or_join_ns_group(group, &apparmor,
+				if (sc_create_or_join_mount_ns(group, &apparmor,
 							       base_snap_name,
 							       snap_instance) ==
 				    EAGAIN) {
 					die("unexpectedly the namespace needs to be discarded again");
 				}
 			}
-			if (sc_should_populate_ns_group(group)) {
+			if (sc_should_populate_mount_ns(group)) {
 				sc_populate_mount_ns(&apparmor,
 						     snap_update_ns_fd,
 						     base_snap_name,
 						     snap_instance);
-				sc_preserve_populated_ns_group(group);
+				sc_preserve_populated_mount_ns(group);
 			}
-			sc_close_ns_group(group);
+			sc_close_mount_ns(group);
 			// older versions of snap-confine created incorrect
 			// 777 permissions for /var/lib and we need to fixup
 			// for systems that had their NS created with an

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -32,11 +32,11 @@ int main(int argc, char **argv)
 
 	int snap_lock_fd = sc_lock_snap(snap_name);
 	debug("initializing mount namespace: %s", snap_name);
-	struct sc_ns_group *group =
-	    sc_open_ns_group(snap_name, SC_NS_FAIL_GRACEFULLY);
+	struct sc_mount_ns *group =
+	    sc_open_mount_ns(snap_name, SC_NS_FAIL_GRACEFULLY);
 	if (group != NULL) {
-		sc_discard_preserved_ns_group(group);
-		sc_close_ns_group(group);
+		sc_discard_preserved_mount_ns(group);
+		sc_close_mount_ns(group);
 	}
 	// Unlink the current mount profile, if any.
 	char profile_path[PATH_MAX] = { 0 };


### PR DESCRIPTION
The concept of namespace groups was designed in the hope that there
would be multiple types of namespaces used together for the purpose of a
given snap. Since only mount namespaces are used and we need to handle
per-snap mount namespaces along with the new per-snap and per-user mount
namespaces, being clear in terminology is important.

As such rename "ns_group" with "mount_ns".

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
