### PR TITLE
snap, store, overlord/snapshotstate: drop epoch pointers

### DIFF
--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -482,7 +482,7 @@ func (s *snapshotSuite) testHappyRoundtrip(c *check.C, marker string) {
 	logger.SimpleSetup()
 
 	epoch := snap.E("42*")
-	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: *epoch}
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: epoch}
 	cfg := map[string]interface{}{"some-setting": false}
 	shID := uint64(12)
 
@@ -492,7 +492,7 @@ func (s *snapshotSuite) testHappyRoundtrip(c *check.C, marker string) {
 	c.Check(shw.Snap, check.Equals, info.InstanceName())
 	c.Check(shw.SnapID, check.Equals, info.SnapID)
 	c.Check(shw.Version, check.Equals, info.Version)
-	c.Check(shw.Epoch, check.DeepEquals, *epoch)
+	c.Check(shw.Epoch, check.DeepEquals, epoch)
 	c.Check(shw.Revision, check.Equals, info.Revision)
 	c.Check(shw.Conf, check.DeepEquals, cfg)
 	c.Check(backend.Filename(shw), check.Equals, filepath.Join(dirs.SnapshotsDir, "12_hello-snap_v1.33_42.zip"))
@@ -513,7 +513,7 @@ func (s *snapshotSuite) testHappyRoundtrip(c *check.C, marker string) {
 		c.Check(sh.Snap, check.Equals, info.InstanceName(), comm)
 		c.Check(sh.SnapID, check.Equals, info.SnapID, comm)
 		c.Check(sh.Version, check.Equals, info.Version, comm)
-		c.Check(sh.Epoch, check.DeepEquals, *epoch)
+		c.Check(sh.Epoch, check.DeepEquals, epoch)
 		c.Check(sh.Revision, check.Equals, info.Revision, comm)
 		c.Check(sh.Conf, check.DeepEquals, cfg, comm)
 		c.Check(sh.SHA3_384, check.DeepEquals, shw.SHA3_384, comm)
@@ -555,7 +555,7 @@ func (s *snapshotSuite) TestRestoreRoundtripDifferentRevision(c *check.C) {
 	logger.SimpleSetup()
 
 	epoch := snap.E("42*")
-	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: *epoch}
+	info := &snap.Info{SideInfo: snap.SideInfo{RealName: "hello-snap", Revision: snap.R(42), SnapID: "hello-id"}, Version: "v1.33", Epoch: epoch}
 	shID := uint64(12)
 
 	shw, err := backend.Save(context.TODO(), shID, info, nil, []string{"snapuser"})

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -237,7 +237,7 @@ func Restore(st *state.State, setID uint64, snapNames []string, users []string) 
 				// how?
 				return nil, nil, fmt.Errorf("unexpected error while reading snap info: %v", err)
 			}
-			if !info.Epoch.CanRead(&summary.epoch) {
+			if !info.Epoch.CanRead(summary.epoch) {
 				const tpl = "cannot restore snapshot for %q: current snap (epoch %s) cannot read snapshot data (epoch %s)"
 				return nil, nil, fmt.Errorf(tpl, summary.snap, &info.Epoch, &summary.epoch)
 			}

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -540,7 +540,7 @@ func (snapshotSuite) TestSaveIntegration(c *check.C) {
 			Snap:     name,
 			Version:  "v1",
 			Revision: sideInfo.Revision,
-			Epoch:    *snap.E("0"),
+			Epoch:    snap.E("0"),
 		}
 	}
 
@@ -855,7 +855,7 @@ func (snapshotSuite) TestRestoreChecksChangesToEpoch(c *check.C) {
 			Snapshot: client.Snapshot{
 				SetID: 42,
 				Snap:  "a-snap",
-				Epoch: *snap.E("42"),
+				Epoch: snap.E("42"),
 			},
 			File: shotfile,
 		}), check.IsNil)
@@ -896,7 +896,7 @@ func (snapshotSuite) TestRestoreWorksWithCompatibleEpoch(c *check.C) {
 			Snapshot: client.Snapshot{
 				SetID: 42,
 				Snap:  "a-snap",
-				Epoch: *snap.E("17"),
+				Epoch: snap.E("17"),
 			},
 			File: shotfile,
 		}), check.IsNil)

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -132,8 +132,7 @@ func (s epochSuite) TestGoodEpochs(c *check.C) {
 }
 
 func (s *epochSuite) TestEpochValidate(c *check.C) {
-	validEpochs := []*snap.Epoch{
-		nil,
+	validEpochs := []snap.Epoch{
 		{},
 		{Read: []uint32{0}, Write: []uint32{0}},
 		{Read: []uint32{0, 1}, Write: []uint32{1}},
@@ -146,26 +145,26 @@ func (s *epochSuite) TestEpochValidate(c *check.C) {
 		c.Check(err, check.IsNil, check.Commentf("%s", epoch))
 	}
 	invalidEpochs := []struct {
-		epoch *snap.Epoch
+		epoch snap.Epoch
 		err   string
 	}{
-		{epoch: &snap.Epoch{Read: []uint32{}}, err: emptyEpochList},
-		{epoch: &snap.Epoch{Write: []uint32{}}, err: emptyEpochList},
-		{epoch: &snap.Epoch{Read: []uint32{}, Write: []uint32{}}, err: emptyEpochList},
-		{epoch: &snap.Epoch{Read: []uint32{1}, Write: []uint32{2}}, err: noEpochIntersection},
-		{epoch: &snap.Epoch{Read: []uint32{1, 3, 5}, Write: []uint32{2, 4, 6}}, err: noEpochIntersection},
-		{epoch: &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{3, 2, 1}}, err: epochListNotSorted},
-		{epoch: &snap.Epoch{Read: []uint32{3, 2, 1}, Write: []uint32{1, 2, 3}}, err: epochListNotSorted},
-		{epoch: &snap.Epoch{Read: []uint32{3, 2, 1}, Write: []uint32{3, 2, 1}}, err: epochListNotSorted},
-		{epoch: &snap.Epoch{
+		{epoch: snap.Epoch{Read: []uint32{}}, err: emptyEpochList},
+		{epoch: snap.Epoch{Write: []uint32{}}, err: emptyEpochList},
+		{epoch: snap.Epoch{Read: []uint32{}, Write: []uint32{}}, err: emptyEpochList},
+		{epoch: snap.Epoch{Read: []uint32{1}, Write: []uint32{2}}, err: noEpochIntersection},
+		{epoch: snap.Epoch{Read: []uint32{1, 3, 5}, Write: []uint32{2, 4, 6}}, err: noEpochIntersection},
+		{epoch: snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{3, 2, 1}}, err: epochListNotSorted},
+		{epoch: snap.Epoch{Read: []uint32{3, 2, 1}, Write: []uint32{1, 2, 3}}, err: epochListNotSorted},
+		{epoch: snap.Epoch{Read: []uint32{3, 2, 1}, Write: []uint32{3, 2, 1}}, err: epochListNotSorted},
+		{epoch: snap.Epoch{
 			Read:  []uint32{0},
 			Write: []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		}, err: epochListJustRidiculouslyLong},
-		{epoch: &snap.Epoch{
+		{epoch: snap.Epoch{
 			Read:  []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			Write: []uint32{0},
 		}, err: epochListJustRidiculouslyLong},
-		{epoch: &snap.Epoch{
+		{epoch: snap.Epoch{
 			Read:  []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			Write: []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		}, err: epochListJustRidiculouslyLong},
@@ -178,16 +177,15 @@ func (s *epochSuite) TestEpochValidate(c *check.C) {
 
 func (s *epochSuite) TestEpochString(c *check.C) {
 	tests := []struct {
-		e *snap.Epoch
+		e snap.Epoch
 		s string
 	}{
-		{e: nil, s: "0"},
-		{e: &snap.Epoch{}, s: "0"},
-		{e: &snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: "0"},
-		{e: &snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: "1*"},
-		{e: &snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: "1"},
-		{e: &snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: "400*"},
-		{e: &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
+		{e: snap.Epoch{}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: "1*"},
+		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: "1"},
+		{e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: "400*"},
+		{e: snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
 	}
 	for _, test := range tests {
 		c.Check(test.e.String(), check.Equals, test.s, check.Commentf(test.s))
@@ -196,25 +194,20 @@ func (s *epochSuite) TestEpochString(c *check.C) {
 
 func (s *epochSuite) TestEpochMarshal(c *check.C) {
 	tests := []struct {
-		e *snap.Epoch
+		e snap.Epoch
 		s string
 	}{
-		{e: nil, s: `{"read":[0],"write":[0]}`},
-		{e: &snap.Epoch{}, s: `{"read":[0],"write":[0]}`},
-		{e: &snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
-		{e: &snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: `{"read":[0,1],"write":[1]}`},
-		{e: &snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: `{"read":[1],"write":[1]}`},
-		{e: &snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: `{"read":[399,400],"write":[400]}`},
-		{e: &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
+		{e: snap.Epoch{}, s: `{"read":[0],"write":[0]}`},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
+		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: `{"read":[0,1],"write":[1]}`},
+		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: `{"read":[1],"write":[1]}`},
+		{e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: `{"read":[399,400],"write":[400]}`},
+		{e: snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
 	}
 	for _, test := range tests {
 		bs, err := test.e.MarshalJSON()
 		c.Assert(err, check.IsNil)
 		c.Check(string(bs), check.Equals, test.s, check.Commentf(test.s))
-		if test.e == nil {
-			// json.Marshal((*foo)(nil)) is "null" no matter how hard you try
-			continue
-		}
 		bs, err = json.Marshal(test.e)
 		c.Assert(err, check.IsNil)
 		c.Check(string(bs), check.Equals, test.s, check.Commentf(test.s))
@@ -223,13 +216,13 @@ func (s *epochSuite) TestEpochMarshal(c *check.C) {
 
 func (s *epochSuite) TestE(c *check.C) {
 	tests := []struct {
-		e *snap.Epoch
+		e snap.Epoch
 		s string
 	}{
-		{s: "0", e: &snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
-		{s: "1", e: &snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}},
-		{s: "1*", e: &snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}},
-		{s: "400*", e: &snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}},
+		{s: "0", e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: "1", e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}},
+		{s: "1*", e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}},
+		{s: "400*", e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}},
 	}
 	for _, test := range tests {
 		c.Check(snap.E(test.s), check.DeepEquals, test.e, check.Commentf(test.s))
@@ -239,25 +232,24 @@ func (s *epochSuite) TestE(c *check.C) {
 
 func (s *epochSuite) TestCanRead(c *check.C) {
 	tests := []struct {
-		a, b   *snap.Epoch
+		a, b   snap.Epoch
 		ab, ba bool
 	}{
-		{ab: true, ba: true},                                     // nil should work (for tests!)
-		{a: &snap.Epoch{}, b: &snap.Epoch{}, ab: true, ba: true}, // test for empty epoch
-		{a: snap.E("0"), ab: true, ba: true},                     // hybrid empty / zero
+		{ab: true, ba: true},                 // test for empty epoch
+		{a: snap.E("0"), ab: true, ba: true}, // hybrid empty / zero
 		{a: snap.E("0"), b: snap.E("1"), ab: false, ba: false},
 		{a: snap.E("0"), b: snap.E("1*"), ab: false, ba: true},
 		{a: snap.E("0"), b: snap.E("2*"), ab: false, ba: false},
 
 		{
-			a:  &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{2}},
-			b:  &snap.Epoch{Read: []uint32{1, 3, 4}, Write: []uint32{4}},
+			a:  snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{2}},
+			b:  snap.Epoch{Read: []uint32{1, 3, 4}, Write: []uint32{4}},
 			ab: false,
 			ba: false,
 		},
 		{
-			a:  &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{3}},
-			b:  &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{2}},
+			a:  snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{3}},
+			b:  snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{2}},
 			ab: true,
 			ba: true,
 		},

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -62,7 +62,7 @@ func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
 	c.Assert(info.InstanceName(), Equals, "foo")
 	c.Assert(info.Version, Equals, "1.0")
 	c.Assert(info.Type, Equals, snap.TypeApp)
-	c.Assert(info.Epoch, DeepEquals, *snap.E("0"))
+	c.Assert(info.Epoch, DeepEquals, snap.E("0"))
 }
 
 func (s *InfoSnapYamlTestSuite) TestSnapdTypeAddedByMagic(c *C) {
@@ -1184,7 +1184,7 @@ slots:
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Type, Equals, snap.TypeApp)
-	c.Check(info.Epoch, DeepEquals, *snap.E("1*"))
+	c.Check(info.Epoch, DeepEquals, snap.E("1*"))
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.Title(), Equals, "Foo")
 	c.Check(info.Summary(), Equals, "foo app")
@@ -1325,7 +1325,7 @@ version: 1.0
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
-	c.Assert(info.Epoch, DeepEquals, *snap.E("0"))
+	c.Assert(info.Epoch, DeepEquals, snap.E("0"))
 }
 
 func (s *YamlSuite) TestSnapYamlConfinementDefault(c *C) {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -163,7 +163,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
 			Private:           false,
 			Paid:              false,
 		},
-		Epoch:       *snap.E("0"),
+		Epoch:       snap.E("0"),
 		Type:        snap.TypeOS,
 		Version:     "16-2.30",
 		Confinement: snap.StrictConfinement,
@@ -353,7 +353,7 @@ func fillStruct(a interface{}, c *C) {
 				Sha3_384: "foo",
 			}
 		case snap.Epoch:
-			x = *snap.E("1")
+			x = snap.E("1")
 		case map[string]string:
 			x = map[string]string{"foo": "bar"}
 		case bool:

--- a/store/store.go
+++ b/store/store.go
@@ -1260,7 +1260,6 @@ func (s *Store) WriteCatalogs(ctx context.Context, names io.Writer, adder SnapAd
 type RefreshCandidate struct {
 	SnapID   string
 	Revision snap.Revision
-	Epoch    snap.Epoch
 	Block    []snap.Revision
 
 	// the desired channel
@@ -1967,7 +1966,6 @@ type SnapAction struct {
 	Channel      string
 	Revision     snap.Revision
 	Flags        SnapActionFlags
-	Epoch        *snap.Epoch
 }
 
 func isValidAction(action string) bool {
@@ -1980,14 +1978,13 @@ func isValidAction(action string) bool {
 }
 
 type snapActionJSON struct {
-	Action           string      `json:"action"`
-	InstanceKey      string      `json:"instance-key"`
-	Name             string      `json:"name,omitempty"`
-	SnapID           string      `json:"snap-id,omitempty"`
-	Channel          string      `json:"channel,omitempty"`
-	Revision         int         `json:"revision,omitempty"`
-	Epoch            *snap.Epoch `json:"epoch,omitempty"`
-	IgnoreValidation *bool       `json:"ignore-validation,omitempty"`
+	Action           string `json:"action"`
+	InstanceKey      string `json:"instance-key"`
+	Name             string `json:"name,omitempty"`
+	SnapID           string `json:"snap-id,omitempty"`
+	Channel          string `json:"channel,omitempty"`
+	Revision         int    `json:"revision,omitempty"`
+	IgnoreValidation *bool  `json:"ignore-validation,omitempty"`
 }
 
 type snapRelease struct {
@@ -2167,7 +2164,6 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			SnapID:           a.SnapID,
 			Channel:          a.Channel,
 			Revision:         a.Revision.N,
-			Epoch:            a.Epoch,
 			IgnoreValidation: ignoreValidation,
 		}
 		if !a.Revision.Unset() {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2024,7 +2024,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Confinement: snap.StrictConfinement,
 			Channel:     "stable",
 			Size:        20480,
-			Epoch:       *snap.E("0"),
+			Epoch:       snap.E("0"),
 		},
 		"latest/candidate": {
 			Revision:    snap.R(27),
@@ -2032,7 +2032,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Confinement: snap.StrictConfinement,
 			Channel:     "candidate",
 			Size:        20480,
-			Epoch:       *snap.E("0"),
+			Epoch:       snap.E("0"),
 		},
 		"latest/beta": {
 			Revision:    snap.R(27),
@@ -2040,7 +2040,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Confinement: snap.StrictConfinement,
 			Channel:     "beta",
 			Size:        20480,
-			Epoch:       *snap.E("0"),
+			Epoch:       snap.E("0"),
 		},
 		"latest/edge": {
 			Revision:    snap.R(28),
@@ -2048,7 +2048,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Confinement: snap.StrictConfinement,
 			Channel:     "edge",
 			Size:        20480,
-			Epoch:       *snap.E("0"),
+			Epoch:       snap.E("0"),
 		},
 	}
 	for k, v := range result.Channels {


### PR DESCRIPTION
I got tired of the `snap.Epoch` vs `*snap.Epoch` mess.
