### PR TITLE
snapstate: add command-chain to supported featureset

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -41,6 +41,8 @@ var featureSet = map[string]bool{
 	"common-data-dir": true,
 	// Support for the "Environment:" feature in snap.yaml
 	"snap-env": true,
+	// Support for the "command-chain" feature for apps and hooks in snap.yaml
+	"command-chain": true,
 }
 
 func checkAssumes(si *snap.Info) error {

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -142,6 +142,8 @@ var assumesTests = []struct {
 	assumes: "[snapd2.15.1]",
 	version: "2.15.0",
 	error:   `.* unsupported features: snapd2\.15\.1 .*`,
+}, {
+	assumes: "[command-chain]",
 }}
 
 func (s *checkSnapSuite) TestCheckSnapAssumes(c *C) {


### PR DESCRIPTION
snapd supports the `assumes` property in a snap.yaml, allowing a snap to depend upon a specific snapd release, or specific snapd feature. Add command-chain as one of those features, which allows snaps to specify that they require command-chain in order to work properly.

It would be great to get this into 2.36 since that's the release actually containing command-chain. Of course, even if that doesn't happen, this should still be useful.