### PR TITLE
osutil: do not import dirs

### DIFF
--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -35,12 +35,11 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/strutil"
 )
 
-func parseCoreLdSoConf(confPath string) []string {
-	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+func parseCoreLdSoConf(snapMountDir string, confPath string) []string {
+	root := filepath.Join(snapMountDir, "/core/current")
 
 	f, err := os.Open(filepath.Join(root, confPath))
 	if err != nil {
@@ -64,7 +63,7 @@ func parseCoreLdSoConf(confPath string) []string {
 				return nil
 			}
 			for _, f := range files {
-				out = append(out, parseCoreLdSoConf(f[len(root):])...)
+				out = append(out, parseCoreLdSoConf(snapMountDir, f[len(root):])...)
 			}
 		default:
 			out = append(out, filepath.Join(root, line))
@@ -105,8 +104,8 @@ func elfInterp(cmd string) (string, error) {
 //
 // At the moment it can only run ELF files, expects a standard ld.so
 // interpreter, and can't handle RPATH.
-func CommandFromCore(name string, cmdArgs ...string) (*exec.Cmd, error) {
-	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+func CommandFromCore(snapMountDir string, name string, cmdArgs ...string) (*exec.Cmd, error) {
+	root := filepath.Join(snapMountDir, "/core/current")
 
 	cmdPath := filepath.Join(root, name)
 	interp, err := elfInterp(cmdPath)
@@ -134,7 +133,7 @@ func CommandFromCore(name string, cmdArgs ...string) (*exec.Cmd, error) {
 		seen[coreLdSo] = true
 	}
 
-	ldLibraryPathForCore := parseCoreLdSoConf("/etc/ld.so.conf")
+	ldLibraryPathForCore := parseCoreLdSoConf(snapMountDir, "/etc/ld.so.conf")
 
 	ldSoArgs := []string{"--library-path", strings.Join(ldLibraryPathForCore, ":"), cmdPath}
 	allArgs := append(ldSoArgs, cmdArgs...)

--- a/osutil/exec_test.go
+++ b/osutil/exec_test.go
@@ -77,7 +77,7 @@ func (s *execSuite) TestCommandFromCore(c *C) {
 
 	os.MkdirAll(filepath.Join(root, "/usr/bin"), 0755)
 	osutil.CopyFile(truePath, filepath.Join(root, "/usr/bin/xdelta3"), 0)
-	cmd, err := osutil.CommandFromCore("/usr/bin/xdelta3", "--some-xdelta-arg")
+	cmd, err := osutil.CommandFromCore(dirs.SnapMountDir, "/usr/bin/xdelta3", "--some-xdelta-arg")
 	c.Assert(err, IsNil)
 
 	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("readelf -l %s |grep interpreter:|cut -f2 -d:|cut -f1 -d]", truePath)).Output()
@@ -108,7 +108,7 @@ func (s *execSuite) TestCommandFromCoreSymlinkCycle(c *C) {
 	c.Assert(os.MkdirAll(filepath.Dir(coreInterp), 0755), IsNil)
 	c.Assert(os.Symlink(filepath.Base(coreInterp), coreInterp), IsNil)
 
-	_, err = osutil.CommandFromCore("/usr/bin/xdelta3", "--some-xdelta-arg")
+	_, err = osutil.CommandFromCore(dirs.SnapMountDir, "/usr/bin/xdelta3", "--some-xdelta-arg")
 	c.Assert(err, ErrorMatches, "cannot run command from core: symlink cycle found")
 
 }

--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -22,6 +22,7 @@ package backend
 import (
 	"fmt"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -31,7 +32,7 @@ var updateFontconfigCaches = updateFontconfigCachesImpl
 func updateFontconfigCachesImpl() error {
 	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
 		// FIXME: also use the snapd snap if available
-		cmd, err := osutil.CommandFromCore("/bin/" + fc)
+		cmd, err := osutil.CommandFromCore(dirs.SnapMountDir, "/bin/"+fc)
 		if err != nil {
 			return fmt.Errorf("cannot get %s from core: %v", fc, err)
 		}

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -43,7 +43,7 @@ func MockLink(newLink func(string, string) error) (restore func()) {
 	}
 }
 
-func MockFromCore(newFromCore func(string, ...string) (*exec.Cmd, error)) (restore func()) {
+func MockFromCore(newFromCore func(string, string, ...string) (*exec.Cmd, error)) (restore func()) {
 	oldFromCore := osutilCommandFromCore
 	osutilCommandFromCore = newFromCore
 	return func() {

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -305,7 +305,7 @@ func (s *Snap) Build(sourceDir, snapType string, excludeFiles ...string) error {
 	if err != nil {
 		return err
 	}
-	cmd, err := osutilCommandFromCore("/usr/bin/mksquashfs")
+	cmd, err := osutilCommandFromCore(dirs.SnapMountDir, "/usr/bin/mksquashfs")
 	if err != nil {
 		cmd = exec.Command("mksquashfs")
 	}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -412,7 +412,8 @@ squashfs-root/random/data.bin
 }
 
 func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcardsFlag(c *C) {
-	defer squashfs.MockFromCore(func(cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
+		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return nil, errors.New("bzzt")
 	})()
@@ -435,8 +436,9 @@ func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcard
 
 func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 	usedFromCore := false
-	defer squashfs.MockFromCore(func(cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
 		usedFromCore = true
+		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return &exec.Cmd{Path: "/bin/true"}, nil
 	})()
@@ -454,8 +456,9 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 
 func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(c *C) {
 	triedFromCore := false
-	defer squashfs.MockFromCore(func(cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
 		triedFromCore = true
+		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return nil, errors.New("bzzt")
 	})()
@@ -473,8 +476,9 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(
 
 func (s *SquashfsTestSuite) TestBuildFailsIfNoMksquashfs(c *C) {
 	triedFromCore := false
-	defer squashfs.MockFromCore(func(cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
 		triedFromCore = true
+		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return nil, errors.New("bzzt")
 	})()
@@ -491,7 +495,8 @@ func (s *SquashfsTestSuite) TestBuildFailsIfNoMksquashfs(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestBuildVariesArgsByType(c *C) {
-	defer squashfs.MockFromCore(func(cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
+		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		return nil, errors.New("bzzt")
 	})()
 	mksq := testutil.MockCommand(c, "mksquashfs", "")

--- a/store/store.go
+++ b/store/store.go
@@ -1582,7 +1582,7 @@ func getXdelta3Cmd(args ...string) (*exec.Cmd, error) {
 	case osutil.ExecutableExists("xdelta3"):
 		return exec.Command("xdelta3", args...), nil
 	case osutil.FileExists(filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3")):
-		return osutil.CommandFromCore("/usr/bin/xdelta3", args...)
+		return osutil.CommandFromCore(dirs.SnapMountDir, "/usr/bin/xdelta3", args...)
 	}
 	return nil, fmt.Errorf("cannot find xdelta3 binary in PATH or core snap")
 }


### PR DESCRIPTION
Importing `dirs` package in `osutil` leads to import cycles if one attempts to
use `osutils` from packages that are directly or indirectly imported by `dirs`,
such as `release`. It doesn't make any sense for `osutil` to depend on
other non `*util` packages.

