### PR TITLE
snapd: allow snap-update-ns to read /proc/version

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -625,6 +625,8 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
 
   # Allow reading file descriptor paths
   @{PROC}/@{pid}/fd/* r,
+  # Allow reading /proc/version. For release.go WSL detection.
+  @{PROC}/version r,
 
   # Allow reading the os-release file (possibly a symlink to /usr/lib).
   /{etc/,usr/lib/}os-release r,


### PR DESCRIPTION
When doing some casual exploratory testing on my branches I noticed an
unrelated apparmor denial.

    type=AVC msg=audit(1542197569.186:1140): apparmor="DENIED"
    operation="open" profile="snap-update-ns.snapd-hacker-toolbelt"
    name="/proc/version" pid=37237 comm="3" requested_mask="r"
    denied_mask="r" fsuid=0 ouid=0

It seems that release/release.go's WSL check now affects snap-update-ns.
While we could do lazy init the denial should go a way as well.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
