### PR TITLE
spread: show AVC audits when debugging, start auditd on Fedora

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -414,8 +414,15 @@ debug-each: |
 
         echo '# journal messages for snapd'
         get_journalctl_log -u snapd
-        echo '# apparmor denials '
-        dmesg --ctime | grep DENIED || true
+        case "$SPREAD_SYSTEM" in
+            fedora-*|centos-*|amazon-*)
+                ausearch -m AVC
+                ;;
+            *)
+               echo '# apparmor denials '
+               dmesg --ctime | grep DENIED || true
+               ;;
+        esac
         echo '# seccomp denials (kills) '
         dmesg --ctime | grep type=1326 || true
         echo '# snap interfaces'

--- a/spread.yaml
+++ b/spread.yaml
@@ -482,6 +482,9 @@ prepare: |
         # https://forum.snapcraft.io/t/issues-with-the-fedora-mirror-network/3489/
         sed -i -s -E -e 's@^#?baseurl=http://download.fedoraproject.org/@baseurl=http://dl.fedoraproject.org/@g' -e 's@^metalink=@#metalink@g' /etc/yum.repos.d/fedora*.repo
         dnf --refresh -y makecache
+
+        # enable audit daemon
+        systemctl enable --now auditd.service
     fi
     if [[ "$SPREAD_SYSTEM" == opensuse-* ]]; then
         # We seem to be hitting a flaky openSUSE mirror from time to time,


### PR DESCRIPTION
Systems that have SELinux enabled typically use audit to log AV denials. Dump the AVC log when debugging.

For some reason, auditd is not started in our Fedora GCP images. It is started in Fedora Cloud images pulled from https://alt.fedoraproject.org/cloud/ though. Make sure that auditd is running when spread takes over the instance.