### PR TITLE
tests: remove test-snapd-with-configure on restore

### DIFF
--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -55,6 +55,8 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+    # Remove the test snap, this also removes the leftover mount namespace.
+    snap remove test-snapd-with-configure
     echo "Undo the rsyslog disable"
     systemctl unmask rsyslog.service || true
     systemctl enable rsyslog.service || true


### PR DESCRIPTION
The tests/main/ubuntu-core-gadget-config-defaults test, when executed,
leaves the mount namespace of the test-snapd-with-configure snap. For
some tests that is not a problem so the mistake was left unnoticed for a
long time. For a new test I was writing it does matter though hence the
chase for leftovers in the test suite.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>