### PR TITLE
tests/lib/prepare: make sure that SELinux context of repacked core snap is controlled

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -141,7 +141,7 @@ update_core_snap_for_classic_reexec() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*|amazon-*)
-            # on these systems just unpacking core snap to $HOME will
+            # On these systems just unpacking core snap to $HOME will
             # automatically apply user_home_t label on all the contents of the
             # snap; since we cannot drop xattrs when calling mksquashfs, make
             # sure that we relabel the contents in way that a squashfs image

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -141,12 +141,14 @@ update_core_snap_for_classic_reexec() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*|amazon-*)
-            # On these systems just unpacking core snap to $HOME will
-            # automatically apply user_home_t label on all the contents of the
-            # snap; since we cannot drop xattrs when calling mksquashfs, make
-            # sure that we relabel the contents in way that a squashfs image
-            # without any labels would look like: system_u:object_r:unlabeled_t
-            chcon -R -u system_u -r object_r -t unlabeled_t squashfs-root
+            if selinuxenabled ; then
+                # On these systems just unpacking core snap to $HOME will
+                # automatically apply user_home_t label on all the contents of the
+                # snap; since we cannot drop xattrs when calling mksquashfs, make
+                # sure that we relabel the contents in way that a squashfs image
+                # without any labels would look like: system_u:object_r:unlabeled_t
+                chcon -R -u system_u -r object_r -t unlabeled_t squashfs-root
+            fi
             ;;
     esac
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -139,6 +139,17 @@ update_core_snap_for_classic_reexec() {
             ;;
     esac
 
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*|amazon-*)
+            # on these systems just unpacking core snap to $HOME will
+            # automatically apply user_home_t label on all the contents of the
+            # snap; since we cannot drop xattrs when calling mksquashfs, make
+            # sure that we relabel the contents in way that a squashfs image
+            # without any labels would look like: system_u:object_r:unlabeled_t
+            chcon -R -u system_u -r object_r -t unlabeled_t squashfs-root
+            ;;
+    esac
+
     # repack, cheating to speed things up (4sec vs 1.5min)
     mv "$snap" "${snap}.orig"
     mksnap_fast "squashfs-root" "$snap"


### PR DESCRIPTION
When the core snap in unpacked to $HOME, user_home_t label will be automatically
applied on all its content. Since we cannot drop xattrs when calling mksquashfs,
as that could introduce breakage in the future, make sure that we relabel the
contents in way that a squashfs image without any labels would look like:
`system_u:object_r:unlabeled_t`

