### PR TITLE
store: also make snaps downloaded via deltas 0600

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1654,6 +1654,10 @@ var applyDelta = func(name string, deltaPath string, deltaInfo *snap.DeltaInfo, 
 		return err
 	}
 
+	if err := os.Chmod(partialTargetPath, 0600); err != nil {
+		return err
+	}
+
 	bsha3_384, _, err := osutil.FileDigest(partialTargetPath, crypto.SHA3_384)
 	if err != nil {
 		return err

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1024,7 +1024,9 @@ func (s *storeTestSuite) TestApplyDelta(c *C) {
 				{"xdelta3", "-d", "-s", currentSnapPath, deltaPath, targetSnapPath + ".partial"},
 			})
 			c.Assert(osutil.FileExists(targetSnapPath+".partial"), Equals, false)
-			c.Assert(osutil.FileExists(targetSnapPath), Equals, true)
+			st, err := os.Stat(targetSnapPath)
+			c.Assert(err, IsNil)
+			c.Check(st.Mode(), Equals, os.FileMode(0600))
 			c.Assert(os.Remove(targetSnapPath), IsNil)
 		} else {
 			c.Assert(err, NotNil)


### PR DESCRIPTION
Before this change, snaps that are recreated from a delta download
would end up with 0644. This fixes that.

Thanks to @sergiocazzolato for spotting the bug.
