### PR TITLE
tests/main/snap-service-after-before-install: verify after/before in snap install

### DIFF
--- a/tests/lib/snaps/test-snapd-after-before-service/bin/start
+++ b/tests/lib/snaps/test-snapd-after-before-service/bin/start
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+echo "before notify"
+sleep 5
+echo "notify ready"
+systemd-notify --ready
+
 while true; do
     echo "running"
     sleep 10

--- a/tests/lib/snaps/test-snapd-after-before-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-after-before-service/meta/snap.yaml
@@ -3,14 +3,17 @@ version: 1.0
 apps:
   before-middle:
     command: bin/start
-    daemon: simple
+    daemon: notify
     before:
       - middle
+    plugs: [daemon-notify]
   middle:
     command: bin/start
-    daemon: simple
+    daemon: notify
+    plugs: [daemon-notify]
   after-middle:
     command: bin/start
-    daemon: simple
+    daemon: notify
     after:
       - middle
+    plugs: [daemon-notify]

--- a/tests/main/snap-service-after-before-install/task.yaml
+++ b/tests/main/snap-service-after-before-install/task.yaml
@@ -1,0 +1,73 @@
+summary: Check that snap install respects after/before ordering of services
+
+debug: |
+    for name in $(snap list |grep '^test-snapd-after-before-service' | awk '{print $1}'); do
+        for service in before-middle middle after-middle; do
+            systemctl status "snap.$name.$service" || true
+        done
+    done
+
+prepare: |
+    snap set system experimental.parallel-instances=true
+
+restore: |
+    snap set system experimental.parallel-instances=null
+
+execute: |
+    echo "When the service snap is installed"
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    get_prop() {
+        prop=$(systemctl show -p "$1" "$2")
+        test -n "$prop"
+        # the format is:
+        # InactiveExitTimestamp=Mon 2018-10-22 10:41:53 CEST
+        echo "$prop" | cut -f2 -d=
+    }
+
+    # try to rule out any cases when things accidentally work by repeating the
+    # test a number of times
+    for _ in $(seq 10); do
+        # install each snap under separate instance name, this makes debugging
+        # easier
+        INSTANCE=$RANDOM
+        # we are using systemd-notify indicate the service is active, this is
+        # currently not allowed by daemon-notify interface, so we may as well
+        # just install in devmode
+        install_local_as test-snapd-after-before-service "test-snapd-after-before-service_$INSTANCE" --devmode
+
+        service_prefix="snap.test-snapd-after-before-service_$INSTANCE"
+
+        echo "We can see all services running"
+        for service in before-middle middle after-middle; do
+            systemctl status "$service_prefix.$service" | MATCH "running"
+        done
+
+        inactive_leave="$(get_prop "InactiveExitTimestampMonotonic" "$service_prefix.before-middle")"
+        active_enter="$(get_prop "ActiveEnterTimestampMonotonic" "$service_prefix.before-middle")"
+        test -n "$inactive_leave"
+        test -n "$active_enter"
+
+        # sanity check
+        test "$active_enter" -gt "$inactive_leave"
+        test -n "$inactive_leave"
+        test -n "$active_enter"
+
+        inactive_leave="$(get_prop "InactiveExitTimestampMonotonic" "$service_prefix.middle")"
+        test -n "$inactive_leave"
+
+        echo "middle service was started after before-middle became active"
+        test "$inactive_leave" -ge "$active_enter"
+
+        active_enter="$(get_prop "ActiveEnterTimestampMonotonic" "$service_prefix.middle")"
+        test -n "$active_enter"
+
+        inactive_leave="$(get_prop "InactiveExitTimestampMonotonic" "$service_prefix.after-middle")"
+        test -n "$inactive_leave"
+
+        echo "after-middle service was started after middle became active"
+        test "$inactive_leave" -ge "$active_enter"
+
+        snap remove "test-snapd-after-before_$INSTANCE"
+    done

--- a/tests/main/snap-service-after-before-install/task.yaml
+++ b/tests/main/snap-service-after-before-install/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that snap install respects after/before ordering of services
 
 debug: |
-    for name in $(snap list |grep '^test-snapd-after-before-service' | awk '{print $1}'); do
+    for name in $(snap list | grep '^test-snapd-after-before-service' | awk '{print $1}'); do
         for service in before-middle middle after-middle; do
             systemctl status "snap.$name.$service" || true
         done

--- a/tests/main/snap-service-after-before/task.yaml
+++ b/tests/main/snap-service-after-before/task.yaml
@@ -4,7 +4,10 @@ execute: |
     echo "When the service snap is installed"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-after-before-service
+    # we are using systemd-notify indicate the service is active, this is
+    # currently not allowed by daemon-notify interface, so we may as well just
+    # install in devmode
+    install_local test-snapd-after-before-service --devmode
 
     echo "We can see all services running"
     for service in before-middle middle after-middle; do


### PR DESCRIPTION
Add spread tests for verification of after/before handling during `snap
install`. To be able to observe the whole process in detail, the after/before
snap had to be modified. Switching to `daemon: notify` allows to have a
controlled time gap between the process leaving inactive and entering active
states.

Further, even before the fix was implemented, the processes could have been
started in the right order. This was internally caused how the application map
of the snap.Info was iterated over in a semi-random fashion. For this reason,
the actual test case is repeated 10 times. With just 3 service applications, it
should be possible to rule out the test passing by accident.
