### PR TITLE
overlord/ifacestate: addHotplugSeqWaitTask helper

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -51,6 +51,7 @@ var (
 	GetHotplugChangeAttrs        = getHotplugChangeAttrs
 	SetHotplugChangeAttrs        = setHotplugChangeAttrs
 	AllocHotplugSeq              = allocHotplugSeq
+	AddHotplugSeqWaitTask        = addHotplugSeqWaitTask
 )
 
 func NewConnectOptsWithAutoSet() connectOpts {


### PR DESCRIPTION
A simple helper using some of the already landed helpers for hotplug. I realized there is a recurring pattern in the main hotplug code, so extracted this into separate method. The comment explains the purpose of the function, it used around all hotplug code that creates hotplug changes.
