### PR TITLE
tests: fix shellcheck

### DIFF
--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -52,6 +52,6 @@ prepare: |
 
 execute: |
     cd /tmp/cross-build/src/github.com/snapcore/snapd
-    for cmd in $( find ./cmd -mindepth 2 -maxdepth 2 -name \*.go -printf "%h\n" | sort -u ); do
+    for cmd in $( find ./cmd -mindepth 2 -maxdepth 2 -name \*.go -printf '%h\n' | sort -u ); do
       su -c "GOPATH=/tmp/cross-build CGO_ENABLED=1 GOARCH=$X_GOARCH CC=$X_CC go build -v -o /dev/null $cmd" test
     done

--- a/tests/regression/lp-1802581/task.yaml
+++ b/tests/regression/lp-1802581/task.yaml
@@ -23,7 +23,7 @@ prepare: |
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
     echo "Create/enable fake gpio"
-    systemd_create_and_start_persistent_unit fake-gpio "$TESTSLIB/fakegpio/fake-gpio.py"  "[Unit]\nBefore=snap.core.interface.gpio-100.service\n[Service]\nType=notify"
+    systemd_create_and_start_persistent_unit fake-gpio "$TESTSLIB/fakegpio/fake-gpio.py"  '[Unit]\nBefore=snap.core.interface.gpio-100.service\n[Service]\nType=notify'
 
 restore: |
     # shellcheck source=tests/lib/systemd.sh


### PR DESCRIPTION
```
ERROR:root:tests/cross/go-build/task.yaml: section 'execute':

In - line 3:
for cmd in $( find ./cmd -mindepth 2 -maxdepth 2 -name \*.go -printf "%h\n" | sort -u ); do
                                                                        ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".

ERROR:root:shellcheck failed for file tests/regression/lp-1802581/task.yaml in sections: prepare; error log follows
ERROR:root:tests/regression/lp-1802581/task.yaml: section 'prepare':

In - line 5:
systemd_create_and_start_persistent_unit fake-gpio "$TESTSLIB/fakegpio/fake-gpio.py"  "[Unit]\nBefore=snap.core.interface.gpio-100.service\n[Service]\nType=notify"
                                                                                             ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
                                                                                                                                          ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
                                                                                                                                                     ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
```
