### PR TITLE
snap: add new `snap run --trace-exec` call (2.36)

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/strace"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapenv"
 	"github.com/snapcore/snapd/strutil/shlex"
@@ -67,8 +68,9 @@ type cmdRun struct {
 	// This options is both a selector (use or don't use strace) and it
 	// can also carry extra options for strace. This is why there is
 	// "default" and "optional-value" to distinguish this.
-	Strace string `long:"strace" optional:"true" optional-value:"with-strace" default:"no-strace" default-mask:"-"`
-	Gdb    bool   `long:"gdb"`
+	Strace    string `long:"strace" optional:"true" optional-value:"with-strace" default:"no-strace" default-mask:"-"`
+	Gdb       bool   `long:"gdb"`
+	TraceExec bool   `long:"trace-exec"`
 
 	// not a real option, used to check if cmdRun is initialized by
 	// the parser
@@ -99,7 +101,9 @@ and environment.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"gdb": i18n.G("Run the command with gdb"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"timer":      i18n.G("Run as a timer service with given schedule"),
+			"timer": i18n.G("Run as a timer service with given schedule"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"trace-exec": i18n.G("Display exec calls timing data"),
 			"parser-ran": "",
 		}, nil)
 }
@@ -645,49 +649,6 @@ func activateXdgDocumentPortal(info *snap.Info, snapApp, hook string) error {
 	return nil
 }
 
-func straceCmd() ([]string, error) {
-	current, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-	sudoPath, err := exec.LookPath("sudo")
-	if err != nil {
-		return nil, fmt.Errorf("cannot use strace without sudo: %s", err)
-	}
-
-	// Try strace from the snap first, we use new syscalls like
-	// "_newselect" that are known to not work with the strace of e.g.
-	// ubuntu 14.04.
-	//
-	// TODO: some architectures do not have some syscalls (e.g.
-	// s390x does not have _newselect). In
-	// https://github.com/strace/strace/issues/57 options are
-	// discussed.  We could use "-e trace=?syscall" but that is
-	// only available since strace 4.17 which is not even in
-	// ubutnu 17.10.
-	var stracePath string
-	cand := filepath.Join(dirs.SnapMountDir, "strace-static", "current", "bin", "strace")
-	if osutil.FileExists(cand) {
-		stracePath = cand
-	}
-	if stracePath == "" {
-		stracePath, err = exec.LookPath("strace")
-		if err != nil {
-			return nil, fmt.Errorf("cannot find an installed strace, please try 'snap install strace-static'")
-		}
-	}
-
-	return []string{
-		sudoPath, "-E",
-		stracePath,
-		"-u", current.Username,
-		"-f",
-		// these syscalls are excluded because they make strace hang
-		// on all or some architectures (gettimeofday on arm64)
-		"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday,nanosleep",
-	}, nil
-}
-
 func (x *cmdRun) runCmdUnderGdb(origCmd, env []string) error {
 	env = append(env, "SNAP_CONFINE_RUN_UNDER_GDB=1")
 
@@ -702,25 +663,76 @@ func (x *cmdRun) runCmdUnderGdb(origCmd, env []string) error {
 	return gcmd.Run()
 }
 
+func (x *cmdRun) runCmdWithTraceExec(origCmd, env []string) error {
+	// setup private tmp dir with strace fifo
+	straceTmp, err := ioutil.TempDir("", "exec-trace")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(straceTmp)
+	straceLog := filepath.Join(straceTmp, "strace.fifo")
+	if err := syscall.Mkfifo(straceLog, 0640); err != nil {
+		return err
+	}
+	// ensure we have one writer on the fifo so that if strace fails
+	// nothing blocks
+	fw, err := os.OpenFile(straceLog, os.O_RDWR, 0640)
+	if err != nil {
+		return err
+	}
+	defer fw.Close()
+
+	// read strace data from fifo async
+	var slg *strace.ExecveTiming
+	var straceErr error
+	doneCh := make(chan bool, 1)
+	go func() {
+		// FIXME: make this configurable?
+		nSlowest := 10
+		slg, straceErr = strace.TraceExecveTimings(straceLog, nSlowest)
+		close(doneCh)
+	}()
+
+	cmd, err := strace.TraceExecCommand(straceLog, origCmd...)
+	if err != nil {
+		return err
+	}
+	// run
+	cmd.Env = env
+	cmd.Stdin = Stdin
+	cmd.Stdout = Stdout
+	cmd.Stderr = Stderr
+	err = cmd.Run()
+	// ensure we close the fifo here so that the strace.TraceExecCommand()
+	// helper gets a EOF from the fifo (i.e. all writers must be closed
+	// for this)
+	fw.Close()
+
+	// wait for strace reader
+	<-doneCh
+	if straceErr == nil {
+		slg.Display(Stderr)
+	} else {
+		logger.Noticef("cannot extract runtime data: %v", straceErr)
+	}
+	return err
+}
+
 func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
-	// prepend strace magic
-	cmd, err := straceCmd()
+	extraStraceOpts, raw, err := x.straceOpts()
 	if err != nil {
 		return err
 	}
-	straceOpts, raw, err := x.straceOpts()
+	cmd, err := strace.Command(extraStraceOpts, origCmd...)
 	if err != nil {
 		return err
 	}
-	cmd = append(cmd, straceOpts...)
-	cmd = append(cmd, origCmd...)
 
 	// run with filter
-	gcmd := exec.Command(cmd[0], cmd[1:]...)
-	gcmd.Env = env
-	gcmd.Stdin = Stdin
-	gcmd.Stdout = Stdout
-	stderr, err := gcmd.StderrPipe()
+	cmd.Env = env
+	cmd.Stdin = Stdin
+	cmd.Stdout = Stdout
+	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return err
 	}
@@ -784,11 +796,11 @@ func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
 		}
 		io.Copy(Stderr, r)
 	}()
-	if err := gcmd.Start(); err != nil {
+	if err := cmd.Start(); err != nil {
 		return err
 	}
 	<-filterDone
-	err = gcmd.Wait()
+	err = cmd.Wait()
 	return err
 }
 
@@ -883,7 +895,9 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	}
 	env := snapenv.ExecEnv(info, extraEnv)
 
-	if x.Gdb {
+	if x.TraceExec {
+		return x.runCmdWithTraceExec(cmd, env)
+	} else if x.Gdb {
 		return x.runCmdUnderGdb(cmd, env)
 	} else if x.useStrace() {
 		return x.runCmdUnderStrace(cmd, env)

--- a/osutil/strace/export_test.go
+++ b/osutil/strace/export_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strace
+
+var (
+	ExcludedSyscalls = excludedSyscalls
+)
+
+func (stt *ExecveTiming) ExeRuntimes() []ExeRuntime {
+	return stt.exeRuntimes
+}
+
+func (stt *ExecveTiming) AddExeRuntime(exe string, totalSec float64) {
+	stt.addExeRuntime(exe, totalSec)
+}

--- a/osutil/strace/strace_test.go
+++ b/osutil/strace/strace_test.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strace_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/strace"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type straceSuite struct {
+	rootdir    string
+	mockSudo   *testutil.MockCmd
+	mockStrace *testutil.MockCmd
+}
+
+var _ = Suite(&straceSuite{})
+
+func (s *straceSuite) SetUpTest(c *C) {
+	s.rootdir = c.MkDir()
+	dirs.SetRootDir(s.rootdir)
+
+	s.mockSudo = testutil.MockCommand(c, "sudo", "")
+	s.mockStrace = testutil.MockCommand(c, "strace", "")
+}
+
+func (s *straceSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+	s.mockSudo.Restore()
+	s.mockStrace.Restore()
+}
+
+func (s *straceSuite) TestStraceCommandHappy(c *C) {
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+
+	cmd, err := strace.Command(nil, "foo")
+	c.Assert(err, IsNil)
+	c.Assert(cmd.Path, Equals, s.mockSudo.Exe())
+	c.Assert(cmd.Args, DeepEquals, []string{
+		s.mockSudo.Exe(), "-E",
+		s.mockStrace.Exe(), "-u", u.Username, "-f",
+		"-e", strace.ExcludedSyscalls,
+		// the command
+		"foo",
+	})
+}
+
+func (s *straceSuite) TestStraceCommandNoSudo(c *C) {
+	origPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", origPath) }()
+
+	os.Setenv("PATH", "/not-exists")
+	_, err := strace.Command(nil, "foo")
+	c.Assert(err, ErrorMatches, `cannot use strace without sudo: exec: "sudo": executable file not found in \$PATH`)
+}
+
+func (s *straceSuite) TestStraceCommandNoStrace(c *C) {
+	origPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", origPath) }()
+
+	tmp := c.MkDir()
+	os.Setenv("PATH", tmp)
+	err := ioutil.WriteFile(filepath.Join(tmp, "sudo"), nil, 0755)
+	c.Assert(err, IsNil)
+
+	_, err = strace.Command(nil, "foo")
+	c.Assert(err, ErrorMatches, `cannot find an installed strace, please try 'snap install strace-static'`)
+}
+
+func (s *straceSuite) TestTraceExecCommand(c *C) {
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+
+	cmd, err := strace.TraceExecCommand("/run/snapd/strace.log", "cmd")
+	c.Assert(err, IsNil)
+	c.Assert(cmd.Path, Equals, s.mockSudo.Exe())
+	c.Assert(cmd.Args, DeepEquals, []string{
+		s.mockSudo.Exe(), "-E",
+		s.mockStrace.Exe(), "-u", u.Username, "-f",
+		"-e", strace.ExcludedSyscalls,
+		// timing specific trace
+		"-ttt",
+		"-e", "trace=execve,execveat",
+		"-o", "/run/snapd/strace.log",
+		// the command
+		"cmd",
+	})
+
+}

--- a/osutil/strace/timing.go
+++ b/osutil/strace/timing.go
@@ -1,0 +1,233 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strace
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+)
+
+// ExeRuntime is the runtime of an individual executable
+type ExeRuntime struct {
+	Exe string
+	// FIXME: move to time.Duration
+	TotalSec float64
+}
+
+// ExecveTiming measures the execve calls timings under strace. This is
+// useful for performance analysis. It keeps the N slowest samples.
+type ExecveTiming struct {
+	TotalTime   float64
+	exeRuntimes []ExeRuntime
+
+	nSlowestSamples int
+}
+
+// NewExecveTiming returns a new ExecveTiming struct that keeps
+// the given amount of the slowest exec samples.
+func NewExecveTiming(nSlowestSamples int) *ExecveTiming {
+	return &ExecveTiming{nSlowestSamples: nSlowestSamples}
+}
+
+func (stt *ExecveTiming) addExeRuntime(exe string, totalSec float64) {
+	stt.exeRuntimes = append(stt.exeRuntimes, ExeRuntime{
+		Exe:      exe,
+		TotalSec: totalSec,
+	})
+	stt.prune()
+}
+
+// prune() ensures the number of exeRuntimes stays with the nSlowestSamples
+// limit
+func (stt *ExecveTiming) prune() {
+	for len(stt.exeRuntimes) > stt.nSlowestSamples {
+		fastest := 0
+		for idx, rt := range stt.exeRuntimes {
+			if rt.TotalSec < stt.exeRuntimes[fastest].TotalSec {
+				fastest = idx
+			}
+		}
+		// delete fastest element
+		stt.exeRuntimes = append(stt.exeRuntimes[:fastest], stt.exeRuntimes[fastest+1:]...)
+	}
+}
+
+func (stt *ExecveTiming) Display(w io.Writer) {
+	if len(stt.exeRuntimes) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "Slowest %d exec calls during snap run:\n", len(stt.exeRuntimes))
+	for _, rt := range stt.exeRuntimes {
+		fmt.Fprintf(w, "  %2.3fs %s\n", rt.TotalSec, rt.Exe)
+	}
+	fmt.Fprintf(w, "Total time: %2.3fs\n", stt.TotalTime)
+}
+
+type exeStart struct {
+	start float64
+	exe   string
+}
+
+type pidTracker struct {
+	pidToExeStart map[string]exeStart
+}
+
+func newPidTracker() *pidTracker {
+	return &pidTracker{
+		pidToExeStart: make(map[string]exeStart),
+	}
+
+}
+
+func (pt *pidTracker) Get(pid string) (startTime float64, exe string) {
+	if exeStart, ok := pt.pidToExeStart[pid]; ok {
+		return exeStart.start, exeStart.exe
+	}
+	return 0, ""
+}
+
+func (pt *pidTracker) Add(pid string, startTime float64, exe string) {
+	pt.pidToExeStart[pid] = exeStart{start: startTime, exe: exe}
+}
+
+func (pt *pidTracker) Del(pid string) {
+	delete(pt.pidToExeStart, pid)
+}
+
+// lines look like:
+// PID   TIME              SYSCALL
+// 17363 1542815326.700248 execve("/snap/brave/44/usr/bin/update-mime-database", ["update-mime-database", "/home/egon/snap/brave/44/.local/"...], 0x1566008 /* 69 vars */) = 0
+var execveRE = regexp.MustCompile(`([0-9]+)\ +([0-9.]+) execve\(\"([^"]+)\"`)
+
+// lines look like:
+// PID   TIME              SYSCALL
+// 14157 1542875582.816782 execveat(3, "", ["snap-update-ns", "--from-snap-confine", "test-snapd-tools"], 0x7ffce7dd6160 /* 0 vars */, AT_EMPTY_PATH) = 0
+var execveatRE = regexp.MustCompile(`([0-9]+)\ +([0-9.]+) execveat\(.*\["([^"]+)"`)
+
+// lines look like (both SIGTERM and SIGCHLD need to be handled):
+// PID   TIME                  SIGNAL
+// 17559 1542815330.242750 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=17643, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
+var sigChldTermRE = regexp.MustCompile(`[0-9]+\ +([0-9.]+).*SIG(CHLD|TERM)\ {.*si_pid=([0-9]+),`)
+
+// all lines start with this:
+// PID   TIME
+// 21616 1542882400.198907 ....
+var timeRE = regexp.MustCompile(`[0-9]+\ +([0-9.]+).*`)
+
+func handleExecMatch(trace *ExecveTiming, pt *pidTracker, match []string) error {
+	if len(match) == 0 {
+		return nil
+	}
+	// the pid of the process that does the execve{,at}()
+	pid := match[1]
+	execStart, err := strconv.ParseFloat(match[2], 64)
+	if err != nil {
+		return err
+	}
+	exe := match[3]
+	// deal with subsequent execve()
+	if start, exe := pt.Get(pid); exe != "" {
+		trace.addExeRuntime(exe, execStart-start)
+	}
+	pt.Add(pid, execStart, exe)
+	return nil
+}
+
+func handleSignalMatch(trace *ExecveTiming, pt *pidTracker, match []string) error {
+	if len(match) == 0 {
+		return nil
+	}
+	sigTime, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return err
+	}
+	sigPid := match[3]
+	if start, exe := pt.Get(sigPid); exe != "" {
+		trace.addExeRuntime(exe, sigTime-start)
+		pt.Del(sigPid)
+	}
+	return nil
+}
+
+func TraceExecveTimings(straceLog string, nSlowest int) (*ExecveTiming, error) {
+	slog, err := os.Open(straceLog)
+	if err != nil {
+		return nil, err
+	}
+	defer slog.Close()
+
+	// pidTracker maps the "pid" string to the executable
+	pidTracker := newPidTracker()
+
+	var line string
+	var start, end, tmp float64
+	trace := NewExecveTiming(nSlowest)
+	r := bufio.NewScanner(slog)
+	for r.Scan() {
+		line = r.Text()
+		if start == 0.0 {
+			if _, err := fmt.Sscanf(line, "%f %f ", &tmp, &start); err != nil {
+				return nil, fmt.Errorf("cannot parse start of exec profile: %s", err)
+			}
+		}
+		// handleExecMatch looks for execve{,at}() calls and
+		// uses the pidTracker to keep track of execution of
+		// things. Because of fork() we may see many pids and
+		// within each pid we can see multiple execve{,at}()
+		// calls.
+		// An example of pids/exec transitions:
+		// $ snap run --trace-exec test-snapd-sh -c "/bin/true"
+		//    pid 20817 execve("snap-confine")
+		//    pid 20817 execve("snap-exec")
+		//    pid 20817 execve("/snap/test-snapd-sh/x2/bin/sh")
+		//    pid 20817 execve("/bin/sh")
+		//    pid 2023  execve("/bin/true")
+		match := execveRE.FindStringSubmatch(line)
+		if err := handleExecMatch(trace, pidTracker, match); err != nil {
+			return nil, err
+		}
+		match = execveatRE.FindStringSubmatch(line)
+		if err := handleExecMatch(trace, pidTracker, match); err != nil {
+			return nil, err
+		}
+		// handleSignalMatch looks for SIG{CHLD,TERM} signals and
+		// maps them via the pidTracker to the execve{,at}() calls
+		// of the terminating PID to calculate the total time of
+		// a execve{,at}() call.
+		match = sigChldTermRE.FindStringSubmatch(line)
+		if err := handleSignalMatch(trace, pidTracker, match); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := fmt.Sscanf(line, "%f %f", &tmp, &end); err != nil {
+		return nil, fmt.Errorf("cannot parse end of exec profile: %s", err)
+	}
+	trace.TotalTime = end - start
+
+	if r.Err() != nil {
+		return nil, r.Err()
+	}
+
+	return trace, nil
+}

--- a/osutil/strace/timing_test.go
+++ b/osutil/strace/timing_test.go
@@ -1,0 +1,137 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strace_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil/strace"
+)
+
+type timingSuite struct{}
+
+var _ = Suite(&timingSuite{})
+
+func (s *timingSuite) TestNewExecveTiming(c *C) {
+	et := strace.NewExecveTiming(10)
+	c.Assert(et, FitsTypeOf, &strace.ExecveTiming{})
+}
+
+func (s *timingSuite) TestDisplayExeRuntimes(c *C) {
+	// setup mock traces
+	stt := strace.NewExecveTiming(3)
+	stt.TotalTime = 2.71828
+	stt.AddExeRuntime("slow", 1.0001)
+	stt.AddExeRuntime("fast", 0.1002)
+	stt.AddExeRuntime("really-fast", 0.0301)
+	stt.AddExeRuntime("medium", 0.5003)
+
+	// display works and shows the slowest 3 calls in order
+	buf := bytes.NewBuffer(nil)
+	stt.Display(buf)
+	c.Check(buf.String(), Equals, `Slowest 3 exec calls during snap run:
+  1.000s slow
+  0.100s fast
+  0.500s medium
+Total time: 2.718s
+`)
+}
+
+func (s *timingSuite) TestExecveTimingPrunes(c *C) {
+	stt := strace.NewExecveTiming(3)
+
+	// simple cases
+	stt.AddExeRuntime("t0", 2)
+	c.Check(stt.ExeRuntimes(), HasLen, 1)
+	stt.AddExeRuntime("t1", 1)
+	c.Check(stt.ExeRuntimes(), HasLen, 2)
+	stt.AddExeRuntime("t2", 5)
+	c.Check(stt.ExeRuntimes(), HasLen, 3)
+
+	// starts pruing the fastest call, keeps order otherwise
+	stt.AddExeRuntime("t3", 4)
+	c.Check(stt.ExeRuntimes(), HasLen, 3)
+	c.Check(stt.ExeRuntimes(), DeepEquals, []strace.ExeRuntime{
+		{Exe: "t0", TotalSec: 2},
+		{Exe: "t2", TotalSec: 5},
+		{Exe: "t3", TotalSec: 4},
+	})
+
+}
+
+// generated with:
+//  sudo /usr/lib/snapd/snap-discard-ns test-snapd-tools && sudo strace -u $USER -o strace.log -f -e trace=execve,execveat -ttt test-snapd-tools.echo foo && cat strace.log
+var sampleStraceSimple = []byte(`21616 1542882400.198907 execve("/snap/bin/test-snapd-tools.echo", ["test-snapd-tools.echo", "foo"], 0x7fff7f275f48 /* 27 vars */) = 0
+21616 1542882400.204710 execve("/snap/core/current/usr/bin/snap", ["test-snapd-tools.echo", "foo"], 0xc42011c8c0 /* 27 vars */ <unfinished ...>
+21621 1542882400.204845 +++ exited with 0 +++
+21620 1542882400.204853 +++ exited with 0 +++
+21619 1542882400.204857 +++ exited with 0 +++
+21618 1542882400.204861 +++ exited with 0 +++
+21617 1542882400.204875 +++ exited with 0 +++
+21616 1542882400.205199 <... execve resumed> ) = 0
+21616 1542882400.220845 execve("/snap/core/5976/usr/lib/snapd/snap-confine", ["/snap/core/5976/usr/lib/snapd/sn"..., "snap.test-snapd-tools.echo", "/usr/lib/snapd/snap-exec", "test-snapd-tools.echo", "foo"], 0xc8200a3600 /* 41 vars */ <unfinished ...>
+21625 1542882400.220994 +++ exited with 0 +++
+21624 1542882400.220999 +++ exited with 0 +++
+21623 1542882400.221002 +++ exited with 0 +++
+21622 1542882400.221005 +++ exited with 0 +++
+21616 1542882400.221634 <... execve resumed> ) = 0
+21629 1542882400.356625 execveat(3, "", ["snap-update-ns", "--from-snap-confine", "test-snapd-tools"], 0x7ffeaf4faa40 /* 0 vars */, AT_EMPTY_PATH) = 0
+21631 1542882400.360708 +++ exited with 0 +++
+21632 1542882400.360723 +++ exited with 0 +++
+21630 1542882400.360727 +++ exited with 0 +++
+21633 1542882400.360842 +++ exited with 0 +++
+21629 1542882400.360848 +++ exited with 0 +++
+21616 1542882400.360869 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=21629, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
+21626 1542882400.375793 +++ exited with 0 +++
+21616 1542882400.375836 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=21626, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
+21616 1542882400.377349 execve("/usr/lib/snapd/snap-exec", ["/usr/lib/snapd/snap-exec", "test-snapd-tools.echo", "foo"], 0x23ebc80 /* 45 vars */) = 0
+21616 1542882400.383698 execve("/snap/test-snapd-tools/6/bin/echo", ["/snap/test-snapd-tools/6/bin/ech"..., "foo"], 0xc420072f00 /* 47 vars */ <unfinished ...>
+21638 1542882400.383855 +++ exited with 0 +++
+21637 1542882400.383862 +++ exited with 0 +++
+21636 1542882400.383877 +++ exited with 0 +++
+21634 1542882400.383884 +++ exited with 0 +++
+21635 1542882400.383890 +++ exited with 0 +++
+21616 1542882400.384105 <... execve resumed> ) = 0
+21616 1542882400.384974 +++ exited with 0 +++
+`)
+
+func (s *timingSuite) TestTraceExecveTimings(c *C) {
+	f, err := ioutil.TempFile("", "strace-extract-test-")
+	c.Assert(err, IsNil)
+	defer os.Remove(f.Name())
+	_, err = f.Write(sampleStraceSimple)
+	c.Assert(err, IsNil)
+	f.Sync()
+
+	st, err := strace.TraceExecveTimings(f.Name(), 10)
+	c.Assert(err, IsNil)
+	c.Assert(st.TotalTime, Equals, 0.1860671043395996)
+	c.Assert(st.ExeRuntimes(), DeepEquals, []strace.ExeRuntime{
+		{Exe: "/snap/bin/test-snapd-tools.echo", TotalSec: 0.005803108215332031},
+		{Exe: "/snap/core/current/usr/bin/snap", TotalSec: 0.016134977340698242},
+		{Exe: "snap-update-ns", TotalSec: 0.0042438507080078125},
+		{Exe: "/snap/core/5976/usr/lib/snapd/snap-confine", TotalSec: 0.15650391578674316},
+		{Exe: "/usr/lib/snapd/snap-exec", TotalSec: 0.006349086761474609},
+	})
+}

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -62,3 +62,8 @@ execute: |
        MATCH hello < stdout
     fi
 
+    snap run --trace-exec test-snapd-tools.echo hello 2> stderr
+    MATCH "Slowest [0-9]+ exec calls during snap run" < stderr
+    MATCH "  [0-9.]+s .*/snap-exec" < stderr
+    MATCH "  [0-9.]+s .*/snap-confine" < stderr
+    MATCH "Total time: [0-9.]+s" < stderr

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -147,3 +147,8 @@ func (cmd *MockCmd) ForgetCalls() {
 func (cmd *MockCmd) BinDir() string {
 	return cmd.binDir
 }
+
+// Exe return the full path of the mock binary
+func (cmd *MockCmd) Exe() string {
+	return filepath.Join(cmd.exeFile)
+}


### PR DESCRIPTION
Cherry-pick of #6185 for 2.36
