### PR TITLE
cmd/snap: make 'snap warnings' output yamlish

### DIFF
--- a/cmd/snap/cmd_warnings_test.go
+++ b/cmd/snap/cmd_warnings_test.go
@@ -102,28 +102,44 @@ func (s *warningSuite) TestNoFurtherWarnings(c *check.C) {
 func (s *warningSuite) TestWarnings(c *check.C) {
 	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, twoWarnings))
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"warnings", "--abs-time"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"warnings", "--abs-time", "--unicode=never"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, `
-Last occurrence       Warning
-2018-09-19T12:41:18Z  hello world number one
-2018-09-19T12:44:19Z  hello world number two
+Last occurrence:  2018-09-19T12:41:18Z
+Warning: |
+  hello world number one
+---
+Last occurrence:  2018-09-19T12:44:19Z
+Warning: |
+  hello world number two
 `[1:])
 }
 
 func (s *warningSuite) TestVerboseWarnings(c *check.C) {
 	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, twoWarnings))
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"warnings", "--abs-time", "--verbose"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"warnings", "--abs-time", "--verbose", "--unicode=never"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, `
-First occurrence      Last occurrence       Expires after  Acknowledged  Repeats after  Warning
-2018-09-19T12:41:18Z  2018-09-19T12:41:18Z  28d0h          -             1d00h          hello world number one
-2018-09-19T12:44:19Z  2018-09-19T12:44:19Z  28d0h          -             1d00h          hello world number two
+First occurrence:  2018-09-19T12:41:18Z
+Last occurrence:   2018-09-19T12:41:18Z
+Expires after:     28d0h
+Acknowledged:      --
+Repeats after:     1d00h
+Warning: |
+  hello world number one
+---
+First occurrence:  2018-09-19T12:44:19Z
+Last occurrence:   2018-09-19T12:44:19Z
+Expires after:     28d0h
+Acknowledged:      --
+Repeats after:     1d00h
+Warning: |
+  hello world number two
 `[1:])
 }
 

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -30,14 +30,12 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-type colorMixin struct {
-	Color   string `long:"color" default:"auto" choice:"auto" choice:"never" choice:"always"`
-	Unicode string `long:"unicode" default:"auto" choice:"auto" choice:"never" choice:"always"` // do we want this hidden?
+type unicodeMixin struct {
+	Unicode string `long:"unicode" default:"auto" choice:"auto" choice:"never" choice:"always"`
 }
 
-func (mx colorMixin) getEscapes() *escapes {
-	esc := colorTable(mx.Color)
-	if canUnicode(mx.Unicode) {
+func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
+	if canUnicode(ux.Unicode) {
 		esc.dash = "–" // that's an en dash (so yaml is happy)
 		esc.uparrow = "↑"
 		esc.tick = "✓"
@@ -46,7 +44,22 @@ func (mx colorMixin) getEscapes() *escapes {
 		esc.uparrow = "^"
 		esc.tick = "*"
 	}
+}
 
+func (ux unicodeMixin) getEscapes() *escapes {
+	esc := &escapes{}
+	ux.addUnicodeChars(esc)
+	return esc
+}
+
+type colorMixin struct {
+	Color string `long:"color" default:"auto" choice:"auto" choice:"never" choice:"always"`
+	unicodeMixin
+}
+
+func (mx colorMixin) getEscapes() *escapes {
+	esc := colorTable(mx.Color)
+	mx.addUnicodeChars(&esc)
 	return &esc
 }
 
@@ -100,7 +113,11 @@ func colorTable(mode string) escapes {
 
 var colorDescs = mixinDescs{
 	// TRANSLATORS: This should not start with a lowercase letter.
-	"color": i18n.G("Use a little bit of color to highlight some things."),
+	"color":   i18n.G("Use a little bit of color to highlight some things."),
+	"unicode": unicodeDescs["unicode"],
+}
+
+var unicodeDescs = mixinDescs{
 	// TRANSLATORS: This should not start with a lowercase letter.
 	"unicode": i18n.G("Use a little bit of Unicode to improve legibility."),
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -205,7 +205,10 @@ func Wait(cli *client.Client, id string) (*client.Change, error) {
 }
 
 func ColorMixin(cmode, umode string) colorMixin {
-	return colorMixin{Color: cmode, Unicode: umode}
+	return colorMixin{
+		Color:        cmode,
+		unicodeMixin: unicodeMixin{Unicode: umode},
+	}
 }
 
 func CmdAdviseSnap() *cmdAdviseSnap {


### PR DESCRIPTION
The first time we tried to use `snap warnings` we found we wanted to
be far more verbose than the current output sensibly allowed. We need
to be verbose because we don't want to say what went wrong, we want to
say how to fix it -- which needs more space.

So this PR changes `snap warnings` output to be yaml-ish.

It means `snap warnings` grows a `--unicode` option (for en-dash), but
as there's no need for color this pr also splits colorMixin.

In a followup I can drop Unicode from colorMixin and make them really
separate (it's probably a little confusing right now). This can be
done as a refactor free of user-visible side effects.
