### PR TITLE
tests: reduce verbosity around package installation

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -191,7 +191,7 @@ distro_install_local_package() {
 }
 
 distro_install_package() {
-    orig_xtrace=$(set -o | grep xtrace | cut -f 2)
+    orig_xtrace=$(set -o | awk '/xtrace / { print $2 }')
     set +x
     echo "distro_install_package $*"
     # Parse additional arguments; once we find the first unknown

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -191,6 +191,9 @@ distro_install_local_package() {
 }
 
 distro_install_package() {
+    orig_xtrace=$(set -o | grep xtrace | cut -f 2)
+    set +x
+    echo "distro_install_package $*"
     # Parse additional arguments; once we find the first unknown
     # part we break argument parsing and process all further
     # arguments as package names.
@@ -272,6 +275,7 @@ distro_install_package() {
             exit 1
             ;;
     esac
+    test "$orig_xtrace" = on && set -x
 }
 
 distro_purge_package() {

--- a/tests/upgrade/snapd-xdg-open/task.yaml
+++ b/tests/upgrade/snapd-xdg-open/task.yaml
@@ -7,7 +7,7 @@ details: |
 # Test case only applies to Ubuntu as that is the only distribution where
 # we had a snapd-xdg-open package ever.
 
-systems: [-ubuntu-core-*, -debian-*, -ubuntu-14.04-*, -fedora-*, -arch-*, -amazon-*]
+systems: [-ubuntu-core-*, -debian-*, -ubuntu-14.04-*, -fedora-*, -arch-*, -amazon-*, -centos-*]
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/upgrade/snapd-xdg-open/task.yaml
+++ b/tests/upgrade/snapd-xdg-open/task.yaml
@@ -34,11 +34,11 @@ execute: |
         fi
     fi
 
-    prevsnapdxdgver=$(dpkg-query --showformat='${Version}' --show snapd-xdg-open)
+    prevsnapdxdgver=$(dpkg-query --showformat='${Version}' --show snapd-xdg-open || true)
 
     # allow-downgrades prevents errors when new versions hit the archive, for instance,
     # trying to install 2.11ubuntu1 over 2.11+0.16.04
     distro_install_local_package --allow-downgrades "$GOHOME"/snapd*.deb
 
-    snapdxdgver=$(dpkg-query --showformat='${Version}' --show snapd-xdg-open)
+    snapdxdgver=$(dpkg-query --showformat='${Version}' --show snapd-xdg-open || true)
     [ "$snapdxdgver" != "$prevsnapdxdgver" ]


### PR DESCRIPTION
Package installation is particularly verbose, not because of actual
invocation of the system package manager, but because there's a pack of
indirection layers to simplify cross distribution portability.

Recently we ran into an issue where a Travis job is killed after
exceeding log size. As the package trace logs are rarely a problem I've
made as small patch that silences shell trace output around that logic.

To maintain minimal trace we now echo the set of packages to install
along with the name of the function that was invoked.

Thanks to Maciej Borzecki for the trick with "set -o"

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
