### PR TITLE
cmd/snap-confine: always put the snap process under a device cgroup

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -315,8 +315,8 @@ int main(int argc, char **argv)
 				}
 			}
 			struct snappy_udev udev_s;
-			if (snappy_udev_init(security_tag, &udev_s) == 0)
-				setup_devices_cgroup(security_tag, &udev_s);
+			snappy_udev_init(security_tag, &udev_s);
+			setup_devices_cgroup(security_tag, &udev_s);
 			snappy_udev_cleanup(&udev_s);
 		}
 		// The rest does not so temporarily drop privs back to calling

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -185,8 +185,6 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		die("snappy_udev->udev is NULL");
 	if (udev_s->devices == NULL)
 		die("snappy_udev->devices is NULL");
-	if (udev_s->assigned == NULL)
-		die("snappy_udev->assigned is NULL");
 	if (udev_s->tagname_len == 0
 	    || udev_s->tagname_len >= MAX_BUF
 	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len


### PR DESCRIPTION
When no devices are tagged for the given snap, snap-confine will not put the
current process under a device cgroup. This may lead to the snap having access
to more devices than allowed by its connected interfaces.

Example case when this happens is input devices, where AppArmor is not
expressive enough and selective access is implemented using a device cgroup.

The problem is also visible with https://github.com/snapcore/snapd/pull/5897 under spread