### PR TITLE
snap/pack, snap/squashfs: remove extra copy before mksquashfs

### DIFF
--- a/snap/pack/export_test.go
+++ b/snap/pack/export_test.go
@@ -20,7 +20,5 @@
 package pack
 
 var (
-	CopyToBuildDir       = copyToBuildDir
-	ShouldExcludeDynamic = shouldExcludeDynamic
-	DebArchitecture      = debArchitecture
+	DebArchitecture = debArchitecture
 )

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -27,15 +27,15 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"testing"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/pack"
+	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/testutil"
-
-	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -140,40 +140,15 @@ apps:
 	c.Assert(err, Equals, snap.ErrMissingPaths)
 }
 
-func (s *packSuite) TestCopyCopies(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
-	// actually this'll be on /tmp so it'll be a link
-	target := c.MkDir()
-	c.Assert(pack.CopyToBuildDir(sourceDir, target), IsNil)
-	out, err := exec.Command("diff", "-qrN", sourceDir, target).Output()
-	c.Check(err, IsNil)
-	c.Check(out, DeepEquals, []byte{})
-}
-
-func (s *packSuite) TestCopyActuallyCopies(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
-
-	// hoping to get the non-linking behaviour via /dev/shm
-	target, err := ioutil.TempDir("/dev/shm", "copy")
-	// sbuild environments won't allow writing to /dev/shm, so its
-	// ok to skip there
-	if os.IsPermission(err) {
-		c.Skip("/dev/shm is not writable for us")
-	}
-	c.Assert(err, IsNil)
-
-	c.Assert(pack.CopyToBuildDir(sourceDir, target), IsNil)
-	out, err := exec.Command("diff", "-qrN", sourceDir, target).Output()
-	c.Check(err, IsNil)
-	c.Check(out, DeepEquals, []byte{})
-}
-
-func (s *packSuite) TestCopyExcludesBackups(c *C) {
+func (s *packSuite) TestPackExcludesBackups(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	target := c.MkDir()
 	// add a backup file
 	c.Assert(ioutil.WriteFile(filepath.Join(sourceDir, "foo~"), []byte("hi"), 0755), IsNil)
-	c.Assert(pack.CopyToBuildDir(sourceDir, target), IsNil)
+	snapfile, err := pack.Snap(sourceDir, c.MkDir())
+	c.Assert(err, IsNil)
+	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
+
 	cmd := exec.Command("diff", "-qr", sourceDir, target)
 	cmd.Env = append(cmd.Env, "LANG=C")
 	out, err := cmd.Output()
@@ -181,14 +156,16 @@ func (s *packSuite) TestCopyExcludesBackups(c *C) {
 	c.Check(string(out), Matches, `(?m)Only in \S+: foo~`)
 }
 
-func (s *packSuite) TestCopyExcludesTopLevelDEBIAN(c *C) {
+func (s *packSuite) TestPackExcludesTopLevelDEBIAN(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	target := c.MkDir()
 	// add a toplevel DEBIAN
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "DEBIAN", "foo"), 0755), IsNil)
 	// and a non-toplevel DEBIAN
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "bar", "DEBIAN", "baz"), 0755), IsNil)
-	c.Assert(pack.CopyToBuildDir(sourceDir, target), IsNil)
+	snapfile, err := pack.Snap(sourceDir, c.MkDir())
+	c.Assert(err, IsNil)
+	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 	cmd := exec.Command("diff", "-qr", sourceDir, target)
 	cmd.Env = append(cmd.Env, "LANG=C")
 	out, err := cmd.Output()
@@ -198,59 +175,28 @@ func (s *packSuite) TestCopyExcludesTopLevelDEBIAN(c *C) {
 	c.Check(strings.Count(string(out), "Only in"), Equals, 1)
 }
 
-func (s *packSuite) TestCopyExcludesWholeDirs(c *C) {
+func (s *packSuite) TestPackExcludesWholeDirs(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	target := c.MkDir()
 	// add a file inside a skipped dir
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, ".bzr"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(sourceDir, ".bzr", "foo"), []byte("hi"), 0755), IsNil)
-	c.Assert(pack.CopyToBuildDir(sourceDir, target), IsNil)
+	snapfile, err := pack.Snap(sourceDir, c.MkDir())
+	c.Assert(err, IsNil)
+	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 	out, _ := exec.Command("find", sourceDir).Output()
 	c.Check(string(out), Not(Equals), "")
 	cmd := exec.Command("diff", "-qr", sourceDir, target)
 	cmd.Env = append(cmd.Env, "LANG=C")
-	out, err := cmd.Output()
+	out, err = cmd.Output()
 	c.Check(err, NotNil)
 	c.Check(string(out), Matches, `(?m)Only in \S+: \.bzr`)
-}
-
-func (s *packSuite) TestExcludeDynamicFalseIfNoSnapignore(c *C) {
-	basedir := c.MkDir()
-	c.Check(pack.ShouldExcludeDynamic(basedir, "foo"), Equals, false)
-}
-
-func (s *packSuite) TestExcludeDynamicWorksIfSnapignore(c *C) {
-	basedir := c.MkDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(basedir, ".snapignore"), []byte("foo\nb.r\n"), 0644), IsNil)
-	c.Check(pack.ShouldExcludeDynamic(basedir, "foo"), Equals, true)
-	c.Check(pack.ShouldExcludeDynamic(basedir, "bar"), Equals, true)
-	c.Check(pack.ShouldExcludeDynamic(basedir, "bzr"), Equals, true)
-	c.Check(pack.ShouldExcludeDynamic(basedir, "baz"), Equals, false)
-}
-
-func (s *packSuite) TestExcludeDynamicWeirdRegexps(c *C) {
-	basedir := c.MkDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(basedir, ".snapignore"), []byte("*hello\n"), 0644), IsNil)
-	// note "*hello" is not a valid regexp, so will be taken literally (not globbed!)
-	c.Check(pack.ShouldExcludeDynamic(basedir, "ahello"), Equals, false)
-	c.Check(pack.ShouldExcludeDynamic(basedir, "*hello"), Equals, true)
 }
 
 func (s *packSuite) TestDebArchitecture(c *C) {
 	c.Check(pack.DebArchitecture(&snap.Info{Architectures: []string{"foo"}}), Equals, "foo")
 	c.Check(pack.DebArchitecture(&snap.Info{Architectures: []string{"foo", "bar"}}), Equals, "multi")
 	c.Check(pack.DebArchitecture(&snap.Info{Architectures: nil}), Equals, "all")
-}
-
-func (s *packSuite) TestPackFailsForUnknownType(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, `name: hello
-version: 1.0.1
-`)
-	err := syscall.Mkfifo(filepath.Join(sourceDir, "fifo"), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = pack.Snap(sourceDir, "")
-	c.Assert(err, ErrorMatches, "cannot handle type of file .*")
 }
 
 func (s *packSuite) TestPackSimple(c *C) {

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -51,6 +51,8 @@ func MockFromCore(newFromCore func(string, ...string) (*exec.Cmd, error)) (resto
 	}
 }
 
+// Alike compares to os.FileInfo to determine if they are sufficiently
+// alike to say they refer to the same thing.
 func Alike(a, b os.FileInfo, c *check.C, comment check.CommentInterface) {
 	c.Check(a, check.NotNil, comment)
 	c.Check(b, check.NotNil, comment)

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -298,28 +298,33 @@ func (s *Snap) ListDir(dirPath string) ([]string, error) {
 }
 
 // Build builds the snap.
-func (s *Snap) Build(buildDir, snapType string) error {
+func (s *Snap) Build(sourceDir, snapType string, excludeFiles ...string) error {
 	fullSnapPath, err := filepath.Abs(s.path)
 	if err != nil {
 		return err
 	}
-
-	args := []string{
+	cmd, err := osutilCommandFromCore("/usr/bin/mksquashfs")
+	if err != nil {
+		cmd = exec.Command("mksquashfs")
+	}
+	cmd.Args = append(cmd.Args,
 		".", fullSnapPath,
 		"-noappend",
 		"-comp", "xz",
 		"-no-fragments",
 		"-no-progress",
+	)
+	if len(excludeFiles) > 0 {
+		cmd.Args = append(cmd.Args, "-wildcards")
+		for _, excludeFile := range excludeFiles {
+			cmd.Args = append(cmd.Args, "-ef", excludeFile)
+		}
 	}
 	if snapType != "os" && snapType != "core" && snapType != "base" {
-		args = append(args, "-all-root", "-no-xattrs")
-	}
-	cmd, err := osutilCommandFromCore("/usr/bin/mksquashfs", args...)
-	if err != nil {
-		cmd = exec.Command("mksquashfs", args...)
+		cmd.Args = append(cmd.Args, "-all-root", "-no-xattrs")
 	}
 
-	return osutil.ChDir(buildDir, func() error {
+	return osutil.ChDir(sourceDir, func() error {
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("mksquashfs call failed: %s", osutil.OutputErr(output, err))


### PR DESCRIPTION
This changes the api of `squashfs.Build` to pass a list of exclude
files on to `mksquashfs`, which enables us to stop copying all the
snap's contents into a build directory to do the exclusions ourselves.
