### PR TITLE
snap,client: use a different exit code for retryable errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -445,9 +445,9 @@ const (
 	ErrorKindDaemonRestart = "daemon-restart"
 )
 
-// IsRetryableError returns true if the given error is an error
+// IsRetryable returns true if the given error is an error
 // that can be retried later.
-func IsRetryableError(err error) bool {
+func IsRetryable(err error) bool {
 	switch e := err.(type) {
 	case *Error:
 		return e.Kind == ErrorKindChangeConflict

--- a/client/client.go
+++ b/client/client.go
@@ -445,6 +445,16 @@ const (
 	ErrorKindDaemonRestart = "daemon-restart"
 )
 
+// IsRetryableError returns true if the given error is an error
+// that can be retried later.
+func IsRetryableError(err error) bool {
+	switch e := err.(type) {
+	case *Error:
+		return e.Kind == ErrorKindChangeConflict
+	}
+	return false
+}
+
 // IsTwoFactorError returns whether the given error is due to problems
 // in two-factor authentication.
 func IsTwoFactorError(err error) bool {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -422,13 +422,13 @@ func (cs *clientSuite) TestIsTwoFactor(c *C) {
 	c.Check(client.IsTwoFactorError((*client.Error)(nil)), Equals, false)
 }
 
-func (cs *clientSuite) TestIsRetryableError(c *C) {
+func (cs *clientSuite) TestIsRetryable(c *C) {
 	// unhappy
-	c.Check(client.IsRetryableError(nil), Equals, false)
-	c.Check(client.IsRetryableError(errors.New("some-error")), Equals, false)
-	c.Check(client.IsRetryableError(&client.Error{Kind: "something-else"}), Equals, false)
+	c.Check(client.IsRetryable(nil), Equals, false)
+	c.Check(client.IsRetryable(errors.New("some-error")), Equals, false)
+	c.Check(client.IsRetryable(&client.Error{Kind: "something-else"}), Equals, false)
 	// happy
-	c.Check(client.IsRetryableError(&client.Error{Kind: client.ErrorKindChangeConflict}), Equals, true)
+	c.Check(client.IsRetryable(&client.Error{Kind: client.ErrorKindChangeConflict}), Equals, true)
 }
 
 func (cs *clientSuite) TestClientCreateUser(c *C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -422,6 +422,15 @@ func (cs *clientSuite) TestIsTwoFactor(c *C) {
 	c.Check(client.IsTwoFactorError((*client.Error)(nil)), Equals, false)
 }
 
+func (cs *clientSuite) TestIsRetryableError(c *C) {
+	// unhappy
+	c.Check(client.IsRetryableError(nil), Equals, false)
+	c.Check(client.IsRetryableError(errors.New("some-error")), Equals, false)
+	c.Check(client.IsRetryableError(&client.Error{Kind: "something-else"}), Equals, false)
+	// happy
+	c.Check(client.IsRetryableError(&client.Error{Kind: client.ErrorKindChangeConflict}), Equals, true)
+}
+
 func (cs *clientSuite) TestClientCreateUser(c *C) {
 	_, err := cs.cli.CreateUser(&client.CreateUserOptions{})
 	c.Assert(err, ErrorMatches, "cannot create a user without providing an email")

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -91,6 +91,10 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 	if !ok {
 		return "", e
 	}
+	// retryable errors are just passed through
+	if client.IsRetryableError(err) {
+		return "", err
+	}
 
 	// ensure the "real" error is available if we ask for it
 	logger.Debugf("error: %s", err)

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -92,7 +92,7 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 		return "", e
 	}
 	// retryable errors are just passed through
-	if client.IsRetryableError(err) {
+	if client.IsRetryable(err) {
 		return "", err
 	}
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -418,7 +418,7 @@ func main() {
 	// no magic /o\
 	if err := run(); err != nil {
 		fmt.Fprintf(Stderr, errorPrefix, err)
-		if client.IsRetryableError(err) {
+		if client.IsRetryable(err) {
 			os.Exit(10)
 		}
 		os.Exit(1)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -418,6 +418,9 @@ func main() {
 	// no magic /o\
 	if err := run(); err != nil {
 		fmt.Fprintf(Stderr, errorPrefix, err)
+		if client.IsRetryableError(err) {
+			os.Exit(10)
+		}
 		os.Exit(1)
 	}
 }

--- a/tests/main/retryable-error/task.yaml
+++ b/tests/main/retryable-error/task.yaml
@@ -11,7 +11,7 @@ execute: |
     while true; do
         if snap changes |grep "Doing.*Install"; then
             if snap install test-snapd-tools; then
-                echo "snap install should retrun a change-conflict: test brokwn"
+                echo "snap install should return a change-conflict: test broken"
                 exit 1
             else
                 errCode=$?

--- a/tests/main/retryable-error/task.yaml
+++ b/tests/main/retryable-error/task.yaml
@@ -1,0 +1,28 @@
+summary: Ensure exit code for retryable error works
+
+# autopkgtest is sometimes super slow and this test is timing dependent
+backends: [-autopkgtest]
+
+execute: |
+    echo "Install a snap"
+    snap install test-snapd-tools &
+
+    echo "And try to install it again which results in a change confict error"
+    while true; do
+        if snap changes |grep "Doing.*Install"; then
+            if snap install test-snapd-tools; then
+                echo "snap install should retrun a change-conflict: test brokwn"
+                exit 1
+            else
+                errCode=$?
+                if [ $errCode != 10 ]; then
+                    echo "go unexpected err code $errCode (expecting 10)"
+                    exit 1
+                fi
+            fi
+        break
+    fi
+    sleep 0.1
+    done
+    # "Ensure background processes are finished"
+    wait


### PR DESCRIPTION
Some errors (like change-conflict) are not fatal and can be
retried later. We ot a request from users to return a different
error code in this case.

