### PR TITLE
interfaces: fix decoding of json numbers for static/dynamic attributes

### DIFF
--- a/interfaces/builtin/dummy.go
+++ b/interfaces/builtin/dummy.go
@@ -72,6 +72,10 @@ func (iface *dummyInterface) BeforeConnectPlug(plug *interfaces.ConnectedPlug) e
 }
 
 func (iface *dummyInterface) BeforeConnectSlot(slot *interfaces.ConnectedSlot) error {
+	var num int64
+	if err := slot.Attr("producer-num-1", &num); err != nil {
+		return err
+	}
 	var value string
 	if err := slot.Attr("before-connect", &value); err != nil {
 		return err

--- a/interfaces/connection_test.go
+++ b/interfaces/connection_test.go
@@ -61,6 +61,7 @@ slots:
     slot:
         interface: interface
         attr: value
+        number: 100
         complex:
             a: b
 `, nil)
@@ -88,6 +89,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *C) {
 	attrs := slot.StaticAttrs()
 	c.Assert(attrs, DeepEquals, map[string]interface{}{
 		"attr":    "value",
+		"number":  int64(100),
 		"complex": map[string]interface{}{"a": "b"},
 	})
 	slot.StaticAttr("attr", &val)

--- a/interfaces/utils/utils.go
+++ b/interfaces/utils/utils.go
@@ -47,12 +47,11 @@ func NormalizeInterfaceAttributes(value interface{}) interface{} {
 		return vc
 	case json.Number:
 		jsonval := value.(json.Number)
-		asInt, err := jsonval.Int64()
-		if err != nil {
-			asFloat, _ := jsonval.Float64()
-			return asFloat
+		if asInt, err := jsonval.Int64(); err == nil {
+			return asInt
 		}
-		return asInt
+		asFloat, _ := jsonval.Float64()
+		return asFloat
 	}
 	return value
 }

--- a/interfaces/utils/utils.go
+++ b/interfaces/utils/utils.go
@@ -19,6 +19,10 @@
 
 package utils
 
+import (
+	"encoding/json"
+)
+
 // NormalizeInterfaceAttributes normalises types of an attribute values.
 // The following transformations are applied: int -> int64, float32 -> float64.
 // The normalisation proceeds recursively through maps and slices.
@@ -41,6 +45,14 @@ func NormalizeInterfaceAttributes(value interface{}) interface{} {
 			vc[key] = NormalizeInterfaceAttributes(item)
 		}
 		return vc
+	case json.Number:
+		jsonval := value.(json.Number)
+		asInt, err := jsonval.Int64()
+		if err != nil {
+			asFloat, _ := jsonval.Float64()
+			return asFloat
+		}
+		return asInt
 	}
 	return value
 }

--- a/interfaces/utils/utils_test.go
+++ b/interfaces/utils/utils_test.go
@@ -20,6 +20,7 @@
 package utils_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -44,10 +45,12 @@ func (s *utilsSuite) TestNormalizeInterfaceAttributes(c *C) {
 	// Funny that, I noticed it only because of missing test coverage.
 	c.Assert(normalize(float32(3.14)), Equals, float64(3.140000104904175))
 	c.Assert(normalize("banana"), Equals, "banana")
-	c.Assert(normalize([]interface{}{42, 3.14, "banana"}), DeepEquals,
-		[]interface{}{int64(42), float64(3.14), "banana"})
+	c.Assert(normalize([]interface{}{42, 3.14, "banana", json.Number("21"), json.Number("0.5")}), DeepEquals,
+		[]interface{}{int64(42), float64(3.14), "banana", int64(21), float64(0.5)})
 	c.Assert(normalize(map[string]interface{}{"i": 42, "f": 3.14, "s": "banana"}),
 		DeepEquals, map[string]interface{}{"i": int64(42), "f": float64(3.14), "s": "banana"})
+	c.Assert(normalize(json.Number("1")), Equals, int64(1))
+	c.Assert(normalize(json.Number("2.5")), Equals, float64(2.5))
 
 	// Normalize doesn't mutate slices it is given
 	sliceIn := []interface{}{42}

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -20,6 +20,7 @@ package ifacestate
 import (
 	"time"
 
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -81,4 +82,29 @@ func UpperCaseConnState() map[string]connState {
 	return map[string]connState{
 		"APP:network CORE:network": {Auto: true, Interface: "network"},
 	}
+}
+
+func UpdateConnectionInConnState(conns map[string]connState, conn *interfaces.Connection, autoConnect, byGadget bool) {
+	connRef := &interfaces.ConnRef{
+		PlugRef: *conn.Plug.Ref(),
+		SlotRef: *conn.Slot.Ref(),
+	}
+
+	conns[connRef.ID()] = connState{
+		Interface:        conn.Interface(),
+		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
+		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
+		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
+		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+		Auto:             autoConnect,
+		ByGadget:         byGadget,
+	}
+}
+
+func GetConnStateAttrs(conns map[string]connState, connID string) (plugStatic, plugDynamic, slotStatic, SlotDynamic map[string]interface{}, ok bool) {
+	conn, ok := conns[connID]
+	if !ok {
+		return nil, nil, nil, nil, false
+	}
+	return conn.StaticPlugAttrs, conn.DynamicPlugAttrs, conn.StaticSlotAttrs, conn.DynamicSlotAttrs, true
 }

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -534,7 +534,7 @@ func getConns(st *state.State) (conns map[string]connState, err error) {
 	if raw != nil {
 		err = jsonutil.DecodeWithNumber(bytes.NewReader(*raw), &conns)
 		if err != nil {
-			return nil, fmt.Errorf("cannot obtain data about existing connections: %s", err)
+			return nil, fmt.Errorf("cannot decode data about existing connections: %s", err)
 		}
 	}
 	if conns == nil {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/policy"
+	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -547,6 +548,10 @@ func getConns(st *state.State) (conns map[string]connState, err error) {
 		}
 		cref.PlugRef.Snap = RemapSnapFromState(cref.PlugRef.Snap)
 		cref.SlotRef.Snap = RemapSnapFromState(cref.SlotRef.Snap)
+		cstate.StaticSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticSlotAttrs).(map[string]interface{})
+		cstate.DynamicSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicSlotAttrs).(map[string]interface{})
+		cstate.StaticPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticPlugAttrs).(map[string]interface{})
+		cstate.DynamicPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicPlugAttrs).(map[string]interface{})
 		remapped[cref.ID()] = cstate
 	}
 	return remapped, nil

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -132,7 +132,7 @@ func (s *helpersSuite) TestGetConns(c *C) {
 		c.Assert(id, Equals, "APP:network CORE:network")
 		c.Assert(connState.Auto, Equals, true)
 		c.Assert(connState.Interface, Equals, "network")
-		c.Assert(connState.StaticSlotAttrs["number"], Equals, int(78))
+		c.Assert(connState.StaticSlotAttrs["number"], Equals, int64(78))
 	}
 }
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -117,6 +117,9 @@ func (s *helpersSuite) TestGetConns(c *C) {
 		"app:network core:network": map[string]interface{}{
 			"auto":      true,
 			"interface": "network",
+			"slot-static": map[string]interface{}{
+				"number": int(78),
+			},
 		},
 	})
 
@@ -129,6 +132,7 @@ func (s *helpersSuite) TestGetConns(c *C) {
 		c.Assert(id, Equals, "APP:network CORE:network")
 		c.Assert(connState.Auto, Equals, true)
 		c.Assert(connState.Interface, Equals, "network")
+		c.Assert(connState.StaticSlotAttrs["number"], Equals, int(78))
 	}
 }
 

--- a/tests/lib/snaps/basic-iface-hooks-producer/meta/snap.yaml
+++ b/tests/lib/snaps/basic-iface-hooks-producer/meta/snap.yaml
@@ -5,3 +5,4 @@ slots:
         interface: dummy
         producer-attr-1: producer-value-1
         producer-attr-2: producer-value-2
+        producer-num-1: 1


### PR DESCRIPTION
Based on PR from @mvo5 - decode json with numbers in getConns, and normalize numbers. NormalizeAttributes understands json.Number and tries to get Int from it in the first place, then falls back to float. The only reasonable type for numbers in interface attributes is Int, but we don't prevent floats from being used at the moment - if we want Ints only, we would need to block them on other levels in the first place (e.g. yaml).
