### PR TITLE
features: add feature test methods

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -109,6 +109,8 @@ var (
 
 	ErrtrackerDbDir string
 	SysfsDir        string
+
+	FeaturesDir string
 )
 
 const (
@@ -292,4 +294,6 @@ func SetRootDir(rootdir string) {
 
 	ErrtrackerDbDir = filepath.Join(rootdir, snappyDir, "errtracker.db")
 	SysfsDir = filepath.Join(rootdir, "/sys")
+
+	FeaturesDir = filepath.Join(rootdir, snappyDir, "features")
 }

--- a/features/features.go
+++ b/features/features.go
@@ -66,7 +66,15 @@ func (f SnapdFeature) String() string {
 	panic(fmt.Sprintf("unknown feature flag code %d", f))
 }
 
+// ControlFile returns the path of the file controlling the feature.
+//
+// Snapd considers the feature enabled if the file is present.
+// The contents of the file are not important.
+func (f SnapdFeature) ControlFile() string {
+	return filepath.Join(dirs.FeaturesDir, f.String())
+}
+
 // IsEnabled checks if a given snapd feature is enabled.
 func (f SnapdFeature) IsEnabled() bool {
-	return osutil.FileExists(filepath.Join(dirs.FeaturesDir, f.String()))
+	return osutil.FileExists(f.ControlFile())
 }

--- a/features/features.go
+++ b/features/features.go
@@ -41,14 +41,11 @@ const (
 	SnapdSnap
 	// PerUserMountNamespace controls the persistence of per-user mount namespaces.
 	PerUserMountNamespace
-	// PerformanceMeasurements controls the collection of performance data.
-	PerformanceMeasurements
 )
 
 // KnownFeatures returns the list of all known features.
 func KnownFeatures() []SnapdFeature {
-	return []SnapdFeature{Layouts, ParallelInstances, Hotplug, SnapdSnap,
-		PerUserMountNamespace, PerformanceMeasurements}
+	return []SnapdFeature{Layouts, ParallelInstances, Hotplug, SnapdSnap, PerUserMountNamespace}
 }
 
 // String returns the name of a snapd feature.
@@ -65,8 +62,6 @@ func (f SnapdFeature) String() string {
 		return "snapd-snap"
 	case PerUserMountNamespace:
 		return "per-user-mount-namespace"
-	case PerformanceMeasurements:
-		return "performance-measurements"
 	}
 	panic(fmt.Sprintf("unknown feature flag code %d", f))
 }

--- a/features/features.go
+++ b/features/features.go
@@ -21,10 +21,10 @@ package features
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // SnapdFeature is a named feature that may be on or off.
@@ -68,9 +68,5 @@ func (f SnapdFeature) String() string {
 
 // IsEnabled checks if a given snapd feature is enabled.
 func (f SnapdFeature) IsEnabled() bool {
-	fi, err := os.Stat(filepath.Join(dirs.FeaturesDir, f.String()))
-	if err != nil {
-		return false
-	}
-	return fi.Mode().IsRegular()
+	return osutil.FileExists(filepath.Join(dirs.FeaturesDir, f.String()))
 }

--- a/features/features.go
+++ b/features/features.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package features
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// SnapdFeature is a named feature that may be on or off.
+type SnapdFeature int
+
+const (
+	// Layouts controls availability of snap layouts.
+	Layouts SnapdFeature = iota
+	// ParallelInstances controls availability installing a snap multiple times.
+	ParallelInstances
+	// Hotplug controls availability of dynamically creating slots based on system hardware.
+	Hotplug
+	// SnapdSnap controls possibility of installing the snapd snap.
+	SnapdSnap
+	// PerUserMountNamespace controls the persistence of per-user mount namespaces.
+	PerUserMountNamespace
+	// PerformanceMeasurements controls the collection of performance data.
+	PerformanceMeasurements
+)
+
+// String returns the name of a snapd feature.
+func (f SnapdFeature) String() string {
+	// The constants here must be synchronized with cmd/libsnap-confine-private/feature.c
+	switch f {
+	case Layouts:
+		return "layouts"
+	case ParallelInstances:
+		return "parallel-instances"
+	case Hotplug:
+		return "hotplug"
+	case SnapdSnap:
+		return "snapd-snap"
+	case PerUserMountNamespace:
+		return "per-user-mount-namespace"
+	case PerformanceMeasurements:
+		return "performance-measurements"
+	}
+	panic(fmt.Sprintf("unknown feature flag code %d", f))
+}
+
+// IsEnabled checks if a given snapd feature is enabled.
+func (f SnapdFeature) IsEnabled() bool {
+	fi, err := os.Stat(filepath.Join(dirs.FeaturesDir, f.String()))
+	if err != nil {
+		return false
+	}
+	return fi.Mode().IsRegular()
+}

--- a/features/features.go
+++ b/features/features.go
@@ -45,6 +45,12 @@ const (
 	PerformanceMeasurements
 )
 
+// KnownFeatures returns the list of all known features.
+func KnownFeatures() []SnapdFeature {
+	return []SnapdFeature{Layouts, ParallelInstances, Hotplug, SnapdSnap,
+		PerUserMountNamespace, PerformanceMeasurements}
+}
+
 // String returns the name of a snapd feature.
 func (f SnapdFeature) String() string {
 	// The constants here must be synchronized with cmd/libsnap-confine-private/feature.c

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package features_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type featureSuite struct{}
+
+var _ = Suite(&featureSuite{})
+
+func (*featureSuite) TestName(c *C) {
+	c.Check(features.Layouts.String(), Equals, "layouts")
+	c.Check(features.ParallelInstances.String(), Equals, "parallel-instances")
+	c.Check(features.Hotplug.String(), Equals, "hotplug")
+	c.Check(features.SnapdSnap.String(), Equals, "snapd-snap")
+	c.Check(features.PerUserMountNamespace.String(), Equals, "per-user-mount-namespace")
+	c.Check(features.PerformanceMeasurements.String(), Equals, "performance-measurements")
+	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
+}
+
+func (*featureSuite) TestIsEnabled(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	// If the feature file is absent then the feature is disabled.
+	f := features.PerUserMountNamespace
+	c.Check(f.IsEnabled(), Equals, false)
+
+	// If the feature file is a regular file then the feature is enabled.
+	err := os.MkdirAll(dirs.FeaturesDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(dirs.FeaturesDir, f.String()), nil, 0644)
+	c.Assert(err, IsNil)
+	c.Check(f.IsEnabled(), Equals, true)
+}

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -46,6 +46,13 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
+func (*featureSuite) TestKnownFeatures(c *C) {
+	// Check that known features have names.
+	for _, f := range features.KnownFeatures() {
+		c.Check(f.String(), Not(Equals), "", Commentf("feature code: %d", int(f)))
+	}
+}
+
 func (*featureSuite) TestIsEnabled(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("")

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -67,3 +67,7 @@ func (*featureSuite) TestIsEnabled(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(f.IsEnabled(), Equals, true)
 }
+
+func (*featureSuite) TestControlFile(c *C) {
+	c.Check(features.Layouts.ControlFile(), Equals, "/var/lib/snapd/features/layouts")
+}

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -42,7 +42,6 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.Hotplug.String(), Equals, "hotplug")
 	c.Check(features.SnapdSnap.String(), Equals, "snapd-snap")
 	c.Check(features.PerUserMountNamespace.String(), Equals, "per-user-mount-namespace")
-	c.Check(features.PerformanceMeasurements.String(), Equals, "performance-measurements")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 


### PR DESCRIPTION
features: add module for querying enabled snapd features
    
This builds upon the ability to export enabled experimental features to
userspace. We have the Go side for controlling features via "snap set
core experimental.foo 1" and the C side for querying them but we still
need the Go counterpart. This patch adds one.

The API is extremely simple, consisting of a new type, SnapdFeature,
along with a IsEnabled method that performs a stat call.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
