### PR TITLE
tests: simple reproducer for snap try and hooks bug

### DIFF
--- a/tests/main/try-with-hooks/task.yaml
+++ b/tests/main/try-with-hooks/task.yaml
@@ -1,0 +1,32 @@
+summary: Reproduce a known issue of snap try failure with hooks
+
+prepare: |
+  cp -R "$TESTSLIB"/snaps/basic ./
+  # in case the snap is modified to have the hook
+  rm -f basic/meta/hooks/pre-refresh
+
+execute: |
+    echo "Snap try a snap without pre-refresh hook"
+    snap try basic
+
+    echo "Snap try again"
+    snap try basic
+
+    echo "Remove the snap and snap try again"
+    snap remove basic
+
+    snap try basic
+
+    echo "Snap try, now with pre-refresh hook"
+    mkdir -p basic/meta/hooks
+    echo "#!/bin/sh" > basic/meta/hooks/pre-refresh
+    chmod +x basic/meta/hooks/pre-refresh
+
+    # TODO: This should not fail, but it does. Update the test once the issue of second snap try with a new hook is fixed.
+    echo "Expecting snap try to fail"
+    if snap try basic; then
+        echo "Expected snap try with a new hook to fail"
+        exit 1
+    fi
+
+    snap remove basic


### PR DESCRIPTION
Simple spread test to reproduce the bug discussed here: https://forum.snapcraft.io/t/snap-try-snap-try-hooks-fun/8400

There is no easy fix, but this test can serve as a reproducer and base for future improvement in this area, e.g. if we decide to print a warning.