### PR TITLE
tests: discard mount namespaces in reset.sh

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -152,9 +152,7 @@ if [ -d /run/snapd/ns ]; then
         umount -l "$mnt" || true
         rm -f "$mnt"
     done
-    for fstab in /run/snapd/ns/*.fstab; do
-        rm -f "$fstab"
-    done
+    rm -f /run/snapd/ns/*.fstab
 fi
 
 if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -144,6 +144,19 @@ else
     reset_classic "$@"
 fi
 
+# Discard all mount namespaces and active mount profiles.
+# This is duplicating logic in snap-discard-ns but it doesn't
+# support --all switch yet so we cannot use it.
+if [ -d /run/snapd/ns ]; then
+    for mnt in /run/snapd/ns/*.mnt; do
+        umount -l "$mnt" || true
+        rm -f "$mnt"
+    done
+    for fstab in /run/snapd/ns/*.fstab; do
+        rm -f "$fstab"
+    done
+fi
+
 if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then
     # shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh


### PR DESCRIPTION
Some tests install snaps and then wipe the state manually. Normally we
remove all snaps in the cleanup section but without state we cannot do
that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
