### PR TITLE
daemon, snap: mark screenshots as deprecated

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1964,9 +1964,23 @@ func (s *apiSuite) TestFindScreenshotted(c *check.C) {
 			"url":    "http://example.com/screenshot.png",
 			"width":  float64(800),
 			"height": float64(1280),
+			"note":   snap.ScreenshotsDeprecationNotice,
 		},
 		map[string]interface{}{
-			"url": "http://example.com/screenshot2.png",
+			"url":  "http://example.com/screenshot2.png",
+			"note": snap.ScreenshotsDeprecationNotice,
+		},
+	})
+	c.Check(snaps[0]["media"], check.DeepEquals, []interface{}{
+		map[string]interface{}{
+			"type":   "screenshot",
+			"url":    "http://example.com/screenshot.png",
+			"width":  float64(800),
+			"height": float64(1280),
+		},
+		map[string]interface{}{
+			"type": "screenshot",
+			"url":  "http://example.com/screenshot2.png",
 		},
 	})
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -750,6 +750,7 @@ type ScreenshotInfo struct {
 	URL    string `json:"url"`
 	Width  int64  `json:"width,omitempty"`
 	Height int64  `json:"height,omitempty"`
+	Note   string `json:"note,omitempty"`
 }
 
 type MediaInfo struct {
@@ -761,6 +762,8 @@ type MediaInfo struct {
 
 type MediaInfos []MediaInfo
 
+const ScreenshotsDeprecationNotice = `'screenshots' is deprecated; use 'media' instead. More info at https://forum.snapcraft.io/t/8086`
+
 func (mis MediaInfos) Screenshots() []ScreenshotInfo {
 	shots := make([]ScreenshotInfo, 0, len(mis))
 	for _, mi := range mis {
@@ -771,6 +774,7 @@ func (mis MediaInfos) Screenshots() []ScreenshotInfo {
 			URL:    mi.URL,
 			Width:  mi.Width,
 			Height: mi.Height,
+			Note:   ScreenshotsDeprecationNotice,
 		})
 	}
 	return shots

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1394,11 +1394,13 @@ func (s *infoSuite) TestMedia(c *C) {
 	c.Check(media.IconURL(), Equals, "https://example.com/icon.png")
 	c.Check(media.Screenshots(), DeepEquals, []snap.ScreenshotInfo{
 		{
-			URL: "https://example.com/shot1.svg",
+			URL:  "https://example.com/shot1.svg",
+			Note: snap.ScreenshotsDeprecationNotice,
 		}, {
 			URL:    "https://example.com/shot2.svg",
 			Width:  42,
 			Height: 17,
+			Note:   snap.ScreenshotsDeprecationNotice,
 		},
 	})
 }


### PR DESCRIPTION
We're still nailing down the details, but screenshots are deprecated
as of 2.36 and will be going away. This adds a note about that.
