### PR TITLE
tests: skip opensuse from interfaces-openvswitch-support test

### DIFF
--- a/tests/main/interfaces-openvswitch-support/task.yaml
+++ b/tests/main/interfaces-openvswitch-support/task.yaml
@@ -5,8 +5,8 @@ details: |
 
 # ubuntu-core, ubuntu-14, fedora, amazon are skipped as /run/uuidd/request file does not
 # exist. On those systems different files are being used instead.
-# arch: uses /run/run/uuidd/request, filed a bug report https://bugs.archlinux.org/task/58122
-systems: [-ubuntu-14.04-*,-ubuntu-core-*,-fedora-*, -arch-*, -amazon-*]
+# arch, opensuse: uses /run/run/uuidd/request, filed a bug report https://bugs.archlinux.org/task/58122
+systems: [-ubuntu-14.04-*,-ubuntu-core-*,-fedora-*, -arch-*, -amazon-*, -opensuse-*]
 
 prepare: |
     snap install test-snapd-openvswitch-support


### PR DESCRIPTION
Next update for opensuse is failing when interfaces-openvswitch-support
test is executed. The cause is the same than for arch system, where the
interface is allowing access to /run/uuidd/request and in these systems
the request is done in /run/run/uuidd/request, making fail the snaps
which try to request a random id.

test error:
https://paste.ubuntu.com/p/bv9xZj36XR/

debug info:
https://paste.ubuntu.com/p/nMF4BR8ZF7/
