### PR TITLE
cmd/snap, daemon, strutil: use CommaSeparatedList to split a CSL

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -523,7 +523,7 @@ func UserFromRequest(st *state.State, req *http.Request) (*auth.UserState, error
 
 	var macaroon string
 	var discharges []string
-	for _, field := range splitQS(authorizationData[1]) {
+	for _, field := range strutil.CommaSeparatedList(authorizationData[1]) {
 		if strings.HasPrefix(field, `root="`) {
 			macaroon = strings.TrimSuffix(field[6:], `"`)
 		}
@@ -823,7 +823,7 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	var wanted map[string]bool
 	if ns := query.Get("snaps"); len(ns) > 0 {
-		nsl := splitQS(ns)
+		nsl := strutil.CommaSeparatedList(ns)
 		wanted = make(map[string]bool, len(nsl))
 		for _, name := range nsl {
 			wanted[name] = true
@@ -1625,24 +1625,11 @@ func appIconGet(c *Command, r *http.Request, user *auth.UserState) Response {
 	return iconGet(c.d.overlord.State(), name)
 }
 
-func splitQS(qs string) []string {
-	qsl := strings.Split(qs, ",")
-	split := make([]string, 0, len(qsl))
-	for _, elem := range qsl {
-		elem = strings.TrimSpace(elem)
-		if len(elem) > 0 {
-			split = append(split, elem)
-		}
-	}
-
-	return split
-}
-
 func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	snapName := configstate.RemapSnapFromRequest(vars["name"])
 
-	keys := splitQS(r.URL.Query().Get("keys"))
+	keys := strutil.CommaSeparatedList(r.URL.Query().Get("keys"))
 
 	s := c.d.overlord.State()
 	s.Lock()
@@ -2804,7 +2791,7 @@ func getAppsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("invalid select parameter: %q", sel)
 	}
 
-	appInfos, rsp := appInfosFor(c.d.overlord.State(), splitQS(query.Get("names")), opts)
+	appInfos, rsp := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
 	if rsp != nil {
 		return rsp
 	}
@@ -2833,7 +2820,7 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	// only services have logs for now
 	opts := appInfoOptions{service: true}
-	appInfos, rsp := appInfosFor(c.d.overlord.State(), splitQS(query.Get("names")), opts)
+	appInfos, rsp := appInfosFor(c.d.overlord.State(), strutil.CommaSeparatedList(query.Get("names")), opts)
 	if rsp != nil {
 		return rsp
 	}

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -54,7 +54,7 @@ func listSnapshots(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	}
 
-	sets, err := snapshotList(context.TODO(), setID, splitQS(r.URL.Query().Get("snaps")))
+	sets, err := snapshotList(context.TODO(), setID, strutil.CommaSeparatedList(r.URL.Query().Get("snaps")))
 	if err != nil {
 		return InternalError("%v", err)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6680,14 +6680,6 @@ func (s *apiSuite) TestInstallPathUnaliased(c *check.C) {
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
 }
 
-func (s *apiSuite) TestSplitQS(c *check.C) {
-	c.Check(splitQS("foo,bar"), check.DeepEquals, []string{"foo", "bar"})
-	c.Check(splitQS("foo , bar"), check.DeepEquals, []string{"foo", "bar"})
-	c.Check(splitQS("foo ,, bar"), check.DeepEquals, []string{"foo", "bar"})
-	c.Check(splitQS(""), check.HasLen, 0)
-	c.Check(splitQS(","), check.HasLen, 0)
-}
-
 func (s *apiSuite) TestSnapctlGetNoUID(c *check.C) {
 	buf := bytes.NewBufferString(`{"context-id": "some-context", "args": ["get", "something"]}`)
 	req, err := http.NewRequest("POST", "/v2/snapctl", buf)

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -166,3 +166,19 @@ func ParseByteSize(inp string) (int64, error) {
 
 	return val * mul, nil
 }
+
+// CommaSeparatedList takes a comman-separated series of identifiers,
+// and returns a slice of the space-trimmed identifiers, without empty
+// entries.
+// So " foo ,, bar,baz" -> {"foo", "bar", "baz"}
+func CommaSeparatedList(str string) []string {
+	fields := strings.FieldsFunc(str, func(r rune) bool { return r == ',' })
+	filtered := fields[:0]
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			filtered = append(filtered, field)
+		}
+	}
+	return filtered
+}

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -181,3 +181,21 @@ func (ts *strutilSuite) TestParseByteSizeUnhappy(c *check.C) {
 		c.Check(err, check.ErrorMatches, t.errStr, check.Commentf("incorrect error for %q", t.str))
 	}
 }
+
+func (strutilSuite) TestCommaSeparatedList(c *check.C) {
+	table := []struct {
+		in  string
+		out []string
+	}{
+		{"", []string{}},
+		{",", []string{}},
+		{"foo,bar", []string{"foo", "bar"}},
+		{"foo , bar", []string{"foo", "bar"}},
+		{"foo ,, bar", []string{"foo", "bar"}},
+		{" foo ,, bar,baz", []string{"foo", "bar", "baz"}},
+	}
+
+	for _, test := range table {
+		c.Check(strutil.CommaSeparatedList(test.in), check.DeepEquals, test.out, check.Commentf("%q", test.in))
+	}
+}


### PR DESCRIPTION
Before this change, `daemon.splitQS` was a private helper that turned
a comma-separated list into a list of strings. Also, cmd/snap's
cmd_snapshot used a simple (and error-prone) strings.Split for the
same purpose.

This change moves `daemon.splitQS` to `strutil.CommaSeparatedList`,
and changes daemon and cmd_snapshot to use it. It also tweaks the
implementation to use strings.FieldsFunc instead of strings.Split,
which has some nice properties.
