### PR TITLE
snapstate,overlord: update fontconfig caches with overlord mocking (2.36)

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/standby"
 	"github.com/snapcore/snapd/overlord/state"
@@ -60,6 +61,7 @@ type daemonSuite struct {
 	err             error
 	lastPolkitFlags polkit.CheckFlags
 	notified        []string
+	restoreBackends func()
 }
 
 var _ = check.Suite(&daemonSuite{})
@@ -79,6 +81,7 @@ func (s *daemonSuite) SetUpTest(c *check.C) {
 	}
 	s.notified = nil
 	polkitCheckAuthorization = s.checkAuthorization
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 }
 
 func (s *daemonSuite) TearDownTest(c *check.C) {
@@ -87,6 +90,7 @@ func (s *daemonSuite) TearDownTest(c *check.C) {
 	s.authorized = false
 	s.err = nil
 	logger.SetLogger(logger.NullLogger)
+	s.restoreBackends()
 }
 
 func (s *daemonSuite) TearDownSuite(c *check.C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -85,6 +86,7 @@ type deviceMgrSuite struct {
 	restoreOnClassic         func()
 	restoreGenericClassicMod func()
 	restoreSanitize          func()
+	restoreBackends          func()
 }
 
 var _ = Suite(&deviceMgrSuite{})
@@ -122,6 +124,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 	s.restoreOnClassic = release.MockOnClassic(false)
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.se = s.o.StateEngine()
@@ -174,6 +177,7 @@ func (s *deviceMgrSuite) TearDownTest(c *C) {
 	s.restoreGenericClassicMod()
 	s.restoreOnClassic()
 	s.restoreSanitize()
+	s.restoreBackends()
 }
 
 var settleTimeout = 15 * time.Second

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -57,10 +57,7 @@ import (
 )
 
 type FirstBootTestSuite struct {
-	aa          *testutil.MockCmd
-	systemctl   *testutil.MockCmd
-	mockUdevAdm *testutil.MockCmd
-	snapSeccomp *testutil.MockCmd
+	systemctl *testutil.MockCmd
 
 	storeSigning *assertstest.StoreStack
 	restore      func()
@@ -71,6 +68,7 @@ type FirstBootTestSuite struct {
 	overlord *overlord.Overlord
 
 	restoreOnClassic func()
+	restoreBackends  func()
 }
 
 var _ = Suite(&FirstBootTestSuite{})
@@ -89,14 +87,7 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	err = os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
-	s.aa = testutil.MockCommand(c, "apparmor_parser", "")
 	s.systemctl = testutil.MockCommand(c, "systemctl", "")
-	s.mockUdevAdm = testutil.MockCommand(c, "udevadm", "")
-
-	snapSeccompPath := filepath.Join(dirs.DistroLibExecDir, "snap-seccomp")
-	err = os.MkdirAll(filepath.Dir(snapSeccompPath), 0755)
-	c.Assert(err, IsNil)
-	s.snapSeccomp = testutil.MockCommand(c, snapSeccompPath, "")
 
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
@@ -106,6 +97,8 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 
 	s.brandPrivKey, _ = assertstest.GenerateKey(752)
 	s.brandSigning = assertstest.NewSigningDB("my-brand", s.brandPrivKey)
+
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
 	ovld, err := overlord.New()
 	c.Assert(err, IsNil)
@@ -119,13 +112,11 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 
 func (s *FirstBootTestSuite) TearDownTest(c *C) {
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	s.aa.Restore()
 	s.systemctl.Restore()
-	s.mockUdevAdm.Restore()
-	s.snapSeccomp.Restore()
 
 	s.restore()
 	s.restoreOnClassic()
+	s.restoreBackends()
 	dirs.SetRootDir("/")
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -67,13 +67,7 @@ type mgrsSuite struct {
 
 	restore func()
 
-	aa               *testutil.MockCmd
-	udev             *testutil.MockCmd
-	umount           *testutil.MockCmd
 	restoreSystemctl func()
-
-	snapDiscardNs *testutil.MockCmd
-	snapSeccomp   *testutil.MockCmd
 
 	storeSigning   *assertstest.StoreStack
 	restoreTrusted func()
@@ -87,6 +81,8 @@ type mgrsSuite struct {
 	hijackServeSnap func(http.ResponseWriter)
 
 	o *overlord.Overlord
+
+	restoreBackends func()
 }
 
 var (
@@ -135,12 +131,6 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		return []byte("ActiveState=inactive\n"), nil
 	})
 
-	ms.aa = testutil.MockCommand(c, "apparmor_parser", "")
-	ms.udev = testutil.MockCommand(c, "udevadm", "")
-	ms.umount = testutil.MockCommand(c, "umount", "")
-	ms.snapDiscardNs = testutil.MockCommand(c, "snap-discard-ns", "")
-	dirs.DistroLibExecDir = ms.snapDiscardNs.BinDir()
-
 	ms.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
 
@@ -155,10 +145,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	ms.serveRevision = make(map[string]string)
 	ms.hijackServeSnap = nil
 
-	snapSeccompPath := filepath.Join(dirs.DistroLibExecDir, "snap-seccomp")
-	err = os.MkdirAll(filepath.Dir(snapSeccompPath), 0755)
-	c.Assert(err, IsNil)
-	ms.snapSeccomp = testutil.MockCommand(c, snapSeccompPath, "")
+	ms.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
@@ -270,11 +257,7 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	ms.restore()
 	ms.restoreSystemctl()
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	ms.udev.Restore()
-	ms.aa.Restore()
-	ms.umount.Restore()
-	ms.snapDiscardNs.Restore()
-	ms.snapSeccomp.Restore()
+	ms.restoreBackends()
 }
 
 var settleTimeout = 15 * time.Second
@@ -1983,6 +1966,8 @@ type authContextSetupSuite struct {
 
 	model  *asserts.Model
 	serial *asserts.Serial
+
+	restoreBackends func()
 }
 
 func (s *authContextSetupSuite) SetUpTest(c *C) {
@@ -2040,6 +2025,8 @@ func (s *authContextSetupSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.serial = serial.(*asserts.Serial)
 
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
+
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
 	o.InterfaceManager().DisableUDevMonitor()
@@ -2058,6 +2045,7 @@ func (s *authContextSetupSuite) SetUpTest(c *C) {
 
 func (s *authContextSetupSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
+	s.restoreBackends()
 	s.restoreTrusted()
 }
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -45,7 +46,9 @@ import (
 
 func TestOverlord(t *testing.T) { TestingT(t) }
 
-type overlordSuite struct{}
+type overlordSuite struct {
+	restoreBackends func()
+}
 
 var _ = Suite(&overlordSuite{})
 
@@ -54,10 +57,12 @@ func (ovs *overlordSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(tmpdir)
 	dirs.SnapStateFile = filepath.Join(tmpdir, "test.json")
 	snapstate.CanAutoRefresh = nil
+	ovs.restoreBackends = ifacestate.MockSecurityBackends(nil)
 }
 
 func (ovs *overlordSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	ovs.restoreBackends()
 }
 
 func (ovs *overlordSuite) TestNew(c *C) {

--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,15 +19,25 @@
 
 package backend
 
-var (
-	AddMountUnit    = addMountUnit
-	RemoveMountUnit = removeMountUnit
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
-func MockUpdateFontconfigCaches(f func() error) (restore func()) {
-	oldUpdateFontconfigCaches := updateFontconfigCaches
-	updateFontconfigCaches = f
-	return func() {
-		updateFontconfigCaches = oldUpdateFontconfigCaches
+var updateFontconfigCaches = updateFontconfigCachesImpl
+
+// updateFontconfigCaches always update the fontconfig caches
+func updateFontconfigCachesImpl() error {
+	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
+		// FIXME: also use the snapd snap if available
+		cmd, err := osutil.CommandFromCore("/bin/" + fc)
+		if err != nil {
+			return fmt.Errorf("cannot get %s from core: %v", fc, err)
+		}
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("cannot run %s on core: %v", fc, osutil.OutputErr(output, err))
+		}
 	}
+	return nil
 }

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -68,6 +68,10 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 		return err
 	}
 
+	if err := updateFontconfigCaches(); err != nil {
+		logger.Noticef("cannot update fontconfig cache: %v", err)
+	}
+
 	// XXX/TODO: this needs to be a task with proper undo and tests!
 	if model != nil && !release.OnClassic {
 		bootBase := "core"

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -68,8 +68,11 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 		return err
 	}
 
-	if err := updateFontconfigCaches(); err != nil {
-		logger.Noticef("cannot update fontconfig cache: %v", err)
+	// fontconfig is only relevant on classic
+	if release.OnClassic {
+		if err := updateFontconfigCaches(); err != nil {
+			logger.Noticef("cannot update fontconfig cache: %v", err)
+		}
 	}
 
 	// XXX/TODO: this needs to be a task with proper undo and tests!

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -311,5 +311,17 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 		c.Check(err, IsNil, Commentf(d))
 		c.Check(l, HasLen, 0, Commentf(d))
 	}
+}
 
+func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCaches(c *C) {
+	var updateFontconfigCaches int
+	restore := backend.MockUpdateFontconfigCaches(func() error {
+		updateFontconfigCaches += 1
+		return nil
+	})
+	defer restore()
+
+	err := s.be.LinkSnap(s.info, nil)
+	c.Assert(err, IsNil)
+	c.Assert(updateFontconfigCaches, Equals, 1)
 }

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
@@ -313,15 +314,25 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 	}
 }
 
-func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCaches(c *C) {
-	var updateFontconfigCaches int
-	restore := backend.MockUpdateFontconfigCaches(func() error {
-		updateFontconfigCaches += 1
-		return nil
-	})
-	defer restore()
+func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCachesClassic(c *C) {
+	for _, onClassic := range []bool{false, true} {
 
-	err := s.be.LinkSnap(s.info, nil)
-	c.Assert(err, IsNil)
-	c.Assert(updateFontconfigCaches, Equals, 1)
+		restore := release.MockOnClassic(onClassic)
+		defer restore()
+
+		var updateFontconfigCaches int
+		restore = backend.MockUpdateFontconfigCaches(func() error {
+			updateFontconfigCaches += 1
+			return nil
+		})
+		defer restore()
+
+		err := s.be.LinkSnap(s.info, nil)
+		c.Assert(err, IsNil)
+		if onClassic {
+			c.Assert(updateFontconfigCaches, Equals, 1)
+		} else {
+			c.Assert(updateFontconfigCaches, Equals, 0)
+		}
+	}
 }

--- a/tests/main/install/task.yaml
+++ b/tests/main/install/task.yaml
@@ -1,0 +1,20 @@
+summary: Check that install works
+
+# limiting to ubuntu because we need a known fonts package
+# to install so that actual caches get generated
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+
+prepare: |
+    apt install -y fonts-kiloji
+
+restore: |
+    apt autoremove -y fonts-kiloji
+
+execute: |
+    echo "With no fontconfig cache"
+    rm /var/cache/fontconfig/*
+
+    echo "Installing a snap generates a fontconfig cache"
+    snap install test-snapd-tools
+    ls /var/cache/fontconfig/*.v6
+    ls /var/cache/fontconfig/*.v7

--- a/tests/main/install/task.yaml
+++ b/tests/main/install/task.yaml
@@ -16,5 +16,5 @@ execute: |
 
     echo "Installing a snap generates a fontconfig cache"
     snap install test-snapd-tools
-    ls /var/cache/fontconfig/*.v6
-    ls /var/cache/fontconfig/*.v7
+    ls /var/cache/fontconfig/*.cache-6
+    ls /var/cache/fontconfig/*.cache-7


### PR DESCRIPTION
As an experiment: merge https://github.com/snapcore/snapd/pull/6226 into https://github.com/snapcore/snapd/pull/6218 to see if that makes a difference in the tests.