### PR TITLE
cmd/snap: tweak `snap services` output when there is no services

### DIFF
--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -125,7 +125,7 @@ func (s *svcStatus) Execute(args []string) error {
 	}
 
 	if len(services) == 0 {
-		fmt.Fprintln(Stderr, i18n.G("There are no snaps installed that provide a service."))
+		fmt.Fprintln(Stderr, i18n.G("There are no services provided by installed snaps."))
 		return nil
 	}
 

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -124,6 +124,11 @@ func (s *svcStatus) Execute(args []string) error {
 		return err
 	}
 
+	if len(services) == 0 {
+		fmt.Fprintln(Stderr, i18n.G("No snaps providing services are installed."))
+		return nil
+	}
+
 	w := tabWriter()
 	defer w.Flush()
 

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -125,7 +125,7 @@ func (s *svcStatus) Execute(args []string) error {
 	}
 
 	if len(services) == 0 {
-		fmt.Fprintln(Stderr, i18n.G("No snaps providing services are installed."))
+		fmt.Fprintln(Stderr, i18n.G("There are no snaps installed that provide a service."))
 		return nil
 	}
 

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -197,7 +197,7 @@ func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "There are no snaps installed that provide a service.\n")
+	c.Check(s.Stderr(), check.Equals, "There are no services provided by installed snaps.\n")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 1)
 }

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -168,4 +169,35 @@ func (s *appOpSuite) TestAppOps(c *check.C) {
 			}
 		}
 	}
+}
+
+func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, check.Equals, "/v2/apps")
+			c.Check(r.URL.Query(), check.HasLen, 1)
+			c.Check(r.URL.Query().Get("select"), check.Equals, "service")
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			enc := json.NewEncoder(w)
+			enc.Encode(map[string]interface{}{
+				"type":        "sync",
+				"result":      []map[string]interface{}{},
+				"status":      "OK",
+				"status-code": 200,
+			})
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+		n++
+	})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"services"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "No snaps providing services are installed.\n")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 1)
 }

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -197,7 +197,7 @@ func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "No snaps providing services are installed.\n")
+	c.Check(s.Stderr(), check.Equals, "There are no snaps installed that provide a service.\n")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 1)
 }


### PR DESCRIPTION
This is the current output when there are no snaps with services:

```
$ snap services
Service  Startup  Current  Notes
```

Try to fix it by printing a more user-friendly message.

Some bits were pulled from #6008 
