### PR TITLE
tests: force test-snapd-daemon-notify exit 0 when the interface is not connected

### DIFF
--- a/tests/lib/snaps/test-snapd-daemon-notify/bin/notify
+++ b/tests/lib/snaps/test-snapd-daemon-notify/bin/notify
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-systemd-notify --ready --status="Test service ready"
+systemd-notify --ready --status="Test service ready" || true


### PR DESCRIPTION
This snap is exiting 1 when the interface is not connected, so systemd
retries trying to start the service making reach the start-limit-hit.

This test is mostly failing on boards where the delay between the snap
installation and the interface is connected is much higher than in cloud
images.
