### PR TITLE
wrappers: rename the desktop file to their apps

### DIFF
--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -247,11 +247,11 @@ apps:
 
 	guiDir := filepath.Join(s.info.MountDir(), "meta", "gui")
 	c.Assert(os.MkdirAll(guiDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(guiDir, "bin.desktop"), []byte(`
+	c.Assert(ioutil.WriteFile(filepath.Join(guiDir, "foo.desktop"), []byte(`
 [Desktop Entry]
 Name=bin
 Icon=${SNAP}/bin.png
-Exec=bin
+Exec=foo
 `), 0644), IsNil)
 
 	r := systemd.MockSystemctl(func(...string) ([]byte, error) {

--- a/tests/lib/snaps/basic-desktop/meta/gui/io.snapcraft.echoecho.desktop
+++ b/tests/lib/snaps/basic-desktop/meta/gui/io.snapcraft.echoecho.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Echoecho
+Comment=It echos echos stuff
+Exec=basic-desktop.echo echo
+Icon=${SNAP}/meta/gui/icon.png
+Terminal=true
+Type=Application
+Categories=Utilities;Useless;
+Keywords=echo;echo;
+StartupNotify=false

--- a/tests/lib/snaps/basic-desktop/meta/snap.yaml
+++ b/tests/lib/snaps/basic-desktop/meta/snap.yaml
@@ -4,3 +4,5 @@ license: GPL-3.0
 apps:
  echo:
   command: bin/echo
+ echoecho:
+  command: bin/echo echo

--- a/tests/main/install-remove-multi/task.yaml
+++ b/tests/main/install-remove-multi/task.yaml
@@ -10,3 +10,13 @@ execute: |
     snap remove test-snapd-tools test-snapd-control-consumer
     snap list | MATCH -v test-snapd-tools
     snap list | MATCH -v test-snapd-control-consumer
+
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    echo "Installing of a snap with a desktop file creates the desktop file"
+    echo "Given a snap declaring the home plug is installed"
+    install_local basic-desktop 
+    test -e /var/lib/snapd/desktop/applications/basic-desktop__io.snapcraft.echoecho.desktop
+    echo "Removing a snap with a desktop file removes the desktop file again"
+    snap remove  basic-desktop
+    ! test -e /var/lib/snapd/desktop/applications/basic-desktop__io.snapcraft.echoecho.desktop

--- a/tests/main/install-remove-multi/task.yaml
+++ b/tests/main/install-remove-multi/task.yaml
@@ -16,7 +16,7 @@ execute: |
     echo "Installing of a snap with a desktop file creates the desktop file"
     echo "Given a snap declaring the home plug is installed"
     install_local basic-desktop 
-    test -e /var/lib/snapd/desktop/applications/basic-desktop__io.snapcraft.echoecho.desktop
+    test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop
     echo "Removing a snap with a desktop file removes the desktop file again"
     snap remove  basic-desktop
-    ! test -e /var/lib/snapd/desktop/applications/basic-desktop__io.snapcraft.echoecho.desktop
+    ! test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop

--- a/tests/main/install-remove-multi/task.yaml
+++ b/tests/main/install-remove-multi/task.yaml
@@ -16,7 +16,7 @@ execute: |
     echo "Installing of a snap with a desktop file creates the desktop file"
     echo "Given a snap declaring the home plug is installed"
     install_local basic-desktop 
-    test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop
+    test -e /var/lib/snapd/desktop/applications/basic-desktop_echoecho.desktop
     echo "Removing a snap with a desktop file removes the desktop file again"
     snap remove  basic-desktop
-    ! test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop
+    ! test -e /var/lib/snapd/desktop/applications/basic-desktop_echoecho.desktop

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -13,15 +13,15 @@ execute: |
     snap set system experimental.parallel-instances=true
 
     for instance in foo longname; do
-        echo "Sideload same snap as different instance named basic-desktop_$instance"
+        echo "Sideload same snap as different instance named basic-desktop+$instance"
         expected="^basic-desktop_$instance 1.0 installed\$"
         install_local_as basic-desktop "basic-desktop_$instance" | MATCH "$expected"
 
-        diff -u <(head -n4 "/var/lib/snapd/desktop/applications/basic-desktop_${instance}_echo.desktop") - <<-EOF
+        diff -u <(head -n4 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
     [Desktop Entry]
     Name=Echo
     Comment=It echos stuff
-    Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop_${instance}_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo
+    Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo
     EOF
 
         test -d "$SNAP_MOUNT_DIR/basic-desktop_$instance/x1"

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -190,6 +190,21 @@ func updateDesktopDatabase(desktopFiles []string) error {
 	return nil
 }
 
+// desktopPrefix returns the prefix string for the desktop files that
+// belongs to the given snapInstance. We need to do something custom
+// here because a) we need to be compatible with the world before we had
+// parallel installs b) we can't just use the usual "_" parallel installs
+// separator because that is already used as the separator between snap
+// and desktop filename.
+func desktopPrefix(s *snap.Info) string {
+	if s.SnapName() == s.InstanceName() {
+		return s.SnapName()
+	}
+	// we cannot use the usual "_" separator because that is also used
+	// to separate "$snap_$desktopfile"
+	return fmt.Sprintf("%s+%s", s.SnapName(), s.InstanceKey)
+}
+
 // AddSnapDesktopFiles puts in place the desktop files for the applications from the snap.
 func AddSnapDesktopFiles(s *snap.Info) (err error) {
 	var created []string
@@ -220,7 +235,11 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 			return err
 		}
 
-		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s__%s", s.InstanceName(), filepath.Base(df)))
+		// FIXME: don't blindly use the snap desktop filename, mangle it
+		// but we can't just use the app name because a desktop file
+		// may call the same app with multiple parameters, e.g.
+		// --create-new, --open-existing etc
+		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s", desktopPrefix(s), filepath.Base(df)))
 		content = sanitizeDesktopFile(s, installedDesktopFileName, content)
 		if err := osutil.AtomicWriteFile(installedDesktopFileName, content, 0755, 0); err != nil {
 			return err
@@ -240,7 +259,7 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 func RemoveSnapDesktopFiles(s *snap.Info) error {
 	removedDesktopFiles := make([]string, 0, len(s.Apps))
 
-	desktopFiles, err := filepath.Glob(filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s__*.desktop", s.InstanceName())))
+	desktopFiles, err := filepath.Glob(filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_*.desktop", desktopPrefix(s))))
 	if err != nil {
 		return nil
 	}

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -73,7 +73,7 @@ Icon=${SNAP}/foo.png`)
 var desktopContents = ""
 
 func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
-	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar.desktop")
+	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, false)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
@@ -95,7 +95,7 @@ func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
 }
 
 func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
-	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar.desktop")
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
@@ -113,8 +113,8 @@ func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
 }
 
 func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
-	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar.desktop")
-	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance__foobar.desktop")
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo+instance_foobar.desktop")
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
@@ -131,7 +131,7 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
 		{"update-desktop-database", dirs.SnapDesktopFilesDir},
 	})
-	// foo_instance file is still there
+	// foo+instance file is still there
 	c.Assert(osutil.FileExists(mockDesktopInstanceFilePath), Equals, true)
 
 	// restore the non-instance file
@@ -152,17 +152,17 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 }
 
 func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
-	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar1.desktop")
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar1.desktop")
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
 
-	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance__foobar.desktop")
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance_foobar.desktop")
 	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
-	err = os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar2.desktop", "potato"), 0755)
+	err = os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
 	c.Assert(err, IsNil)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -73,7 +73,7 @@ Icon=${SNAP}/foo.png`)
 var desktopContents = ""
 
 func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
-	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
+	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar.desktop")
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, false)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
@@ -95,7 +95,7 @@ func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
 }
 
 func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
-	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar.desktop")
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
@@ -113,8 +113,8 @@ func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
 }
 
 func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
-	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
-	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance_foobar.desktop")
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar.desktop")
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance__foobar.desktop")
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
@@ -152,17 +152,17 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 }
 
 func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
-	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar1.desktop")
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar1.desktop")
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
 
-	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance_foobar.desktop")
+	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_instance__foobar.desktop")
 	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
-	err = os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
+	err = os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo__foobar2.desktop", "potato"), 0755)
 	c.Assert(err, IsNil)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})


### PR DESCRIPTION
Followup for https://github.com/snapcore/snapd/pull/6156

This renames the desktop files instead of blindly trusting the name that comes from the snap. 

Only 5d46f8c08c077a3bdfdf4243af50603aa4ca28d3 is new in this PR the other bits are from the previous PR. 