### PR TITLE
cmd/snap-discard-ns: add support for --from-snap-confine

### DIFF
--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -48,7 +48,10 @@ int main(int argc, char** argv) {
     const char* snap_instance_name;
     bool from_snap_confine;
 
-    if (argc == 3 && sc_streq(argv[1], "--from-snap-confine")) {
+    if (argc == 3) {
+        if (!sc_streq(argv[1], "--from-snap-confine")) {
+            die("unexpected argument %s", argv[1]);
+        }
         from_snap_confine = true;
         snap_instance_name = argv[2];
     } else {

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -60,15 +60,15 @@ int main(int argc, char** argv) {
     sc_instance_name_validate(snap_instance_name, &err);
     sc_die_on_error(err);
 
-    /* Grab the lock holding the snap instance. This prevents races from
-     * concurrently executing snap-confine. The lock is explicitly released
-     * during normal operation but it is not preserved across the life-cycle of
-     * the process anyway so no attempt is made to unlock it ahead of any call
-     * to die() */
     int snap_lock_fd = -1;
     if (from_snap_confine) {
         sc_verify_snap_lock(snap_instance_name);
     } else {
+        /* Grab the lock holding the snap instance. This prevents races from
+         * concurrently executing snap-confine. The lock is explicitly released
+         * during normal operation but it is not preserved across the life-cycle of
+         * the process anyway so no attempt is made to unlock it ahead of any call
+         * to die() */
         snap_lock_fd = sc_lock_snap(snap_instance_name);
     }
     debug("discarding mount namespaces of snap %s", snap_instance_name);

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -212,6 +212,8 @@ int main(int argc, char** argv) {
     if (closedir(ns_dir) < 0) {
         die("cannot close directory");
     }
-    sc_unlock(snap_lock_fd);
+    if (snap_lock_fd != -1) {
+        sc_unlock(snap_lock_fd);
+    }
     return 0;
 }

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -24,7 +24,6 @@
 #include <limits.h>
 #include <linux/magic.h>
 #include <stdio.h>
-#include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -42,49 +41,24 @@
 #endif
 
 int main(int argc, char** argv) {
-    bool from_snap_confine = false;
-    const char* snap_instance_name = NULL;
-    int optind;
-
-    for (optind = 1; optind < argc; ++optind) {
-        const char* opt = argv[optind];
-        if (sc_streq(opt, "--from-snap-confine")) {
-            from_snap_confine = true;
-            continue;
-        }
-        if (sc_streq(opt, "--")) {
-            /* Start parsing positional arguments. */
-            optind++;
-            break;
-        }
-        if (strlen(opt) > 0 && opt[0] == '-') {
-            errno = 0;
-            die("unsupported option: %s", opt);
-        }
-        break;
+    if (argc != 2 && argc != 3) {
+        printf("Usage: snap-discard-ns [--from-snap-confine] <SNAP-INSTANCE-NAME>\n");
+        return 0;
     }
-    for (/* continue */; optind < argc; ++optind) {
-        const char* opt = argv[optind];
-        if (strlen(opt) > 0 && opt[0] == '-') {
-            errno = 0;
-            die("cannot use options after the first positional argument");
-        }
-        if (snap_instance_name == NULL) {
-            struct sc_error* err = NULL;
-            sc_instance_name_validate(opt, &err);
-            sc_die_on_error(err);
-            snap_instance_name = opt;
-        } else {
-            errno = 0;
-            die("too many positional arguments");
-        }
+    const char* snap_instance_name;
+    bool from_snap_confine;
+
+    if (argc == 3 && sc_streq(argv[1], "--from-snap-confine")) {
+        from_snap_confine = true;
+        snap_instance_name = argv[2];
+    } else {
+        from_snap_confine = false;
+        snap_instance_name = argv[1];
     }
 
-    if (snap_instance_name == NULL) {
-        errno = 0;
-        die("Usage: snap-discard-ns "
-            "[--from-snap-confine] <SNAP-INSTANCE-NAME>");
-    }
+    struct sc_error* err = NULL;
+    sc_instance_name_validate(snap_instance_name, &err);
+    sc_die_on_error(err);
 
     int snap_lock_fd = -1;
     if (from_snap_confine) {

--- a/cmd/snap-discard-ns/snap-discard-ns.rst
+++ b/cmd/snap-discard-ns/snap-discard-ns.rst
@@ -16,7 +16,7 @@ internal tool for discarding preserved namespaces of snappy applications
 SYNOPSIS
 ========
 
-	snap-discard-ns SNAP_INSTANCE_NAME
+	snap-discard-ns [--from-snap-confine] SNAP_INSTANCE_NAME
 
 DESCRIPTION
 ===========
@@ -27,7 +27,8 @@ mount namespace of a particular snap.
 OPTIONS
 =======
 
-The `snap-discard-ns` program does not support any options.
+The --from-snap-confine option is used internally by snap-confine to tell
+snap-discard-ns that it is invoked from snap-confine and can disable locking.
 
 ENVIRONMENT
 ===========


### PR DESCRIPTION
The snap-confine program delegates some work to external programs such
as snap-update-ns. When doing that it passes an extra option that indicates
the program is invoked by snap-confine and should not perform its own
locking.

We are about to start calling snap-discard-ns this way so it needs to
grow a command line option to express this.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
