### PR TITLE
tests: fix for failover test on how logs are checked

### DIFF
--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -68,6 +68,9 @@ execute: |
     . "$TESTSLIB"/names.sh
     #shellcheck source=tests/lib/boot.sh
     . "$TESTSLIB"/boot.sh
+    #shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB"/journalctl.sh
+
     if [ "$TARGET_SNAP" = kernel ]; then
         TARGET_SNAP_NAME=$kernel_name
     else
@@ -87,10 +90,17 @@ execute: |
         # repack new target snap
         snap pack "$BUILD_DIR/unpack" && mv ${TARGET_SNAP_NAME}_*.snap failing.snap
 
+        if check_journalctl_log "Waiting for system reboot"; then
+            echo "Already waiting for system reboot, exiting..."
+            exit 1
+        fi
+
         # install new target snap
         snap install --dangerous failing.snap
 
-        while ! journalctl -b -u snapd|grep -q "Waiting for system reboot" ; do sleep 1 ; done
+        while ! check_journalctl_log "Waiting for system reboot"; do
+            sleep 1
+        done
 
         # check boot env vars
         readlink /snap/core/current > failBoot

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -90,6 +90,7 @@ execute: |
         # repack new target snap
         snap pack "$BUILD_DIR/unpack" && mv ${TARGET_SNAP_NAME}_*.snap failing.snap
 
+        # use journalctl wrapper to grep only the logs collected while the test is running
         if check_journalctl_log "Waiting for system reboot"; then
             echo "Already waiting for system reboot, exiting..."
             exit 1
@@ -98,6 +99,7 @@ execute: |
         # install new target snap
         snap install --dangerous failing.snap
 
+        # use journalctl wrapper to grep only the logs collected while the test is running
         while ! check_journalctl_log "Waiting for system reboot"; do
             sleep 1
         done


### PR DESCRIPTION
Otherwise logs used are since last reboot.

error:
https://api.travis-ci.org/v3/job/460209244/log.txt
