### PR TITLE
cmd: remove remnants of sc_should_populate_mount_ns

### DIFF
--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -77,7 +77,6 @@ enum {
  * The following methods should be called only while holding a lock protecting
  * that specific snap namespace:
  * - sc_create_or_join_mount_ns()
- * - sc_should_populate_mount_ns()
  * - sc_preserve_populated_mount_ns()
  * - sc_discard_preserved_mount_ns()
  */
@@ -95,9 +94,7 @@ void sc_close_mount_ns(struct sc_mount_ns *group);
  * Join a preserved mount namespace if one exists.
  *
  * Technically the function opens /run/snapd/ns/${group_name}.mnt and tries to
- * use setns() with the obtained file descriptor. If the call succeeds then the
- * function returns and subsequent call to sc_should_populate_mount_ns() will
- * return false.
+ * use setns() with the obtained file descriptor.
  *
  * If the preserved mount namespace does not exist or exists but is stale and
  * was discarded and returns ESRCH. If the mount namespace was joined the
@@ -106,15 +103,6 @@ void sc_close_mount_ns(struct sc_mount_ns *group);
 int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 			 *apparmor, const char *base_snap_name,
 			 const char *snap_name);
-
-/**
- * Check if the namespace needs to be populated.
- *
- * If the return value is true then at this stage the namespace is already
- * unshared. The caller should perform any mount operations that are desired
- * and then proceed to call sc_preserve_populated_mount_ns().
- **/
-bool sc_should_populate_mount_ns(struct sc_mount_ns *group);
 
 /**
  * Fork off a helper process for mount namespace capture.


### PR DESCRIPTION
In the past snap-confine asked the mount namespace helper if the mount
namespace needs to be initialized. Since the changes to the IPC system
that code was removed but the corresponding header bits remained.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
