### PR TITLE
many: add snap debug refresh-catalogs

### DIFF
--- a/cmd/snap/cmd_refresh_catalogs.go
+++ b/cmd/snap/cmd_refresh_catalogs.go
@@ -28,7 +28,7 @@ import (
 var shortRefreshCatalogsHelp = i18n.G("Refresh the catalog from the store")
 var longRefreshCatalogsHelp = i18n.G(`
 The refresh-catalogs command fetches section names and other data from the store
-ands stores it locally on the system.
+and stores it locally on the system.
 `)
 
 type cmdRefreshCatalogs struct {

--- a/cmd/snap/cmd_refresh_catalogs.go
+++ b/cmd/snap/cmd_refresh_catalogs.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
+)
+
+var shortRefreshCatalogsHelp = i18n.G("Refresh the catalog from the store")
+var longRefreshCatalogsHelp = i18n.G(`
+The refresh-catalogs command fetches section names and other data from the store
+ands stores it locally on the system.
+`)
+
+type cmdRefreshCatalogs struct {
+	clientMixin
+}
+
+func init() {
+	addDebugCommand("refresh-catalogs", shortRefreshCatalogsHelp, longRefreshCatalogsHelp, func() flags.Commander {
+		return &cmdRefreshCatalogs{}
+	}, nil, nil)
+}
+
+func (cmd cmdRefreshCatalogs) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	return cmd.client.Debug("refresh-catalogs", nil, nil)
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -923,6 +923,7 @@ var (
 	snapstateInstall           = snapstate.Install
 	snapstateInstallPath       = snapstate.InstallPath
 	snapstateRefreshCandidates = snapstate.RefreshCandidates
+	snapstateRefreshCatalogs   = snapstate.RefreshCatalogs
 	snapstateTryPath           = snapstate.TryPath
 	snapstateUpdate            = snapstate.Update
 	snapstateUpdateMany        = snapstate.UpdateMany
@@ -2549,8 +2550,12 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 			}
 		}
 		sort.Strings(status.Unreachable)
-
 		return SyncResponse(status, nil)
+	case "refresh-catalogs":
+		if err := snapstateRefreshCatalogs(st); err != nil {
+			return InternalError("cannot refresh catalogs: %s", err)
+		}
+		return SyncResponse(true, nil)
 	default:
 		return BadRequest("unknown debug action: %v", a.Action)
 	}

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -79,6 +79,10 @@ func (r *catalogRefresh) Ensure() error {
 	return err
 }
 
+func RefreshCatalogs(st *state.State) error {
+	return refreshCatalogs(st, Store(st))
+}
+
 var newCmdDB = advisor.Create
 
 func refreshCatalogs(st *state.State, theStore StoreService) error {

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -13,9 +13,8 @@ debug: |
     
 execute: |
     echo "Ensure we have a snap catalog in our cache"
-    while ! test -s /var/cache/snapd/commands.db; do
-        sleep 1
-    done
+    snap debug refresh-catalogs
+    test -s /var/cache/snapd/commands.db
 
     echo "Creating expected file"
     cat > expected <<EOF


### PR DESCRIPTION
This command can be used to force the refresh of the "catalogs", namely
some of the store side meta-data collection that is cached locally for
performance.

The command is used to improve one of the existing tests that fails on
timeout if the store responds with a 403, like it does now.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
