### PR TITLE
overlord/ifacestate: use map[string]*connState when passing conns around

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -79,19 +79,19 @@ func MockUDevInitRetryTimeout(t time.Duration) (restore func()) {
 
 // UpperCaseConnState returns a canned connection state map.
 // This allows us to keep connState private and still write some tests for it.
-func UpperCaseConnState() map[string]connState {
-	return map[string]connState{
+func UpperCaseConnState() map[string]*connState {
+	return map[string]*connState{
 		"APP:network CORE:network": {Auto: true, Interface: "network"},
 	}
 }
 
-func UpdateConnectionInConnState(conns map[string]connState, conn *interfaces.Connection, autoConnect, byGadget bool) {
+func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.Connection, autoConnect, byGadget bool) {
 	connRef := &interfaces.ConnRef{
 		PlugRef: *conn.Plug.Ref(),
 		SlotRef: *conn.Slot.Ref(),
 	}
 
-	conns[connRef.ID()] = connState{
+	conns[connRef.ID()] = &connState{
 		Interface:        conn.Interface(),
 		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
 		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
@@ -102,7 +102,7 @@ func UpdateConnectionInConnState(conns map[string]connState, conn *interfaces.Co
 	}
 }
 
-func GetConnStateAttrs(conns map[string]connState, connID string) (plugStatic, plugDynamic, slotStatic, SlotDynamic map[string]interface{}, ok bool) {
+func GetConnStateAttrs(conns map[string]*connState, connID string) (plugStatic, plugDynamic, slotStatic, SlotDynamic map[string]interface{}, ok bool) {
 	conn, ok := conns[connID]
 	if !ok {
 		return nil, nil, nil, nil, false

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -270,7 +270,7 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 	if err != nil {
 		return err
 	}
-	removed := make(map[string]connState)
+	removed := make(map[string]*connState)
 	for id := range conns {
 		connRef, err := interfaces.ParseConnRef(id)
 		if err != nil {
@@ -291,7 +291,7 @@ func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) erro
 	st.Lock()
 	defer st.Unlock()
 
-	var removed map[string]connState
+	var removed map[string]*connState
 	err := task.Get("removed", &removed)
 	if err != nil && err != state.ErrNoState {
 		return err
@@ -428,7 +428,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	conns[connRef.ID()] = connState{
+	conns[connRef.ID()] = &connState{
 		Interface:        conn.Interface(),
 		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
 		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
@@ -576,7 +576,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, _ *tomb.Tomb) error 
 		return err
 	}
 
-	conns[connRef.ID()] = oldconn
+	conns[connRef.ID()] = &oldconn
 	setConns(st, conns)
 
 	return nil

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -526,7 +526,7 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 // getConns returns information about connections from the state.
 //
 // Connections are transparently re-mapped according to remapIncomingConnRef
-func getConns(st *state.State) (conns map[string]connState, err error) {
+func getConns(st *state.State) (conns map[string]*connState, err error) {
 	var raw *json.RawMessage
 	err = st.Get("conns", &raw)
 	if err != nil && err != state.ErrNoState {
@@ -539,9 +539,9 @@ func getConns(st *state.State) (conns map[string]connState, err error) {
 		}
 	}
 	if conns == nil {
-		conns = make(map[string]connState)
+		conns = make(map[string]*connState)
 	}
-	remapped := make(map[string]connState, len(conns))
+	remapped := make(map[string]*connState, len(conns))
 	for id, cstate := range conns {
 		cref, err := interfaces.ParseConnRef(id)
 		if err != nil {
@@ -561,8 +561,8 @@ func getConns(st *state.State) (conns map[string]connState, err error) {
 // setConns sets information about connections in the state.
 //
 // Connections are transparently re-mapped according to remapOutgoingConnRef
-func setConns(st *state.State, conns map[string]connState) {
-	remapped := make(map[string]connState, len(conns))
+func setConns(st *state.State, conns map[string]*connState) {
+	remapped := make(map[string]*connState, len(conns))
 	for id, cstate := range conns {
 		cref, err := interfaces.ParseConnRef(id)
 		if err != nil {
@@ -822,7 +822,7 @@ func setHotplugSlots(st *state.State, slots map[string]*HotplugSlotInfo) {
 	st.Set("hotplug-slots", slots)
 }
 
-func findConnsForHotplugKey(conns map[string]connState, ifaceName, hotplugKey string) []string {
+func findConnsForHotplugKey(conns map[string]*connState, ifaceName, hotplugKey string) []string {
 	var connsForDevice []string
 	for id, connSt := range conns {
 		if connSt.Interface != ifaceName || connSt.HotplugKey != hotplugKey {


### PR DESCRIPTION
Followup to previous PR. Use map[string]*connState to pass conns to/from helpers.
