### PR TITLE
spread: make opensuse-42.3 manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -83,6 +83,7 @@ backends:
                 workers: 4
             - opensuse-42.3-64:
                 workers: 4
+                manual: true
             - arch-linux-64:
                 workers: 4
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -83,7 +83,8 @@ backends:
                 workers: 4
             - opensuse-42.3-64:
                 workers: 4
-                manual: true // golang stack cannot compile anything, needs investigation
+                # golang stack cannot compile anything, needs investigation
+                manual: true
             - arch-linux-64:
                 workers: 4
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -83,7 +83,7 @@ backends:
                 workers: 4
             - opensuse-42.3-64:
                 workers: 4
-                manual: true
+                manual: true // golang stack cannot compile anything, needs investigation
             - arch-linux-64:
                 workers: 4
 


### PR DESCRIPTION
openSUSE 42.3 does not build again. Needs investigation.

