### PR TITLE
tests: removing fedora 26 system from spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -76,9 +76,6 @@ backends:
                 workers: 6
                 manual: true
 
-            - fedora-26-64:
-                workers: 4
-                manual: true
             - fedora-27-64:
                 workers: 4
                 manual: true
@@ -171,10 +168,10 @@ backends:
             - debian-sid-64:
                 username: debian
                 password: debian
-            - fedora-26-64:
+            - fedora-27-64:
                 username: fedora
                 password: fedora
-            - fedora-27-64:
+            - fedora-28-64:
                 username: fedora
                 password: fedora
     autopkgtest:


### PR DESCRIPTION
It is already EOL
Soon we are gonna need to remove fedora 17 and add fedora 29 