### PR TITLE
snap: make description maximum in runes, not bytes

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -328,8 +328,8 @@ func validateSocketAddrNetPort(socket *SocketInfo, fieldName string, port string
 }
 
 func validateDescription(descr string) error {
-	if count := utf8.RuneCountInString(descr); count > 1000 {
-		return fmt.Errorf("description can have up to 1000 codepoints, got %d", count)
+	if count := utf8.RuneCountInString(descr); count > 4096 {
+		return fmt.Errorf("description can have up to 4096 codepoints, got %d", count)
 	}
 	return nil
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/snapcore/snapd/spdx"
 	"github.com/snapcore/snapd/strutil"
@@ -327,8 +328,8 @@ func validateSocketAddrNetPort(socket *SocketInfo, fieldName string, port string
 }
 
 func validateDescription(descr string) error {
-	if len(descr) > 4000 {
-		return fmt.Errorf("description can have up to 4000 bytes, got %d", len(descr))
+	if count := utf8.RuneCountInString(descr); count > 1000 {
+		return fmt.Errorf("description can have up to 1000 codepoints, got %d", count)
 	}
 	return nil
 }

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1435,8 +1435,14 @@ apps:
 }
 
 func (s *validateSuite) TestValidateDescription(c *C) {
-	c.Check(ValidateDescription(strings.Repeat("x", 5000)), ErrorMatches, `description can have up to 4000 bytes, got 5000`)
-	c.Check(ValidateDescription(strings.Repeat("x", 4000)), IsNil)
+	for _, s := range []string{
+		"xx", // boringest ASCII
+		"🐧🐧", // len("🐧🐧") == 8
+		"á", // á (combining)
+	} {
+		c.Check(ValidateDescription(strings.Repeat(s, 600)), ErrorMatches, `description can have up to 1000 codepoints, got 1200`)
+		c.Check(ValidateDescription(strings.Repeat(s, 500)), IsNil)
+	}
 }
 
 func (s *validateSuite) TestValidatePlugSlotName(c *C) {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1440,8 +1440,9 @@ func (s *validateSuite) TestValidateDescription(c *C) {
 		"🐧🐧", // len("🐧🐧") == 8
 		"á", // á (combining)
 	} {
-		c.Check(ValidateDescription(strings.Repeat(s, 600)), ErrorMatches, `description can have up to 1000 codepoints, got 1200`)
-		c.Check(ValidateDescription(strings.Repeat(s, 500)), IsNil)
+		c.Check(ValidateDescription(s), IsNil)
+		c.Check(ValidateDescription(strings.Repeat(s, 2049)), ErrorMatches, `description can have up to 4096 codepoints, got 4098`)
+		c.Check(ValidateDescription(strings.Repeat(s, 2048)), IsNil)
 	}
 }
 


### PR DESCRIPTION
after some testing the store determined the maximum they set is in
codepoints (aka runes in go). This changes the maximum to 4096 of
those things.
