### PR TITLE
cmd/snap-confine: capture initialized per-user mount ns

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -566,6 +566,7 @@ int sc_join_preserved_per_user_ns(struct sc_mount_ns *group,
 		die("cannot inspect preserved mount namespace file");
 	}
 #ifndef NSFS_MAGIC
+	/* Define NSFS_MAGIC for Ubuntu 14.04 and other older systems. */
 #define NSFS_MAGIC 0x6e736673
 #endif
 	if (ns_statfs_buf.f_type == NSFS_MAGIC

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -728,10 +728,9 @@ static void helper_capture_per_user_ns(struct sc_mount_ns *group, pid_t parent)
 	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
 	sc_must_snprintf(dst, sizeof dst, "%s.%d.mnt", group->name, (int)uid);
 	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
-		die("cannot preserve mount namespace of process %d as %s",
-		    (int)parent, dst);
+		die("cannot preserve per-user mount namespace of process %d as %s", (int)parent, dst);
 	}
-	debug("mount namespace of process %d preserved as %s",
+	debug("per-user mount namespace of process %d preserved as %s",
 	      (int)parent, dst);
 }
 

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -75,7 +75,8 @@ static const char *sc_ns_dir = SC_NS_DIR;
 
 enum {
 	HELPER_CMD_EXIT,
-	HELPER_CMD_CAPTURE_NS,
+	HELPER_CMD_CAPTURE_MOUNT_NS,
+	HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS,
 };
 
 /**
@@ -464,6 +465,7 @@ static void helper_fork(struct sc_mount_ns *group,
 static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
 			pid_t parent);
 static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent);
+static void helper_capture_per_user_ns(struct sc_mount_ns *group, pid_t parent);
 
 int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 			 *apparmor, const char *base_snap_name,
@@ -529,6 +531,56 @@ int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 
 		// Try to re-locate back to vanilla working directory. This can fail
 		// because that directory is no longer present.
+		if (chdir(vanilla_cwd) != 0) {
+			debug("cannot enter %s, moving to void", vanilla_cwd);
+			if (chdir(SC_VOID_DIR) != 0) {
+				die("cannot change directory to %s",
+				    SC_VOID_DIR);
+			}
+		}
+		return 0;
+	}
+	return ESRCH;
+}
+
+int sc_join_preserved_per_user_ns(struct sc_mount_ns *group,
+				  const char *snap_name)
+{
+	uid_t uid = getuid();
+	char mnt_fname[PATH_MAX] = { 0 };
+	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s.%d.mnt", group->name,
+			 (int)uid);
+
+	int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
+	mnt_fd = openat(group->dir_fd, mnt_fname,
+			O_CREAT | O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
+	if (mnt_fd < 0) {
+		die("cannot open preserved mount namespace %s", group->name);
+	}
+	struct statfs ns_statfs_buf;
+	if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
+		die("cannot inspect filesystem of preserved mount namespace file");
+	}
+	struct stat ns_stat_buf;
+	if (fstat(mnt_fd, &ns_stat_buf) < 0) {
+		die("cannot inspect preserved mount namespace file");
+	}
+#ifndef NSFS_MAGIC
+#define NSFS_MAGIC 0x6e736673
+#endif
+	if (ns_statfs_buf.f_type == NSFS_MAGIC
+	    || ns_statfs_buf.f_type == PROC_SUPER_MAGIC) {
+		// TODO: refactor the cwd workflow across all of snap-confine.
+		char *vanilla_cwd SC_CLEANUP(sc_cleanup_string) = NULL;
+		vanilla_cwd = get_current_dir_name();
+		if (vanilla_cwd == NULL) {
+			die("cannot get the current working directory");
+		}
+		if (setns(mnt_fd, CLONE_NEWNS) < 0) {
+			die("cannot join preserved per-user mount namespace %s",
+			    group->name);
+		}
+		debug("joined preserved mount namespace %s", group->name);
 		if (chdir(vanilla_cwd) != 0) {
 			debug("cannot enter %s, moving to void", vanilla_cwd);
 			if (chdir(SC_VOID_DIR) != 0) {
@@ -634,8 +686,11 @@ static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
 		case HELPER_CMD_EXIT:
 			run = 0;
 			break;
-		case HELPER_CMD_CAPTURE_NS:
+		case HELPER_CMD_CAPTURE_MOUNT_NS:
 			helper_capture_ns(group, parent);
+			break;
+		case HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS:
+			helper_capture_per_user_ns(group, parent);
 			break;
 		}
 		if (write(group->pipe_helper[1], &command, sizeof command) < 0) {
@@ -654,6 +709,23 @@ static void helper_capture_ns(struct sc_mount_ns *group, pid_t parent)
 	debug("capturing per-snap mount namespace");
 	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", group->name, SC_NS_MNT_FILE);
+	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
+		die("cannot preserve mount namespace of process %d as %s",
+		    (int)parent, dst);
+	}
+	debug("mount namespace of process %d preserved as %s",
+	      (int)parent, dst);
+}
+
+static void helper_capture_per_user_ns(struct sc_mount_ns *group, pid_t parent)
+{
+	char src[PATH_MAX] = { 0 };
+	char dst[PATH_MAX] = { 0 };
+	uid_t uid = getuid();
+
+	debug("capturing per-snap, per-user mount namespace");
+	sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt", (int)parent);
+	sc_must_snprintf(dst, sizeof dst, "%s.%d.mnt", group->name, (int)uid);
 	if (mount(src, dst, NULL, MS_BIND, NULL) < 0) {
 		die("cannot preserve mount namespace of process %d as %s",
 		    (int)parent, dst);
@@ -710,7 +782,12 @@ void sc_fork_helper(struct sc_mount_ns *group, struct sc_apparmor *apparmor)
 
 void sc_preserve_populated_mount_ns(struct sc_mount_ns *group)
 {
-	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_NS);
+	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_MOUNT_NS);
+}
+
+void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group)
+{
+	sc_message_capture_helper(group, HELPER_CMD_CAPTURE_PER_USER_MOUNT_NS);
 }
 
 void sc_wait_for_helper(struct sc_mount_ns *group)

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -96,6 +96,18 @@ int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 			 const char *snap_name);
 
 /**
+ * Join a preserved, per-user, mount namespace if one exists.
+ *
+ * Technically the function opens /run/snapd/ns/snap.$SNAP_NAME.$UID.mnt and
+ * tries to use setns() with the obtained file descriptor.
+ *
+ * The return is ESRCH if a preserved per-user mount namespace does not exist
+ * and cannot be joined or zero otherwise.
+**/
+int sc_join_preserved_per_user_ns(struct sc_mount_ns *group,
+				  const char *snap_name);
+
+/**
  * Fork off a helper process for mount namespace capture.
  *
  * This function forks the helper process. It needs to be paired with
@@ -121,6 +133,8 @@ void sc_fork_helper(struct sc_mount_ns *group, struct sc_apparmor *apparmor);
  * sc_wait_for_helper() to terminate it.
  **/
 void sc_preserve_populated_mount_ns(struct sc_mount_ns *group);
+
+void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group);
 
 /**
  * Ask the helper process to terminate and wait for it to finish.


### PR DESCRIPTION
When the experimental feature with persistent per-user mount namespaces
is enabled then a new mount namespace is created in /run/snapd/ns,
alongside $SNAP_NAME.mnt we now get $SNAP_NAME.$UID.mnt.

Note that per-user mount namespaces are not supported for the root user.
As a design decision root user is synonymous with the per-snap mount
namespace.

Preserved per-user mount namespaces are not inspected to detect
staleness. Instead the per-snap mount namespace, if stale, is discarded
alongside the mount namespaces of all the users of that snap on the
system, by calling snap-discard-ns.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
