### PR TITLE
interfaces/backends: detect too old apparmor_parser (2.36)

### DIFF
--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -67,7 +67,11 @@ func backends() []interfaces.SecurityBackend {
 	// When some features are missing the backend will generate more permissive
 	// profiles that keep applications operational, in forced-devmode.
 	switch release.AppArmorLevel() {
-	case release.FullAppArmor, release.PartialAppArmor:
+	case release.PartialAppArmor:
+		if len(release.AppArmorParserFeatures()) != 0 {
+			all = append(all, &apparmor.Backend{})
+		}
+	case release.FullAppArmor:
 		all = append(all, &apparmor.Backend{})
 	}
 	return all

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -45,12 +45,20 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 		for i, backend := range all {
 			names[i] = string(backend.Name())
 		}
-
-		if level == release.NoAppArmor {
+		switch level {
+		case release.NoAppArmor:
 			c.Assert(names, Not(testutil.Contains), "apparmor")
-		} else {
+		case release.PartialAppArmor:
+			// Partial support depends on modern apparmor_parser.
+			if len(release.AppArmorParserFeatures()) == 0 {
+				c.Assert(names, Not(testutil.Contains), "apparmor")
+			} else {
+				c.Assert(names, testutil.Contains, "apparmor")
+			}
+		case release.FullAppArmor:
 			c.Assert(names, testutil.Contains, "apparmor")
 		}
+
 	}
 }
 

--- a/tests/regression/lp-1805485/task.yaml
+++ b/tests/regression/lp-1805485/task.yaml
@@ -5,6 +5,11 @@ details: |
     apparmor backend even though it resulted in constant problems with setting
     up security for the core snap. With this bug fixed the old version of
     apparmor_parser makes snapd disable the relevant security backend. 
-systems: [opensuse-42.3-64]
+systems: [ubuntu-*, opensuse-*, arch-linux-*]
 execute: |
-    snap debug sandbox-features | MATCH -v "^apparmor:"
+    if [[ "$SPREAD_SYSTEM" == opensuse-42.3* ]]; then
+        # openSUSE 43.2 has AppArmor parser in version too old to parse snap-confine profile
+        snap debug sandbox-features | MATCH -v "^apparmor:"
+    else
+        snap debug sandbox-features | MATCH "^apparmor:"
+    fi

--- a/tests/regression/lp-1805485/task.yaml
+++ b/tests/regression/lp-1805485/task.yaml
@@ -1,0 +1,10 @@
+summary: apparmor backend is not used on openSUSE Leap 42.3
+details: |
+    AppArmor on openSUSE Leap 43.2 is too old to parse the snap-confine
+    apparmor profile.  Because of "relaxed" error handling snapd was enabling
+    apparmor backend even though it resulted in constant problems with setting
+    up security for the core snap. With this bug fixed the old version of
+    apparmor_parser makes snapd disable the relevant security backend. 
+systems: [opensuse-42.3-64]
+execute: |
+    snap debug sandbox-features | MATCH -v "^apparmor:"


### PR DESCRIPTION
This patch changes logic conditionally adding the apparmor backend to not do so
if the kernel has some support in the case that the userspace parser is too old
to parse the profiles we generate.

In practical terms this means we run without apparmor on openSUSE Leap
42.3 which in turn fixes a bug that prevented snapd from working
correctly with stricter error reporting during startup phase when system
key is considered.

A simple spread test ensures that openSUSE Leap 42.3 is not using
apparmor anymore.

Fixes: https://bugs.launchpad.net/snapd/+bug/1805485
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
