### PR TITLE
tests: add debug output for degraded test

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -7,6 +7,16 @@ backends: [-autopkgtest]
 # run this early to ensure no test created failed units yet
 priority: 500
 
+debug: |
+    # Print the status for the failed units
+    for unit_type in service socket device mount automount swap target path timer slice scope; do
+        units="$(systemctl --failed --type=$unit_type --no-pager | grep -o -E ".*.$unit_type" | tr '●' ' ' )"
+        for unit in $units; do
+            echo " -- systemctl status $unit --"
+            systemctl status "$unit"
+        done
+    done
+
 execute: |
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh


### PR DESCRIPTION
The idea is to show the status of each failing unit to get more info
when this test fails.
