### PR TITLE
interfaces: typo 'allows' for consistency with other ifaces

### DIFF
--- a/interfaces/builtin/password_manager_service.go
+++ b/interfaces/builtin/password_manager_service.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const passwordManagerServiceSummary = `allow access to common password manager services`
+const passwordManagerServiceSummary = `allows access to common password manager services`
 
 const passwordManagerBaseDeclarationSlots = `
   password-manager-service:


### PR DESCRIPTION
Everything else uses allows so so should this.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
