### PR TITLE
 cmd/snap, userd, testutil: tweak DBus tests to use private session bus connection (2.36)

### DIFF
--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -60,24 +60,39 @@ func (s *userdSuite) TestUserdBadCommandline(c *C) {
 	c.Assert(err, ErrorMatches, "too many arguments for command")
 }
 
-func (s *userdSuite) TestUserd(c *C) {
+func (s *userdSuite) TestUserdDBus(c *C) {
 	go func() {
+		myPid := os.Getpid()
 		defer func() {
-			me, err := os.FindProcess(os.Getpid())
+			me, err := os.FindProcess(myPid)
 			c.Assert(err, IsNil)
 			me.Signal(syscall.SIGUSR1)
 		}()
 
-		needle := "io.snapcraft.Launcher"
+		names := map[string]bool{
+			"io.snapcraft.Launcher": false,
+			"io.snapcraft.Settings": false,
+		}
 		for i := 0; i < 1000; i++ {
-			for _, objName := range s.SessionBus.Names() {
-				if objName == needle {
-					return
+			seenCount := 0
+			for name, seen := range names {
+				if seen {
+					seenCount++
+					continue
 				}
+				pid, err := testutil.DBusGetConnectionUnixProcessID(s.SessionBus, name)
+				c.Logf("name: %v pid: %v err: %v", name, pid, err)
+				if pid == myPid {
+					names[name] = true
+					seenCount++
+				}
+			}
+			if seenCount == len(names) {
+				return
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
-		c.Fatalf("%s has not appeared on the bus", needle)
+		c.Fatalf("not all names have appeared on the bus: %v", names)
 	}()
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd"})

--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -30,6 +30,24 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+func dbusSessionBus() (*dbus.Conn, error) {
+	// the test suite *must* use a private connection to the bus to avoid
+	// breaking things for code that might use a shared connection
+	conn, err := dbus.SessionBusPrivate()
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.Auth(nil); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := conn.Hello(); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
 // DBusTest provides a separate dbus session bus for running tests
 type DBusTest struct {
 	tmpdir           string
@@ -63,11 +81,15 @@ func (s *DBusTest) SetUpSuite(c *C) {
 	s.oldSessionBusEnv = os.Getenv("DBUS_SESSION_BUS_ADDRESS")
 	os.Setenv("DBUS_SESSION_BUS_ADDRESS", scanner.Text())
 
-	s.SessionBus, err = dbus.SessionBus()
+	s.SessionBus, err = dbusSessionBus()
 	c.Assert(err, IsNil)
 }
 
 func (s *DBusTest) TearDownSuite(c *C) {
+	if s.SessionBus != nil {
+		s.SessionBus.Close()
+	}
+
 	os.Setenv("DBUS_SESSION_BUS_ADDRESS", s.oldSessionBusEnv)
 	if s.dbusDaemon != nil && s.dbusDaemon.Process != nil {
 		err := s.dbusDaemon.Process.Kill()
@@ -75,8 +97,14 @@ func (s *DBusTest) TearDownSuite(c *C) {
 		err = s.dbusDaemon.Wait() // do cleanup
 		c.Assert(err, ErrorMatches, `(?i)signal: killed`)
 	}
-
 }
 
 func (s *DBusTest) SetUpTest(c *C)    {}
 func (s *DBusTest) TearDownTest(c *C) {}
+
+func DBusGetConnectionUnixProcessID(conn *dbus.Conn, name string) (pid int, err error) {
+	obj := conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+
+	err = obj.Call("org.freedesktop.DBus.GetConnectionUnixProcessID", 0, name).Store(&pid)
+	return pid, err
+}

--- a/userd/userd.go
+++ b/userd/userd.go
@@ -41,10 +41,28 @@ type Userd struct {
 	dbusIfaces []dbusInterface
 }
 
+func dbusSessionBus() (*dbus.Conn, error) {
+	// use a private connection to the session bus, this way we can manage
+	// its lifetime without worrying of breaking other code
+	conn, err := dbus.SessionBusPrivate()
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.Auth(nil); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := conn.Hello(); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
 func (ud *Userd) Init() error {
 	var err error
 
-	ud.conn, err = dbus.SessionBus()
+	ud.conn, err = dbusSessionBus()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Port of 2.36 of https://github.com/snapcore/snapd/pull/6049
