### PR TITLE
cmd/snap: try not to panic on error from "snap try"

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -721,13 +721,13 @@ func (x *cmdTry) Execute([]string) error {
 	}
 
 	changeID, err := x.client.Try(path, opts)
-	if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindNotSnap {
-		return fmt.Errorf(i18n.G(`%q does not contain an unpacked snap.
-
-Try 'snapcraft prime' in your project directory, then 'snap try' again.`), path)
-	}
 	if err != nil {
-		return err
+		msg, err := errorToCmdMessage(name, err, opts)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stderr, msg)
+		return nil
 	}
 
 	chg, err := x.wait(changeID)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/progress/progresstest"
 	"github.com/snapcore/snapd/testutil"
+	"os"
 )
 
 type snapOpTestServer struct {
@@ -1280,9 +1281,50 @@ func (s *SnapOpSuite) TestTryNoSnapDirErrors(c *check.C) {
 
 	cmd := []string{"try", "/"}
 	_, err := snap.Parser(snap.Client()).ParseArgs(cmd)
-	c.Assert(err, check.ErrorMatches, `"/" does not contain an unpacked snap.
+	c.Assert(err, check.ErrorMatches, rewrappingMatcher(`
+"/" does not contain an unpacked snap.
 
-Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
+Try 'snapcraft prime' in your project directory, then 'snap try' again.`))
+}
+
+func (s *SnapOpSuite) TestTryMissingOpt(c *check.C) {
+	oldArgs := os.Args
+	defer func() {
+		os.Args = oldArgs
+	}()
+	os.Args = []string{"snap", "try", "./"}
+	var kind string
+
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST", check.Commentf("%q", kind))
+		w.WriteHeader(400)
+		fmt.Fprintf(w, `
+{
+  "type": "error",
+  "result": {
+    "message":"error from server",
+    "value": "some-snap",
+    "kind": %q
+  },
+  "status-code": 400
+}`, kind)
+	})
+
+	type table struct {
+		kind, expected string
+	}
+
+	tests := []table{
+		{"snap-needs-classic", "published using classic confinement"},
+		{"snap-needs-devmode", "only meant for development"},
+	}
+
+	for _, test := range tests {
+		kind = test.kind
+		rx := rewrappingMatcher(test.expected)
+		err := snap.RunMain()
+		c.Check(err, check.ErrorMatches, rx, check.Commentf("%q", kind))
+	}
 }
 
 func (s *SnapSuite) TestInstallChannelDuplicationError(c *check.C) {

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -101,6 +101,16 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 	usesSnapName := true
 	var msg string
 	switch err.Kind {
+	case client.ErrorKindNotSnap:
+		msg = i18n.G(`%q does not contain an unpacked snap.
+
+Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
+		if snapName == "" || snapName == "./" {
+			errValStr, ok := err.Value.(string)
+			if ok && errValStr != "" {
+				snapName = errValStr
+			}
+		}
 	case client.ErrorKindSnapNotFound:
 		msg = i18n.G("snap %q not found")
 		if snapName == "" {
@@ -155,7 +165,7 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 		isError = false
 		msg = i18n.G(`snap %q is already installed, see 'snap help refresh'`)
 	case client.ErrorKindSnapNeedsDevMode:
-		if opts.Dangerous {
+		if opts != nil && opts.Dangerous {
 			msg = i18n.G("snap %q requires devmode or confinement override")
 			break
 		}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -327,4 +328,14 @@ func (s *SnapSuite) TestFirstNonOptionIsRun(c *C) {
 		os.Args = strings.Fields(positive)
 		c.Check(snap.FirstNonOptionIsRun(), Equals, true)
 	}
+}
+
+// rewrappingMatcher takes a string that's expected to be in the output of
+// a command, and turns it into a regexp that survives rewraps
+func rewrappingMatcher(expected string) string {
+	fields := strings.Fields(expected)
+	for i, field := range fields {
+		fields[i] = regexp.QuoteMeta(field)
+	}
+	return "(?s).*" + strings.Join(fields, `\s+`) + ".*"
 }


### PR DESCRIPTION
Without this change, when a user tries a "devmode" snap without saying
`--devmode`, the following happens:

    $ snap try
    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
            panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x2b pc=0x55df7eb53bab]

    goroutine 1 [running]:
    panic(0x55df7f54b140, 0xc82000e140)
            /usr/lib/go-1.6/src/runtime/panic.go:481 +0x3ea
    main.main.func1()
            /build/snapd-zo0q60/snapd-2.36~pre2+git966.ef04a35~ubuntu16.04.1/_build/src/github.com/snapcore/snapd/cmd/snap/main.go:414 +0x7b
    panic(0x55df7f54b140, 0xc82000e140)
            /usr/lib/go-1.6/src/runtime/panic.go:443 +0x4ed
    main.errorToCmdMessage(0x0, 0x0, 0x7fbfc1736150, 0xc820286140, 0x0, 0x0, 0x0, 0x0, 0x0)
            /build/snapd-zo0q60/snapd-2.36~pre2+git966.ef04a35~ubuntu16.04.1/_build/src/github.com/snapcore/snapd/cmd/snap/error.go:158 +0xd2b
    main.run(0x0, 0x0)
            /build/snapd-zo0q60/snapd-2.36~pre2+git966.ef04a35~ubuntu16.04.1/_build/src/github.com/snapcore/snapd/cmd/snap/main.go:464 +0x2c3
    main.main()
            /build/snapd-zo0q60/snapd-2.36~pre2+git966.ef04a35~ubuntu16.04.1/_build/src/github.com/snapcore/snapd/cmd/snap/main.go:419 +0xab7

This affects 2.36 only. The root cause was older, but the panic is
caused by #5791 which is not yet released.

This change addresses the problem in two separate ways: it catches the
nil `opts` (which is always the case when `errorToCmdMessage` is
called from main), but also it calls `errorToCmdMessage` from
`(cmdTry).Execute` directly, which is where `opts` is known.
