### PR TITLE
wrappers: only restart service in core18 when they are active

### DIFF
--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/wrappers"
 )
 
@@ -65,6 +66,16 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCore(c *C) {
 
 	// reset root dir
 	dirs.SetRootDir(s.tempdir)
+
+	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if cmd[0] == "show" && cmd[1] == "--property=Id,ActiveState,UnitFileState,Type" {
+			s := fmt.Sprintf("Type=oneshot\nId=%s\nActiveState=inactive\nUnitFileState=enabled\n", cmd[2])
+			return []byte(s), nil
+		}
+		return []byte("ActiveState=inactive\n"), nil
+	})
+	defer systemctlRestorer()
 
 	info := makeMockSnapdSnap(c)
 	// add the snapd service
@@ -117,8 +128,7 @@ WantedBy=snapd.service
 		{"--root", dirs.GlobalRootDir, "enable", "snapd.autoimport.service"},
 		{"--root", dirs.GlobalRootDir, "enable", "snapd.service"},
 		{"--root", dirs.GlobalRootDir, "enable", "snapd.system-shutdown.service"},
-		{"stop", "snapd.autoimport.service"},
-		{"show", "--property=ActiveState", "snapd.autoimport.service"},
+		{"show", "--property=Id,ActiveState,UnitFileState,Type", "snapd.autoimport.service"},
 		{"start", "snapd.autoimport.service"},
 		{"start", "snapd.service"},
 		{"start", "--no-block", "snapd.seeded.service"},


### PR DESCRIPTION
This fixes the issue that on the very first boot the
snapd.seeded.service must not be restarted. This service has a
"Requires=snapd.socket" relation and that means that when we
seed and we start snapd.socket for the first time we must not
stop it or otherwise systemd will also stop snapd.seeded.service
which will means that systemd will start the units configured with
"After=snapd.seeded.service" which would be too early.
