### PR TITLE
cmd/snap-confine: remove stale mount profile along stale namespace

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -454,6 +454,12 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 	if (umount2(mnt_fname, MNT_DETACH | UMOUNT_NOFOLLOW) < 0) {
 		die("cannot discard stale mount namespace %s", mnt_fname);
 	}
+	char fstab_fname[PATH_MAX] = { 0 };
+	sc_must_snprintf(fstab_fname, sizeof fstab_fname,
+			 "%s/snap.%s.fstab", sc_ns_dir, snap_name);
+	if (unlink(fstab_fname) < 0) {
+		die("cannot remove stale mount profile %s", fstab_fname);
+	}
 	debug("stale mount namespace discarded");
 	return EAGAIN;
 }

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -336,6 +336,7 @@
 
     # Allow snap-confine to unmount stale mount namespaces.
     umount /run/snapd/ns/*.mnt,
+    /run/snapd/ns/snap.*.fstab w,
     # Required to correctly unmount bound mount namespace.
     # See LP: #1735459 for details.
     umount /,


### PR DESCRIPTION
When snap-confine attempts to start up and notices that the mount
namespace is stale and can be discarded it does so correctly but it
doesn't remove the .fstab file that has become stale because the mount
namespace was discarded. When snap-update-ns is subsequently used it
thinks that the mount namespace has all the changes applied to it and
then does nothing.

Thanks to Alan Pope for reporting the issue and providing helpful data.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
