### PR TITLE
systemd/systemd.go: add missing tests for systemd.IsActive

### DIFF
--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -46,3 +46,11 @@ func MockJournalStdoutPath(path string) func() {
 		journalStdoutPath = oldPath
 	}
 }
+
+func (e *Error) SetExitCode(i int) {
+	e.exitCode = i
+}
+
+func (e *Error) SetMsg(msg []byte) {
+	e.msg = msg
+}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -342,7 +342,7 @@ func (s *systemd) IsActive(serviceName string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	// "systemctl is-enabled <name>" prints `inactive\n` to stderr and returns exit code 1 for inactive services
+	// "systemctl is-active <name>" prints `inactive\n` to stderr and returns exit code 1 for inactive services
 	sysdErr, ok := err.(*Error)
 	if ok && sysdErr.exitCode > 0 && strings.TrimSpace(string(sysdErr.msg)) == "inactive" {
 		return false, nil


### PR DESCRIPTION
This adds the missing tests for the new systemd.IsActive
code. 

Also addresses one copy/paste error (thanks to Samuele) in the IsActive() doc string.