### PR TITLE
cmd/snap-confine: remove unused sc_discard_preserved_mount_ns

### DIFF
--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -70,7 +70,6 @@ struct sc_mount_ns;
  * that specific snap namespace:
  * - sc_create_or_join_mount_ns()
  * - sc_preserve_populated_mount_ns()
- * - sc_discard_preserved_mount_ns()
  */
 struct sc_mount_ns *sc_open_mount_ns(const char *group_name);
 
@@ -145,13 +144,5 @@ void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group);
  * terminate cleanly.
  **/
 void sc_wait_for_helper(struct sc_mount_ns *group);
-
-/**
- * Discard the preserved namespace group.
- *
- * This function unmounts the bind-mounted files representing the kernel mount
- * namespace.
- **/
-void sc_discard_preserved_mount_ns(struct sc_mount_ns *group);
 
 #endif


### PR DESCRIPTION
The responsibilities of said functions moved entirely into
snap-discard-ns and that binary is used by other parts of the stack
instead of calling the now-unused function.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
