### PR TITLE
tests/main: fixes for the new shellcheck

### DIFF
--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -27,7 +27,7 @@ execute: |
 
     echo "Given account store credentials are available"
     # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-    if [ ! -z "$SPREAD_STORE_USER" ] && [ ! -z "$SPREAD_STORE_PASSWORD" ] && is_classic_system; then
+    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ] && is_classic_system; then
         echo "And the user has logged in"
         expect -f "$TESTSLIB"/successful_login.exp
 

--- a/tests/main/install-refresh-private/task.yaml
+++ b/tests/main/install-refresh-private/task.yaml
@@ -19,7 +19,7 @@ execute: |
 
     echo "Given account store credentials are available"
     # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-    if [ ! -z "$SPREAD_STORE_USER" ] && [ ! -z "$SPREAD_STORE_PASSWORD" ]; then
+    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ]; then
         echo "And the user has logged in"
         expect -f "$TESTSLIB"/successful_login.exp
 

--- a/tests/main/interfaces-broadcom-asic-control/task.yaml
+++ b/tests/main/interfaces-broadcom-asic-control/task.yaml
@@ -60,7 +60,7 @@ execute: |
         subsystem_device="$(find /sys/devices/pci0000:00/ -name subsystem_device | head -n1)"
 
         for file in "$config" "$vendor" "$device" "$subsystem_vendor" "$subsystem_device"; do
-            if ! [ -z "$file" ]; then
+            if [ -n "$file" ]; then
                 test-snapd-sh.with-broadcom-asic-control-plug -c "cat $file"
             fi
         done

--- a/tests/main/interfaces-joystick/task.yaml
+++ b/tests/main/interfaces-joystick/task.yaml
@@ -49,7 +49,7 @@ execute: |
 
     echo "Then the snap is able to read the supported event reports for the input device"
     capabilities="$(find /sys/devices/ -type d -name capabilities | grep -E "/sys/devices/.*/input[0-9].*/capabilities" | head -n1)"
-    if [ ! -z "$capabilities" ]; then
+    if [ -n "$capabilities" ]; then
         test-snapd-sh.with-joystick-plug -c "ls $capabilities"
     fi
 

--- a/tests/main/interfaces-raw-usb/task.yaml
+++ b/tests/main/interfaces-raw-usb/task.yaml
@@ -32,7 +32,7 @@ execute: |
     echo "And the snap has read access to ACM USB modems and various USB devices"
     for exp in 'c166:*' 'c167:*' 'b180:*' 'c180:*' 'c188:*' 'c189:*' '+usb:*'; do
         file=$(find /run/udev/data/ -name "$exp" | head -1)
-        if ! [ -z "$file" ]; then 
+        if [ -n "$file" ]; then 
             test-snapd-sh.with-raw-usb-plug -c "cat \"$file\""
         fi
     done


### PR DESCRIPTION
We got a fresh shellcheck! It now features a check for needless
negation of -z/-n flags on `test`,
https://github.com/koalaman/shellcheck/wiki/SC2236

QOTD for me, from that page:

> This is a stylistic issue that does not affect correctness. If you
> prefer the original expression, you can't not Ignore it with a
> directive or flag.
