### PR TITLE
cmd/snap: fix missing newline in "snap keys" error message

### DIFF
--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -66,7 +66,7 @@ func outputJSON(keys []Key) error {
 
 func outputText(keys []Key) error {
 	if len(keys) == 0 {
-		fmt.Fprintf(Stdout, "No keys registered, see `snapcraft create-key`")
+		fmt.Fprintf(Stdout, "No keys registered, see `snapcraft create-key`\n")
 		return nil
 	}
 

--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -66,7 +66,7 @@ func outputJSON(keys []Key) error {
 
 func outputText(keys []Key) error {
 	if len(keys) == 0 {
-		fmt.Fprintf(Stdout, "No keys registered, see `snapcraft create-key`\n")
+		fmt.Fprintf(Stderr, "No keys registered, see `snapcraft create-key`\n")
 		return nil
 	}
 

--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -109,8 +109,8 @@ func (s *SnapKeysSuite) TestKeysEmptyNoHeader(c *C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"keys"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
-	c.Check(s.Stdout(), Equals, "No keys registered, see `snapcraft create-key`\n")
-	c.Check(s.Stderr(), Equals, "")
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(s.Stderr(), Equals, "No keys registered, see `snapcraft create-key`\n")
 }
 
 func (s *SnapKeysSuite) TestKeysJSON(c *C) {

--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -109,7 +109,7 @@ func (s *SnapKeysSuite) TestKeysEmptyNoHeader(c *C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"keys"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
-	c.Check(s.Stdout(), Equals, "No keys registered, see `snapcraft create-key`")
+	c.Check(s.Stdout(), Equals, "No keys registered, see `snapcraft create-key`\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 


### PR DESCRIPTION
While testing if a fix for an old bug for snap keys landed, I noticed the error message is missing a newline.
