### PR TITLE
cmd/libsnap: introduce and use sc_strdup

### DIFF
--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -780,6 +780,14 @@ static void test_sc_string_quote(void)
 #undef DQ
 }
 
+static void test_sc_strdup(void)
+{
+	char *s = sc_strdup("snap install everything");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "snap install everything");
+	free(s);
+}
+
 static void __attribute__ ((constructor)) init(void)
 {
 	g_test_add_func("/string-utils/sc_streq", test_sc_streq);
@@ -836,4 +844,5 @@ static void __attribute__ ((constructor)) init(void)
 	    ("/string-utils/sc_string_append_char_pair__uninitialized_buf",
 	     test_sc_string_append_char_pair__uninitialized_buf);
 	g_test_add_func("/string-utils/sc_string_quote", test_sc_string_quote);
+	g_test_add_func("/string-utils/sc_strdup", test_sc_strdup);
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -56,6 +56,22 @@ bool sc_endswith(const char *str, const char *suffix)
 	return strncmp(str - xlen + slen, suffix, xlen) == 0;
 }
 
+char *sc_strdup(const char *str)
+{
+	size_t len;
+	char *copy;
+	if (str == NULL) {
+		die("cannot duplicate NULL string");
+	}
+	len = strlen(str);
+	copy = malloc(len + 1);
+	if (copy == NULL) {
+		die("cannot allocate string copy (len: %zd)", len);
+	}
+	memcpy(copy, str, len + 1);
+	return copy;
+}
+
 int sc_must_snprintf(char *str, size_t size, const char *format, ...)
 {
 	int n;

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -32,6 +32,11 @@ bool sc_streq(const char *a, const char *b);
 bool sc_endswith(const char *str, const char *suffix);
 
 /**
+ * Allocate and return a copy of a string.
+**/
+char *sc_strdup(const char *str);
+
+/**
  * Safer version of snprintf.
  *
  * This version dies on any error condition.

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -166,12 +166,9 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 		char prefix_dir[512] = { 0 };
 		const char *pathname = glob_res.gl_pathv[i];
 		char *pathname_copy1
-		    SC_CLEANUP(sc_cleanup_string) = strdup(pathname);
+		    SC_CLEANUP(sc_cleanup_string) = sc_strdup(pathname);
 		char *pathname_copy2
-		    SC_CLEANUP(sc_cleanup_string) = strdup(pathname);
-		if (pathname_copy1 == NULL || pathname_copy2 == NULL) {
-			die("failed to copy pathname");
-		}
+		    SC_CLEANUP(sc_cleanup_string) = sc_strdup(pathname);
 		// POSIX dirname() and basename() may modify their input arguments
 		char *filename = basename(pathname_copy1);
 		char *directory_name = dirname(pathname_copy2);

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -75,10 +75,7 @@ static void setup_private_mount(const char *snap_name)
 	}
 	// now we create a 1777 /tmp inside our private dir
 	mode_t old_mask = umask(0);
-	char *d = strdup(tmpdir);
-	if (!d) {
-		die("cannot allocate memory for string copy");
-	}
+	char *d = sc_strdup(tmpdir);
 	sc_must_snprintf(tmpdir, sizeof(tmpdir), "%s/tmp", d);
 	free(d);
 
@@ -164,10 +161,7 @@ static void sc_setup_mount_profiles(struct sc_apparmor *apparmor,
 		      profile);
 		sc_maybe_aa_change_onexec(apparmor, profile);
 		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-		snap_name_copy = strdup(snap_name);
-		if (snap_name_copy == NULL) {
-			die("cannot copy snap name");
-		}
+		snap_name_copy = sc_strdup(snap_name);
 		char *argv[] = {
 			"snap-update-ns", "--from-snap-confine", snap_name_copy,
 			NULL
@@ -813,10 +807,7 @@ void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 		      profile);
 		sc_maybe_aa_change_onexec(apparmor, profile);
 		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-		snap_name_copy = strdup(snap_name);
-		if (snap_name_copy == NULL) {
-			die("cannot allocate memory for snap name");
-		}
+		snap_name_copy = sc_strdup(snap_name);
 		char *argv[] = {
 			"snap-update-ns", "--user-mounts", snap_name_copy,
 			NULL

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -214,10 +214,7 @@ struct sc_mount_ns *sc_open_mount_ns(const char *group_name)
 	if (group->dir_fd < 0) {
 		die("cannot open directory %s", sc_ns_dir);
 	}
-	group->name = strdup(group_name);
-	if (group->name == NULL) {
-		die("cannot allocate memory for string copy");
-	}
+	group->name = sc_strdup(group_name);
 	return group;
 }
 
@@ -316,10 +313,7 @@ static void call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name)
 	}
 	if (child == 0) {
 		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-		snap_name_copy = strdup(snap_name);
-		if (snap_name_copy == NULL) {
-			die("cannot allocate memory for snap name");
-		}
+		snap_name_copy = sc_strdup(snap_name);
 		char *argv[] =
 		    { "snap-discard-ns", "--from-snap-confine", snap_name_copy,
 			NULL

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -83,10 +83,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	}
 	// strtok_r() modifies its first argument, so work on a copy
 	char *tokenized SC_CLEANUP(sc_cleanup_string) = NULL;
-	tokenized = strdup(path);
-	if (tokenized == NULL) {
-		die("cannot allocate memory for copy of path");
-	}
+	tokenized = sc_strdup(path);
 	// allocate a string large enough to hold path, and initialize it to
 	// '/'
 	size_t checked_path_size = strlen(path) + 1;
@@ -110,10 +107,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	char *buf_token = strtok_r(tokenized, "/", &buf_saveptr);
 	while (buf_token != NULL) {
 		char *prev SC_CLEANUP(sc_cleanup_string) = NULL;
-		prev = strdup(checked_path);	// needed by vsnprintf in sc_must_snprintf
-		if (prev == NULL) {
-			die("cannot allocate memory for copy of checked_path");
-		}
+		prev = sc_strdup(checked_path);	// needed by vsnprintf in sc_must_snprintf
 		// append '<buf_token>' if checked_path is '/', otherwise '/<buf_token>'
 		if (strlen(checked_path) == 1) {
 			sc_must_snprintf(checked_path, checked_path_size,

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -42,7 +42,7 @@ static void
 		argv = realloc(argv, sizeof(const char **) * (argc + 1));
 		g_assert_nonnull(argv);
 		if (arg != NULL) {
-			char *arg_copy = strdup(arg);
+			char *arg_copy = sc_strdup(arg);
 			g_test_queue_free(arg_copy);
 			argv[argc] = arg_copy;
 			argc += 1;

--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "../libsnap-confine-private/utils.h"
+#include "../libsnap-confine-private/string-utils.h"
 
 struct sc_args {
 	// The security tag that the application is intended to run with
@@ -119,10 +120,7 @@ struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
 				goto out;
 
 			}
-			args->base_snap = strdup(argv[optind + 1]);
-			if (args->base_snap == NULL) {
-				die("cannot allocate memory for base snap name");
-			}
+			args->base_snap = sc_strdup(argv[optind + 1]);
 			optind += 1;
 		} else {
 			// Report unhandled option switches
@@ -148,16 +146,10 @@ struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
 				ignore_first_tag = false;
 				continue;
 			}
-			args->security_tag = strdup(argv[optind]);
-			if (args->security_tag == NULL) {
-				die("cannot allocate memory for security tag");
-			}
+			args->security_tag = sc_strdup(argv[optind]);
 		} else if (args->executable == NULL) {
 			// The second positional argument becomes the executable name.
-			args->executable = strdup(argv[optind]);
-			if (args->executable == NULL) {
-				die("cannot allocate memory for executable name");
-			}
+			args->executable = sc_strdup(argv[optind]);
 			// No more positional arguments are required.
 			// Stop the parsing process.
 			break;


### PR DESCRIPTION
We have a small but common pattern where we need to duplicate a string,
check for memory allocation errors and carry on. This patch introduces
sc_strdup that does that internally.

All of the instances of strdup and error checking in the code were
updated to use it.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
