### PR TITLE
centos: enable SELinux support on CentOS 7

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -90,9 +90,6 @@
 %if 0%{?amzn2} == 1
 %global with_selinux 0
 %endif
-%if 0%{?centos} == 7
-%global with_selinux 0
-%endif
 
 Name:           snapd
 Version:        2.36.2

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -223,7 +223,11 @@ BuildArch:      noarch
 BuildRequires:  selinux-policy, selinux-policy-devel
 Requires(post): selinux-policy-base >= %{_selinux_policy_version}
 Requires(post): policycoreutils
+%if 0%{?rhel} == 7
+Requires(post): policycoreutils-python
+%else
 Requires(post): policycoreutils-python-utils
+%endif
 Requires(pre):  libselinux-utils
 Requires(post): libselinux-utils
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -152,11 +152,7 @@ build_rpm() {
         -ba \
         "$packaging_path/snapd.spec"
 
-    cp "$rpm_dir"/RPMS/$arch/snap*.rpm "${GOPATH%%:*}"
-    if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
-        # On Fedora we have an additional package for SELinux
-        cp "$rpm_dir"/RPMS/noarch/snap*.rpm "${GOPATH%%:*}"
-    fi
+    find "$rpm_dir"/RPMS -name '*.rpm' -exec cp -v {} "${GOPATH%%:*}" \;
 }
 
 build_arch_pkg() {


### PR DESCRIPTION
CentOS 7.6 has SELinux policy is up to date and allows us to build the module
for snapd.

Ths will allow #6270 to run the tests on CentOS.