### PR TITLE
interfaces/builtin: support hotplug for camera interface

### DIFF
--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,20 @@
 
 package builtin
 
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/hotplug"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+)
+
 const cameraSummary = `allows access to all cameras`
+
+type cameraInterface struct{}
 
 const cameraBaseDeclarationSlots = `
   camera:
@@ -47,17 +60,89 @@ const cameraConnectedPlugAppArmor = `
 /sys/devices/pci**/usb*/**/video4linux/** r,
 `
 
-var cameraConnectedPlugUDev = []string{`KERNEL=="video[0-9]*"`}
+const cameraConnectedPlugAppArmorHotplug = `
+###PATH### rw,
+
+# Allow listing of all devices, however only the designated camera can discovered
+/sys/bus/usb/devices/ r,
+###DEVPATH### r,
+/run/udev/data/c81:###MINOR### r, # video4linux (/dev/video*, etc)
+/sys/class/video4linux/ r,
+`
+
+var cameraConnectedPlugUDev = []string{`KERNEL=="###KERNEL###"`}
+
+// Name of the serial-port interface.
+func (iface *cameraInterface) Name() string {
+	return "camera"
+}
+
+func (iface *cameraInterface) String() string {
+	return iface.Name()
+}
+
+func (iface *cameraInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              cameraSummary,
+		BaseDeclarationSlots: cameraBaseDeclarationSlots,
+		ImplicitOnCore:       true,
+		ImplicitOnClassic:    true,
+	}
+}
+
+func (iface *cameraInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
+	return sanitizeSlotReservedForOS(iface, slot)
+}
+
+func (iface *cameraInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	var path, devpath, minor string
+	// if path/devpath/minor attributes are set by hotplug, then use very precise rules
+	if slot.Attr("path", &path) == nil && slot.Attr("devpath", &devpath) == nil && slot.Attr("minor", &minor) == nil {
+		snippet := strings.Replace(cameraConnectedPlugAppArmorHotplug, "###PATH###", path, -1)
+		snippet = strings.Replace(snippet, "###DEVPATH###", devpath, -1)
+		snippet = strings.Replace(snippet, "###MINOR###", minor, -1)
+		spec.AddSnippet(snippet)
+	} else {
+		spec.AddSnippet(cameraConnectedPlugAppArmor)
+	}
+	return nil
+}
+
+func (iface *cameraInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	kernel := "video[0-9]*"
+	var path string
+	// if path attribute is set by hotplug, then tag specific device
+	if slot.Attr("path", &path) == nil {
+		if dir, file := filepath.Split(path); dir == "/dev/" {
+			kernel = file
+		}
+	}
+	for _, rule := range cameraConnectedPlugUDev {
+		snippet := strings.Replace(rule, "###KERNEL###", kernel, -1)
+		spec.TagDevice(snippet)
+	}
+	return nil
+}
+
+func (iface *cameraInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func (iface *cameraInterface) HotplugDeviceDetected(di *hotplug.HotplugDeviceInfo, spec *hotplug.Specification) error {
+	if di.Subsystem() == "video4linux" && strings.HasPrefix(di.DeviceName(), "/dev/video") {
+		slot := hotplug.RequestedSlotSpec{
+			Attrs: map[string]interface{}{
+				"path":    di.DeviceName(), // e.g. /dev/video0
+				"devpath": di.DevicePath(), // e.g. /sys/devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11:1.0/video4linux/video0
+				"minor":   di.Minor(),
+			},
+		}
+		return spec.SetSlot(&slot)
+	}
+	return nil
+}
 
 func init() {
-	registerIface(&commonInterface{
-		name:                  "camera",
-		summary:               cameraSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  cameraBaseDeclarationSlots,
-		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
-		connectedPlugUDev:     cameraConnectedPlugUDev,
-		reservedForOS:         true,
-	})
+	registerIface(&cameraInterface{})
 }

--- a/interfaces/builtin/camera_test.go
+++ b/interfaces/builtin/camera_test.go
@@ -25,17 +25,19 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/hotplug"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type CameraInterfaceSuite struct {
-	iface    interfaces.Interface
-	slot     *interfaces.ConnectedSlot
-	slotInfo *snap.SlotInfo
-	plug     *interfaces.ConnectedPlug
-	plugInfo *snap.PlugInfo
+	iface       interfaces.Interface
+	slot        *interfaces.ConnectedSlot
+	hotplugSlot *interfaces.ConnectedSlot
+	slotInfo    *snap.SlotInfo
+	plug        *interfaces.ConnectedPlug
+	plugInfo    *snap.PlugInfo
 }
 
 var _ = Suite(&CameraInterfaceSuite{
@@ -59,6 +61,10 @@ slots:
 func (s *CameraInterfaceSuite) SetUpTest(c *C) {
 	s.plug, s.plugInfo = MockConnectedPlug(c, cameraConsumerYaml, nil, "camera")
 	s.slot, s.slotInfo = MockConnectedSlot(c, cameraCoreYaml, nil, "camera")
+
+	attrs := map[string]interface{}{"path": "/dev/video0", "devpath": "/sys/somepath", "minor": "1"}
+	hotplugSlotInfo := MockHotplugSlot(c, cameraCoreYaml, nil, "1234", "camera", "integratedwebcam1", attrs)
+	s.hotplugSlot = interfaces.NewConnectedSlot(hotplugSlotInfo, nil, nil)
 }
 
 func (s *CameraInterfaceSuite) TestName(c *C) {
@@ -87,12 +93,28 @@ func (s *CameraInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/video[0-9]* rw")
 }
 
+func (s *CameraInterfaceSuite) TestAppArmorSpecHotplug(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.hotplugSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/video0 rw")
+}
+
 func (s *CameraInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# camera
 KERNEL=="video[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
+}
+
+func (s *CameraInterfaceSuite) TestUDevSpecHotplug(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.hotplugSlot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# camera
+KERNEL=="video0", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 
@@ -110,4 +132,45 @@ func (s *CameraInterfaceSuite) TestAutoConnect(c *C) {
 
 func (s *CameraInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *CameraInterfaceSuite) TestHotplugRequiresV4LSubsystem(c *C) {
+	hotplugIface := s.iface.(hotplug.Definer)
+
+	di, err := hotplug.NewHotplugDeviceInfo(map[string]string{
+		"SUBSYSTEM": "tty",
+		"DEVNAME":   "/dev/ttyUSB0",
+		"DEVPATH":   "/other",
+	})
+	c.Assert(err, IsNil)
+
+	var spec hotplug.Specification
+	c.Assert(hotplugIface.HotplugDeviceDetected(di, &spec), IsNil)
+	c.Assert(spec.Slot(), IsNil)
+}
+
+func (s *CameraInterfaceSuite) TestHotplugDeviceDetected(c *C) {
+	hotplugIface := s.iface.(hotplug.Definer)
+
+	di, err := hotplug.NewHotplugDeviceInfo(map[string]string{
+		"SUBSYSTEM":       "video4linux",
+		"ID_SERIAL_SHORT": "200901010001",
+		"ID_V4L_PRODUCT":  "Integrated_Webcam_HD: Integrate",
+		"DEVNAME":         "/dev/video0",
+		"DEVPATH":         "/devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11:1.0/video4linux/video0",
+		"MAJOR":           "81",
+		"MINOR":           "0",
+	})
+	c.Assert(err, IsNil)
+
+	var spec hotplug.Specification
+	c.Assert(hotplugIface.HotplugDeviceDetected(di, &spec), IsNil)
+
+	slotSpec := spec.Slot()
+	c.Assert(slotSpec, NotNil)
+	c.Assert(slotSpec.Attrs, DeepEquals, map[string]interface{}{
+		"path":    "/dev/video0",
+		"devpath": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11:1.0/video4linux/video0",
+		"minor":   "0",
+	})
 }

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -89,3 +89,16 @@ func MockConnectedSlot(c *C, yaml string, si *snap.SideInfo, slotName string) (*
 	}
 	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
 }
+
+func MockHotplugSlot(c *C, yaml string, si *snap.SideInfo, hotplugKey, ifaceName, slotName string, staticAttrs map[string]interface{}) *snap.SlotInfo {
+	info := snaptest.MockInfo(c, yaml, si)
+	if _, ok := info.Slots[slotName]; ok {
+		panic(fmt.Sprintf("slot %q already present in the snap yaml", slotName))
+	}
+	return &snap.SlotInfo{
+		Snap:       info,
+		Name:       slotName,
+		Attrs:      staticAttrs,
+		HotplugKey: hotplugKey,
+	}
+}


### PR DESCRIPTION
Refactored camera interface to support hotplug. As part of this change the interface has to be made independent of common interface. These changes should be completely transparent until hotplug functionality lands and is enabled.

The hotplug version of this interface works as follows (and this applies to any other hotplug-aware interface to follow):

1. If hotplug subsystem detects a device, it calls _HotplugDeviceDetected_ method. This method receives HotplugDeviceInfo which carries all uevent attributes.
3. If device is relevant for given interface, the interface creates a specification of the hotplug slot. In case of camera, we react on devices with _subsystem = video4linux_ and paths starting with _/dev/video_.
4. The specification of the slot created by this method carries _path_, _sysfs_ path and _minor_ number of the detected camera and stores them in static attributes of the slot.
5. The existing _Connected*Plug_ methods of the interface contain new logic to look up for the attributes mentioned above and create fine-grained policy for specific device. If these attributes are missing, they falls back to the old model of permissions for all cameras.

I've succesfully verified the operations of the hotplug variant of this interface with obs-studio snap in strict mode.

Note: The MockHotplugSlot helper is proposed separately in #6097.
