### PR TITLE
interfaces: return security setup errors (2.36)

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -305,11 +305,9 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	spec.(*Specification).AddLayout(snapInfo)
 
 	// core on classic is special
-	//
-	// TODO: we need to deal with the "snapd" snap here soon
 	if snapName == "core" && release.OnClassic && release.AppArmorLevel() != release.NoAppArmor {
 		if err := setupSnapConfineReexec(snapInfo); err != nil {
-			logger.Noticef("cannot create host snap-confine apparmor configuration: %s", err)
+			return fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
 	}
 
@@ -318,7 +316,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// systems but /etc/apparmor.d is not writable on core18 systems
 	if snapName == "snapd" && release.AppArmorLevel() != release.NoAppArmor {
 		if err := setupSnapConfineReexec(snapInfo); err != nil {
-			logger.Noticef("cannot create host snap-confine apparmor configuration: %s", err)
+			return fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
 	}
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -182,8 +182,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 			}
 			// Refresh security of this snap and backend
 			if err := backend.Setup(snapInfo, opts, m.repo); err != nil {
-				// Let's log this but carry on
-				logger.Noticef("cannot regenerate %s profile for snap %q: %s",
+				return fmt.Errorf("cannot regenerate %s profile for snap %q: %s",
 					backend.Name(), snapName, err)
 			}
 		}


### PR DESCRIPTION
Snapd used to ignore errors from backend.Setup calls
and within apparmor backend it also used to ignore errors
from a special code path generating snap-confine profile for when
snap-confine is used from {core,snapd} snaps.

We are observing a peculiar error, where snapd is trying to compile and
load the profile for snap-confine, an operation involving executing
apparmor_parser process, but that operation fails because apparmor
parser is killed with SIGTERM. The origin of the signal is unknown
but being vocal about the problem occurring might help us understand the
problem better.

The problem is only visible in log files as a following message:

    Nov 27 10:58:09 nov271039-251208 snapd[24167]: backend.go:312:
    cannot create host snap-confine apparmor configuration: cannot
    reload snap-confine apparmor profile: cannot load apparmor profiles:
    signal: terminated

There is no output from apparmor_parser.

Note: this issue is very likely not new. The existing test setup would
mask it. It is only visible now because snapd in 2.36 release branch
requires more permissions to execute snap-confine than it does with
edge. In the past if this problem had occurred the test machine would
carry on running with the apparmor profile from the edge channel.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
