### PR TITLE
cmd/snap-confine: remove SC_NS_FAIL_GRACEFULLY

### DIFF
--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -95,7 +95,7 @@ static struct sc_mount_ns *sc_test_open_mount_ns(const char *group_name)
 	if (group_name == NULL) {
 		group_name = "test-group";
 	}
-	group = sc_open_mount_ns(group_name, 0);
+	group = sc_open_mount_ns(group_name);
 	g_test_queue_destroy((GDestroyNotify) sc_close_mount_ns, group);
 	// Check if the returned group data looks okay
 	g_assert_nonnull(group);
@@ -118,15 +118,6 @@ static void test_sc_open_mount_ns(void)
 	// Check that the group directory exists
 	g_assert_true(g_file_test
 		      (ns_dir, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR));
-}
-
-static void test_sc_open_mount_ns_graceful(void)
-{
-	sc_set_ns_dir("/nonexistent");
-	g_test_queue_destroy((GDestroyNotify) sc_set_ns_dir, SC_NS_DIR);
-	struct sc_mount_ns *group =
-	    sc_open_mount_ns("foo", SC_NS_FAIL_GRACEFULLY);
-	g_assert_null(group);
 }
 
 static void unmount_dir(void *dir)
@@ -212,8 +203,6 @@ static void __attribute__ ((constructor)) init(void)
 {
 	g_test_add_func("/ns/sc_alloc_mount_ns", test_sc_alloc_mount_ns);
 	g_test_add_func("/ns/sc_open_mount_ns", test_sc_open_mount_ns);
-	g_test_add_func("/ns/sc_open_mount_ns/graceful",
-			test_sc_open_mount_ns_graceful);
 	g_test_add_func("/ns/nsfs_fs_id", test_nsfs_fs_id);
 	g_test_add_func("/system/ns/sc_is_mount_ns_dir_private",
 			test_sc_is_mount_ns_dir_private);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -206,17 +206,12 @@ static struct sc_mount_ns *sc_alloc_mount_ns(void)
 	return group;
 }
 
-struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
-				     const unsigned flags)
+struct sc_mount_ns *sc_open_mount_ns(const char *group_name)
 {
 	struct sc_mount_ns *group = sc_alloc_mount_ns();
 	group->dir_fd = open(sc_ns_dir,
 			     O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
 	if (group->dir_fd < 0) {
-		if (flags & SC_NS_FAIL_GRACEFULLY && errno == ENOENT) {
-			free(group);
-			return NULL;
-		}
 		die("cannot open directory %s", sc_ns_dir);
 	}
 	group->name = strdup(group_name);

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -61,18 +61,10 @@ void sc_initialize_mount_ns(void);
  */
 struct sc_mount_ns;
 
-enum {
-	SC_NS_FAIL_GRACEFULLY = 1
-};
-
 /**
  * Open a namespace group.
  *
  * This will open and keep file descriptors for /run/snapd/ns/.
- *
- * If the flags argument is SC_NS_FAIL_GRACEFULLY then the function returns
- * NULL if the /run/snapd/ns directory doesn't exist. In all other cases it
- * calls die() and exits the process.
  *
  * The following methods should be called only while holding a lock protecting
  * that specific snap namespace:
@@ -81,8 +73,7 @@ enum {
  * - sc_preserve_populated_mount_ns()
  * - sc_discard_preserved_mount_ns()
  */
-struct sc_mount_ns *sc_open_mount_ns(const char *group_name,
-				     const unsigned flags);
+struct sc_mount_ns *sc_open_mount_ns(const char *group_name);
 
 /**
  * Close namespace group.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 			debug("initializing mount namespace: %s",
 			      snap_instance);
 			struct sc_mount_ns *group = NULL;
-			group = sc_open_mount_ns(snap_instance, 0);
+			group = sc_open_mount_ns(snap_instance);
 			int retval = sc_join_preserved_ns(group, &apparmor,
 							  base_snap_name,
 							  snap_instance);


### PR DESCRIPTION
This flag was only needed by snap-discard-ns code. Since the
re-factoring of snap-discard-ns the flag can be removed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
