### PR TITLE
overlord,tests: expose enabled features to /var/lib/snapd/features

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -136,6 +136,9 @@ purge() {
     echo "Removing downloaded snaps"
     rm -rf /var/lib/snapd/snaps/*
 
+    echo "Removing features exported from snapd to helper tools"
+    rm -rf /var/lib/snapd/features
+
     echo "Final directory cleanup"
     rm -rf "${SNAP_MOUNT_DIR}"
     rm -rf /var/snap

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -109,6 +109,8 @@ var (
 
 	ErrtrackerDbDir string
 	SysfsDir        string
+
+	FeaturesDir string
 )
 
 const (
@@ -292,4 +294,6 @@ func SetRootDir(rootdir string) {
 
 	ErrtrackerDbDir = filepath.Join(rootdir, snappyDir, "errtracker.db")
 	SysfsDir = filepath.Join(rootdir, "/sys")
+
+	FeaturesDir = filepath.Join(rootdir, snappyDir, "features")
 }

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -52,8 +52,8 @@ func coreCfg(tr Conf, key string) (result string, err error) {
 	return fmt.Sprintf("%v", v), nil
 }
 
-// supportedConfigurations will be filled in by the files (like proxy.go)
-// that handle this configuration.
+// supportedConfigurations contains a set of handled configuration keys.
+// The actual values are populated by `init()` functions in each module.
 var supportedConfigurations = make(map[string]bool, 32)
 
 func validateBoolFlag(tr Conf, flag string) error {

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -103,7 +103,7 @@ func Run(tr Conf) error {
 		return err
 	}
 
-	// Export experimental.* flags to a place easily accessible from C.
+	// Export experimental.* flags to a place easily accessible from snapd helpers.
 	if err := handleExperimentalFlags(tr); err != nil {
 		return err
 	}

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -22,7 +22,6 @@ package configcore
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
@@ -55,12 +54,7 @@ func coreCfg(tr Conf, key string) (result string, err error) {
 
 // supportedConfigurations will be filled in by the files (like proxy.go)
 // that handle this configuration.
-var supportedConfigurations = map[string]bool{
-	"core.experimental.layouts":            true,
-	"core.experimental.parallel-instances": true,
-	"core.experimental.hotplug":            true,
-	"core.experimental.snapd-snap":         true,
-}
+var supportedConfigurations = make(map[string]bool, 32)
 
 func validateBoolFlag(tr Conf, flag string) error {
 	value, err := coreCfg(tr, flag)
@@ -72,18 +66,6 @@ func validateBoolFlag(tr Conf, flag string) error {
 		// noop
 	default:
 		return fmt.Errorf("%s can only be set to 'true' or 'false'", flag)
-	}
-	return nil
-}
-
-func validateExperimentalSettings(tr Conf) error {
-	for k := range supportedConfigurations {
-		if !strings.HasPrefix(k, "core.experimental.") {
-			continue
-		}
-		if err := validateBoolFlag(tr, strings.TrimPrefix(k, "core.")); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -103,6 +103,11 @@ func Run(tr Conf) error {
 		return err
 	}
 
+	// Export experimental.* flags to a place easily accessible from C.
+	if err := handleExperimentalFlags(tr); err != nil {
+		return err
+	}
+
 	// see if it makes sense to run at all
 	if release.OnClassic {
 		// nothing to do

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -41,6 +41,7 @@ type Conf interface {
 	State() *state.State
 }
 
+// coreCfg returns the configuration value for the core snap.
 func coreCfg(tr Conf, key string) (result string, err error) {
 	var v interface{} = ""
 	if err := tr.Get("core", key, &v); err != nil && !config.IsNoOption(err) {

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/systemd"
@@ -104,7 +105,12 @@ func (s *configcoreSuite) TearDownSuite(c *C) {
 }
 
 func (s *configcoreSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
 	s.state = state.New(nil)
+}
+
+func (s *configcoreSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
 }
 
 // runCfgSuite tests configcore.Run()

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -120,41 +120,6 @@ type runCfgSuite struct {
 
 var _ = Suite(&runCfgSuite{})
 
-func (r *runCfgSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
-	for setting, value := range map[string]interface{}{
-		"experimental.layouts":            "foo",
-		"experimental.parallel-instances": "foo",
-		"experimental.hotplug":            "foo",
-		"experimental.snapd-snap":         "foo",
-	} {
-		conf := &mockConf{
-			state: r.state,
-			changes: map[string]interface{}{
-				setting: value,
-			},
-		}
-
-		err := configcore.Run(conf)
-		c.Check(err, ErrorMatches, fmt.Sprintf(`%s can only be set to 'true' or 'false'`, setting))
-	}
-}
-
-func (r *runCfgSuite) TestConfigureExperimentalSettingsHappy(c *C) {
-	for _, setting := range []string{"experimental.layouts", "experimental.parallel-instances", "experimental.hotplug"} {
-		for _, t := range []string{"true", "false"} {
-			conf := &mockConf{
-				state: r.state,
-				conf: map[string]interface{}{
-					setting: t,
-				},
-			}
-
-			err := configcore.Run(conf)
-			c.Check(err, IsNil)
-		}
-	}
-}
-
 func (r *runCfgSuite) TestConfigureUnknownOption(c *C) {
 	conf := &mockConf{
 		state: r.state,
@@ -165,21 +130,4 @@ func (r *runCfgSuite) TestConfigureUnknownOption(c *C) {
 
 	err := configcore.Run(conf)
 	c.Check(err, ErrorMatches, `cannot set "core.unknown.option": unsupported system option`)
-}
-
-func (r *runCfgSuite) TestConfigureKnownOption(c *C) {
-	for setting, value := range map[string]interface{}{
-		"experimental.layouts":            true,
-		"experimental.parallel-instances": false,
-	} {
-		conf := &mockConf{
-			state: r.state,
-			changes: map[string]interface{}{
-				setting: value,
-			},
-		}
-
-		err := configcore.Run(conf)
-		c.Check(err, IsNil)
-	}
 }

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -33,7 +33,7 @@ func init() {
 	}
 }
 
-var experimentalFlags = []string{"hotplug", "layouts", "parallel-instances", "snapd-snap"}
+var experimentalFlags = []string{"hotplug", "layouts", "parallel-instances", "snapd-snap", "per-user-mount-namespace"}
 
 func validateExperimentalSettings(tr Conf) error {
 	for k := range supportedConfigurations {

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"strings"
+)
+
+func init() {
+	for _, flag := range experimentalFlags {
+		supportedConfigurations["core.experimental."+flag] = true
+	}
+}
+
+var experimentalFlags = []string{"hotplug", "layouts", "parallel-instances", "snapd-snap"}
+
+func validateExperimentalSettings(tr Conf) error {
+	for k := range supportedConfigurations {
+		if !strings.HasPrefix(k, "core.experimental.") {
+			continue
+		}
+		if err := validateBoolFlag(tr, strings.TrimPrefix(k, "core.")); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -20,7 +20,11 @@
 package configcore
 
 import (
+	"os"
 	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 func init() {
@@ -41,4 +45,25 @@ func validateExperimentalSettings(tr Conf) error {
 		}
 	}
 	return nil
+}
+
+func handleExperimentalFlags(tr Conf) error {
+	dir := dirs.FeaturesDir
+	if !osutil.IsDirectory(dir) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	content := make(map[string]*osutil.FileState, len(experimentalFlags))
+	for _, flag := range experimentalFlags {
+		value, err := coreCfg(tr, "experimental."+flag)
+		if err != nil {
+			return err
+		}
+		if value == "true" {
+			content[flag] = &osutil.FileState{Mode: 0644}
+		}
+	}
+	_, _, err := osutil.EnsureDirState(dir, "*", content)
+	return err
 }

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -49,10 +49,8 @@ func validateExperimentalSettings(tr Conf) error {
 
 func handleExperimentalFlags(tr Conf) error {
 	dir := dirs.FeaturesDir
-	if !osutil.IsDirectory(dir) {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
 	}
 	content := make(map[string]*osutil.FileState, len(experimentalFlags))
 	for _, flag := range experimentalFlags {

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -21,10 +21,13 @@ package configcore_test
 
 import (
 	"fmt"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type experimentalSuite struct {
@@ -83,4 +86,18 @@ func (s *experimentalSuite) TestConfigureKnownOption(c *C) {
 		err := configcore.Run(conf)
 		c.Check(err, IsNil)
 	}
+}
+
+func (s *experimentalSuite) TestExportedState(c *C) {
+	conf := &mockConf{
+		state:   s.state,
+		conf:    map[string]interface{}{"experimental.hotplug": true},
+		changes: map[string]interface{}{"experimental.layouts": true},
+	}
+
+	err := configcore.Run(conf)
+	c.Check(err, IsNil)
+
+	c.Assert(filepath.Join(dirs.FeaturesDir, "hotplug"), testutil.FileEquals, "")
+	c.Assert(filepath.Join(dirs.FeaturesDir, "layouts"), testutil.FileEquals, "")
 }

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -76,8 +76,15 @@ func (s *experimentalSuite) TestExportedFeatures(c *C) {
 	}
 
 	err := configcore.Run(conf)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 
-	c.Assert(filepath.Join(dirs.FeaturesDir, "hotplug"), testutil.FileEquals, "")
-	c.Assert(filepath.Join(dirs.FeaturesDir, "layouts"), testutil.FileEquals, "")
+	c.Assert(filepath.Join(dirs.FeaturesDir, "hotplug"), testutil.FilePresent)
+	c.Assert(filepath.Join(dirs.FeaturesDir, "layouts"), testutil.FilePresent)
+
+	delete(conf.changes, "experimental.layouts")
+	err = configcore.Run(conf)
+	c.Assert(err, IsNil)
+
+	c.Assert(filepath.Join(dirs.FeaturesDir, "hotplug"), testutil.FilePresent)
+	c.Assert(filepath.Join(dirs.FeaturesDir, "layouts"), testutil.FileAbsent)
 }

--- a/overlord/configstate/configcore/experimental_test.go
+++ b/overlord/configstate/configcore/experimental_test.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+)
+
+type experimentalSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&experimentalSuite{})
+
+func (s *experimentalSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
+	for setting, value := range map[string]interface{}{
+		"experimental.layouts":            "foo",
+		"experimental.parallel-instances": "foo",
+		"experimental.hotplug":            "foo",
+		"experimental.snapd-snap":         "foo",
+	} {
+		conf := &mockConf{
+			state: s.state,
+			changes: map[string]interface{}{
+				setting: value,
+			},
+		}
+
+		err := configcore.Run(conf)
+		c.Check(err, ErrorMatches, fmt.Sprintf(`%s can only be set to 'true' or 'false'`, setting))
+	}
+}
+
+func (s *experimentalSuite) TestConfigureExperimentalSettingsHappy(c *C) {
+	for _, setting := range []string{"experimental.layouts", "experimental.parallel-instances", "experimental.hotplug"} {
+		for _, t := range []string{"true", "false"} {
+			conf := &mockConf{
+				state: s.state,
+				conf: map[string]interface{}{
+					setting: t,
+				},
+			}
+
+			err := configcore.Run(conf)
+			c.Check(err, IsNil)
+		}
+	}
+}
+
+func (s *experimentalSuite) TestConfigureKnownOption(c *C) {
+	for setting, value := range map[string]interface{}{
+		"experimental.layouts":            true,
+		"experimental.parallel-instances": false,
+	} {
+		conf := &mockConf{
+			state: s.state,
+			changes: map[string]interface{}{
+				setting: value,
+			},
+		}
+
+		err := configcore.Run(conf)
+		c.Check(err, IsNil)
+	}
+}

--- a/tests/main/experimental-features/task.yaml
+++ b/tests/main/experimental-features/task.yaml
@@ -1,0 +1,11 @@
+summary: experimental features are exported by snapd
+details: |
+    Experimental features are exported as flag files that can be easily read by
+    snap-confine and snap-update-ns that otherwise don't have access to the
+    system state.
+execute: |
+    snap set core experimental.layouts=true
+    test -f /var/lib/snapd/features/layouts
+
+    snap set core experimental.layouts=false
+    test ! -f /var/lib/snapd/features/layouts

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -28,6 +28,7 @@ package testutil
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -327,6 +328,26 @@ func (s *CheckersS) TestFileMatches(c *check.C) {
 	testCheck(c, FileMatches, false, `Cannot read file "": open : no such file or directory`, "", "")
 	testCheck(c, FileMatches, false, "Filename must be a string", 42, ".*")
 	testCheck(c, FileMatches, false, "Regex must be a string", filename, 1)
+}
+
+func (s *CheckersS) TestFilePresent(c *check.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "foo")
+	testInfo(c, FilePresent, "FilePresent", []string{"filename"})
+	testCheck(c, FilePresent, false, `filename must be a string`, 42)
+	testCheck(c, FilePresent, false, fmt.Sprintf(`file %q is absent but should exist`, filename), filename)
+	c.Assert(ioutil.WriteFile(filename, nil, 0644), check.IsNil)
+	testCheck(c, FilePresent, true, "", filename)
+}
+
+func (s *CheckersS) TestFileAbsent(c *check.C) {
+	d := c.MkDir()
+	filename := filepath.Join(d, "foo")
+	testInfo(c, FileAbsent, "FileAbsent", []string{"filename"})
+	testCheck(c, FileAbsent, false, `filename must be a string`, 42)
+	testCheck(c, FileAbsent, true, "", filename)
+	c.Assert(ioutil.WriteFile(filename, nil, 0644), check.IsNil)
+	testCheck(c, FileAbsent, false, fmt.Sprintf(`file %q is present but should not exist`, filename), filename)
 }
 
 func (s *CheckersS) TestSystemCallSequenceEqual(c *check.C) {


### PR DESCRIPTION
This is a re-iteration of the earlier facts patch-set. Instead of a facts file
we now have flag files. The files are empty and are stored in
/var/lib/snapd/features. I also added the feature flag for per-user mount
namespaces. This will be handy in upcoming tests.

I chose not to change packaging to reduce the impact since the directory is
dynamically created. I will %ghost the directory later in RPM-specific
packages, before the next release.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
