### PR TITLE
many: fix composite literals with unkeyed fields

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4097,7 +4097,10 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	repo := d.overlord.InterfaceManager().Repository()
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 1)
-	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"},
+	}})
 }
 
 func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
@@ -4355,7 +4358,9 @@ func (s *apiSuite) TestConnectCoreSystemAlias(c *check.C) {
 	repo := d.overlord.InterfaceManager().Repository()
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 1)
-	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "core", Name: "slot"}}})
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "slot"}}})
 }
 
 func (s *apiSuite) testDisconnect(c *check.C, plugSnap, plugName, slotSnap, slotName string) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1012,7 +1012,9 @@ func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 	repo := s.manager(c).Repository()
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, HasLen, 1)
-	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 }
 
 func (s *interfaceManagerSuite) TestConnectTaskCheckInterfaceMismatch(c *C) {
@@ -1104,7 +1106,9 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckNotAllowedButNoDecl(c *C) {
 		repo := s.manager(c).Repository()
 		ifaces := repo.Interfaces()
 		c.Assert(ifaces.Connections, HasLen, 1)
-		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+			PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+			SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 	})
 }
 
@@ -1123,7 +1127,9 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckAllowed(c *C) {
 		repo := s.manager(c).Repository()
 		ifaces := repo.Interfaces()
 		c.Assert(ifaces.Connections, HasLen, 1)
-		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+			PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+			SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 	})
 }
 
@@ -1206,7 +1212,9 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeRightStore(c *C) 
 		repo := s.manager(c).Repository()
 		ifaces := repo.Interfaces()
 		c.Assert(ifaces.Connections, HasLen, 1)
-		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+			PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+			SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 	})
 }
 
@@ -1245,7 +1253,9 @@ func (s *interfaceManagerSuite) TestConnectTaskCheckDeviceScopeRightFriendlyStor
 		repo := s.manager(c).Repository()
 		ifaces := repo.Interfaces()
 		c.Assert(ifaces.Connections, HasLen, 1)
-		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+		c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+			PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+			SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 	})
 }
 
@@ -1945,7 +1955,9 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	c.Assert(slot, Not(IsNil))
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, HasLen, 1)
-	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 }
 
 // The auto-connect task will auto-connect slots with viable multiple candidates.
@@ -2006,8 +2018,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiple
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, HasLen, 2)
 	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{
-		{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}},
-		{interfaces.PlugRef{Snap: "consumer2", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}},
+		{PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"}, SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}},
+		{PlugRef: interfaces.PlugRef{Snap: "consumer2", Name: "plug"}, SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}},
 	})
 }
 
@@ -2464,7 +2476,9 @@ func (s *interfaceManagerSuite) testDoSetupSnapSecurityReloadsConnectionsWhenInv
 	// Repository shows the connection
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, HasLen, 1)
-	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "consumer", Name: "plug"}, interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
+	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Snap: "producer", Name: "slot"}}})
 }
 
 // The setup-profiles task will honor snapstate.DevMode flag by storing it
@@ -3757,7 +3771,9 @@ func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
 	c.Assert(plug, Not(IsNil))
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, HasLen, 1)
-	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{interfaces.PlugRef{Snap: "snap", Name: "network"}, interfaces.SlotRef{Snap: "core", Name: "network"}}})
+	c.Check(ifaces.Connections, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "snap", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "network"}}})
 }
 
 func makeAutoConnectChange(st *state.State, plugSnap, plug, slotSnap, slot string) *state.Change {

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -93,11 +93,11 @@ func (s *snapmgrTestSuite) TestApplyAliasesChange(c *C) {
 
 		var add, rm []*backend.Alias
 		if strings.Contains(scenario.ops, "rm") {
-			rm = []*backend.Alias{{"myalias", fmt.Sprintf("alias-snap1.%s", target(scenario.target))}}
+			rm = []*backend.Alias{{Name: "myalias", Target: fmt.Sprintf("alias-snap1.%s", target(scenario.target))}}
 		}
 
 		if strings.Contains(scenario.ops, "add") {
-			add = []*backend.Alias{{"myalias", fmt.Sprintf("alias-snap1.%s", target(scenario.newTarget))}}
+			add = []*backend.Alias{{Name: "myalias", Target: fmt.Sprintf("alias-snap1.%s", target(scenario.newTarget))}}
 		}
 
 		expected := fakeOps{
@@ -133,8 +133,8 @@ func (s *snapmgrTestSuite) TestApplyAliasesChangeMulti(c *C) {
 	expected := fakeOps{
 		{
 			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"myalias0", "alias-snap1.cmd0"}},
-			aliases:   []*backend.Alias{{"myalias1", "alias-snap1"}},
+			rmAliases: []*backend.Alias{{Name: "myalias0", Target: "alias-snap1.cmd0"}},
+			aliases:   []*backend.Alias{{Name: "myalias1", Target: "alias-snap1"}},
 		},
 	}
 
@@ -585,7 +585,7 @@ func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			aliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -644,7 +644,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceAliasRunThrough(c *C) {
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap_foo.cmd1"}},
+			aliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap_foo.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -764,8 +764,8 @@ func (s *snapmgrTestSuite) TestAliasOverAutoRunThrough(c *C) {
 	expected := fakeOps{
 		{
 			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
-			aliases:   []*backend.Alias{{"alias1", "alias-snap.cmd5"}},
+			rmAliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd1"}},
+			aliases:   []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd5"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -968,9 +968,9 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesRunThrough(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd5"},
-				{"alias2", "alias-snap.cmd2"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias1", Target: "alias-snap.cmd5"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 		},
 	}
@@ -1040,9 +1040,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceDisableAllAliasesRunThrough(c *C)
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias1", "alias-snap_instance.cmd1"},
-				{"alias2", "alias-snap_instance.cmd2"},
-				{"alias3", "alias-snap_instance.cmd3"},
+				{Name: "alias1", Target: "alias-snap_instance.cmd1"},
+				{Name: "alias2", Target: "alias-snap_instance.cmd2"},
+				{Name: "alias3", Target: "alias-snap_instance.cmd3"},
 			},
 		},
 	}
@@ -1136,7 +1136,7 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasRunThrough(c *C) {
 	expected := fakeOps{
 		{
 			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd5"}},
+			rmAliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd5"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -1188,8 +1188,8 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasOverAutoRunThrough(c *C) {
 	expected := fakeOps{
 		{
 			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd5"}},
-			aliases:   []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			rmAliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd5"}},
+			aliases:   []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -1237,8 +1237,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveManualAliasRunThrough(c *C)
 	expected := fakeOps{
 		{
 			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"alias1", "alias-snap_instance.cmd2"}},
-			aliases:   []*backend.Alias{{"alias1", "alias-snap_instance.cmd1"}},
+			rmAliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap_instance.cmd2"}},
+			aliases:   []*backend.Alias{{Name: "alias1", Target: "alias-snap_instance.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -1406,8 +1406,8 @@ func (s *snapmgrTestSuite) TestPreferRunThrough(c *C) {
 		{
 			op: "update-aliases",
 			aliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd1"},
-				{"alias2", "alias-snap.cmd2"},
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
 			},
 		},
 	}
@@ -1470,15 +1470,15 @@ func (s *snapmgrTestSuite) TestParallelInstancePreferRunThrough(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd1"},
-				{"alias2", "alias-snap.cmd2"},
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
 			},
 		},
 		{
 			op: "update-aliases",
 			aliases: []*backend.Alias{
-				{"alias1", "alias-snap_instance.cmd1"},
-				{"alias2", "alias-snap_instance.cmd2"},
+				{Name: "alias1", Target: "alias-snap_instance.cmd1"},
+				{Name: "alias2", Target: "alias-snap_instance.cmd2"},
 			},
 		},
 	}

--- a/overlord/snapstate/backend/aliases_test.go
+++ b/overlord/snapstate/backend/aliases_test.go
@@ -76,10 +76,10 @@ func (s *aliasesSuite) TestMissingAliases(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(os.Symlink("x.a", filepath.Join(dirs.CompletersDir, "a")), IsNil)
 
-	missingAs, missingCs, err := missingAliases([]*backend.Alias{{"a", "x.a"}, {"foo", "x.foo"}})
+	missingAs, missingCs, err := missingAliases([]*backend.Alias{{Name: "a", Target: "x.a"}, {Name: "foo", Target: "x.foo"}})
 	c.Assert(err, IsNil)
-	c.Check(missingAs, DeepEquals, []*backend.Alias{{"a", "x.a"}})
-	c.Check(missingCs, DeepEquals, []*backend.Alias{{"foo", "x.foo"}})
+	c.Check(missingAs, DeepEquals, []*backend.Alias{{Name: "a", Target: "x.a"}})
+	c.Check(missingCs, DeepEquals, []*backend.Alias{{Name: "foo", Target: "x.foo"}})
 }
 
 func matchingAliases(aliases []*backend.Alias) (matchingAs, matchingCs []*backend.Alias, err error) {
@@ -113,14 +113,14 @@ func (s *aliasesSuite) TestMatchingAliases(c *C) {
 	c.Assert(os.Symlink("y.foo", filepath.Join(dirs.CompletersDir, "foo")), IsNil)
 	c.Assert(os.Symlink("x.bar", filepath.Join(dirs.CompletersDir, "bar")), IsNil)
 
-	matchingAs, matchingCs, err := matchingAliases([]*backend.Alias{{"a", "x.a"}, {"foo", "x.foo"}, {"bar", "x.bar"}})
+	matchingAs, matchingCs, err := matchingAliases([]*backend.Alias{{Name: "a", Target: "x.a"}, {Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}})
 	c.Assert(err, IsNil)
-	c.Check(matchingAs, DeepEquals, []*backend.Alias{{"foo", "x.foo"}})
-	c.Check(matchingCs, DeepEquals, []*backend.Alias{{"bar", "x.bar"}})
+	c.Check(matchingAs, DeepEquals, []*backend.Alias{{Name: "foo", Target: "x.foo"}})
+	c.Check(matchingCs, DeepEquals, []*backend.Alias{{Name: "bar", Target: "x.bar"}})
 }
 
 func (s *aliasesSuite) TestUpdateAliasesAdd(c *C) {
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -139,7 +139,7 @@ func mkCompleters(c *C, apps ...string) {
 
 func (s *aliasesSuite) TestUpdateAliasesAddWithCompleter(c *C) {
 	mkCompleters(c, "x.bar", "x.foo")
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -151,7 +151,7 @@ func (s *aliasesSuite) TestUpdateAliasesAddWithCompleter(c *C) {
 }
 
 func (s *aliasesSuite) TestUpdateAliasesAddIdempot(c *C) {
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -167,7 +167,7 @@ func (s *aliasesSuite) TestUpdateAliasesAddIdempot(c *C) {
 
 func (s *aliasesSuite) TestUpdateAliasesAddWithCompleterIdempot(c *C) {
 	mkCompleters(c, "x.foo", "x.bar")
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -182,7 +182,7 @@ func (s *aliasesSuite) TestUpdateAliasesAddWithCompleterIdempot(c *C) {
 }
 
 func (s *aliasesSuite) TestUpdateAliasesRemove(c *C) {
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -208,7 +208,7 @@ func (s *aliasesSuite) TestUpdateAliasesRemove(c *C) {
 
 func (s *aliasesSuite) TestUpdateAliasesWithCompleterRemove(c *C) {
 	mkCompleters(c, "x.foo", "x.bar")
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -233,7 +233,7 @@ func (s *aliasesSuite) TestUpdateAliasesWithCompleterRemove(c *C) {
 }
 
 func (s *aliasesSuite) TestUpdateAliasesRemoveIdempot(c *C) {
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -257,7 +257,7 @@ func (s *aliasesSuite) TestUpdateAliasesRemoveIdempot(c *C) {
 
 func (s *aliasesSuite) TestUpdateAliasesWithCompleterRemoveIdempot(c *C) {
 	mkCompleters(c, "x.foo", "x.bar")
-	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+	aliases := []*backend.Alias{{Name: "foo", Target: "x.foo"}, {Name: "bar", Target: "x.bar"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -280,8 +280,8 @@ func (s *aliasesSuite) TestUpdateAliasesWithCompleterRemoveIdempot(c *C) {
 }
 
 func (s *aliasesSuite) TestUpdateAliasesAddRemoveOverlap(c *C) {
-	before := []*backend.Alias{{"bar", "x.bar"}}
-	after := []*backend.Alias{{"bar", "x.baz"}}
+	before := []*backend.Alias{{Name: "bar", Target: "x.bar"}}
+	after := []*backend.Alias{{Name: "bar", Target: "x.baz"}}
 
 	err := s.be.UpdateAliases(before, nil)
 	c.Assert(err, IsNil)
@@ -301,8 +301,8 @@ func (s *aliasesSuite) TestUpdateAliasesAddRemoveOverlap(c *C) {
 
 func (s *aliasesSuite) TestUpdateAliasesWithCompleterAddRemoveOverlap(c *C) {
 	mkCompleters(c, "x.baz", "x.bar")
-	before := []*backend.Alias{{"bar", "x.bar"}}
-	after := []*backend.Alias{{"bar", "x.baz"}}
+	before := []*backend.Alias{{Name: "bar", Target: "x.bar"}}
+	after := []*backend.Alias{{Name: "bar", Target: "x.baz"}}
 
 	err := s.be.UpdateAliases(before, nil)
 	c.Assert(err, IsNil)
@@ -321,7 +321,7 @@ func (s *aliasesSuite) TestUpdateAliasesWithCompleterAddRemoveOverlap(c *C) {
 }
 
 func (s *aliasesSuite) TestRemoveSnapAliases(c *C) {
-	aliases := []*backend.Alias{{"bar", "x.bar"}, {"baz", "y.baz"}}
+	aliases := []*backend.Alias{{Name: "bar", Target: "x.bar"}, {Name: "baz", Target: "y.baz"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -331,14 +331,18 @@ func (s *aliasesSuite) TestRemoveSnapAliases(c *C) {
 
 	matchingAs, matchingCs, err := matchingAliases(aliases)
 	c.Assert(err, IsNil)
-	c.Check(matchingAs, DeepEquals, []*backend.Alias{{"baz", "y.baz"}})
+	c.Check(matchingAs, DeepEquals, []*backend.Alias{{Name: "baz", Target: "y.baz"}})
 	// no completion for the commands -> no completion for the aliases
 	c.Check(matchingCs, HasLen, 0)
 }
 
 func (s *aliasesSuite) TestRemoveSnapAliasesWithCompleter(c *C) {
 	mkCompleters(c, "x", "x.bar", "y", "y.baz")
-	aliases := []*backend.Alias{{"xx", "x"}, {"bar", "x.bar"}, {"baz", "y.baz"}, {"yy", "y"}}
+	aliases := []*backend.Alias{
+		{Name: "xx", Target: "x"},
+		{Name: "bar", Target: "x.bar"},
+		{Name: "baz", Target: "y.baz"},
+		{Name: "yy", Target: "y"}}
 
 	err := s.be.UpdateAliases(aliases, nil)
 	c.Assert(err, IsNil)
@@ -348,6 +352,6 @@ func (s *aliasesSuite) TestRemoveSnapAliasesWithCompleter(c *C) {
 
 	matchingAs, matchingCs, err := matchingAliases(aliases)
 	c.Assert(err, IsNil)
-	c.Check(matchingAs, DeepEquals, []*backend.Alias{{"baz", "y.baz"}, {"yy", "y"}})
-	c.Check(matchingCs, DeepEquals, []*backend.Alias{{"baz", "y.baz"}, {"yy", "y"}})
+	c.Check(matchingAs, DeepEquals, []*backend.Alias{{Name: "baz", Target: "y.baz"}, {Name: "yy", Target: "y"}})
+	c.Check(matchingCs, DeepEquals, []*backend.Alias{{Name: "baz", Target: "y.baz"}, {Name: "yy", Target: "y"}})
 }

--- a/overlord/snapstate/handlers_aliasesv2_test.go
+++ b/overlord/snapstate/handlers_aliasesv2_test.go
@@ -488,7 +488,7 @@ func (s *snapmgrTestSuite) TestDoSetupAliases(c *C) {
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: []*backend.Alias{{"manual1", "alias-snap.cmd1"}},
+			aliases: []*backend.Alias{{Name: "manual1", Target: "alias-snap.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -544,7 +544,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliases(c *C) {
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: []*backend.Alias{{"manual1", "alias-snap.cmd1"}},
+			aliases: []*backend.Alias{{Name: "manual1", Target: "alias-snap.cmd1"}},
 		},
 		{
 			op:   "remove-snap-aliases",
@@ -598,7 +598,7 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesAuto(c *C) {
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			aliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -654,7 +654,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			aliases: []*backend.Alias{{Name: "alias1", Target: "alias-snap.cmd1"}},
 		},
 		{
 			op:   "remove-snap-aliases",
@@ -812,8 +812,8 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAuto(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 		},
 	}
@@ -981,12 +981,12 @@ func (s *snapmgrTestSuite) TestDoRefreshAliases(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2x"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 			aliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 	}
@@ -1060,23 +1060,23 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliases(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2x"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 			aliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 		{
 			op: "update-aliases",
 			aliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2x"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 			rmAliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 	}
@@ -1145,17 +1145,17 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesFromEmpty(c *C) {
 		{
 			op: "update-aliases",
 			aliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd1"},
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd1"},
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 	}
@@ -1429,20 +1429,20 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesConflict(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2x"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias2", Target: "alias-snap.cmd2x"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 			aliases: []*backend.Alias{
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd1"},
-				{"alias2", "alias-snap.cmd2"},
-				{"alias4", "alias-snap.cmd4"},
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias4", Target: "alias-snap.cmd4"},
 			},
 		},
 	}
@@ -1516,17 +1516,17 @@ func (s *snapmgrTestSuite) TestDoUndoDisableAliases(c *C) {
 		{
 			op: "update-aliases",
 			rmAliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd5"},
-				{"alias2", "alias-snap.cmd2"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias1", Target: "alias-snap.cmd5"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 		},
 		{
 			op: "update-aliases",
 			aliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd5"},
-				{"alias2", "alias-snap.cmd2"},
-				{"alias3", "alias-snap.cmd3"},
+				{Name: "alias1", Target: "alias-snap.cmd5"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
+				{Name: "alias3", Target: "alias-snap.cmd3"},
 			},
 		},
 	}
@@ -1621,9 +1621,9 @@ func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 	c.Assert(s.fakeBackend.ops[2], DeepEquals, fakeOp{
 		op: "update-aliases",
 		aliases: []*backend.Alias{
-			{"alias1", "alias-snap.cmd1"},
-			{"alias2", "alias-snap.cmd2"},
-			{"alias3", "alias-snap.cmd3"},
+			{Name: "alias1", Target: "alias-snap.cmd1"},
+			{Name: "alias2", Target: "alias-snap.cmd2"},
+			{Name: "alias3", Target: "alias-snap.cmd3"},
 		},
 	})
 
@@ -1745,9 +1745,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 	c.Assert(s.fakeBackend.ops[3], DeepEquals, fakeOp{
 		op: "update-aliases",
 		rmAliases: []*backend.Alias{
-			{"alias1", "alias-snap.cmd1"},
-			{"alias2", "alias-snap.cmd2"},
-			{"alias3", "alias-snap.cmd3"},
+			{Name: "alias1", Target: "alias-snap.cmd1"},
+			{Name: "alias2", Target: "alias-snap.cmd2"},
+			{Name: "alias3", Target: "alias-snap.cmd3"},
 		},
 	})
 	c.Assert(s.fakeBackend.ops[4].aliases, HasLen, 1)
@@ -1898,15 +1898,15 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 	c.Assert(s.fakeBackend.ops[3], DeepEquals, fakeOp{
 		op: "update-aliases",
 		rmAliases: []*backend.Alias{
-			{"alias1", "alias-snap.cmd1"},
-			{"alias2", "alias-snap.cmd2"},
-			{"alias3", "alias-snap.cmd3"},
+			{Name: "alias1", Target: "alias-snap.cmd1"},
+			{Name: "alias2", Target: "alias-snap.cmd2"},
+			{Name: "alias3", Target: "alias-snap.cmd3"},
 		},
 	})
 	c.Assert(s.fakeBackend.ops[4], DeepEquals, fakeOp{
 		op: "update-aliases",
 		aliases: []*backend.Alias{
-			{"alias3", "other-alias-snap3.cmd5"},
+			{Name: "alias3", Target: "other-alias-snap3.cmd5"},
 		},
 	})
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -11207,8 +11207,8 @@ func (s *snapmgrTestSuite) TestEnsureAliasesV2(c *C) {
 		{
 			op: "update-aliases",
 			aliases: []*backend.Alias{
-				{"alias1", "alias-snap.cmd1"},
-				{"alias2", "alias-snap.cmd2"},
+				{Name: "alias1", Target: "alias-snap.cmd1"},
+				{Name: "alias2", Target: "alias-snap.cmd2"},
 			},
 		},
 	}


### PR DESCRIPTION
Running ./run-checks --static on openSUSE Tumbleweed produces numerous
errors. One of those is the use of unkeyed fields in test code.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
