### PR TITLE
overlord/standby: fix a race between standby goroutine and stop

### DIFF
--- a/overlord/standby/export_test.go
+++ b/overlord/standby/export_test.go
@@ -20,8 +20,18 @@ package standby
 
 import (
 	"time"
+
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 func (m *StandbyOpinions) SetStartTime(t time.Time) {
 	m.startTime = t
+}
+
+func MockStateRequestRestart(newStateRequestRestart func(*state.State, state.RestartType)) (restore func()) {
+	oldStateRequestRestart := stateRequestRestart
+	stateRequestRestart = newStateRequestRestart
+	return func() {
+		stateRequestRestart = oldStateRequestRestart
+	}
 }

--- a/overlord/standby/standby.go
+++ b/overlord/standby/standby.go
@@ -78,7 +78,8 @@ func New(st *state.State) *StandbyOpinions {
 }
 
 func (m *StandbyOpinions) Start() {
-	m.stopCh = make(chan interface{})
+	stopCh := make(chan interface{})
+	m.stopCh = stopCh
 	go func() {
 		for {
 			m.timerCh = time.NewTimer(m.sleep).C
@@ -90,7 +91,7 @@ func (m *StandbyOpinions) Start() {
 				if m.sleep < 5*time.Minute {
 					m.sleep *= 2
 				}
-			case <-m.stopCh:
+			case <-stopCh:
 				return
 			}
 		}

--- a/overlord/standby/standby_test.go
+++ b/overlord/standby/standby_test.go
@@ -166,7 +166,7 @@ func (s *standbySuite) TestStopWaits(c *C) {
 		if !synced {
 			// synchronize with the main goroutine only at the
 			// beginning
-			opineReady <- struct{}{}
+			close(opineReady)
 			synced = true
 		}
 		select {


### PR DESCRIPTION
When standby.Stop() is called before the goroutine enters the select {} block,
m.stopCh will be nil. Due to short circuit evaluation in select, the stopCh case
will never be evaluated and we will always wait for the timer to expire instead
of exiting right away.

We should probably use tomb and make Stop() wait for the goroutine to exit.
