### PR TITLE
spread: disable fedora-29-64

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -81,6 +81,8 @@ backends:
                 manual: true
             - fedora-29-64:
                 workers: 4
+                # https://twitter.com/zygoon/status/1073629342884864000
+                manual: true
             - opensuse-42.3-64:
                 workers: 4
                 # golang stack cannot compile anything, needs investigation
@@ -117,6 +119,8 @@ backends:
                 workers: 1
             - fedora-29-64:
                 workers: 1
+                # https://twitter.com/zygoon/status/1073629342884864000
+                manual: true
             - arch-linux-64:
                 workers: 1
             - amazon-linux-2-64:


### PR DESCRIPTION
We're seeing dnf synchronization failures related to the modularity
repository. Since this breaks all builds let's disable Fedora 29
for now.
