### PR TITLE
cmd: use relative file names in locking APIs

### DIFF
--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -104,11 +104,11 @@ static int sc_lock_generic(const char *scope, uid_t uid)
 		// The root user doesn't have a per-user mount namespace.
 		// Doing so would be confusing for services which use $SNAP_DATA
 		// as home, and not in $SNAP_USER_DATA.
-		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s/%s.lock",
-				 sc_lock_dir, scope ? : "");
+		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s.lock",
+				 scope ? : "");
 	} else {
-		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s/%s.%d.lock",
-				 sc_lock_dir, scope ? : "", uid);
+		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s.%d.lock",
+				 scope ? : "", uid);
 	}
 
 	// Open the lock file and acquire an exclusive lock.


### PR DESCRIPTION
The locking APIs were carefully opening a directory and using openat(2)
against a file descriptor but due to a simple oversight the passed
filename was an absolute path making openat(2) equivalent to open(2).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
