### PR TITLE
tests: improve how the log is checked to see if the system is waiting for a reboot

### DIFF
--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -91,7 +91,7 @@ execute: |
         snap pack "$BUILD_DIR/unpack" && mv ${TARGET_SNAP_NAME}_*.snap failing.snap
 
         # use journalctl wrapper to grep only the logs collected while the test is running
-        if check_journalctl_log "Waiting for system reboot"; then
+        if get_journalctl_log | MATCH "Waiting for system reboot"; then
             echo "Already waiting for system reboot, exiting..."
             exit 1
         fi


### PR DESCRIPTION
The previous function retries several times checking in the logs, but
this method retrieve the logs and we match, which is much better.
