### PR TITLE
snap: make Epoch's MarshalJSON not simplify

### DIFF
--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -182,7 +182,12 @@ func (e *Epoch) simplify() interface{} {
 }
 
 func (e *Epoch) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.simplify())
+	// note the nil case doesn't happen unless called explicitly
+	if e == nil || (e.Read == nil && e.Write == nil) {
+		// lazy special case
+		return []byte(`{"read":[0],"write":[0]}`), nil
+	}
+	return json.Marshal(&structuredEpoch{Read: e.Read, Write: e.Write})
 }
 
 func (Epoch) MarshalYAML() (interface{}, error) {

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -199,16 +199,23 @@ func (s *epochSuite) TestEpochMarshal(c *check.C) {
 		e *snap.Epoch
 		s string
 	}{
-		//		{e: nil, s: `"0"`},
-		{e: &snap.Epoch{}, s: `"0"`},
-		{e: &snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: `"0"`},
-		{e: &snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: `"1*"`},
-		{e: &snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: `"1"`},
-		{e: &snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: `"400*"`},
+		{e: nil, s: `{"read":[0],"write":[0]}`},
+		{e: &snap.Epoch{}, s: `{"read":[0],"write":[0]}`},
+		{e: &snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
+		{e: &snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: `{"read":[0,1],"write":[1]}`},
+		{e: &snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: `{"read":[1],"write":[1]}`},
+		{e: &snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: `{"read":[399,400],"write":[400]}`},
 		{e: &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
 	}
 	for _, test := range tests {
-		bs, err := json.Marshal(test.e)
+		bs, err := test.e.MarshalJSON()
+		c.Assert(err, check.IsNil)
+		c.Check(string(bs), check.Equals, test.s, check.Commentf(test.s))
+		if test.e == nil {
+			// json.Marshal((*foo)(nil)) is "null" no matter how hard you try
+			continue
+		}
+		bs, err = json.Marshal(test.e)
 		c.Assert(err, check.IsNil)
 		c.Check(string(bs), check.Equals, test.s, check.Commentf(test.s))
 	}


### PR DESCRIPTION
Before this change, snap.Epoch's marshaller tried to use the
simplified notation when possible, i.e. it'd write `"1*"` instead of
`{"read":[0,1],"write":[1]}`.

While we still want to do this when printing it to the user, the store
has dropped support for the more compact representation (if it ever
had it), which means we'd need a different marshaller there. Rather
than that, this just drops the smarts from the marshaller. String()
still calls simplify() so that path is unchanged (and we explicitly
don't serialise to YAML).
