### PR TITLE
interfaces/apparmor: allow access to /run/snap.$SNAP_INSTANCE_NAME

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -488,6 +488,11 @@ var defaultTemplate = `
   # Allow read-access to / for navigating to other parts of the filesystem.
   / r,
 
+  # Snap-specific run directory. Bind mount *not* used here
+  # (see 'parallel installs', above)
+  /run/snap.@{SNAP_INSTANCE_NAME}/ rw,
+  /run/snap.@{SNAP_INSTANCE_NAME}/** mrwklix,
+
 ###SNIPPETS###
 }
 `


### PR DESCRIPTION
This patch allows snaps to write to a snap-specific directory in /run.
This can be used for arbitrary purpose. See the referenced bug report
for difference between XDG_RUNTIME_DIR and this.

Fixes: https://bugs.launchpad.net/snapd/+bug/1802112
Forum: https://forum.snapcraft.io/t/snaps-can-not-write-to-run-by-default/8367
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
