### PR TITLE
overlord/snapshotstate/backend: be more verbose when SNAPPY_TESTING=1

### DIFF
--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -32,6 +32,14 @@ var (
 	PickUserWrapper = pickUserWrapper
 )
 
+func MockIsTesting(newIsTesting bool) func() {
+	oldIsTesting := isTesting
+	isTesting = newIsTesting
+	return func() {
+		isTesting = oldIsTesting
+	}
+}
+
 func MockUserLookupId(newLookupId func(string) (*user.User, error)) func() {
 	oldLookupId := userLookupId
 	userLookupId = newLookupId

--- a/overlord/snapshotstate/backend/reader.go
+++ b/overlord/snapshotstate/backend/reader.go
@@ -309,11 +309,20 @@ func (r *Reader) Restore(ctx context.Context, current snap.Revision, usernames [
 			"--directory", tempdir)
 		cmd.Env = []string{}
 		cmd.Stdin = tr
-		cmd.Stderr = os.Stderr
+		matchCounter := &strutil.MatchCounter{N: 1}
+		cmd.Stderr = matchCounter
 		cmd.Stdout = os.Stderr
+		if isTesting {
+			matchCounter.N = -1
+			cmd.Stderr = io.MultiWriter(os.Stderr, matchCounter)
+		}
 
 		if err = osutil.RunWithContext(ctx, cmd); err != nil {
-			return rs, err
+			matches, count := matchCounter.Matches()
+			if count > 0 {
+				return rs, fmt.Errorf("cannot unpack archive: %s (and %d more)", matches[0], count-1)
+			}
+			return rs, fmt.Errorf("tar failed: %v", err)
 		}
 
 		if sz.size != expectedSize {

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -1115,7 +1115,7 @@ func (snapshotSuite) TestRestoreIntegrationFails(c *check.C) {
 			// finished and needed to be undone (UndoneStatus); it's
 			// a race, but either is fine.
 			if task.Status() == state.ErrorStatus {
-				c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR context canceled`)
+				c.Check(strings.Join(task.Log(), "\n"), check.Matches, `\S+ ERROR.* context canceled`)
 			} else {
 				c.Check(task.Status(), check.Equals, state.UndoneStatus)
 			}


### PR DESCRIPTION
We've seen some very weird errors from tests/main/snapshot*
occasionally pop up in spread, with tar failing with weird
errors. This change makes tar's stderr reach stderr, so we can see the
error itself.

It also makes the reader and writer errors more similar.