### PR TITLE
snap,snap-exec: add SNAP_DEBUG_START_TIME environment

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 
@@ -213,6 +215,13 @@ func execApp(snapApp, revision, command string, args []string) error {
 	fullCmd = append(fullCmd, args...)
 
 	fullCmd = append(absoluteCommandChain(app.Snap, app.CommandChain), fullCmd...)
+
+	if osutil.GetenvBool("SNAP_DEBUG_START_TIME") {
+		if runTimeStart, err := strconv.ParseInt(os.Getenv("SNAP_RUN_TIME_START"), 10, 64); err == nil {
+			d := time.Now().Sub(time.Unix(0, runTimeStart))
+			fmt.Fprintf(os.Stderr, "Seconds until exec %q: %v\n", fullCmd, d.Seconds())
+		}
+	}
 
 	if err := syscallExec(fullCmd[0], fullCmd, env); err != nil {
 		return fmt.Errorf("cannot exec %q: %s", fullCmd[0], err)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -152,6 +152,9 @@ func (x *cmdRun) Execute(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf(i18n.G("need the application to run as argument"))
 	}
+	if osutil.GetenvBool("SNAP_DEBUG_START_TIME") {
+		os.Setenv("SNAP_RUN_TIME_START", fmt.Sprintf("%d", time.Now().UnixNano()))
+	}
 	snapApp := args[0]
 	args = args[1:]
 

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -62,3 +62,6 @@ execute: |
        MATCH hello < stdout
     fi
 
+    echo "Ensure debug of startup time works"
+    SNAP_DEBUG_START_TIME=1 snap run test-snapd-tools.echo foo 2> stderr.log
+    MATCH "Seconds until exec: " < stderr.log


### PR DESCRIPTION
This helps analyzing the startup overhead that snap-{run,confine,exec}
impose on top of the actual application. Its important to measure
this to know what part of the startup is the snapcraft wrappers and
what part is our own namespace setup.
