### PR TITLE
tests: make security-device-cgroups-{devmode,jailmode} work on arm devices

### DIFF
--- a/tests/main/security-device-cgroups-devmode/task.yaml
+++ b/tests/main/security-device-cgroups-devmode/task.yaml
@@ -31,7 +31,7 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test-devmode-cgroup.read-dev mem
+    test-devmode-cgroup.read-dev random
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
@@ -40,4 +40,4 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test-devmode-cgroup.read-dev mem
+    test-devmode-cgroup.read-dev random

--- a/tests/main/security-device-cgroups-devmode/task.yaml
+++ b/tests/main/security-device-cgroups-devmode/task.yaml
@@ -15,7 +15,7 @@ prepare: |
 
     # Create a test char device so we can verify the test snap cannot read.
     if [ ! -e /dev/test1 ]; then
-        mknod /dev/test1 c 29 0
+        mknod /dev/test1 c 29 1
         touch /dev/test1.spread
     fi
 

--- a/tests/main/security-device-cgroups-devmode/task.yaml
+++ b/tests/main/security-device-cgroups-devmode/task.yaml
@@ -13,6 +13,12 @@ prepare: |
         touch /dev/fb0.spread
     fi
 
+    # Create a test char device so we can verify the test snap cannot read.
+    if [ ! -e /dev/test1 ]; then
+        mknod /dev/test1 c 29 0
+        touch /dev/test1.spread
+    fi
+
     echo "Given a snap declaring a plug on framebuffer is installed in devmode"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
@@ -21,6 +27,9 @@ prepare: |
 restore: |
     if [ -e /dev/fb0.spread ]; then
         rm -f /dev/fb0 /dev/fb0.spread
+    fi
+    if [ -e /dev/test1.spread ]; then
+        rm -f /dev/test1 /dev/test1.spread
     fi
 
 execute: |
@@ -31,7 +40,7 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test-devmode-cgroup.read-dev random
+    test-devmode-cgroup.read-dev test1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
@@ -40,4 +49,4 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test-devmode-cgroup.read-dev random
+    test-devmode-cgroup.read-dev test1 | MATCH -v '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -34,7 +34,7 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    test-devmode-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev random 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
@@ -43,4 +43,4 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    test-devmode-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev random 2>&1 | MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -16,6 +16,12 @@ prepare: |
         touch /dev/fb0.spread
     fi
 
+    # Create a test char device so we can verify the test snap cannot read.
+    if [ ! -e /dev/test1 ]; then
+        mknod /dev/test1 c 29 0
+        touch /dev/test1.spread
+    fi
+
     echo "Given a snap declaring a plug on framebuffer is installed in jailmode"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
@@ -24,6 +30,9 @@ prepare: |
 restore: |
     if [ -e /dev/fb0.spread ]; then
         rm -f /dev/fb0 /dev/fb0.spread
+    fi
+    if [ -e /dev/test1.spread ]; then
+        rm -f /dev/test1 /dev/test1.spread
     fi
 
 execute: |
@@ -34,7 +43,7 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    test-devmode-cgroup.read-dev random 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev test1 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
@@ -43,4 +52,4 @@ execute: |
     test-devmode-cgroup.read-dev fb0 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    test-devmode-cgroup.read-dev random 2>&1 | MATCH '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev test1 2>&1 | MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -18,7 +18,7 @@ prepare: |
 
     # Create a test char device so we can verify the test snap cannot read.
     if [ ! -e /dev/test1 ]; then
-        mknod /dev/test1 c 29 0
+        mknod /dev/test1 c 29 1
         touch /dev/test1.spread
     fi
 


### PR DESCRIPTION
Currently we use mem device on the tests but it is not allowed to access
on arm device such as rpi3 and dragonboard. The idea is to use random
device instead.

example for rpi3:

test@localhost:~$ dd if=/dev/mem of=/dev/null count=10
dd: failed to open '/dev/mem': Permission denied

test@localhost:~$ dd if=/dev/random of=/dev/null count=10
10+0 records in
10+0 records out
5120 bytes (5.1 kB, 5.0 KiB) copied, 0.00265199 s, 1.9 MB/s

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
