### PR TITLE
tests/main/parallel-install-store: the store has caught up, do not expect failures

### DIFF
--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -18,13 +18,11 @@ execute: |
     su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
     MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/current/data
 
-    # TODO parallel-install: extend the test once we can install more than one
-    # instance of a snap from the store
-    ! snap install test-snapd-tools 2> run.err
-    # exact error message:
-    # error: cannot install "test-snapd-tools": cannot refresh, install, or download: The Snap is present
-    #   more than once in the request.
-    MATCH 'cannot install "test-snapd-tools"' < run.err
+    echo "Installing another instance, without instance key, succeeds"
+    snap install test-snapd-tools
+
+    echo "And so does another one, but with different instance key"
+    snap install test-snapd-tools_bar
 
 restore: |
     snap set system experimental.parallel-instances=


### PR DESCRIPTION
The store has caught up on support for parallel installs. Do not expect errors
when installing more than one snap from the store anymore.
