### PR TITLE
cmd/snap-update-ns: parse the -u <uid> command line option

### DIFF
--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -369,12 +369,12 @@ void process_arguments(int argc, char *const *argv, const char **snap_name_out,
 				// called from snap-confine.
 				should_setns = false;
 			} else if (!strcmp(arg, "-u")) {
-				const char *uid_text = argv[i + 1];
-				if (i + 1 == argc || uid_text == NULL) {
+				if (i + 1 == argc || argv[i + 1] == NULL) {
 					bootstrap_msg = "-u requires an argument";
 					bootstrap_errno = 0;
 					return;
 				}
+				const char *uid_text = argv[i + 1];
 				errno = 0;
 				char *uid_text_end = NULL;
 				int parsed_uid = (int)strtol(uid_text, &uid_text_end, 10);

--- a/cmd/snap-update-ns/bootstrap.go
+++ b/cmd/snap-update-ns/bootstrap.go
@@ -114,21 +114,21 @@ func validateInstanceName(instanceName string) int {
 //
 // This function is here only to make the C.validate_instance_name
 // code testable from go.
-func processArguments(args []string) (snapName string, shouldSetNs bool, processUserFstab bool, uid int) {
+func processArguments(args []string) (snapName string, shouldSetNs bool, processUserFstab bool, uid uint) {
 	argv := makeArgv(args)
 	defer freeArgv(argv)
 
 	var snapNameOut *C.char
 	var shouldSetNsOut C.bool
 	var processUserFstabOut C.bool
-	var uidOut C.int
+	var uidOut C.ulong
 	C.process_arguments(C.int(len(args)), &argv[0], &snapNameOut, &shouldSetNsOut, &processUserFstabOut, &uidOut)
 	if snapNameOut != nil {
 		snapName = C.GoString(snapNameOut)
 	}
 	shouldSetNs = bool(shouldSetNsOut)
 	processUserFstab = bool(processUserFstabOut)
-	uid = int(uidOut)
+	uid = uint(uidOut)
 
 	return snapName, shouldSetNs, processUserFstab, uid
 }

--- a/cmd/snap-update-ns/bootstrap.go
+++ b/cmd/snap-update-ns/bootstrap.go
@@ -114,19 +114,21 @@ func validateInstanceName(instanceName string) int {
 //
 // This function is here only to make the C.validate_instance_name
 // code testable from go.
-func processArguments(args []string) (snapName string, shouldSetNs bool, processUserFstab bool) {
+func processArguments(args []string) (snapName string, shouldSetNs bool, processUserFstab bool, uid int) {
 	argv := makeArgv(args)
 	defer freeArgv(argv)
 
 	var snapNameOut *C.char
 	var shouldSetNsOut C.bool
 	var processUserFstabOut C.bool
-	C.process_arguments(C.int(len(args)), &argv[0], &snapNameOut, &shouldSetNsOut, &processUserFstabOut)
+	var uidOut C.int
+	C.process_arguments(C.int(len(args)), &argv[0], &snapNameOut, &shouldSetNsOut, &processUserFstabOut, &uidOut)
 	if snapNameOut != nil {
 		snapName = C.GoString(snapNameOut)
 	}
 	shouldSetNs = bool(shouldSetNsOut)
 	processUserFstab = bool(processUserFstabOut)
+	uid = int(uidOut)
 
-	return snapName, shouldSetNs, processUserFstab
+	return snapName, shouldSetNs, processUserFstab, uid
 }

--- a/cmd/snap-update-ns/bootstrap.h
+++ b/cmd/snap-update-ns/bootstrap.h
@@ -28,7 +28,7 @@ extern const char *bootstrap_msg;
 
 void bootstrap(int argc, char **argv, char **envp);
 void process_arguments(int argc, char *const *argv, const char **snap_name_out,
-		       bool * should_setns_out, bool * process_user_fstab);
+		       bool * should_setns_out, bool * process_user_fstab, int * uid_out);
 int validate_instance_name(const char *instance_name);
 
 #endif

--- a/cmd/snap-update-ns/bootstrap.h
+++ b/cmd/snap-update-ns/bootstrap.h
@@ -28,7 +28,7 @@ extern const char *bootstrap_msg;
 
 void bootstrap(int argc, char **argv, char **envp);
 void process_arguments(int argc, char *const *argv, const char **snap_name_out,
-		       bool * should_setns_out, bool * process_user_fstab, int * uid_out);
+		       bool * should_setns_out, bool * process_user_fstab, unsigned long * uid_out);
 int validate_instance_name(const char *instance_name);
 
 #endif

--- a/cmd/snap-update-ns/bootstrap_test.go
+++ b/cmd/snap-update-ns/bootstrap_test.go
@@ -65,7 +65,7 @@ func (s *bootstrapSuite) TestProcessArguments(c *C) {
 		snapName    string
 		shouldSetNs bool
 		userFstab   bool
-		uid         int
+		uid         uint
 		errPattern  string
 	}{
 		// Corrupted buffer is dealt with.
@@ -100,6 +100,9 @@ func (s *bootstrapSuite) TestProcessArguments(c *C) {
 		{[]string{"argv0", "-u", "", "snapname"}, "", false, false, 0, "cannot parse user id"},
 		{[]string{"argv0", "-u", "1foo", "snapname"}, "", false, false, 0, "cannot parse user id"},
 		{[]string{"argv0", "-u", "0x16", "snapname"}, "", false, false, 0, "cannot parse user id"},
+		{[]string{"argv0", "-u", "42 ", "snapname"}, "", false, false, 0, "cannot parse user id"},
+		{[]string{"argv0", "-u", " 42", "snapname"}, "", false, false, 0, "cannot parse user id"},
+		{[]string{"argv0", "-u", " 42 ", "snapname"}, "", false, false, 0, "cannot parse user id"},
 		{[]string{"argv0", "-u", "-1", "snapname"}, "", false, false, 0, "user id cannot be negative"},
 		{[]string{"argv0", "snapname", "-u"}, "", false, false, 0, "-u requires an argument"},
 		{[]string{"argv0", "snapname", "-u", "1234"}, "snapname", true, true, 1234, ""},


### PR DESCRIPTION
This patch extends the C command line parser to support the -u <uid>
option. The option implies we are being called by snapd to update the
mount namespace of a given user. It implies we should jump to the
appropriate namespace ourselves, use per-user mount profile and perform
our task.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
