### PR TITLE
[RFC] snap-exec: add comment about usage of ReadInfoExceptSize()

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -157,6 +157,8 @@ func execApp(snapApp, revision, command string, args []string) error {
 	}
 
 	snapName, appName := snap.SplitSnapApp(snapApp)
+	// Use ReadInfoExceptSize because snap maybe in try mode with a
+	// dangling symlink, c.f. https://github.com/snapcore/snapd/pull/6048
 	info, err := snap.ReadInfoExceptSize(snapName, &snap.SideInfo{
 		Revision: rev,
 	})
@@ -227,6 +229,8 @@ func execHook(snapName, revision, hookName string) error {
 		return err
 	}
 
+	// Use ReadInfoExceptSize because snap maybe in try mode with a
+	// dangling symlink, c.f. https://github.com/snapcore/snapd/pull/6048
 	info, err := snap.ReadInfoExceptSize(snapName, &snap.SideInfo{
 		Revision: rev,
 	})


### PR DESCRIPTION
In https://github.com/snapcore/snapd/pull/6048 we added
ReadInfoExceptSize(). This PR adds a small comment in the
code about why its used instead of the regular ReadInfo().

Note sure if we *really* need it, just thought it would be nice when
reading the original PR.