### PR TITLE
tests: reset the snapd package to make the first test on the suite work properly

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -412,6 +412,11 @@ prepare_suite() {
     else
         prepare_classic
     fi
+
+    # Reset snapd to run the first test on the suite properly
+    # This reset has to be removed and it needs to be slit and reorganized
+    # shellcheck source=tests/lib/reset.sh
+    "$TESTSLIB"/reset.sh --reuse-core
 }
 
 prepare_suite_each() {


### PR DESCRIPTION
By this change we ensure the first test on the suite is gonna run
with the same environment/state than the other tests.

This fixes the error on completion suite.
errors:
	https://travis-ci.org/snapcore/snapd/builds/459668876
	https://travis-ci.org/snapcore/snapd/builds/459629226
