### PR TITLE
spread, tests: use checkpoints when dumping audit log

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -415,7 +415,11 @@ debug-each: |
         get_journalctl_log -u snapd
         case "$SPREAD_SYSTEM" in
             fedora-*|centos-*|amazon-*)
-                ausearch -m AVC
+                if [ -e "$RUNTIME_STATE_PATH/audit-stamp" ]; then
+                    ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" --start checkpoint
+                else
+                    ausearch -m AVC
+                fi
                 ;;
             *)
                echo '# apparmor denials '

--- a/spread.yaml
+++ b/spread.yaml
@@ -416,9 +416,9 @@ debug-each: |
         case "$SPREAD_SYSTEM" in
             fedora-*|centos-*|amazon-*)
                 if [ -e "$RUNTIME_STATE_PATH/audit-stamp" ]; then
-                    ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" --start checkpoint
+                    ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" --start checkpoint || true
                 else
-                    ausearch -m AVC
+                    ausearch -m AVC || true
                 fi
                 ;;
             *)

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -428,10 +428,16 @@ prepare_suite_each() {
     fi
     # Check if journalctl is ready to run the test
     check_journalctl_ready
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*|amazon-*)
+            ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp"
+            ;;
+    esac
 }
 
 restore_suite_each() {
-    true
+    rm -f "$RUNTIME_STATE_PATH/audit-stamp"
 }
 
 restore_suite() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -431,7 +431,7 @@ prepare_suite_each() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*|amazon-*)
-            ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp"
+            ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" || true
             ;;
     esac
 }


### PR DESCRIPTION
Audit has support for checkpoints. Use this to display audit logs only from the
specific test. Otherwise, the log builds up and displaying it will be a problem
on Travis.

