### PR TITLE
cmd/snap-confine: allow mapping more libc shards

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -25,6 +25,9 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libresolv{,-[0-9]*}.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
     # normal libs in order
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
@@ -394,6 +397,9 @@
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libresolv{,-[0-9]*}.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
         # normal libs in order
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -26,8 +26,6 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
     # normal libs in order
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
@@ -398,8 +396,6 @@
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
         # normal libs in order
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,


### PR DESCRIPTION
Libc seems to split into ever-growing list of shared libraries,
unfortunately we need to know about all of them. It was reported that
the latest update of openSUSE tumbleweed snap-confine fails to start
because it cannot map libmount due to self-imposed apparmor confinement.

    type=AVC msg=audit(1542580432.818:874): apparmor="DENIED"
    operation="file_mmap" profile="/usr/lib/snapd/snap-confine"
    name="/usr/lib64/libmount.so.1.1.0" pid=63751 comm="snap-confine"
    requested_mask="m" denied_mask="m" fsuid=0 ouid=0

While investigating this I noticed we also link to (but do not allow
mapping libblkid and libuuid. This patch addresses all three missing
shared libraries.

Fixes: https://bugs.launchpad.net/snapd/+bug/1803903
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
