### PR TITLE
many: move regexp.(Must)Compile out of non-init functions into variables

### DIFF
--- a/asserts/user.go
+++ b/asserts/user.go
@@ -158,6 +158,9 @@ func parseShadowLine(line string) (*shadow, error) {
 	}, nil
 }
 
+// see crypt(3) for the legal chars
+var isValidSaltAndHash = regexp.MustCompile(`^[a-zA-Z0-9./]+$`).MatchString
+
 func checkHashedPassword(headers map[string]interface{}, name string) (string, error) {
 	pw, err := checkOptionalString(headers, name)
 	if err != nil {
@@ -197,12 +200,10 @@ func checkHashedPassword(headers map[string]interface{}, name string) (string, e
 		}
 	}
 
-	// see crypt(3) for the legal chars
-	validSaltAndHash := regexp.MustCompile(`^[a-zA-Z0-9./]+$`)
-	if !validSaltAndHash.MatchString(shd.Salt) {
+	if !isValidSaltAndHash(shd.Salt) {
 		return "", fmt.Errorf("%q header has invalid chars in salt %q", name, shd.Salt)
 	}
-	if !validSaltAndHash.MatchString(shd.Hash) {
+	if !isValidSaltAndHash(shd.Hash) {
 		return "", fmt.Errorf("%q header has invalid chars in hash %q", name, shd.Hash)
 	}
 

--- a/client/icons.go
+++ b/client/icons.go
@@ -31,6 +31,8 @@ type Icon struct {
 	Content  []byte
 }
 
+var contentDispositionMatcher = regexp.MustCompile(`attachment; filename=(.+)`).FindStringSubmatch
+
 // Icon returns the Icon belonging to an installed snap
 func (c *Client) Icon(pkgID string) (*Icon, error) {
 	const errPrefix = "cannot retrieve icon"
@@ -45,8 +47,7 @@ func (c *Client) Icon(pkgID string) (*Icon, error) {
 		return nil, fmt.Errorf("%s: Not Found", errPrefix)
 	}
 
-	re := regexp.MustCompile(`attachment; filename=(.+)`)
-	matches := re.FindStringSubmatch(response.Header.Get("Content-Disposition"))
+	matches := contentDispositionMatcher(response.Header.Get("Content-Disposition"))
 
 	if matches == nil || matches[1] == "" {
 		return nil, fmt.Errorf("%s: cannot determine filename", errPrefix)

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -220,6 +220,12 @@ func (iface *dbusInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
+// snapd has AppArmor rules (see above) allowing binds to busName-PID
+// so to avoid overlap with different snaps (eg, busName running as PID
+// 123 and busName-123), don't allow busName to end with -PID. If that
+// rule is removed, this limitation can be lifted.
+var isInvalidSnappyBusName = regexp.MustCompile("-[0-9]+$").MatchString
+
 // Obtain yaml-specified bus well-known name
 func (iface *dbusInterface) getAttribs(attribs interfaces.Attrer) (string, string, error) {
 	// bus attribute
@@ -243,12 +249,7 @@ func (iface *dbusInterface) getAttribs(attribs interfaces.Attrer) (string, strin
 		return "", "", err
 	}
 
-	// snapd has AppArmor rules (see above) allowing binds to busName-PID
-	// so to avoid overlap with different snaps (eg, busName running as PID
-	// 123 and busName-123), don't allow busName to end with -PID. If that
-	// rule is removed, this limitation can be lifted.
-	invalidSnappyBusName := regexp.MustCompile("-[0-9]+$")
-	if invalidSnappyBusName.MatchString(name) {
+	if isInvalidSnappyBusName(name) {
 		return "", "", fmt.Errorf("DBus bus name must not end with -NUMBER")
 	}
 

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -196,6 +196,8 @@ func (iface *mprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 	return nil
 }
 
+var isValidDBusElement = regexp.MustCompile("^[a-zA-Z0-9_-]*$").MatchString
+
 func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, error) {
 	// default to snap instance name if 'name' attribute not set
 	// parallel-installs: snaps utilizing the mpris interface must adjust
@@ -215,8 +217,7 @@ func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, er
 			return "", fmt.Errorf("name element %v is not a string", raw)
 		}
 
-		validDBusElement := regexp.MustCompile("^[a-zA-Z0-9_-]*$")
-		if !validDBusElement.MatchString(name) {
+		if !isValidDBusElement(name) {
 			return "", fmt.Errorf("invalid name element: %q", name)
 		}
 		mprisName = name

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -216,6 +216,8 @@ const (
 	SecuritySystemd SecuritySystem = "systemd"
 )
 
+var isValidBusName = regexp.MustCompile(`^[a-zA-Z_-][a-zA-Z0-9_-]*(\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$`).MatchString
+
 // ValidateDBusBusName checks if a string conforms to
 // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
 func ValidateDBusBusName(busName string) error {
@@ -225,8 +227,7 @@ func ValidateDBusBusName(busName string) error {
 		return fmt.Errorf("DBus bus name is too long (must be <= 255)")
 	}
 
-	validBusName := regexp.MustCompile("^[a-zA-Z_-][a-zA-Z0-9_-]*(\\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$")
-	if !validBusName.MatchString(busName) {
+	if !isValidBusName(busName) {
 		return fmt.Errorf("invalid DBus bus name: %q", busName)
 	}
 	return nil

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -50,16 +50,17 @@ type AddUserOptions struct {
 	ForcePasswordChange bool
 }
 
+// we check the (user)name ourselves, adduser is a bit too
+// strict (i.e. no `.`) - this regexp is in sync with that SSO
+// allows as valid usernames
+var isValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9+.-_]*$`).MatchString
+
 func AddUser(name string, opts *AddUserOptions) error {
 	if opts == nil {
 		opts = &AddUserOptions{}
 	}
 
-	// we check the (user)name ourselves, adduser is a bit too
-	// strict (i.e. no `.`) - this regexp is in sync with that SSO
-	// allows as valid usernames
-	validNames := regexp.MustCompile(`^[a-z0-9][-a-z0-9+.-_]*$`)
-	if !validNames.MatchString(name) {
+	if !isValidUsername(name) {
 		return fmt.Errorf("cannot add user %q: name contains invalid characters", name)
 	}
 

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -116,9 +116,11 @@ type unsquashfsStderrWriter struct {
 	strutil.MatchCounter
 }
 
+var unsquashfsStderrRegexp = regexp.MustCompile(`(?m).*\b[Ff]ailed\b.*`)
+
 func newUnsquashfsStderrWriter() *unsquashfsStderrWriter {
 	return &unsquashfsStderrWriter{strutil.MatchCounter{
-		Regexp: regexp.MustCompile(`(?m).*\b[Ff]ailed\b.*`),
+		Regexp: unsquashfsStderrRegexp,
 		N:      4, // note Err below uses this value
 	}}
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -591,12 +591,11 @@ func validateAppRestart(app *AppInfo) error {
 // command-chain, which also doesn't allow whitespace.
 var appContentWhitelist = regexp.MustCompile(`^[A-Za-z0-9/. _#:$-]*$`)
 var commandChainContentWhitelist = regexp.MustCompile(`^[A-Za-z0-9/._#:$-]*$`)
+var validAppName = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$").MatchString
 
 // ValidAppName tells whether a string is a valid application name.
 func ValidAppName(n string) bool {
-	var validAppName = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
-
-	return validAppName.MatchString(n)
+	return validAppName(n)
 }
 
 // ValidateApp verifies the content in the app info.


### PR DESCRIPTION
Several regexp compilations had snuck in. This fixes that.
