### PR TITLE
daemon, vendor: bump github.com/coreos/go-systemd/activation, handle API changes (2.36)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -335,18 +335,30 @@ func getListener(socketPath string, listenerMap map[string]net.Listener) (net.Li
 	return listener, nil
 }
 
+// activationListeners builds a map of addresses to listeners that were passed
+// during systemd activation
+func activationListeners() (lns map[string]net.Listener, err error) {
+	// pass false to keep LISTEN_* environment variables passed by systemd
+	files := activation.Files(false)
+	lns = make(map[string]net.Listener, len(files))
+
+	for _, f := range files {
+		ln, err := net.FileListener(f)
+		if err != nil {
+			return nil, err
+		}
+		addr := ln.Addr().String()
+		lns[addr] = ln
+	}
+	return lns, nil
+}
+
 // Init sets up the Daemon's internal workings.
 // Don't call more than once.
 func (d *Daemon) Init() error {
-	listeners, err := activation.Listeners(false)
+	listenerMap, err := activationListeners()
 	if err != nil {
 		return err
-	}
-
-	listenerMap := make(map[string]net.Listener, len(listeners))
-
-	for _, listener := range listeners {
-		listenerMap[listener.Addr().String()] = listener
 	}
 
 	// The SnapdSocket is required-- without it, die.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,10 +7,10 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "RBwpnMpfQt7Jo7YWrRph0Vwe+f0=",
+			"checksumSHA1": "zg16zjZTQ9R89+UOLmEZxHgxDtM=",
 			"path": "github.com/coreos/go-systemd/activation",
-			"revision": "48702e0da86bd25e76cfef347e2adeb434a0d0a6",
-			"revisionTime": "2016-11-14T12:22:54Z"
+			"revision": "39ca1b05acc7ad1220e09f133283b8859a8b71ab",
+			"revisionTime": "2018-05-11T13:34:05Z"
 		},
 		{
 			"checksumSHA1": "h77tT8kVh8x/J5ikkZReONPUjU0=",


### PR DESCRIPTION
Backport of #6188 to 2.36
