### PR TITLE
overlord/ifacestate: setup systemd backend in separate pass

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -888,6 +888,19 @@ func (r *Repository) Backends() []SecurityBackend {
 	return result
 }
 
+// Backend returns the backend with the given security system name, if any.
+func (r *Repository) Backend(securitySystem SecuritySystem) SecurityBackend {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	for _, backend := range r.backends {
+		if backend.Name() == securitySystem {
+			return backend
+		}
+	}
+	return nil
+}
+
 // Interfaces returns object holding a lists of all the plugs and slots and their connections.
 func (r *Repository) Interfaces() *Interfaces {
 	r.m.Lock()

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -225,6 +225,16 @@ func (s *RepositorySuite) TestBackends(c *C) {
 	c.Assert(s.emptyRepo.Backends(), DeepEquals, []SecurityBackend{b2, b1})
 }
 
+func (s *RepositorySuite) TestBackend(c *C) {
+	b1 := &ifacetest.TestSecurityBackend{BackendName: "b1"}
+	b2 := &ifacetest.TestSecurityBackend{BackendName: "b2"}
+	c.Assert(s.emptyRepo.AddBackend(b2), IsNil)
+	c.Assert(s.emptyRepo.AddBackend(b1), IsNil)
+	c.Assert(s.emptyRepo.Backend("b1"), Equals, b1)
+	c.Assert(s.emptyRepo.Backend("b2"), Equals, b2)
+	c.Assert(s.emptyRepo.Backend("b3"), IsNil)
+}
+
 // Tests for Repository.Interface()
 
 func (s *RepositorySuite) TestInterface(c *C) {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -105,6 +105,8 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 }
 
 func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, snapInfo *snap.Info, opts interfaces.ConfinementOptions) error {
+	st := task.State()
+
 	if err := addImplicitSlots(task.State(), snapInfo); err != nil {
 		return err
 	}
@@ -137,11 +139,15 @@ func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, 
 		task.Logf("%s", snap.BadInterfacesSummary(snapInfo))
 	}
 
+	// Reload the connections and compute the set of affected snaps. The set
+	// affectedSet set contains name of all the affected snap instances.  The
+	// arrays affectedNames and affectedSnaps contain, arrays of snap names and
+	// snapInfo's, respectively. The arrays are sorted by name with the special
+	// exception that the snap being setup is always first. The affectedSnaps
+	// array may be shorter than the set of affected snaps in case any of the
+	// snaps cannot be found in the state.
 	reconnectedSnaps, err := m.reloadConnections(snapName)
 	if err != nil {
-		return err
-	}
-	if err := m.setupSnapSecurity(task, snapInfo, opts); err != nil {
 		return err
 	}
 	affectedSet := make(map[string]bool)
@@ -151,14 +157,43 @@ func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, 
 	for _, name := range reconnectedSnaps {
 		affectedSet[name] = true
 	}
-	// The principal snap was already handled above.
-	delete(affectedSet, snapInfo.InstanceName())
-	affectedSnaps := make([]string, 0, len(affectedSet))
+
+	// Sort the set of affected names, ensuring that the snap being setup
+	// is first regardless of the name it has.
+	affectedNames := make([]string, 0, len(affectedSet))
 	for name := range affectedSet {
-		affectedSnaps = append(affectedSnaps, name)
+		if name != snapName {
+			affectedNames = append(affectedNames, name)
+		}
 	}
-	sort.Strings(affectedSnaps)
-	return m.setupAffectedSnaps(task, snapName, affectedSnaps)
+	sort.Strings(affectedNames)
+	affectedNames = append([]string{snapName}, affectedNames...)
+
+	// Obtain snap.Info for each affected snap, skipping those that cannot be
+	// found and compute the confinement options that apply to it.
+	affectedSnaps := make([]*snap.Info, 0, len(affectedSet))
+	confinementOpts := make([]interfaces.ConfinementOptions, 0, len(affectedSet))
+	// For the snap being setup we know exactly what was requested.
+	affectedSnaps = append(affectedSnaps, snapInfo)
+	confinementOpts = append(confinementOpts, opts)
+	// For remaining snaps we need to interrogate the state.
+	for _, name := range affectedNames[1:] {
+		var snapst snapstate.SnapState
+		if err := snapstate.Get(st, name, &snapst); err != nil {
+			task.Errorf("cannot obtain state of snap %s: %s", name, err)
+			continue
+		}
+		snapInfo, err := snapst.CurrentInfo()
+		if err != nil {
+			return err
+		}
+		if err := addImplicitSlots(st, snapInfo); err != nil {
+			return err
+		}
+		affectedSnaps = append(affectedSnaps, snapInfo)
+		confinementOpts = append(confinementOpts, confinementOptions(snapst.Flags))
+	}
+	return m.setupPhasedSecurity(task, affectedSnaps, confinementOpts)
 }
 
 func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) error {


### PR DESCRIPTION
This branch ensures that the systemd backed is setup, across all affected
snaps, in a separate pass, distinct from regular procedure where the main snap
(being acted upon) is entirely setup before proceeding to setup the affected
snaps (due to connections) one by one.

This is done so that the systemd backend, which is only used by the GPIO
interface, can have a chance to export the GPIO pin to user space. This is in
turn required by the apparmor backend which needs to know the full pathname of
the GPIO control file. The file is hidden behind a symbolic link that resolves
to platform-specific device name.

This allows to disable and then re-enable a snap that is connected to a GPIO
pin successfully.

This branch contains minimal solution of the problem. There are no tests yet
and individual commits have insufficient documentation. It is aimed at an early
review.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>