### PR TITLE
daemon: spool sideloaded snap into blob dir

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1489,7 +1489,7 @@ out:
 	// we are in charge of the tempfile life cycle until we hand it off to the change
 	changeTriggered := false
 	// if you change this prefix, look for it in the tests
-	tmpf, err := ioutil.TempFile(dirs.SnapBlobDir, ".snapd-sideload-")
+	tmpf, err := ioutil.TempFile(dirs.SnapBlobDir, dirs.SideloadedBlobTempPrefix)
 	if err != nil {
 		return InternalError("cannot create temporary file: %v", err)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1489,7 +1489,7 @@ out:
 	// we are in charge of the tempfile life cycle until we hand it off to the change
 	changeTriggered := false
 	// if you change this prefix, look for it in the tests
-	tmpf, err := ioutil.TempFile("", "snapd-sideload-pkg-")
+	tmpf, err := ioutil.TempFile(dirs.SnapBlobDir, ".snapd-sideload-")
 	if err != nil {
 		return InternalError("cannot create temporary file: %v", err)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1489,7 +1489,8 @@ out:
 	// we are in charge of the tempfile life cycle until we hand it off to the change
 	changeTriggered := false
 	// if you change this prefix, look for it in the tests
-	tmpf, err := ioutil.TempFile(dirs.SnapBlobDir, dirs.SideloadedBlobTempPrefix)
+	// also see localInstallCleanup in snapstate/snapmgr.go
+	tmpf, err := ioutil.TempFile(dirs.SnapBlobDir, dirs.LocalInstallBlobTempPrefix)
 	if err != nil {
 		return InternalError("cannot create temporary file: %v", err)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -246,6 +246,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, check.IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), check.IsNil)
+	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), check.IsNil)
 
 	s.rsnaps = nil
 	s.suggestedCurrency = ""
@@ -2513,7 +2514,7 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 	c.Assert(rsp.Type, check.Equals, ResponseTypeAsync)
 	n := 1
 	c.Assert(installQueue, check.HasLen, n)
-	c.Check(installQueue[n-1], check.Matches, "local::.*/snapd-sideload-pkg-.*")
+	c.Check(installQueue[n-1], check.Matches, `local::.*/\.snapd-sideload-.*`)
 
 	st := d.overlord.State()
 	st.Lock()

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -35,6 +35,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -2514,7 +2515,7 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 	c.Assert(rsp.Type, check.Equals, ResponseTypeAsync)
 	n := 1
 	c.Assert(installQueue, check.HasLen, n)
-	c.Check(installQueue[n-1], check.Matches, `local::.*/\.snapd-sideload-.*`)
+	c.Check(installQueue[n-1], check.Matches, "local::.*/"+regexp.QuoteMeta(dirs.SideloadedBlobTempPrefix)+".*")
 
 	st := d.overlord.State()
 	st.Lock()

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2515,7 +2515,7 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 	c.Assert(rsp.Type, check.Equals, ResponseTypeAsync)
 	n := 1
 	c.Assert(installQueue, check.HasLen, n)
-	c.Check(installQueue[n-1], check.Matches, "local::.*/"+regexp.QuoteMeta(dirs.SideloadedBlobTempPrefix)+".*")
+	c.Check(installQueue[n-1], check.Matches, "local::.*/"+regexp.QuoteMeta(dirs.LocalInstallBlobTempPrefix)+".*")
 
 	st := d.overlord.State()
 	st.Lock()

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -123,10 +123,10 @@ const (
 	// Directory with snap data inside user's home
 	UserHomeSnapDir = "snap"
 
-	// SideloadedBlobTempPrefix is used as the second argument to
-	// ioutil.TempFile in daemon, and looked for by auto-cleanup
-	// from snapstate
-	SideloadedBlobTempPrefix = ".snapd-sideload-"
+	// LocalInstallBlobTempPrefix is used by local install code:
+	// * in daemon to spool the snap file to <SnapBlobDir>/<LocalInstallBlobTempPrefix>*
+	// * in snapstate to auto-cleans them up using the same prefix
+	LocalInstallBlobTempPrefix = ".local-install-"
 )
 
 var (

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -122,6 +122,11 @@ const (
 
 	// Directory with snap data inside user's home
 	UserHomeSnapDir = "snap"
+
+	// SideloadedBlobTempPrefix is used as the second argument to
+	// ioutil.TempFile in daemon, and looked for by auto-cleanup
+	// from snapstate
+	SideloadedBlobTempPrefix = ".snapd-sideload-"
 )
 
 var (

--- a/osutil/unlink.go
+++ b/osutil/unlink.go
@@ -48,6 +48,11 @@ func UnlinkMany(dirname string, filenames []string) error {
 	}
 	defer syscall.Close(dirfd)
 
+	return unlinkMany(dirfd, filenames)
+}
+
+func unlinkMany(dirfd int, filenames []string) error {
+	var err error
 	for _, filename := range filenames {
 		if err = sysUnlinkat(dirfd, filename); err != nil && err != syscall.ENOENT {
 			return &os.PathError{
@@ -58,4 +63,10 @@ func UnlinkMany(dirname string, filenames []string) error {
 		}
 	}
 	return nil
+}
+
+// FUnlinkMany is like UnlinkMany but takes an open directory *os.File
+// instead of a dirname.
+func FUnlinkMany(dir *os.File, filenames []string) error {
+	return unlinkMany(int(dir.Fd()), filenames)
 }

--- a/osutil/unlink.go
+++ b/osutil/unlink.go
@@ -65,8 +65,8 @@ func unlinkMany(dirfd int, filenames []string) error {
 	return nil
 }
 
-// FUnlinkMany is like UnlinkMany but takes an open directory *os.File
+// UnlinkManyAt is like UnlinkMany but takes an open directory *os.File
 // instead of a dirname.
-func FUnlinkMany(dir *os.File, filenames []string) error {
+func UnlinkManyAt(dir *os.File, filenames []string) error {
 	return unlinkMany(int(dir.Fd()), filenames)
 }

--- a/osutil/unlink_test.go
+++ b/osutil/unlink_test.go
@@ -71,10 +71,10 @@ func (s *unlinkSuite) TestUnlinkMany(c *check.C) {
 	s.checkDirnames(c, []string{"foo", "quux", "dir"})
 }
 
-func (s *unlinkSuite) TestFUnlinkMany(c *check.C) {
+func (s *unlinkSuite) TestUnlinkManyAt(c *check.C) {
 	d, err := os.Open(s.d)
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.FUnlinkMany(d, []string{"bar", "does-not-exist", "baz"}), check.IsNil)
+	c.Assert(osutil.UnlinkManyAt(d, []string{"bar", "does-not-exist", "baz"}), check.IsNil)
 
 	s.checkDirnames(c, []string{"foo", "quux", "dir"})
 }

--- a/osutil/unlink_test.go
+++ b/osutil/unlink_test.go
@@ -71,6 +71,14 @@ func (s *unlinkSuite) TestUnlinkMany(c *check.C) {
 	s.checkDirnames(c, []string{"foo", "quux", "dir"})
 }
 
+func (s *unlinkSuite) TestFUnlinkMany(c *check.C) {
+	d, err := os.Open(s.d)
+	c.Assert(err, check.IsNil)
+	c.Assert(osutil.FUnlinkMany(d, []string{"bar", "does-not-exist", "baz"}), check.IsNil)
+
+	s.checkDirnames(c, []string{"foo", "quux", "dir"})
+}
+
 func (s *unlinkSuite) TestUnlinkManyFails(c *check.C) {
 	type T struct {
 		dirname   string

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -143,11 +143,19 @@ func MockIsOnMeteredConnection(mock func() (bool, error)) func() {
 	}
 }
 
-func MockSideloadCleanupWait(d time.Duration) (restore func()) {
-	old := sideloadCleanupWait
-	sideloadCleanupWait = d
+func MockLocalInstallCleanupWait(d time.Duration) (restore func()) {
+	old := localInstallCleanupWait
+	localInstallCleanupWait = d
 	return func() {
-		sideloadCleanupWait = old
+		localInstallCleanupWait = old
+	}
+}
+
+func MockLocalInstallLastCleanup(t time.Time) (restore func()) {
+	old := localInstallLastCleanup
+	localInstallLastCleanup = t
+	return func() {
+		localInstallLastCleanup = old
 	}
 }
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -143,6 +143,14 @@ func MockIsOnMeteredConnection(mock func() (bool, error)) func() {
 	}
 }
 
+func MockSideloadCleanupWait(d time.Duration) (restore func()) {
+	old := sideloadCleanupWait
+	sideloadCleanupWait = d
+	return func() {
+		sideloadCleanupWait = old
+	}
+}
+
 func SetModelWithBase(baseName string) {
 	setModel(map[string]string{"base": baseName})
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -608,7 +608,7 @@ func (m *SnapManager) cleanOldTemps() error {
 		// fis is nil if err isn't
 		for _, fi := range fis {
 			name := fi.Name()
-			if !strings.HasPrefix(name, ".snapd-sideload-") {
+			if !strings.HasPrefix(name, dirs.SideloadedBlobTempPrefix) {
 				continue
 			}
 			if fi.ModTime().After(cutoff) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8216,8 +8216,8 @@ func (s *snapmgrTestSuite) TestEsnureCleansOldSideloads(c *C) {
 	c.Assert(filenames(), HasLen, 0)
 
 	s0 := filepath.Join(dirs.SnapBlobDir, "some.snap")
-	s1 := filepath.Join(dirs.SnapBlobDir, ".snapd-sideload-12345")
-	s2 := filepath.Join(dirs.SnapBlobDir, ".snapd-sideload-67890")
+	s1 := filepath.Join(dirs.SnapBlobDir, dirs.SideloadedBlobTempPrefix+"-12345")
+	s2 := filepath.Join(dirs.SnapBlobDir, dirs.SideloadedBlobTempPrefix+"-67890")
 
 	c.Assert(ioutil.WriteFile(s0, nil, 0600), IsNil)
 	c.Assert(ioutil.WriteFile(s1, nil, 0600), IsNil)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8210,20 +8210,25 @@ func (s *snapmgrTestSuite) TestEsnureCleansOldSideloads(c *C) {
 		return filenames
 	}
 
-	defer snapstate.MockSideloadCleanupWait(2 * time.Second)()
+	defer snapstate.MockSideloadCleanupWait(200 * time.Millisecond)()
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0700), IsNil)
 	// sanity check; note * in go glob matches .foo
 	c.Assert(filenames(), HasLen, 0)
 
 	s0 := filepath.Join(dirs.SnapBlobDir, "some.snap")
 	s1 := filepath.Join(dirs.SnapBlobDir, ".snapd-sideload-12345")
-	t1 := time.Now().Add(-time.Hour)
 	s2 := filepath.Join(dirs.SnapBlobDir, ".snapd-sideload-67890")
 
-	c.Assert(ioutil.WriteFile(s1, nil, 0600), IsNil)
-	c.Assert(os.Chtimes(s1, t1, t1), IsNil)
 	c.Assert(ioutil.WriteFile(s0, nil, 0600), IsNil)
+	c.Assert(ioutil.WriteFile(s1, nil, 0600), IsNil)
 	c.Assert(ioutil.WriteFile(s2, nil, 0600), IsNil)
+
+	t1 := time.Now()
+	t0 := t1.Add(-time.Hour)
+
+	c.Assert(os.Chtimes(s0, t0, t0), IsNil)
+	c.Assert(os.Chtimes(s1, t0, t0), IsNil)
+	c.Assert(os.Chtimes(s2, t1, t1), IsNil)
 
 	// all there
 	c.Assert(filenames(), DeepEquals, []string{s1, s2, s0})
@@ -8232,7 +8237,7 @@ func (s *snapmgrTestSuite) TestEsnureCleansOldSideloads(c *C) {
 	// oldest sideload gone
 	c.Assert(filenames(), DeepEquals, []string{s2, s0})
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 
 	s.snapmgr.Ensure()
 	// all sideloads gone


### PR DESCRIPTION
Before this change a sideloaded snap would get written out to /tmp
before being copied into /var/lib/snapd/snaps. As these are often
separate devices this means sideloading a snap would be unnecessarily
slow, and use up a potentially large amount of /tmp (which might be
small and in-memory, on core).

This change makes it so that the snap is instead written to a
temporary (and hidden) file in /var/lib/snapd/snaps directly.

This fixes lp:1667865.