### PR TITLE
cmd: handle tumbleweed and leap in autogen.sh

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -41,7 +41,7 @@ case "$ID" in
 	fedora|centos|rhel)
 		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor"
 		;;
-	opensuse)
+	opensuse|opensuse-tumbleweed)
 		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-biarch --with-32bit-libdir=/usr/lib --enable-merged-usr"
 		;;
 	solus)


### PR DESCRIPTION
The openSUSE Tumbleweed distribution has a different os-release(5) ID
field than the more traditional Leap releases. Using autogen.sh on such
distribution would result in the wrong locations being used by "make
install". This patch fixes that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
