### PR TITLE
spread: record each tests/upgrade job

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -636,6 +636,12 @@ suites:
         # autopkgtest runs against localhost which causes problems with
         # this test prepare
         backends: [-autopkgtest]
+        prepare-each: |
+            # shellcheck source=tests/lib/state.sh
+            "$TESTSLIB"/state.sh
+            mkdir -p "$RUNTIME_STATE_PATH"
+            # save the job which is going to be executed in the system
+            echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
         restore: |
             if [ "$REMOTE_STORE" = staging ]; then
                 echo "skip upgrade tests while talking to the staging store"


### PR DESCRIPTION
Spread jobs under tests/upgrade/ suite were not being recorded in the 'runs'
file.
