### PR TITLE
tests/lib: do not pick up xatts when repacking core snap

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -141,7 +141,8 @@ update_core_snap_for_classic_reexec() {
 
     # repack, cheating to speed things up (4sec vs 1.5min)
     mv "$snap" "${snap}.orig"
-    mksnap_fast "squashfs-root" "$snap"
+    # make sure that SELinux context is not picked up by accident
+    mksnap_fast "squashfs-root" "$snap" -no-xattrs
     chmod --reference="${snap}.orig" "$snap"
     rm -rf squashfs-root
 

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -50,14 +50,15 @@ install_local_jailmode() {
 mksnap_fast() {
     dir="$1"
     snap="$2"
+    shift 2
 
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*|amazon-*|centos-*)
             # trusty, AMZN2 and CentOS 7 do not support -Xcompression-level 1
-            mksquashfs "$dir" "$snap" -comp gzip -no-fragments -no-progress
+            mksquashfs "$dir" "$snap" -comp gzip -no-fragments -no-progress "$@"
             ;;
         *)
-            mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1 -no-fragments -no-progress
+            mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1 -no-fragments -no-progress "$@"
             ;;
     esac
 }


### PR DESCRIPTION
Avoid picking up xattrs when repacking core snap. On systems supporting SELinux
this may accidentally pick up the file context from where the core snap was
initially unpack. In case of tests, the core snap is unpacked to test home
directory and the repacked snap files have `user_home_t` context.
