### PR TITLE
overlord: don't write system key if security setup fails

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -122,3 +122,10 @@ func GetConnStateAttrs(conns map[string]*connState, connID string) (plugStatic, 
 func (m *IdentityMapper) SystemSnapName() string {
 	return "unknown"
 }
+
+// MockProfilesNeedRegeneration mocks the function checking if profiles need regeneration.
+func MockProfilesNeedRegeneration(fn func() bool) func() {
+	old := profilesNeedRegeneration
+	profilesNeedRegeneration = fn
+	return func() { profilesNeedRegeneration = old }
+}

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -129,3 +129,10 @@ func MockProfilesNeedRegeneration(fn func() bool) func() {
 	profilesNeedRegeneration = fn
 	return func() { profilesNeedRegeneration = old }
 }
+
+// MockWriteSystemKey mocks the function responsible for writing the system key.
+func MockWriteSystemKey(fn func() error) func() {
+	old := writeSystemKey
+	writeSystemKey = fn
+	return func() { writeSystemKey = old }
+}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -139,7 +139,7 @@ func (m *InterfaceManager) addSnaps(snaps []*snap.Info) error {
 	return nil
 }
 
-func profilesNeedRegeneration() bool {
+func profilesNeedRegenerationImpl() bool {
 	mismatch, err := interfaces.SystemKeyMismatch()
 	if err != nil {
 		logger.Noticef("error trying to compare the snap system key: %v", err)
@@ -147,6 +147,8 @@ func profilesNeedRegeneration() bool {
 	}
 	return mismatch
 }
+
+var profilesNeedRegeneration = profilesNeedRegenerationImpl
 
 // regenerateAllSecurityProfiles will regenerate all security profiles.
 func (m *InterfaceManager) regenerateAllSecurityProfiles() error {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -149,6 +149,7 @@ func profilesNeedRegenerationImpl() bool {
 }
 
 var profilesNeedRegeneration = profilesNeedRegenerationImpl
+var writeSystemKey = interfaces.WriteSystemKey
 
 // regenerateAllSecurityProfiles will regenerate all security profiles.
 func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
@@ -199,7 +200,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 	}
 
 	if shouldWriteSystemKey {
-		if err := interfaces.WriteSystemKey(); err != nil {
+		if err := writeSystemKey(); err != nil {
 			logger.Noticef("cannot write system key: %v", err)
 		}
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -168,7 +168,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
-	writeSystemKey := true
+	shouldWriteSystemKey := true
 	os.Remove(dirs.SnapSystemKeyFile)
 
 	// For each snap:
@@ -193,12 +193,12 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 				// Let's log this but carry on without writing the system key.
 				logger.Noticef("cannot regenerate %s profile for snap %q: %s",
 					backend.Name(), snapName, err)
-				writeSystemKey = false
+				shouldWriteSystemKey = false
 			}
 		}
 	}
 
-	if writeSystemKey {
+	if shouldWriteSystemKey {
 		if err := interfaces.WriteSystemKey(); err != nil {
 			logger.Noticef("cannot write system key: %v", err)
 		}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -76,7 +76,7 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 	if _, err := m.reloadConnections(""); err != nil {
 		return err
 	}
-	if m.profilesNeedRegeneration() {
+	if profilesNeedRegeneration() {
 		if err := m.regenerateAllSecurityProfiles(); err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func (m *InterfaceManager) addSnaps(snaps []*snap.Info) error {
 	return nil
 }
 
-func (m *InterfaceManager) profilesNeedRegeneration() bool {
+func profilesNeedRegeneration() bool {
 	mismatch, err := interfaces.SystemKeyMismatch()
 	if err != nil {
 		logger.Noticef("error trying to compare the snap system key: %v", err)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -169,6 +169,13 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
+	// The reason the system key is unlinked is to prevent snapd from believing
+	// that an old system key is valid and represents security setup
+	// established in the system. If snapd is reverted following a failed
+	// startup then system key may match the system key that used to be on disk
+	// but some of the system security may have been changed by the new snapd,
+	// the one that was reverted. Unlinking avoids such possibility, forcing
+	// old snapd to re-establish proper security view.
 	shouldWriteSystemKey := true
 	os.Remove(dirs.SnapSystemKeyFile)
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -20,16 +20,26 @@
 package ifacestate_test
 
 import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type helpersSuite struct {
@@ -332,4 +342,72 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithSnapd(c *C) {
 	s.st.Unlock()
 
 	c.Assert(ifacestate.CheckSystemSnapIsPresent(s.st), Equals, true)
+}
+
+// Check what happens with system-key when security profile regeneration fails.
+func (s *helpersSuite) TestSystemKeyAndFailingProfileRegeneration(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	// Create a fake security backend with failing Setup method and mock all
+	// security backends away so that we only use this special one. Note that
+	// the backend is given a non-empty name as the interface manager skips
+	// test backends with empty name for convenience.
+	backend := &ifacetest.TestSecurityBackend{
+		BackendName: "BROKEN",
+		SetupCallback: func(snapInfo *snap.Info, opts interfaces.ConfinementOptions, repo *interfaces.Repository) error {
+			return errors.New("cannot setup security profile")
+		},
+	}
+	restore := ifacestate.MockSecurityBackends([]interfaces.SecurityBackend{backend})
+	defer restore()
+
+	// Create a mock overlord, mainly to have state.
+	ovld := overlord.Mock()
+	st := ovld.State()
+
+	// Put a fake snap in the state, we need to setup security for at least one
+	// snap to give the fake security backend a chance to fail.
+	yamlText := `
+name: test-snapd-canary
+version: 1
+apps:
+  test-snapd-canary:
+    command: bin/canary
+`
+	si := &snap.SideInfo{Revision: snap.R(1), RealName: "test-snapd-canary"}
+	snapInfo := snaptest.MockSnap(c, yamlText, si)
+	st.Lock()
+	snapst := &snapstate.SnapState{
+		SnapType: string(snap.TypeApp),
+		Sequence: []*snap.SideInfo{si},
+		Active:   true,
+		Current:  snap.R(1),
+	}
+	snapstate.Set(st, snapInfo.InstanceName(), snapst)
+	st.Unlock()
+
+	// Pretend that security profiles are out of date and mock the
+	// function that writes the new system key with one always panics.
+	restore = ifacestate.MockProfilesNeedRegeneration(func() bool { return true })
+	defer restore()
+	restore = ifacestate.MockWriteSystemKey(func() error { panic("system key should not be written") })
+	defer restore()
+	// Put a fake system key in place, we just want to see that file being removed.
+	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte("system-key"), 0755)
+	c.Assert(err, IsNil)
+
+	// Put up a fake logger to capture logged messages.
+	log, restore := logger.MockLogger()
+	defer restore()
+
+	// Construct the interface manager.
+	_, err = ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	c.Assert(err, IsNil)
+
+	// Check that system key is not on disk.
+	c.Check(log.String(), testutil.Contains, `cannot regenerate BROKEN profile for snap "test-snapd-canary": cannot setup security profile`)
+	c.Check(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 }

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -391,7 +391,7 @@ apps:
 	// function that writes the new system key with one always panics.
 	restore = ifacestate.MockProfilesNeedRegeneration(func() bool { return true })
 	defer restore()
-	restore = ifacestate.MockWriteSystemKey(func() error { panic("system key should not be written") })
+	restore = ifacestate.MockWriteSystemKey(func() error { panic("should not attempt to write system key") })
 	defer restore()
 	// Put a fake system key in place, we just want to see that file being removed.
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)

--- a/tests/regression/lp-1805838/task.yaml
+++ b/tests/regression/lp-1805838/task.yaml
@@ -1,0 +1,26 @@
+summary: system key is not written if security setup fails
+details: |
+    When snapd is started up and the system key needs regeneration errors from
+    establishing the new security profiles should not stop snapd from running
+    but should prevent snapd from writing the system key.
+prepare: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    mount --bind /bin/false "$LIBEXECDIR/snapd/snap-seccomp"
+    test -d "$SNAP_MOUNT_DIR/core" && mount --bind /bin/false "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-seccomp"
+    test -d "$SNAP_MOUNT_DIR/snapd" && mount --bind /bin/false "$SNAP_MOUNT_DIR/snapd/current/usr/lib/snapd/snap-seccomp"
+    mv /var/lib/snapd/system-key /var/lib/snapd/system-key.orig
+    echo '{}' > /var/lib/snapd/system-key
+restore: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    umount "$LIBEXECDIR/snapd/snap-seccomp" || true
+    test -d "$SNAP_MOUNT_DIR/core" && ( umount "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-seccomp" || true )
+    test -d "$SNAP_MOUNT_DIR/snapd" && ( umount "$SNAP_MOUNT_DIR/snapd/current/usr/lib/snapd/snap-seccomp" || true )
+    mv /var/lib/snapd/system-key.orig /var/lib/snapd/system-key || true
+execute: |
+    systemctl stop snapd.socket snapd.service
+    systemctl start snapd.socket snapd.service
+    journalctl -u snapd | MATCH 'cannot regenerate seccomp profile for snap "(core|snapd|test-snapd-rsync-core18)"'
+    snap list | MATCH "(core|snapd)"
+    test ! -e /var/lib/snapd/system-key


### PR DESCRIPTION
Currently the snapd interface manager, when starting the overlord,
computes and compares the system key with the one on disk. If the system
key is absent or differs then all security profiles are re-generated.

We found out that restarting snapd can kill snap-seccomp or
apparmor-parser running in the same systemd service control group. We
have observed system traces using forkstat and strace on pid 1 (systemd)
that indicate that exact thing occurring.

When a security profile regeneration fails it the failure is logged but
otherwise ignored. This can mean that we have attempted to compile an
apparmor or seccomp profile, failed, but carried on anyway and *wrote
the system key*. When this happens, on the next startup of snapd the
system key will match but the security setup will be incomplete.

This patch changes that logic as follows. When system key mismatch is
detected then the old system key is immediately unlinked. Profile
re-generation proceeds. Errors are logged but they do not prevent snapd
form starting up. This is done so that snapd can, if all else fails,
refresh or revert itself. If any error occurs the system key is *not*
written. This means that on next startup the procedure will be attempted
again.

The reason the system key is unlinked is to prevent snapd from believing
that an old system key is valid and represents security setup
established in the system. If snapd is reverted following a failed
startup then system key may match the system key that used to be on disk
but some of the system security may have been changed by the new snapd,
the one that was reverted. Unlinking avoids such possibility, forcing
old snapd to re-establish proper security view.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
