### PR TITLE
Granted 'account_control' access to /home/**

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -46,6 +46,10 @@ const accountControlConnectedPlugAppArmor = `
 /var/lib/extrausers/ r,
 /var/lib/extrausers/** rwkl,
 
+# Allow removal of users home directories
+/home/ r,
+/home/** rwkl,
+
 # Needed by useradd
 /etc/login.defs r,
 /etc/default/useradd r,


### PR DESCRIPTION
Would this be an OK solution?

```
When carrying out account management tasks via a snap with 'account_control' access we're unable 
to fully get rid of a user(i.e. home dir) with 'userdel ACCOUNT' since 'userdel' does not yet
support --extrausers (like "adduser --extrausers" does).

I believe we could work around this by adding permissions to /home/** for interface 'account_control' 
and allow app devs to manually remove user's home dir manually. Until proper support
for --extrausers have been implemented in 'userdel'.
```

https://bugs.launchpad.net/snappy/+bug/1801567