### PR TITLE
overlord/ifacestate: use remapper when checking if system snap is installed

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -44,6 +44,7 @@ var (
 	GetHotplugSlots              = getHotplugSlots
 	SetHotplugSlots              = setHotplugSlots
 	FindConnsForHotplugKey       = findConnsForHotplugKey
+	CheckSystemSnapIsPresent     = checkSystemSnapIsPresent
 )
 
 func NewConnectOptsWithAutoSet() connectOpts {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -777,13 +777,13 @@ func connectDisconnectAffectedSnaps(t *state.Task) ([]string, error) {
 	return []string{plugRef.Snap, slotRef.Snap}, nil
 }
 
-func checkSystemSnapIsPresent(st *state.State) error {
+func checkSystemSnapIsPresent(st *state.State) bool {
 	// "system" gets remapped to either snapd or a core snap.
 	systemSnap := mapper.RemapSnapFromRequest("system")
 	st.Lock()
 	defer st.Unlock()
 	_, err := snapstate.CurrentInfo(st, systemSnap)
-	return err
+	return err == nil
 }
 
 func setHotplugAttrs(task *state.Task, ifaceName, hotplugKey string) {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -778,6 +778,7 @@ func connectDisconnectAffectedSnaps(t *state.Task) ([]string, error) {
 }
 
 func checkSystemSnapIsPresent(st *state.State) error {
+	// "system" gets remapped to either snapd or a core snap.
 	systemSnap := mapper.RemapSnapFromRequest("system")
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -777,10 +777,11 @@ func connectDisconnectAffectedSnaps(t *state.Task) ([]string, error) {
 	return []string{plugRef.Snap, slotRef.Snap}, nil
 }
 
-func ensureSystemSnapIsPresent(st *state.State) error {
+func checkSystemSnapIsPresent(st *state.State) error {
+	systemSnap := mapper.RemapSnapFromRequest("system")
 	st.Lock()
 	defer st.Unlock()
-	_, err := snapstate.CoreInfo(st)
+	_, err := snapstate.CurrentInfo(st, systemSnap)
 	return err
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -110,8 +110,8 @@ func (m *InterfaceManager) Ensure() error {
 	}
 
 	// don't initialize udev monitor until we have a system snap so that we
-	// can attach the hotplug interfaces to the core/snapd snap.
-	if err := ensureSystemSnapIsPresent(m.state); err != nil {
+	// can attach hotplug interfaces to it.
+	if err := checkSystemSnapIsPresent(m.state); err != nil {
 		return nil
 	}
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -111,7 +111,7 @@ func (m *InterfaceManager) Ensure() error {
 
 	// don't initialize udev monitor until we have a system snap so that we
 	// can attach hotplug interfaces to it.
-	if err := checkSystemSnapIsPresent(m.state); err != nil {
+	if !checkSystemSnapIsPresent(m.state) {
 		return nil
 	}
 


### PR DESCRIPTION
Rename ensureSystemSnapIsPresent to checkSystemSnapIsPresent and use remapper to find system snap name and make sure it's installed, instead of just `CoreInfo()`.
