### PR TITLE
tests: install dependencies during prepare

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -627,6 +627,7 @@ pkg_dependencies_fedora(){
         rpm-build
         udisks2
         xdg-user-dirs
+        xdg-utils
         "
 }
 
@@ -637,17 +638,18 @@ pkg_dependencies_amazon(){
         expect
         git
         golang
+        grub2-tools
         jq
         iptables-services
         man
         mock
+        nc
         net-tools
         nfs-utils
         system-lsb-core
         rpm-build
         xdg-user-dirs
-        grub2-tools
-        nc
+        xdg-utils
         udisks2
         "
 }
@@ -670,8 +672,8 @@ pkg_dependencies_opensuse(){
         osc
         udisks2
         uuidd
-        xdg-utils
         xdg-user-dirs
+        xdg-utils
         "
 }
 
@@ -701,6 +703,7 @@ pkg_dependencies_arch(){
     strace
     udisks2
     xdg-user-dirs
+    xdg-utils
     xfsprogs
     apparmor
     "

--- a/tests/main/snap-handle-link/task.yaml
+++ b/tests/main/snap-handle-link/task.yaml
@@ -10,17 +10,10 @@ environment:
     DISPLAY: :placeholder
 
 prepare: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB/pkgdb.sh"
-    distro_install_package xdg-utils
     touch /usr/bin/zenity
 
 restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB/pkgdb.sh"
     umount -f /usr/bin/zenity || :
-    distro_purge_package xdg-utils
-    distro_auto_remove_packages
 
 execute: |
     #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
Install xdg utils on prepare and reorder packages to install.

Error:
https://api.travis-ci.org/v3/job/449917780/log.txt