### PR TITLE
Revert "cmd/snap-confine: don't allow mapping lib{uuid,blkid}"

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -26,6 +26,8 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
     # normal libs in order
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
@@ -396,6 +398,8 @@
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
         # normal libs in order
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
         /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,


### PR DESCRIPTION
It turns out that without ability to map the two libraries the
permissions snap-confine no longer starts on current snapshots of
openSUSE Tumbleweed.

Fixes: https://bugs.launchpad.net/snapd/+bug/1803903

This reverts commit 38df5f9d2ac93a85258491e31346f1c8e0dd3684.
