### PR TITLE
sanity: extend the kernel version check to cover CentOS/RHEL kernels

### DIFF
--- a/sanity/version.go
+++ b/sanity/version.go
@@ -20,9 +20,13 @@
 package sanity
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
@@ -33,21 +37,65 @@ func init() {
 	checks = append(checks, checkKernelVersion)
 }
 
+// supportsMayDetachMounts checks whether a RHEL 7.4+ specific kernel knob is present
+// and set to proper value
+func supportsMayDetachMounts(kver string) error {
+	p := filepath.Join(dirs.GlobalRootDir, "/proc/sys/fs/may_detach_mounts")
+	value, err := ioutil.ReadFile(p)
+	if err != nil {
+		return fmt.Errorf("cannot read fs.may_detach_mounts state: %v", err)
+	}
+	if !bytes.Equal(value, []byte("1\n")) {
+		return fmt.Errorf("fs.may_detach_mounts is present but disabled")
+	}
+	return nil
+}
+
 // checkKernelVersion looks for some unsupported configurations that users may
 // encounter and provides advice on how to resolve them.
 func checkKernelVersion() error {
-	if release.OnClassic && release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04" {
-		kver := osutil.KernelVersion()
-		// a kernel version looks like this: "4.4.0-112-generic" and
-		// we are only interested in the bits before the "-"
-		kver = strings.SplitN(kver, "-", 2)[0]
-		cmp, err := strutil.VersionCompare(kver, "3.13.0")
+	if !release.OnClassic {
+		return nil
+	}
+
+	switch release.ReleaseInfo.ID {
+	case "ubuntu":
+		if release.ReleaseInfo.VersionID == "14.04" {
+			kver := osutil.KernelVersion()
+			// a kernel version looks like this: "4.4.0-112-generic" and
+			// we are only interested in the bits before the "-"
+			kver = strings.SplitN(kver, "-", 2)[0]
+			cmp, err := strutil.VersionCompare(kver, "3.13.0")
+			if err != nil {
+				logger.Noticef("cannot check kernel: %v", err)
+				return nil
+			}
+			if cmp <= 0 {
+				return fmt.Errorf("you need to reboot into a 4.4 kernel to start using snapd")
+			}
+		}
+	case "rhel", "centos":
+		// check for kernel tweaks on RHEL/CentOS 7.5+
+		// CentoS 7.5 has VERSION_ID="7", RHEL 7.6 has VERSION_ID="7.6"
+		if release.ReleaseInfo.VersionID == "" || release.ReleaseInfo.VersionID[0] != '7' {
+			return nil
+		}
+		fullKver := osutil.KernelVersion()
+		// kernel version looks like this: "3.10.0-957.el7.x86_64"
+		kver := strings.SplitN(fullKver, "-", 2)[0]
+		cmp, err := strutil.VersionCompare(kver, "3.18.0")
 		if err != nil {
 			logger.Noticef("cannot check kernel: %v", err)
 			return nil
 		}
-		if cmp <= 0 {
-			return fmt.Errorf("you need to reboot into a 4.4 kernel to start using snapd")
+		if cmp < 0 {
+			// pre 3.18 kernels here
+			if idx := strings.Index(fullKver, ".el7."); idx == -1 {
+				// non stock kernel, assume it's not supported
+				return fmt.Errorf("unsupported kernel version %q, you need to switch to the stock kernel", fullKver)
+			}
+			// stock kernel had bugfixes backported to it
+			return supportsMayDetachMounts(kver)
 		}
 	}
 	return nil

--- a/sanity/version.go
+++ b/sanity/version.go
@@ -43,10 +43,10 @@ func supportsMayDetachMounts(kver string) error {
 	p := filepath.Join(dirs.GlobalRootDir, "/proc/sys/fs/may_detach_mounts")
 	value, err := ioutil.ReadFile(p)
 	if err != nil {
-		return fmt.Errorf("cannot read fs.may_detach_mounts state: %v", err)
+		return fmt.Errorf("cannot read the value of fs.may_detach_mounts kernel parameter: %v", err)
 	}
 	if !bytes.Equal(value, []byte("1\n")) {
-		return fmt.Errorf("fs.may_detach_mounts is present but disabled")
+		return fmt.Errorf("fs.may_detach_mounts kernel parameter is supported but disabled")
 	}
 	return nil
 }

--- a/sanity/version_test.go
+++ b/sanity/version_test.go
@@ -97,7 +97,7 @@ func (s *sanitySuite) TestRHEL7x(c *C) {
 
 	// pretend the kernel knob is not there
 	err := sanity.CheckKernelVersion()
-	c.Assert(err, ErrorMatches, "cannot read fs.may_detach_mounts state: .*")
+	c.Assert(err, ErrorMatches, "cannot read the value of fs.may_detach_mounts kernel parameter: .*")
 
 	p := filepath.Join(dir, "/proc/sys/fs/may_detach_mounts")
 	err = os.MkdirAll(filepath.Dir(p), 0755)
@@ -108,7 +108,7 @@ func (s *sanitySuite) TestRHEL7x(c *C) {
 	c.Assert(err, IsNil)
 
 	err = sanity.CheckKernelVersion()
-	c.Assert(err, ErrorMatches, "fs.may_detach_mounts is present but disabled")
+	c.Assert(err, ErrorMatches, "fs.may_detach_mounts kernel parameter is supported but disabled")
 
 	// actually enabled
 	err = ioutil.WriteFile(p, []byte("1\n"), 0644)
@@ -156,7 +156,7 @@ func (s *sanitySuite) TestCentOS7x(c *C) {
 	c.Assert(err, IsNil)
 
 	err = sanity.CheckKernelVersion()
-	c.Assert(err, ErrorMatches, "fs.may_detach_mounts is present but disabled")
+	c.Assert(err, ErrorMatches, "fs.may_detach_mounts kernel parameter is supported but disabled")
 
 	// actually enabled
 	err = ioutil.WriteFile(p, []byte("1\n"), 0644)

--- a/sanity/version_test.go
+++ b/sanity/version_test.go
@@ -20,8 +20,13 @@
 package sanity_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sanity"
@@ -56,5 +61,107 @@ func (s *sanitySuite) TestRebootedOnTrusty(c *C) {
 
 	// Check for the given advice.
 	err := sanity.CheckKernelVersion()
+	c.Assert(err, IsNil)
+}
+
+func (s *sanitySuite) TestRHEL80OK(c *C) {
+	// Mock an Ubuntu 14.04 system running a 4.4.0 kernel
+	restore := release.MockOnClassic(true)
+	defer restore()
+	restore = release.MockReleaseInfo(&release.OS{ID: "rhel", VersionID: "8.0"})
+	defer restore()
+	// RHEL 8 beta
+	restore = osutil.MockKernelVersion("4.18.0-32.el8.x86_64")
+	defer restore()
+
+	// Check for the given advice.
+	err := sanity.CheckKernelVersion()
+	c.Assert(err, IsNil)
+}
+
+func (s *sanitySuite) TestRHEL7x(c *C) {
+	dir := c.MkDir()
+	dirs.SetRootDir(dir)
+	defer dirs.SetRootDir("/")
+	// mock RHEL 7.6
+	restore := release.MockOnClassic(true)
+	defer restore()
+	// VERSION="7.6 (Maipo)"
+	// ID="rhel"
+	// ID_LIKE="fedora"
+	// VERSION_ID="7.6"
+	restore = release.MockReleaseInfo(&release.OS{ID: "rhel", VersionID: "7.6"})
+	defer restore()
+	restore = osutil.MockKernelVersion("3.10.0-957.el7.x86_64")
+	defer restore()
+
+	// pretend the kernel knob is not there
+	err := sanity.CheckKernelVersion()
+	c.Assert(err, ErrorMatches, "cannot read fs.may_detach_mounts state: .*")
+
+	p := filepath.Join(dir, "/proc/sys/fs/may_detach_mounts")
+	err = os.MkdirAll(filepath.Dir(p), 0755)
+	c.Assert(err, IsNil)
+
+	// the knob is there, but disabled
+	err = ioutil.WriteFile(p, []byte("0\n"), 0644)
+	c.Assert(err, IsNil)
+
+	err = sanity.CheckKernelVersion()
+	c.Assert(err, ErrorMatches, "fs.may_detach_mounts is present but disabled")
+
+	// actually enabled
+	err = ioutil.WriteFile(p, []byte("1\n"), 0644)
+	c.Assert(err, IsNil)
+
+	err = sanity.CheckKernelVersion()
+	c.Assert(err, IsNil)
+
+	// custom kernel version, which is old and we have no knowledge about
+	restore = osutil.MockKernelVersion("3.10.0-1024.foo.x86_64")
+	defer restore()
+	err = sanity.CheckKernelVersion()
+	c.Assert(err, ErrorMatches, `unsupported kernel version "3.10.0-1024.foo.x86_64", you need to switch to the stock kernel`)
+
+	// custom kernel version, but new enough
+	restore = osutil.MockKernelVersion("4.18.0-32.foo.x86_64")
+	defer restore()
+	err = sanity.CheckKernelVersion()
+	c.Assert(err, IsNil)
+}
+
+func (s *sanitySuite) TestCentOS7x(c *C) {
+	dir := c.MkDir()
+	dirs.SetRootDir(dir)
+	defer dirs.SetRootDir("/")
+	// mock CentOS 7.5
+	restore := release.MockOnClassic(true)
+	defer restore()
+	// NAME="CentOS Linux"
+	// VERSION="7 (Core)"
+	// ID="centos"
+	// ID_LIKE="rhel fedora"
+	// VERSION_ID="7"
+	restore = release.MockReleaseInfo(&release.OS{ID: "centos", VersionID: "7"})
+	defer restore()
+	restore = osutil.MockKernelVersion("3.10.0-862.14.4.el7.x86_64")
+	defer restore()
+
+	p := filepath.Join(dir, "/proc/sys/fs/may_detach_mounts")
+	err := os.MkdirAll(filepath.Dir(p), 0755)
+	c.Assert(err, IsNil)
+
+	// the knob there, but disabled
+	err = ioutil.WriteFile(p, []byte("0\n"), 0644)
+	c.Assert(err, IsNil)
+
+	err = sanity.CheckKernelVersion()
+	c.Assert(err, ErrorMatches, "fs.may_detach_mounts is present but disabled")
+
+	// actually enabled
+	err = ioutil.WriteFile(p, []byte("1\n"), 0644)
+	c.Assert(err, IsNil)
+
+	err = sanity.CheckKernelVersion()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Extend the check to cover kernel versions in CentOS/RHEL 7.x. Probe for a known
sysctl that needs to be enabled.
