### PR TITLE
cmd/snap-seccomp: only look for PTRACE_GETFPX?REGS where available

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -390,14 +390,12 @@ var seccompResolver = map[string]uint64{
 	"NETLINK_INET_DIAG":      C.NETLINK_INET_DIAG, // synonymous with NETLINK_SOCK_DIAG
 
 	// man 2 ptrace (subset)
-	"PTRACE_ATTACH":     syscall.PTRACE_ATTACH,
-	"PTRACE_DETACH":     syscall.PTRACE_DETACH,
-	"PTRACE_GETREGS":    syscall.PTRACE_GETREGS,
-	"PTRACE_GETFPREGS":  syscall.PTRACE_GETFPREGS,
-	"PTRACE_GETFPXREGS": syscall.PTRACE_GETFPXREGS,
-	"PTRACE_GETREGSET":  syscall.PTRACE_GETREGSET,
-	"PTRACE_PEEKDATA":   syscall.PTRACE_PEEKDATA,
-	"PTRACE_CONT":       syscall.PTRACE_CONT,
+	"PTRACE_ATTACH":    syscall.PTRACE_ATTACH,
+	"PTRACE_DETACH":    syscall.PTRACE_DETACH,
+	"PTRACE_GETREGS":   syscall.PTRACE_GETREGS,
+	"PTRACE_GETREGSET": syscall.PTRACE_GETREGSET,
+	"PTRACE_PEEKDATA":  syscall.PTRACE_PEEKDATA,
+	"PTRACE_CONT":      syscall.PTRACE_CONT,
 	// <linux/ptrace.h> and <sys/ptrace.h> have different spellings for PEEKUS{,E}R
 	"PTRACE_PEEKUSR":  syscall.PTRACE_PEEKUSR,
 	"PTRACE_PEEKUSER": syscall.PTRACE_PEEKUSR,
@@ -444,6 +442,9 @@ func (sc *SeccompData) SetArgs(args [6]uint64) {
 
 func readNumber(token string) (uint64, error) {
 	if value, ok := seccompResolver[token]; ok {
+		return value, nil
+	}
+	if value, ok := fpSeccompResolver(token); ok {
 		return value, nil
 	}
 

--- a/cmd/snap-seccomp/ptrace_nofp.go
+++ b/cmd/snap-seccomp/ptrace_nofp.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build arm64 s390x
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+func fpSeccompResolver(token string) (uint64, bool) {
+	return 0, false
+}

--- a/cmd/snap-seccomp/ptrace_withfp.go
+++ b/cmd/snap-seccomp/ptrace_withfp.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build arm ppc64le
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import "syscall"
+
+func fpSeccompResolver(token string) (uint64, bool) {
+	return syscall.PTRACE_GETFPREGS, token == "PTRACE_GETFPREGS"
+}

--- a/cmd/snap-seccomp/ptrace_withfpx.go
+++ b/cmd/snap-seccomp/ptrace_withfpx.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build 386 amd64
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import "syscall"
+
+func fpSeccompResolver(token string) (uint64, bool) {
+	switch token {
+	case "PTRACE_GETFPREGS":
+		return syscall.PTRACE_GETFPREGS, true
+	case "PTRACE_GETFPXREGS":
+		return syscall.PTRACE_GETFPXREGS, true
+	default:
+		return 0, false
+	}
+}

--- a/spread.yaml
+++ b/spread.yaml
@@ -543,6 +543,9 @@ suites:
             . "$TESTSLIB"/pkgdb.sh
             distro_purge_package snapd
             distro_purge_package snapd-xdg-open || true
+    tests/cross/:
+        summary: Cross-compile tests
+        systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
     tests/unit/:
         summary: Suite to run unit tests (non-go and different go runtimes)

--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -1,56 +1,57 @@
 summary: Build Go commands across multiple arches
 
 environment:
-  xDEBARCH/armhf: armhf
-  xGOARCH/armhf: arm
-  xGCC/armhf: gcc-arm-linux-gnueabihf
-  xCC/armhf: arm-linux-gnueabihf-gcc
-  
-  xDEBARCH/arm64: arm64
-  xGOARCH/arm64: arm64
-  xGCC/arm64: gcc-aarch64-linux-gnu
-  xCC/arm64: aarch64-linux-gnu-gcc
-  
-  xDEBARCH/s390x: s390x
-  xGOARCH/s390x: s390x
-  xGCC/s390x: gcc-s390x-linux-gnu
-  xCC/s390x: s390x-linux-gnu-gcc
+    X_DEBARCH/armhf: armhf
+    X_GOARCH/armhf: arm
+    X_GCC/armhf: gcc-arm-linux-gnueabihf
+    X_CC/armhf: arm-linux-gnueabihf-gcc
 
-  xDEBARCH/ppc64el: ppc64el
-  xGOARCH/ppc64el: ppc64le
-  xGCC/ppc64el: gcc-powerpc64le-linux-gnu
-  xCC/ppc64el: powerpc64le-linux-gnu-gcc
+    X_DEBARCH/arm64: arm64
+    X_GOARCH/arm64: arm64
+    X_GCC/arm64: gcc-aarch64-linux-gnu
+    X_CC/arm64: aarch64-linux-gnu-gcc
+
+    X_DEBARCH/s390x: s390x
+    X_GOARCH/s390x: s390x
+    X_GCC/s390x: gcc-s390x-linux-gnu
+    X_CC/s390x: s390x-linux-gnu-gcc
+
+    X_DEBARCH/ppc64el: ppc64el
+    X_GOARCH/ppc64el: ppc64le
+    X_GCC/ppc64el: gcc-powerpc64le-linux-gnu
+    X_CC/ppc64el: powerpc64le-linux-gnu-gcc
 
 restore: |
-  rm -rf /tmp/cross-build
-  dpkg -l | awk "/^ii.*$xDEBARCH/{print \$2}" | xargs apt --yes --quiet -o Dpkg::Progress-Fancy=false autoremove --purge
-  dpkg --remove-architecture "$xDEBARCH"
-  mv /etc/apt/sources.list.orig /etc/apt/sources.list
-  apt --quiet -o Dpkg::Progress-Fancy=false update
+    rm -rf /tmp/cross-build
+    dpkg -l | awk "/^ii.*$X_DEBARCH/{print \$2}" | xargs apt --yes --quiet -o Dpkg::Progress-Fancy=false autoremove --purge
+    dpkg --remove-architecture "$X_DEBARCH"
+    mv /etc/apt/sources.list.orig /etc/apt/sources.list
+    apt --quiet -o Dpkg::Progress-Fancy=false update
 
 prepare: |
-  mkdir -p /tmp/cross-build/src/github.com/snapcore
-  cp -ar "$PROJECT_PATH" /tmp/cross-build/src/github.com/snapcore
-  chown -R test:12345 /tmp/cross-build
+    source /etc/os-release
+    mkdir -p /tmp/cross-build/src/github.com/snapcore
+    cp -ar "$PROJECT_PATH" /tmp/cross-build/src/github.com/snapcore
+    chown -R test:12345 /tmp/cross-build
 
-  mv /etc/apt/sources.list /etc/apt/sources.list.orig
-  cat > /etc/apt/sources.list <<-EOF
-  	deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  xenial           main universe
-  	deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  xenial-updates   main universe
-  	deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  xenial-backports main universe
-  	deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu/ xenial-security  main universe
+    mv /etc/apt/sources.list /etc/apt/sources.list.orig
+    cat > /etc/apt/sources.list <<-EOF
+          deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  $UBUNTU_CODENAME           main universe
+          deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  $UBUNTU_CODENAME-updates   main universe
+          deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  $UBUNTU_CODENAME-backports main universe
+          deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu/ $UBUNTU_CODENAME-security  main universe
 
-  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial           main universe
-  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial-updates   main universe
-  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial-backports main universe
-  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial-security  main universe
-  EOF
-  dpkg --add-architecture "$xDEBARCH"
-  apt --quiet -o Dpkg::Progress-Fancy=false update
-  apt --yes --quiet -o Dpkg::Progress-Fancy=false install "$xGCC" libseccomp-dev:"$xDEBARCH"
+          deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ $UBUNTU_CODENAME           main universe
+          deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ $UBUNTU_CODENAME-updates   main universe
+          deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ $UBUNTU_CODENAME-backports main universe
+          deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ $UBUNTU_CODENAME-security  main universe
+    EOF
+    dpkg --add-architecture "$X_DEBARCH"
+    apt --quiet -o Dpkg::Progress-Fancy=false update
+    apt --yes --quiet -o Dpkg::Progress-Fancy=false install "$X_GCC" libseccomp-dev:"$X_DEBARCH"
 
 execute: |
-  cd /tmp/cross-build/src/github.com/snapcore/snapd
-  for cmd in $( find ./cmd -mindepth 2 -maxdepth 2 -name \*.go -printf "%h\n" | sort -u ); do
-    su -c "GOPATH=/tmp/cross-build CGO_ENABLED=1 GOARCH=$xGOARCH CC=$xCC go build -v -o /dev/null $cmd" test
-  done
+    cd /tmp/cross-build/src/github.com/snapcore/snapd
+    for cmd in $( find ./cmd -mindepth 2 -maxdepth 2 -name \*.go -printf "%h\n" | sort -u ); do
+      su -c "GOPATH=/tmp/cross-build CGO_ENABLED=1 GOARCH=$X_GOARCH CC=$X_CC go build -v -o /dev/null $cmd" test
+    done

--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -1,0 +1,56 @@
+summary: Build Go commands across multiple arches
+
+environment:
+  xDEBARCH/armhf: armhf
+  xGOARCH/armhf: arm
+  xGCC/armhf: gcc-arm-linux-gnueabihf
+  xCC/armhf: arm-linux-gnueabihf-gcc
+  
+  xDEBARCH/arm64: arm64
+  xGOARCH/arm64: arm64
+  xGCC/arm64: gcc-aarch64-linux-gnu
+  xCC/arm64: aarch64-linux-gnu-gcc
+  
+  xDEBARCH/s390x: s390x
+  xGOARCH/s390x: s390x
+  xGCC/s390x: gcc-s390x-linux-gnu
+  xCC/s390x: s390x-linux-gnu-gcc
+
+  xDEBARCH/ppc64el: ppc64el
+  xGOARCH/ppc64el: ppc64le
+  xGCC/ppc64el: gcc-powerpc64le-linux-gnu
+  xCC/ppc64el: powerpc64le-linux-gnu-gcc
+
+restore: |
+  rm -rf /tmp/cross-build
+  dpkg -l | awk "/^ii.*$xDEBARCH/{print \$2}" | xargs apt --yes --quiet -o Dpkg::Progress-Fancy=false autoremove --purge
+  dpkg --remove-architecture "$xDEBARCH"
+  mv /etc/apt/sources.list.orig /etc/apt/sources.list
+  apt --quiet -o Dpkg::Progress-Fancy=false update
+
+prepare: |
+  mkdir -p /tmp/cross-build/src/github.com/snapcore
+  cp -ar "$PROJECT_PATH" /tmp/cross-build/src/github.com/snapcore
+  chown -R test:12345 /tmp/cross-build
+
+  mv /etc/apt/sources.list /etc/apt/sources.list.orig
+  cat > /etc/apt/sources.list <<-EOF
+  	deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  xenial           main universe
+  	deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  xenial-updates   main universe
+  	deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/  xenial-backports main universe
+  	deb [arch=amd64,i386] http://security.ubuntu.com/ubuntu/ xenial-security  main universe
+
+  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial           main universe
+  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial-updates   main universe
+  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial-backports main universe
+  	deb [arch=armhf,arm64,powerpc,ppc64el,s390x] http://ports.ubuntu.com/ xenial-security  main universe
+  EOF
+  dpkg --add-architecture "$xDEBARCH"
+  apt --quiet -o Dpkg::Progress-Fancy=false update
+  apt --yes --quiet -o Dpkg::Progress-Fancy=false install "$xGCC" libseccomp-dev:"$xDEBARCH"
+
+execute: |
+  cd /tmp/cross-build/src/github.com/snapcore/snapd
+  for cmd in $( find ./cmd -mindepth 2 -maxdepth 2 -name \*.go -printf "%h\n" | sort -u ); do
+    su -c "GOPATH=/tmp/cross-build CGO_ENABLED=1 GOARCH=$xGOARCH CC=$xCC go build -v -o /dev/null $cmd" test
+  done


### PR DESCRIPTION
Before this change, building `snap-seccomp` would fail on architectures
other than 386 and amd64 because they didn't have `PTRACE_GETFPXREGS` or
even `PTRACE_GETFPREGS`.

This change makes support for those arch-dependent, and adds a spread
suite that tries to protect us from the same bug happening again
elsewhere.
