### PR TITLE
many: validate title

### DIFF
--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -22,6 +22,7 @@ package snap
 var (
 	ValidateSocketName           = validateSocketName
 	ValidateDescription          = validateDescription
+	ValidateTitle                = validateTitle
 	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
 )
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/snapcore/snapd/spdx"
 	"github.com/snapcore/snapd/strutil"
@@ -333,6 +334,13 @@ func validateDescription(descr string) error {
 	return nil
 }
 
+func validateTitle(title string) error {
+	if count := utf8.RuneCountInString(title); count > 40 {
+		return fmt.Errorf("title can have up to 40 codepoints, got %d", count)
+	}
+	return nil
+}
+
 // Validate verifies the content in the info.
 func Validate(info *Info) error {
 	name := info.InstanceName()
@@ -344,6 +352,10 @@ func Validate(info *Info) error {
 		return err
 	}
 	if err := ValidateInstanceName(name); err != nil {
+		return err
+	}
+
+	if err := validateTitle(info.Title()); err != nil {
 		return err
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1439,6 +1439,17 @@ func (s *validateSuite) TestValidateDescription(c *C) {
 	c.Check(ValidateDescription(strings.Repeat("x", 4000)), IsNil)
 }
 
+func (s *validateSuite) TestValidateTitle(c *C) {
+	for _, s := range []string{
+		"xx", // boringest ASCII
+		"🐧🐧", // len("🐧🐧") == 8
+		"á", // á (combining)
+	} {
+		c.Check(ValidateTitle(strings.Repeat(s, 21)), ErrorMatches, `title can have up to 40 codepoints, got 42`)
+		c.Check(ValidateTitle(strings.Repeat(s, 20)), IsNil)
+	}
+}
+
 func (s *validateSuite) TestValidatePlugSlotName(c *C) {
 	validNames := []string{
 		"a", "aa", "aaa", "aaaa",

--- a/store/details.go
+++ b/store/details.go
@@ -22,6 +22,7 @@ package store
 import (
 	"github.com/snapcore/snapd/jsonutil/safejson"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // snapDetails encapsulates the data sent to us from the store as JSON.
@@ -75,7 +76,10 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.RealName = d.Name
 	info.SnapID = d.SnapID
 	info.Revision = snap.R(d.Revision)
-	info.EditedTitle = d.Title.Clean()
+
+	// https://forum.snapcraft.io/t/title-length-in-snapcraft-yaml-snap-yaml/8625/10
+	info.EditedTitle = strutil.ElliptRight(d.Title.Clean(), 40)
+
 	info.EditedSummary = d.Summary.Clean()
 	info.EditedDescription = d.Description.Clean()
 	// Note that the store side is using confusing terminology here.

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/jsonutil/safejson"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // storeSnap holds the information sent as JSON by the store for a snap.
@@ -220,7 +221,10 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.RealName = d.Name
 	info.Revision = snap.R(d.Revision)
 	info.SnapID = d.SnapID
-	info.EditedTitle = d.Title.Clean()
+
+	// https://forum.snapcraft.io/t/title-length-in-snapcraft-yaml-snap-yaml/8625/10
+	info.EditedTitle = strutil.ElliptRight(d.Title.Clean(), 40)
+
 	info.EditedSummary = d.Summary.Clean()
 	info.EditedDescription = d.Description.Clean()
 	info.Private = d.Private

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -121,7 +121,7 @@ const (
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
   "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\n",
   "summary": "useful thingy",
-  "title": "thingy",
+  "title": "This Is The Most Fantastical Snap of Thingy",
   "type": "app",
   "version": "9.50",
   "media": [
@@ -205,7 +205,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			SnapID:            "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
 			Revision:          snap.R(21),
 			Contact:           "https://thingy.com",
-			EditedTitle:       "thingy",
+			EditedTitle:       "This Is The Most Fantastical Snap of Th…",
 			EditedSummary:     "useful thingy",
 			EditedDescription: "Useful thingy for thinging",
 			Private:           false,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2322,7 +2322,7 @@ func (s *storeTestSuite) TestNoInfo(c *C) {
 /* acquired via looking at the query snapd does for "snap find 'hello-world of snaps' --narrow" (on core) and adding size=1:
 curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64" 'https://api.snapcraft.io/api/v1/snaps/search?confinement=strict&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Clicense%2Cbase%2Cmedia%2Csupport_url%2Ccontact%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cdeveloper_name%2Cdeveloper_validation%2Cprivate%2Cconfinement%2Ccommon_ids&q=hello-world+of+snaps&size=1' | python -m json.tool | xsel -b
 
-And then add base and prices, and remove the _links dict
+And then add base and prices, increase title's length, and remove the _links dict
 */
 const MockSearchJSON = `{
     "_embedded": {
@@ -2367,7 +2367,7 @@ const MockSearchJSON = `{
                 "snap_id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
                 "summary": "The 'hello-world' of snaps",
                 "support_url": "",
-                "title": "Hello World",
+                "title": "This Is The Most Fantastical Snap of Hello World",
                 "version": "6.3"
             }
         ]
@@ -2691,7 +2691,7 @@ func (s *storeTestSuite) TestFind(c *C) {
 	c.Check(snp.Channel, Equals, "stable")
 	c.Check(snp.Description(), Equals, "This is a simple hello world example.")
 	c.Check(snp.Summary(), Equals, "The 'hello-world' of snaps")
-	c.Check(snp.Title(), Equals, "Hello World")
+	c.Check(snp.Title(), Equals, "This Is The Most Fantastical Snap of He…")
 	c.Check(snp.License, Equals, "MIT")
 	// this is more a "we know this isn't there" than an actual test for a wanted feature
 	// NOTE snap.Epoch{} (which prints as "0", and is thus Unset) is not a valid Epoch.

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 )
 
 func init() {
@@ -181,4 +182,19 @@ func CommaSeparatedList(str string) []string {
 		}
 	}
 	return filtered
+}
+
+// ElliptRight returns a string that is at most n runes long,
+// replacing the last rune with an ellipsis if necessary. If N is less
+// than 1 it's treated as a 1.
+func ElliptRight(str string, n int) string {
+	if n < 1 {
+		n = 1
+	}
+	if utf8.RuneCountInString(str) <= n {
+		return str
+	}
+
+	// this is expensive; look into a cheaper way maybe sometime
+	return string([]rune(str)[:n-1]) + "…"
 }

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -200,3 +200,25 @@ func (strutilSuite) TestCommaSeparatedList(c *check.C) {
 		c.Check(strutil.CommaSeparatedList(test.in), check.DeepEquals, test.out, check.Commentf("%q", test.in))
 	}
 }
+
+func (strutilSuite) TestElliptRight(c *check.C) {
+	type T struct {
+		in  string
+		n   int
+		out string
+	}
+	for _, t := range []T{
+		{"", 10, ""},
+		{"", -1, ""},
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 3, "he…"},
+		{"hello", 0, "…"},
+		{"héllo", 4, "hé…"},
+		{"héllo", 3, "he…"},
+		{"he🐧lo", 4, "he🐧…"},
+		{"he🐧lo", 3, "he…"},
+	} {
+		c.Check(strutil.ElliptRight(t.in, t.n), check.Equals, t.out, check.Commentf("%q[:%d] -> %q", t.in, t.n, t.out))
+	}
+}


### PR DESCRIPTION
Three commits for your consideration:
1. `strutil.ElliptRight` (need I say more?)
2. ellipt titles coming from the store (in json), both for v1 and v2 paths, to 40 codepoints.
3. reject as invalid snaps that have titles >40 codepoints. This affects `snap pack` as well as install etc (but the review tools rejected titles altogether until really recently so that's ok).

[relevant forum topic](https://forum.snapcraft.io/t/title-length-in-snapcraft-yaml-snap-yaml/8625?u=chipaca).