### PR TITLE
tests: fix for tests test-*-cgroup

### DIFF
--- a/tests/lib/snaps/test-devmode-cgroup/bin/read-dev
+++ b/tests/lib/snaps/test-devmode-cgroup/bin/read-dev
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
-device=$1
+device="$1"
 dd if="/dev/$device" of=/dev/null count=10

--- a/tests/lib/snaps/test-devmode-cgroup/bin/read-dev
+++ b/tests/lib/snaps/test-devmode-cgroup/bin/read-dev
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+device=$1
+dd if="/dev/$device" of=/dev/null count=10

--- a/tests/lib/snaps/test-devmode-cgroup/bin/read-fb
+++ b/tests/lib/snaps/test-devmode-cgroup/bin/read-fb
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -e
-cat /dev/fb0

--- a/tests/lib/snaps/test-devmode-cgroup/bin/read-kmsg
+++ b/tests/lib/snaps/test-devmode-cgroup/bin/read-kmsg
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -e
-head -1 /dev/kmsg

--- a/tests/lib/snaps/test-devmode-cgroup/meta/snap.yaml
+++ b/tests/lib/snaps/test-devmode-cgroup/meta/snap.yaml
@@ -6,9 +6,6 @@ description: A basic snap declaring a plug to a udev tagged interface
 confinement: devmode
 
 apps:
-  read-fb:
-    command: bin/read-fb
-    plugs: [framebuffer]
-  read-kmsg:
-    command: bin/read-kmsg
+  read-dev:
+    command: bin/read-dev
     plugs: [framebuffer]

--- a/tests/lib/snaps/test-strict-cgroup/bin/read-dev
+++ b/tests/lib/snaps/test-strict-cgroup/bin/read-dev
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eu
 
-device=$1
+device="$1"
 dd if="/dev/$device" of=/dev/null count=10

--- a/tests/lib/snaps/test-strict-cgroup/bin/read-dev
+++ b/tests/lib/snaps/test-strict-cgroup/bin/read-dev
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+device=$1
+dd if="/dev/$device" of=/dev/null count=10

--- a/tests/lib/snaps/test-strict-cgroup/bin/read-fb
+++ b/tests/lib/snaps/test-strict-cgroup/bin/read-fb
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -e
-cat /dev/fb0

--- a/tests/lib/snaps/test-strict-cgroup/bin/read-kmsg
+++ b/tests/lib/snaps/test-strict-cgroup/bin/read-kmsg
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -e
-head -1 /dev/kmsg

--- a/tests/lib/snaps/test-strict-cgroup/meta/snap.yaml
+++ b/tests/lib/snaps/test-strict-cgroup/meta/snap.yaml
@@ -6,9 +6,6 @@ description: A basic snap declaring a plug to a udev tagged interface
 confinement: strict
 
 apps:
-  read-fb:
-    command: bin/read-fb
-    plugs: [framebuffer]
-  read-kmsg:
-    command: bin/read-kmsg
+  read-dev:
+    command: bin/read-dev
     plugs: [framebuffer]

--- a/tests/main/security-device-cgroups-devmode/task.yaml
+++ b/tests/main/security-device-cgroups-devmode/task.yaml
@@ -24,21 +24,20 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
     echo "And the framebuffer plug is connected"
     snap connect test-devmode-cgroup:framebuffer
+
     echo "the devmode snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test "$($SNAP_MOUNT_DIR/bin/test-devmode-cgroup.read-kmsg)"
+    test-devmode-cgroup.read-dev mem
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
+
     echo "the devmode snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test "$($SNAP_MOUNT_DIR/bin/test-devmode-cgroup.read-kmsg)"
+    test-devmode-cgroup.read-dev mem

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -27,21 +27,20 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
     echo "And the framebuffer plug is connected"
     snap connect test-devmode-cgroup:framebuffer
+
     echo "the jailmode snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
+
     echo "the jailmode snap cannot access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-strict/task.yaml
+++ b/tests/main/security-device-cgroups-strict/task.yaml
@@ -26,21 +26,20 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
     echo "And the framebuffer plug is connected"
     snap connect test-strict-cgroup:framebuffer
+
     echo "the strict snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-strict-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the strict snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-strict-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-strict-cgroup:framebuffer
+
     echo "the strict snap cannot access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-fb 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-strict-cgroup.read-dev fb0 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "the strict snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-strict-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'


### PR DESCRIPTION
This change makes more simple the snaps used and changes the char device
used which was causing issues sporadically.

The errror in travis:
google:arch-linux-64 .../tests/main/security-device-cgroups-devmode#
test-devmode-cgroup.read-kmsg
head: error reading '/dev/kmsg': Broken pipe
