### PR TITLE
snap: use Lstat to determine snap size, remove ReadSnapInfoExceptSize

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -157,7 +157,7 @@ func execApp(snapApp, revision, command string, args []string) error {
 	}
 
 	snapName, appName := snap.SplitSnapApp(snapApp)
-	info, err := snap.ReadInfoExceptSize(snapName, &snap.SideInfo{
+	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
 		Revision: rev,
 	})
 	if err != nil {
@@ -227,7 +227,7 @@ func execHook(snapName, revision, hookName string) error {
 		return err
 	}
 
-	info, err := snap.ReadInfoExceptSize(snapName, &snap.SideInfo{
+	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
 		Revision: rev,
 	})
 	if err != nil {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -334,13 +334,16 @@ func (s *infoSuite) TestReadInfoUnfindable(c *C) {
 	c.Check(info, IsNil)
 }
 
-func (s *infoSuite) TestReadInfoExceptSizeUnfindable(c *C) {
+func (s *infoSuite) TestReadInfoDanglingSymlink(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
-	p := filepath.Join(snap.MinimalPlaceInfo("sample", si.Revision).MountDir(), "meta", "snap.yaml")
+	mpi := snap.MinimalPlaceInfo("sample", si.Revision)
+	p := filepath.Join(mpi.MountDir(), "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(p, []byte(`name: test`), 0644), IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(mpi.MountFile()), 0755), IsNil)
+	c.Assert(os.Symlink("/dangling", mpi.MountFile()), IsNil)
 
-	info, err := snap.ReadInfoExceptSize("sample", si)
+	info, err := snap.ReadInfo("sample", si)
 	c.Check(err, IsNil)
 	c.Check(info.SnapName(), Equals, "test")
 	c.Check(info.Revision, Equals, snap.R(42))

--- a/tests/regression/lp-1764977/task.yaml
+++ b/tests/regression/lp-1764977/task.yaml
@@ -20,11 +20,11 @@ execute: |
     snap try test-snapd-sh
 
     snap list | MATCH test-snapd-sh
-    mv test-snapd-sh test-snapd-sh.moved
+    mv test-snapd-sh/meta/snap.yaml test-snapd-sh/meta/snap.yaml.moved
     snap list # should not break
     snap list test-snapd-sh | MATCH broken
 
-    mv test-snapd-sh.moved test-snapd-sh
+    mv test-snapd-sh/meta/snap.yaml.moved test-snapd-sh/meta/snap.yaml
     snap list # should still just work
     snap list test-snapd-sh | MATCH -v broken
 


### PR DESCRIPTION
Since we can os.Lstat any symlink safely we can determine that it is
actually a symbolic link and then decide not to follow it or use any
information about it.

This simplifies the API, keeping the fix to LP: #1800004 fixed.
Thanks to Chipaca for the idea.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
