### PR TITLE
snap: make Epoch default to {[0],[0]} on load from yaml

### DIFF
--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -225,6 +225,12 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 		typ = TypeSnapd
 	}
 
+	if len(y.Epoch.Read) == 0 {
+		// normalize
+		y.Epoch.Read = []uint32{0}
+		y.Epoch.Write = []uint32{0}
+	}
+
 	confinement := StrictConfinement
 	if y.Confinement != "" {
 		confinement = y.Confinement

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -62,6 +62,7 @@ func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
 	c.Assert(info.InstanceName(), Equals, "foo")
 	c.Assert(info.Version, Equals, "1.0")
 	c.Assert(info.Type, Equals, snap.TypeApp)
+	c.Assert(info.Epoch, DeepEquals, *snap.E("0"))
 }
 
 func (s *InfoSnapYamlTestSuite) TestSnapdTypeAddedByMagic(c *C) {
@@ -1183,7 +1184,7 @@ slots:
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Type, Equals, snap.TypeApp)
-	c.Check(info.Epoch.String(), Equals, "1*")
+	c.Check(info.Epoch, DeepEquals, *snap.E("1*"))
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.Title(), Equals, "Foo")
 	c.Check(info.Summary(), Equals, "foo app")
@@ -1324,7 +1325,7 @@ version: 1.0
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
-	c.Assert(info.Epoch.String(), Equals, "0")
+	c.Assert(info.Epoch, DeepEquals, *snap.E("0"))
 }
 
 func (s *YamlSuite) TestSnapYamlConfinementDefault(c *C) {


### PR DESCRIPTION
Without this change, a snap's Epoch would default to nil if unset in
the yaml. This was fine when we used the serialiser that treated nil
and "0" as the same, but we're moving away from that so it needs to
change.
