### PR TITLE
overlord: move Conf interface to configstate/config to avoid cyclic imports

### DIFF
--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -31,6 +31,14 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
+// Conf is an interface describing both state and transaction.
+type Conf interface {
+	Get(snapName, key string, result interface{}) error
+	Set(snapName, key string, value interface{}) error
+	Changes() []string
+	State() *state.State
+}
+
 // Transaction holds a copy of the configuration originally present in the
 // provided state which can be queried and mutated in isolation from
 // concurrent logic. All changes performed into it are persisted back into

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
-	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 )
 
@@ -35,10 +34,7 @@ var (
 )
 
 type Conf interface {
-	Get(snapName, key string, result interface{}) error
-	Set(snapName, key string, value interface{}) error
-	Changes() []string
-	State() *state.State
+	config.Conf
 }
 
 func coreCfg(tr Conf, key string) (result string, err error) {


### PR DESCRIPTION
I will need the Conf interface from configcore, snapstate and config itself
next. This simple move is the easiest way to avoid the cyclic imports.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
