### PR TITLE
ifstate: fix decoding of json numbers

### DIFF
--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -117,6 +117,9 @@ func (s *helpersSuite) TestGetConns(c *C) {
 		"app:network core:network": map[string]interface{}{
 			"auto":      true,
 			"interface": "network",
+			"slot-static": map[string]interface{}{
+				"number": int(78),
+			},
 		},
 	})
 
@@ -129,6 +132,7 @@ func (s *helpersSuite) TestGetConns(c *C) {
 		c.Assert(id, Equals, "APP:network CORE:network")
 		c.Assert(connState.Auto, Equals, true)
 		c.Assert(connState.Interface, Equals, "network")
+		c.Assert(connState.StaticSlotAttrs["number"], Equals, int(78))
 	}
 }
 


### PR DESCRIPTION
When we read the static slots/plugs from the state we decode them
as with the default json decoding. This leads to float64 instead
of the expected int. This PR fixes it and adds tests.
