### PR TITLE
snapstate: update fontconfig caches on install

### DIFF
--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,15 +19,25 @@
 
 package backend
 
-var (
-	AddMountUnit    = addMountUnit
-	RemoveMountUnit = removeMountUnit
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
-func MockUpdateFontconfigCaches(f func() error) (restore func()) {
-	oldUpdateFontconfigCaches := updateFontconfigCaches
-	updateFontconfigCaches = f
-	return func() {
-		updateFontconfigCaches = oldUpdateFontconfigCaches
+var updateFontconfigCaches = updateFontconfigCachesImpl
+
+// updateFontconfigCaches always update the fontconfig caches
+func updateFontconfigCachesImpl() error {
+	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
+		// FIXME: also use the snapd snap if available
+		cmd, err := osutil.CommandFromCore("/bin/" + fc)
+		if err != nil {
+			return fmt.Errorf("cannot get %s from core: %v", fc, err)
+		}
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("cannot run %s on core: %v", fc, osutil.OutputErr(output, err))
+		}
 	}
+	return nil
 }

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -69,6 +69,7 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 	}
 
 	// fontconfig is only relevant on classic
+	// TODO: consider moving this to a less hidden place
 	if release.OnClassic {
 		if err := updateFontconfigCaches(); err != nil {
 			logger.Noticef("cannot update fontconfig cache: %v", err)

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -68,6 +68,10 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 		return err
 	}
 
+	if err := updateFontconfigCaches(); err != nil {
+		logger.Noticef("cannot update fontconfig cache: %v", err)
+	}
+
 	// XXX/TODO: this needs to be a task with proper undo and tests!
 	if model != nil && !release.OnClassic {
 		bootBase := "core"

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -68,8 +68,11 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 		return err
 	}
 
-	if err := updateFontconfigCaches(); err != nil {
-		logger.Noticef("cannot update fontconfig cache: %v", err)
+	// fontconfig is only relevant on classic
+	if release.OnClassic {
+		if err := updateFontconfigCaches(); err != nil {
+			logger.Noticef("cannot update fontconfig cache: %v", err)
+		}
 	}
 
 	// XXX/TODO: this needs to be a task with proper undo and tests!

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -311,5 +311,17 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 		c.Check(err, IsNil, Commentf(d))
 		c.Check(l, HasLen, 0, Commentf(d))
 	}
+}
 
+func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCaches(c *C) {
+	var updateFontconfigCaches int
+	restore := backend.MockUpdateFontconfigCaches(func() error {
+		updateFontconfigCaches += 1
+		return nil
+	})
+	defer restore()
+
+	err := s.be.LinkSnap(s.info, nil)
+	c.Assert(err, IsNil)
+	c.Assert(updateFontconfigCaches, Equals, 1)
 }

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
@@ -313,15 +314,25 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 	}
 }
 
-func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCaches(c *C) {
-	var updateFontconfigCaches int
-	restore := backend.MockUpdateFontconfigCaches(func() error {
-		updateFontconfigCaches += 1
-		return nil
-	})
-	defer restore()
+func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCachesClassic(c *C) {
+	for _, onClassic := range []bool{false, true} {
 
-	err := s.be.LinkSnap(s.info, nil)
-	c.Assert(err, IsNil)
-	c.Assert(updateFontconfigCaches, Equals, 1)
+		restore := release.MockOnClassic(onClassic)
+		defer restore()
+
+		var updateFontconfigCaches int
+		restore = backend.MockUpdateFontconfigCaches(func() error {
+			updateFontconfigCaches += 1
+			return nil
+		})
+		defer restore()
+
+		err := s.be.LinkSnap(s.info, nil)
+		c.Assert(err, IsNil)
+		if onClassic {
+			c.Assert(updateFontconfigCaches, Equals, 1)
+		} else {
+			c.Assert(updateFontconfigCaches, Equals, 0)
+		}
+	}
 }

--- a/tests/main/install/task.yaml
+++ b/tests/main/install/task.yaml
@@ -1,0 +1,20 @@
+summary: Check that install works
+
+# limiting to ubuntu because we need a known fonts package
+# to install so that actual caches get generated
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+
+prepare: |
+    apt install -y fonts-kiloji
+
+restore: |
+    apt autoremove -y fonts-kiloji
+
+execute: |
+    echo "With no fontconfig cache"
+    rm /var/cache/fontconfig/*
+
+    echo "Installing a snap generates a fontconfig cache"
+    snap install test-snapd-tools
+    ls /var/cache/fontconfig/*.v6
+    ls /var/cache/fontconfig/*.v7

--- a/tests/main/install/task.yaml
+++ b/tests/main/install/task.yaml
@@ -16,5 +16,5 @@ execute: |
 
     echo "Installing a snap generates a fontconfig cache"
     snap install test-snapd-tools
-    ls /var/cache/fontconfig/*.v6
-    ls /var/cache/fontconfig/*.v7
+    ls /var/cache/fontconfig/*.cache-6
+    ls /var/cache/fontconfig/*.cache-7


### PR DESCRIPTION
A common issue with snap is that the embedded fontconfig library
does not match the version on the host. This may lead to very
slow startup times of applications because the fontconfig caches
must be generated on first-run. This is bad user experience.

This PR is a very simplistic fix that will generate the two most
common versions of fontconfig caches on package install/refresh.
The fc-cache command is extremly quick (0m0,020s on my system)
if the caches are up-to-date so it seems to be fine to just run
it always.

There are various more options:
- run fc-cache only for classic and desktop snaps
- do not (ab)use link-snap but instead we could:
  a) implement a fontconfig security backend
  b) add a fontconfig specific task
- a virtual hook (but it would need to run unconfined)

I'm happy about suggestions how to make this more elaborate if
desired.
