### PR TITLE
apparmor: allow hard link to snap-specific semaphore files

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -412,7 +412,7 @@ var defaultTemplate = `
   # bind mount *not* used here (see 'parallel installs', above)
   /{dev,run}/shm/snap.@{SNAP_INSTANCE_NAME}.** mrwlkix,
   # Also allow app-specific access for sem_open()
-  /{dev,run}/shm/sem.snap.@{SNAP_INSTANCE_NAME}.* mrwk,
+  /{dev,run}/shm/sem.snap.@{SNAP_INSTANCE_NAME}.* mrwlk,
 
   # Snap-specific XDG_RUNTIME_DIR that is based on the UID of the user
   # bind mount *not* used here (see 'parallel installs', above)


### PR DESCRIPTION
When adding the accessing for /dev/shm/sem.snap..., 'l' was forgotten.
Hard linking to this file is important for race-free semaphore handling.

References:
https://forum.snapcraft.io/t/python-multiprocessing-sem-open-blocked-in-strict-mode/962/14
