### PR TITLE
snap/pack, cmd/snap: allow specifying the filename of 'snap pack'

### DIFF
--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/jessevdk/go-flags"
 
@@ -67,7 +68,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"check-skeleton": i18n.G("Validate snap-dir metadata only"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"filename": i18n.G("Use this filename"),
+			"filename": i18n.G("Output to this filename"),
 		}, nil)
 	cmd.extra = func(cmd *flags.Command) {
 		// TRANSLATORS: this describes the default filename for a snap, e.g. core_16-2.35.2_amd64.snap
@@ -76,6 +77,10 @@ func init() {
 }
 
 func (x *packCmd) Execute([]string) error {
+	if x.Positional.TargetDir != "" && x.Filename != "" && filepath.IsAbs(x.Filename) {
+		return fmt.Errorf(i18n.G("you can't specify an absolute filename while also specifying target dir."))
+	}
+
 	if x.Positional.SnapDir == "" {
 		x.Positional.SnapDir = "."
 	}
@@ -93,9 +98,12 @@ func (x *packCmd) Execute([]string) error {
 
 	snapPath, err := pack.Snap(x.Positional.SnapDir, x.Positional.TargetDir, x.Filename)
 	if err != nil {
-		return fmt.Errorf("cannot pack %q: %v", x.Positional.SnapDir, err)
+		// TRANSLATORS: the %q is the snap-dir (the first positional
+		// argument to the command); the %v is an error
+		return fmt.Errorf(i18n.G("cannot pack %q: %v"), x.Positional.SnapDir, err)
 
 	}
-	fmt.Fprintf(Stdout, "built: %s\n", snapPath)
+	// TRANSLATORS: %s is the path to the built snap file
+	fmt.Fprintf(Stdout, i18n.G("built: %s\n"), snapPath)
 	return nil
 }

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -90,6 +90,7 @@ type cmdInfo struct {
 	optDescs                  map[string]string
 	argDescs                  []argDesc
 	alias                     string
+	extra                     func(*flags.Command)
 }
 
 // commands holds information about all non-debug commands.
@@ -261,6 +262,9 @@ func Parser(cli *client.Client) *flags.Parser {
 			lintArg(c.name, name, desc, arg.Description)
 			arg.Name = name
 			arg.Description = desc
+		}
+		if c.extra != nil {
+			c.extra(cmd)
 		}
 	}
 	// Add the debug command

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -119,9 +119,11 @@ func loadAndValidate(sourceDir string) (*snap.Info, error) {
 	return info, nil
 }
 
-func snapPath(info *snap.Info, targetDir string) string {
-	snapName := fmt.Sprintf("%s_%s_%v.snap", info.InstanceName(), info.Version, debArchitecture(info))
-	if targetDir != "" {
+func snapPath(info *snap.Info, targetDir, snapName string) string {
+	if snapName == "" {
+		snapName = fmt.Sprintf("%s_%s_%v.snap", info.InstanceName(), info.Version, debArchitecture(info))
+	}
+	if targetDir != "" && !filepath.IsAbs(snapName) {
 		snapName = filepath.Join(targetDir, snapName)
 	}
 	return snapName
@@ -167,7 +169,7 @@ func excludesFile() (filename string, err error) {
 
 // Snap the given sourceDirectory and return the generated
 // snap file
-func Snap(sourceDir, targetDir string) (string, error) {
+func Snap(sourceDir, targetDir, snapName string) (string, error) {
 	info, err := prepare(sourceDir, targetDir)
 	if err != nil {
 		return "", err
@@ -179,7 +181,7 @@ func Snap(sourceDir, targetDir string) (string, error) {
 	}
 	defer os.Remove(excludes)
 
-	snapName := snapPath(info, targetDir)
+	snapName = snapPath(info, targetDir, snapName)
 	d := squashfs.New(snapName)
 	if err = d.Build(sourceDir, string(info.Type), excludes); err != nil {
 		return "", err

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -195,7 +195,7 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 
 	err = osutil.ChDir(snapSource, func() error {
 		var err error
-		snapFilePath, err = pack.Snap(snapSource, "")
+		snapFilePath, err = pack.Snap(snapSource, "", "")
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Before this change, 'snap pack' built the snap name from the yaml.
This is fiddly to use in automated tools in some situations; it's
better, there, to be able to inject the expected filename. This adds
that option, while preserving the old behaviour.

Cc @sergiusens.
