### PR TITLE
cmd/snap-confine: remove unneeded unshare

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -575,13 +575,6 @@ static void helper_fork(struct sc_mount_ns *group, struct sc_apparmor *apparmor)
 		// print pid's portably so this is the best we can do.
 		debug("forked support process %d", (int)pid);
 		group->child = pid;
-
-		// Unshare the mount namespace and set a flag instructing the caller that
-		// the namespace is pristine and needs to be populated now.
-		if (unshare(CLONE_NEWNS) < 0) {
-			die("cannot unshare the mount namespace");
-		}
-		debug("created new mount namespace");
 	}
 }
 


### PR DESCRIPTION
During prior work I accidentally left unshare that is no longer needed
in helper_fork(). This specific unshare is now performed in
snap-confine.c in main(). The one here doesn't hurt but serves no
purpose.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
