### PR TITLE
overlord/snapstate: use file timestamp to initialize timer

### DIFF
--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -56,8 +56,15 @@ func (r *catalogRefresh) Ensure() error {
 		return nil
 	}
 
-	theStore := Store(r.state)
 	now := time.Now()
+	if r.nextCatalogRefresh.IsZero() {
+		// try to use the timestamp on the sections file
+		if st, err := os.Stat(dirs.SnapSectionsFile); err == nil && st.ModTime().Before(now) {
+			r.nextCatalogRefresh = st.ModTime().Add(catalogRefreshDelay)
+		}
+	}
+
+	theStore := Store(r.state)
 	needsRefresh := r.nextCatalogRefresh.IsZero() || r.nextCatalogRefresh.Before(now)
 
 	if !needsRefresh {

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -21,6 +21,9 @@ package snapstate_test
 
 import (
 	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/net/context"
@@ -120,4 +123,29 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshNotNeeded(c *C) {
 	c.Check(s.store.ops, HasLen, 0)
 	c.Check(osutil.FileExists(dirs.SnapSectionsFile), Equals, false)
 	c.Check(osutil.FileExists(dirs.SnapNamesFile), Equals, false)
+}
+
+func (s *catalogRefreshTestSuite) TestCatalogRefreshNewEnough(c *C) {
+	// write a fake sections file just to have it
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapSectionsFile), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.SnapSectionsFile, nil, 0644), IsNil)
+
+	cr7 := snapstate.NewCatalogRefresh(s.state)
+	err := cr7.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 0)
+}
+
+func (s *catalogRefreshTestSuite) TestCatalogRefreshTooNew(c *C) {
+	// write a fake sections file just to have it
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapSectionsFile), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.SnapSectionsFile, nil, 0644), IsNil)
+	// but set the timestamp in the future
+	t := time.Now().Add(time.Hour)
+	c.Assert(os.Chtimes(dirs.SnapSectionsFile, t, t), IsNil)
+
+	cr7 := snapstate.NewCatalogRefresh(s.state)
+	err := cr7.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, DeepEquals, []string{"sections", "write-catalog"})
 }


### PR DESCRIPTION
Without this change, the catalog refresh wass done every time snapd
started. Usually not too bad, but in tests or dev it could get
onerous.

This change makes it so that the time of the last catalog refresh is
initialized from the timestamp of the sections file, which is a
sensible lower bound for the last time the catalog refresh was done
(unless the system clock is broken -- against which we protect by
ignoring times that are in the future).
