### PR TITLE
cmd/snap-exec: don't fail on some try mode snaps

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -157,7 +157,7 @@ func execApp(snapApp, revision, command string, args []string) error {
 	}
 
 	snapName, appName := snap.SplitSnapApp(snapApp)
-	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
+	info, err := snap.ReadInfoExceptSize(snapName, &snap.SideInfo{
 		Revision: rev,
 	})
 	if err != nil {
@@ -227,7 +227,7 @@ func execHook(snapName, revision, hookName string) error {
 		return err
 	}
 
-	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
+	info, err := snap.ReadInfoExceptSize(snapName, &snap.SideInfo{
 		Revision: rev,
 	})
 	if err != nil {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -334,6 +334,19 @@ func (s *infoSuite) TestReadInfoUnfindable(c *C) {
 	c.Check(info, IsNil)
 }
 
+func (s *infoSuite) TestReadInfoExceptSizeUnfindable(c *C) {
+	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
+	p := filepath.Join(snap.MinimalPlaceInfo("sample", si.Revision).MountDir(), "meta", "snap.yaml")
+	c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(p, []byte(`name: test`), 0644), IsNil)
+
+	info, err := snap.ReadInfoExceptSize("sample", si)
+	c.Check(err, IsNil)
+	c.Check(info.SnapName(), Equals, "test")
+	c.Check(info.Revision, Equals, snap.R(42))
+	c.Check(info.Summary(), Equals, "esummary")
+}
+
 // makeTestSnap here can also be used to produce broken snaps (differently from snaptest.MakeTestSnapWithFiles)!
 func makeTestSnap(c *C, snapYaml string) string {
 	var m struct {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -345,6 +345,7 @@ func (s *infoSuite) TestReadInfoExceptSizeUnfindable(c *C) {
 	c.Check(info.SnapName(), Equals, "test")
 	c.Check(info.Revision, Equals, snap.R(42))
 	c.Check(info.Summary(), Equals, "esummary")
+	c.Check(info.Size, Equals, int64(0))
 }
 
 // makeTestSnap here can also be used to produce broken snaps (differently from snaptest.MakeTestSnapWithFiles)!

--- a/tests/regression/lp-1800004/task.yaml
+++ b/tests/regression/lp-1800004/task.yaml
@@ -1,0 +1,11 @@
+summary: Check that snap try can be used for snaps in /tmp 
+
+prepare: |
+    cp -a "$TESTSLIB"/snaps/test-snapd-sh /tmp
+
+restore: |
+    rm -rf /tmp/test-snapd-sh
+
+execute: |
+    ( cd /tmp && snap try test-snapd-sh )
+    test-snapd-sh -c /bin/true


### PR DESCRIPTION
Snaps installed via "snap try" may have a dangling symlink from
/var/lib/snapd/snaps/snap_rev since the source location is unconstrained.  In
the execution environment that path may not exist or may point to unrelated
data, in a malicious case. The snap-exec command used snap.ReadInfo to obtain
information about the application or hook to exec. That function tries to stat
the snap file to compute the size of the snap. Since snap-exec does not need
the size and since this cannot be achieved in the execution environment we
should not attempt that.

This branch adds and uses a new helper that is exactly like ReadInfo but
doesn't compute the size of the snap.

Fixes: https://bugs.launchpad.net/snapd/+bug/1800004
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
