### PR TITLE
image: do not write empty etc/cloud

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -287,19 +287,17 @@ func makeFetcher(tsto *ToolingStore, dlOpts *DownloadOptions, db *asserts.Databa
 }
 
 func installCloudConfig(gadgetDir string) error {
-	var err error
+	cloudConfig := filepath.Join(gadgetDir, "cloud.conf")
+	if !osutil.FileExists(cloudConfig) {
+		return nil
+	}
 
 	cloudDir := filepath.Join(dirs.GlobalRootDir, "/etc/cloud")
 	if err := os.MkdirAll(cloudDir, 0755); err != nil {
 		return err
 	}
-
-	cloudConfig := filepath.Join(gadgetDir, "cloud.conf")
-	if osutil.FileExists(cloudConfig) {
-		dst := filepath.Join(cloudDir, "cloud.cfg")
-		err = osutil.CopyFile(cloudConfig, dst, osutil.CopyFlagOverwrite)
-	}
-	return err
+	dst := filepath.Join(cloudDir, "cloud.cfg")
+	return osutil.CopyFile(cloudConfig, dst, osutil.CopyFlagOverwrite)
 }
 
 // defaultCore is used if no base is specified by the model

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -990,7 +990,7 @@ func (s *imageSuite) TestInstallCloudConfigNoConfig(c *C) {
 	dirs.SetRootDir(targetDir)
 	err := image.InstallCloudConfig(emptyGadgetDir)
 	c.Assert(err, IsNil)
-	c.Check(osutil.FileExists(filepath.Join(targetDir, "etc/cloud")), Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(targetDir, "etc/cloud")), Equals, false)
 }
 
 func (s *imageSuite) TestInstallCloudConfigWithCloudConfig(c *C) {


### PR DESCRIPTION
The `snap --prepare-image` command will currently look into the
gadget and create a /etc/cloud/cloud.cfg configuration if the
gadget contains a "cloud.conf" file in cloud-init format. But
even if there is no such file an empty /etc/cloud directory is
created.

This empty directory ends up on /writable/system-data/etc/cloud
and that will block the initial boot from populating that dir
with the data from the core18 /etc/cloud directory when this
dir is in "transition" mode in the /etc/system-image/writable-paths.

As a first step we should not create this /etc/cloud directory if
there is nothing in it. This means we will be able to revert:
https://github.com/snapcore/core18/pull/106

Once that is done we need to also support ds-identify.conf or
switch to a cloud.conf/ directory instead of the current file
only approach. The reason is that we do not want to merge the
cloud config from core18 and from the gadget as this is messy.
Instead it should either come from the gadget or from the core18.
