### PR TITLE
apparmor: allow snap-update-ns access to common devices

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -597,6 +597,13 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libc{,-[0-9]*}.so* mr,
   /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpthread{,-[0-9]*}.so* mr,
 
+  # Common devices accesses
+  /dev/null rw,
+  /dev/full rw,
+  /dev/zero rw,
+  /dev/random r,
+  /dev/urandom r,
+
   # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
   @{PROC}/@{pid}/cmdline r,
 


### PR DESCRIPTION
During a snap refresh on arm64, a urandom read denial was seen:
```
kernel: [   40.746771] audit: type=1400 audit(1543923082.646:26): apparmor="DENIED" operation="open" profile="snap-update-ns.ufw" name="/dev/urandom" pid=1496 comm="3" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

The above did not seem to cause a problem, and I'm not sure what caused it but I decided to compare the common device accesses allowed to snap-confine with those allowed in snap-update-ns and discovered that snap-update-ns was missing a few extremely common accesses. This PR adds those.