### PR TITLE
cmd/snap-confine: handle mounted shared /run/snapd/ns

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -135,7 +135,7 @@ void sc_initialize_mount_ns(void)
 		die("cannot create directory %s", sc_ns_dir);
 	}
 
-	/* Read and analyze the mount table. We need to see if /run/snapd/ns
+	/* Read and analyze the mount table. We need to see whether /run/snapd/ns
 	 * is a mount point with private event propagation. */
 	struct sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	info = sc_parse_mountinfo(NULL);

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -1,0 +1,43 @@
+summary: Regression test for https://bugs.launchpad.net/snapd/+bug/1803542
+environment:
+    VARIANT/gone: gone
+    VARIANT/present: present 
+    VARIANT/shared: shared
+    VARIANT/private: private 
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-sh
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB/dirs.sh"
+    # Ensure that every snap namespace is discarded.
+    for name in $(snap list | awk '!/Name/ {print $1}'); do
+        "$LIBEXECDIR"/snapd/snap-discard-ns "$name"
+    done
+    if findmnt --noheadings /run/snapd/ns >/dev/null; then
+        umount /run/snapd/ns
+    fi
+    ! findmnt --noheadings /run/snapd/ns
+execute: |
+    case "$VARIANT" in
+       absent)
+            rmdir /run/snapd/ns
+            ;;
+       present)
+            mkdir -p /run/snapd/ns
+            ;;
+       shared)
+            mkdir -p /run/snapd/ns
+            mount --bind /run/snapd/ns /run/snapd/ns
+            mount --make-shared /run/snapd/ns
+            test "$(findmnt --noheadings  --output=PROPAGATION /run/snapd/ns)" = shared
+            ;;
+        private)
+            mkdir -p /run/snapd/ns
+            mount --bind /run/snapd/ns /run/snapd/ns
+            mount --make-private /run/snapd/ns
+            test "$(findmnt --noheadings  --output=PROPAGATION /run/snapd/ns)" = private 
+    esac
+    # We can run snap-confine and it will do the right thing.
+    test-snapd-sh -c /bin/true
+    test "$(findmnt --noheadings  --output=PROPAGATION /run/snapd/ns)" = private

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -1,9 +1,9 @@
 summary: Regression test for https://bugs.launchpad.net/snapd/+bug/1803542
 environment:
-    VARIANT/gone: gone
-    VARIANT/present: present 
+    VARIANT/absent: absent
+    VARIANT/present: present
     VARIANT/shared: shared
-    VARIANT/private: private 
+    VARIANT/private: private
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
@@ -39,6 +39,11 @@ execute: |
             mount --make-private /run/snapd/ns
             # Ensure the mount point is private
             test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}')" = -
+            ;;
+        *)
+            echo "unknown variant: $VARIANT"
+            exit 1
+            ;;
     esac
     # We can run snap-confine and it will do the right thing.
     test-snapd-sh -c /bin/true

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -31,15 +31,15 @@ execute: |
             mount --bind /run/snapd/ns /run/snapd/ns
             mount --make-shared /run/snapd/ns
             # This ensure the mount point is shared
-            test "$(cat /proc/self/mountinfo | grep '/snapd/ns /run/snapd/ns' | awk '{print $7}' | cut -d : -f 1)" = shared
+            test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}' | cut -d : -f 1)" = shared
             ;;
         private)
             mkdir -p /run/snapd/ns
             mount --bind /run/snapd/ns /run/snapd/ns
             mount --make-private /run/snapd/ns
             # Ensure the mount point is private
-            test "$(cat /proc/self/mountinfo | grep '/snapd/ns /run/snapd/ns' | awk '{print $7}')" = -
+            test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}')" = -
     esac
     # We can run snap-confine and it will do the right thing.
     test-snapd-sh -c /bin/true
-    test "$(cat /proc/self/mountinfo | grep '/snapd/ns /run/snapd/ns' | awk '{print $7}')" = -
+    test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}')" = -

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -30,14 +30,16 @@ execute: |
             mkdir -p /run/snapd/ns
             mount --bind /run/snapd/ns /run/snapd/ns
             mount --make-shared /run/snapd/ns
-            test "$(findmnt --noheadings  --output=PROPAGATION /run/snapd/ns)" = shared
+            # This ensure the mount point is shared
+            test "$(cat /proc/self/mountinfo | grep '/snapd/ns /run/snapd/ns' | awk '{print $7}' | cut -d : -f 1)" = shared
             ;;
         private)
             mkdir -p /run/snapd/ns
             mount --bind /run/snapd/ns /run/snapd/ns
             mount --make-private /run/snapd/ns
-            test "$(findmnt --noheadings  --output=PROPAGATION /run/snapd/ns)" = private 
+            # Ensure the mount point is private
+            test "$(cat /proc/self/mountinfo | grep '/snapd/ns /run/snapd/ns' | awk '{print $7}')" = -
     esac
     # We can run snap-confine and it will do the right thing.
     test-snapd-sh -c /bin/true
-    test "$(findmnt --noheadings  --output=PROPAGATION /run/snapd/ns)" = private
+    test "$(cat /proc/self/mountinfo | grep '/snapd/ns /run/snapd/ns' | awk '{print $7}')" = -

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -30,14 +30,14 @@ execute: |
             mkdir -p /run/snapd/ns
             mount --bind /run/snapd/ns /run/snapd/ns
             mount --make-shared /run/snapd/ns
-            # This ensure the mount point is shared
+            # verify mount tags to ensure the mount point has shared propagation (format shared:<nnnn>)
             test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}' | cut -d : -f 1)" = shared
             ;;
         private)
             mkdir -p /run/snapd/ns
             mount --bind /run/snapd/ns /run/snapd/ns
             mount --make-private /run/snapd/ns
-            # Ensure the mount point is private
+            # verify mount tags to ensure the mount point has private propagation (no mount tags set)
             test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}')" = -
             ;;
         *)
@@ -47,4 +47,5 @@ execute: |
     esac
     # We can run snap-confine and it will do the right thing.
     test-snapd-sh -c /bin/true
+    # verify that no mount tags are set, private propagation does not set any
     test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}')" = -

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -21,7 +21,7 @@ prepare: |
 execute: |
     case "$VARIANT" in
        absent)
-            rmdir /run/snapd/ns
+            test -d /run/snapd/ns && rmdir /run/snapd/ns
             ;;
        present)
             mkdir -p /run/snapd/ns

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -18,6 +18,8 @@ prepare: |
         umount /run/snapd/ns
     fi
     ! findmnt --noheadings /run/snapd/ns
+debug: |
+    cat /proc/self/mountinfo
 execute: |
     case "$VARIANT" in
        absent)


### PR DESCRIPTION
The code that handles special sharing mode of /run/snapd/ns did cope
with /run/snapd/ns being a private mount point and not being a mount
point at all. When it was a mount point but one with shared mount event
propagation all kinds of hell would break loose. This patch fixes this.

The existing unit tests were nixed and replaced with a much more
readable and comprehensive spread test.

Fixes: https://bugs.launchpad.net/snapd/+bug/1803542
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
