### PR TITLE
packaging/opensuse: stop using golang-packaging

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -209,8 +209,8 @@ popd
 GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snap
 GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snapctl
 GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snap-seccomp
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=default --ldflags '-extldflags "-static"' %{import_path}/cmd/snap-update-ns
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=default --ldflags '-extldflags "-static"' %{import_path}/cmd/snap-exec
+GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=default -ldflags '-extldflags "-static"' %{import_path}/cmd/snap-update-ns
+GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=default -ldflags '-extldflags "-static"' %{import_path}/cmd/snap-exec
 %if 0%{?with_test_keys}
 GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie -tags withtestkeys %{import_path}/cmd/snapd
 %else

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -204,17 +204,18 @@ popd
 # Build golang executables, with the following exceptions everything is built the same way:
 # - snap-exec and snap-update-ns is built statically.
 # - snapd has a variant that uses test keys instead of production keys.
-
-# build snap-exec and snap-update-ns completely static for base snaps
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snap
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snapctl
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snap-seccomp
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=default -ldflags '-extldflags "-static"' %{import_path}/cmd/snap-update-ns
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=default -ldflags '-extldflags "-static"' %{import_path}/cmd/snap-exec
+#
+# NOTE: indigo_gopath takes priority over GOPATH. This ensures that we
+# build the code that we intended in case GOPATH points to another copy.
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=pie %{import_path}/cmd/snap
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=pie %{import_path}/cmd/snapctl
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=pie %{import_path}/cmd/snap-seccomp
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=default -ldflags '-extldflags "-static"' %{import_path}/cmd/snap-update-ns
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=default -ldflags '-extldflags "-static"' %{import_path}/cmd/snap-exec
 %if 0%{?with_test_keys}
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie -tags withtestkeys %{import_path}/cmd/snapd
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=pie -tags withtestkeys %{import_path}/cmd/snapd
 %else
-GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snapd
+GOPATH=%{indigo_gopath}:$GOPATH go build -buildmode=pie %{import_path}/cmd/snapd
 %endif
 
 # Build C executables
@@ -222,7 +223,7 @@ GOPATH=$GOPATH:%{indigo_gopath} go build -buildmode=pie %{import_path}/cmd/snapd
 
 %check
 # Run tests with fixed locale that is expected by unicode/color code.
-LC_ALL=C.UTF-8 GOPATH=$GOPATH:%{indigo_gopath} go test %{import_path}/...
+LC_ALL=C.UTF-8 GOPATH=%{indigo_gopath}:$GOPATH go test %{import_path}/...
 %make_build -C %{indigo_srcdir}/cmd check
 
 %install

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -165,11 +165,6 @@ pushd %{indigo_srcdir}
 # Add patch0 -p1 ... as appropriate here.
 popd
 
-# Patch snap-seccomp to use dynamic linking. This is not a problem because
-# snap-seccomp only requires static linking when it runs from the core-snap via
-# re-exec.
-sed -e "s/-Bstatic -lseccomp/-Bstatic/g" -i %{indigo_srcdir}/cmd/snap-seccomp/main.go
-
 # Set the version that is compiled into the various executables/
 pushd %{indigo_srcdir}
 ./mkversion.sh %{version}-%{release}

--- a/run-checks
+++ b/run-checks
@@ -177,10 +177,10 @@ if [ "$STATIC" = 1 ]; then
             xargs -0 file -N |
             awk -F": " '$2~/shell.script/{print $1}' |
             xargs shellcheck
-        regexp='GOPATH(?!%%:\*)(?!:)[^=]*/'
-        if grep -qPr --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
+        regexp='GOPATH(?!%%:\*)(?!:)[^= ]*/'
+        if  grep -qPr                   --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"; then
             echo "Using GOPATH as if it were a single entry and not a list:"
-            grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude-dir .git --exclude-dir vendor "$regexp"
+            grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude 'Makefile.*' --exclude-dir .git --exclude-dir vendor "$regexp"
             echo "Use GOHOME, or {GOPATH%%:*}, instead."
             exit 1
         fi


### PR DESCRIPTION
This patch switches the openSUSE packaging to stop using go-packaging.
The state of golang in openSUSE is not perfect. The existing helpers are
very cumbersome, verbose and don't provide useful features. In cases
like passing special linker flags the helpers require us to work around
them.

I've been in contact with Go maintainers in openSUSE and they recommend
to just use go directly. The only real value of the packaging helpers as
they exist today is to pass "-buildmode pie". In this patch I did just
that, switching to pure go for building.

The patch refers to "indigo" that I'm also working on, as a better and
less weird packaging helper for distributions. I used some the same
directory structure during the build process that Indigo uses directly
and I plan to switch to Indigo 0.3 or 0.4, as time permits. This will
simply replace "GOPATH=... go build -buildmode pie" with "indigo build"
and remove some of the setup boilerplate.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
