### PR TITLE
cmd/snap: block 'snap help <cmd> --all'

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -110,11 +110,15 @@ func (cmd cmdHelp) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 	if cmd.Manpage {
-
+		// you shouldn't try to to combine --man with --all nor a
+		// subcommand, but --man is hidden so no real need to check.
 		cmd.parser.WriteManPage(&manfixer{})
 		return nil
 	}
 	if cmd.All {
+		if cmd.Positional.Sub != "" {
+			return fmt.Errorf(i18n.G("help accepts a command, or '--all', but not both."))
+		}
 		printLongHelp(cmd.parser)
 		return nil
 	}

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -155,6 +155,15 @@ func (s *SnapSuite) TestHelpCategories(c *check.C) {
 	}
 }
 
+func (s *SnapSuite) TestHelpCommandAllFails(c *check.C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "help", "interfaces", "--all"}
+
+	err := snap.RunMain()
+	c.Assert(err, check.ErrorMatches, "help accepts a command, or '--all', but not both.")
+}
+
 func (s *SnapSuite) TestManpageInSection8(c *check.C) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()


### PR DESCRIPTION
Without this change, e.g. 'snap help list --all' works, which can be
confusing. This catches the mistake, and errors out:

    $ snap help list --all
    error: help accepts a command, or '--all', but not both.
