### PR TITLE
nvidia, interfaces/builtin: OpenCL fixes

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -111,6 +111,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-glvkspirv.so*",
 	"libnvidia-ifr.so*",
 	"libnvidia-ml.so*",
+	"libnvidia-opencl.so*",
 	"libnvidia-ptxjitcompiler.so*",
 	"libnvidia-tls.so*",
 	"tls/libnvidia-tls.so*",

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -79,6 +79,9 @@ unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
 unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /{dev,run}/shm/cuda.* rw,
 
+# OpenCL ICD files
+/etc/OpenCL/vendors/ r,
+/etc/OpenCL/vendors/** r,
 
 # Parallels guest tools 3D acceleration (video toolgate)
 @{PROC}/driver/prl_vtg rw,


### PR DESCRIPTION
Two patches related to OpenCL and nvidia. The first one allows picking up `libnvidia-opencl.so` from the host. The second one opens `/etc/OpenCL/vendor` for reading in the `opengl` interface. This is needed when one wants to reasonably implement OpenCL support with nvidia.