### PR TITLE
overlord/snapshots: survive an unknown user

### DIFF
--- a/tests/regression/lp-1801955/task.yaml
+++ b/tests/regression/lp-1801955/task.yaml
@@ -1,0 +1,13 @@
+summary: Check that snapshot works with unknown users in /home/*/snap
+
+prepare: |
+    snap install test-snapd-tools
+    ! grep :9999: /etc/passwd
+    mkdir -pv /home/potato/snap/
+    chown -vR 9999:9999 /home/potato
+
+restore: |
+    rm -rv /home/potato
+
+execute: |
+    snap save test-snapd-tools


### PR DESCRIPTION
Without this change, a system with a directory /home/foo/snap with a
uid not in /etc/passwd will fail to snapshot, with an error such as

```
- Save data of snap "some-snap" in snapshot set #1 (user: unknown userid 1234)
```

This change instead ignores that data.
