### PR TITLE
release: detect too old apparmor_parser

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -522,7 +522,8 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 		case "###PROFILEATTACH###":
 			return fmt.Sprintf("profile \"%s\"", securityTag)
 		case "###CHANGEPROFILE_RULE###":
-			for _, f := range parserFeatures() {
+			features, _ := parserFeatures()
+			for _, f := range features {
 				if f == "unsafe" {
 					return fmt.Sprintf("change_profile unsafe /**,")
 				}
@@ -587,7 +588,7 @@ func (b *Backend) SandboxFeatures() []string {
 	}
 
 	features := kernelFeatures()
-	pFeatures := parserFeatures()
+	pFeatures, _ := parserFeatures()
 	tags := make([]string, 0, len(features)+len(pFeatures))
 	for _, feature := range features {
 		// Prepend "kernel:" to apparmor kernel features to namespace them and

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -60,7 +60,7 @@ var (
 	procSelfExe           = "/proc/self/exe"
 	isHomeUsingNFS        = osutil.IsHomeUsingNFS
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
-	kernelFeatures        = release.AppArmorFeatures
+	kernelFeatures        = release.AppArmorKernelFeatures
 	parserFeatures        = release.AppArmorParserFeatures
 )
 
@@ -587,10 +587,10 @@ func (b *Backend) SandboxFeatures() []string {
 		return nil
 	}
 
-	features := kernelFeatures()
+	kFeatures, _ := kernelFeatures()
 	pFeatures, _ := parserFeatures()
-	tags := make([]string, 0, len(features)+len(pFeatures))
-	for _, feature := range features {
+	tags := make([]string, 0, len(kFeatures)+len(pFeatures))
+	for _, feature := range kFeatures {
 		// Prepend "kernel:" to apparmor kernel features to namespace them and
 		// allow us to introduce our own tags later.
 		tags = append(tags, "kernel:"+feature)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -539,7 +539,7 @@ func (s *backendSuite) TestCombineSnippetsChangeProfile(c *C) {
 	}}
 
 	for i, scenario := range changeProfileScenarios {
-		restore = apparmor.MockParserFeatures(func() []string { return scenario.features })
+		restore = apparmor.MockParserFeatures(func() ([]string, error) { return scenario.features, nil })
 		defer restore()
 
 		snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{Classic: true}, "", ifacetest.SambaYamlV1, 1)
@@ -1444,7 +1444,7 @@ func (s *backendSuite) TestSandboxFeatures(c *C) {
 	defer restore()
 	restore = apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
-	restore = apparmor.MockParserFeatures(func() []string { return []string{"baz", "norf"} })
+	restore = apparmor.MockParserFeatures(func() ([]string, error) { return []string{"baz", "norf"}, nil })
 	defer restore()
 
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "parser:baz", "parser:norf", "support-level:full", "policy:default"})
@@ -1459,7 +1459,7 @@ func (s *backendSuite) TestSandboxFeaturesPartial(c *C) {
 	defer restore()
 	restore = apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
-	restore = apparmor.MockParserFeatures(func() []string { return []string{"baz", "norf"} })
+	restore = apparmor.MockParserFeatures(func() ([]string, error) { return []string{"baz", "norf"}, nil })
 	defer restore()
 
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "parser:baz", "parser:norf", "support-level:partial", "policy:default"})

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1442,7 +1442,7 @@ func (s *backendSuite) TestNsProfile(c *C) {
 func (s *backendSuite) TestSandboxFeatures(c *C) {
 	restore := release.MockAppArmorLevel(release.FullAppArmor)
 	defer restore()
-	restore = apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
+	restore = apparmor.MockKernelFeatures(func() ([]string, error) { return []string{"foo", "bar"}, nil })
 	defer restore()
 	restore = apparmor.MockParserFeatures(func() ([]string, error) { return []string{"baz", "norf"}, nil })
 	defer restore()
@@ -1457,7 +1457,7 @@ func (s *backendSuite) TestSandboxFeaturesPartial(c *C) {
 	defer restore()
 	restore = osutil.MockKernelVersion("4.16.10-1-default")
 	defer restore()
-	restore = apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
+	restore = apparmor.MockKernelFeatures(func() ([]string, error) { return []string{"foo", "bar"}, nil })
 	defer restore()
 	restore = apparmor.MockParserFeatures(func() ([]string, error) { return []string{"baz", "norf"}, nil })
 	defer restore()

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -102,7 +102,7 @@ func MockKernelFeatures(f func() []string) (resture func()) {
 	}
 }
 
-func MockParserFeatures(f func() []string) (resture func()) {
+func MockParserFeatures(f func() ([]string, error)) (resture func()) {
 	old := parserFeatures
 	parserFeatures = f
 	return func() {

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -94,7 +94,7 @@ func SetSpecScope(spec *Specification, securityTags []string) (restore func()) {
 	return spec.setScope(securityTags)
 }
 
-func MockKernelFeatures(f func() []string) (resture func()) {
+func MockKernelFeatures(f func() ([]string, error)) (resture func()) {
 	old := kernelFeatures
 	kernelFeatures = f
 	return func() {

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -158,7 +158,7 @@ func WriteSystemKey() error {
 	// We only want to calculate this when the mtime of the parser changes.
 	// Since we calculate the mtime() as part of generateSystemKey, we can
 	// simply unconditionally write this out here.
-	sk.AppArmorParserFeatures = release.AppArmorParserFeatures()
+	sk.AppArmorParserFeatures, _ = release.AppArmorParserFeatures()
 
 	sks, err := json.Marshal(sk)
 	if err != nil {

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -118,7 +118,7 @@ func generateSystemKey() (*systemKey, error) {
 	sk.BuildID = buildID
 
 	// Add apparmor-features (which is already sorted)
-	sk.AppArmorFeatures = release.AppArmorFeatures()
+	sk.AppArmorFeatures, _ = release.AppArmorKernelFeatures()
 
 	// Add apparmor-parser-mtime
 	sk.AppArmorParserMtime = release.AppArmorParserMtime()

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -79,7 +79,10 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 	systemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)
 
-	apparmorFeaturesStr, err := json.Marshal(release.AppArmorFeatures())
+	kernelFeatures, err := release.AppArmorKernelFeatures()
+	c.Assert(err, IsNil)
+
+	apparmorFeaturesStr, err := json.Marshal(kernelFeatures)
 	c.Assert(err, IsNil)
 
 	apparmorParserMtime, err := json.Marshal(release.AppArmorParserMtime())

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -79,8 +79,7 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 	systemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)
 
-	kernelFeatures, err := release.AppArmorKernelFeatures()
-	c.Assert(err, IsNil)
+	kernelFeatures, _ := release.AppArmorKernelFeatures()
 
 	apparmorFeaturesStr, err := json.Marshal(kernelFeatures)
 	c.Assert(err, IsNil)

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -85,7 +85,8 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 	apparmorParserMtime, err := json.Marshal(release.AppArmorParserMtime())
 	c.Assert(err, IsNil)
 
-	apparmorParserFeaturesStr, err := json.Marshal(release.AppArmorParserFeatures())
+	parserFeatures, _ := release.AppArmorParserFeatures()
+	apparmorParserFeaturesStr, err := json.Marshal(parserFeatures)
 	c.Assert(err, IsNil)
 
 	seccompActionsStr, err := json.Marshal(release.SecCompActions())

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -123,12 +123,6 @@ func AppArmorParserFeatures() ([]string, error) {
 	return appArmorParserFeatures, appArmorParserError
 }
 
-// AppArmorFeatures is a deprecated version for AppArmorKernelFeatures.
-func AppArmorFeatures() []string {
-	features, _ := AppArmorKernelFeatures()
-	return features
-}
-
 // AppArmorParserMtime returns the mtime of the parser, else 0.
 func AppArmorParserMtime() int64 {
 	var mtime int64

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -197,7 +197,7 @@ var (
 	// requiredAppArmorKernelFeatures denotes the features that must be present in the kernel.
 	// Absence of any of those features results in the effective level be at most UnusableAppArmor.
 	requiredAppArmorKernelFeatures = []string{
-		// TODO: what is the minimal set?
+		// For now, require at least file and simply prefer the rest.
 		"file",
 	}
 	// preferredAppArmorKernelFeatures denotes the features that should be present in the kernel.

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -98,7 +98,7 @@ func AppArmorSummary() string {
 	return appArmorSummary
 }
 
-// AppArmorFeatures returns a sorted list of apparmor features like
+// AppArmorKernelFeatures returns a sorted list of apparmor features like
 // []string{"dbus", "network"}. The result is cached internally.
 func AppArmorKernelFeatures() []string {
 	if appArmorKernelFeatures == nil {

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -154,6 +154,7 @@ func MockAppArmorLevel(level AppArmorLevelType) (restore func()) {
 	}
 }
 
+// MockAppArmorFeatures makes the system believe it has certain kernel and parser features.
 func MockAppArmorFeatures(kernelFeatures, parserFeatures []string) (restore func()) {
 	oldAppArmorKernelFeatures := appArmorKernelFeatures
 	oldAppArmorParserFeatures := appArmorParserFeatures

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -194,6 +194,7 @@ var (
 )
 
 func assessAppArmor() {
+	// First, quickly check if apparmor is available in the kernel at all.
 	kernelFeatures := AppArmorKernelFeatures()
 
 	if len(kernelFeatures) == 0 {
@@ -202,6 +203,7 @@ func assessAppArmor() {
 		return
 	}
 
+	// Then check that the parser supports the required parser features.
 	parserFeatures := AppArmorParserFeatures()
 	var missingParserFeatures []string
 	for _, feature := range requiredAppArmorParserFeatures {
@@ -217,6 +219,7 @@ func assessAppArmor() {
 		return
 	}
 
+	// Lastly, check that the kernel supports the required kernel features.
 	var missingKernelFeatures []string
 	for _, feature := range requiredAppArmorKernelFeatures {
 		if !strutil.SortedListContains(kernelFeatures, feature) {

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -210,7 +210,7 @@ func assessAppArmor() {
 		}
 	}
 	if len(missingParserFeatures) > 0 {
-		// If we have no parser features then apparmor is not usable.
+		// If we have any missing required features then apparmor is unusable.
 		appArmorLevel = UnusableAppArmor
 		appArmorSummary = fmt.Sprintf("apparmor_parser lacks essential features: %s",
 			strings.Join(missingParserFeatures, ", "))

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -79,9 +79,8 @@ var (
 	appArmorParserFeatures []string
 )
 
-// AppArmorLevel quantifies how well apparmor is supported on the
-// current kernel. The computation is performed once and
-// cached but it is somewhat cosly to perform.
+// AppArmorLevel quantifies how well apparmor is supported on the current
+// kernel. The computation is costly to perform. The result is cached internally.
 func AppArmorLevel() AppArmorLevelType {
 	if appArmorLevel == UnknownAppArmor {
 		assessAppArmor()
@@ -89,9 +88,9 @@ func AppArmorLevel() AppArmorLevelType {
 	return appArmorLevel
 }
 
-// AppArmorSummary describes how well apparmor is supported on the
-// current kernel. The computation is performed once and
-// cached but it is somewhat cosly to perform.
+// AppArmorSummary describes how well apparmor is supported on the current
+// kernel. The computation is costly to perform. The result is cached
+// internally.
 func AppArmorSummary() string {
 	if appArmorLevel == UnknownAppArmor {
 		assessAppArmor()
@@ -100,8 +99,7 @@ func AppArmorSummary() string {
 }
 
 // AppArmorFeatures returns a sorted list of apparmor features like
-// []string{"dbus", "network"}. The computation is performed once and
-// cached.
+// []string{"dbus", "network"}. The result is cached internally.
 func AppArmorKernelFeatures() []string {
 	if appArmorKernelFeatures == nil {
 		appArmorKernelFeatures = probeAppArmorKernelFeatures()
@@ -110,8 +108,8 @@ func AppArmorKernelFeatures() []string {
 }
 
 // AppArmorParserFeatures returns a sorted list of apparmor parser features
-// like []string{"unsafe", ...}.  The computation is performed once and
-// cached but is is somewhat costly to perform.
+// like []string{"unsafe", ...}. The computation is costly to perform. The
+// result is cached internally.
 func AppArmorParserFeatures() []string {
 	if appArmorParserFeatures == nil {
 		appArmorParserFeatures = probeAppArmorParserFeatures()

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -63,7 +63,7 @@ func (level AppArmorLevelType) String() string {
 	case FullAppArmor:
 		return "full"
 	}
-	return "???"
+	return fmt.Sprintf("AppArmorLevelType:%d", level)
 }
 
 var (

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -32,7 +32,7 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-// ApparmorLevelType encodes the kind of support for apparmor
+// AppArmorLevelType encodes the kind of support for apparmor
 // found on this system.
 type AppArmorLevelType int
 

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -50,8 +50,8 @@ const (
 	FullAppArmor
 )
 
-func (l AppArmorLevelType) String() string {
-	switch l {
+func (level AppArmorLevelType) String() string {
+	switch level {
 	case UnknownAppArmor:
 		return "unknown"
 	case NoAppArmor:

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -68,7 +68,7 @@ func (level AppArmorLevelType) String() string {
 
 var (
 	// appArmorLevel contains the assessment of the "level" of apparmor support.
-	appArmorLevel AppArmorLevelType = UnknownAppArmor
+	appArmorLevel = UnknownAppArmor
 	// appArmorSummary contains a human readable description of the assessment.
 	appArmorSummary string
 	// appArmorKernelFeatures contains a list of kernel features that are supported.

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -332,7 +332,7 @@ func probeAppArmorKernelFeatures() ([]string, error) {
 
 func probeAppArmorParserFeatures() ([]string, error) {
 	parser, err := findAppArmorParser()
-	if os.IsNotExist(err) {
+	if err != nil {
 		return []string{}, err
 	}
 	features := make([]string, 0, 1)

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -169,11 +169,15 @@ func MockAppArmorFeatures(kernelFeatures, parserFeatures []string) (restore func
 	oldAppArmorParserFeatures := appArmorParserFeatures
 	appArmorKernelFeatures = kernelFeatures
 	appArmorParserFeatures = parserFeatures
-	assessAppArmor()
+	if appArmorKernelFeatures != nil && appArmorParserFeatures != nil {
+		assessAppArmor()
+	}
 	return func() {
 		appArmorKernelFeatures = oldAppArmorKernelFeatures
 		appArmorParserFeatures = oldAppArmorParserFeatures
-		assessAppArmor()
+		if appArmorKernelFeatures != nil && appArmorParserFeatures != nil {
+			assessAppArmor()
+		}
 	}
 }
 

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -135,7 +135,7 @@ func AppArmorParserMtime() int64 {
 	return mtime
 }
 
-// MockAppArmorSupportLevel makes the system believe it has certain
+// MockAppArmorLevel makes the system believe it has certain
 // level of apparmor support.
 func MockAppArmorLevel(level AppArmorLevelType) (restore func()) {
 	oldAppArmorLevel := appArmorLevel

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -135,8 +135,12 @@ func AppArmorParserMtime() int64 {
 	return mtime
 }
 
-// MockAppArmorLevel makes the system believe it has certain
-// level of apparmor support.
+// MockAppArmorLevel makes the system believe it has certain level of apparmor
+// support.
+//
+// AppArmor kernel and parser features are set to unrealistic values that do
+// not match the requested level. Use this function to observe behavior that
+// relies solely on the apparmor level value.
 func MockAppArmorLevel(level AppArmorLevelType) (restore func()) {
 	oldAppArmorLevel := appArmorLevel
 	oldAppArmorSummary := appArmorSummary
@@ -154,7 +158,12 @@ func MockAppArmorLevel(level AppArmorLevelType) (restore func()) {
 	}
 }
 
-// MockAppArmorFeatures makes the system believe it has certain kernel and parser features.
+// MockAppArmorFeatures makes the system believe it has certain kernel and
+// parser features.
+//
+// AppArmor level and summary are automatically re-assessed on both the change
+// and the restore process. Use this function to observe real assessment of
+// arbitrary features.
 func MockAppArmorFeatures(kernelFeatures, parserFeatures []string) (restore func()) {
 	oldAppArmorKernelFeatures := appArmorKernelFeatures
 	oldAppArmorParserFeatures := appArmorParserFeatures

--- a/release/apparmor.go
+++ b/release/apparmor.go
@@ -188,7 +188,7 @@ var (
 	// Since AppArmorParserMtime() will be called by generateKey() in
 	// system-key and that could be called by different users on the
 	// system, use a predictable search path for finding the parser.
-	appArmorParserSearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin"
+	appArmorParserSearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	// Each apparmor feature is manifested as a directory entry.
 	appArmorFeaturesSysPath = "/sys/kernel/security/apparmor/features"
 )

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -130,6 +130,12 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	c.Assert(os.Mkdir(filepath.Join(d, "foo"), 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d, "bar"), 0755), IsNil)
 	c.Check(release.ProbeAppArmorKernelFeatures(), DeepEquals, []string{"bar", "foo"})
+
+	// Pretend that apparmor kernel features directory doesn't exist.
+	restore = release.MockAppArmorFeaturesSysPath(filepath.Join(d, "non-existent"))
+	defer restore()
+	c.Check(release.ProbeAppArmorKernelFeatures(), DeepEquals, []string{})
+
 }
 
 func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -190,3 +190,21 @@ func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 	// Deprecated API
 	c.Check(release.AppArmorFeatures(), DeepEquals, []string{"network", "policy"})
 }
+
+func (s *apparmorSuite) TestAppArmorParserMtime(c *C) {
+	// Pretend that we have apparmor_parser.
+	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
+	defer mockParserCmd.Restore()
+	restore := release.MockAppArmorParserSearchPath(mockParserCmd.BinDir())
+	defer restore()
+	mtime := release.AppArmorParserMtime()
+	fi, err := os.Stat(filepath.Join(mockParserCmd.BinDir(), "apparmor_parser"))
+	c.Assert(err, IsNil)
+	c.Check(mtime, Equals, fi.ModTime().Unix())
+
+	// Pretend that we don't have apparmor_parser.
+	restore = release.MockAppArmorParserSearchPath(c.MkDir())
+	defer restore()
+	mtime = release.AppArmorParserMtime()
+	c.Check(mtime, Equals, int64(0))
+}

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -35,6 +35,15 @@ type apparmorSuite struct{}
 
 var _ = Suite(&apparmorSuite{})
 
+func (*apparmorSuite) TestAppArmorLevelTypeStringer(c *C) {
+	c.Check(release.UnknownAppArmor.String(), Equals, "unknown")
+	c.Check(release.NoAppArmor.String(), Equals, "none")
+	c.Check(release.UnusableAppArmor.String(), Equals, "unusable")
+	c.Check(release.PartialAppArmor.String(), Equals, "partial")
+	c.Check(release.FullAppArmor.String(), Equals, "full")
+	c.Check(release.AppArmorLevelType(42).String(), Equals, "AppArmorLevelType:42")
+}
+
 func (*apparmorSuite) TestMockAppArmorLevel(c *C) {
 	for _, lvl := range []release.AppArmorLevelType{release.NoAppArmor, release.UnusableAppArmor, release.PartialAppArmor, release.FullAppArmor} {
 		restore := release.MockAppArmorLevel(lvl)

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -156,6 +156,12 @@ func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(string(data), Equals, "profile snap-test {\n change_profile unsafe /**,\n}")
 	}
+
+	// Pretend that we just don't have apparmor_parser at all.
+	restore := release.MockAppArmorParserSearchPath(c.MkDir())
+	defer restore()
+	features := release.ProbeAppArmorParserFeatures()
+	c.Check(features, DeepEquals, []string{})
 }
 
 func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -243,9 +243,6 @@ func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
 	features, err = release.AppArmorParserFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"unsafe"})
-
-	// Deprecated API
-	c.Check(release.AppArmorFeatures(), DeepEquals, []string{"network", "policy"})
 }
 
 func (s *apparmorSuite) TestAppArmorParserMtime(c *C) {

--- a/release/apparmor_test.go
+++ b/release/apparmor_test.go
@@ -44,6 +44,35 @@ func (*apparmorSuite) TestAppArmorLevelTypeStringer(c *C) {
 	c.Check(release.AppArmorLevelType(42).String(), Equals, "AppArmorLevelType:42")
 }
 
+func (*apparmorSuite) TestAppArmorLevelTriggersAssesment(c *C) {
+	// Pretend that we know the apparmor kernel and parser features.
+	restore := release.MockAppArmorFeatures([]string{"feature"}, []string{"feature"})
+	defer restore()
+	// Pretend that we don't know what the state of apparmor is.
+	release.ResetAppArmorAssesment()
+
+	// Calling AppArmorLevel assesses the kernel and parser features and sets
+	// the level to not-unknown value, returning it.
+	c.Check(release.CurrentAppArmorLevel(), Equals, release.UnknownAppArmor)
+	level := release.AppArmorLevel()
+	c.Check(level, Not(Equals), release.UnknownAppArmor)
+	c.Check(level, Equals, release.CurrentAppArmorLevel())
+}
+
+func (*apparmorSuite) TestAppArmorSummaryTriggersAssesment(c *C) {
+	// Pretend that we know the apparmor kernel and parser features.
+	restore := release.MockAppArmorFeatures([]string{"feature"}, []string{"feature"})
+	defer restore()
+	// Pretend that we don't know what the state of apparmor is.
+	release.ResetAppArmorAssesment()
+
+	// Calling AppArmorSummary assesses the kernel and parser features and sets
+	// the level to something other than unknown.
+	c.Check(release.CurrentAppArmorLevel(), Equals, release.UnknownAppArmor)
+	release.AppArmorSummary()
+	c.Check(release.CurrentAppArmorLevel(), Not(Equals), release.UnknownAppArmor)
+}
+
 func (*apparmorSuite) TestMockAppArmorLevel(c *C) {
 	for _, lvl := range []release.AppArmorLevelType{release.NoAppArmor, release.UnusableAppArmor, release.PartialAppArmor, release.FullAppArmor} {
 		restore := release.MockAppArmorLevel(lvl)

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -43,10 +43,10 @@ func MockAppArmorFeaturesSysPath(path string) (restorer func()) {
 }
 
 func MockAppArmorParserSearchPath(new string) (restore func()) {
-	oldParserSearchPath := parserSearchPath
-	parserSearchPath = new
+	oldAppArmorParserSearchPath := appArmorParserSearchPath
+	appArmorParserSearchPath = new
 	return func() {
-		parserSearchPath = oldParserSearchPath
+		appArmorParserSearchPath = oldAppArmorParserSearchPath
 	}
 }
 
@@ -59,7 +59,13 @@ func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func
 }
 
 var (
-	ProbeAppArmor            = probeAppArmor
-	RequiredAppArmorFeatures = requiredAppArmorFeatures
-	IsWSL                    = isWSL
+	ProbeAppArmorKernelFeatures = probeAppArmorKernelFeatures
+	ProbeAppArmorParserFeatures = probeAppArmorParserFeatures
+
+	AssessAppArmor = assessAppArmor
+
+	RequiredAppArmorKernelFeatures = requiredAppArmorKernelFeatures
+	RequiredAppArmorParserFeatures = requiredAppArmorParserFeatures
+
+	IsWSL = isWSL
 )

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -58,6 +58,20 @@ func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func
 	}
 }
 
+// CurrentAppArmorLevel returns the internal cached apparmor level.
+func CurrentAppArmorLevel() AppArmorLevelType {
+	return appArmorLevel
+}
+
+// ResetAppArmorAssesment resets the internal apparmor level and summary.
+//
+// Both appArmorLevel and appArmorSummary are assigned with zero values
+// that trigger probing and assessment on the next access via the public APIs.
+func ResetAppArmorAssesment() {
+	appArmorLevel = UnknownAppArmor
+	appArmorSummary = ""
+}
+
 var (
 	ProbeAppArmorKernelFeatures = probeAppArmorKernelFeatures
 	ProbeAppArmorParserFeatures = probeAppArmorParserFeatures

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -78,8 +78,10 @@ var (
 
 	AssessAppArmor = assessAppArmor
 
-	RequiredAppArmorKernelFeatures = requiredAppArmorKernelFeatures
-	RequiredAppArmorParserFeatures = requiredAppArmorParserFeatures
+	RequiredAppArmorKernelFeatures  = requiredAppArmorKernelFeatures
+	RequiredAppArmorParserFeatures  = requiredAppArmorParserFeatures
+	PreferredAppArmorKernelFeatures = preferredAppArmorKernelFeatures
+	PreferredAppArmorParserFeatures = preferredAppArmorParserFeatures
 
 	IsWSL = isWSL
 )

--- a/release/release.go
+++ b/release/release.go
@@ -46,6 +46,7 @@ func (o *OS) ForceDevMode() bool {
 	return AppArmorLevel() != FullAppArmor
 }
 
+// DistroLike checks if the distribution ID or ID_LIKE matches one of the given names.
 func DistroLike(distros ...string) bool {
 	for _, distro := range distros {
 		if ReleaseInfo.ID == distro || strutil.ListContains(ReleaseInfo.IDLike, distro) {

--- a/tests/regression/lp-1805485/task.yaml
+++ b/tests/regression/lp-1805485/task.yaml
@@ -5,6 +5,11 @@ details: |
     apparmor backend even though it resulted in constant problems with setting
     up security for the core snap. With this bug fixed the old version of
     apparmor_parser makes snapd disable the relevant security backend. 
-systems: [opensuse-42.3-64]
+systems: [ubuntu-*, opensuse-*, arch-linux-*]
 execute: |
-    snap debug sandbox-features | MATCH -v "^apparmor:"
+    if [[ "$SPREAD_SYSTEM" == opensuse-42.3* ]]; then
+        # openSUSE 43.2 has AppArmor parser in version too old to parse snap-confine profile
+        snap debug sandbox-features | MATCH -v "^apparmor:"
+    else
+        snap debug sandbox-features | MATCH "^apparmor:"
+    fi

--- a/tests/regression/lp-1805485/task.yaml
+++ b/tests/regression/lp-1805485/task.yaml
@@ -1,0 +1,10 @@
+summary: apparmor backend is not used on openSUSE Leap 42.3
+details: |
+    AppArmor on openSUSE Leap 43.2 is too old to parse the snap-confine
+    apparmor profile.  Because of "relaxed" error handling snapd was enabling
+    apparmor backend even though it resulted in constant problems with setting
+    up security for the core snap. With this bug fixed the old version of
+    apparmor_parser makes snapd disable the relevant security backend. 
+systems: [opensuse-42.3-64]
+execute: |
+    snap debug sandbox-features | MATCH -v "^apparmor:"


### PR DESCRIPTION
This patch re-factors apparmor probing logic so that we can detect older
apparmor parser (with fewer features than required to run snapd in any
way). The API has been streamlined, tests simplified.

The main change is that probing of kernel and parser features happens in
tandem. If some kernel features are present but required parser features
are absent then "level" is set to unusable. This is a new level that
that sits between none and partial.

Most importantly this is the level that is not causing the apparmor
backend to be added to all security backends.

In practical terms this means we run without apparmor on openSUSE Leap
42.3 which in turn fixes a bug that prevented snapd from working
correctly with stricter error reporting during startup phase when system
key is considered.

Extra care has been taken to preserve the property that comparing the system
key does not necessarily need to run apparmor_parser, so that fast path of
"snap run <snap>" remains efficient.

A simple spread test ensures that openSUSE Leap 42.3 is not using
apparmor anymore.

Fixes: https://bugs.launchpad.net/snapd/+bug/1805485
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
