### PR TITLE
tests: update parallel-install-store test

### DIFF
--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -18,13 +18,11 @@ execute: |
     su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
     MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/current/data
 
-    # TODO parallel-install: extend the test once we can install more than one
-    # instance of a snap from the store
-    ! snap install test-snapd-tools 2> run.err
-    # exact error message:
-    # error: cannot install "test-snapd-tools": cannot refresh, install, or download: The Snap is present
-    #   more than once in the request.
-    MATCH 'cannot install "test-snapd-tools"' < run.err
+    snap install test-snapd-tools
+    test-snapd-tools.cmd sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
+    MATCH 'hello data from test-snapd-tools_foo' < /var/snap/test-snapd-tools/current/data
+    su -l -c "test-snapd-tools.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
+    MATCH 'hello user data from test-snapd-tools' < /home/test/snap/test-snapd-tools/current/data
 
 restore: |
     snap set system experimental.parallel-instances=


### PR DESCRIPTION
The store supports parallel installs now, this updates the test
to reflect this.

