### PR TITLE
overlord/snapstate: support for pre-remove hook

### DIFF
--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -121,4 +121,5 @@ func setupHooks(hookMgr *HookManager) {
 	hookMgr.Register(regexp.MustCompile("^post-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^pre-refresh$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^remove$"), handlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^pre-remove$"), handlerGenerator)
 }

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -31,6 +31,7 @@ func init() {
 	snapstate.SetupPreRefreshHook = SetupPreRefreshHook
 	snapstate.SetupPostRefreshHook = SetupPostRefreshHook
 	snapstate.SetupRemoveHook = SetupRemoveHook
+	snapstate.SetupPreRemoveHook = SetupPreRemoveHook
 }
 
 func SetupInstallHook(st *state.State, snapName string) *state.Task {
@@ -96,6 +97,18 @@ func SetupRemoveHook(st *state.State, snapName string) *state.Task {
 	summary := fmt.Sprintf(i18n.G("Run remove hook of %q snap if present"), hooksup.Snap)
 	task := HookTask(st, summary, hooksup, nil)
 
+	return task
+}
+
+func SetupPreRemoveHook(st *state.State, snapName string) *state.Task {
+	hooksup := &HookSetup{
+		Snap:        snapName,
+		Hook:        "pre-remove",
+		Optional:    true,
+		IgnoreError: true,
+	}
+	summary := fmt.Sprintf(i18n.G("Run pre-remove hook of %q snap if present"), hooksup.Snap)
+	task := HookTask(st, summary, hooksup, nil)
 	return task
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -119,14 +119,17 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 
 	oldSetupInstallHook := snapstate.SetupInstallHook
 	oldSetupRemoveHook := snapstate.SetupRemoveHook
+	oldSetupPreRemoveHook := snapstate.SetupPreRemoveHook
 	snapstate.SetupRemoveHook = hookstate.SetupRemoveHook
 	snapstate.SetupInstallHook = hookstate.SetupInstallHook
+	snapstate.SetupPreRemoveHook = hookstate.SetupPreRemoveHook
 
 	restoreConnectRetryTimeout := ifacestate.MockConnectRetryTimeout(connectRetryTimeout)
 
 	ms.restore = func() {
 		snapstate.SetupRemoveHook = oldSetupRemoveHook
 		snapstate.SetupInstallHook = oldSetupInstallHook
+		snapstate.SetupPreRemoveHook = oldSetupPreRemoveHook
 		restoreConnectRetryTimeout()
 	}
 

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -29,6 +29,7 @@ var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^install$")),
 	NewHookType(regexp.MustCompile("^pre-refresh$")),
 	NewHookType(regexp.MustCompile("^post-refresh$")),
+	NewHookType(regexp.MustCompile("^pre-remove$")),
 	NewHookType(regexp.MustCompile("^remove$")),
 	NewHookType(regexp.MustCompile("^prepare-(?:plug|slot)-[-a-z0-9]+$")),
 	NewHookType(regexp.MustCompile("^unprepare-(?:plug|slot)-[-a-z0-9]+$")),

--- a/tests/main/install-refresh-remove-hooks/task.yaml
+++ b/tests/main/install-refresh-remove-hooks/task.yaml
@@ -2,9 +2,10 @@ summary: Check install, remove and pre-refresh/post-refresh hooks.
 
 environment:
     REMOVE_HOOK_FILE: "$HOME/snap/snap-hooks/common/remove-hook-executed"
+    PREREMOVE_HOOK_FILE: "$HOME/snap/snap-hooks/common/pre-remove-hook-executed"
 
 restore: |
-    rm -f "$REMOVE_HOOK_FILE"
+    rm -f "$REMOVE_HOOK_FILE" "$PREREMOVE_HOOK_FILE"
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh
@@ -44,15 +45,19 @@ execute: |
     snap set snap-hooks exitcode=0
     snap remove --revision=x1 snap-hooks
     if test -f "$REMOVE_HOOK_FILE"; then
-        echo "Remove hook was executed. It shouldn't."
+        echo "remove hook was executed. It shouldn't."
         exit 1
     fi
 
-    echo "Verify that remove hook is executed"
+    echo "Verify that remove and pre-remove hooks are executed"
     snap set snap-hooks exitcode=0
     snap remove snap-hooks
+    if ! test -f "$PREREMOVE_HOOK_FILE"; then
+        echo "pre-remove hook was not executed"
+        exit 1
+    fi
     if ! test -f "$REMOVE_HOOK_FILE"; then
-        echo "Remove hook was not executed"
+        echo "remove hook was not executed"
         exit 1
     fi
 


### PR DESCRIPTION
Support for `pre-remove` hook, executed before stop-snap-services (contrary to `remove` hook which runs later). This addresses https://bugs.launchpad.net/snapd/+bug/1777121

Note, the case where pre-remove hook is not run at all is covered by existing test case (that checks no hooks were run on remove with 2 revisions), so not visible in the diff.