### PR TITLE
2strutil: let MatchCounter work with a nil regexp

### DIFF
--- a/strutil/matchcounter_benchmark_test.go
+++ b/strutil/matchcounter_benchmark_test.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/snapcore/snapd/strutil"
+)
+
+func benchmarkMatchCounter(b *testing.B, wrx *regexp.Regexp, wn int) {
+	buf := []byte(out)
+	for n := 0; n < b.N; n++ {
+		for step := 1; step < 100; step++ {
+			w := &strutil.MatchCounter{Regexp: wrx, N: wn}
+			var i int
+			for i = 0; i+step < len(buf); i += step {
+				_, err := w.Write(buf[i : i+step])
+				if err != nil {
+					b.Fatalf("step:%d i:%d: %v", step, i, err)
+				}
+			}
+			_, err := w.Write(buf[i:])
+			if err != nil {
+				b.Fatalf("step:%d tail: %v", step, err)
+			}
+		}
+	}
+}
+
+func BenchmarkNil(b *testing.B)         { benchmarkMatchCounter(b, nil, 3) }
+func BenchmarkNilAll(b *testing.B)      { benchmarkMatchCounter(b, nil, -1) }
+func BenchmarkNilEquiv(b *testing.B)    { benchmarkMatchCounter(b, nilRegexpEquiv, 3) }
+func BenchmarkNilEquivAll(b *testing.B) { benchmarkMatchCounter(b, nilRegexpEquiv, -1) }

--- a/strutil/matchcounter_test.go
+++ b/strutil/matchcounter_test.go
@@ -79,6 +79,7 @@ Failed to write /tmp/1/snap/snapcraft.yaml, skipping
 `
 
 var thisRegexp = regexp.MustCompile("(?m).*[Ff]ailed.*")
+var nilRegexpEquiv = regexp.MustCompile("(?m).+")
 
 func (mcSuite) TestMatchCounterFull(c *check.C) {
 	// check a single write
@@ -162,4 +163,45 @@ func (mcSuite) TestMatchCounterNegative(c *check.C) {
 	c.Check(count, check.Equals, 19)
 	c.Check(count, check.Equals, len(matches))
 	c.Assert(matches, check.DeepEquals, expected)
+}
+
+func (mcSuite) TestMatchCounterNilRegexpFull(c *check.C) {
+	expected := nilRegexpEquiv.FindAllString(out, -1)
+	w := &strutil.MatchCounter{N: -1}
+	_, err := w.Write([]byte(out))
+	c.Assert(err, check.IsNil)
+	matches, count := w.Matches()
+	c.Check(count, check.Equals, len(matches))
+	c.Check(len(matches), check.Equals, len(expected))
+	c.Assert(matches, check.DeepEquals, expected)
+}
+
+func (mcSuite) TestMatchCounterNilRegexpLimited(c *check.C) {
+	expected := nilRegexpEquiv.FindAllString(out, 10)
+	w := &strutil.MatchCounter{N: 10}
+	_, err := w.Write([]byte(out))
+	c.Assert(err, check.IsNil)
+	matches, count := w.Matches()
+	c.Check(count, check.Equals, 22)
+	c.Check(len(matches), check.Equals, len(expected))
+	c.Assert(matches, check.DeepEquals, expected)
+}
+
+func (mcSuite) TestMatchCounterNilRegexpPartials(c *check.C) {
+	expected := nilRegexpEquiv.FindAllString(out, 3)
+
+	buf := []byte(out)
+	for step := 1; step < 100; step++ {
+		w := &strutil.MatchCounter{N: 3}
+		var i int
+		for i = 0; i+step < len(buf); i += step {
+			_, err := w.Write(buf[i : i+step])
+			c.Assert(err, check.IsNil, check.Commentf("step:%d i:%d", step, i))
+		}
+		_, err := w.Write(buf[i:])
+		c.Assert(err, check.IsNil, check.Commentf("step:%d tail", step))
+		matches, count := w.Matches()
+		c.Check(count, check.Equals, 22, check.Commentf("step:%d", step))
+		c.Check(matches, check.DeepEquals, expected, check.Commentf("step:%d", step))
+	}
 }


### PR DESCRIPTION
Some concerns were raised about usig MatchCounter with a regexp to
match whole lines. This addresses that.

From the benchmarks:

    BenchmarkNil         3000   480553 ns/op    64354 B/op        802 allocs/op
    BenchmarkNilAll      2000   619675 ns/op   260776 B/op       2980 allocs/op
    BenchmarkNilEquiv     500  3673992 ns/op   953872 B/op       6544 allocs/op
    BenchmarkNilEquivAll  500  3837003 ns/op  1150292 B/op       8722 allocs/op

the two first use the new code, the first one saving just 3 lines, the
second one any number of them.

The second two use the old code (with a regexp of `(?m).+` which is
equivalent to the `nil` case). The new code is both faster and more
efficient, as expected.
