### PR TITLE
cmd/snap-confine: refactor calling snapd tools into helper module

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -115,6 +115,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/snap.h \
 	libsnap-confine-private/string-utils.c \
 	libsnap-confine-private/string-utils.h \
+	libsnap-confine-private/tool.c \
+	libsnap-confine-private/tool.h \
 	libsnap-confine-private/utils.c \
 	libsnap-confine-private/utils.h
 libsnap_confine_private_a_CFLAGS = $(CHECK_CFLAGS)

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -50,7 +50,7 @@ static int sc_open_snapd_tool(const char *tool_name);
  * anymore. The caller establishes an open file descriptor in one namespace and later on
  * performs the call in another mount namespace.
  *
- * The environment vector has special support for expanding he string "SNAPD_DEBUG=x".
+ * The environment vector has special support for expanding the string "SNAPD_DEBUG=x".
  * If such string is present, the "x" is replaced with either "0" or "1" depending on
  * the result of is_sc_debug_enabled().
  **/

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tool.h"
+
+#include <fcntl.h>
+#include <libgen.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../libsnap-confine-private/apparmor-support.h"
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
+
+/**
+ * sc_open_snapd_tool returns a file descriptor of the given internal executable.
+ *
+ * The executable is located based on the location of the currently executing process.
+ * The returning file descriptor can be used with fexecve function, like in sc_call_snapd_tool.
+**/
+static int sc_open_snapd_tool(const char *tool_name);
+
+/**
+ * sc_call_snapd_tool calls a snapd tool by file descriptor.
+ *
+ * The idea with calling with an open file descriptor is to allow calling executables
+ * across mount namespaces, where the executable may not be visible in the new filesystem
+ * anymore. The caller establishes an open file descriptor in one namespace and later on
+ * performs the call in another mount namespace.
+ *
+ * The environment vector has special support for expanding he string "SNAPD_DEBUG=x".
+ * If such string is present, the "x" is replaced with either "0" or "1" depending on
+ * the result of is_sc_debug_enabled().
+ **/
+static void sc_call_snapd_tool(int tool_fd, const char *tool_name, char **argv,
+			       char **envp);
+
+/**
+ * sc_call_snapd_tool_with_apparmor calls a snapd tool by file descriptor,
+ * possibly confining the program with a specific apparmor profile.
+**/
+static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
+					     struct sc_apparmor *apparmor,
+					     const char *aa_profile,
+					     char **argv, char **envp);
+
+int sc_open_snap_update_ns(void)
+{
+	return sc_open_snapd_tool("snap-update-ns");
+}
+
+void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
+			    struct sc_apparmor *apparmor)
+{
+	char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+	snap_name_copy = sc_strdup(snap_name);
+	char *argv[] =
+	    { "snap-update-ns", "--from-snap-confine", snap_name_copy, NULL };
+	char *envp[] = { "SNAPD_DEBUG=x", NULL };
+	char profile[PATH_MAX] = { 0 };
+	sc_must_snprintf(profile, sizeof profile, "snap-update-ns.%s",
+			 snap_name);
+	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd, "snap-update-ns",
+					 apparmor, profile, argv, envp);
+}
+
+int sc_open_snap_discard_ns(void)
+{
+	return sc_open_snapd_tool("snap-discard-ns");
+}
+
+void sc_call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name)
+{
+	char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
+	snap_name_copy = sc_strdup(snap_name);
+	char *argv[] =
+	    { "snap-discard-ns", "--from-snap-confine", snap_name_copy, NULL };
+	char *envp[] = { "SNAPD_DEBUG=x", NULL };
+	sc_call_snapd_tool(snap_discard_ns_fd, "snap-discard-ns", argv, envp);
+}
+
+static int sc_open_snapd_tool(const char *tool_name)
+{
+	// +1 is for the case where the link is exactly PATH_MAX long but we also
+	// want to store the terminating '\0'. The readlink system call doesn't add
+	// terminating null, but our initialization of buf handles this for us.
+	char buf[PATH_MAX + 1] = { 0 };
+	if (readlink("/proc/self/exe", buf, sizeof buf) < 0) {
+		die("cannot readlink /proc/self/exe");
+	}
+	if (buf[0] != '/') {	// this shouldn't happen, but make sure have absolute path
+		die("readlink /proc/self/exe returned relative path");
+	}
+	char *dir_name = dirname(buf);
+	int dir_fd SC_CLEANUP(sc_cleanup_close) = 1;
+	dir_fd = open(dir_name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+	if (dir_fd < 0) {
+		die("cannot open path %s", dir_name);
+	}
+	int tool_fd = -1;
+	tool_fd = openat(dir_fd, tool_name, O_PATH | O_NOFOLLOW | O_CLOEXEC);
+	if (tool_fd < 0) {
+		die("cannot open path %s/%s", dir_name, tool_name);
+	}
+	debug("opened %s executable as file descriptor %d", tool_name, tool_fd);
+	return tool_fd;
+}
+
+static void sc_call_snapd_tool(int tool_fd, const char *tool_name, char **argv,
+			       char **envp)
+{
+	sc_call_snapd_tool_with_apparmor(tool_fd, tool_name, NULL, NULL, argv,
+					 envp);
+}
+
+static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
+					     struct sc_apparmor *apparmor,
+					     const char *aa_profile,
+					     char **argv, char **envp)
+{
+	debug("calling snapd tool %s", tool_name);
+	pid_t child = fork();
+	if (child < 0) {
+		die("cannot fork to run snapd tool %s", tool_name);
+	}
+	if (child == 0) {
+		/* If the caller provided template environment entry for SNAPD_DEBUG
+		 * then expand it to the actual value. */
+		for (char **env = envp;
+		     /* Mama mia, that's a spicy meatball. */
+		     env != NULL && *env != NULL && **env != '\0'; env++) {
+			if (sc_streq(*env, "SNAPD_DEBUG=x")) {
+				/* NOTE: this is not released, on purpose. */
+				char *entry = sc_strdup(*env);
+				entry[strlen("SNAPD_DEBUG=x") - 1] =
+				    sc_is_debug_enabled()? '1' : '0';
+				*env = entry;
+			}
+		}
+		/* As the child ensure that the file descriptor is remains open across exec. */
+		int flags = fcntl(tool_fd, F_GETFD);
+		if (flags < 0) {
+			die("cannot get file descriptor flags");
+		}
+		flags &= ~FD_CLOEXEC;
+		if (fcntl(tool_fd, F_SETFD, flags) < 0) {
+			die("cannot set file descriptor flags");
+		}
+		/* Switch apparmor profile for the process after exec. */
+		if (apparmor != NULL && aa_profile != NULL) {
+			sc_maybe_aa_change_onexec(apparmor, aa_profile);
+		}
+		fexecve(tool_fd, argv, envp);
+		die("cannot execute snapd tool %s", tool_name);
+	} else {
+		int status = 0;
+		debug("waiting for snapd tool %s to terminate", tool_name);
+		if (waitpid(child, &status, 0) < 0) {
+			die("cannot wait for snapd tool %s to terminate",
+			    tool_name);
+		}
+		if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+			die("%s failed with code %i", tool_name,
+			    WEXITSTATUS(status));
+		} else if (WIFSIGNALED(status)) {
+			die("%s killed by signal %i", tool_name,
+			    WTERMSIG(status));
+		}
+		debug("%s finished successfully", tool_name);
+	}
+}

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -178,8 +178,7 @@ static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
 		int status = 0;
 		debug("waiting for snapd tool %s to terminate", tool_name);
 		if (waitpid(child, &status, 0) < 0) {
-			die("cannot wait for snapd tool %s to terminate",
-			    tool_name);
+			die("cannot get snapd tool %s termination status via waitpid", tool_name);
 		}
 		if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
 			die("%s failed with code %i", tool_name,

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -159,7 +159,7 @@ static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
 				*env = entry;
 			}
 		}
-		/* As the child ensure that the file descriptor is remains open across exec. */
+		/* As the child ensure that the file descriptor remains open across exec. */
 		int flags = fcntl(tool_fd, F_GETFD);
 		if (flags < 0) {
 			die("cannot get file descriptor flags");

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -159,15 +159,6 @@ static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
 				*env = entry;
 			}
 		}
-		/* As the child ensure that the file descriptor remains open across exec. */
-		int flags = fcntl(tool_fd, F_GETFD);
-		if (flags < 0) {
-			die("cannot get file descriptor flags");
-		}
-		flags &= ~FD_CLOEXEC;
-		if (fcntl(tool_fd, F_SETFD, flags) < 0) {
-			die("cannot set file descriptor flags");
-		}
 		/* Switch apparmor profile for the process after exec. */
 		if (apparmor != NULL && aa_profile != NULL) {
 			sc_maybe_aa_change_onexec(apparmor, aa_profile);

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -78,6 +78,8 @@ void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
 	snap_name_copy = sc_strdup(snap_name);
 	char *argv[] =
 	    { "snap-update-ns", "--from-snap-confine", snap_name_copy, NULL };
+	/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor with
+	 * either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function for details. */
 	char *envp[] = { "SNAPD_DEBUG=x", NULL };
 	char profile[PATH_MAX] = { 0 };
 	sc_must_snprintf(profile, sizeof profile, "snap-update-ns.%s",
@@ -97,6 +99,8 @@ void sc_call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name)
 	snap_name_copy = sc_strdup(snap_name);
 	char *argv[] =
 	    { "snap-discard-ns", "--from-snap-confine", snap_name_copy, NULL };
+	/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor with
+	 * either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function for details. */
 	char *envp[] = { "SNAPD_DEBUG=x", NULL };
 	sc_call_snapd_tool(snap_discard_ns_fd, "snap-discard-ns", argv, envp);
 }

--- a/cmd/libsnap-confine-private/tool.h
+++ b/cmd/libsnap-confine-private/tool.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_TOOL_H
+#define SNAP_CONFINE_TOOL_H
+
+/* Forward declaration, for real see apparmor-support.h */
+struct sc_apparmor;
+
+/**
+ * sc_open_snap_update_ns returns a file descriptor for the snap-update-ns tool.
+**/
+int sc_open_snap_update_ns(void);
+
+/**
+ * sc_call_snap_update_ns calls snap-update-ns from snap-confine.
+ **/
+void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
+			    struct sc_apparmor *apparmor);
+
+/**
+ * sc_open_snap_update_ns returns a file descriptor for the snap-discard-ns tool.
+**/
+int sc_open_snap_discard_ns(void);
+
+/**
+ * sc_call_snap_discard_ns calls the snap-discard-ns from snap confine.
+**/
+void sc_call_snap_discard_ns(int snap_discard_ns_fd, const char *snap_name);
+
+#endif

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -14,7 +14,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
+
 #include "mount-support.h"
 
 #include <errno.h>
@@ -33,7 +36,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <libgen.h>
 
 #include "../libsnap-confine-private/apparmor-support.h"
 #include "../libsnap-confine-private/classic.h"
@@ -42,6 +44,7 @@
 #include "../libsnap-confine-private/mountinfo.h"
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
 #include "mount-support-nvidia.h"
 
@@ -134,59 +137,6 @@ static void setup_private_pts(void)
 	sc_do_mount("devpts", "/dev/pts", "devpts", MS_MGC_VAL,
 		    "newinstance,ptmxmode=0666,mode=0620,gid=5");
 	sc_do_mount("/dev/pts/ptmx", "/dev/ptmx", "none", MS_BIND, 0);
-}
-
-/**
- * Setup mount profiles by running snap-update-ns.
- *
- * The first argument is an open file descriptor (though opened with O_PATH, so
- * not as powerful), to a copy of snap-update-ns. The program is opened before
- * the root filesystem is pivoted so that it is easier to pick the right copy.
- **/
-static void sc_setup_mount_profiles(struct sc_apparmor *apparmor,
-				    int snap_update_ns_fd,
-				    const char *snap_name)
-{
-	debug("calling snap-update-ns to initialize mount namespace");
-	pid_t child = fork();
-	if (child < 0) {
-		die("cannot fork to run snap-update-ns");
-	}
-	if (child == 0) {
-		// We are the child, execute snap-update-ns under a dedicated profile.
-		char profile[PATH_MAX] = { 0 };
-		sc_must_snprintf(profile, sizeof profile, "snap-update-ns.%s",
-				 snap_name);
-		debug("launching snap-update-ns under per-snap profile %s",
-		      profile);
-		sc_maybe_aa_change_onexec(apparmor, profile);
-		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-		snap_name_copy = sc_strdup(snap_name);
-		char *argv[] = {
-			"snap-update-ns", "--from-snap-confine", snap_name_copy,
-			NULL
-		};
-		char *envp[3] = { NULL };
-		if (sc_is_debug_enabled()) {
-			envp[0] = "SNAPD_DEBUG=1";
-		}
-		debug("fexecv(%d (snap-update-ns), %s %s %s,)",
-		      snap_update_ns_fd, argv[0], argv[1], argv[2]);
-		fexecve(snap_update_ns_fd, argv, envp);
-		die("cannot execute snap-update-ns");
-	}
-	// We are the parent, so wait for snap-update-ns to finish.
-	int status = 0;
-	debug("waiting for snap-update-ns to finish...");
-	if (waitpid(child, &status, 0) < 0) {
-		die("waitpid() failed for snap-update-ns process");
-	}
-	if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
-		die("snap-update-ns failed with code %i", WEXITSTATUS(status));
-	} else if (WIFSIGNALED(status)) {
-		die("snap-update-ns killed by signal %i", WTERMSIG(status));
-	}
-	debug("snap-update-ns finished successfully");
 }
 
 struct sc_mount {
@@ -568,49 +518,6 @@ static bool __attribute__ ((used))
 	return false;
 }
 
-/**
- * open_intenral_tool returns a file descriptor of the given internal executable.
- *
- * The executable is located based on the location of the currently executing process.
- * The returning file descriptor can be used with fexecve function.
-**/
-static int open_internal_tool(const char *tool_name)
-{
-	// +1 is for the case where the link is exactly PATH_MAX long but we also
-	// want to store the terminating '\0'. The readlink system call doesn't add
-	// terminating null, but our initialization of buf handles this for us.
-	char buf[PATH_MAX + 1] = { 0 };
-	if (readlink("/proc/self/exe", buf, sizeof buf) < 0) {
-		die("cannot readlink /proc/self/exe");
-	}
-	if (buf[0] != '/') {	// this shouldn't happen, but make sure have absolute path
-		die("readlink /proc/self/exe returned relative path");
-	}
-	char *dir_name = dirname(buf);
-	int dir_fd SC_CLEANUP(sc_cleanup_close) = 1;
-	dir_fd = open(dir_name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (dir_fd < 0) {
-		die("cannot open path %s", dir_name);
-	}
-	int tool_fd = -1;
-	tool_fd = openat(dir_fd, tool_name, O_PATH | O_NOFOLLOW | O_CLOEXEC);
-	if (tool_fd < 0) {
-		die("cannot open path %s/%s", dir_name, tool_name);
-	}
-	debug("opened %s executable as file descriptor %d", tool_name, tool_fd);
-	return tool_fd;
-}
-
-int sc_open_snap_update_ns(void)
-{
-	return open_internal_tool("snap-update-ns");
-}
-
-int sc_open_snap_discard_ns(void)
-{
-	return open_internal_tool("snap-discard-ns");
-}
-
 void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			  const char *base_snap_name, const char *snap_name)
 {
@@ -711,7 +618,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	setup_private_pts();
 
 	// setup the security backend bind mounts
-	sc_setup_mount_profiles(apparmor, snap_update_ns_fd, snap_name);
+	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor);
 
 	// Try to re-locate back to vanilla working directory. This can fail
 	// because that directory is no longer present.


### PR DESCRIPTION
The module allows opening tool by name, opening the two tools we
are known to open (snap-{update,discard}-ns) and calling a function
by open descriptor, with apparmor confinement if desired.

There's a small skew that tool.c includes snap-confine/apparmor-support.h
but that's a low price to pay for this cleanup.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
