### PR TITLE
dirs, wrappers, overlord/snapstate: make completion + bases work

### DIFF
--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -39,6 +39,7 @@ var _ = Suite(&DirsTestSuite{})
 type DirsTestSuite struct{}
 
 func (s *DirsTestSuite) TestStripRootDir(c *C) {
+	dirs.SetRootDir("/")
 	// strip does nothing if the default (empty) root directory is used
 	c.Check(dirs.StripRootDir("/foo/bar"), Equals, "/foo/bar")
 	// strip only works on absolute paths
@@ -122,4 +123,34 @@ func (s *DirsTestSuite) TestInsideBaseSnap(c *C) {
 	inside, err = dirs.IsInsideBaseSnap()
 	c.Assert(err, IsNil)
 	c.Assert(inside, Equals, true)
+}
+
+func (s *DirsTestSuite) TestCompleteShPath(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	// old-style in-core complete.sh
+	c.Check(dirs.CompleteShPath(""), Equals, filepath.Join(dirs.SnapMountDir, "core/current/usr/lib/snapd/complete.sh"))
+	// new-style in-host complete.sh
+	c.Check(dirs.CompleteShPath("x"), Equals, filepath.Join(dirs.DistroLibExecDir, "complete.sh"))
+	// new-style in-snapd complete.sh
+	c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
+	c.Check(dirs.CompleteShPath("x"), Equals, filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd/complete.sh"))
+}
+
+func (s *DirsTestSuite) TestIsCompleteShSymlink(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	tests := map[string]string{
+		filepath.Join(dirs.GlobalRootDir, "no-base"):        filepath.Join(dirs.SnapMountDir, "core/current/usr/lib/snapd/complete.sh"),
+		filepath.Join(dirs.GlobalRootDir, "no-snapd"):       filepath.Join(dirs.DistroLibExecDir, "complete.sh"),
+		filepath.Join(dirs.GlobalRootDir, "base-and-snapd"): filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd/complete.sh"),
+	}
+	for target, d := range tests {
+		c.Check(os.Symlink(d, target), IsNil)
+		c.Check(dirs.IsCompleteShSymlink(target), Equals, true)
+	}
+	c.Check(dirs.IsCompleteShSymlink("/etc/passwd"), Equals, false)
+	c.Check(dirs.IsCompleteShSymlink("/does-not-exist"), Equals, false)
 }

--- a/overlord/snapstate/backend/aliases.go
+++ b/overlord/snapstate/backend/aliases.go
@@ -68,8 +68,7 @@ func (b Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
 			return fmt.Errorf("cannot create alias symlink: %v", err)
 		}
 
-		target, err := os.Readlink(filepath.Join(dirs.CompletersDir, alias.Target))
-		if err == nil && target == dirs.CompleteSh {
+		if dirs.IsCompleteShSymlink(filepath.Join(dirs.CompletersDir, alias.Target)) {
 			os.Symlink(alias.Target, filepath.Join(dirs.CompletersDir, alias.Name))
 		}
 	}

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -44,7 +44,8 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		return err
 	}
 
-	noCompletion := !osutil.IsWritable(dirs.CompletersDir) || !osutil.FileExists(dirs.CompletersDir) || !osutil.FileExists(dirs.CompleteSh)
+	completeSh := dirs.CompleteShPath(s.Base)
+	noCompletion := !osutil.IsWritable(dirs.CompletersDir) || !osutil.FileExists(completeSh)
 	for _, app := range s.Apps {
 		if app.IsService() {
 			continue
@@ -64,7 +65,7 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		}
 		// symlink the completion snippet
 		compPath := app.CompleterPath()
-		if err := os.Symlink(dirs.CompleteSh, compPath); err == nil {
+		if err := os.Symlink(completeSh, compPath); err == nil {
 			created = append(created, compPath)
 		} else if !os.IsExist(err) {
 			return err
@@ -82,7 +83,7 @@ func RemoveSnapBinaries(s *snap.Info) error {
 			continue
 		}
 		compPath := app.CompleterPath()
-		if target, err := os.Readlink(compPath); err == nil && target == dirs.CompleteSh {
+		if dirs.IsCompleteShSymlink(compPath) {
 			os.Remove(compPath)
 		}
 	}


### PR DESCRIPTION
The old completion code assumed that if a snap was installed `<snap
mount dir>/core/current/usr/lib/snapd/complete.sh` was there, and used
that to complete things.

This is not true now that you can have a purely core18-based system,
for example, so completers wouldn't get created.

This fixes that: complete.sh is from core if the snap has no base,
from the snapd snap if it is installed, and otherwise from the host.

This is the first half of the fix for [lp:1802721](https://bugs.launchpad.net/snapd/+bug/1802721).