### PR TITLE
interfaces: export gpio pin in AppArmorConnectedPlug

### DIFF
--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
@@ -116,6 +117,16 @@ func (iface *gpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 			if !osutil.FileExists(path) {
 				return err
 			}
+		}
+		// give the kernel/mock a bit of time to export the device
+		for i := 0; i < 100; i++ {
+			if osutil.FileExists(path) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if !osutil.FileExists(path) {
+			return fmt.Errorf("%q was not created", path)
 		}
 	}
 

--- a/tests/regression/lp-1802581/mock-gpio.py
+++ b/tests/regression/lp-1802581/mock-gpio.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+
+import os
+import selectors
+import sys
+
+
+def data_to_gpio(data):
+    return "gpio"+data.decode().strip()
+
+
+def export_ready(fd, mask):
+    data = os.read(fd, 128)
+    # allow quit
+    if data == b'quit\n':
+        return False
+    with open(data_to_gpio(data), "w"):
+        pass
+    return True
+    
+
+def unexport_ready(fd, mask):
+    os.remove(data_to_gpio(os.read(fd, 128)))
+    return True
+
+
+def dispatch(sel):
+    for key, mask in sel.select():
+        callback = key.data
+        if not callback(key.fileobj, mask):
+            return False
+    return True
+
+
+if __name__ == "__main__":
+    os.chdir(sys.argv[1])
+    
+    # fake gpio export/unexport files
+    os.mkfifo("export")
+    os.mkfifo("unexport")
+
+    # ensure that we create the right 
+    sel = selectors.DefaultSelector()
+    efd = os.open("export", os.O_RDWR | os.O_NONBLOCK)
+    ufd = os.open("unexport", os.O_RDWR | os.O_NONBLOCK)
+    sel.register(efd, selectors.EVENT_READ, export_ready)
+    sel.register(ufd, selectors.EVENT_READ, unexport_ready)
+    while True:
+        if not dispatch(sel):
+            break
+
+    # cleanup
+    os.close(efd)
+    os.close(ufd)

--- a/tests/regression/lp-1802581/task.yaml
+++ b/tests/regression/lp-1802581/task.yaml
@@ -2,22 +2,20 @@ summary: Regression test for  1802581
 
 systems: [ubuntu-core-16-64]
 
-environment:
-    GPIO_MOCK_DIR: /home/test/gpio-mock
-
 prepare: |
-    echo "Mock gpio"
-    mkdir -p "$GPIO_MOCK_DIR"
-    systemd-run --unit mock-gpio -- "$(pwd)/mock-gpio.py" "$GPIO_MOCK_DIR"
+    echo "Run mock gpio daemon"
+    systemd-run --unit mock-gpio -- "$(pwd)/mock-gpio.py"
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
     wait_for_service mock-gpio
-    mount --bind "$GPIO_MOCK_DIR" /sys/class/gpio
 
 restore: |
     systemctl stop mock-gpio || true
+    # for good measure, mock-gpio.py does this umount already on exit
     umount /sys/class/gpio || true
-    rm -rf "$GPIO_MOCK_DIR"
+
+debug: |
+    journalctl -u mock-gpio.service
 
 execute: |
     echo "Install a snap that uses the gpio consumer"
@@ -36,3 +34,6 @@ execute: |
 
     echo "Check that the connection is still here after enable"
     snap interfaces | MATCH ":gpio-pin.*gpio-consumer:gpio"
+
+    echo "Ensure that our mock service is full functional"
+    systemctl status mock-gpio.service | MATCH "Active: active"

--- a/tests/regression/lp-1802581/task.yaml
+++ b/tests/regression/lp-1802581/task.yaml
@@ -1,4 +1,21 @@
-summary: Regression test for  1802581
+summary: Regression test for LP 1802581
+
+description: |
+    When using the snapd GPIO interface the slot side needs to export the GPIO
+    pint so that a file appears under /sys/class/gpio/gpioNNN. That file is a
+    symbolic link to a special, platform specific device path. The symbolic
+    link needs to be evaluated so that apparmor rules for the plug side can be
+    constructed.
+
+    A customer has reported that when a snap is disabled and then re-enabled
+    the GPIO pin is not exported and apparmor backend cannot setup security
+    of the snap being enabled.
+
+    A similar issue has occurred once in the past where the order in which
+    security backends operated was not deterministic. We fixed the issue by
+    applying a fixed order so that the systemd backend, responsible for
+    exporting the pin, would always run before the apparmor backend, which
+    could now rely on the pin being exposed to userspace.
 
 systems: [ubuntu-core-16-64]
 

--- a/tests/regression/lp-1802581/task.yaml
+++ b/tests/regression/lp-1802581/task.yaml
@@ -1,0 +1,38 @@
+summary: Regression test for  1802581
+
+systems: [ubuntu-core-16-64]
+
+environment:
+    GPIO_MOCK_DIR: /home/test/gpio-mock
+
+prepare: |
+    echo "Mock gpio"
+    mkdir -p "$GPIO_MOCK_DIR"
+    systemd-run --unit mock-gpio -- "$(pwd)/mock-gpio.py" "$GPIO_MOCK_DIR"
+    # shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB/systemd.sh"
+    wait_for_service mock-gpio
+    mount --bind "$GPIO_MOCK_DIR" /sys/class/gpio
+
+restore: |
+    systemctl stop mock-gpio || true
+    umount /sys/class/gpio || true
+    rm -rf "$GPIO_MOCK_DIR"
+
+execute: |
+    echo "Install a snap that uses the gpio consumer"
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local gpio-consumer
+
+    echo "And connect the gpio pin"
+    snap connect gpio-consumer:gpio :gpio-pin
+    snap interfaces | MATCH ":gpio-pin.*gpio-consumer:gpio"
+
+    # LP-1802581
+    echo "Now disable and enable the snap to ensure lp: #1802581 is fixed"
+    snap disable gpio-consumer
+    snap enable gpio-consumer
+
+    echo "Check that the connection is still here after enable"
+    snap interfaces | MATCH ":gpio-pin.*gpio-consumer:gpio"


### PR DESCRIPTION
This is an alternative and simpler approach to fix the ordering issue we have with the apparmor backend and the systemd backend. The other two approaches are #6127  and #6128.

By exporting the gpio pin in the apparmor connected plug code we
avoid the implicit dependency between the apparmor and the systemd
security backends.
    
The layering is not ideal but by doing it this way we avoid
complicating the generic interfaces code that so far has no
concept of dependencies between security backends. If we ever
add such a concept we can tweak this the gpioInterface by modeling
that for a gpio connection we always run the "slot systemd backend
 first".
    
This should also allow us to get rid of the order when adding
the backends and we could potentially run all security setup in
parallel (this PR is not doing any of this though :)

If this looks reasonable I will:
- add a proper unit test
- extend the spread test so that it also checks that the exported gpio100 is there even after rebooting