### PR TITLE
overlord/snapstate, store: always send epochs

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -658,6 +658,7 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		SideInfo:      *si,
 		Architectures: []string{"all"},
 		Type:          snap.TypeApp,
+		Epoch:         snap.E("1*"),
 	}
 	if strings.Contains(snapName, "alias-snap") {
 		// only for the switch below

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2799,6 +2799,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "stable",
 				RefreshedDate:   refreshedDate,
+				Epoch:           snap.E("0"),
 			}},
 			userID: 1,
 		},
@@ -3016,6 +3017,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "stable",
 				RefreshedDate:   refreshedDate,
+				Epoch:           snap.E("0"),
 			}},
 			userID: 1,
 		},
@@ -3498,9 +3500,27 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 		case "storesvc-snap-action":
 			ir++
 			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
-				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
-				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
-				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+				{
+					InstanceName:  "core",
+					SnapID:        "core-snap-id",
+					Revision:      snap.R(1),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1),
+					Epoch:         snap.E("1*"),
+				},
+				{
+					InstanceName:  "services-snap",
+					SnapID:        "services-snap-id",
+					Revision:      snap.R(2),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2),
+					Epoch:         snap.E("0"),
+				},
+				{
+					InstanceName:  "some-snap",
+					SnapID:        "some-snap-id",
+					Revision:      snap.R(5),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5),
+					Epoch:         snap.E("1*"),
+				},
 			})
 		case "storesvc-snap-action:action":
 			snapID := op.action.SnapID
@@ -3592,9 +3612,27 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 		case "storesvc-snap-action":
 			ir++
 			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
-				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
-				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
-				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+				{
+					InstanceName:  "core",
+					SnapID:        "core-snap-id",
+					Revision:      snap.R(1),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1),
+					Epoch:         snap.E("1*"),
+				},
+				{
+					InstanceName:  "services-snap",
+					SnapID:        "services-snap-id",
+					Revision:      snap.R(2),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2),
+					Epoch:         snap.E("0"),
+				},
+				{
+					InstanceName:  "some-snap",
+					SnapID:        "some-snap-id",
+					Revision:      snap.R(5),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5),
+					Epoch:         snap.E("1*"),
+				},
 			})
 		case "storesvc-snap-action:action":
 			snapID := op.action.SnapID
@@ -3697,9 +3735,27 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThro
 		case "storesvc-snap-action":
 			ir++
 			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
-				{InstanceName: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
-				{InstanceName: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
-				{InstanceName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+				{
+					InstanceName:  "core",
+					SnapID:        "core-snap-id",
+					Revision:      snap.R(1),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1),
+					Epoch:         snap.E("1*"),
+				},
+				{
+					InstanceName:  "services-snap",
+					SnapID:        "services-snap-id",
+					Revision:      snap.R(2),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2),
+					Epoch:         snap.E("0"),
+				},
+				{
+					InstanceName:  "some-snap",
+					SnapID:        "some-snap-id",
+					Revision:      snap.R(5),
+					RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5),
+					Epoch:         snap.E("1*"),
+				},
 			})
 		case "storesvc-snap-action:action":
 			snapID := op.action.SnapID
@@ -3762,6 +3818,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 				SnapID:        "some-snap-id",
 				Revision:      snap.R(7),
 				RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+				Epoch:         snap.E("1*"),
 			}},
 			userID: 1,
 		},
@@ -3943,6 +4000,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "stable",
 				RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 7),
+				Epoch:           snap.E("1*"),
 			}},
 			userID: 1,
 		},
@@ -4236,6 +4294,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 				Revision:        snap.R(7),
 				TrackingChannel: "other-channel",
 				RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 7),
+				Epoch:           snap.E("1*"),
 			}},
 			userID: 1,
 		},
@@ -4509,6 +4568,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 			Revision:         snap.R(7),
 			IgnoreValidation: false,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 7),
+			Epoch:            snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -4557,6 +4617,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 			TrackingChannel:  "stable",
 			IgnoreValidation: true,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 11),
+			Epoch:            snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -4609,6 +4670,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 			TrackingChannel:  "stable",
 			IgnoreValidation: true,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 12),
+			Epoch:            snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -4694,12 +4756,14 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 			Revision:         snap.R(7),
 			IgnoreValidation: false,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 7),
+			Epoch:            snap.E("1*"),
 		}, {
 			InstanceName:     "some-snap_instance",
 			SnapID:           "some-snap-id",
 			Revision:         snap.R(7),
 			IgnoreValidation: false,
 			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 7),
+			Epoch:            snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -4786,6 +4850,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 					Revision:         snap.R(7),
 					IgnoreValidation: false,
 					RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 7),
+					Epoch:            snap.E("1*"),
 				}, {
 					InstanceName:     "some-snap_instance",
 					SnapID:           "some-snap-id",
@@ -4793,6 +4858,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 					TrackingChannel:  "stable",
 					IgnoreValidation: true,
 					RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 11),
+					Epoch:            snap.E("1*"),
 				}},
 				userID: 1,
 			})
@@ -4935,6 +5001,7 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 			SnapID:        "some-snap-id",
 			Revision:      snap.R(7),
 			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+			Epoch:         snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -4975,6 +5042,7 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 			SnapID:        "some-snap-id",
 			Revision:      snap.R(7),
 			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+			Epoch:         snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -5015,6 +5083,7 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 			Revision:      snap.R(7),
 			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
 			Block:         []snap.Revision{snap.R(11)},
+			Epoch:         snap.E("1*"),
 		}},
 		userID: 1,
 	})
@@ -10515,7 +10584,14 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		{
 			op: "storesvc-snap-action",
 			curSnaps: []store.CurrentSnap{
-				{InstanceName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1), TrackingChannel: "beta", RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
+				{
+					InstanceName:    "ubuntu-core",
+					SnapID:          "ubuntu-core-snap-id",
+					Revision:        snap.R(1),
+					TrackingChannel: "beta",
+					RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 1),
+					Epoch:           snap.E("1*"),
+				},
 			},
 		},
 		{

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2754,6 +2754,126 @@ func (s *snapmgrTestSuite) TestInstalling(c *C) {
 	c.Check(snapstate.Installing(s.state), Equals, true)
 }
 
+func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
+	si := snap.SideInfo{
+		RealName: "some-snap",
+		Revision: snap.R(7),
+	}
+	snaptest.MockSnap(c, `name: some-snap`, &si)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Current:  si.Revision,
+		SnapType: "app",
+		Channel:  "stable",
+	})
+
+	chg := s.state.NewChange("refresh", "refresh a snap")
+	ts, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{Amend: true})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	// ensure all our tasks ran
+	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
+		macaroon: s.user.StoreMacaroon,
+		name:     "some-snap",
+		target:   filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+	}})
+	c.Check(s.fakeStore.seenPrivacyKeys["privacy-key"], Equals, true, Commentf("salts seen: %v", s.fakeStore.seenPrivacyKeys))
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, []string{
+		"storesvc-snap-action",
+		"storesvc-snap-action:action",
+		"storesvc-download",
+		"validate-snap:Doing",
+		"current",
+		"open-snap-file",
+		"setup-snap",
+		"remove-snap-aliases",
+		"unlink-snap",
+		"copy-data",
+		"setup-profiles:Doing",
+		"candidate",
+		"link-snap",
+		"auto-connect:Doing",
+		"update-aliases",
+		"cleanup-trash",
+	})
+	// just check the interesting op
+	c.Check(s.fakeBackend.ops[1], DeepEquals, fakeOp{
+		op: "storesvc-snap-action:action",
+		action: store.SnapAction{
+			Action:       "install", // we asked for an Update, but an amend is actually an Install
+			InstanceName: "some-snap",
+			Channel:      "some-channel",
+			Epoch:        snap.E("1*"), // in amend, epoch in the action is not nil!
+			Flags:        store.SnapActionEnforceValidation,
+		},
+		revno:  snap.R(11),
+		userID: 1,
+	})
+
+	task := ts.Tasks()[1]
+	// verify snapSetup info
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
+		Channel: "some-channel",
+		UserID:  s.user.ID,
+
+		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+		DownloadInfo: &snap.DownloadInfo{
+			DownloadURL: "https://some-server.com/some/path.snap",
+		},
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
+		Flags:     snapstate.Flags{Amend: true},
+	})
+	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		RealName: "some-snap",
+		Revision: snap.R(11),
+		Channel:  "some-channel",
+		SnapID:   "some-snap-id",
+	})
+
+	// verify services stop reason
+	verifyStopReason(c, ts, "refresh")
+
+	// check post-refresh hook
+	task = ts.Tasks()[14]
+	c.Assert(task.Kind(), Equals, "run-hook")
+	c.Assert(task.Summary(), Matches, `Run post-refresh hook of "some-snap" snap if present`)
+
+	// verify snaps in the system state
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, "some-snap", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Sequence, HasLen, 2)
+	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		RealName: "some-snap",
+		Channel:  "",
+		Revision: snap.R(7),
+	})
+	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+		RealName: "some-snap",
+		Channel:  "some-channel",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(11),
+	})
+}
+
 func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	// use services-snap here to make sure services would be stopped/started appropriately
 	si := snap.SideInfo{

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -315,6 +315,7 @@ func collectCurrentSnaps(snapStates map[string]*SnapState, consider func(*store.
 			Revision:         snapInfo.Revision,
 			RefreshedDate:    revisionDate(snapInfo),
 			IgnoreValidation: snapst.IgnoreValidation,
+			Epoch:            snapInfo.Epoch,
 		}
 		curSnaps = append(curSnaps, installed)
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -167,6 +167,7 @@ func updateInfo(st *state.State, snapst *SnapState, opts *updateInfoOpts, userID
 
 	if curInfo.SnapID == "" { // amend
 		action.Action = "install"
+		action.Epoch = curInfo.Epoch
 	}
 
 	theStore := Store(st)

--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -146,9 +146,14 @@ func (e *Epoch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return e.fromStructured(structured)
 }
 
+// Unset checks if a snap is not set
+func (e *Epoch) Unset() bool {
+	return e == nil || (e.Read == nil && e.Write == nil)
+}
+
 // Validate checks that the epoch makes sense.
 func (e *Epoch) Validate() error {
-	if e == nil || (e.Read == nil && e.Write == nil) {
+	if e.Unset() {
 		// (*Epoch)(nil) and &Epoch{} are valid epochs, equivalent to "0"
 		return nil
 	}
@@ -169,7 +174,7 @@ func (e *Epoch) Validate() error {
 }
 
 func (e *Epoch) simplify() interface{} {
-	if e == nil || (e.Read == nil && e.Write == nil) {
+	if e.Unset() {
 		return "0"
 	}
 	if len(e.Write) == 1 && len(e.Read) == 1 && e.Read[0] == e.Write[0] {

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -230,6 +230,20 @@ func (s *epochSuite) TestE(c *check.C) {
 	}
 }
 
+func (s *epochSuite) TestUnset(c *check.C) {
+	for _, e := range []*snap.Epoch{nil, {}} {
+		c.Check(e.Unset(), check.Equals, true, check.Commentf("%#v", e))
+	}
+	for _, e := range []*snap.Epoch{
+		{Read: []uint32{0}, Write: []uint32{0}},
+		{Read: []uint32{}, Write: []uint32{}}, // invalid
+		{Read: []uint32{0}},                   // invalid
+		{Write: []uint32{0}},                  // invalid
+	} {
+		c.Check(e.Unset(), check.Equals, false, check.Commentf("%#v", e))
+	}
+}
+
 func (s *epochSuite) TestCanRead(c *check.C) {
 	tests := []struct {
 		a, b   snap.Epoch

--- a/store/store.go
+++ b/store/store.go
@@ -2202,10 +2202,10 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 
 		if a.Action != "refresh" {
 			aJSON.Name = snap.InstanceSnap(a.InstanceName)
-			if a.SnapID != "" {
-				aJSON.Epoch = &a.Epoch
-			} else {
+			if a.Epoch.Unset() {
 				aJSON.Epoch = (*snap.Epoch)(nil)
+			} else {
+				aJSON.Epoch = &a.Epoch
 			}
 		}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -64,6 +64,9 @@ type configTestSuite struct{}
 
 var _ = Suite(&configTestSuite{})
 
+// this is what snap.E("0") looks like when decoded into an interface{} (the /^i/ is for "interface")
+var iZeroEpoch = map[string]interface{}{"read": []interface{}{0.}, "write": []interface{}{0.}}
+
 func (suite *configTestSuite) TestSetBaseURL(c *C) {
 	// Sanity check to prove at least one URI changes.
 	cfg := store.DefaultConfig()
@@ -4065,6 +4068,7 @@ func (s *storeTestSuite) TestSnapAction(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4155,6 +4159,7 @@ func (s *storeTestSuite) TestSnapActionNoResults(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 0)
 		io.WriteString(w, `{
@@ -4218,6 +4223,7 @@ func (s *storeTestSuite) TestSnapActionRefreshedDateIsOptional(c *C) {
 
 			"revision":         float64(1),
 			"tracking-channel": "beta",
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 0)
 		io.WriteString(w, `{
@@ -4270,6 +4276,7 @@ func (s *storeTestSuite) TestSnapActionSkipBlocked(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4358,6 +4365,7 @@ func (s *storeTestSuite) TestSnapActionSkipCurrent(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4519,6 +4527,7 @@ func (s *storeTestSuite) TestSnapActionIgnoreValidation(c *C) {
 			"tracking-channel":  "stable",
 			"refreshed-date":    helloRefreshedDateStr,
 			"ignore-validation": true,
+			"epoch":             iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4607,6 +4616,7 @@ func (s *storeTestSuite) TestInstallFallbackChannelIsStable(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4700,6 +4710,7 @@ func (s *storeTestSuite) TestSnapActionNonDefaultsHeaders(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4794,6 +4805,7 @@ func (s *storeTestSuite) TestSnapActionWithDeltas(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "beta",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4879,6 +4891,7 @@ func (s *storeTestSuite) TestSnapActionOptions(c *C) {
 			"revision":         float64(1),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -4984,6 +4997,7 @@ func (s *storeTestSuite) testSnapActionGet(action string, c *C) {
 			"instance-key": action + "-1",
 			"name":         "hello-world",
 			"channel":      "beta",
+			"epoch":        nil,
 		})
 
 		fmt.Fprintf(w, `{
@@ -5037,6 +5051,102 @@ func (s *storeTestSuite) testSnapActionGet(action string, c *C) {
 	// effective-channel
 	c.Assert(results[0].Channel, Equals, "candidate")
 }
+
+func (s *storeTestSuite) TestSnapActionInstallAmend(c *C) {
+	// this is what amend would look like
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Refresh-Managed"), Equals, "")
+
+		// no store ID by default
+		storeID := r.Header.Get("Snap-Device-Store")
+		c.Check(storeID, Equals, "")
+
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, release.Series)
+		c.Check(r.Header.Get("Snap-Device-Architecture"), Equals, arch.UbuntuArchitecture())
+		c.Check(r.Header.Get("Snap-Classic"), Equals, "false")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "install",
+			"instance-key": "install-1",
+			"name":         "hello-world",
+			"channel":      "beta",
+			"epoch":        map[string]interface{}{"read": []interface{}{0., 1.}, "write": []interface{}{1.}},
+			"snap-id":      helloWorldSnapID,
+		})
+
+		fmt.Fprint(w, `{
+  "results": [{
+     "result": "install",
+     "instance-key": "install-1",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "effective-channel": "candidate",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := store.New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), nil,
+		[]*store.SnapAction{
+			{
+				Action:       "install",
+				InstanceName: "hello-world",
+				Channel:      "beta",
+				SnapID:       helloWorldSnapID,
+				Epoch:        snap.E("1*"),
+			},
+		}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].InstanceName(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].Publisher.ID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+	// effective-channel
+	c.Assert(results[0].Channel, Equals, "candidate")
+}
+
 func (s *storeTestSuite) TestSnapActionDownloadParallelInstanceKey(c *C) {
 	// action here is one of install or download
 	restore := release.MockOnClassic(false)
@@ -5112,6 +5222,7 @@ func (s *storeTestSuite) testSnapActionGetWithRevision(action string, c *C) {
 			"instance-key": action + "-1",
 			"name":         "hello-world",
 			"revision":     float64(28),
+			"epoch":        nil,
 		})
 
 		fmt.Fprintf(w, `{
@@ -5188,6 +5299,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
 			"snap-id":          "snap2-id",
@@ -5195,6 +5307,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "edge",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 4)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -5213,12 +5326,14 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 			"instance-key": "install-1",
 			"name":         "foo",
 			"channel":      "stable",
+			"epoch":        nil,
 		})
 		c.Assert(req.Actions[3], DeepEquals, map[string]interface{}{
 			"action":       "download",
 			"instance-key": "download-1",
 			"name":         "bar",
 			"revision":     42.,
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{
@@ -5365,6 +5480,7 @@ func (s *storeTestSuite) TestSnapActionSnapNotFound(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 3)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -5378,12 +5494,14 @@ func (s *storeTestSuite) TestSnapActionSnapNotFound(c *C) {
 			"instance-key": "install-1",
 			"name":         "foo",
 			"channel":      "stable",
+			"epoch":        nil,
 		})
 		c.Assert(req.Actions[2], DeepEquals, map[string]interface{}{
 			"action":       "download",
 			"instance-key": "download-1",
 			"name":         "bar",
 			"revision":     42.,
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{
@@ -5486,6 +5604,7 @@ func (s *storeTestSuite) TestSnapActionOtherErrors(c *C) {
 			"instance-key": "install-1",
 			"name":         "foo",
 			"channel":      "stable",
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{
@@ -5910,6 +6029,7 @@ func (s *storeTestSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
 			"snap-id":          helloWorldSnapID,
@@ -5917,6 +6037,7 @@ func (s *storeTestSuite) TestSnapActionRefreshParallelInstall(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -6011,6 +6132,7 @@ func (s *storeTestSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
 			"snap-id":          helloWorldSnapID,
@@ -6018,6 +6140,7 @@ func (s *storeTestSuite) TestSnapActionRefreshStableInstanceKey(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -6118,6 +6241,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *C)
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
 			"snap-id":          helloWorldSnapID,
@@ -6125,6 +6249,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *C)
 			"revision":         float64(2),
 			"tracking-channel": "edge",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 3)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -6142,6 +6267,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailableParallelInstall(c *C)
 			"instance-key": "install-1",
 			"name":         "other",
 			"channel":      "stable",
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{
@@ -6261,6 +6387,7 @@ func (s *storeTestSuite) TestSnapActionInstallParallelInstall(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -6268,6 +6395,7 @@ func (s *storeTestSuite) TestSnapActionInstallParallelInstall(c *C) {
 			"instance-key": "install-1",
 			"name":         "hello-world",
 			"channel":      "stable",
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{
@@ -6373,6 +6501,7 @@ func (s *storeTestSuite) TestSnapActionInstallUnexpectedInstallKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -6380,6 +6509,7 @@ func (s *storeTestSuite) TestSnapActionInstallUnexpectedInstallKey(c *C) {
 			"instance-key": "install-1",
 			"name":         "hello-world",
 			"channel":      "stable",
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{
@@ -6455,6 +6585,7 @@ func (s *storeTestSuite) TestSnapActionRefreshUnexpectedInstanceKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -6538,6 +6669,7 @@ func (s *storeTestSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			"revision":         float64(26),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Context[1], DeepEquals, map[string]interface{}{
 			"snap-id":          helloWorldSnapID,
@@ -6545,12 +6677,14 @@ func (s *storeTestSuite) TestSnapActionUnexpectedErrorKey(c *C) {
 			"revision":         float64(2),
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iZeroEpoch,
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
 			"action":       "install",
 			"instance-key": "install-1",
 			"name":         "foo-2",
+			"epoch":        nil,
 		})
 
 		io.WriteString(w, `{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -5090,7 +5090,6 @@ func (s *storeTestSuite) TestSnapActionInstallAmend(c *C) {
 			"name":         "hello-world",
 			"channel":      "beta",
 			"epoch":        map[string]interface{}{"read": []interface{}{0., 1.}, "write": []interface{}{1.}},
-			"snap-id":      helloWorldSnapID,
 		})
 
 		fmt.Fprint(w, `{
@@ -5131,7 +5130,6 @@ func (s *storeTestSuite) TestSnapActionInstallAmend(c *C) {
 				Action:       "install",
 				InstanceName: "hello-world",
 				Channel:      "beta",
-				SnapID:       helloWorldSnapID,
 				Epoch:        snap.E("1*"),
 			},
 		}, nil, nil)


### PR DESCRIPTION
Without this change, epochs weren't being sent to the store, which
meant the store couldn't know to tell us about snaps with non-default
epochs (so we'd never do an epoched upgrade). This changes that.
