### PR TITLE
[RFC] daemon: support `snap logs snapd` to get snapd logs

### DIFF
--- a/tests/main/snap-logs/task.yaml
+++ b/tests/main/snap-logs/task.yaml
@@ -21,6 +21,9 @@ execute: |
     echo "check output lines for the logs"
     snap logs -n=1 test-snapd-service | MATCH "running"
     snap logs -n=all test-snapd-service | MATCH "running"
+
+    echo "check that the snapd service logs can be obtained"
+    snap logs snapd | MATCH "started snapd/.*"
     
     echo "check -f option works"
     snap logs -f test-snapd-service > service.log &    


### PR DESCRIPTION
This PR adds support for `snap logs snapd` to show the snapd.service
log. With this PR the experience with an installed snapd snap becomes
more consistent. The other benefit is that this way users of the
snapd API (like a management snap) can access the snapd logs for
debugging and error detection.

*If* this looks reasonable I will add more tests and cleanup things a bit more.