### PR TITLE
userd: force zenity width if the text displayed is long

### DIFF
--- a/userd/ui/zenity.go
+++ b/userd/ui/zenity.go
@@ -42,6 +42,15 @@ func (*Zenity) YesNo(primary, secondary string, options *DialogOptions) bool {
 	if options.Timeout > 0 {
 		args = append(args, fmt.Sprintf("--timeout=%d", int(options.Timeout/time.Second)))
 	}
+	// Gtk is not doing a good job with long labels. It will
+	// create a very narrow and long window (minimal width to fit
+	// the buttons).  So force a bigger width here. See also LP:
+	// 1778484. The primary number is lower because the header is
+	// in a bigger font.
+	if len(primary) > 10 || len(secondary) > 20 {
+		args = append(args, "--width=500")
+	}
+
 	cmd := exec.Command("zenity", args...)
 	if err := cmd.Start(); err != nil {
 		return false

--- a/userd/ui/zenity_test.go
+++ b/userd/ui/zenity_test.go
@@ -62,6 +62,17 @@ func (s *zenitySuite) TestYesNoSimpleNo(c *C) {
 	})
 }
 
+func (s *zenitySuite) TestYesNoLong(c *C) {
+	mock := testutil.MockCommand(c, "zenity", "true")
+	defer mock.Restore()
+
+	z := &ui.Zenity{}
+	_ = z.YesNo("01234567890", "01234567890", nil)
+	c.Check(mock.Calls(), DeepEquals, [][]string{
+		{"zenity", "--question", "--modal", "--text=<big><b>01234567890</b></big>\n\n01234567890", "--width=500"},
+	})
+}
+
 func (s *zenitySuite) TestYesNoSimpleFooter(c *C) {
 	mock := testutil.MockCommand(c, "zenity", "")
 	defer mock.Restore()


### PR DESCRIPTION
Gtk is not doing a good job with long labels. It will
create a very narrow and long window (minimal width to fit
the buttons).  So force a bigger width when there is a lot
of text. See also LP: 1778484
