### PR TITLE
cmd: make coreSupportsReExec faster

### DIFF
--- a/cmd/cmd_linux_test.go
+++ b/cmd/cmd_linux_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+const dataOK = `one line
+another line
+yadda yadda
+VERSION=42
+potatoes
+`
+
+const dataNOK = `a line
+another
+this is a very long line
+that wasn't long what are you talking about long lines are like, so long you need to add things like commas to them for them to even make sense
+a short one
+and another
+what is this
+why
+no
+stop
+`
+
+const dataHuge = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Quisque euismod ac elit ac auctor.
+Proin malesuada diam ac tellus maximus aliquam.
+Aenean tincidunt mi et tortor bibendum fringilla.
+Phasellus finibus, urna id convallis vestibulum, metus metus venenatis massa, et efficitur nisi elit in massa.
+Mauris at nisl leo.
+Nulla ullamcorper risus venenatis massa venenatis, ac finibus lacus aliquam.
+Nunc tempor convallis cursus.
+Maecenas id rhoncus orci, eget pretium eros.
+
+Donec et consectetur lacus.
+Nam nec mattis elit, id sollicitudin magna.
+Aenean sit amet diam vitae tellus finibus tristique.
+Duis et pharetra tortor, id pharetra erat.
+Suspendisse commodo venenatis blandit.
+Morbi tellus est, iaculis et tincidunt nec, semper ut ipsum.
+Mauris quis condimentum risus.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Mauris gravida turpis ut urna laoreet, sit amet tempor odio porttitor.
+
+Aliquam nibh libero, venenatis ac vehicula at, blandit id odio.
+Etiam malesuada consectetur porta.
+Fusce consectetur ligula et metus interdum sollicitudin.
+Pellentesque odio neque, pharetra et gravida non, vestibulum nec lorem.
+Sed condimentum velit ex, sit amet viverra lectus aliquet quis.
+Aliquam tincidunt eu elit at condimentum.
+Donec feugiat urna tortor, pellentesque tincidunt quam congue eu.
+
+Phasellus vel libero molestie, semper erat at, suscipit nisi.
+Nullam euismod neque ut turpis molestie, eu fringilla elit volutpat.
+Phasellus maximus, urna eget porta congue, diam enim volutpat diam, nec ultrices lorem risus ac metus.
+Vivamus convallis eros non nunc pretium bibendum.
+Maecenas consectetur metus metus.
+Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+Morbi scelerisque urna at arcu tristique feugiat.
+Vestibulum condimentum odio sed tortor vulputate, eget hendrerit mi consequat.
+Integer egestas finibus augue, ac scelerisque ex pretium aliquam.
+Aliquam erat volutpat.
+Suspendisse a nulla ultrices, porttitor tellus ut, bibendum diam.
+Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+In nibh dui, tempus eget vestibulum in, euismod in ex.
+In tempus felis lectus.
+
+Maecenas suscipit turpis eget velit molestie, quis luctus nibh placerat.
+Nulla semper eleifend nisi ut dignissim.
+Donec eu massa maximus, blandit massa ac, lobortis risus.
+Donec id condimentum libero, vel fringilla diam.
+Praesent ultrices, ante congue sollicitudin sagittis, orci ex maximus ipsum, at convallis nunc nisl nec lorem.
+Duis iaculis finibus fermentum.
+Curabitur quis pharetra metus.
+Donec nisl ipsum, faucibus vitae odio sed, mattis feugiat nisl.
+Pellentesque nec justo in magna volutpat accumsan.
+Pellentesque porttitor justo non velit porta rhoncus.
+Nulla ut lectus quis lectus rutrum dignissim.
+Pellentesque posuere sagittis felis, quis varius purus pharetra eu.
+Nam blandit diam ullamcorper, auctor massa at, aliquet dui.
+Aliquam erat volutpat.
+Nullam sit amet augue nec diam sollicitudin ullamcorper a vitae neque.
+VERSION=42
+`
+
+func benchmarkCSRE(b *testing.B, data string) {
+	tempdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		b.Fatalf("tempdir: %v", err)
+	}
+	defer os.RemoveAll(tempdir)
+	if err = os.MkdirAll(filepath.Join(tempdir, dirs.CoreLibExecDir), 0755); err != nil {
+		b.Fatalf("mkdirall: %v", err)
+	}
+
+	if err = ioutil.WriteFile(filepath.Join(tempdir, dirs.CoreLibExecDir, "info"), []byte(data), 0600); err != nil {
+		b.Fatalf("%v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		coreSupportsReExec(tempdir)
+	}
+}
+
+func BenchmarkCSRE_fakeOK(b *testing.B)   { benchmarkCSRE(b, dataOK) }
+func BenchmarkCSRE_fakeNOK(b *testing.B)  { benchmarkCSRE(b, dataNOK) }
+func BenchmarkCSRE_fakeHuge(b *testing.B) { benchmarkCSRE(b, dataHuge) }
+
+func BenchmarkCSRE_real(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		coreSupportsReExec("/snap/core/current")
+	}
+}

--- a/cmd/cmd_linux_test.go
+++ b/cmd/cmd_linux_test.go
@@ -61,13 +61,11 @@ Nullam euismod neque ut turpis molestie, eu fringilla elit volutpat.
 Phasellus maximus, urna eget porta congue, diam enim volutpat diam, nec ultrices lorem risus ac metus.
 Vivamus convallis eros non nunc pretium bibendum.
 Maecenas consectetur metus metus.
-Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
 Morbi scelerisque urna at arcu tristique feugiat.
 Vestibulum condimentum odio sed tortor vulputate, eget hendrerit mi consequat.
 Integer egestas finibus augue, ac scelerisque ex pretium aliquam.
 Aliquam erat volutpat.
 Suspendisse a nulla ultrices, porttitor tellus ut, bibendum diam.
-Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
 In nibh dui, tempus eget vestibulum in, euismod in ex.
 In tempus felis lectus.
 

--- a/strutil/version.go
+++ b/strutil/version.go
@@ -63,6 +63,7 @@ func trimLeadingZeroes(a string) string {
 	return ""
 }
 
+// a and b both match /[0-9]+/
 func cmpNumeric(a, b string) int {
 	a = trimLeadingZeroes(a)
 	b = trimLeadingZeroes(b)
@@ -91,7 +92,7 @@ func matchEpoch(a string) bool {
 	if a[0] < '0' || a[0] > '9' {
 		return false
 	}
-	i := 0
+	var i int
 	for i = 1; i < len(a) && a[i] >= '0' && a[i] <= '9'; i++ {
 	}
 	return i < len(a) && a[i] == ':'
@@ -132,7 +133,6 @@ func nextFrag(s string) (frag, rest string, numeric bool) {
 		numeric = true
 	} else {
 		// not digit
-		numeric = false
 		for i = 1; i < len(s) && (s[i] < '0' || s[i] > '9'); i++ {
 		}
 	}


### PR DESCRIPTION
coreSupportsReExec is rather critical performance-wise, as it's used
for every invocation of snap, including every binary in /snap/bin.

So I thought I might try to speed it up a bit. This ended up with some
work in `strutil` which got split into #6074, but there was still room
for improvement here. Even with that on master, this change helps:

```
$ benchcmp /tmp/master.txt /tmp/this.txt
benchmark                    old ns/op     new ns/op     delta
BenchmarkCSRE_real-8         18511         4256          -77.01%

benchmark                    old allocs     new allocs     delta
BenchmarkCSRE_real-8         50             12             -76.00%

benchmark                    old bytes     new bytes     delta
BenchmarkCSRE_real-8         44041         1176          -97.33%
```

HTH, HAND.