### PR TITLE
cmd/snap-confine: reduce verbosity of debug and error messages

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -392,10 +392,9 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 
 		// Send this back to the parent: 2 - discard, 1 - keep.
 		// Note that we cannot just use 0 and 1 because of the semantics of eventfd(2).
-		if (eventfd_write
-		    (event_fd,
-		     should_discard ? SC_DISCARD_YES : SC_DISCARD_NO) < 0) {
-			die("cannot send information about freshness of preserved mount namespace");
+		if (eventfd_write(event_fd, should_discard ?
+				  SC_DISCARD_YES : SC_DISCARD_NO) < 0) {
+			die("cannot send information to %s preserved mount namespace", should_discard ? "discard" : "keep");
 		}
 		// Exit, we're done.
 		exit(0);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -589,7 +589,7 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 		if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
 			die("cannot preserve mount namespace of process %d as %s", (int)parent, dst);
 		}
-		debug("preserved mount namespace of process %d as %s",
+		debug("mount namespace of process %d preserved as %s",
 		      (int)parent, dst);
 		exit(0);
 	} else {

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -248,16 +248,17 @@ static dev_t find_base_snap_device(const char *base_snap_name,
 	     mie = sc_next_mountinfo_entry(mie)) {
 		if (sc_streq(mie->mount_dir, base_squashfs_path)) {
 			base_snap_dev = MKDEV(mie->dev_major, mie->dev_minor);
-			debug("found base snap filesystem device %d:%d",
-			      mie->dev_major, mie->dev_minor);
+			debug("block device of snap %s, revision %s is %d:%d",
+			      base_snap_name, base_snap_rev, mie->dev_major,
+			      mie->dev_minor);
 			// Don't break when found, we are interested in the last
 			// entry as this is the "effective" one.
 			found = true;
 		}
 	}
 	if (!found) {
-		die("cannot find device backing the base snap %s",
-		    base_snap_name);
+		die("cannot find mount entry for snap %s revision %s",
+		    base_snap_name, base_snap_rev);
 	}
 	return base_snap_dev;
 }

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -137,7 +137,7 @@ void sc_reassociate_with_pid1_mount_ns(void)
 		die("cannot read mount namespace identifier of this process");
 	}
 	if (memcmp(init_buf, self_buf, sizeof init_buf) != 0) {
-		debug("NOTE: moving to mount namespace of pid 1");
+		debug("moving to mount namespace of pid 1");
 		// We cannot use O_NOFOLLOW here because that file will always be a
 		// symbolic link. We actually want to open it this way.
 		int init_mnt_fd_real SC_CLEANUP(sc_cleanup_close) = -1;
@@ -373,8 +373,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 			}
 		}
 
-		debug
-		    ("NOTE: joining preserved mount namespace (for inspection)");
+		debug("joining preserved mount namespace (for inspection)");
 		// Move to the mount namespace of the snap we're trying to inspect.
 		if (setns(mnt_fd, CLONE_NEWNS) < 0) {
 			die("cannot join preserved mount namespace");
@@ -422,7 +421,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 	}
 	// If the namespace is up-to-date then we are done.
 	if (value == SC_DISCARD_NO) {
-		debug("NOTE: preserved mount namespace can be reused");
+		debug("preserved mount namespace can be reused");
 		return 0;
 	}
 	// The namespace is stale, let's check if we can discard it.
@@ -430,7 +429,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 		// Some processes are still using the namespace so we cannot discard it
 		// as that would fracture the view that the set of processes inside
 		// have on what is mounted.
-		debug("NOTE: preserved mount namespace is stale but occupied");
+		debug("preserved mount namespace is stale but occupied");
 		return 0;
 	}
 	// The namespace is both stale and empty. We can discard it now.
@@ -441,7 +440,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 	if (umount2(mnt_fname, MNT_DETACH | UMOUNT_NOFOLLOW) < 0) {
 		die("cannot discard stale mount namespace %s", mnt_fname);
 	}
-	debug("NOTE: stale mount namespace discarded");
+	debug("stale mount namespace discarded");
 	return EAGAIN;
 }
 
@@ -506,12 +505,12 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 			die("cannot join preserved mount namespace %s",
 			    group->name);
 		}
-		debug("NOTE: joined preserved mount namespace %s", group->name);
+		debug("joined preserved mount namespace %s", group->name);
 
 		// Try to re-locate back to vanilla working directory. This can fail
 		// because that directory is no longer present.
 		if (chdir(vanilla_cwd) != 0) {
-			debug("NOTE: cannot remain in %s,"
+			debug("cannot remain in %s,"
 			      " moving to the void directory", vanilla_cwd);
 			if (chdir(SC_VOID_DIR) != 0) {
 				die("cannot change directory to %s",
@@ -539,7 +538,7 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 	// Glibc defines pid as a signed 32bit integer. There's no standard way to
 	// print pid's portably so this is the best we can do.
 	pid_t pid = fork();
-	debug("NOTE: forked support process has pid %d", (int)pid);
+	debug("forked support process has pid %d", (int)pid);
 	if (pid < 0) {
 		die("cannot fork support process for mount namespace capture");
 	}
@@ -592,7 +591,7 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 		if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
 			die("cannot preserve mount namespace of process %d as %s", (int)parent, dst);
 		}
-		debug("NOTE: preserved mount namespace of process %d as %s",
+		debug("preserved mount namespace of process %d as %s",
 		      (int)parent, dst);
 		exit(0);
 	} else {
@@ -602,7 +601,7 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 		if (unshare(CLONE_NEWNS) < 0) {
 			die("cannot unshare the mount namespace");
 		}
-		debug("NOTE: created new mount namespace");
+		debug("created new mount namespace");
 		group->should_populate = true;
 	}
 	return 0;

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -220,8 +220,6 @@ struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
 
 void sc_close_mount_ns(struct sc_mount_ns *group)
 {
-	debug("releasing resources associated with namespace group %s",
-	      group->name);
 	sc_cleanup_close(&group->dir_fd);
 	sc_cleanup_close(&group->event_fd);
 	free(group->name);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -134,7 +134,7 @@ void sc_reassociate_with_pid1_mount_ns(void)
 	}
 	memset(self_buf, 0, sizeof self_buf);
 	if (readlinkat(self_mnt_fd, "", self_buf, sizeof self_buf) < 0) {
-		die("cannot read mount namespace identifier of this process");
+		die("cannot read mount namespace identifier of the current process");
 	}
 	if (memcmp(init_buf, self_buf, sizeof init_buf) != 0) {
 		debug("moving to mount namespace of pid 1");
@@ -373,7 +373,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 			}
 		}
 
-		debug("joining preserved mount namespace (for inspection)");
+		debug("joining preserved mount namespace for inspection");
 		// Move to the mount namespace of the snap we're trying to inspect.
 		if (setns(mnt_fd, CLONE_NEWNS) < 0) {
 			die("cannot join preserved mount namespace");

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -202,19 +202,18 @@ struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
 				     const unsigned flags)
 {
 	struct sc_mount_ns *group = sc_alloc_mount_ns();
-	debug("opening namespace group directory %s", sc_ns_dir);
-	group->dir_fd =
-	    open(sc_ns_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
+	group->dir_fd = open(sc_ns_dir,
+			     O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
 	if (group->dir_fd < 0) {
 		if (flags & SC_NS_FAIL_GRACEFULLY && errno == ENOENT) {
 			free(group);
 			return NULL;
 		}
-		die("cannot open directory for namespace group %s", group_name);
+		die("cannot open directory %s", sc_ns_dir);
 	}
 	group->name = strdup(group_name);
 	if (group->name == NULL) {
-		die("cannot duplicate namespace group name %s", group_name);
+		die("cannot allocate memory for string copy");
 	}
 	return group;
 }

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -188,7 +188,7 @@ static struct sc_mount_ns *sc_alloc_mount_ns(void)
 {
 	struct sc_mount_ns *group = calloc(1, sizeof *group);
 	if (group == NULL) {
-		die("cannot allocate memory for namespace group");
+		die("cannot allocate memory for sc_mount_ns");
 	}
 	group->dir_fd = -1;
 	group->event_fd = -1;

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -537,7 +537,6 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 	// Glibc defines pid as a signed 32bit integer. There's no standard way to
 	// print pid's portably so this is the best we can do.
 	pid_t pid = fork();
-	debug("forked support process has pid %d", (int)pid);
 	if (pid < 0) {
 		die("cannot fork support process for mount namespace capture");
 	}
@@ -594,6 +593,7 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 		      (int)parent, dst);
 		exit(0);
 	} else {
+		debug("forked support process %d", (int)pid);
 		group->child = pid;
 		// Unshare the mount namespace and set a flag instructing the caller that
 		// the namespace is pristine and needs to be populated now.

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -473,14 +473,14 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 	// We can just ensure that this is the case thanks to fstatfs.
 	struct statfs ns_statfs_buf;
 	if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
-		die("cannot inspect filesystem of file with preserved namespace");
+		die("cannot inspect filesystem of preserved mount namespace file");
 	}
 	// Stat the mount namespace as well, this is later used to check if the
 	// namespace is used by other processes if we are considering discarding a
 	// stale namespace.
 	struct stat ns_stat_buf;
 	if (fstat(mnt_fd, &ns_stat_buf) < 0) {
-		die("cannot inspect file with preserved namespace");
+		die("cannot inspect preserved mount namespace file");
 	}
 #ifndef NSFS_MAGIC
 // Account for kernel headers old enough to not know about NSFS_MAGIC.
@@ -510,8 +510,7 @@ int sc_create_or_join_mount_ns(struct sc_mount_ns *group,
 		// Try to re-locate back to vanilla working directory. This can fail
 		// because that directory is no longer present.
 		if (chdir(vanilla_cwd) != 0) {
-			debug("cannot remain in %s,"
-			      " moving to the void directory", vanilla_cwd);
+			debug("cannot enter %s, moving to void", vanilla_cwd);
 			if (chdir(SC_VOID_DIR) != 0) {
 				die("cannot change directory to %s",
 				    SC_VOID_DIR);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -159,25 +159,18 @@ void sc_reassociate_with_pid1_mount_ns(void)
 
 void sc_initialize_mount_ns(void)
 {
-	debug("creating namespace group directory %s", sc_ns_dir);
 	if (sc_nonfatal_mkpath(sc_ns_dir, 0755) < 0) {
-		die("cannot create namespace group directory %s", sc_ns_dir);
+		die("cannot create directory %s", sc_ns_dir);
 	}
-	if (!sc_is_mount_ns_dir_private()) {
-		debug
-		    ("bind mounting the namespace group directory over itself");
-		if (mount(sc_ns_dir, sc_ns_dir, NULL, MS_BIND | MS_REC, NULL) <
-		    0) {
-			die("cannot bind mount namespace group directory over itself");
-		}
-		debug
-		    ("making the namespace group directory mount point private");
-		if (mount(NULL, sc_ns_dir, NULL, MS_PRIVATE, NULL) < 0) {
-			die("cannot make the namespace group directory mount point private");
-		}
-	} else {
-		debug
-		    ("namespace group directory does not require intialization");
+	if (sc_is_mount_ns_dir_private()) {
+		return;
+	}
+	if (mount(sc_ns_dir, sc_ns_dir, NULL, MS_BIND | MS_REC, NULL) < 0) {
+		die("cannot self-bind mount %s", sc_ns_dir);
+	}
+	if (mount(NULL, sc_ns_dir, NULL, MS_PRIVATE, NULL) < 0) {
+		die("cannot change propagation type to MS_PRIVATE in %s",
+		    sc_ns_dir);
 	}
 }
 

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -286,11 +286,11 @@ static bool should_discard_current_ns(dev_t base_snap_dev)
 		// was used to do something weird. The initial rootfs was
 		// set up by snap-confine and that is the one we want to
 		// measure.
-		debug("found root filesystem inside the mount namespace %d:%d",
+		debug("block device of the root filesystem is %d:%d",
 		      mie->dev_major, mie->dev_minor);
 		return base_snap_dev != MKDEV(mie->dev_major, mie->dev_minor);
 	}
-	die("cannot find mount entry of the root filesystem inside snap namespace");
+	die("cannot find mount entry of the root filesystem");
 }
 
 enum sc_discard_vote {


### PR DESCRIPTION
This branch contains various tweaks to debugging and error messages from namespace
management code. This also prepares the code for managing multiple mount namespaces
and less from managing multiple types of namespaces (just in the terms of wording used).

There are several formatting changes to the code to avoid wrapping but no semantic
changes.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>