### PR TITLE
tests: fail if install_snap_local fails

### DIFF
--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -8,7 +8,7 @@ make_snap() {
     # assigned in a separate step to avoid hiding a failure
     SNAP_DIR="$(dirname "$SNAP_FILE")"
     if [ ! -f "$SNAP_FILE" ]; then
-        snap pack "$SNAP_DIR" "$SNAP_DIR" >/dev/null
+        snap pack "$SNAP_DIR" "$SNAP_DIR" >/dev/null || return 1
     fi
     # echo the snap name
     if [ -f "$SNAP_FILE" ]; then


### PR DESCRIPTION
While hacking a new test I forgot to add the version field. The snap
failed to install but the make_snap helper used internally happily
passed. This patch fixes this.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
