### PR TITLE
tests: new backend used to run upgrade test suite

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -273,7 +273,7 @@ if [ "$SPREAD" = 1 ]; then
     export PATH=$TMP_SPREAD:$PATH
     ( cd "$TMP_SPREAD" && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    spread google:
+    spread google: google-upgrade:
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/run-checks
+++ b/run-checks
@@ -273,7 +273,7 @@ if [ "$SPREAD" = 1 ]; then
     export PATH=$TMP_SPREAD:$PATH
     ( cd "$TMP_SPREAD" && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    spread google: google-upgrade:
+    spread google: google-upgrade:tests/upgrade/
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/spread.yaml
+++ b/spread.yaml
@@ -96,6 +96,36 @@ backends:
                 workers: 4
                 image: centos-7-64
 
+    google-upgrade:
+        type: google
+        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        location: computeengine/us-east1-b
+        halt-timeout: 2h
+        systems:
+            - ubuntu-14.04-64:
+                workers: 1
+            - ubuntu-16.04-32:
+                workers: 1
+            - ubuntu-16.04-64:
+                workers: 1
+            - ubuntu-18.04-64:
+                workers: 1
+            - ubuntu-18.10-64:
+                image: ubuntu-1810
+                workers: 1
+            - debian-9-64:
+                workers: 1
+            - fedora-29-64:
+                workers: 1
+            - arch-linux-64:
+                workers: 1
+            - amazon-linux-2-64:
+                workers: 1
+                storage: preserve-size
+            - centos-7-64:
+                workers: 1
+
+
     google-sru:
         type: google
         key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
@@ -124,23 +154,6 @@ backends:
             - ubuntu-18.04-64:
                 image: ubuntu-1804-64-virt-enabled
                 workers: 1
-
-    linode:
-        key: "$(HOST: echo $SPREAD_LINODE_KEY)"
-        plan: 4GB
-        location: Fremont
-        halt-timeout: 2h
-        environment:
-            # Using proxy can help to accelerate testing in local conditions
-            # but it is unlikely anyone has a proxy that is addressable from
-            # Linode network. As such, don't honor host's SPREAD_HTTP_PROXY
-            # that was set globally above.
-            HTTP_PROXY: null
-            HTTPS_PROXY: null
-        systems:
-            - fedora-25-64:
-                workers: 4
-                manual: true
 
     qemu:
         systems:
@@ -569,6 +582,7 @@ restore-each: |
 suites:
     tests/main/:
         summary: Full-system tests for snapd
+        backends: [-google-upgrade]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -579,6 +593,7 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite
     tests/core18/:
         summary: Subset of core18 specific tests
+        backends: [-google-upgrade]
         systems: [ubuntu-core-18-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -590,6 +605,7 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite
     tests/completion/:
         summary: completion tests
+        backends: [-google-upgrade]
         # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
         systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
         prepare: |
@@ -618,6 +634,7 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
+        backends: [-google-upgrade]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -635,7 +652,7 @@ suites:
         systems: [-ubuntu-core-*, -opensuse-*]
         # autopkgtest runs against localhost which causes problems with
         # this test prepare
-        backends: [-autopkgtest]
+        backends: [google-upgrade]
         prepare-each: |
             # FIXME: this should really use prepare-restore.sh --prepare-suite-each
             # like other suites, needs more investigation
@@ -661,6 +678,7 @@ suites:
             distro_purge_package snapd-xdg-open || true
     tests/cross/:
         summary: Cross-compile tests
+        backends: [-google-upgrade]
         systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
     tests/unit/:
@@ -670,7 +688,7 @@ suites:
         # drop this blacklist.
         systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
         # unittests are run as part of the autopkgtest build already
-        backends: [-autopkgtest]
+        backends: [-autopkgtest, -google-upgrade]
         environment:
             # env vars required for coverage reporting from a spread task
             TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"
@@ -713,6 +731,7 @@ suites:
         # Test cases are not yet ported to Fedora/openSUSE/Arch/AMZN2 that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
+        backends: [-google-upgrade]
         systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite

--- a/spread.yaml
+++ b/spread.yaml
@@ -582,7 +582,6 @@ restore-each: |
 suites:
     tests/main/:
         summary: Full-system tests for snapd
-        backends: [-google-upgrade]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -593,7 +592,6 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite
     tests/core18/:
         summary: Subset of core18 specific tests
-        backends: [-google-upgrade]
         systems: [ubuntu-core-18-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -605,7 +603,6 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite
     tests/completion/:
         summary: completion tests
-        backends: [-google-upgrade]
         # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
         systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
         prepare: |
@@ -634,7 +631,6 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
-        backends: [-google-upgrade]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -678,7 +674,6 @@ suites:
             distro_purge_package snapd-xdg-open || true
     tests/cross/:
         summary: Cross-compile tests
-        backends: [-google-upgrade]
         systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
     tests/unit/:
@@ -688,7 +683,7 @@ suites:
         # drop this blacklist.
         systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
         # unittests are run as part of the autopkgtest build already
-        backends: [-autopkgtest, -google-upgrade]
+        backends: [-autopkgtest]
         environment:
             # env vars required for coverage reporting from a spread task
             TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"
@@ -731,7 +726,6 @@ suites:
         # Test cases are not yet ported to Fedora/openSUSE/Arch/AMZN2 that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
-        backends: [-google-upgrade]
         systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite


### PR DESCRIPTION
This change introduces a new backed to run the upgrade test suite and
also removes the linode backend from the spread.yaml
