### PR TITLE
overlord,daemon: mock security backends for testing

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/standby"
 	"github.com/snapcore/snapd/overlord/state"
@@ -60,6 +61,7 @@ type daemonSuite struct {
 	err             error
 	lastPolkitFlags polkit.CheckFlags
 	notified        []string
+	restoreBackends func()
 }
 
 var _ = check.Suite(&daemonSuite{})
@@ -79,6 +81,7 @@ func (s *daemonSuite) SetUpTest(c *check.C) {
 	}
 	s.notified = nil
 	polkitCheckAuthorization = s.checkAuthorization
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 }
 
 func (s *daemonSuite) TearDownTest(c *check.C) {
@@ -87,6 +90,7 @@ func (s *daemonSuite) TearDownTest(c *check.C) {
 	s.authorized = false
 	s.err = nil
 	logger.SetLogger(logger.NullLogger)
+	s.restoreBackends()
 }
 
 func (s *daemonSuite) TearDownSuite(c *check.C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
-	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -86,7 +85,6 @@ type deviceMgrSuite struct {
 	restoreOnClassic         func()
 	restoreGenericClassicMod func()
 	restoreSanitize          func()
-	restoreBackends          func()
 }
 
 var _ = Suite(&deviceMgrSuite{})
@@ -124,7 +122,6 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 	s.restoreOnClassic = release.MockOnClassic(false)
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
-	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.se = s.o.StateEngine()
@@ -177,7 +174,6 @@ func (s *deviceMgrSuite) TearDownTest(c *C) {
 	s.restoreGenericClassicMod()
 	s.restoreOnClassic()
 	s.restoreSanitize()
-	s.restoreBackends()
 }
 
 var settleTimeout = 15 * time.Second

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -85,6 +86,7 @@ type deviceMgrSuite struct {
 	restoreOnClassic         func()
 	restoreGenericClassicMod func()
 	restoreSanitize          func()
+	restoreBackends          func()
 }
 
 var _ = Suite(&deviceMgrSuite{})
@@ -122,6 +124,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 	s.restoreOnClassic = release.MockOnClassic(false)
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.se = s.o.StateEngine()
@@ -174,6 +177,7 @@ func (s *deviceMgrSuite) TearDownTest(c *C) {
 	s.restoreGenericClassicMod()
 	s.restoreOnClassic()
 	s.restoreSanitize()
+	s.restoreBackends()
 }
 
 var settleTimeout = 15 * time.Second

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -57,10 +57,7 @@ import (
 )
 
 type FirstBootTestSuite struct {
-	aa          *testutil.MockCmd
-	systemctl   *testutil.MockCmd
-	mockUdevAdm *testutil.MockCmd
-	snapSeccomp *testutil.MockCmd
+	systemctl *testutil.MockCmd
 
 	storeSigning *assertstest.StoreStack
 	restore      func()
@@ -71,6 +68,7 @@ type FirstBootTestSuite struct {
 	overlord *overlord.Overlord
 
 	restoreOnClassic func()
+	restoreBackends  func()
 }
 
 var _ = Suite(&FirstBootTestSuite{})
@@ -89,14 +87,7 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	err = os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
-	s.aa = testutil.MockCommand(c, "apparmor_parser", "")
 	s.systemctl = testutil.MockCommand(c, "systemctl", "")
-	s.mockUdevAdm = testutil.MockCommand(c, "udevadm", "")
-
-	snapSeccompPath := filepath.Join(dirs.DistroLibExecDir, "snap-seccomp")
-	err = os.MkdirAll(filepath.Dir(snapSeccompPath), 0755)
-	c.Assert(err, IsNil)
-	s.snapSeccomp = testutil.MockCommand(c, snapSeccompPath, "")
 
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
@@ -106,6 +97,8 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 
 	s.brandPrivKey, _ = assertstest.GenerateKey(752)
 	s.brandSigning = assertstest.NewSigningDB("my-brand", s.brandPrivKey)
+
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
 	ovld, err := overlord.New()
 	c.Assert(err, IsNil)
@@ -119,13 +112,11 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 
 func (s *FirstBootTestSuite) TearDownTest(c *C) {
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	s.aa.Restore()
 	s.systemctl.Restore()
-	s.mockUdevAdm.Restore()
-	s.snapSeccomp.Restore()
 
 	s.restore()
 	s.restoreOnClassic()
+	s.restoreBackends()
 	dirs.SetRootDir("/")
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -67,13 +67,7 @@ type mgrsSuite struct {
 
 	restore func()
 
-	aa               *testutil.MockCmd
-	udev             *testutil.MockCmd
-	umount           *testutil.MockCmd
 	restoreSystemctl func()
-
-	snapDiscardNs *testutil.MockCmd
-	snapSeccomp   *testutil.MockCmd
 
 	storeSigning   *assertstest.StoreStack
 	restoreTrusted func()
@@ -88,6 +82,8 @@ type mgrsSuite struct {
 	hijackServeSnap func(http.ResponseWriter)
 
 	o *overlord.Overlord
+
+	restoreBackends func()
 }
 
 var (
@@ -139,12 +135,6 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		return []byte("ActiveState=inactive\n"), nil
 	})
 
-	ms.aa = testutil.MockCommand(c, "apparmor_parser", "")
-	ms.udev = testutil.MockCommand(c, "udevadm", "")
-	ms.umount = testutil.MockCommand(c, "umount", "")
-	ms.snapDiscardNs = testutil.MockCommand(c, "snap-discard-ns", "")
-	dirs.DistroLibExecDir = ms.snapDiscardNs.BinDir()
-
 	ms.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
 
@@ -159,10 +149,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	ms.serveRevision = make(map[string]string)
 	ms.hijackServeSnap = nil
 
-	snapSeccompPath := filepath.Join(dirs.DistroLibExecDir, "snap-seccomp")
-	err = os.MkdirAll(filepath.Dir(snapSeccompPath), 0755)
-	c.Assert(err, IsNil)
-	ms.snapSeccomp = testutil.MockCommand(c, snapSeccompPath, "")
+	ms.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
@@ -275,11 +262,7 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	ms.restoreSystemctl()
 	ms.mockSnapCmd.Restore()
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	ms.udev.Restore()
-	ms.aa.Restore()
-	ms.umount.Restore()
-	ms.snapDiscardNs.Restore()
-	ms.snapSeccomp.Restore()
+	ms.restoreBackends()
 }
 
 var settleTimeout = 15 * time.Second
@@ -1988,6 +1971,8 @@ type authContextSetupSuite struct {
 
 	model  *asserts.Model
 	serial *asserts.Serial
+
+	restoreBackends func()
 }
 
 func (s *authContextSetupSuite) SetUpTest(c *C) {
@@ -2045,6 +2030,8 @@ func (s *authContextSetupSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.serial = serial.(*asserts.Serial)
 
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
+
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
 	o.InterfaceManager().DisableUDevMonitor()
@@ -2063,6 +2050,7 @@ func (s *authContextSetupSuite) SetUpTest(c *C) {
 
 func (s *authContextSetupSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
+	s.restoreBackends()
 	s.restoreTrusted()
 }
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -45,7 +46,9 @@ import (
 
 func TestOverlord(t *testing.T) { TestingT(t) }
 
-type overlordSuite struct{}
+type overlordSuite struct {
+	restoreBackends func()
+}
 
 var _ = Suite(&overlordSuite{})
 
@@ -54,10 +57,12 @@ func (ovs *overlordSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(tmpdir)
 	dirs.SnapStateFile = filepath.Join(tmpdir, "test.json")
 	snapstate.CanAutoRefresh = nil
+	ovs.restoreBackends = ifacestate.MockSecurityBackends(nil)
 }
 
 func (ovs *overlordSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	ovs.restoreBackends()
 }
 
 func (ovs *overlordSuite) TestNew(c *C) {


### PR DESCRIPTION
Testing the overlord involves initializing the overlord, which in turn
does the same to each of the managers. The interface manager is
particularly active during the initialization phase. It will initialize
all the security backends, some which deeply interrogate the system .
It will compute and compare the system key. Lastly it will regenerate
security profiles for all the snaps if said profile is mismatching. When
setting up core the apparmor security backend performs special handling
for the snap-confine program running from core or from snapd snaps.

All of that interacts with the system. While we could, with enough
effort, mock it away at a very fine grained level we could just replace
all the real security backends with a test backend. This is easy and has
no consequences because we were not measuring anything about the
interactions of the security backend anyway.

This patch does just that. In addition, now-useless mocking of various
system commands has been removed.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
