### PR TITLE
daemon: remove enableInternalInterfaceActions

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1845,8 +1845,6 @@ func snapNamesFromConns(conns []*interfaces.ConnRef) []string {
 
 // changeInterfaces controls the interfaces system.
 // Plugs can be connected to and disconnected from slots.
-// When enableInternalInterfaceActions is true plugs and slots can also be
-// explicitly added and removed.
 func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Response {
 	var a interfaceAction
 	decoder := json.NewDecoder(r.Body)
@@ -1855,9 +1853,6 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 	}
 	if a.Action == "" {
 		return BadRequest("interface action not specified")
-	}
-	if !c.d.enableInternalInterfaceActions && a.Action != "connect" && a.Action != "disconnect" {
-		return BadRequest("internal interface actions are disabled")
 	}
 	if len(a.Plugs) > 1 || len(a.Slots) > 1 {
 		return NotImplemented("many-to-many operations are not implemented")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -67,8 +67,6 @@ type Daemon struct {
 	router          *mux.Router
 	standbyOpinions *standby.StandbyOpinions
 
-	// enableInternalInterfaceActions controls if adding and removing slots and plugs is allowed.
-	enableInternalInterfaceActions bool
 	// set to remember we need to restart the system
 	restartSystem bool
 	// set to remember that we need to exit the daemon in a way that
@@ -699,9 +697,5 @@ func New() (*Daemon, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Daemon{
-		overlord: ovld,
-		// TODO: Decide when this should be disabled by default.
-		enableInternalInterfaceActions: true,
-	}, nil
+	return &Daemon{overlord: ovld}, nil
 }

--- a/daemon/export_snapshots_test.go
+++ b/daemon/export_snapshots_test.go
@@ -33,10 +33,7 @@ import (
 )
 
 func NewWithOverlord(o *overlord.Overlord) *Daemon {
-	d := &Daemon{
-		overlord:                       o,
-		enableInternalInterfaceActions: true,
-	}
+	d := &Daemon{overlord: o}
 	d.addRoutes()
 	return d
 }


### PR DESCRIPTION
This property used to control now-gone interface actions for creating
and destroying plugs and slots. It has no purpose now.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
