### PR TITLE
ifacestate/helpers: added SystemSnapName mapper helper method

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4016,6 +4016,10 @@ func (m *inverseCaseMapper) RemapSnapToResponse(snapName string) string {
 	return strings.ToUpper(snapName)
 }
 
+func (m *inverseCaseMapper) SystemSnapName() string {
+	return "core"
+}
+
 // Tests for GET /v2/interfaces
 
 func (s *apiSuite) TestInterfacesLegacy(c *check.C) {

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -45,6 +45,7 @@ var (
 	SetHotplugSlots              = setHotplugSlots
 	FindConnsForHotplugKey       = findConnsForHotplugKey
 	CheckSystemSnapIsPresent     = checkSystemSnapIsPresent
+	SystemSnapInfo               = systemSnapInfo
 )
 
 func NewConnectOptsWithAutoSet() connectOpts {

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -116,3 +116,8 @@ func GetConnStateAttrs(conns map[string]*connState, connID string) (plugStatic, 
 	}
 	return conn.StaticPlugAttrs, conn.DynamicPlugAttrs, conn.StaticSlotAttrs, conn.DynamicSlotAttrs, true
 }
+
+// SystemSnapName returns actual name of the system snap - reimplemented by concrete mapper.
+func (m *IdentityMapper) SystemSnapName() string {
+	return "unknown"
+}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -679,11 +679,6 @@ func (m *IdentityMapper) RemapSnapFromRequest(snapName string) string {
 	return snapName
 }
 
-// SystemSnapName returns actual name of the system snap - needs to be reimplemented by concrete mapper.
-func (m *IdentityMapper) SystemSnapName() string {
-	return "unknown"
-}
-
 // CoreCoreSystemMapper implements SnapMapper and makes implicit slots
 // appear to be on "core" in the state and in memory but as "system" in the API.
 //

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -696,7 +696,7 @@ type CoreCoreSystemMapper struct {
 // explicitly refer to "core" or using the "system" nickname.
 func (m *CoreCoreSystemMapper) RemapSnapFromRequest(snapName string) string {
 	if snapName == "system" {
-		return "core"
+		return m.SystemSnapName()
 	}
 	return snapName
 }
@@ -720,7 +720,7 @@ type CoreSnapdSystemMapper struct {
 // using "snapd" snap for hosting those slots and this lets us stay compatible.
 func (m *CoreSnapdSystemMapper) RemapSnapFromState(snapName string) string {
 	if snapName == "core" {
-		return "snapd"
+		return m.SystemSnapName()
 	}
 	return snapName
 }
@@ -731,7 +731,7 @@ func (m *CoreSnapdSystemMapper) RemapSnapFromState(snapName string) string {
 // seem to refer to the "core" snap, as in pre core{16,18} days where there was
 // only one core snap.
 func (m *CoreSnapdSystemMapper) RemapSnapToState(snapName string) string {
-	if snapName == "snapd" {
+	if snapName == m.SystemSnapName() {
 		return "core"
 	}
 	return snapName
@@ -746,7 +746,7 @@ func (m *CoreSnapdSystemMapper) RemapSnapToState(snapName string) string {
 // even if the request used "core".
 func (m *CoreSnapdSystemMapper) RemapSnapFromRequest(snapName string) string {
 	if snapName == "system" || snapName == "core" {
-		return "snapd"
+		return m.SystemSnapName()
 	}
 	return snapName
 }

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -679,7 +679,7 @@ func (m *IdentityMapper) RemapSnapFromRequest(snapName string) string {
 	return snapName
 }
 
-// Returns actual name of the system snap - needs to be reimplemented by concrete mapper.
+// SystemSnapName returns actual name of the system snap - needs to be reimplemented by concrete mapper.
 func (m *IdentityMapper) SystemSnapName() string {
 	return "unknown"
 }
@@ -706,7 +706,7 @@ func (m *CoreCoreSystemMapper) RemapSnapFromRequest(snapName string) string {
 	return snapName
 }
 
-// Returns actual name of the system snap.
+// SystemSnapName returns actual name of the system snap.
 func (m *CoreCoreSystemMapper) SystemSnapName() string {
 	return "core"
 }
@@ -756,7 +756,7 @@ func (m *CoreSnapdSystemMapper) RemapSnapFromRequest(snapName string) string {
 	return snapName
 }
 
-// Returns actual name of the system snap.
+// SystemSnapName returns actual name of the system snap.
 func (m *CoreSnapdSystemMapper) SystemSnapName() string {
 	return "snapd"
 }
@@ -786,9 +786,14 @@ func RemapSnapFromRequest(snapName string) string {
 	return mapper.RemapSnapFromRequest(snapName)
 }
 
-// Returns actual name of the system snap.
+// SystemSnapName returns actual name of the system snap.
 func SystemSnapName() string {
 	return mapper.SystemSnapName()
+}
+
+// systemSnapInfo returns current info for system snap.
+func systemSnapInfo(st *state.State) (*snap.Info, error) {
+	return snapstate.CurrentInfo(st, SystemSnapName())
 }
 
 func connectDisconnectAffectedSnaps(t *state.Task) ([]string, error) {
@@ -802,7 +807,7 @@ func connectDisconnectAffectedSnaps(t *state.Task) ([]string, error) {
 func checkSystemSnapIsPresent(st *state.State) bool {
 	st.Lock()
 	defer st.Unlock()
-	_, err := snapstate.CurrentInfo(st, mapper.SystemSnapName())
+	_, err := systemSnapInfo(st)
 	return err == nil
 }
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -324,6 +324,11 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithSnapd(c *C) {
 		SnapType:    string(snapInfo.Type),
 		InstanceKey: snapInfo.InstanceKey,
 	})
+
+	inf, err := ifacestate.SystemSnapInfo(s.st)
+	c.Assert(err, IsNil)
+	c.Assert(inf.InstanceName(), Equals, "snapd")
+
 	s.st.Unlock()
 
 	c.Assert(ifacestate.CheckSystemSnapIsPresent(s.st), Equals, true)

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -54,6 +54,8 @@ func (s *helpersSuite) TestIdentityMapper(c *C) {
 	c.Assert(m.RemapSnapFromState("example"), Equals, "example")
 	c.Assert(m.RemapSnapToState("example"), Equals, "example")
 	c.Assert(m.RemapSnapFromRequest("example"), Equals, "example")
+
+	c.Assert(m.SystemSnapName(), Equals, "unknown")
 }
 
 func (s *helpersSuite) TestCoreCoreSystemMapper(c *C) {
@@ -71,6 +73,8 @@ func (s *helpersSuite) TestCoreCoreSystemMapper(c *C) {
 	c.Assert(m.RemapSnapFromState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapToState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapFromRequest("potato"), Equals, "potato")
+
+	c.Assert(m.SystemSnapName(), Equals, "core")
 }
 
 func (s *helpersSuite) TestCoreSnapdSystemMapper(c *C) {
@@ -93,6 +97,8 @@ func (s *helpersSuite) TestCoreSnapdSystemMapper(c *C) {
 	c.Assert(m.RemapSnapFromState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapToState("potato"), Equals, "potato")
 	c.Assert(m.RemapSnapFromRequest("potato"), Equals, "potato")
+
+	c.Assert(m.SystemSnapName(), Equals, "snapd")
 }
 
 // caseMapper implements SnapMapper to use upper case internally and lower case externally.
@@ -110,6 +116,10 @@ func (m *caseMapper) RemapSnapFromRequest(snapName string) string {
 	return strings.ToUpper(snapName)
 }
 
+func (m *caseMapper) SystemSnapName() string {
+	return "unknown"
+}
+
 func (s *helpersSuite) TestMappingFunctions(c *C) {
 	restore := ifacestate.MockSnapMapper(&caseMapper{})
 	defer restore()
@@ -117,6 +127,7 @@ func (s *helpersSuite) TestMappingFunctions(c *C) {
 	c.Assert(ifacestate.RemapSnapFromState("example"), Equals, "EXAMPLE")
 	c.Assert(ifacestate.RemapSnapToState("EXAMPLE"), Equals, "example")
 	c.Assert(ifacestate.RemapSnapFromRequest("example"), Equals, "EXAMPLE")
+	c.Assert(ifacestate.SystemSnapName(), Equals, "unknown")
 }
 
 func (s *helpersSuite) TestGetConns(c *C) {


### PR DESCRIPTION
Added `SystemSnapName` helper method to mapper, followup to #6138.