### PR TITLE
cmd: add tests for lintArg and lintDesc

### DIFF
--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -70,6 +70,9 @@ var (
 	SnapHelpAllFooter       = snapHelpAllFooter
 	SnapHelpFooter          = snapHelpFooter
 	HelpCategories          = helpCategories
+
+	LintArg  = lintArg
+	LintDesc = lintDesc
 )
 
 func MockPollTime(d time.Duration) (restore func()) {


### PR DESCRIPTION
While investigating a bug report about localization issues I realised
the problem is related to the pair of lint functions. Since they were
not tested I decided to write some quick tests before attempting any
changes.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
