### PR TITLE
overlord/snapshotstate/backend: survive missing directories

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -229,14 +229,58 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 var isTesting = osutil.GetenvBool("SNAPPY_TESTING")
 
 func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, username string, entry, dir string) error {
-	hasher := crypto.SHA3_384.New()
-	if exists, isDir, err := osutil.DirExists(dir); !exists || !isDir || err != nil {
-		if exists && !isDir {
-			logger.Noticef("Not saving %q in snapshot #%d of %q as it is not a directory.", dir, snapshot.SetID, snapshot.Snap)
+	parent, revdir := filepath.Split(dir)
+	if exists, isDir, err := osutil.DirExists(parent); !(err == nil && exists && isDir) {
+		if err != nil {
+			return err
 		}
-		return err
+		if exists {
+			logger.Noticef("Not saving directories under %q in snapshot #%d of %q as it is not a directory.", parent, snapshot.SetID, snapshot.Snap)
+		} else {
+			logger.Debugf("Not saving directories under %q in snapshot #%d of %q as it is does not exist.", parent, snapshot.SetID, snapshot.Snap)
+		}
+		return nil
 	}
-	parent, dir := filepath.Split(dir)
+	tarArgs := []string{
+		"--create",
+		"--sparse", "--gzip",
+		"--directory", parent,
+	}
+
+	noRev, noCommon := true, true
+
+	if exists, isDir, err := osutil.DirExists(dir); err == nil && exists && isDir {
+		tarArgs = append(tarArgs, revdir)
+		noRev = false
+	} else {
+		if err != nil {
+			return err
+		}
+		if exists {
+			logger.Noticef("Not saving %q in snapshot #%d of %q as it is not a directory.", dir, snapshot.SetID, snapshot.Snap)
+		} else {
+			logger.Debugf("Not saving %q in snapshot #%d of %q as it is does not exist.", dir, snapshot.SetID, snapshot.Snap)
+		}
+	}
+
+	common := filepath.Join(parent, "common")
+	if exists, isDir, err := osutil.DirExists(common); err == nil && exists && isDir {
+		tarArgs = append(tarArgs, "common")
+		noCommon = false
+	} else {
+		if err != nil {
+			return err
+		}
+		if exists {
+			logger.Noticef("Not saving %q in snapshot #%d of %q as it is not a directory.", common, snapshot.SetID, snapshot.Snap)
+		} else {
+			logger.Debugf("Not saving %q in snapshot #%d of %q as it is does not exist.", common, snapshot.SetID, snapshot.Snap)
+		}
+	}
+
+	if noCommon && noRev {
+		return nil
+	}
 
 	archiveWriter, err := w.CreateHeader(&zip.FileHeader{Name: entry})
 	if err != nil {
@@ -244,12 +288,9 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	}
 
 	var sz sizer
+	hasher := crypto.SHA3_384.New()
 
-	cmd := tarAsUser(username,
-		"--create",
-		"--sparse", "--gzip",
-		"--directory", parent, dir, "common")
-	cmd.Env = []string{"GZIP=-9 -n"}
+	cmd := tarAsUser(username, tarArgs...)
 	cmd.Stdout = io.MultiWriter(archiveWriter, hasher, &sz)
 	matchCounter := &strutil.MatchCounter{N: 1}
 	cmd.Stderr = matchCounter


### PR DESCRIPTION
Without this change a missing "common" directory is enough to abort a
snapshot.

I'm not sure how a "common" directory can exist when the revisioned
directory exists (need to chase zyga for that), but it happens. So
this deals with that, and with the reverse situation (where common
exists but no revisined directory does). It also logs a bit more about
what's going on (in DEBUG), to help if things misbehave in the future.
