### PR TITLE
data/systemd, wrappers: tweak system-shutdown helper for core18 (2.36)

### DIFF
--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -96,7 +96,7 @@ static void detach_loop(const char *src)
 		     strerror(errno));
 	} else {
 		if (ioctl(fd, LOOP_CLR_FD) < 0) {
-			kmsg("* unable to disassociate loop device %ss: %s",
+			kmsg("* unable to disassociate loop device %s: %s",
 			     src, strerror(errno));
 		}
 		close(fd);

--- a/data/systemd/snapd.system-shutdown.service.in
+++ b/data/systemd/snapd.system-shutdown.service.in
@@ -10,7 +10,9 @@ ConditionPathExists=@libexecdir@/snapd/system-shutdown
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -euc 'mount /run -o remount,exec; mkdir -p /run/initramfs; cp @libexecdir@/snapd/system-shutdown /run/initramfs/shutdown'
+ExecStart=/bin/mount /run -o remount,exec
+ExecStart=/bin/mkdir -p /run/initramfs
+ExecStart=/bin/cp @libexecdir@/snapd/system-shutdown /run/initramfs/shutdown
 
 [Install]
 WantedBy=final.target

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -36,7 +36,8 @@ import (
 	"github.com/snapcore/snapd/systemd"
 )
 
-var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(.*)$`)
+// catches units that run /usr/bin/snap (with args), or things in /usr/lib/snapd/
+var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/lib/snapd/.*)$`)
 
 func writeSnapdToolingMountUnit(sysd systemd.Systemd, prefix string) error {
 	// Not using WriteMountUnitFile() because we need

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -40,11 +40,19 @@ func makeMockSnapdSnap(c *C) *snap.Info {
 	c.Assert(err, IsNil)
 
 	info := snaptest.MockSnap(c, snapdYaml, &snap.SideInfo{Revision: snap.R(1)})
-	snapdSrv := filepath.Join(info.MountDir(), "/lib/systemd/system/snapd.service")
-	err = os.MkdirAll(filepath.Dir(snapdSrv), 0755)
+	snapdDir := filepath.Join(info.MountDir(), "lib", "systemd", "system")
+	err = os.MkdirAll(snapdDir, 0755)
 	c.Assert(err, IsNil)
+	snapdSrv := filepath.Join(snapdDir, "snapd.service")
 	err = ioutil.WriteFile(snapdSrv, []byte("[Unit]\nExecStart=/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start"), 0644)
 	c.Assert(err, IsNil)
+	snapdShutdown := filepath.Join(snapdDir, "snapd.system-shutdown.service")
+	err = ioutil.WriteFile(snapdShutdown, []byte("[Unit]\nExecStart=/bin/umount --everything\n# X-Snapd-Snap: do-not-start"), 0644)
+	c.Assert(err, IsNil)
+	snapdAutoimport := filepath.Join(snapdDir, "snapd.autoimport.service")
+	err = ioutil.WriteFile(snapdAutoimport, []byte("[Unit]\nExecStart=/usr/bin/snap auto-import"), 0644)
+	c.Assert(err, IsNil)
+
 	return info
 }
 
@@ -69,6 +77,18 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCore(c *C) {
 	// and paths get re-written
 	c.Check(string(content), Equals, fmt.Sprintf("[Unit]\nExecStart=%s/snapd/1/usr/lib/snapd/snapd\n# X-Snapd-Snap: do-not-start", dirs.SnapMountDir))
 
+	// check that snapd.autoimport.service is created
+	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapServicesDir, "snapd.autoimport.service"))
+	c.Assert(err, IsNil)
+	// and paths get re-written
+	c.Check(string(content), Equals, fmt.Sprintf("[Unit]\nExecStart=%s/snapd/1/usr/bin/snap auto-import", dirs.SnapMountDir))
+
+	// check that snapd.system-shutdown.service is created
+	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapServicesDir, "snapd.system-shutdown.service"))
+	c.Assert(err, IsNil)
+	// and paths *do not* get re-written
+	c.Check(string(content), Equals, "[Unit]\nExecStart=/bin/umount --everything\n# X-Snapd-Snap: do-not-start")
+
 	// check that usr-lib-snapd.mount is created
 	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapServicesDir, "usr-lib-snapd.mount"))
 	c.Assert(err, IsNil)
@@ -86,7 +106,7 @@ Options=bind
 WantedBy=snapd.service
 `, dirs.GlobalRootDir))
 
-	// check that systemd got started
+	// check the systemctl calls
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
 		{"--root", dirs.GlobalRootDir, "enable", "usr-lib-snapd.mount"},
@@ -94,7 +114,12 @@ WantedBy=snapd.service
 		{"show", "--property=ActiveState", "usr-lib-snapd.mount"},
 		{"start", "usr-lib-snapd.mount"},
 		{"daemon-reload"},
+		{"--root", dirs.GlobalRootDir, "enable", "snapd.autoimport.service"},
 		{"--root", dirs.GlobalRootDir, "enable", "snapd.service"},
+		{"--root", dirs.GlobalRootDir, "enable", "snapd.system-shutdown.service"},
+		{"stop", "snapd.autoimport.service"},
+		{"show", "--property=ActiveState", "snapd.autoimport.service"},
+		{"start", "snapd.autoimport.service"},
 		{"start", "snapd.service"},
 		{"start", "--no-block", "snapd.seeded.service"},
 	})
@@ -109,11 +134,12 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnClassic(c *C) {
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, IsNil)
 
-	// check that snapd.service is created
+	// check that snapd services were *not* created
 	c.Check(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, "snapd.service")), Equals, false)
-
+	c.Check(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, "snapd.autoimport.service")), Equals, false)
+	c.Check(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, "snapd.system-shutdown.service")), Equals, false)
 	c.Check(osutil.FileExists(filepath.Join(dirs.SnapServicesDir, "usr-lib-snapd.mount")), Equals, false)
 
-	// check that systemd got started
+	// check that no systemctl calls happened
 	c.Check(s.sysdLog, IsNil)
 }


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/5986 for 2.36.

We'd broken the system-shutdown helper service by including its
/bin/sh in the list of things that got redirected to the snapd snap
(which does not ship a /bin/sh). This fixes that, by only rewriting
things that point to /usr/bin/snap or /usr/lib/snapd in the first place.

While there I also changed snapd.system-shutdown.service to not call
/bin/sh, but instead use multiple ExecStart= lines. This might make
debug logs from systemd a little bit clearer when things break again.

