### PR TITLE
Revert "cmd/snap, tests/main/snap-info: highlight the current channel" (2.36)

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -321,20 +321,14 @@ func maybePrintServices(w io.Writer, snapName string, allApps []client.AppInfo, 
 var channelRisks = []string{"stable", "candidate", "beta", "edge"}
 
 // displayChannels displays channels and tracks in the right order
-func displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.Snap, currentChannel string) {
+func displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.Snap) {
 	fmt.Fprintf(w, "channels:"+strings.Repeat("\t", strings.Count(chantpl, "\t"))+"\n")
 
 	// order by tracks
 	for _, tr := range remote.Tracks {
 		trackHasOpenChannel := false
 		for _, risk := range channelRisks {
-			maybeCaret := ""
 			chName := fmt.Sprintf("%s/%s", tr, risk)
-			style := esc.end
-			if chName == currentChannel || (tr == "latest" && risk == currentChannel) {
-				maybeCaret = "<"
-				style = esc.bold
-			}
 			ch, ok := remote.Channels[chName]
 			if tr == "latest" {
 				chName = risk
@@ -353,7 +347,7 @@ func displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.S
 					version = esc.dash
 				}
 			}
-			fmt.Fprintf(w, chantpl, style+"  ", chName, version, revision, size, notes, maybeCaret, esc.end)
+			fmt.Fprintf(w, "  "+chantpl, chName, version, revision, size, notes)
 		}
 	}
 }
@@ -463,20 +457,17 @@ func (x *infoCmd) Execute([]string) error {
 			}
 		}
 
-		chantpl := "%s%s:\t%s %s %s %s%s%s\n"
+		chantpl := "%s:\t%s %s %s %s\n"
 		if remote != nil && remote.Channels != nil && remote.Tracks != nil {
-			chantpl = "%s%s:\t%s\t%s\t%s\t%s\t%s%s\n"
-			var cur string
-			if local != nil {
-				cur = local.TrackingChannel
-			}
+			chantpl = "%s:\t%s\t%s\t%s\t%s\n"
+
 			w.Flush()
-			displayChannels(w, chantpl, esc, remote, cur)
+			displayChannels(w, chantpl, esc, remote)
 		}
 		if local != nil {
 			revstr := fmt.Sprintf("(%s)", local.Revision)
 			fmt.Fprintf(w, chantpl,
-				esc.end, "installed", local.Version, revstr, strutil.SizeToStr(local.InstalledSize), notes, "", "")
+				"installed", local.Version, revstr, strutil.SizeToStr(local.InstalledSize), notes)
 		}
 
 	}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -417,12 +417,12 @@ description: |
 snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
-channels:                             
-  1/stable:    2.10 (1) 65kB -        
-  1/candidate: ↑                      
-  1/beta:      ↑                      
-  1/edge:      ↑                      
-installed:     2.10 (1) 1kB  disabled 
+channels:                    
+  1/stable:    2.10 (1) 65kB -
+  1/candidate: ↑             
+  1/beta:      ↑             
+  1/edge:      ↑             
+installed:     2.10 (1) 1kB  disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -107,7 +107,6 @@ var colorDescs = mixinDescs{
 
 type escapes struct {
 	green string
-	bold  string
 	end   string
 
 	tick, dash, uparrow string
@@ -115,13 +114,11 @@ type escapes struct {
 
 var (
 	color = escapes{
-		bold:  "\033[1m",
 		green: "\033[32m",
 		end:   "\033[0m",
 	}
 
 	mono = escapes{
-		bold:  "\033[1m",
 		green: "\033[1m",
 		end:   "\033[0m",
 	}

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -37,7 +37,7 @@ def maybe(name, d):
 
 verNotesRx = re.compile(r"^\w\S*\s+-$")
 def verRevNotesRx(s):
-    return re.compile(r"^\w\S*\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + r"(?:\s+<?)?$")
+    return re.compile(r"^\w\S*\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$")
 
 if os.environ['SNAPPY_USE_STAGING_STORE'] == '1':
     snap_ids={


### PR DESCRIPTION
This reverts commit 40e299154324315957d31eb89823c5267c0d9e85 (#5848).
