### PR TITLE
many: staticcheck fixes

### DIFF
--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -196,8 +196,6 @@ func checkDigest(headers map[string]interface{}, name string, h crypto.Hash) ([]
 	return b, nil
 }
 
-var anyString = regexp.MustCompile("")
-
 func checkStringListInMap(m map[string]interface{}, name, what string, pattern *regexp.Regexp) ([]string, error) {
 	value, ok := m[name]
 	if !ok {
@@ -216,7 +214,7 @@ func checkStringListInMap(m map[string]interface{}, name, what string, pattern *
 		if !ok {
 			return nil, fmt.Errorf("%s must be a list of strings", what)
 		}
-		if !pattern.MatchString(s) {
+		if pattern != nil && !pattern.MatchString(s) {
 			return nil, fmt.Errorf("%s contains an invalid element: %q", what, s)
 		}
 		res[i] = s
@@ -225,7 +223,7 @@ func checkStringListInMap(m map[string]interface{}, name, what string, pattern *
 }
 
 func checkStringList(headers map[string]interface{}, name string) ([]string, error) {
-	return checkStringListMatches(headers, name, anyString)
+	return checkStringListMatches(headers, name, nil)
 }
 
 func checkStringListMatches(headers map[string]interface{}, name string, pattern *regexp.Regexp) ([]string, error) {

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -197,10 +197,10 @@ func adviseViaAptHook() error {
 		}
 
 	}
-	if rpc.Method == "org.debian.apt.hooks.search.post" {
-		// FIXME: do a snap search here
-		// FIXME2: figure out why apt does not tell us the search results
-	}
+	// if rpc.Method == "org.debian.apt.hooks.search.post" {
+	// 	// FIXME: do a snap search here
+	// 	// FIXME2: figure out why apt does not tell us the search results
+	// }
 
 	// bye
 	rpc, err = readRpc(r)

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -99,7 +99,11 @@ func (w *manfixer) Write(buf []byte) (int, error) {
 	if !w.done {
 		w.done = true
 		if bytes.HasPrefix(buf, []byte(".TH snap 1 ")) {
-			buf[9] = '8'
+			// io.Writer.Write must not modify the buffer, even temporarily
+			n, _ := Stdout.Write(buf[:9])
+			Stdout.Write([]byte{'8'})
+			m, err := Stdout.Write(buf[10:])
+			return n + m + 1, err
 		}
 	}
 	return Stdout.Write(buf)

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -69,7 +69,7 @@ func (x *cmdUserd) Execute(args []string) error {
 	}
 	x.userd.Start()
 
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 3)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 	select {
 	case sig := <-ch:

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -91,7 +91,7 @@ func runWatchdog(d *daemon.Daemon) (*time.Ticker, error) {
 				//       replies with valid data
 				systemd.SdNotify("WATCHDOG=1")
 			case <-d.Dying():
-				break
+				return
 			}
 		}
 	}()

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -989,7 +989,7 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 			// TRANSLATORS: the %s is a comma-separated list of quoted snap names
 			msg = fmt.Sprintf(i18n.G("Refresh snaps %s: no updates"), strutil.Quoted(inst.Snaps))
 		} else {
-			msg = fmt.Sprintf(i18n.G("Refresh all snaps: no updates"))
+			msg = i18n.G("Refresh all snaps: no updates")
 		}
 	case 1:
 		msg = fmt.Sprintf(i18n.G("Refresh snap %q"), updated[0])

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -408,10 +408,12 @@ func (b *Backend) Remove(snapName string) error {
 
 var (
 	templatePattern = regexp.MustCompile("(###[A-Z_]+###)")
-	attachPattern   = regexp.MustCompile(`\(attach_disconnected,mediate_deleted\)`)
 )
 
-const attachComplain = "(attach_disconnected,mediate_deleted,complain)"
+const (
+	attachPattern  = "(attach_disconnected,mediate_deleted)"
+	attachComplain = "(attach_disconnected,mediate_deleted,complain)"
+)
 
 func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts interfaces.ConfinementOptions) (content map[string]*osutil.FileState, err error) {
 	content = make(map[string]*osutil.FileState, len(snapInfo.Apps)+len(snapInfo.Hooks)+1)
@@ -513,7 +515,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 	// This is also done for classic so that no confinement applies. Just in
 	// case the profile we start with is not permissive enough.
 	if (opts.DevMode || opts.Classic) && !opts.JailMode {
-		policy = attachPattern.ReplaceAllString(policy, attachComplain)
+		policy = strings.Replace(policy, attachPattern, attachComplain, -1)
 	}
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -33,7 +33,7 @@ if [ "$1" = "--output-only" ]; then
 fi
 
 # If the version is passed in as an argument to mkversion.sh, let's use that.
-if [ ! -z "$1" ]; then
+if [ -n "$1" ]; then
     v="$1"
     o=shell
 fi

--- a/osutil/udev/netlink/conn.go
+++ b/osutil/udev/netlink/conn.go
@@ -112,12 +112,10 @@ func (c *UEventConn) Monitor(queue chan UEvent, errors chan error, matcher Match
 	}
 
 	go func() {
-		loop := true
-		for loop {
+		for {
 			select {
 			case <-quit:
-				loop = false
-				break
+				return
 			default:
 				uevent, err := c.ReadUEvent()
 				if err != nil {

--- a/overlord/patch/patch3.go
+++ b/overlord/patch/patch3.go
@@ -20,8 +20,6 @@
 package patch
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -41,7 +39,7 @@ func patch3(s *state.State) error {
 		}
 
 		if t.Kind() == "link-snap" {
-			startSnapServices := s.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap services")))
+			startSnapServices := s.NewTask("start-snap-services", i18n.G("Start snap services"))
 			startSnapServices.Set("snap-setup-task", t.ID())
 			startSnapServices.WaitFor(t)
 
@@ -50,7 +48,7 @@ func patch3(s *state.State) error {
 		}
 
 		if t.Kind() == "unlink-snap" || t.Kind() == "unlink-current-snap" {
-			stopSnapServices := s.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap services")))
+			stopSnapServices := s.NewTask("stop-snap-services", i18n.G("Stop snap services"))
 			stopSnapServices.Set("snap-setup-task", t.ID())
 			t.WaitFor(stopSnapServices)
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -550,7 +550,7 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 		return err
 	}
 
-	msg := fmt.Sprintf(i18n.G("Transition ubuntu-core to core"))
+	msg := i18n.G("Transition ubuntu-core to core")
 	chg := m.state.NewChange("transition-ubuntu-core", msg)
 	for _, ts := range tss {
 		chg.AddAll(ts)

--- a/run-checks
+++ b/run-checks
@@ -218,7 +218,7 @@ if [ "$STATIC" = 1 ]; then
     echo Checking all interfaces have minimal spread test
     missing_interface_spread_test
 
-    if command -v staticcheck >/dev/null || [[ "$(go version)" =~ go1\.(9|1[0-9])\.[0-9] ]]; then
+    if command -v staticcheck >/dev/null || ( go version | grep -E 'go1\.(9|1[0-9])\.[0-9]' ); then
         # either you already have staticcheck on your path, or you're on a new enough go
         echo Running staticcheck
         if ! command -v staticcheck >/dev/null; then

--- a/run-checks
+++ b/run-checks
@@ -217,6 +217,12 @@ if [ "$STATIC" = 1 ]; then
 
     echo Checking all interfaces have minimal spread test
     missing_interface_spread_test
+
+    echo Running staticcheck
+    if ! command -v staticcheck >/dev/null; then
+        go get -u honnef.co/go/tools/cmd/staticcheck
+    fi
+    go list ./... | grep -v '/vendor/' | xargs staticcheck -tests=false
 fi
 
 if [ "$UNIT" = 1 ]; then

--- a/run-checks
+++ b/run-checks
@@ -218,11 +218,14 @@ if [ "$STATIC" = 1 ]; then
     echo Checking all interfaces have minimal spread test
     missing_interface_spread_test
 
-    echo Running staticcheck
-    if ! command -v staticcheck >/dev/null; then
-        go get -u honnef.co/go/tools/cmd/staticcheck
+    if command -v staticcheck >/dev/null || [[ "$(go version)" =~ go1\.(9|1[0-9])\.[0-9] ]]; then
+        # either you already have staticcheck on your path, or you're on a new enough go
+        echo Running staticcheck
+        if ! command -v staticcheck >/dev/null; then
+            go get -u honnef.co/go/tools/cmd/staticcheck
+        fi
+        go list ./... | grep -v '/vendor/' | xargs staticcheck -tests=false
     fi
-    go list ./... | grep -v '/vendor/' | xargs staticcheck -tests=false
 fi
 
 if [ "$UNIT" = 1 ]; then

--- a/run-checks
+++ b/run-checks
@@ -224,7 +224,11 @@ if [ "$STATIC" = 1 ]; then
         if ! command -v staticcheck >/dev/null; then
             go get -u honnef.co/go/tools/cmd/staticcheck
         fi
-        go list ./... | grep -v '/vendor/' | xargs staticcheck -tests=false
+        # SA1019 https://github.com/dominikh/go-tools/blob/master/cmd/staticcheck/docs/checks/SA1019
+        # complains about using os.SEEK_* instead of io.Seek*, when the latter don't exist in 1.6 yet
+        # SA1012 https://github.com/dominikh/go-tools/blob/master/cmd/staticcheck/docs/checks/SA1012
+        # complains about tomb.Context(nil), which is wrong -- that is, tomb.Context(nil) is right.
+        go list ./... | grep -v '/vendor/' | xargs staticcheck -tests=false -ignore '*:SA1019,SA1012'
     fi
 fi
 

--- a/spdx/parser.go
+++ b/spdx/parser.go
@@ -25,13 +25,11 @@ import (
 	"strings"
 )
 
-type operator string
-
 const (
-	opUNSET operator = ""
-	opAND            = "AND"
-	opOR             = "OR"
-	opWITH           = "WITH"
+	opUNSET = ""
+	opAND   = "AND"
+	opOR    = "OR"
+	opWITH  = "WITH"
 )
 
 func isOperator(tok string) bool {

--- a/tests/lib/fakedevicesvc/main.go
+++ b/tests/lib/fakedevicesvc/main.go
@@ -51,7 +51,7 @@ func main() {
 	s := &http.Server{Handler: http.HandlerFunc(handle)}
 	go s.Serve(l)
 
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 

--- a/tests/lib/fakestore/cmd/fakestore/cmd_run.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_run.go
@@ -62,7 +62,7 @@ func runServer(topDir, addr string, assertFallback bool) error {
 		return err
 	}
 
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 

--- a/tests/lib/systemd-escape/main.go
+++ b/tests/lib/systemd-escape/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	for i, arg := range args[1:] {
-		fmt.Printf(systemd.EscapeUnitNamePath(arg))
+		fmt.Print(systemd.EscapeUnitNamePath(arg))
 		if i < len(args[1:])-1 {
 			fmt.Printf(" ")
 		}


### PR DESCRIPTION
This is the result of running

    staticcheck -tests=false $(go list ./... | grep -v '/vendor/')

and then fixing each issue.

One commit per file/issue (with one exception where the same issue was present twice in the same file).

`-tests=false` was necessary because we have way more dubious stuff going on in the tests... :-)