### PR TITLE
tests, fakestore: extend refresh tests with parallel installed snaps

### DIFF
--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -172,6 +172,7 @@ type essentialInfo struct {
 	Size        uint64
 	Digest      string
 	Confinement string
+	Type        string
 }
 
 var errInfo = errors.New("cannot get info")
@@ -228,6 +229,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 		Digest:      snapDigest,
 		Size:        size,
 		Confinement: string(info.Confinement),
+		Type:        string(info.Type),
 	}, nil
 }
 
@@ -247,6 +249,7 @@ type detailsReplyJSON struct {
 	Revision        int      `json:"revision"`
 	DownloadDigest  string   `json:"download_sha3_384"`
 	Confinement     string   `json:"confinement"`
+	Type            string   `json:"type"`
 }
 
 func (s *Store) searchEndpoint(w http.ResponseWriter, req *http.Request) {
@@ -297,6 +300,7 @@ func (s *Store) detailsEndpoint(w http.ResponseWriter, req *http.Request) {
 		Revision:        essInfo.Revision,
 		DownloadDigest:  hexify(essInfo.Digest),
 		Confinement:     essInfo.Confinement,
+		Type:            essInfo.Type,
 	}
 
 	// use indent because this is a development tool, output
@@ -434,6 +438,7 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 				Revision:        essInfo.Revision,
 				DownloadDigest:  hexify(essInfo.Digest),
 				Confinement:     essInfo.Confinement,
+				Type:            essInfo.Type,
 			})
 		}
 	}
@@ -531,6 +536,7 @@ type detailsResultV2 struct {
 	Version     string `json:"version"`
 	Revision    int    `json:"revision"`
 	Confinement string `json:"confinement"`
+	Type        string `json:"type"`
 }
 
 func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
@@ -613,6 +619,7 @@ func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
 					Version:       essInfo.Version,
 					Revision:      essInfo.Revision,
 					Confinement:   essInfo.Confinement,
+					Type:          essInfo.Type,
 				},
 			}
 			res.Snap.Publisher.ID = essInfo.DeveloperID

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -140,6 +140,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 		"revision":          float64(77),
 		"download_sha3_384": sha3_384,
 		"confinement":       "strict",
+		"type":              "app",
 	})
 }
 
@@ -166,6 +167,7 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 		"revision":          float64(424242),
 		"download_sha3_384": sha3_384,
 		"confinement":       "strict",
+		"type":              "app",
 	})
 
 	snapFn = s.makeTestSnap(c, "name: foo-classic\nversion: 1\nconfinement: classic")
@@ -188,6 +190,30 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 		"revision":          float64(424242),
 		"download_sha3_384": sha3_384,
 		"confinement":       "classic",
+		"type":              "app",
+	})
+
+	snapFn = s.makeTestSnap(c, "name: foo-base\nversion: 1\ntype: base")
+	resp, err = s.StoreGet(`/api/v1/snaps/details/foo-base`)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	sha3_384, _ = getSha(snapFn)
+	c.Check(body, DeepEquals, map[string]interface{}{
+		"architecture":      []interface{}{"all"},
+		"snap_id":           "",
+		"package_name":      "foo-base",
+		"origin":            "canonical",
+		"developer_id":      "canonical",
+		"anon_download_url": s.store.URL() + "/download/foo-base_1_all.snap",
+		"download_url":      s.store.URL() + "/download/foo-base_1_all.snap",
+		"version":           "1",
+		"revision":          float64(424242),
+		"download_sha3_384": sha3_384,
+		"confinement":       "strict",
+		"type":              "base",
 	})
 }
 
@@ -222,6 +248,7 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
 		"revision":          float64(424242),
 		"download_sha3_384": sha3_384,
 		"confinement":       "strict",
+		"type":              "app",
 	}})
 }
 
@@ -255,6 +282,7 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 		"revision":          float64(99),
 		"download_sha3_384": sha3_384,
 		"confinement":       "strict",
+		"type":              "app",
 	}})
 }
 
@@ -459,6 +487,7 @@ func (s *storeTestSuite) TestSnapActionEndpoint(c *C) {
 			"version":     "1",
 			"revision":    float64(424242),
 			"confinement": "strict",
+			"type":        "app",
 		},
 	})
 }
@@ -502,6 +531,7 @@ func (s *storeTestSuite) TestSnapActionEndpointWithAssertions(c *C) {
 			"version":     "10",
 			"revision":    float64(99),
 			"confinement": "strict",
+			"type":        "app",
 		},
 	})
 }
@@ -544,6 +574,7 @@ func (s *storeTestSuite) TestSnapActionEndpointRefreshAll(c *C) {
 			"version":     "1",
 			"revision":    float64(424242),
 			"confinement": "strict",
+			"type":        "app",
 		},
 	})
 }
@@ -587,6 +618,7 @@ func (s *storeTestSuite) TestSnapActionEndpointWithAssertionsInstall(c *C) {
 			"version":     "10",
 			"revision":    float64(99),
 			"confinement": "strict",
+			"type":        "app",
 		},
 	})
 }

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -7,8 +7,20 @@ summary: Check that auto-refresh works
 # for the serial happens after 5min, then 10min, then 20min.
 systems: [-ubuntu-core-18-*]
 
+environment:
+    SNAP_NAME/regular: test-snapd-tools
+    SNAP_NAME/parallel: test-snapd-tools_instance
+
 prepare: |
     snap install --devmode jq
+    if [[ "$SPREAD_VARIANT" =~ parallel ]]; then
+        snap set system experimental.parallel-instances=true
+    fi
+
+restore: |
+    if [[ "$SPREAD_VARIANT" =~ parallel ]]; then
+        snap set system experimental.parallel-instances=null
+    fi
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
@@ -32,14 +44,14 @@ execute: |
     fi
 
     echo "Install a snap from stable"
-    snap install test-snapd-tools
-    snap list | MATCH 'test-snapd-tools +[0-9]+\.[0-9]+'
+    snap install "$SNAP_NAME"
+    snap list | MATCH "$SNAP_NAME +[0-9]+\\.[0-9]+"
 
     snap set core refresh.schedule="0:00-23:59"
     systemctl stop snapd.{service,socket}
 
     echo "Modify the snap to track the edge channel"
-    jq '.data.snaps["test-snapd-tools"].channel = "edge"' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    jq ".data.snaps[\"$SNAP_NAME\"].channel = \"edge\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
     mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
 
     echo "And force auto-refresh to happen"
@@ -50,7 +62,7 @@ execute: |
 
     echo "wait for auto-refresh to happen"
     for _ in $(seq 120); do
-        if snap changes|grep -q "Done.*Auto-refresh snap \"test-snapd-tools\""; then
+        if snap changes|grep -q "Done.*Auto-refresh snap \"$SNAP_NAME\""; then
             break
         fi
         echo "Ensure refresh"
@@ -59,7 +71,7 @@ execute: |
     done
 
     echo "Ensure our snap got updated"
-    snap list|MATCH 'test-snapd-tools +[0-9]+\.[0-9]+\+fake1'
+    snap list|MATCH "$SNAP_NAME +[0-9]+\\.[0-9]+\\+fake1"
 
     echo "Ensure refresh.last is set"
     jq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH "$(date +%Y)"

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -19,8 +19,11 @@ prepare: |
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
 
-    echo "Given two snaps are installed"
-    for snap in test-snapd-tools test-snapd-python-webserver; do
+    # needed for test-snapd-tools_instance
+    snap set system experimental.parallel-instances=true
+
+    echo "Given snaps installed"
+    for snap in test-snapd-tools test-snapd-tools_instance test-snapd-python-webserver; do
         snap install $snap
     done
 
@@ -37,6 +40,8 @@ restore: |
     . "$TESTSLIB"/store.sh
     teardown_fake_store "$BLOB_DIR"
     rm -rf "$BLOB_DIR"
+
+    snap set system experimental.parallel-instances=null
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -61,6 +66,6 @@ execute: |
     snap refresh
 
     echo "Then the new versions are installed"
-    for snap in test-snapd-tools test-snapd-python-webserver; do
-        snap list | MATCH "$snap.*fake1"
+    for snap in test-snapd-tools test-snapd-tools_instance test-snapd-python-webserver; do
+        snap list | MATCH "$snap .*fake1"
     done

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -10,12 +10,13 @@ details: |
     edge channel.
 
 environment:
+    SNAP_NAME/parallel_strict_fake,parallel_strict_remote: test-snapd-tools_instance
     SNAP_NAME/strict_fake,strict_remote: test-snapd-tools
     SNAP_NAME/classic_fake,classic_remote: test-snapd-classic-confinement
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
-    STORE_TYPE/strict_fake,classic_fake: fake
-    STORE_TYPE/strict_remote,classic_remote: ${REMOTE_STORE}
+    STORE_TYPE/parallel_strict_fake,strict_fake,classic_fake: fake
+    STORE_TYPE/parallel_strict_remote,strict_remote,classic_remote: ${REMOTE_STORE}
 
 prepare: |
     #shellcheck source=tests/lib/systems.sh
@@ -39,6 +40,10 @@ prepare: |
                 ;;
         esac
         flags=--classic
+    fi
+
+    if [[ "$SPREAD_VARIANT" =~ parallel ]]; then
+        snap set system experimental.parallel-instances=true
     fi
 
     echo "Given a snap is installed"
@@ -71,6 +76,10 @@ restore: |
         #shellcheck source=tests/lib/store.sh
         . "$TESTSLIB"/store.sh
         teardown_fake_store "$BLOB_DIR"
+    fi
+
+    if [[ "$SPREAD_VARIANT" =~ parallel ]]; then
+        snap set system experimental.parallel-instances=null
     fi
 
 execute: |


### PR DESCRIPTION
Extend the refresh tests to cover snaps with instance key. As a prerequisite, extend the fakestore to properly report snap type, which we expect to be always reported back by the store.
