### PR TITLE
spread: run tests on Fedora 28 again

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -81,7 +81,6 @@ backends:
                 manual: true
             - fedora-28-64:
                 workers: 4
-                manual: true
 
             - opensuse-42.3-64:
                 workers: 4


### PR DESCRIPTION
There are some issues in running tests on Fedora 29 in #6139. Meanwhile, we should be able to run everything on Fedora 28 to make sure stuff does not break.
