### PR TITLE
travis: short circuit failures in static and unit tests travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
         - ./get-deps.sh
       script:
+        - set -e
         - ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ jobs:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
         - ./get-deps.sh
       script:
-        - ./run-checks --static
-        - ./run-checks --short-unit
+        - ./run-checks --static && ./run-checks --short-unit
     - stage: quick
       go: 1.10
       name: OSX build and minimal runtime sanity check

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ jobs:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false build-dep snapd
         - ./get-deps.sh
       script:
-        - ./run-checks --static && ./run-checks --short-unit
+        - ./run-checks --static
+        - ./run-checks --short-unit
     - stage: quick
       go: 1.10
       name: OSX build and minimal runtime sanity check


### PR DESCRIPTION
It's super annoying to have the Travis job execute all scripts, while the first
one has failed. This makes it hard to find out the failure that occurred in
--static checks as it doesn't really stand out and it followed by a couple of
pages of unit tests log.

Alternative to #6209 