### PR TITLE
tests: fix how pinentry is prepared for new gpg v 2.1 and 2.2

### DIFF
--- a/tests/lib/mkpinentry.sh
+++ b/tests/lib/mkpinentry.sh
@@ -1,30 +1,21 @@
 #!/bin/bash
 
-prepare_pinentry_v2(){
-    mkdir -p ~/.snap/gnupg/
-    # It is just created once by gpg-agent, then if this dir does not exist gpg will
-    # fail to create the key
-    mkdir -p ~/.snap/gnupg/private-keys-v1.d
-    echo pinentry-program "$TESTSLIB/pinentry-fake.sh" > ~/.snap/gnupg/gpg-agent.conf
-    chmod -R go-rwx ~/.snap
-}
-
 if gpg --version | MATCH 'gpg \(GnuPG\) 1.'; then
     echo "fake gpg pinentry not used for gpg v1"
 else
     echo "setup fake gpg pinentry environment for gpg v2 or higher"
-    case "$SPREAD_SYSTEM" in
-        opensuse-*)
-            if gpg --version | MATCH 'gpg \(GnuPG\) 2.0'; then
-                mkdir -p ~/.gnupg
-                echo "no-grab" > ~/.gnupg/gpg-agent.conf
-                echo pinentry-program "$TESTSLIB/pinentry-fake.sh" >> ~/.gnupg/gpg-agent.conf
-            else
-                prepare_pinentry_v2
-            fi
-            ;;
-        *)
-            prepare_pinentry_v2
-            ;;
-    esac
+    gpgdir=~/.snap/gnupg
+    if gpg --version | MATCH 'gpg \(GnuPG\) 2.0'; then
+        gpgdir=~/.gnupg
+    fi
+    mkdir -p "$gpgdir"
+    # It is just created once by gpg-agent, then if this dir does not exist gpg will
+    # fail to create the key
+    mkdir -p "$gpgdir/private-keys-v1.d"
+    echo pinentry-program "$TESTSLIB/pinentry-fake.sh" > "$gpgdir/gpg-agent.conf"
+    chmod -R go-rwx "$gpgdir"
+    if [ -d ~/.snap ]; then
+        chmod -R go-rwx ~/.snap
+    fi
 fi
+

--- a/tests/lib/mkpinentry.sh
+++ b/tests/lib/mkpinentry.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 
+prepare_pinentry_v2(){
+    mkdir -p ~/.snap/gnupg/
+    # It is just created once by gpg-agent, then if this dir does not exist gpg will
+    # fail to create the key
+    mkdir -p ~/.snap/gnupg/private-keys-v1.d
+    echo pinentry-program "$TESTSLIB/pinentry-fake.sh" > ~/.snap/gnupg/gpg-agent.conf
+    chmod -R go-rwx ~/.snap
+}
+
 if gpg --version | MATCH 'gpg \(GnuPG\) 1.'; then
     echo "fake gpg pinentry not used for gpg v1"
 else
     echo "setup fake gpg pinentry environment for gpg v2 or higher"
     case "$SPREAD_SYSTEM" in
         opensuse-*)
-            mkdir -p ~/.gnupg
-            echo pinentry-program "$TESTSLIB/pinentry-fake.sh" > ~/.gnupg/gpg-agent.conf
+            if gpg --version | MATCH 'gpg \(GnuPG\) 2.0'; then
+                mkdir -p ~/.gnupg
+                echo "no-grab" > ~/.gnupg/gpg-agent.conf
+                echo pinentry-program "$TESTSLIB/pinentry-fake.sh" >> ~/.gnupg/gpg-agent.conf
+            else
+                prepare_pinentry_v2
+            fi
             ;;
         *)
-            mkdir -p ~/.snap/gnupg/
-            # It is just created once by gpg-agent, then if this dir does not exist gpg will
-            # fail to create the key
-            mkdir -p ~/.snap/gnupg/private-keys-v1.d
-            echo pinentry-program "$TESTSLIB/pinentry-fake.sh" > ~/.snap/gnupg/gpg-agent.conf
-            chmod -R go-rwx ~/.snap
+            prepare_pinentry_v2
             ;;
     esac
 fi


### PR DESCRIPTION
The new version of gpg available for opensuse 2.2.5 needs a new
configuration for the pinentry. This new gpg is available on the update
for opensuse which is comming soon.

To validate this test use the image test-opensuse-new.
