### PR TITLE
client, store: don't use store from client (use client from store)

### DIFF
--- a/client/buy.go
+++ b/client/buy.go
@@ -22,13 +22,23 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-
-	"github.com/snapcore/snapd/store"
 )
 
-func (client *Client) Buy(opts *store.BuyOptions) (*store.BuyResult, error) {
+// BuyOptions specifies parameters to buy from the store.
+type BuyOptions struct {
+	SnapID   string  `json:"snap-id"`
+	Price    float64 `json:"price"`
+	Currency string  `json:"currency"` // ISO 4217 code as string
+}
+
+// BuyResult holds the state of a buy attempt.
+type BuyResult struct {
+	State string `json:"state,omitempty"`
+}
+
+func (client *Client) Buy(opts *BuyOptions) (*BuyResult, error) {
 	if opts == nil {
-		opts = &store.BuyOptions{}
+		opts = &BuyOptions{}
 	}
 
 	var body bytes.Buffer
@@ -36,7 +46,7 @@ func (client *Client) Buy(opts *store.BuyOptions) (*store.BuyResult, error) {
 		return nil, err
 	}
 
-	var result store.BuyResult
+	var result BuyResult
 	_, err := client.doSync("POST", "/v2/buy", nil, nil, &body, &result)
 
 	if err != nil {

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/store"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -76,7 +75,7 @@ func buySnap(cli *client.Client, snapName string) error {
 		return err
 	}
 
-	opts := &store.BuyOptions{
+	opts := &client.BuyOptions{
 		SnapID:   snap.ID,
 		Currency: resultInfo.SuggestedCurrency,
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2552,7 +2552,7 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 func postBuy(c *Command, r *http.Request, user *auth.UserState) Response {
-	var opts store.BuyOptions
+	var opts client.BuyOptions
 
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&opts)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -90,8 +90,8 @@ type apiBaseSuite struct {
 	restoreBackends   func()
 	currentSnaps      []*store.CurrentSnap
 	actions           []*store.SnapAction
-	buyOptions        *store.BuyOptions
-	buyResult         *store.BuyResult
+	buyOptions        *client.BuyOptions
+	buyResult         *client.BuyResult
 	storeSigning      *assertstest.StoreStack
 	restoreRelease    func()
 	trustedRestorer   func()
@@ -163,7 +163,7 @@ func (s *apiBaseSuite) SuggestedCurrency() string {
 	return s.suggestedCurrency
 }
 
-func (s *apiBaseSuite) Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error) {
+func (s *apiBaseSuite) Buy(options *client.BuyOptions, user *auth.UserState) (*client.BuyResult, error) {
 	s.pokeStateLock()
 
 	s.buyOptions = options
@@ -5242,7 +5242,7 @@ const validBuyInput = `{
 		  "currency": "EUR"
 		}`
 
-var validBuyOptions = &store.BuyOptions{
+var validBuyOptions = &client.BuyOptions{
 	SnapID:   "the-snap-id-1234abcd",
 	Price:    1.23,
 	Currency: "EUR",
@@ -5250,21 +5250,21 @@ var validBuyOptions = &store.BuyOptions{
 
 var buyTests = []struct {
 	input                string
-	result               *store.BuyResult
+	result               *client.BuyResult
 	err                  error
 	expectedStatus       int
 	expectedResult       interface{}
 	expectedResponseType ResponseType
-	expectedBuyOptions   *store.BuyOptions
+	expectedBuyOptions   *client.BuyOptions
 }{
 	{
 		// Success
 		input: validBuyInput,
-		result: &store.BuyResult{
+		result: &client.BuyResult{
 			State: "Complete",
 		},
 		expectedStatus: 200,
-		expectedResult: &store.BuyResult{
+		expectedResult: &client.BuyResult{
 			State: "Complete",
 		},
 		expectedResponseType: ResponseTypeSync,
@@ -5283,7 +5283,7 @@ var buyTests = []struct {
 		expectedResult: &errorResult{
 			Message: "internal error banana",
 		},
-		expectedBuyOptions: &store.BuyOptions{
+		expectedBuyOptions: &client.BuyOptions{
 			SnapID:   "the-snap-id-1234abcd",
 			Price:    1.23,
 			Currency: "EUR",

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
@@ -47,7 +48,7 @@ type StoreService interface {
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 
 	SuggestedCurrency() string
-	Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error)
+	Buy(options *client.BuyOptions, user *auth.UserState) (*client.BuyResult, error)
 	ReadyToBuy(*auth.UserState) error
 	ConnectivityCheck() (map[string]bool, error)
 

--- a/store/store.go
+++ b/store/store.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
@@ -1742,18 +1743,6 @@ func (s *Store) SuggestedCurrency() string {
 	return s.suggestedCurrency
 }
 
-// BuyOptions specifies parameters to buy from the store.
-type BuyOptions struct {
-	SnapID   string  `json:"snap-id"`
-	Price    float64 `json:"price"`
-	Currency string  `json:"currency"` // ISO 4217 code as string
-}
-
-// BuyResult holds the state of a buy attempt.
-type BuyResult struct {
-	State string `json:"state,omitempty"`
-}
-
 // orderInstruction holds data sent to the store for orders.
 type orderInstruction struct {
 	SnapID   string `json:"snap_id"`
@@ -1788,13 +1777,13 @@ func (s *storeErrors) Error() string {
 	return s.Errors[0].Error()
 }
 
-func buyOptionError(message string) (*BuyResult, error) {
+func buyOptionError(message string) (*client.BuyResult, error) {
 	return nil, fmt.Errorf("cannot buy snap: %s", message)
 }
 
 // Buy sends a buy request for the specified snap.
 // Returns the state of the order: Complete, Cancelled.
-func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, error) {
+func (s *Store) Buy(options *client.BuyOptions, user *auth.UserState) (*client.BuyResult, error) {
 	if options.SnapID == "" {
 		return buyOptionError("snap ID missing")
 	}
@@ -1841,7 +1830,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 			return buyOptionError("payment cancelled")
 		}
 
-		return &BuyResult{
+		return &client.BuyResult{
 			State: orderDetails.State,
 		}, nil
 	case 400:

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/advisor"
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
@@ -3548,7 +3549,7 @@ var buyTests = []struct {
 	snapID            string
 	price             float64
 	currency          string
-	expectedResult    *store.BuyResult
+	expectedResult    *client.BuyResult
 	expectedError     string
 }{
 	{
@@ -3556,7 +3557,7 @@ var buyTests = []struct {
 		suggestedCurrency: "EUR",
 		expectedInput:     `{"snap_id":"` + helloWorldSnapID + `","amount":"0.99","currency":"EUR"}`,
 		buyResponse:       mockOrderResponseJSON,
-		expectedResult:    &store.BuyResult{State: "Complete"},
+		expectedResult:    &client.BuyResult{State: "Complete"},
 	},
 	{
 		// failure due to invalid price
@@ -3633,7 +3634,7 @@ func (s *storeTestSuite) TestBuy500(c *C) {
 	}
 	sto := store.New(&cfg, authContext)
 
-	buyOptions := &store.BuyOptions{
+	buyOptions := &client.BuyOptions{
 		SnapID:   helloWorldSnapID,
 		Currency: "USD",
 		Price:    1,
@@ -3713,7 +3714,7 @@ func (s *storeTestSuite) TestBuy(c *C) {
 		c.Assert(snap, NotNil)
 		c.Assert(err, IsNil)
 
-		buyOptions := &store.BuyOptions{
+		buyOptions := &client.BuyOptions{
 			SnapID:   snap.SnapID,
 			Currency: sto.SuggestedCurrency(),
 			Price:    snap.Prices[sto.SuggestedCurrency()],
@@ -3747,7 +3748,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	sto := store.New(&store.Config{}, nil)
 
 	// no snap ID
-	result, err := sto.Buy(&store.BuyOptions{
+	result, err := sto.Buy(&client.BuyOptions{
 		Price:    1.0,
 		Currency: "USD",
 	}, s.user)
@@ -3756,7 +3757,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	c.Check(err.Error(), Equals, "cannot buy snap: snap ID missing")
 
 	// no price
-	result, err = sto.Buy(&store.BuyOptions{
+	result, err = sto.Buy(&client.BuyOptions{
 		SnapID:   "snap ID",
 		Currency: "USD",
 	}, s.user)
@@ -3765,7 +3766,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	c.Check(err.Error(), Equals, "cannot buy snap: invalid expected price")
 
 	// no currency
-	result, err = sto.Buy(&store.BuyOptions{
+	result, err = sto.Buy(&client.BuyOptions{
 		SnapID: "snap ID",
 		Price:  1.0,
 	}, s.user)
@@ -3774,7 +3775,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	c.Check(err.Error(), Equals, "cannot buy snap: currency missing")
 
 	// no user
-	result, err = sto.Buy(&store.BuyOptions{
+	result, err = sto.Buy(&client.BuyOptions{
 		SnapID:   "snap ID",
 		Price:    1.0,
 		Currency: "USD",

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/progress"
@@ -61,7 +62,7 @@ func (Store) SuggestedCurrency() string {
 	panic("Store.SuggestedCurrency not expected")
 }
 
-func (Store) Buy(*store.BuyOptions, *auth.UserState) (*store.BuyResult, error) {
+func (Store) Buy(*client.BuyOptions, *auth.UserState) (*client.BuyResult, error) {
 	panic("Store.Buy not expected")
 }
 


### PR DESCRIPTION
This moves the definition of BuyOptions and BuyResult from store to
client, and inverts the dependency.

The dependency graph goes from

![dependency graph before the refactor](https://r.chipaca.com/client_before.png)

to

![dependency graph after the refactor](https://r.chipaca.com/client_after.png)

(everything there is probably OK for "client" 🙌