### PR TITLE
cmd, dirs, interfaces/apparmor: update distro identification to support ID="archlinux"

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -148,7 +148,7 @@ func (s *cmdSuite) TestNonClassicDistroNoSupportsReExec(c *C) {
 	// no distro supports re-exec when not on classic :-)
 	for _, id := range []string{
 		"fedora", "centos", "rhel", "opensuse", "suse", "poky",
-		"debian", "ubuntu", "arch",
+		"debian", "ubuntu", "arch", "archlinux",
 	} {
 		restore = release.MockReleaseInfo(&release.OS{ID: id})
 		defer restore()

--- a/cmd/snap/cmd_paths_test.go
+++ b/cmd/snap/cmd_paths_test.go
@@ -58,12 +58,29 @@ func (s *SnapSuite) TestPathsFedora(c *C) {
 }
 
 func (s *SnapSuite) TestPathsArch(c *C) {
-	restore := release.MockReleaseInfo(&release.OS{IDLike: []string{"arch"}})
-	defer restore()
 	defer dirs.SetRootDir("/")
+
+	// old /etc/os-release contents
+	restore := release.MockReleaseInfo(&release.OS{ID: "arch", IDLike: []string{"archlinux"}})
+	defer restore()
 
 	dirs.SetRootDir("/")
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, ""+
+		"SNAPD_MOUNT=/var/lib/snapd/snap\n"+
+		"SNAPD_BIN=/var/lib/snapd/snap/bin\n"+
+		"SNAPD_LIBEXEC=/usr/lib/snapd\n")
+	c.Assert(s.Stderr(), Equals, "")
+
+	s.ResetStdStreams()
+
+	// new contents, as set by filesystem-2018.12-1
+	restore = release.MockReleaseInfo(&release.OS{ID: "archlinux"})
+	defer restore()
+
+	dirs.SetRootDir("/")
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "paths"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
 		"SNAPD_MOUNT=/var/lib/snapd/snap\n"+

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -201,7 +201,7 @@ func SetRootDir(rootdir string) {
 	GlobalRootDir = rootdir
 
 	isInsideBase, _ := isInsideBaseSnap()
-	if !isInsideBase && release.DistroLike("fedora", "arch", "manjaro", "antergos") {
+	if !isInsideBase && release.DistroLike("fedora", "arch", "archlinux", "manjaro", "antergos") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -95,6 +95,8 @@ func (s *DirsTestSuite) TestClassicConfinementSupportOnSpecificDistributions(c *
 		{"debian", nil, true},
 		{"suse", nil, true},
 		{"yocto", nil, true},
+		{"arch", []string{"archlinux"}, false},
+		{"archlinux", nil, false},
 	} {
 		reset := release.MockReleaseInfo(&release.OS{ID: t.ID, IDLike: t.IDLike})
 		defer reset()

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -476,7 +476,7 @@ func downgradeConfinement() bool {
 			// 4.16, do not downgrade the confinement template.
 			return false
 		}
-	case release.DistroLike("arch"):
+	case release.DistroLike("arch", "archlinux"):
 		// The default kernel has AppArmor enabled since 4.18.8, the
 		// hardened one since 4.17.4
 		return false

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -673,10 +673,45 @@ func (s *backendSuite) TestCombineSnippetsOpenSUSETumbleweedOldKernel(c *C) {
 	c.Check(profile, testutil.FileEquals, "\n#classic"+commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\n\n}\n")
 }
 
+func (s *backendSuite) TestCombineSnippetsArchOldIDSufficientHardened(c *C) {
+	restore := release.MockAppArmorLevel(release.PartialAppArmor)
+	defer restore()
+	restore = release.MockReleaseInfo(&release.OS{ID: "arch", IDLike: []string{"archlinux"}})
+	defer restore()
+	restore = osutil.MockKernelVersion("4.18.2.a-1-hardened")
+	defer restore()
+	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
+	defer restore()
+	restore = apparmor.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+	// NOTE: replace the real template with a shorter variant
+	restoreTemplate := apparmor.MockTemplate("\n" +
+		"###VAR###\n" +
+		"###PROFILEATTACH### (attach_disconnected) {\n" +
+		"###SNIPPETS###\n" +
+		"}\n")
+	defer restoreTemplate()
+	restoreClassicTemplate := apparmor.MockClassicTemplate("\n" +
+		"#classic\n" +
+		"###VAR###\n" +
+		"###PROFILEATTACH### (attach_disconnected) {\n" +
+		"###SNIPPETS###\n" +
+		"}\n")
+	defer restoreClassicTemplate()
+	s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+		spec.AddSnippet("snippet")
+		return nil
+	}
+
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+	c.Check(profile, testutil.FileEquals, commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n")
+}
+
 func (s *backendSuite) TestCombineSnippetsArchSufficientHardened(c *C) {
 	restore := release.MockAppArmorLevel(release.PartialAppArmor)
 	defer restore()
-	restore = release.MockReleaseInfo(&release.OS{ID: "arch"})
+	restore = release.MockReleaseInfo(&release.OS{ID: "archlinux"})
 	defer restore()
 	restore = osutil.MockKernelVersion("4.18.2.a-1-hardened")
 	defer restore()
@@ -1506,6 +1541,7 @@ func (s *backendSuite) TestDowngradeConfinement(c *C) {
 		{"opensuse-tumbleweed", "4.14.1-default", true},
 		{"arch", "4.18.2.a-1-hardened", false},
 		{"arch", "4.18.8-arch1-1-ARCH", false},
+		{"archlinux", "4.18.2.a-1-hardened", false},
 	} {
 		c.Logf("trying: %+v", tc)
 		restore := release.MockReleaseInfo(&release.OS{ID: tc.distro})


### PR DESCRIPTION
In filesystem-2018.12-1 Arch is switching its /etc/os-release to:
```
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=archlinux
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
```

Before we had:
```
ID=arch
ID_LIKE=archlinux
...
```

Update relevant locations to support the new IDs.

Relevant change in Arch packaging: https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/filesystem&id=6fa932aa685da87e78e0f845bd890645607d302e
