### PR TITLE
data/selinux: fix syntax error in definition of snappy_admin interface

### DIFF
--- a/data/selinux/snappy.if
+++ b/data/selinux/snappy.if
@@ -256,18 +256,18 @@ interface(`snappy_stream_connect',`
 ## <rolecap/>
 #
 
-interface(`snappy_admin',
-         gen_require(`
-                 type snappy_t, snappy_config_t; 
-                 type snappy_var_run_t;
-         ')
+interface(`snappy_admin',`
+	gen_require(`
+		type snappy_t, snappy_config_t;
+		type snappy_var_run_t;
+	')
 
-         allow $1 snappy_t:process signal_perms;
+	allow $1 snappy_t:process signal_perms;
 
-         ps_process_pattern($1, snappy_t);
+	ps_process_pattern($1, snappy_t);
 
-         admin_pattern($1, snappy_config_t);
+	admin_pattern($1, snappy_config_t);
 
-         files_list_pids($1, snappy_var_run_t);
-         admin_pattern($1, snappy_var_run_t);
+	files_list_pids($1, snappy_var_run_t);
+	admin_pattern($1, snappy_var_run_t);
 ')


### PR DESCRIPTION
The snappy_admin interface in snappy.if is incorrectly defined. It is missing a
start quote in the interface name. This causes sepolgen-ifgen to raise an error
when installing selinux-policy-devel package. The error is logged as follows:

```
/usr/share/selinux/devel/include/contrib/snappy.if: Syntax error on line 260 gen_require [type=GEN_REQ]
/usr/share/selinux/devel/include/contrib/snappy.if: Syntax error on line 263 ' [type=SQUOTE]
/usr/share/selinux/devel/include/contrib/snappy.if: Syntax error on line 273 ' [type=SQUOTE]
```

The problem was there from the beginning , but has been noticed only now.

Fixes:
  https://bugzilla.redhat.com/show_bug.cgi?id=1658152

cc @Conan-Kudo 