### PR TITLE
run-checks: discard test good/bad banner

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -74,23 +74,6 @@ addtrap() {
     trap "store_exit_code; $CURRENTTRAP ; exit_with_exit_code" EXIT
 }
 
-endmsg() {
-    if [ $EXIT_CODE -eq 0 ]; then
-        p="success.txt"
-        m="All good, what could possibly go wrong."
-    else
-        p="failure.txt"
-        m="Crushing failure and despair."
-    fi
-    echo
-    if [ -t 1 ] && [ -z "$STATIC" ]; then
-        cat "data/$p"
-    else
-        echo "$m"
-    fi
-}
-addtrap endmsg
-
 # Append the coverage profile of a package to the project coverage.
 append_coverage() (
     profile="$1"


### PR DESCRIPTION
The endmsg function prints a banner that shows if tests passed or
failed. There are two problems with the banner:

It rarely formats correctly, making error logs show wrapped mess.

It is printed at the end of the execution of several separate tests
so it is possible to end up with a log that looks roughly like this:

- good stuff
- some error stuff
- lots of good stuff (pages and pages)
- +1 message

So we are getting:
 - big banner saying it's good
 - error code saying it is bad

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>