### PR TITLE
systemd: allow only a single daemon-reload at the same time

### DIFF
--- a/overlord/snapstate/backend/aliases.go
+++ b/overlord/snapstate/backend/aliases.go
@@ -38,7 +38,7 @@ type Alias struct {
 // MatchingAliases returns the subset of aliases that exist on disk and have the expected targets.
 
 // UpdateAliases adds and removes the given aliases.
-func (b Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
+func (b *Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
 	removed := make(map[string]bool, len(remove))
 	for _, alias := range remove {
 		err := os.Remove(filepath.Join(dirs.SnapBinariesDir, alias.Name))
@@ -76,7 +76,7 @@ func (b Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
 }
 
 // RemoveSnapAliases removes all the aliases targeting the given snap.
-func (b Backend) RemoveSnapAliases(snapName string) error {
+func (b *Backend) RemoveSnapAliases(snapName string) error {
 	removeSymlinksTo(dirs.CompletersDir, snapName)
 	return removeSymlinksTo(dirs.SnapBinariesDir, snapName)
 }

--- a/overlord/snapstate/backend/backend.go
+++ b/overlord/snapstate/backend/backend.go
@@ -21,11 +21,18 @@
 package backend
 
 import (
+	"sync"
+
 	"github.com/snapcore/snapd/snap"
 )
 
 // Backend exposes all the low-level primitives to manage snaps and their installation on disk.
-type Backend struct{}
+type Backend struct {
+	// mountLock ensures there is only a single concurrent mountunit
+	// operation. This works around this systemd bug:
+	//   https://github.com/systemd/systemd/issues/10872
+	mountLock sync.Mutex
+}
 
 // Candidate is a test hook.
 func (b Backend) Candidate(*snap.SideInfo) {}

--- a/overlord/snapstate/backend/backend.go
+++ b/overlord/snapstate/backend/backend.go
@@ -35,10 +35,10 @@ type Backend struct {
 }
 
 // Candidate is a test hook.
-func (b Backend) Candidate(*snap.SideInfo) {}
+func (b *Backend) Candidate(*snap.SideInfo) {}
 
 // CurrentInfo is a test hook.
-func (b Backend) CurrentInfo(*snap.Info) {}
+func (b *Backend) CurrentInfo(*snap.Info) {}
 
 // OpenSnapFile opens a snap blob returning both a snap.Info completed
 // with sideInfo (if not nil) and a corresponding snap.Container.

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CopySnapData makes a copy of oldSnap data for newSnap in its data directories.
-func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error {
+func (b *Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error {
 	// deal with the old data or
 	// otherwise just create a empty data dir
 
@@ -57,7 +57,7 @@ func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter)
 }
 
 // UndoCopySnapData removes the copy that may have been done for newInfo snap of oldInfo snap data and also the data directories that may have been created for newInfo snap.
-func (b Backend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.Info, meter progress.Meter) error {
+func (b *Backend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.Info, meter progress.Meter) error {
 	if oldInfo != nil && oldInfo.Revision == newInfo.Revision {
 		// nothing to do
 		return nil
@@ -85,7 +85,7 @@ func (b Backend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.Info, meter 
 }
 
 // ClearTrashedData removes the trash. It returns no errors on the assumption that it is called very late in the game.
-func (b Backend) ClearTrashedData(oldSnap *snap.Info) {
+func (b *Backend) ClearTrashedData(oldSnap *snap.Info) {
 	dirs, err := snapDataDirs(oldSnap)
 	if err != nil {
 		logger.Noticef("Cannot remove previous data for %q: %v", oldSnap.InstanceName(), err)

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 type copydataSuite struct {
-	be      backend.Backend
+	be      *backend.Backend
 	tempdir string
 }
 

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -19,10 +19,18 @@
 
 package backend
 
-var (
-	AddMountUnit    = addMountUnit
-	RemoveMountUnit = removeMountUnit
+import (
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
 )
+
+func (b *Backend) AddMountUnit(s *snap.Info, meter progress.Meter) error {
+	return b.addMountUnit(s, meter)
+}
+
+func (b *Backend) RemoveMountUnit(baseDir string, meter progress.Meter) error {
+	return b.removeMountUnit(baseDir, meter)
+}
 
 func MockUpdateFontconfigCaches(f func() error) (restore func()) {
 	oldUpdateFontconfigCaches := updateFontconfigCaches

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -59,7 +59,7 @@ func updateCurrentSymlinks(info *snap.Info) error {
 }
 
 // LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
-func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
+func (b *Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 	if info.Revision.Unset() {
 		return fmt.Errorf("cannot link snap %q with unset revision", info.InstanceName())
 	}
@@ -93,11 +93,11 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model) error {
 	return updateCurrentSymlinks(info)
 }
 
-func (b Backend) StartServices(apps []*snap.AppInfo, meter progress.Meter) error {
+func (b *Backend) StartServices(apps []*snap.AppInfo, meter progress.Meter) error {
 	return wrappers.StartServices(apps, meter)
 }
 
-func (b Backend) StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter) error {
+func (b *Backend) StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter) error {
 	return wrappers.StopServices(apps, reason, meter)
 }
 
@@ -141,7 +141,7 @@ func removeGeneratedWrappers(s *snap.Info, meter progress.Meter) error {
 }
 
 // UnlinkSnap makes the snap unavailable to the system removing wrappers and symlinks.
-func (b Backend) UnlinkSnap(info *snap.Info, meter progress.Meter) error {
+func (b *Backend) UnlinkSnap(info *snap.Info, meter progress.Meter) error {
 	// remove generated services, binaries etc
 	err1 := removeGeneratedWrappers(info, meter)
 

--- a/overlord/snapstate/backend/mountns.go
+++ b/overlord/snapstate/backend/mountns.go
@@ -24,6 +24,6 @@ import (
 )
 
 // Discard the mount namespace of a given snap.
-func (b Backend) DiscardSnapNamespace(snapName string) error {
+func (b *Backend) DiscardSnapNamespace(snapName string) error {
 	return mount.DiscardSnapNamespace(snapName)
 }

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -36,9 +35,9 @@ import (
 // addMountUnit adds a new mount unit for the given snap "s". It requires
 // a lock that ensures there is only a single concurrent operation that
 // manipulates mount units (see https://github.com/systemd/systemd/issues/10872)
-func addMountUnit(s *snap.Info, meter progress.Meter, lock *sync.Mutex) error {
-	lock.Lock()
-	defer lock.Unlock()
+func (b *Backend) addMountUnit(s *snap.Info, meter progress.Meter) error {
+	b.mountLock.Lock()
+	defer b.mountLock.Unlock()
 
 	squashfsPath := dirs.StripRootDir(s.MountFile())
 	whereDir := dirs.StripRootDir(s.MountDir())
@@ -65,9 +64,9 @@ func addMountUnit(s *snap.Info, meter progress.Meter, lock *sync.Mutex) error {
 // removeMountUnit removes the mount unit for the given baseDir. It requires
 // a lock that ensures there is only a single concurrent operation that
 // manipulates mount units (see https://github.com/systemd/systemd/issues/10872)
-func removeMountUnit(baseDir string, meter progress.Meter, lock *sync.Mutex) error {
-	lock.Lock()
-	defer lock.Unlock()
+func (b *Backend) removeMountUnit(baseDir string, meter progress.Meter) error {
+	b.mountLock.Lock()
+	defer b.mountLock.Unlock()
 
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
 	unit := systemd.MountUnitPath(dirs.StripRootDir(baseDir))

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -33,11 +33,11 @@ import (
 	"github.com/snapcore/snapd/systemd"
 )
 
-var GIL = &sync.Mutex{}
+var GML = &sync.Mutex{}
 
 func addMountUnit(s *snap.Info, meter progress.Meter) error {
-	GIL.Lock()
-	defer GIL.Unlock()
+	GML.Lock()
+	defer GML.Unlock()
 
 	squashfsPath := dirs.StripRootDir(s.MountFile())
 	whereDir := dirs.StripRootDir(s.MountDir())
@@ -62,8 +62,8 @@ func addMountUnit(s *snap.Info, meter progress.Meter) error {
 }
 
 func removeMountUnit(baseDir string, meter progress.Meter) error {
-	GIL.Lock()
-	defer GIL.Unlock()
+	GML.Lock()
+	defer GML.Unlock()
 
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
 	unit := systemd.MountUnitPath(dirs.StripRootDir(baseDir))

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -120,27 +120,3 @@ func (s *mountunitSuite) TestRemoveMountUnit(c *C) {
 	p = filepath.Join(dirs.SnapServicesDir, un)
 	c.Assert(osutil.FileExists(p), Equals, false)
 }
-
-func (s *mountunitSuite) TestAddMountUnitLocks(c *C) {
-	info := &snap.Info{
-		SideInfo: snap.SideInfo{
-			RealName: "foo",
-			Revision: snap.R(13),
-		},
-		Version:       "1.1",
-		Architectures: []string{"all"},
-	}
-
-	// created a locked mutex
-	lock := sync.Mutex{}
-	lock.Lock()
-
-	// run AddMountUnit and ensure it does not run until the lock is
-	// released
-	doneCh := make(chan bool, 1)
-	go func() {
-		backend.AddMountUnit(info, progress.Null, lock)
-		close(doneCh)
-	}()
-
-}

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -69,7 +69,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 	}
 
 	// generate the mount unit for the squashfs
-	if err := addMountUnit(s, meter); err != nil {
+	if err := addMountUnit(s, meter, &b.mountLock); err != nil {
 		return snapType, err
 	}
 
@@ -87,7 +87,7 @@ func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progress
 	mountDir := s.MountDir()
 
 	// this also ensures that the mount unit stops
-	if err := removeMountUnit(mountDir, meter); err != nil {
+	if err := removeMountUnit(mountDir, meter, &b.mountLock); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -69,7 +69,7 @@ func (b *Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Si
 	}
 
 	// generate the mount unit for the squashfs
-	if err := addMountUnit(s, meter, &b.mountLock); err != nil {
+	if err := b.addMountUnit(s, meter); err != nil {
 		return snapType, err
 	}
 
@@ -87,7 +87,7 @@ func (b *Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progres
 	mountDir := s.MountDir()
 
 	// this also ensures that the mount unit stops
-	if err := removeMountUnit(mountDir, meter, &b.mountLock); err != nil {
+	if err := b.removeMountUnit(mountDir, meter); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -30,7 +30,7 @@ import (
 )
 
 // SetupSnap does prepare and mount the snap for further processing.
-func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, meter progress.Meter) (snapType snap.Type, err error) {
+func (b *Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, meter progress.Meter) (snapType snap.Type, err error) {
 	// This assumes that the snap was already verified or --dangerous was used.
 
 	s, snapf, oErr := OpenSnapFile(snapFilePath, sideInfo)
@@ -83,7 +83,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 }
 
 // RemoveSnapFiles removes the snap files from the disk after unmounting the snap.
-func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progress.Meter) error {
+func (b *Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progress.Meter) error {
 	mountDir := s.MountDir()
 
 	// this also ensures that the mount unit stops
@@ -114,7 +114,7 @@ func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progress
 	return nil
 }
 
-func (b Backend) RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error {
+func (b *Backend) RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error {
 	mountDir := s.MountDir()
 
 	snapName, instanceKey := snap.SplitInstanceName(s.InstanceName())
@@ -132,6 +132,6 @@ func (b Backend) RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error {
 }
 
 // UndoSetupSnap undoes the work of SetupSnap using RemoveSnapFiles.
-func (b Backend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, meter progress.Meter) error {
+func (b *Backend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, meter progress.Meter) error {
 	return b.RemoveSnapFiles(s, typ, meter)
 }

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -33,7 +33,7 @@ import (
 )
 
 // RemoveSnapData removes the data for the given version of the given snap.
-func (b Backend) RemoveSnapData(snap *snap.Info) error {
+func (b *Backend) RemoveSnapData(snap *snap.Info) error {
 	dirs, err := snapDataDirs(snap)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (b Backend) RemoveSnapData(snap *snap.Info) error {
 }
 
 // RemoveSnapCommonData removes the data common between versions of the given snap.
-func (b Backend) RemoveSnapCommonData(snap *snap.Info) error {
+func (b *Backend) RemoveSnapCommonData(snap *snap.Info) error {
 	dirs, err := snapCommonDataDirs(snap)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func (b Backend) RemoveSnapCommonData(snap *snap.Info) error {
 }
 
 // RemoveSnapDataDir removes base snap data directory
-func (b Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error {
+func (b *Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error {
 	if info.InstanceKey != "" {
 		// data directories of snaps with instance key are never used by
 		// other instances
@@ -72,7 +72,7 @@ func (b Backend) RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) erro
 	return nil
 }
 
-func (b Backend) untrashData(snap *snap.Info) error {
+func (b *Backend) untrashData(snap *snap.Info) error {
 	dirs, err := snapDataDirs(snap)
 	if err != nil {
 		return err

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -323,7 +323,7 @@ func Store(st *state.State) StoreService {
 func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	m := &SnapManager{
 		state:          st,
-		backend:        backend.Backend{},
+		backend:        &backend.Backend{},
 		autoRefresh:    newAutoRefresh(st),
 		refreshHints:   newRefreshHints(st),
 		catalogRefresh: newCatalogRefresh(st),


### PR DESCRIPTION
This is an experiment to see if the "mount protocol error" reported in https://github.com/systemd/systemd/issues/10872 can be worked around by serializing the mount unit adding/removal. Proposing to get full spread runs.