### PR TITLE
tests: do not run degraded test in autopkgtest env

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that the system is not in "degraded" state
 
+# autopkgtest images sometimes have failing services (cosmic/s390x)
+# in their images so this test is not useful there.
+backends: [-autopkgtest]
+
 # run this early to ensure no test created failed units yet
 priority: 500
 


### PR DESCRIPTION
The autopkgtest environment sometimes has failing services. This
means that our degraded test leads to false positivies here. This
PR disables the test in the autopkgtest environment because we
have no control over the images in autopkgtest (unlike in our
spread CI) so the test is not useful here.
