### PR TITLE
tests: move fedora 28 to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -84,6 +84,7 @@ backends:
                 manual: true
             - fedora-28-64:
                 workers: 4
+                manual: true
 
             - opensuse-42.3-64:
                 workers: 4


### PR DESCRIPTION
The execution on fedora 28 is being delayed and it is making fail the
test suites. I propose to move it to manual and research deeply why it
is happenning.
Build are taking about 47 minutes to finish and some of them are not finishing in the 50 min available on travis.  This could be cause because fedora 29 was release yesterday.