### PR TITLE
overlord/ifacestate: don't conflict on own discard-snap tasks when refreshing & doing garbage collection

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -635,7 +635,7 @@ func obsoleteCorePhase2SetupProfiles(kind string, task *state.Task) (bool, error
 	return corePhase2, nil
 }
 
-func checkAutoconnectConflicts(st *state.State, plugSnap, slotSnap string) error {
+func checkAutoconnectConflicts(st *state.State, autoconnectTask *state.Task, plugSnap, slotSnap string) error {
 	for _, task := range st.Tasks() {
 		if task.Status().Ready() {
 			continue
@@ -650,8 +650,11 @@ func checkAutoconnectConflicts(st *state.State, plugSnap, slotSnap string) error
 			if err != nil {
 				return err
 			}
-			if plugRef.Snap == plugSnap || slotRef.Snap == slotSnap {
-				return &state.Retry{After: connectRetryTimeout}
+			if plugRef.Snap == plugSnap {
+				return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting snap %s, task %q", plugSnap, k)}
+			}
+			if slotRef.Snap == slotSnap {
+				return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting snap %s, task %q", slotSnap, k)}
 			}
 			continue
 		}
@@ -682,9 +685,19 @@ func checkAutoconnectConflicts(st *state.State, plugSnap, slotSnap string) error
 
 		// other snap that affects us because of plug or slot
 		if k == "unlink-snap" || k == "link-snap" || k == "setup-profiles" || k == "discard-snap" {
+			autoconnectsup, err := snapstate.TaskSnapSetup(autoconnectTask)
+			if err != nil {
+				return err
+			}
+
+			// discard-snap is scheduled as part of garbage collection during refresh, if multiple revsions are already installed.
+			// this revision check avoids conflict with own discard tasks created as part of install/refresh.
+			if k == "discard-snap" && autoconnectsup.Revision().N != snapsup.Revision().N {
+				continue
+			}
 			// if snap is getting removed, we will retry but the snap will be gone and auto-connect becomes no-op
 			// if snap is getting installed/refreshed - temporary conflict, retry later
-			return &state.Retry{After: connectRetryTimeout}
+			return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting snap %s with task %q", otherSnapName, k)}
 		}
 	}
 	return nil
@@ -872,10 +885,9 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 			continue
 		}
 
-		if err := checkAutoconnectConflicts(st, plug.Snap.InstanceName(), slot.Snap.InstanceName()); err != nil {
-			if _, retry := err.(*state.Retry); retry {
-				logger.Debugf("auto-connect of snap %q will be retried because of %q - %q conflict", snapName, plug.Snap.InstanceName(), slot.Snap.InstanceName())
-				task.Logf("Waiting for conflicting change in progress...")
+		if err := checkAutoconnectConflicts(st, task, plug.Snap.InstanceName(), slot.Snap.InstanceName()); err != nil {
+			if retry, ok := err.(*state.Retry); ok {
+				task.Logf("Waiting for conflicting change in progress: %s", retry.Reason)
 				return err // will retry
 			}
 			return fmt.Errorf("auto-connect conflict check failed: %s", err)
@@ -924,10 +936,9 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 				continue
 			}
 
-			if err := checkAutoconnectConflicts(st, plug.Snap.InstanceName(), slot.Snap.InstanceName()); err != nil {
-				if _, retry := err.(*state.Retry); retry {
-					logger.Debugf("auto-connect of snap %q will be retried because of %q - %q conflict", snapName, plug.Snap.InstanceName(), slot.Snap.InstanceName())
-					task.Logf("Waiting for conflicting change in progress...")
+			if err := checkAutoconnectConflicts(st, task, plug.Snap.InstanceName(), slot.Snap.InstanceName()); err != nil {
+				if retry, ok := err.(*state.Retry); ok {
+					task.Logf("Waiting for conflicting change in progress: %s", retry.Reason)
 					return err // will retry
 				}
 				return fmt.Errorf("auto-connect conflict check failed: %s", err)
@@ -1134,9 +1145,9 @@ func (m *InterfaceManager) doGadgetConnect(task *state.Task, _ *tomb.Tomb) error
 			continue
 		}
 
-		if err := checkAutoconnectConflicts(st, plug.Snap.InstanceName(), slot.Snap.InstanceName()); err != nil {
-			if _, retry := err.(*state.Retry); retry {
-				task.Logf("gadget connect will be retried because of %q - %q conflict", plug.Snap.InstanceName(), slot.Snap.InstanceName())
+		if err := checkAutoconnectConflicts(st, task, plug.Snap.InstanceName(), slot.Snap.InstanceName()); err != nil {
+			if retry, ok := err.(*state.Retry); ok {
+				task.Logf("gadget connect will be retried: %s", retry.Reason)
 				return err // will retry
 			}
 			return fmt.Errorf("gadget connect conflict check failed: %s", err)

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -651,10 +651,10 @@ func checkAutoconnectConflicts(st *state.State, autoconnectTask *state.Task, plu
 				return err
 			}
 			if plugRef.Snap == plugSnap {
-				return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting snap %s, task %q", plugSnap, k)}
+				return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting plug snap %s, task %q", plugSnap, k)}
 			}
 			if slotRef.Snap == slotSnap {
-				return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting snap %s, task %q", slotSnap, k)}
+				return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting slot snap %s, task %q", slotSnap, k)}
 			}
 			continue
 		}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -685,14 +685,9 @@ func checkAutoconnectConflicts(st *state.State, autoconnectTask *state.Task, plu
 
 		// other snap that affects us because of plug or slot
 		if k == "unlink-snap" || k == "link-snap" || k == "setup-profiles" || k == "discard-snap" {
-			autoconnectsup, err := snapstate.TaskSnapSetup(autoconnectTask)
-			if err != nil {
-				return err
-			}
-
 			// discard-snap is scheduled as part of garbage collection during refresh, if multiple revsions are already installed.
 			// this revision check avoids conflict with own discard tasks created as part of install/refresh.
-			if k == "discard-snap" && autoconnectsup.Revision().N != snapsup.Revision().N {
+			if k == "discard-snap" && autoconnectTask.Change() != nil && autoconnectTask.Change().ID() == task.Change().ID() {
 				continue
 			}
 			// if snap is getting removed, we will retry but the snap will be gone and auto-connect becomes no-op

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -722,7 +722,7 @@ func (s *interfaceManagerSuite) TestAutoconnectDoesntConflictOnInstallingDiffere
 	ignore, err := ifacestate.FindSymmetricAutoconnectTask(s.state, "consumer", "producer", t)
 	c.Assert(err, IsNil)
 	c.Assert(ignore, Equals, false)
-	c.Assert(ifacestate.CheckAutoconnectConflicts(s.state, "consumer", "producer"), IsNil)
+	c.Assert(ifacestate.CheckAutoconnectConflicts(s.state, t, "consumer", "producer"), IsNil)
 
 	ts, err := ifacestate.ConnectPriv(s.state, "consumer", "plug", "producer", "slot", ifacestate.NewConnectOptsWithAutoSet())
 	c.Assert(err, IsNil)
@@ -761,7 +761,7 @@ func (s *interfaceManagerSuite) createAutoconnectChange(c *C, conflictingTask *s
 	c.Assert(err, IsNil)
 	c.Assert(ignore, Equals, false)
 
-	return ifacestate.CheckAutoconnectConflicts(s.state, "consumer", "producer")
+	return ifacestate.CheckAutoconnectConflicts(s.state, t2, "consumer", "producer")
 }
 
 func (s *interfaceManagerSuite) testRetryError(c *C, err error) {
@@ -4412,7 +4412,7 @@ func (s *interfaceManagerSuite) TestGadgetConnectConflictRetry(c *C) {
 	c.Assert(tasks, HasLen, 1)
 
 	c.Check(t.Status(), Equals, state.DoingStatus)
-	c.Check(t.Log()[0], Matches, `.*gadget connect will be retried because of "consumer" - "producer" conflict`)
+	c.Check(t.Log()[0], Matches, `.*gadget connect will be retried: conflicting snap producer with task "link-snap"`)
 }
 
 func (s *interfaceManagerSuite) TestGadgetConnectSkipUnknown(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2412,6 +2412,88 @@ version: @VERSION@`
 	c.Assert(connections, HasLen, 3)
 }
 
+func (ms *mgrsSuite) TestUpdateWithAutoconnectAndInactiveRevisions(c *C) {
+	const someSnapYaml = `name: some-snap
+version: 1.0
+apps:
+   foo:
+        command: bin/bar
+        plugs: [network]
+`
+	const coreSnapYaml = `name: core
+type: os
+version: 1`
+
+	snapPath, _ := ms.makeStoreTestSnap(c, someSnapYaml, "40")
+	ms.serveSnap(snapPath, "40")
+
+	mockServer := ms.mockStore(c)
+	defer mockServer.Close()
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	si1 := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
+	snapInfo := snaptest.MockSnap(c, someSnapYaml, si1)
+	c.Assert(snapInfo.Plugs, HasLen, 1)
+
+	csi := &snap.SideInfo{RealName: "core", SnapID: fakeSnapID("core"), Revision: snap.R(1)}
+	coreInfo := snaptest.MockSnap(c, coreSnapYaml, csi)
+
+	// add implicit slots
+	coreInfo.Slots["network"] = &snap.SlotInfo{
+		Name:      "network",
+		Snap:      coreInfo,
+		Interface: "network",
+	}
+
+	// some-snap has inactive revisions
+	si0 := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(0)}
+	si2 := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(2)}
+	snapstate.Set(st, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si0, si1, si2},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	repo := ms.o.InterfaceManager().Repository()
+
+	// add snaps to the repo to have plugs/slots
+	c.Assert(repo.AddSnap(snapInfo), IsNil)
+	c.Assert(repo.AddSnap(coreInfo), IsNil)
+
+	// refresh all
+	err := assertstate.RefreshSnapDeclarations(st, 0)
+	c.Assert(err, IsNil)
+
+	updates, tts, err := snapstate.UpdateMany(context.TODO(), st, []string{"some-snap"}, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(updates, HasLen, 1)
+	c.Assert(tts, HasLen, 1)
+
+	// to make TaskSnapSetup work
+	chg := st.NewChange("refresh", "...")
+	for _, ts := range tts {
+		chg.AddAll(ts)
+	}
+
+	st.Unlock()
+	err = ms.o.Settle(settleTimeout)
+	st.Lock()
+
+	c.Assert(err, IsNil)
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+
+	// check connections
+	var conns map[string]interface{}
+	st.Get("conns", &conns)
+	c.Assert(conns, DeepEquals, map[string]interface{}{
+		"some-snap:network core:network": map[string]interface{}{"interface": "network", "auto": true},
+	})
+}
+
 const someSnapYaml = `name: some-snap
 version: 1.0
 apps:
@@ -2506,7 +2588,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	}
 
 	c.Check(retryCheck, Equals, true)
-	c.Assert(autoconnectLog, Matches, `.*Waiting for conflicting change in progress...`)
+	c.Assert(autoconnectLog, Matches, `.*Waiting for conflicting change in progress: conflicting snap.*`)
 
 	// back to default state, that will unblock autoconnect
 	ts2.Tasks()[0].SetStatus(state.DefaultStatus)

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -36,8 +36,10 @@ type HandlerFunc func(task *Task, tomb *tomb.Tomb) error
 // is asked to stop through its tomb. After can be used to indicate
 // how much to postpone the retry, 0 (the default) means at the next
 // ensure pass and is what should be used if stopped through its tomb.
+// Reason is an optional explanation of the conflict.
 type Retry struct {
-	After time.Duration
+	After  time.Duration
+	Reason string
 }
 
 func (r *Retry) Error() string {


### PR DESCRIPTION
The change made ~1 month ago made auto-connect conflict with retry on "discard-snap" tasks, I missed however that "discard-snap" tasks are created also as part of refresh to remove inactive revisions (normal garbage collection). The trigger to this issue is to have at least 2 revisions of a snap installed, and making a refresh into a new revision. This was recently seen with 2.36pre2.

This PR fixes that by not conflicting on discard-snap if it affects different revision of a snap. I've also enhanced Retry error type to carry optional reason, and enhanced auto-connect error messages on Retry to give precise reason, making figuring these kind of problems out much easier. The existing debug message we had was not precise and was in fact misleading about true cause; also it required snapd executed with SNAPD_DEBUG=1.

