### PR TITLE
cmd/snap-confine: refactor call to snap-update-ns --user-mounts

### DIFF
--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -105,7 +105,7 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
 			 snap_name);
 
 	const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
-	char xdg_runtime_dir_env[PATH_MAX];
+	char xdg_runtime_dir_env[PATH_MAX+strlen("XDG_RUNTIME_DIR=")];
 	if (xdg_runtime_dir != NULL) {
 		sc_must_snprintf(xdg_runtime_dir_env,
 				 sizeof(xdg_runtime_dir_env),

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -72,20 +72,52 @@ int sc_open_snap_update_ns(void)
 }
 
 void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
-			    struct sc_apparmor *apparmor)
+			    struct sc_apparmor *apparmor, bool is_user_profile)
 {
 	char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
 	snap_name_copy = sc_strdup(snap_name);
-	char *argv[] =
-	    { "snap-update-ns", "--from-snap-confine", snap_name_copy, NULL };
-	/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor with
-	 * either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function for details. */
-	char *envp[] = { "SNAPD_DEBUG=x", NULL };
-	char profile[PATH_MAX] = { 0 };
-	sc_must_snprintf(profile, sizeof profile, "snap-update-ns.%s",
+
+	char aa_profile[PATH_MAX] = { 0 };
+	sc_must_snprintf(aa_profile, sizeof aa_profile, "snap-update-ns.%s",
 			 snap_name);
-	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd, "snap-update-ns",
-					 apparmor, profile, argv, envp);
+
+	if (is_user_profile) {
+		const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+		char xdg_runtime_dir_env[PATH_MAX];
+		if (xdg_runtime_dir != NULL) {
+			sc_must_snprintf(xdg_runtime_dir_env,
+					 sizeof(xdg_runtime_dir_env),
+					 "XDG_RUNTIME_DIR=%s", xdg_runtime_dir);
+		}
+		char *argv[] = {
+			"snap-update-ns",
+			/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
+			/* TODO: enable this in sync with snap-update-ns changes, "--from-snap-confine", */
+			/* This tells snap-update-ns that we want to process the per-user profile */
+			"--user-mounts", snap_name_copy, NULL
+		};
+		char *envp[] = {
+			/* SNAPD_DEBUG=x is replaced by sc_call_snapd_tool_with_apparmor
+			 * with either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function
+			 * for details. */
+			"SNAPD_DEBUG=x",
+			xdg_runtime_dir_env, NULL
+		};
+		sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
+						 "snap-update-ns", apparmor,
+						 aa_profile, argv, envp);
+	} else {
+		char *argv[] = {
+			"snap-update-ns",
+			/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
+			"--from-snap-confine",
+			snap_name_copy, NULL
+		};
+		char *envp[] = { "SNAPD_DEBUG=x", NULL };
+		sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
+						 "snap-update-ns", apparmor,
+						 aa_profile, argv, envp);
+	}
 }
 
 int sc_open_snap_discard_ns(void)

--- a/cmd/libsnap-confine-private/tool.h
+++ b/cmd/libsnap-confine-private/tool.h
@@ -18,8 +18,6 @@
 #ifndef SNAP_CONFINE_TOOL_H
 #define SNAP_CONFINE_TOOL_H
 
-#include <stdbool.h>
-
 /* Forward declaration, for real see apparmor-support.h */
 struct sc_apparmor;
 
@@ -32,7 +30,14 @@ int sc_open_snap_update_ns(void);
  * sc_call_snap_update_ns calls snap-update-ns from snap-confine
  **/
 void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
-			    struct sc_apparmor *apparmor, bool is_user_profile);
+			    struct sc_apparmor *apparmor);
+
+/**
+ * sc_call_snap_update_ns calls snap-update-ns --user-mounts from snap-confine
+ **/
+void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
+				    const char *snap_name,
+				    struct sc_apparmor *apparmor);
 
 /**
  * sc_open_snap_update_ns returns a file descriptor for the snap-discard-ns tool.

--- a/cmd/libsnap-confine-private/tool.h
+++ b/cmd/libsnap-confine-private/tool.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_CONFINE_TOOL_H
 #define SNAP_CONFINE_TOOL_H
 
+#include <stdbool.h>
+
 /* Forward declaration, for real see apparmor-support.h */
 struct sc_apparmor;
 
@@ -27,10 +29,10 @@ struct sc_apparmor;
 int sc_open_snap_update_ns(void);
 
 /**
- * sc_call_snap_update_ns calls snap-update-ns from snap-confine.
+ * sc_call_snap_update_ns calls snap-update-ns from snap-confine
  **/
 void sc_call_snap_update_ns(int snap_update_ns_fd, const char *snap_name,
-			    struct sc_apparmor *apparmor);
+			    struct sc_apparmor *apparmor, bool is_user_profile);
 
 /**
  * sc_open_snap_update_ns returns a file descriptor for the snap-discard-ns tool.

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -618,7 +618,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	setup_private_pts();
 
 	// setup the security backend bind mounts
-	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor, false);
+	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor);
 
 	// Try to re-locate back to vanilla working directory. This can fail
 	// because that directory is no longer present.
@@ -699,5 +699,5 @@ void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	}
 
 	sc_make_slave_mount_ns();
-	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor, true);
+	sc_call_snap_update_ns_as_user(snap_update_ns_fd, snap_name, apparmor);
 }

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -618,7 +618,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	setup_private_pts();
 
 	// setup the security backend bind mounts
-	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor);
+	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor, false);
 
 	// Try to re-locate back to vanilla working directory. This can fail
 	// because that directory is no longer present.
@@ -699,55 +699,5 @@ void sc_setup_user_mounts(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	}
 
 	sc_make_slave_mount_ns();
-
-	debug("calling snap-update-ns to initialize user mounts");
-	pid_t child = fork();
-	if (child < 0) {
-		die("cannot fork to run snap-update-ns");
-	}
-	if (child == 0) {
-		// We are the child, execute snap-update-ns under a dedicated profile.
-		char profile[PATH_MAX] = { 0 };
-		sc_must_snprintf(profile, sizeof profile, "snap-update-ns.%s",
-				 snap_name);
-		debug("launching snap-update-ns under per-snap profile %s",
-		      profile);
-		sc_maybe_aa_change_onexec(apparmor, profile);
-		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
-		snap_name_copy = sc_strdup(snap_name);
-		char *argv[] = {
-			"snap-update-ns", "--user-mounts", snap_name_copy,
-			NULL
-		};
-		char *envp[3] = { NULL };
-		int last_env = 0;
-		if (sc_is_debug_enabled()) {
-			envp[last_env++] = "SNAPD_DEBUG=1";
-		}
-		const char *xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
-		char xdg_runtime_dir_env[PATH_MAX];
-		if (xdg_runtime_dir != NULL) {
-			sc_must_snprintf(xdg_runtime_dir_env,
-					 sizeof(xdg_runtime_dir_env),
-					 "XDG_RUNTIME_DIR=%s", xdg_runtime_dir);
-			envp[last_env++] = xdg_runtime_dir_env;
-		}
-
-		debug("fexecv(%d (snap-update-ns), %s %s %s,)",
-		      snap_update_ns_fd, argv[0], argv[1], argv[2]);
-		fexecve(snap_update_ns_fd, argv, envp);
-		die("cannot execute snap-update-ns");
-	}
-	// We are the parent, so wait for snap-update-ns to finish.
-	int status = 0;
-	debug("waiting for snap-update-ns to finish...");
-	if (waitpid(child, &status, 0) < 0) {
-		die("waitpid() failed for snap-update-ns process");
-	}
-	if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
-		die("snap-update-ns failed with code %i", WEXITSTATUS(status));
-	} else if (WIFSIGNALED(status)) {
-		die("snap-update-ns killed by signal %i", WTERMSIG(status));
-	}
-	debug("snap-update-ns finished successfully");
+	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor, true);
 }


### PR DESCRIPTION
Having introduced tool helper module we have cut a significant amount of
boiler-plate code related to calling snap-update-ns and snap-discard-ns.
Somehow I totally neglected the call to snap-update-ns --user-mounts,
so here it is.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
