### PR TITLE
snap: check max description length in validate

### DIFF
--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -21,6 +21,7 @@ package snap
 
 var (
 	ValidateSocketName           = validateSocketName
+	ValidateDescription          = validateDescription
 	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
 )
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -326,6 +326,13 @@ func validateSocketAddrNetPort(socket *SocketInfo, fieldName string, port string
 	return nil
 }
 
+func validateDescription(descr string) error {
+	if len(descr) > 4000 {
+		return fmt.Errorf("description can have up to 4000 bytes, got %d", len(descr))
+	}
+	return nil
+}
+
 // Validate verifies the content in the info.
 func Validate(info *Info) error {
 	name := info.InstanceName()
@@ -337,6 +344,10 @@ func Validate(info *Info) error {
 		return err
 	}
 	if err := ValidateInstanceName(name); err != nil {
+		return err
+	}
+
+	if err := validateDescription(info.Description()); err != nil {
 		return err
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -1431,6 +1432,11 @@ apps:
 			c.Check(err, ErrorMatches, tc.err)
 		}
 	}
+}
+
+func (s *validateSuite) TestValidateDescription(c *C) {
+	c.Check(ValidateDescription(strings.Repeat("x", 5000)), ErrorMatches, `description can have up to 4000 bytes, got 5000`)
+	c.Check(ValidateDescription(strings.Repeat("x", 4000)), IsNil)
 }
 
 func (s *validateSuite) TestValidatePlugSlotName(c *C) {


### PR DESCRIPTION
Without this change a snap could have an arbitrarily long description,
which can lead to a poor user experience in a number of ways. This
limits it to 4000 bytes, which ought to be enough for anybody.
