### PR TITLE
tests: run interfaces-openvswitch-support on arch again, the arch bug is fixed

### DIFF
--- a/tests/main/interfaces-openvswitch-support/task.yaml
+++ b/tests/main/interfaces-openvswitch-support/task.yaml
@@ -5,8 +5,7 @@ details: |
 
 # ubuntu-core, ubuntu-14, fedora, amazon are skipped as /run/uuidd/request file does not
 # exist. On those systems different files are being used instead.
-# arch: uses /run/run/uuidd/request, filed a bug report https://bugs.archlinux.org/task/58122
-systems: [-ubuntu-14.04-*,-ubuntu-core-*,-fedora-*, -arch-*, -amazon-*]
+systems: [-ubuntu-14.04-*,-ubuntu-core-*,-fedora-*,-amazon-*]
 
 prepare: |
     snap install test-snapd-openvswitch-support


### PR DESCRIPTION
Bug https://bugs.archlinux.org/task/58122 is marked fixed so we can enable this test on arch again (presumably).