### PR TITLE
overlord/ifacestate: helpers for serializing hotplug changes

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -47,6 +47,9 @@ var (
 	FindConnsForHotplugKey       = findConnsForHotplugKey
 	CheckSystemSnapIsPresent     = checkSystemSnapIsPresent
 	SystemSnapInfo               = systemSnapInfo
+	IsHotplugChange              = isHotplugChange
+	GetHotplugChangeAttrs        = getHotplugChangeAttrs
+	ObtainHotplugSeq             = obtainHotplugSeq
 )
 
 func NewConnectOptsWithAutoSet() connectOpts {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -859,6 +859,32 @@ func getHotplugAttrs(task *state.Task) (ifaceName, hotplugKey string, err error)
 	return ifaceName, hotplugKey, err
 }
 
+func obtainHotplugSeq(st *state.State) (int, error) {
+	var seq int
+	if err := st.Get("hotplug-seq", &seq); err != nil && err != state.ErrNoState {
+		return 0, err
+	}
+	seq++
+	st.Set("hotplug-seq", seq)
+	return seq, nil
+}
+
+func isHotplugChange(chg *state.Change) bool {
+	return strings.HasPrefix(chg.Kind(), "hotplug-")
+}
+
+func getHotplugChangeAttrs(chg *state.Change) (int, string, error) {
+	var hotplugKey string
+	var seq int
+	if err := chg.Get("hotplug-key", &hotplugKey); err != nil {
+		return 0, "", fmt.Errorf("internal error: hotplug-key not set on change %q", chg.Kind())
+	}
+	if err := chg.Get("hotplug-seq", &seq); err != nil {
+		return 0, "", fmt.Errorf("internal error: hotplug-seq not set on change %q", chg.Kind())
+	}
+	return seq, hotplugKey, nil
+}
+
 type HotplugSlotInfo struct {
 	Name        string                 `json:"name"`
 	Interface   string                 `json:"interface"`

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -82,6 +82,9 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	addHandler("gadget-connect", m.doGadgetConnect, nil)
 	addHandler("auto-disconnect", m.doAutoDisconnect, nil)
 
+	// don't block on hotplug-seq-wait task
+	runner.AddHandler("hotplug-seq-wait", m.doHotplugSeqWait, nil)
+
 	// helper for ubuntu-core -> core
 	addHandler("transition-ubuntu-core", m.doTransitionUbuntuCore, m.undoTransitionUbuntuCore)
 

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -39,6 +39,7 @@ import (
 )
 
 var connectRetryTimeout = time.Second * 5
+var hotplugRetryTimeout = time.Second * 3
 
 // ErrAlreadyConnected describes the error that occurs when attempting to connect already connected interface.
 type ErrAlreadyConnected struct {
@@ -472,4 +473,10 @@ func MockConnectRetryTimeout(d time.Duration) (restore func()) {
 	old := connectRetryTimeout
 	connectRetryTimeout = d
 	return func() { connectRetryTimeout = old }
+}
+
+func MockHotplugRetryTimeout(d time.Duration) (restore func()) {
+	old := hotplugRetryTimeout
+	hotplugRetryTimeout = d
+	return func() { hotplugRetryTimeout = old }
 }


### PR DESCRIPTION
Implementation of helpers for serializing hotplug-related changes affecting same device. The general idea is to control the order of task exection by maintaining a sequence number:
- all tasks related to given hotplug event are added to a `hotplug-...` change.
- the change has `hotplug-key` (that identifies a device) and `hotplug-seq` value that gets increased every time as new changes are created. Current value of this counter is remembered in state.
- a special task (`hotplug-sequence-wait`) is added to the same change, before actual tasks. This task looks into all currently running hotplug changes and returns `Retry` error if there is another change with a lower sequence number for same hotplug key.