### PR TITLE
overlord: don't write system key if security setup fails (2.36)

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -23,9 +23,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
@@ -163,6 +165,9 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
+	writeSystemKey := true
+	os.Remove(dirs.SnapSystemKeyFile)
+
 	// For each snap:
 	for _, snapInfo := range snaps {
 		snapName := snapInfo.InstanceName()
@@ -182,15 +187,18 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 			}
 			// Refresh security of this snap and backend
 			if err := backend.Setup(snapInfo, opts, m.repo); err != nil {
-				// Let's log this but carry on
+				// Let's log this but carry on without writing the system key.
 				logger.Noticef("cannot regenerate %s profile for snap %q: %s",
 					backend.Name(), snapName, err)
+				writeSystemKey = false
 			}
 		}
 	}
 
-	if err := interfaces.WriteSystemKey(); err != nil {
-		logger.Noticef("cannot write system key: %v", err)
+	if writeSystemKey {
+		if err := interfaces.WriteSystemKey(); err != nil {
+			logger.Noticef("cannot write system key: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Currently the snapd interface manager, when starting the overlord,
computes and compares the system key with the one on disk. If the system
key is absent or differs then all security profiles are re-generated.

We found out that restarting systemd can kill snap-seccomp or
apparmor-parser running in the same systemd service control group. We
have observed system traces using forkstat and strace on pid 1 (systemd)
that indicate that exact thing occurring.

When a security profile regeneration fails it the failure is logged but
otherwise ignored. This can mean that we have attempted to compile an
apparmor or seccomp profile, failed, but carried on anyway and *wrote
the system key*. When this happens, on the next startup of snapd the
system key will match but the security setup will be incomplete.

This patch changes that logic as follows. When system key mismatch is
detected then the old system key is immediately unlinked. Profile
re-generation proceeds. Errors are logged but they do not prevent snapd
form starting up. This is done so that snapd can, if all else fails,
refresh or revert itself. If any error occurs the system key is *not*
written. This means that on next startup the procedure will be attempted
again.

The reason the system key is unlinked is to prevent snapd from believing
that an old system key is valid and represents security setup
established in the system. If snapd is reverted following a failed
startup then system key may match the system key that used to be on disk
but some of the system security may have been changed by the new snapd,
the one that was reverted. Unlinking avoids such possibility, forcing
old snapd to re-establish proper security view.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
