### PR TITLE
httputil: retry on temporary net errors

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -100,7 +100,7 @@ func ShouldRetryError(attempt *retry.Attempt, err error) bool {
 		if dnsErr, ok := opErr.Err.(*net.DNSError); ok {
 			// The horror, the horror
 			if strings.Contains(dnsErr.Err, "connection refused") {
-				logger.Debugf("Retrying because DNS connection refused error: %#v", dnsErr)
+				logger.Debugf("Retrying because of temporary net error (DNS): %#v", dnsErr)
 				return true
 			}
 		}

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -99,7 +99,9 @@ func ShouldRetryError(attempt *retry.Attempt, err error) bool {
 		// use go1.9+ only.
 		if dnsErr, ok := opErr.Err.(*net.DNSError); ok {
 			// The horror, the horror
-			if strings.Contains(dnsErr.Err, "connection refused") {
+			// TODO: stop Arch to use the cgo resolver
+			// which requires the right side of the OR
+			if strings.Contains(dnsErr.Err, "connection refused") || strings.Contains(dnsErr.Err, "Temporary failure in name resolution") {
 				logger.Debugf("Retrying because of temporary net error (DNS): %#v", dnsErr)
 				return true
 			}

--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -21,8 +21,8 @@ package httputil_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -403,9 +403,7 @@ func (s *retrySuite) TestRetryRequestTimeoutHandling(c *C) {
 	c.Assert(somewhatBrokenSrvCalls, Equals, 3)
 }
 
-func (s *retrySuite) TestRetryRequestFailOnDNS(c *C) {
-	// TODO: retry some types of DNS errors?
-
+func (s *retrySuite) TestRetryDoesNotFailForPermanentDNSErrors(c *C) {
 	url := "http://nonexistingserver909123.com/"
 
 	cli := httputil.NewHTTPClient(nil)
@@ -416,14 +414,31 @@ func (s *retrySuite) TestRetryRequestFailOnDNS(c *C) {
 		return cli.Get(url)
 	}
 
-	var got interface{}
 	readResponseBody := func(resp *http.Response) error {
-		if resp.StatusCode >= 500 {
-			return fmt.Errorf("proxy error")
-		}
-		return json.NewDecoder(resp.Body).Decode(&got)
+		return nil
 	}
 
 	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
 	c.Assert(err, NotNil)
+	// we try exactly once, a non-existing server is a permanent error
+	c.Assert(n, Equals, 1)
+}
+
+func (s *retrySuite) TestRetryOnTemporaryDNSfailure(c *C) {
+	n := 0
+	doRequest := func() (*http.Response, error) {
+		n++
+		return nil, &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: &net.DNSError{IsTemporary: true},
+		}
+	}
+	readResponseBody := func(resp *http.Response) error {
+		return nil
+	}
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, NotNil)
+	c.Assert(n > 1, Equals, true, Commentf("%v not > 1", n))
+
 }

--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -440,5 +440,24 @@ func (s *retrySuite) TestRetryOnTemporaryDNSfailure(c *C) {
 	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
 	c.Assert(err, NotNil)
 	c.Assert(n > 1, Equals, true, Commentf("%v not > 1", n))
+}
 
+func (s *retrySuite) TestRetryOnTemporaryDNSfailureNotGo19(c *C) {
+	n := 0
+	doRequest := func() (*http.Response, error) {
+		n++
+		return nil, &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: &net.DNSError{
+				Err: "[::1]:42463->[::1]:53: read: connection refused",
+			},
+		}
+	}
+	readResponseBody := func(resp *http.Response) error {
+		return nil
+	}
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, NotNil)
+	c.Assert(n > 1, Equals, true, Commentf("%v not > 1", n))
 }

--- a/store/download_test.go
+++ b/store/download_test.go
@@ -56,7 +56,7 @@ var _ = Suite(&downloadSuite{})
 func (s *downloadSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	store.MockDefaultRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.Exponential{
+	store.MockDownloadRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.Exponential{
 		Initial: time.Millisecond,
 		Factor:  2.5,
 	}))

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -69,6 +69,15 @@ func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	})
 }
 
+func MockDownloadRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
+	originalDownloadRetryStrategy := downloadRetryStrategy
+	downloadRetryStrategy = strategy
+	t.AddCleanup(func() {
+		downloadRetryStrategy = originalDownloadRetryStrategy
+	})
+}
+
+
 func MockConnCheckStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	originalConnCheckStrategy := connCheckStrategy
 	connCheckStrategy = strategy

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -77,7 +77,6 @@ func MockDownloadRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	})
 }
 
-
 func MockConnCheckStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	originalConnCheckStrategy := connCheckStrategy
 	connCheckStrategy = strategy

--- a/store/store.go
+++ b/store/store.go
@@ -90,11 +90,11 @@ var defaultRetryStrategy = retry.LimitCount(6, retry.LimitTime(38*time.Second,
 ))
 
 var downloadRetryStrategy = retry.LimitCount(7, retry.LimitTime(90*time.Second,
-		retry.Exponential{
-			Initial: 500 * time.Millisecond,
-			Factor:  2.5,
-		},
-	))
+	retry.Exponential{
+		Initial: 500 * time.Millisecond,
+		Factor:  2.5,
+	},
+))
 
 var connCheckStrategy = retry.LimitCount(3, retry.LimitTime(38*time.Second,
 	retry.Exponential{

--- a/store/store.go
+++ b/store/store.go
@@ -82,12 +82,19 @@ type RefreshOptions struct {
 
 // the LimitTime should be slightly more than 3 times of our http.Client
 // Timeout value
-var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(38*time.Second,
+var defaultRetryStrategy = retry.LimitCount(6, retry.LimitTime(38*time.Second,
 	retry.Exponential{
-		Initial: 300 * time.Millisecond,
+		Initial: 350 * time.Millisecond,
 		Factor:  2.5,
 	},
 ))
+
+var downloadRetryStrategy = retry.LimitCount(7, retry.LimitTime(90*time.Second,
+		retry.Exponential{
+			Initial: 500 * time.Millisecond,
+			Factor:  2.5,
+		},
+	))
 
 var connCheckStrategy = retry.LimitCount(3, retry.LimitTime(38*time.Second,
 	retry.Exponential{
@@ -1443,7 +1450,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 	var finalErr error
 	var dlSize float64
 	startTime := time.Now()
-	for attempt := retry.Start(defaultRetryStrategy, nil); attempt.Next(); {
+	for attempt := retry.Start(downloadRetryStrategy, nil); attempt.Next(); {
 		reqOptions := reqOptions(storeURL, cdnHeader)
 
 		httputil.MaybeLogRetryAttempt(reqOptions.URL.String(), attempt, startTime)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -402,6 +402,13 @@ func (s *storeTestSuite) SetUpTest(c *C) {
 			Factor:  1,
 		},
 	)))
+
+	store.MockDownloadRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.LimitTime(1*time.Second,
+		retry.Exponential{
+			Initial: 1 * time.Millisecond,
+			Factor:  1,
+		},
+	)))
 }
 
 func (s *storeTestSuite) TearDownTest(c *C) {

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -2,11 +2,22 @@ summary: Ensure network retry works correctly
 
 prepare: |
     echo "Break DNS"
-    mv /etc/resolv.conf /etc/resolv.conf.save
-
+    if [[ "$SPREAD_SYSTEM" = ubuntu-core-* ]]; then
+       resolvConf=$(realpath /etc/resolv.conf)
+       mv "${resolvConf}" "${resolvConf}.save"
+       echo "${resolvConf}" > resolvConf.txt
+    else
+        mv /etc/resolv.conf /etc/resolv.conf.save
+    fi
 restore: |
     echo "Unbreak DNS"
-    mv /etc/resolv.conf.save /etc/resolv.conf
+    if [[ "$SPREAD_SYSTEM" = ubuntu-core-* ]]; then
+       resolvConf=$(cat resolvConf.txt)
+       mv "${resolvConf}.save" "${resolvConf}"
+       rm resolvConf.txt
+    else
+       mv /etc/resolv.conf.save /etc/resolv.conf
+    fi
 
 execute: |
     echo "Try to install a snap with broken DNS"

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -1,0 +1,22 @@
+summary: Ensure network retry works correctly
+
+prepare: |
+    echo "Break DNS"
+    mv /etc/resolv.conf /etc/resolv.conf.save
+
+restore: |
+    echo "Unbreak DNS"
+    mv /etc/resolv.conf.save /etc/resolv.conf
+
+execute: |
+    echo "Try to install a snap with broken DNS"
+    if snap install test-snapd-tools; then
+        echo "Installing test-snapd-tools with broken DNS should not work"
+        echo "Test broken"
+        exit 1
+    fi
+
+    # shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB/journalctl.sh"
+    echo "Ensure we tried to retry this operation"
+    check_journalctl_log 'Retrying because of temporary net error'


### PR DESCRIPTION
We currently retry network operations on various high level errors
like 500. However we do not retry on network errors like DNS
connection refused. To fix that this PR will also retry when
we hit net.Error conditions that are marked as Temporary() (like
dns connection refused errors when the DNS server is not quite
ready yet).

This should fix LP: #1807770
