### PR TITLE
snap: add new `snap run --perf` call

### DIFF
--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -72,6 +72,9 @@ var (
 	HelpCategories          = helpCategories
 
 	NotesForSvc = notesForSvc
+
+	StraceExtractExecRuntime  = straceExtractExecRuntime
+	DisplaySortedExecRuntimes = displaySortedExecRuntimes
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -62,3 +62,7 @@ execute: |
        MATCH hello < stdout
     fi
 
+    snap run --perf test-snapd-tools.echo hello 2> stderr
+    MATCH "Slowest 2 exec calls during snap run" < stderr
+    MATCH "[0-9.]+: .*/snap-exec" < stderr
+    MATCH "[0-9.]+: .*/snap-confine" < stderr


### PR DESCRIPTION
This new argument will allow to trace what is exec()ed when a snap
runs. This allows to e.g. run `snap run vlc --play-and-exit nothing`
to see how much overhead the various wrappers generate.

Sample output:
```
$ snap run --perf test-snapd-tools.echo hello

Slowest 2 exec calls during snap run:
0.011: /usr/lib/snapd/snap-confine
0.016: /usr/lib/snapd/snap-exec
```

This is a bit of a preview, I will add more tests before this land but its already useful to measure real-world issues.