### PR TITLE
tests: core 18 does not support classic confinement

### DIFF
--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -73,7 +73,7 @@ install_generic_consumer() {
 
 is_classic_confinement_supported() {
     case "$SPREAD_SYSTEM" in
-        ubuntu-core-16-*)
+        ubuntu-core-*)
             return 1
             ;;
         ubuntu-*|debian-*)


### PR DESCRIPTION
This change will fix the install-snaps test.

Error:
https://travis-ci.org/snapcore/spread-cron/builds/449653485#L1686