### PR TITLE
tests: make tinyproxy support systemd notify

### DIFF
--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -27,7 +27,7 @@ execute: |
     iptables -I OUTPUT -j ACCEPT -p tcp -m owner --uid-owner "$(id -u test)"
 
     # run a proxy that can access http/https (via the owner rule)
-    systemd-run --uid=test --unit tinyproxy -- python3 "$TESTSLIB/tinyproxy/tinyproxy.py"
+    systemd-run --service-type=notify --uid=test --unit tinyproxy -- python3 "$TESTSLIB/tinyproxy/tinyproxy.py"
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
     wait_for_service tinyproxy

--- a/tests/main/proxy/task.yaml
+++ b/tests/main/proxy/task.yaml
@@ -13,7 +13,7 @@ execute: |
        exit 0
     fi
 
-    systemd-run --unit tinyproxy -- python3 "$TESTSLIB/tinyproxy/tinyproxy.py"
+    systemd-run --service-type=notify --unit tinyproxy -- python3 "$TESTSLIB/tinyproxy/tinyproxy.py"
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
     wait_for_service tinyproxy


### PR DESCRIPTION
The tinyproxy has a bit of a startup delay (python init and all that).
This means that sometimes in tests the proxy is not fully ready when
the test tries to talk to it. This PR makes the proxy a "notify"
service that only notifies after the proxy is ready.
