### PR TITLE
tests/lib/reset: restore context of removed snapd directories

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -61,6 +61,12 @@ reset_classic() {
         exit 1
     fi
 
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*)
+            restorecon -F -v -R "$SNAP_MOUNT_DIR" /var/snap /var/lib/snapd
+            ;;
+    esac
+
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         systemctl start snap.mount.service
     fi

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -63,6 +63,9 @@ reset_classic() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)
+            # On systems running SELinux we need to restore the context of the
+            # directories we just recreated. Otherwise, the entries created
+            # inside will be incorrectly labeled.
             restorecon -F -v -R "$SNAP_MOUNT_DIR" /var/snap /var/lib/snapd
             ;;
     esac


### PR DESCRIPTION
SELinux context of filesystem objects is the same as their parent. Once the top
level snapd directories are purged and remade, they will end up with a context
that stems off respective parent directories, which can end up being `var_t`,
`var_lib_t` (or even `root_t` if `/snap` was used). Make sure to restore the context
of these locations according to our targeted policy.
