### PR TITLE
testutil, cmd/snap: introduce and use testutil.EqualsWrapped and fly

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1281,10 +1281,10 @@ func (s *SnapOpSuite) TestTryNoSnapDirErrors(c *check.C) {
 
 	cmd := []string{"try", "/"}
 	_, err := snap.Parser(snap.Client()).ParseArgs(cmd)
-	c.Assert(err, check.ErrorMatches, rewrappingMatcher(`
+	c.Assert(err, testutil.EqualsWrapped, `
 "/" does not contain an unpacked snap.
 
-Try 'snapcraft prime' in your project directory, then 'snap try' again.`))
+Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
 }
 
 func (s *SnapOpSuite) TestTryMissingOpt(c *check.C) {
@@ -1321,9 +1321,7 @@ func (s *SnapOpSuite) TestTryMissingOpt(c *check.C) {
 
 	for _, test := range tests {
 		kind = test.kind
-		rx := rewrappingMatcher(test.expected)
-		err := snap.RunMain()
-		c.Check(err, check.ErrorMatches, rx, check.Commentf("%q", kind))
+		c.Check(snap.RunMain(), testutil.ContainsWrapped, test.expected, check.Commentf("%q", kind))
 	}
 }
 

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -28,7 +28,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -328,14 +327,4 @@ func (s *SnapSuite) TestFirstNonOptionIsRun(c *C) {
 		os.Args = strings.Fields(positive)
 		c.Check(snap.FirstNonOptionIsRun(), Equals, true)
 	}
-}
-
-// rewrappingMatcher takes a string that's expected to be in the output of
-// a command, and turns it into a regexp that survives rewraps
-func rewrappingMatcher(expected string) string {
-	fields := strings.Fields(expected)
-	for i, field := range fields {
-		fields[i] = regexp.QuoteMeta(field)
-	}
-	return "(?s).*" + strings.Join(fields, `\s+`) + ".*"
 }

--- a/testutil/checkers.go
+++ b/testutil/checkers.go
@@ -239,6 +239,125 @@ func (c *deepContainsChecker) Check(params []interface{}, names []string) (resul
 	}
 }
 
+type paddedChecker struct {
+	*check.CheckerInfo
+	isRegexp  bool
+	isPartial bool
+	isLine    bool
+}
+
+// EqualsPadded is a Checker that looks for an expected string to
+// be equal to another except that the other might have been padded
+// out to align with something else (so arbitrary amounts of
+// horizontal whitespace is ok at the ends, and between non-whitespace
+// bits).
+var EqualsPadded = &paddedChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "EqualsPadded", Params: []string{"padded", "expected"}},
+	isLine:      true,
+}
+
+// MatchesPadded is a Checker that looks for an expected regexp in
+// a string that might have been padded out to align with something
+// else (so whitespace in the regexp is changed to [ \t]+, and ^[ \t]*
+// is added to the beginning, and [ \t]*$ to the end of it).
+var MatchesPadded = &paddedChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "MatchesPadded", Params: []string{"padded", "expected"}},
+	isRegexp:    true,
+	isLine:      true,
+}
+
+// ContainsPadded is a Checker that looks for an expected string
+// in another that might have been padded out to align with something
+// else (so arbitrary amounts of horizontal whitespace is ok between
+// non-whitespace bits).
+var ContainsPadded = &paddedChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "ContainsPadded", Params: []string{"padded", "expected"}},
+	isPartial:   true,
+	isLine:      true,
+}
+
+// EqualsWrapped is a Checker that looks for an expected string to be
+// equal to another except that the other might have been padded out
+// and wrapped (so arbitrary amounts of whitespace is ok at the ends,
+// and between non-whitespace bits).
+var EqualsWrapped = &paddedChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "EqualsWrapped", Params: []string{"wrapped", "expected"}},
+}
+
+// MatchesWrapped is a Checker that looks for an expected regexp in a
+// string that might have been padded and wrapped (so whitespace in
+// the regexp is changed to \s+, and (?s)^\s* is added to the
+// beginning, and \s*$ to the end of it).
+var MatchesWrapped = &paddedChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "MatchesWrapped", Params: []string{"wrapped", "expected"}},
+	isRegexp:    true,
+}
+
+// ContainsWrapped is a Checker that looks for an expected string in
+// another that might have been padded out and wrapped (so arbitrary
+// amounts of whitespace is ok between non-whitespace bits).
+var ContainsWrapped = &paddedChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "EqualsWrapped", Params: []string{"wrapped", "expected"}},
+	isRegexp:    false,
+	isPartial:   true,
+}
+
+var spaceinator = regexp.MustCompile(`\s+`).ReplaceAllLiteralString
+
+func (c *paddedChecker) Check(params []interface{}, names []string) (result bool, errstr string) {
+	var other string
+	switch v := params[0].(type) {
+	case string:
+		other = v
+	case []byte:
+		other = string(v)
+	case error:
+		if v != nil {
+			other = v.Error()
+		}
+	default:
+		return false, "left-hand value must be a string or []byte or error"
+	}
+	expected, ok := params[1].(string)
+	if !ok {
+		ebuf, ok := params[1].([]byte)
+		if !ok {
+			return false, "right-hand value must be a string or []byte"
+		}
+		expected = string(ebuf)
+	}
+	ws := `\s`
+	if c.isLine {
+		ws = `[\t ]`
+	}
+	if c.isRegexp {
+		_, err := regexp.Compile(expected)
+		if err != nil {
+			return false, fmt.Sprintf("right-hand value must be a valid regexp: %v", err)
+		}
+		expected = spaceinator(expected, ws+"+")
+	} else {
+		fields := strings.Fields(expected)
+		for i := range fields {
+			fields[i] = regexp.QuoteMeta(fields[i])
+		}
+		expected = strings.Join(fields, ws+"+")
+	}
+	if !c.isPartial {
+		expected = "^" + ws + "*" + expected + ws + "*$"
+	}
+	if !c.isLine {
+		expected = "(?s)" + expected
+	}
+
+	matches, err := regexp.MatchString(expected, other)
+	if err != nil {
+		// can't happen (really)
+		panic(err)
+	}
+	return matches, ""
+}
+
 type syscallsEqualChecker struct {
 	*check.CheckerInfo
 }


### PR DESCRIPTION
This introduces a family of checkers to `testutil`, which are useful
for when you want to check for a string in output that can be wrapped
to fit the terminal, or aligned as part of a table. E.g. if you want
to check for the third line in

```
Name   Version                      Rev   Tracking  Publisher   Notes
bare   1.0                          5     edge      canonical✓  base
black  18.6b4                       1     edge      sergiusens  devmode
core   16-2.36~pre2+git967.54466bd  5780  edge      canonical✓  core
```

then you can use

```go
Check(theLine, EqualsPadded, "black 18.6b4 1 edge sergiusens devmode")
```

Similarily, to check that the output of installing a `devmode` snap
without `--devmode`,

```
error: The publisher of snap "eggg" has indicated that they do not consider this
       revision to be of production quality and that it is only meant for
       development or testing at this point. As a consequence this snap will not
       refresh automatically and may perform arbitrary system changes outside of
       the security sandbox snaps are generally confined to, which may put your
       system at risk.

       If you understand and want to proceed repeat the command including
       --devmode; if instead you want to install the snap forcing it into strict
       confinement repeat the command including --jailmode.
```

if you wanted to check that it says "only meant for development",
which might be on the same line or not depending on terminal width,
you'd simply say

```go
Check(output, ContainsWrapped, "only meant for development")
```

HTH, HAND!

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
