### PR TITLE
cmd: automatically fix localized <option>s to <option>

### DIFF
--- a/cmd/snap/cmd_ack.go
+++ b/cmd/snap/cmd_ack.go
@@ -52,7 +52,7 @@ func init() {
 	addCommand("ack", shortAckHelp, longAckHelp, func() flags.Commander {
 		return &cmdAck{}
 	}, nil, []argDesc{{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<assertion file>"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Assertion file"),

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -68,7 +68,7 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"format": i18n.G("Use the given output format"),
 	}, []argDesc{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<command or pkg>")},
 	})
 	cmd.hidden = true

--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -54,7 +54,7 @@ func init() {
 		return &cmdAlias{}
 	}, waitDescs, []argDesc{
 		{name: "<snap.app>"},
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<alias>")},
 	})
 }

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -58,9 +58,9 @@ func init() {
 	addCommand("connect", shortConnectHelp, longConnectHelp, func() flags.Commander {
 		return &cmdConnect{}
 	}, waitDescs, []argDesc{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<snap>:<plug>")},
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<snap>:<slot>")},
 	})
 }

--- a/cmd/snap/cmd_create_key.go
+++ b/cmd/snap/cmd_create_key.go
@@ -46,7 +46,7 @@ used for signing assertions.
 		func() flags.Commander {
 			return &cmdCreateKey{}
 		}, nil, []argDesc{{
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<key-name>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to create; defaults to 'default'"),

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -61,7 +61,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"force-managed": i18n.G("Force adding the user, even if the device is already managed"),
 		}, []argDesc{{
-			// TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+			// TRANSLATORS: This is a noun and it needs to begin with < and end with >
 			name: i18n.G("<email>"),
 			// TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 			desc: i18n.G("An email of a user on login.ubuntu.com"),

--- a/cmd/snap/cmd_delete_key.go
+++ b/cmd/snap/cmd_delete_key.go
@@ -42,7 +42,7 @@ the given name.
 		func() flags.Commander {
 			return &cmdDeleteKey{}
 		}, nil, []argDesc{{
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<key-name>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to delete"),

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -55,9 +55,9 @@ func init() {
 	addCommand("disconnect", shortDisconnectHelp, longDisconnectHelp, func() flags.Commander {
 		return &cmdDisconnect{}
 	}, waitDescs, []argDesc{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<snap>:<plug>")},
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<snap>:<slot>")},
 	})
 }

--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -48,7 +48,7 @@ imported by other systems.
 		}, map[string]string{
 			"account": i18n.G("Format public key material as a request for an account-key for this account-id"),
 		}, []argDesc{{
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<key-name>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Name of key to export"),

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -171,7 +171,7 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"section": i18n.G("Restrict the search to a given section"),
 	}), []argDesc{{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<query>"),
 	}}).alias = "search"
 

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -79,7 +79,7 @@ func init() {
 				desc: i18n.G("The snap whose conf is being requested"),
 			},
 			{
-				// TRANSLATORS: This needs to be wrapped in <>s.
+				// TRANSLATORS: This needs to begin with < and end with >
 				name: i18n.G("<key>"),
 				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("Key of interest within the configuration"),

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -58,7 +58,7 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"all": i18n.G("Include unused interfaces"),
 	}, []argDesc{{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<interface>"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Show details of a specific interface"),

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -62,7 +62,7 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"i": i18n.G("Constrain listing to specific interfaces"),
 	}, []argDesc{{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<snap>:<slot or plug>"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Constrain listing to a specific snap or snap:name"),

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -54,12 +54,12 @@ func init() {
 		return &cmdKnown{}
 	}, nil, []argDesc{
 		{
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<assertion type>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Assertion type name"),
 		}, {
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<header filter>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Constrain listing to those matching header=value"),

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -58,7 +58,7 @@ func init() {
 		func() flags.Commander {
 			return &cmdLogin{}
 		}, nil, []argDesc{{
-			// TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+			// TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 			name: i18n.G("<email>"),
 			// TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 			desc: i18n.G("The login.ubuntu.com email to login as"),

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -54,12 +54,12 @@ core device images.
 			"channel": i18n.G("The channel to use"),
 		}, []argDesc{
 			{
-				// TRANSLATORS: This needs to be wrapped in <>s.
+				// TRANSLATORS: This needs to begin with < and end with >
 				name: i18n.G("<model-assertion>"),
 				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The model assertion name"),
 			}, {
-				// TRANSLATORS: This needs to be wrapped in <>s.
+				// TRANSLATORS: This needs to begin with < and end with >
 				name: i18n.G("<root-dir>"),
 				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The output directory"),

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -76,7 +76,7 @@ command, a reload is performed instead of a restart.
 
 func init() {
 	argdescs := []argDesc{{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<service>"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("A service specification, which can be just a snap name (for all services in the snap), or <snap>.<app> for a single service."),

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -58,7 +58,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("The snap to configure (e.g. hello-world)"),
 		}, {
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<conf value>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Configuration value (key=value)"),

--- a/cmd/snap/cmd_sign_build.go
+++ b/cmd/snap/cmd_sign_build.go
@@ -65,7 +65,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"grade": i18n.G("Grade states the build quality of the snap (defaults to 'stable')"),
 		}, []argDesc{{
-			// TRANSLATORS: This needs to be wrapped in <>s.
+			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<filename>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			desc: i18n.G("Filename of the snap you want to assert a build for"),

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -43,7 +43,7 @@ func init() {
 	addCommand("unalias", shortUnaliasHelp, longUnaliasHelp, func() flags.Commander {
 		return &cmdUnalias{}
 	}, waitDescs.also(nil), []argDesc{
-		// TRANSLATORS: This needs to be wrapped in <>s.
+		// TRANSLATORS: This needs to begin with < and end with >
 		{name: i18n.G("<alias-or-snap>")},
 	})
 }

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -52,7 +52,7 @@ func init() {
 				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("The snap for which configuration will be checked"),
 			}, {
-				// TRANSLATORS: This needs to be wrapped in <>s.
+				// TRANSLATORS: This needs to begin with < and end with >
 				name: i18n.G("<key>"),
 				// TRANSLATORS: This should not start with a lowercase letter.
 				desc: i18n.G("Key of interest within the configuration"),

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -73,6 +73,8 @@ var (
 
 	LintArg  = lintArg
 	LintDesc = lintDesc
+
+	FixupArg = fixupArg
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -41,7 +41,7 @@ var changeIDMixinOptDesc = mixinDescs{
 }
 
 var changeIDMixinArgDesc = []argDesc{{
-	// TRANSLATORS: This needs to be wrapped in <>s.
+	// TRANSLATORS: This needs to begin with < and end with >
 	name: i18n.G("<change-id>"),
 	// TRANSLATORS: This should not start with a lowercase letter.
 	desc: i18n.G("Change ID"),

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -373,7 +373,26 @@ func (s *SnapSuite) TestLintArg(c *C) {
 	c.Check(log.String(), HasLen, 0)
 	log.Reset()
 
-	// LintArg complains about when option is not enclosed with < >.
+	// LintArg complains about when option is not properly enclosed with < >.
 	snap.LintArg("command", "option", "Description", "")
-	c.Check(log.String(), testutil.Contains, `argument "command"'s "option" should be wrapped in <>s`)
+	c.Check(log.String(), testutil.Contains, `argument "command"'s "option" should begin with < and end with >`)
+	log.Reset()
+	snap.LintArg("command", "<option", "Description", "")
+	c.Check(log.String(), testutil.Contains, `argument "command"'s "<option" should begin with < and end with >`)
+	log.Reset()
+	snap.LintArg("command", "option>", "Description", "")
+	c.Check(log.String(), testutil.Contains, `argument "command"'s "option>" should begin with < and end with >`)
+	log.Reset()
+
+	// LintArg ignores the special case of <option>s.
+	snap.LintArg("command", "<option>s", "Description", "")
+	c.Check(log.String(), HasLen, 0)
+	log.Reset()
+}
+
+func (s *SnapSuite) TestFixupArg(c *C) {
+	c.Check(snap.FixupArg("option"), Equals, "option")
+	c.Check(snap.FixupArg("<option>"), Equals, "<option>")
+	// Trailing ">s" is fixed to just >.
+	c.Check(snap.FixupArg("<option>s"), Equals, "<option>")
 }


### PR DESCRIPTION
Apparently our translators took the advice to enclose option names with
<>s literally, resulting in localization such as "<файл
подтверждения>s" which result in an ugly (and verbose) debug message
being printed:

    main.go:160: argument "ack"'s "<файл подтверждения>s" should be wrapped in <>s

Since there are dozen such messages printed it can have a discouraging
effect on our users. This patch strips the "s" off of trailing ">s".

I also changed all of the translator suggestions to say:

  // TRANSLATORS: This needs to begin with < and end with >

Fixes: https://bugs.launchpad.net/snapd/+bug/1806761
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
