### PR TITLE
data/completion: pass documented arguments to completion functions

### DIFF
--- a/data/completion/etelpmoc.sh
+++ b/data/completion/etelpmoc.sh
@@ -180,7 +180,7 @@ if [[ "${_comp[*]}" ]]; then
                 _compfunc="$OPTARG"
                 ;;
             W)
-                readarray -t COMPREPLY < <( builtin compgen -W "$OPTARG" -- "${COMP_WORDS[$COMP_CWORD]}" )
+                readarray -t COMPREPLY < <( builtin compgen -W "$OPTARG" -- "${COMP_WORDS[COMP_CWORD]}" )
                 _compfunc=""
                 ;;
             *)
@@ -202,10 +202,19 @@ esac
 
 if [ ! "$_bounce" ]; then
     if [ "$_compact" ]; then
-        readarray -t COMPREPLY < <( builtin compgen -A "$_compact" -- "${COMP_WORDS[$COMP_CWORD]}" )
+        readarray -t COMPREPLY < <( builtin compgen -A "$_compact" -- "${COMP_WORDS[COMP_CWORD]}" )
     elif [ "$_compfunc" ]; then
         # execute completion function (or the command if -C)
-        $_compfunc
+
+        # from https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html:
+        #   When the function or command is invoked, the first argument ($1) is
+        #   the name of the command whose arguments are being completed, the
+        #   second argument ($2) is the word being completed, and the third
+        #   argument ($3) is the word preceding the word being completed on the
+        #   current command line.
+        # that's "$1" "${COMP_WORDS[COMP_CWORD]}" and "${COMP_WORDS[COMP_CWORD-1]}"
+        # (probably)
+        $_compfunc "$1" "${COMP_WORDS[COMP_CWORD]}" "${COMP_WORDS[COMP_CWORD-1]}"
     fi
 fi
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -597,6 +597,7 @@ suites:
           # _/twisted: _
           _/func: _
           _/funkyfunc: _
+          _/funcarg: _
 
     tests/regression/:
         summary: Regression tests for snapd

--- a/tests/completion/funcarg.complete
+++ b/tests/completion/funcarg.complete
@@ -1,0 +1,12 @@
+# -*- sh -*-
+
+# this is about stopping lp:1802721 (the second part, about the python
+# tab completion failing)
+
+_complete() {
+    if [[ ! "$1" =~ ^test-snapd-complexion ]]; then exit 1; fi
+    COMPREPLY=($( compgen -W "won too tree" "${COMP_WORDS[$COMP_CWORD]}" ))
+}
+
+complete -F _complete test-snapd-complexion
+complete -F _complete test-snapd-complexion.two

--- a/tests/completion/funcarg.vars
+++ b/tests/completion/funcarg.vars
@@ -1,0 +1,7 @@
+# -*- sh -*-
+
+_OUT0="too   tree  won"
+_KEY1="w"
+_OUT1="won"
+_KEY2="t"
+_OUT2="too   tree"


### PR DESCRIPTION
completion functions (and commands, which we treat the same way) are
documented as receiving three arguments. I hadn't noticed, as almost
nobody uses them because most everything you need is in the different
COMP_ variables, but python's argcomplete module uses it.

This fixes that, and adds a spread test just in case.

This is the second half of the fix for [lp:1802721](https://bugs.launchpad.net/snapd/+bug/1802721).