### PR TITLE
tests/main/interfces-accounts-service: switch to busctl, more debugging (2.36)

### DIFF
--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -15,6 +15,7 @@ prepare: |
     . "$TESTSLIB"/pkgdb.sh
     snap install --edge test-snapd-accounts-service
     mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+    pkill -9 goa || true
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -22,21 +23,30 @@ restore: |
     # this will also kill the "gdbus monitor" command
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
+    rm -f dbus.env
     rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
     # usually not needed, this should die when dbus goes down
     kill "$(cat gdbus-monitor.pid)" || true
+    pkill -9 goa || true
 
 debug: |
     cat gdbus.log || true
+    if [[ -f dbus.env ]]; then
+        #shellcheck disable=SC1091
+        source dbus.env
+        busctl --user status org.gnome.OnlineAccounts
+    fi
 
 execute: |
     echo "Ensure things run"
-    eval "$(dbus-launch --sh-syntax)"
+    dbus-launch --sh-syntax > dbus.env
+    #shellcheck disable=SC1091
+    source dbus.env
     echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
     eval "$(printf password|gnome-keyring-daemon --login)"
     eval "$(gnome-keyring-daemon --start)"
     # add debug
-    gdbus monitor --session --dest org.gnome.OnlineAccounts >gdbus.log 2>&1 &
+    dbus-monitor --session >gdbus.log 2>&1 &
     echo "$!" > gdbus-monitor.pid
 
     echo "Creating account"

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -53,15 +53,16 @@ execute: |
     # We set a long timeout here because goa-daemon will be activated
     # by the method call, and this can take a while on heavily loaded
     # or IO constrianed VMs.
-    gdbus call --session --timeout 300 \
-      --dest=org.gnome.OnlineAccounts \
-      --object-path=/org/gnome/OnlineAccounts/Manager \
-      --method=org.gnome.OnlineAccounts.Manager.AddAccount \
+    busctl call --verbose --user --timeout 300 \
+      org.gnome.OnlineAccounts \
+      /org/gnome/OnlineAccounts/Manager \
+      org.gnome.OnlineAccounts.Manager AddAccount \
+      'sssa{sv}a{ss}' \
       "imap_smtp" \
       "test@example.com" \
       "Display Name" \
-      "{}" \
-      "{'Enabled': 'true', 'EmailAddress': 'test@example.com', 'Name': 'Test User', 'ImapHost': 'imap.example.com', 'SmtpHost': 'mail.example.com'}"
+      0 \
+      5 'Enabled' 'true' 'EmailAddress' 'test@example.com' 'Name' 'Test User' 'ImapHost' 'imap.example.com' 'SmtpHost': 'mail.example.com'
 
     echo "The interface is initially disconnected"
     snap interfaces -i accounts-service | MATCH '\- +test-snapd-accounts-service:accounts-service'

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -15,7 +15,6 @@ prepare: |
     . "$TESTSLIB"/pkgdb.sh
     snap install --edge test-snapd-accounts-service
     mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
-    pkill -9 goa || true
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -27,7 +26,6 @@ restore: |
     rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
     # usually not needed, this should die when dbus goes down
     kill "$(cat gdbus-monitor.pid)" || true
-    pkill -9 goa || true
 
 debug: |
     cat gdbus.log || true

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -42,11 +42,13 @@ execute: |
     #shellcheck disable=SC1091
     source dbus.env
     echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
-    eval "$(printf password|gnome-keyring-daemon --login)"
-    eval "$(gnome-keyring-daemon --start)"
-    # add debug
+
+    # the test failed often in the past, log all dbus activity to ease debugging
     dbus-monitor --session >gdbus.log 2>&1 &
     echo "$!" > gdbus-monitor.pid
+
+    eval "$(printf password|gnome-keyring-daemon --login)"
+    eval "$(gnome-keyring-daemon --start)"
 
     echo "Creating account"
     # We set a long timeout here because goa-daemon will be activated

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -28,6 +28,7 @@ restore: |
     kill "$(cat gdbus-monitor.pid)" || true
 
 debug: |
+    ps aux
     cat gdbus.log || true
     if [[ -f dbus.env ]]; then
         #shellcheck disable=SC1091


### PR DESCRIPTION
Changes from #5994 cherry-picked for 2.36.
