### PR TITLE
tests/lib: adjust to changed systemctl behaviour on debian-9 (2.36)

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -81,9 +81,12 @@ $START_LIMIT_INTERVAL
 EOF
 
     # We change the service configuration so reload and restart
-    # the snapd socket unit to get them applied
+    # the units to get them applied
     systemctl daemon-reload
-    systemctl restart snapd.socket
+    # stop the socket (it pulls down the service)
+    systemctl stop snapd.socket
+    # start the service (it pulls up the socket)
+    systemctl start snapd.service
 }
 
 update_core_snap_for_classic_reexec() {


### PR DESCRIPTION
#6083, but for 2.36

---

in debian 9, we will *sometimes* but not always get failures in suite
prepare, along the lines of

    + systemctl daemon-reload
    + systemctl restart snapd.socket
    Job for snapd.socket failed.
    See "systemctl status snapd.socket" and "journalctl -xe" for details.

if you go and look, you'll see

    snapd.socket: Socket service snapd.service already active, refusing.
    Failed to listen on Socket activation for snappy daemon.

which means `systemctl restart foo.socket` no longer restarts
`foo.service`.  This sounds like a bug, but while it gets fixed, this
change works around it.
