### PR TITLE
cmd/libsnap: add sc_verify_snap_lock

### DIFF
--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -92,6 +92,29 @@ static void test_sc_lock_unlock(void)
 	g_assert_cmpint(err, ==, 0);
 }
 
+// Check that holding a lock is properly detected.
+static void test_sc_verify_snap_lock__locked(void)
+{
+	(void)sc_test_use_fake_lock_dir();
+	int fd = sc_lock_snap("foo");
+	sc_verify_snap_lock("foo");
+	sc_unlock(fd);
+}
+
+// Check that holding a lock is properly detected.
+static void test_sc_verify_snap_lock__unlocked(void)
+{
+	(void)sc_test_use_fake_lock_dir();
+	if (g_test_subprocess()) {
+		sc_verify_snap_lock("foo");
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("unexpectedly managed to acquire exclusive lock over snap foo\n");
+}
+
 static void test_sc_enable_sanity_timeout(void)
 {
 	if (g_test_subprocess()) {
@@ -112,4 +135,8 @@ static void __attribute__ ((constructor)) init(void)
 	g_test_add_func("/locking/sc_lock_unlock", test_sc_lock_unlock);
 	g_test_add_func("/locking/sc_enable_sanity_timeout",
 			test_sc_enable_sanity_timeout);
+	g_test_add_func("/locking/sc_verify_snap_lock__locked",
+			test_sc_verify_snap_lock__locked);
+	g_test_add_func("/locking/sc_verify_snap_lock__unlocked",
+			test_sc_verify_snap_lock__unlocked);
 }

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -176,14 +176,11 @@ void sc_verify_snap_lock(const char *snap_name)
 		errno = 0;
 		die("unexpectedly managed to acquire exclusive lock over snap %s", snap_name);
 	}
-	if (retval < 0) {
-		if (errno == EWOULDBLOCK) {
-			/* We tried but failed to grab the lock because the file is already
-			 * locked. Good, this is what we expected. */
-			return;
-		}
-		die("cannot acquire exclusive lock over snap %s", snap_name);
+	if (retval < 0 && errno != EWOULDBLOCK) {
+		die("cannot verify exclusive lock over snap %s", snap_name);
 	}
+	/* We tried but failed to grab the lock because the file is already locked.
+	 * Good, this is what we expected. */
 }
 
 int sc_lock_snap_user(const char *snap_name, uid_t uid)

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -166,7 +166,8 @@ void sc_verify_snap_lock(const char *snap_name)
 	int lock_fd, retval;
 
 	lock_fd = open_lock(snap_name, 0);
-	debug("trying to acquire exclusive lock over snap %s", snap_name);
+	debug("trying to verify whether exclusive lock over snap %s is held",
+	      snap_name);
 	retval = flock(lock_fd, LOCK_EX | LOCK_NB);
 	if (retval == 0) {
 		/* We managed to grab the lock, the lock was not held! */

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -21,6 +21,7 @@
 
 #include "locking.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -84,7 +85,7 @@ void sc_disable_sanity_timeout(void)
 
 static const char *sc_lock_dir = SC_LOCK_DIR;
 
-static int sc_lock_generic(const char *scope, uid_t uid)
+static int get_lock_directory(void)
 {
 	// Create (if required) and open the lock directory.
 	debug("creating lock directory %s (if missing)", sc_lock_dir);
@@ -92,33 +93,50 @@ static int sc_lock_generic(const char *scope, uid_t uid)
 		die("cannot create lock directory %s", sc_lock_dir);
 	}
 	debug("opening lock directory %s", sc_lock_dir);
-	int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	dir_fd =
+	int dir_fd =
 	    open(sc_lock_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
 	if (dir_fd < 0) {
 		die("cannot open lock directory");
 	}
-	// Construct the name of the lock file.
-	char lock_fname[PATH_MAX] = { 0 };
+	return dir_fd;
+}
+
+static void get_lock_name(char *lock_fname, size_t size, const char *scope,
+			  uid_t uid)
+{
 	if (uid == 0) {
 		// The root user doesn't have a per-user mount namespace.
 		// Doing so would be confusing for services which use $SNAP_DATA
 		// as home, and not in $SNAP_USER_DATA.
-		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s.lock",
-				 scope ? : "");
+		sc_must_snprintf(lock_fname, size, "%s.lock", scope ? : "");
 	} else {
-		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s.%d.lock",
+		sc_must_snprintf(lock_fname, size, "%s.%d.lock",
 				 scope ? : "", uid);
 	}
+}
+
+static int open_lock(const char *scope, uid_t uid)
+{
+	int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
+	char lock_fname[PATH_MAX] = { 0 };
+	int lock_fd;
+
+	dir_fd = get_lock_directory();
+	get_lock_name(lock_fname, sizeof lock_fname, scope, uid);
 
 	// Open the lock file and acquire an exclusive lock.
 	debug("opening lock file: %s/%s", sc_lock_dir, lock_fname);
-	int lock_fd = openat(dir_fd, lock_fname,
-			     O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+	lock_fd = openat(dir_fd, lock_fname,
+			 O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
 	if (lock_fd < 0) {
 		die("cannot open lock file: %s/%s", sc_lock_dir, lock_fname);
 	}
+	return lock_fd;
+}
 
+static int sc_lock_generic(const char *scope, uid_t uid)
+{
+	int lock_fd = open_lock(scope, uid);
 	sc_enable_sanity_timeout();
 	debug("acquiring exclusive lock (scope %s, uid %d)",
 	      scope ? : "(global)", uid);
@@ -141,6 +159,30 @@ int sc_lock_global(void)
 int sc_lock_snap(const char *snap_name)
 {
 	return sc_lock_generic(snap_name, 0);
+}
+
+void sc_verify_snap_lock(const char *snap_name)
+{
+	int lock_fd, retval;
+
+	lock_fd = open_lock(snap_name, 0);
+	debug("trying to acquire exclusive lock over snap %s", snap_name);
+	retval = flock(lock_fd, LOCK_EX | LOCK_NB);
+	if (retval == 0) {
+		/* We managed to grab the lock, the lock was not held! */
+		flock(lock_fd, LOCK_UN);
+		close(lock_fd);
+		errno = 0;
+		die("unexpectedly managed to acquire exclusive lock over snap %s", snap_name);
+	}
+	if (retval < 0) {
+		if (errno == EWOULDBLOCK) {
+			/* We tried but failed to grab the lock because the file is already
+			 * locked. Good, this is what we expected. */
+			return;
+		}
+		die("cannot acquire exclusive lock over snap %s", snap_name);
+	}
 }
 
 int sc_lock_snap_user(const char *snap_name, uid_t uid)

--- a/cmd/libsnap-confine-private/locking.h
+++ b/cmd/libsnap-confine-private/locking.h
@@ -54,6 +54,14 @@ int sc_lock_global(void);
 int sc_lock_snap(const char *snap_name);
 
 /**
+ * Verify that a flock-based, exclusive, snap-scoped, lock is held.
+ *
+ * If the lock is not held the process dies. The details about the lock
+ * are exactly the same as for sc_lock_snap().
+ **/
+void sc_verify_snap_lock(const char *snap_name);
+
+/**
  * Obtain a flock-based, exclusive, snap-scoped, lock.
  *
  * The actual lock is placed in "/run/snapd/ns/$SNAP_NAME.$UID.lock"


### PR DESCRIPTION
This new API allows ensuring that a lock is held. This is needed by
tools that are invoked from snap-confine that would otherwise normally
grab a lock themselves. Instead when they are invoked from snap-confine
they check that a lock is held.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>