### PR TITLE
cmd/snap-confine: use snap-discard-ns ns to discard stale namespaces

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -574,7 +574,13 @@ static bool __attribute__ ((used))
 	return false;
 }
 
-int sc_open_snap_update_ns(void)
+/**
+ * open_intenral_tool returns a file descriptor of the given internal executable.
+ *
+ * The executable is located based on the location of the currently executing process.
+ * The returning file descriptor can be used with fexecve function.
+**/
+static int open_internal_tool(const char *tool_name)
 {
 	// +1 is for the case where the link is exactly PATH_MAX long but we also
 	// want to store the terminating '\0'. The readlink system call doesn't add
@@ -586,20 +592,29 @@ int sc_open_snap_update_ns(void)
 	if (buf[0] != '/') {	// this shouldn't happen, but make sure have absolute path
 		die("readlink /proc/self/exe returned relative path");
 	}
-	char *bufcopy SC_CLEANUP(sc_cleanup_string) = NULL;
-	bufcopy = strdup(buf);
-	if (bufcopy == NULL) {
-		die("cannot copy buffer");
+	char *dir_name = dirname(buf);
+	int dir_fd SC_CLEANUP(sc_cleanup_close) = 1;
+	dir_fd = open(dir_name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+	if (dir_fd < 0) {
+		die("cannot open path %s", dir_name);
 	}
-	char *dname = dirname(bufcopy);
-	sc_must_snprintf(buf, sizeof buf, "%s/%s", dname, "snap-update-ns");
-	debug("snap-update-ns executable: %s", buf);
-	int fd = open(buf, O_PATH | O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
-	if (fd < 0) {
-		die("cannot open snap-update-ns executable");
+	int tool_fd = -1;
+	tool_fd = openat(dir_fd, tool_name, O_PATH | O_NOFOLLOW | O_CLOEXEC);
+	if (tool_fd < 0) {
+		die("cannot open path %s/%s", dir_name, tool_name);
 	}
-	debug("opened snap-update-ns executable as file descriptor %d", fd);
-	return fd;
+	debug("opened %s executable as file descriptor %d", tool_name, tool_fd);
+	return tool_fd;
+}
+
+int sc_open_snap_update_ns(void)
+{
+	return open_internal_tool("snap-update-ns");
+}
+
+int sc_open_snap_discard_ns(void)
+{
+	return open_internal_tool("snap-discard-ns");
 }
 
 void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -30,6 +30,15 @@
 int sc_open_snap_update_ns(void);
 
 /**
+ * Return a file descriptor referencing the snap-discard-ns utility
+ *
+ * By calling this prior to changing the mount namespace, it is
+ * possible to execute the utility even if a different version is now
+ * mounted at the expected location.
+ **/
+int sc_open_snap_discard_ns(void);
+
+/**
  * Assuming a new mountspace, populate it accordingly.
  *
  * This function performs many internal tasks:

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -689,7 +689,7 @@ static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
 			 O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW | O_RDONLY,
 			 0600);
 		if (fd < 0) {
-			die("cannot open file: %s", dst);
+			die("cannot create file %s", dst);
 		}
 		close(fd);
 	}

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -684,8 +684,10 @@ static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
 	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", group->name, SC_NS_MNT_FILE);
 	if (access(dst, F_OK) < 0 && errno == ENOENT) {
-		int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY,
-			      0600);
+		int fd =
+		    open(dst,
+			 O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW | O_RDONLY,
+			 0600);
 		if (fd < 0) {
 			die("cannot open file: %s", dst);
 		}

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -307,6 +307,47 @@ enum sc_discard_vote {
 	SC_DISCARD_YES = 2,
 };
 
+static void call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name)
+{
+	debug("calling snap-discard-ns to discard preserved mount namespaces");
+	pid_t child = fork();
+	if (child < 0) {
+		die("cannot fork to run snap-discard-ns");
+	}
+	if (child == 0) {
+		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+		snap_name_copy = strdup(snap_name);
+		if (snap_name_copy == NULL) {
+			die("cannot allocate memory for snap name");
+		}
+		char *argv[] =
+		    { "snap-discard-ns", "--from-snap-confine", snap_name_copy,
+			NULL
+		};
+		char *envp[2] = { NULL };
+		int last_env = 0;
+		if (sc_is_debug_enabled()) {
+			envp[last_env++] = "SNAPD_DEBUG=1";
+		}
+		debug("fexecv(%d (snap-discard-ns), %s %s %s %s,)",
+		      snap_discard_ns_fd, argv[0], argv[1], argv[2], argv[3]);
+		fexecve(snap_discard_ns_fd, argv, envp);
+		die("cannot execute snap-discard-ns");
+	}
+	// We are the parent, so wait for snap-discard-ns to finish.
+	int status = 0;
+	debug("waiting for snap-discard-ns to finish...");
+	if (waitpid(child, &status, 0) < 0) {
+		die("waitpid() failed for snap-discard-ns process");
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+		die("snap-discard-ns failed with code %i", WEXITSTATUS(status));
+	} else if (WIFSIGNALED(status)) {
+		die("snap-discard-ns killed by signal %i", WTERMSIG(status));
+	}
+	debug("snap-discard-ns finished successfully");
+}
+
 // The namespace may be stale. To check this we must actually switch into it
 // but then we use up our setns call (the kernel misbehaves if we setns twice).
 // To work around this we'll fork a child and use it to probe. The child will
@@ -314,11 +355,11 @@ enum sc_discard_vote {
 // unconditionally.
 static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 						 const char *snap_name,
-						 const char *base_snap_name)
+						 const char *base_snap_name,
+						 int snap_discard_ns_fd)
 {
 	char base_snap_rev[PATH_MAX] = { 0 };
 	char fname[PATH_MAX] = { 0 };
-	char mnt_fname[PATH_MAX] = { 0 };
 	dev_t base_snap_dev;
 	int event_fd SC_CLEANUP(sc_cleanup_close) = -1;
 
@@ -442,20 +483,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 		return 0;
 	}
 	// The namespace is both stale and empty. We can discard it now.
-	sc_must_snprintf(mnt_fname, sizeof mnt_fname,
-			 "%s/%s%s", sc_ns_dir, snap_name, SC_NS_MNT_FILE);
-
-	// Use MNT_DETACH as otherwise we get EBUSY.
-	if (umount2(mnt_fname, MNT_DETACH | UMOUNT_NOFOLLOW) < 0) {
-		die("cannot discard stale mount namespace %s", mnt_fname);
-	}
-	char fstab_fname[PATH_MAX] = { 0 };
-	sc_must_snprintf(fstab_fname, sizeof fstab_fname,
-			 "%s/snap.%s.fstab", sc_ns_dir, snap_name);
-	if (unlink(fstab_fname) < 0) {
-		die("cannot remove stale mount profile %s", fstab_fname);
-	}
-	debug("stale mount namespace discarded");
+	call_snap_discard_ns(snap_discard_ns_fd, snap_name);
 	return EAGAIN;
 }
 
@@ -467,7 +495,7 @@ static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent);
 
 int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 			 *apparmor, const char *base_snap_name,
-			 const char *snap_name)
+			 const char *snap_name, int snap_discard_ns_fd)
 {
 	// Open the mount namespace file.
 	char mnt_fname[PATH_MAX] = { 0 };
@@ -511,7 +539,8 @@ int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 
 		// Inspect and perhaps discard the preserved mount namespace.
 		if (sc_inspect_and_maybe_discard_stale_ns
-		    (mnt_fd, snap_name, base_snap_name) == EAGAIN) {
+		    (mnt_fd, snap_name, base_snap_name,
+		     snap_discard_ns_fd) == EAGAIN) {
 			return ESRCH;
 		}
 		// Remember the vanilla working directory so that we may attempt to restore it later.
@@ -654,6 +683,14 @@ static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
 	debug("capturing per-snap mount namespace");
 	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", group->name, SC_NS_MNT_FILE);
+	if (access(dst, F_OK) < 0 && errno == ENOENT) {
+		int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY,
+			      0600);
+		if (fd < 0) {
+			die("cannot open file: %s", dst);
+		}
+		close(fd);
+	}
 	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
 		die("cannot preserve mount namespace of process %d as %s",
 		    (int)parent, dst);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -676,16 +676,13 @@ static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
 	debug("capturing per-snap mount namespace");
 	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", group->name, SC_NS_MNT_FILE);
-	if (access(dst, F_OK) < 0 && errno == ENOENT) {
-		int fd =
-		    open(dst,
-			 O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW | O_RDONLY,
-			 0600);
-		if (fd < 0) {
-			die("cannot create file %s", dst);
-		}
-		close(fd);
+
+	/* Ensure the bind mount destination exists. */
+	int fd = open(dst, O_CREAT | O_CLOEXEC | O_NOFOLLOW | O_RDONLY, 0600);
+	if (fd < 0) {
+		die("cannot create file %s", dst);
 	}
+	close(fd);
 	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
 		die("cannot preserve mount namespace of process %d as %s",
 		    (int)parent, dst);

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -93,7 +93,7 @@ void sc_close_mount_ns(struct sc_mount_ns *group);
  **/
 int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 			 *apparmor, const char *base_snap_name,
-			 const char *snap_name);
+			 const char *snap_name, int snap_discard_ns_fd);
 
 /**
  * Fork off a helper process for mount namespace capture.

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -451,26 +451,26 @@
     # Allow switching to snap-update-ns with a per-snap profile.
     change_profile -> snap-update-ns.*,
 
-    # Allow executing snap-update-ns when...
+    # Allow executing snap-update-ns and snap-discard-ns when...
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the distribution package. This is also the location used when using
     # the core/base snap on all-snap systems. The variants here represent
     # various locations of libexecdir across distributions.
-    /usr/lib{,exec,64}/snapd/snap-update-ns r,
+    /usr/lib{,exec,64}/snapd/snap-{update,discard}-ns rix,
 
     # ...snap-confine is not, conceptually, re-executing and uses
     # snap-update-ns from the distribution package but we are already inside
     # the constructed mount namespace so we must traverse "hostfs". The
     # variants here represent various locations of libexecdir across
     # distributions.
-    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-{update,discard}-ns rix,
 
     # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap. Note that the location of the core snap varies from
     # distribution to distribution. The variants here represent different
     # locations of snap mount directory across distributions.
-    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
+    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-{update,discard}-ns rix,
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap but we are already inside the constructed mount
@@ -479,5 +479,5 @@
     # "natural" /snap mount entry but we have no control over that.  This is
     # reported as (LP: #1716339). The variants here represent different
     # locations of snap mount directory across distributions.
-    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-{update,discard}-ns rix,
 }

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -455,26 +455,26 @@
     # Allow switching to snap-update-ns with a per-snap profile.
     change_profile -> snap-update-ns.*,
 
-    # Allow executing snap-update-ns and snap-discard-ns when...
+    # Allow executing snap-update-ns when...
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the distribution package. This is also the location used when using
     # the core/base snap on all-snap systems. The variants here represent
     # various locations of libexecdir across distributions.
-    /usr/lib{,exec,64}/snapd/snap-{update,discard}-ns rix,
+    /usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ...snap-confine is not, conceptually, re-executing and uses
     # snap-update-ns from the distribution package but we are already inside
     # the constructed mount namespace so we must traverse "hostfs". The
     # variants here represent various locations of libexecdir across
     # distributions.
-    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-{update,discard}-ns rix,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap. Note that the location of the core snap varies from
     # distribution to distribution. The variants here represent different
     # locations of snap mount directory across distributions.
-    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-{update,discard}-ns rix,
+    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap but we are already inside the constructed mount
@@ -483,5 +483,15 @@
     # "natural" /snap mount entry but we have no control over that.  This is
     # reported as (LP: #1716339). The variants here represent different
     # locations of snap mount directory across distributions.
-    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-{update,discard}-ns rix,
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
+
+    # Allow executing snap-discard-ns, just like the set for snap-update-ns
+    # above but with the key difference that snap-discard-ns does not
+    # have a dedicated profile so we need to inherit snap-confine's profile.
+
+    /usr/lib{,exec,64}/snapd/snap-discard-ns rix,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-discard-ns rix,
+    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
+
 }

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -219,11 +219,13 @@ int main(int argc, char **argv)
 			sc_initialize_mount_ns();
 			sc_unlock(global_lock_fd);
 
-			// Find and open snap-update-ns from the same
-			// path as where we (snap-confine) were
-			// called.
+			// Find and open snap-update-ns and snap-discard-ns from the same
+			// path as where we (snap-confine) were called.
 			int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
 			snap_update_ns_fd = sc_open_snap_update_ns();
+			int snap_discard_ns_fd SC_CLEANUP(sc_cleanup_close) =
+			    -1;
+			snap_discard_ns_fd = sc_open_snap_discard_ns();
 
 			// Do per-snap initialization.
 			int snap_lock_fd = sc_lock_snap(snap_instance);
@@ -233,7 +235,8 @@ int main(int argc, char **argv)
 			group = sc_open_mount_ns(snap_instance);
 			int retval = sc_join_preserved_ns(group, &apparmor,
 							  base_snap_name,
-							  snap_instance);
+							  snap_instance,
+							  snap_discard_ns_fd);
 			if (retval == ESRCH) {
 				/* Stale mount namespace discarded or no mount namespace to
 				   join. We need to construct a new mount namespace ourselves.


### PR DESCRIPTION
During startup snap-confine may decide to discard a preserved mount
namespace that became stale. This used to involve unmounting one file.
Then we realized we had a bug because the .fstab file was not unlinked.
With the introduction of per-user mount namespaces we need to do a little
bit more. Instead of duplicating this logic or providing library code
I believe the easiest way is to execute snap-discard-ns itself.

The same patch contains a small refactoring for opening internal tools.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
