### PR TITLE
tests: restore in restore, not in prepare

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -550,8 +550,6 @@ restore: |
     "$TESTSLIB"/prepare-restore.sh --restore-project
 restore-each: |
     "$TESTSLIB"/prepare-restore.sh --restore-project-each
-    # XXX: something is hosing the filesystem so look for signs of that
-    ! grep -F "//deleted /etc" /proc/self/mountinfo
 
 suites:
     tests/main/:

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -417,8 +417,6 @@ prepare_suite() {
 prepare_suite_each() {
     # save the job which is going to be executed in the system
     echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
-    # shellcheck source=tests/lib/reset.sh
-    "$TESTSLIB"/reset.sh --reuse-core
     # Reset systemd journal cursor.
     start_new_journalctl_log
     # shellcheck source=tests/lib/prepare.sh
@@ -431,7 +429,8 @@ prepare_suite_each() {
 }
 
 restore_suite_each() {
-    true
+    # shellcheck source=tests/lib/reset.sh
+    "$TESTSLIB"/reset.sh --reuse-core
 }
 
 restore_suite() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -488,6 +488,9 @@ restore_project_each() {
         dmesg
         exit 1
     fi
+
+    # Domething is hosing the filesystem so look for signs of that
+    ! grep -F "//deleted /etc" /proc/self/mountinfo
 }
 
 restore_project() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -488,7 +488,7 @@ restore_project_each() {
         exit 1
     fi
 
-    # Domething is hosing the filesystem so look for signs of that
+    # Something is hosing the filesystem so look for signs of that
     ! grep -F "//deleted /etc" /proc/self/mountinfo
 }
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -415,7 +415,7 @@ prepare_suite() {
 }
 
 prepare_suite_each() {
-    # save the job which is going to be exeuted in the system
+    # save the job which is going to be executed in the system
     echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
     # shellcheck source=tests/lib/reset.sh
     "$TESTSLIB"/reset.sh --reuse-core


### PR DESCRIPTION
The test suite is not doing any restore logic in per-test-case restore
section. Instead that is done in the front of the per-test-case prepare
section. The reason for that is unclear but it makes no apparent sense
on a quick inspection.

Putting actual restore in the restore section will open the path to
adding safeguards that system state before prepare is measurably the
same as after restore, that is, that test doesn't affect the system.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
