### PR TITLE
Send epochs followup

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2761,7 +2761,7 @@ func (s *snapmgrTestSuite) TestInstalling(c *C) {
 func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 	si := snap.SideInfo{
 		RealName: "some-snap",
-		Revision: snap.R(7),
+		Revision: snap.R(-42),
 	}
 	snaptest.MockSnap(c, `name: some-snap`, &si)
 
@@ -2868,7 +2868,7 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
-		Revision: snap.R(7),
+		Revision: snap.R(-42),
 	})
 	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -140,8 +140,9 @@ func (s epochSuite) TestGoodEpochsInSnapYAML(c *check.C) {
 	}
 
 	tests := []Tt{
-		{s: `epoch: 0`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
 		{s: ``, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `epoch: null`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `epoch: 0`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
 		{s: `epoch: "0"`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
 		{s: `epoch: {}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
 		{s: `epoch: "2*"`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -131,6 +131,67 @@ func (s epochSuite) TestGoodEpochs(c *check.C) {
 	}
 }
 
+func (s epochSuite) TestGoodEpochsInSnapYAML(c *check.C) {
+	defer snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})()
+
+	type Tt struct {
+		s string
+		e snap.Epoch
+	}
+
+	tests := []Tt{
+		{s: `epoch: 0`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: ``, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `epoch: "0"`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `epoch: {}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `epoch: "2*"`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},
+		{s: `epoch: {"read": [2]}`, e: snap.Epoch{Read: []uint32{2}, Write: []uint32{2}}},
+		{s: `epoch: {"read": [1, 2]}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},
+		{s: `epoch: {"write": [2]}`, e: snap.Epoch{Read: []uint32{2}, Write: []uint32{2}}},
+		{s: `epoch: {"write": [1, 2]}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{1, 2}}},
+		{s: `epoch: {"read": [2,4,8], "write": [2,3,5]}`, e: snap.Epoch{Read: []uint32{2, 4, 8}, Write: []uint32{2, 3, 5}}},
+	}
+
+	for _, test := range tests {
+		info, err := snap.InfoFromSnapYaml([]byte(test.s))
+		c.Check(err, check.IsNil, check.Commentf("YAML: %s", test.s))
+		c.Check(info.Epoch, check.DeepEquals, test.e)
+	}
+}
+
+func (s epochSuite) TestGoodEpochsInJSON(c *check.C) {
+	type Tt struct {
+		s string
+		e snap.Epoch
+	}
+
+	type Tinfo struct {
+		Epoch snap.Epoch `json:"epoch"`
+	}
+
+	tests := []Tt{
+		// {} should give snap.Epoch{Read: []uint32{0}, Write: []uint32{0}} but needs an UnmarshalJSON on the parent
+		{s: `{"epoch": null}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `{"epoch": "0"}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `{"epoch": {}}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `{"epoch": "2*"}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},
+		{s: `{"epoch": {"read": [0]}}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `{"epoch": {"write": [0]}}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `{"epoch": {"read": [2]}}`, e: snap.Epoch{Read: []uint32{2}, Write: []uint32{2}}},
+		{s: `{"epoch": {"read": [1, 2]}}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},
+		{s: `{"epoch": {"write": [2]}}`, e: snap.Epoch{Read: []uint32{2}, Write: []uint32{2}}},
+		{s: `{"epoch": {"write": [1, 2]}}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{1, 2}}},
+		{s: `{"epoch": {"read": [2,4,8], "write": [2,3,5]}}`, e: snap.Epoch{Read: []uint32{2, 4, 8}, Write: []uint32{2, 3, 5}}},
+	}
+
+	for _, test := range tests {
+		var info Tinfo
+		err := json.Unmarshal([]byte(test.s), &info)
+		c.Check(err, check.IsNil, check.Commentf("JSON: %s", test.s))
+		c.Check(info.Epoch, check.DeepEquals, test.e, check.Commentf("JSON: %s", test.s))
+	}
+}
+
 func (s *epochSuite) TestEpochValidate(c *check.C) {
 	validEpochs := []snap.Epoch{
 		{},
@@ -181,6 +242,11 @@ func (s *epochSuite) TestEpochString(c *check.C) {
 		s string
 	}{
 		{e: snap.Epoch{}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{0}}, s: "0"},
+		{e: snap.Epoch{Write: []uint32{0}}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{}}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{}, Write: []uint32{0}}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{}, Write: []uint32{}}, s: "0"},
 		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: "0"},
 		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: "1*"},
 		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: "1"},
@@ -198,6 +264,10 @@ func (s *epochSuite) TestEpochMarshal(c *check.C) {
 		s string
 	}{
 		{e: snap.Epoch{}, s: `{"read":[0],"write":[0]}`},
+		{e: snap.Epoch{Read: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
+		{e: snap.Epoch{Write: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{}}, s: `{"read":[0],"write":[0]}`},
+		{e: snap.Epoch{Read: []uint32{}, Write: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
 		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: `{"read":[0],"write":[0]}`},
 		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: `{"read":[0,1],"write":[1]}`},
 		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: `{"read":[1],"write":[1]}`},
@@ -231,14 +301,20 @@ func (s *epochSuite) TestE(c *check.C) {
 }
 
 func (s *epochSuite) TestUnset(c *check.C) {
-	for _, e := range []*snap.Epoch{nil, {}} {
+	for _, e := range []*snap.Epoch{
+		nil,
+		{},
+		{Read: []uint32{0}},
+		{Write: []uint32{0}},
+		{Read: []uint32{0}, Write: []uint32{}},
+		{Read: []uint32{}, Write: []uint32{0}},
+		{Read: []uint32{0}, Write: []uint32{0}},
+	} {
 		c.Check(e.Unset(), check.Equals, true, check.Commentf("%#v", e))
 	}
 	for _, e := range []*snap.Epoch{
-		{Read: []uint32{0}, Write: []uint32{0}},
-		{Read: []uint32{}, Write: []uint32{}}, // invalid
-		{Read: []uint32{0}},                   // invalid
-		{Write: []uint32{0}},                  // invalid
+		{Read: []uint32{0, 1}, Write: []uint32{0}},
+		{Read: []uint32{1}, Write: []uint32{1, 2}},
 	} {
 		c.Check(e.Unset(), check.Equals, false, check.Commentf("%#v", e))
 	}

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -300,7 +300,7 @@ func (s *epochSuite) TestE(c *check.C) {
 	}
 }
 
-func (s *epochSuite) TestUnset(c *check.C) {
+func (s *epochSuite) TestIsZero(c *check.C) {
 	for _, e := range []*snap.Epoch{
 		nil,
 		{},
@@ -310,13 +310,13 @@ func (s *epochSuite) TestUnset(c *check.C) {
 		{Read: []uint32{}, Write: []uint32{0}},
 		{Read: []uint32{0}, Write: []uint32{0}},
 	} {
-		c.Check(e.Unset(), check.Equals, true, check.Commentf("%#v", e))
+		c.Check(e.IsZero(), check.Equals, true, check.Commentf("%#v", e))
 	}
 	for _, e := range []*snap.Epoch{
 		{Read: []uint32{0, 1}, Write: []uint32{0}},
 		{Read: []uint32{1}, Write: []uint32{1, 2}},
 	} {
-		c.Check(e.Unset(), check.Equals, false, check.Commentf("%#v", e))
+		c.Check(e.IsZero(), check.Equals, false, check.Commentf("%#v", e))
 	}
 }
 

--- a/store/details.go
+++ b/store/details.go
@@ -34,7 +34,6 @@ type snapDetails struct {
 	Description      safejson.Paragraph `json:"description,omitempty"`
 	DownloadSize     int64              `json:"binary_filesize,omitempty"`
 	DownloadURL      string             `json:"download_url,omitempty"`
-	Epoch            snap.Epoch         `json:"epoch"`
 	LastUpdated      string             `json:"last_updated,omitempty"`
 	Name             string             `json:"package_name"`
 	Prices           map[string]float64 `json:"prices,omitempty"`
@@ -73,7 +72,6 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Architectures = d.Architectures
 	info.Type = d.Type
 	info.Version = d.Version
-	info.Epoch = d.Epoch
 	info.RealName = d.Name
 	info.SnapID = d.SnapID
 	info.Revision = snap.R(d.Revision)

--- a/store/store.go
+++ b/store/store.go
@@ -2200,7 +2200,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 
 		if a.Action != "refresh" {
 			aJSON.Name = snap.InstanceSnap(a.InstanceName)
-			if a.Epoch.Unset() {
+			if a.Epoch.IsZero() {
 				// Let the store know we can handle epochs, by sending the `epoch`
 				// field in the request.  A nil epoch is not an empty interface{},
 				// you'll get the null in the json. See comment in snapActionJSON.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2310,7 +2310,7 @@ func (s *storeTestSuite) TestNoInfo(c *C) {
 }
 
 /* acquired via looking at the query snapd does for "snap find 'hello-world of snaps' --narrow" (on core) and adding size=1:
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64" 'https://api.snapcraft.io/api/v1/snaps/search?confinement=strict&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cepoch%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Clicense%2Cbase%2Cmedia%2Csupport_url%2Ccontact%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cdeveloper_name%2Cdeveloper_validation%2Cprivate%2Cconfinement%2Ccommon_ids&q=hello-world+of+snaps&size=1' | python -m json.tool | xsel -b
+curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64" 'https://api.snapcraft.io/api/v1/snaps/search?confinement=strict&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Clicense%2Cbase%2Cmedia%2Csupport_url%2Ccontact%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cdeveloper_name%2Cdeveloper_validation%2Cprivate%2Cconfinement%2Ccommon_ids&q=hello-world+of+snaps&size=1' | python -m json.tool | xsel -b
 
 And then add base and prices, and remove the _links dict
 */
@@ -2683,6 +2683,9 @@ func (s *storeTestSuite) TestFind(c *C) {
 	c.Check(snp.Summary(), Equals, "The 'hello-world' of snaps")
 	c.Check(snp.Title(), Equals, "Hello World")
 	c.Check(snp.License, Equals, "MIT")
+	// this is more a "we know this isn't there" than an actual test for a wanted feature
+	// NOTE snap.Epoch{} (which prints as "0", and is thus Unset) is not a valid Epoch.
+	c.Check(snp.Epoch, DeepEquals, snap.Epoch{})
 	c.Assert(snp.Prices, DeepEquals, map[string]float64{"EUR": 2.99, "USD": 3.49})
 	c.Assert(snp.Paid, Equals, true)
 	c.Assert(snp.Media, DeepEquals, snap.MediaInfos{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -64,8 +64,18 @@ type configTestSuite struct{}
 
 var _ = Suite(&configTestSuite{})
 
-// this is what snap.E("0") looks like when decoded into an interface{} (the /^i/ is for "interface")
-var iZeroEpoch = map[string]interface{}{"read": []interface{}{0.}, "write": []interface{}{0.}}
+var (
+	// this is what snap.E("0") looks like when decoded into an interface{} (the /^i/ is for "interface")
+	iZeroEpoch = map[string]interface{}{
+		"read":  []interface{}{0.},
+		"write": []interface{}{0.},
+	}
+	// ...and this is snap.E("5*")
+	iFiveStarEpoch = map[string]interface{}{
+		"read":  []interface{}{4., 5.},
+		"write": []interface{}{5.},
+	}
+)
 
 func (suite *configTestSuite) TestSetBaseURL(c *C) {
 	// Sanity check to prove at least one URI changes.
@@ -4091,6 +4101,7 @@ func (s *storeTestSuite) TestSnapAction(c *C) {
        "name": "hello-world",
        "revision": 26,
        "version": "6.1",
+       "epoch": {"read": [0], "write": [0]},
        "publisher": {
           "id": "canonical",
           "username": "canonical",
@@ -4134,6 +4145,118 @@ func (s *storeTestSuite) TestSnapAction(c *C) {
 	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
 	c.Assert(results[0].Publisher.ID, Equals, helloWorldDeveloperID)
 	c.Assert(results[0].Deltas, HasLen, 0)
+	c.Assert(results[0].Epoch, DeepEquals, snap.E("0"))
+}
+
+func (s *storeTestSuite) TestSnapActionNonZeroEpochAndEpochBump(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	numReqs := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		numReqs++
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Refresh-Managed"), Equals, "")
+
+		// no store ID by default
+		storeID := r.Header.Get("Snap-Device-Store")
+		c.Check(storeID, Equals, "")
+
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, release.Series)
+		c.Check(r.Header.Get("Snap-Device-Architecture"), Equals, arch.UbuntuArchitecture())
+		c.Check(r.Header.Get("Snap-Classic"), Equals, "false")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Fields  []string                 `json:"fields"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Check(req.Fields, DeepEquals, store.SnapActionFields)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "beta",
+			"refreshed-date":   helloRefreshedDateStr,
+			"epoch":            iFiveStarEpoch,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "epoch": {"read": [5, 6], "write": [6]},
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := store.New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*store.CurrentSnap{
+		{
+			InstanceName:    "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+			Epoch:           snap.E("5*"),
+		},
+	}, []*store.SnapAction{
+		{
+			Action:       "refresh",
+			SnapID:       helloWorldSnapID,
+			InstanceName: "hello-world",
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].InstanceName(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].Publisher.ID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+	c.Assert(results[0].Epoch, DeepEquals, snap.E("6*"))
+
+	c.Assert(numReqs, Equals, 1) // should be >1 soon :-)
 }
 
 func (s *storeTestSuite) TestSnapActionNoResults(c *C) {


### PR DESCRIPTION
This is a followup  for #6142:
1. in overlord/snapstate, use local revision in the amend case
2. make any "0" snap be Unset, and serialise to `{[0],[0]}`
3. stop pretending v1 search sends the epoch (it doesn't)
4. add a non-zero epoch refresh (with epoch bump)

it's four commits that you could look at separately. I could actually make them four separate PRs, but travis would hate that... and even all together it's still small.