### PR TITLE
tests: add a tests for xdg-desktop-portal integration

### DIFF
--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#shellcheck source=tests/lib/pkgdb.sh
+. "$TESTSLIB"/pkgdb.sh
+
+TEST_UID="$(id -u test)"
+USER_RUNTIME_DIR="/run/user/${TEST_UID}"
+
+setup_portals() {
+    # Clean up any stale configuration
+    teardown_portals
+
+    # Install dependencies and configure service activation for fake
+    # portal UI.
+    distro_install_package python3-dbus python3-gi xdg-desktop-portal
+    cat << EOF > /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
+[D-BUS Service]
+Name=org.freedesktop.impl.portal.spread
+Exec=/usr/bin/python3 $TESTSLIB/fakeportalui/portalui.py
+SystemdService=spread-portal-ui.service
+EOF
+    cat << EOF > /usr/lib/systemd/user/spread-portal-ui.service
+[Unit]
+Description=Fake portal UI
+[Service]
+Type=dbus
+BusName=org.freedesktop.impl.portal.spread
+ExecStart=/usr/bin/python3 $TESTSLIB/fakeportalui/portalui.py
+EOF
+    mkdir -p /usr/share/xdg-desktop-portal/portals
+    cat << EOF > /usr/share/xdg-desktop-portal/portals/spread.portal
+[portal]
+DBusName=org.freedesktop.impl.portal.spread
+Interfaces=org.freedesktop.impl.portal.FileChooser
+UseIn=spread
+EOF
+
+    # Make sure the test user's XDG_RUNTIME_DIR exists
+    mkdir -p "$USER_RUNTIME_DIR"
+    chmod u=rwX,go= "$USER_RUNTIME_DIR"
+    chown test:test "$USER_RUNTIME_DIR"
+
+    systemctl start "user@${TEST_UID}.service"
+    as_user systemctl --user set-environment XDG_CURRENT_DESKTOP=spread
+}
+
+teardown_portals() {
+    systemctl stop "user@${TEST_UID}.service"
+
+    rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
+    rm -f /usr/lib/systemd/user/spread-portal-ui.service
+    rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
+    distro_purge_package python3-dbus python3-gi xdg-desktop-portal
+    distro_auto_remove_packages
+
+    if [ -d "${USER_RUNTIME_DIR}" ]; then 
+        umount --lazy "${USER_RUNTIME_DIR}/doc" || :
+        rm -rf "${USER_RUNTIME_DIR:?}"/* "${USER_RUNTIME_DIR:?}"/.[!.]*
+    fi
+
+    rm -f /tmp/file-to-read.txt
+    rm -f /tmp/file-to-write.txt
+}
+
+DBUS_SESSION_BUS_ADDRESS=
+as_user() {
+    if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+        eval "$(su -l -c "XDG_RUNTIME_DIR=\"${USER_RUNTIME_DIR}\" systemctl --user show-environment" test | grep ^DBUS_SESSION_BUS_ADDRESS)"
+    fi
+    su -l -c "XDG_RUNTIME_DIR=\"${USER_RUNTIME_DIR}\" DBUS_SESSION_BUS_ADDRESS=\"${DBUS_SESSION_BUS_ADDRESS}\" $*" test
+}

--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -31,7 +31,7 @@ EOF
     cat << EOF > /usr/share/xdg-desktop-portal/portals/spread.portal
 [portal]
 DBusName=org.freedesktop.impl.portal.spread
-Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot
+Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.AppChooser;
 UseIn=spread
 EOF
 

--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -8,7 +8,7 @@ USER_RUNTIME_DIR="/run/user/${TEST_UID}"
 
 setup_portals() {
     # Clean up any stale configuration
-    teardown_portals
+    teardown_portals --no-purge-packages
 
     # Install dependencies and configure service activation for fake
     # portal UI.
@@ -50,8 +50,11 @@ teardown_portals() {
     rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
     rm -f /usr/lib/systemd/user/spread-portal-ui.service
     rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
-    distro_purge_package python3-dbus python3-gi xdg-desktop-portal
-    distro_auto_remove_packages
+
+    if [ "$1" != "--no-purge-packages" ]; then
+        distro_purge_package python3-dbus python3-gi xdg-desktop-portal
+        distro_auto_remove_packages
+    fi
 
     if [ -d "${USER_RUNTIME_DIR}" ]; then 
         umount --lazy "${USER_RUNTIME_DIR}/doc" || :

--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -7,12 +7,7 @@ TEST_UID="$(id -u test)"
 USER_RUNTIME_DIR="/run/user/${TEST_UID}"
 
 setup_portals() {
-    # Clean up any stale configuration
-    teardown_portals
-
-    # Install dependencies and configure service activation for fake
-    # portal UI.
-    distro_install_package python3-dbus python3-gi xdg-desktop-portal
+    # Configure service activation for fake portal UI.
     cat << EOF > /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.spread
@@ -51,17 +46,10 @@ teardown_portals() {
     rm -f /usr/lib/systemd/user/spread-portal-ui.service
     rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
 
-    distro_purge_package python3-dbus python3-gi xdg-desktop-portal
-    distro_auto_remove_packages
-
     if [ -d "${USER_RUNTIME_DIR}" ]; then 
         umount --lazy "${USER_RUNTIME_DIR}/doc" || :
         rm -rf "${USER_RUNTIME_DIR:?}"/* "${USER_RUNTIME_DIR:?}"/.[!.]*
     fi
-
-    rm -f /tmp/file-to-read.txt
-    rm -f /tmp/file-to-write.txt
-    rm -f /tmp/screenshot.txt
 }
 
 DBUS_SESSION_BUS_ADDRESS=

--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -8,7 +8,7 @@ USER_RUNTIME_DIR="/run/user/${TEST_UID}"
 
 setup_portals() {
     # Clean up any stale configuration
-    teardown_portals --no-purge-packages
+    teardown_portals
 
     # Install dependencies and configure service activation for fake
     # portal UI.
@@ -31,7 +31,7 @@ EOF
     cat << EOF > /usr/share/xdg-desktop-portal/portals/spread.portal
 [portal]
 DBusName=org.freedesktop.impl.portal.spread
-Interfaces=org.freedesktop.impl.portal.FileChooser
+Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.Screenshot
 UseIn=spread
 EOF
 
@@ -51,10 +51,8 @@ teardown_portals() {
     rm -f /usr/lib/systemd/user/spread-portal-ui.service
     rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
 
-    if [ "$1" != "--no-purge-packages" ]; then
-        distro_purge_package python3-dbus python3-gi xdg-desktop-portal
-        distro_auto_remove_packages
-    fi
+    distro_purge_package python3-dbus python3-gi xdg-desktop-portal
+    distro_auto_remove_packages
 
     if [ -d "${USER_RUNTIME_DIR}" ]; then 
         umount --lazy "${USER_RUNTIME_DIR}/doc" || :
@@ -63,6 +61,7 @@ teardown_portals() {
 
     rm -f /tmp/file-to-read.txt
     rm -f /tmp/file-to-write.txt
+    rm -f /tmp/screenshot.txt
 }
 
 DBUS_SESSION_BUS_ADDRESS=

--- a/tests/lib/desktop-portal.sh
+++ b/tests/lib/desktop-portal.sh
@@ -7,7 +7,9 @@ TEST_UID="$(id -u test)"
 USER_RUNTIME_DIR="/run/user/${TEST_UID}"
 
 setup_portals() {
-    # Configure service activation for fake portal UI.
+    # Install xdg-desktop-portal and configure service activation for
+    # fake portal UI.
+    distro_install_package xdg-desktop-portal
     cat << EOF > /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.spread
@@ -45,6 +47,9 @@ teardown_portals() {
     rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
     rm -f /usr/lib/systemd/user/spread-portal-ui.service
     rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
+
+    distro_purge_package xdg-desktop-portal
+    distro_auto_remove_packages
 
     if [ -d "${USER_RUNTIME_DIR}" ]; then 
         umount --lazy "${USER_RUNTIME_DIR}/doc" || :

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+BUS_NAME = "org.freedesktop.impl.portal.spread"
+OBJECT_PATH = "/org/freedesktop/portal/desktop"
+
+FILE_CHOOSER_IFACE = "org.freedesktop.impl.portal.FileChooser"
+
+class PortalImpl(dbus.service.Object):
+    def __init__(self, connection, object_path, config):
+        super(PortalImpl, self).__init__(connection, object_path)
+        self._config = config
+
+    @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
+                         in_signature="osssa{sv}", out_signature="ua{sv}")
+    def OpenFile(self, handle, app_id, parent_window, title, options):
+        return (0, dict(uris=dbus.Array(['file:///tmp/file-to-read.txt'], signature='s'),
+                        writable=False))
+
+    @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
+                         in_signature="osssa{sv}", out_signature="ua{sv}")
+    def SaveFile(self, handle, app_id, parent_window, title, options):
+        return (0, dict(uris=dbus.Array(['file:///tmp/file-to-write.txt'], signature='s'),
+                        writable=True))
+
+
+def main(argv):
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    main_loop = GLib.MainLoop()
+
+    bus = dbus.SessionBus()
+    # Make sure we quit when the bus shuts down
+    bus.add_signal_receiver(
+        main_loop.quit, signal_name="Disconnected",
+        path="/org/freedesktop/DBus/Local",
+        dbus_interface="org.freedesktop.DBus.Local")
+
+    portal = PortalImpl(bus, OBJECT_PATH, None)
+
+    # Allow other services to assume our bus name
+    bus_name = dbus.service.BusName(
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
+        do_not_queue=True)
+
+    main_loop.run()
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -40,7 +40,10 @@ class PortalImpl(dbus.service.Object):
                          in_signature="ossasa{sv}", out_signature="ua{sv}")
     def ChooseApplication(self, handle, app_id, parent_window, choices,
                           options):
-        return (0, dict(choice=choices[0]))
+        if options["content_type"] == "text/plain":
+            return (0, dict(choice="test-editor"))
+        else:
+            return (1, {})
 
 
 def main(argv):

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -10,6 +10,7 @@ from gi.repository import GLib
 BUS_NAME = "org.freedesktop.impl.portal.spread"
 OBJECT_PATH = "/org/freedesktop/portal/desktop"
 
+APP_CHOOSER_IFACE = "org.freedesktop.impl.portal.AppChooser"
 FILE_CHOOSER_IFACE = "org.freedesktop.impl.portal.FileChooser"
 SCREENSHOT_IFACE = "org.freedesktop.impl.portal.Screenshot"
 
@@ -34,6 +35,12 @@ class PortalImpl(dbus.service.Object):
                          in_signature="ossa{sv}", out_signature="ua{sv}")
     def Screenshot(self, handle, app_id, parent_window, options):
         return (0, dict(uri="file:///tmp/screenshot.txt"))
+
+    @dbus.service.method(dbus_interface=APP_CHOOSER_IFACE,
+                         in_signature="ossasa{sv}", out_signature="ua{sv}")
+    def ChooseApplication(self, handle, app_id, parent_window, choices,
+                          options):
+        return (0, dict(choice=choices[0]))
 
 
 def main(argv):

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -11,6 +11,7 @@ BUS_NAME = "org.freedesktop.impl.portal.spread"
 OBJECT_PATH = "/org/freedesktop/portal/desktop"
 
 FILE_CHOOSER_IFACE = "org.freedesktop.impl.portal.FileChooser"
+SCREENSHOT_IFACE = "org.freedesktop.impl.portal.Screenshot"
 
 class PortalImpl(dbus.service.Object):
     def __init__(self, connection, object_path, config):
@@ -20,14 +21,19 @@ class PortalImpl(dbus.service.Object):
     @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
                          in_signature="osssa{sv}", out_signature="ua{sv}")
     def OpenFile(self, handle, app_id, parent_window, title, options):
-        return (0, dict(uris=dbus.Array(['file:///tmp/file-to-read.txt'], signature='s'),
+        return (0, dict(uris=dbus.Array(["file:///tmp/file-to-read.txt"], signature="s"),
                         writable=False))
 
     @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
                          in_signature="osssa{sv}", out_signature="ua{sv}")
     def SaveFile(self, handle, app_id, parent_window, title, options):
-        return (0, dict(uris=dbus.Array(['file:///tmp/file-to-write.txt'], signature='s'),
+        return (0, dict(uris=dbus.Array(["file:///tmp/file-to-write.txt"], signature="s"),
                         writable=True))
+
+    @dbus.service.method(dbus_interface=SCREENSHOT_IFACE,
+                         in_signature="ossa{sv}", out_signature="ua{sv}")
+    def Screenshot(self, handle, app_id, parent_window, options):
+        return (0, dict(uri="file:///tmp/screenshot.txt"))
 
 
 def main(argv):
@@ -50,5 +56,5 @@ def main(argv):
 
     main_loop.run()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -584,13 +584,11 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 gccgo-8
                 evolution-data-server
-                xdg-desktop-portal
                 "
             ;;
         ubuntu-18.10-64)
             echo "
                 evolution-data-server
-                xdg-desktop-portal
                 "
             ;;
         ubuntu-*)
@@ -602,7 +600,6 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 evolution-data-server
                 net-tools
-                xdg-desktop-portal
                 "
             ;;
     esac

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -543,6 +543,8 @@ pkg_dependencies_ubuntu_classic(){
         man
         nfs-kernel-server
         printer-driver-cups-pdf
+        python3-dbus
+        python3-gi
         python3-yaml
         upower
         weston
@@ -582,11 +584,13 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 gccgo-8
                 evolution-data-server
+                xdg-desktop-portal
                 "
             ;;
         ubuntu-18.10-64)
             echo "
                 evolution-data-server
+                xdg-desktop-portal
                 "
             ;;
         ubuntu-*)
@@ -598,6 +602,7 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 evolution-data-server
                 net-tools
+                xdg-desktop-portal
                 "
             ;;
     esac

--- a/tests/lib/snaps/test-snapd-portal-client/client.py
+++ b/tests/lib/snaps/test-snapd-portal-client/client.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python3
+
+import sys
+from urllib.parse import urlparse
+
+import dbus
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+class Client:
+
+    def __init__(self, bus, main_loop):
+        self._bus = bus
+        self._main_loop = main_loop
+        self._request_path = None
+        self._response = None
+        self._results = None
+        bus.add_signal_receiver(
+            self._response_cb,
+            signal_name="Response",
+            dbus_interface="org.freedesktop.portal.Request",
+            bus_name="org.freedesktop.portal.Desktop",
+            path_keyword="object_path")
+        self._portal = self._bus.get_object("org.freedesktop.portal.Desktop",
+                                            "/org/freedesktop/portal/desktop",
+                                            introspect=False)
+
+    def _response_cb(self, response, results, object_path):
+        if object_path == self._request_path:
+            self._response = response
+            self._results = results
+            self._main_loop.quit()
+
+    def run(self, args):
+        command_name = args.pop(0).replace("-", "_")
+        command = getattr(self, "cmd_{}".format(command_name), None)
+        if command is None:
+            sys.stderr.write("Unknown command: {}\n".format(command_name))
+            sys.exit(1)
+        return command(*args)
+
+    def cmd_open_file(self):
+        iface = dbus.Interface(
+            self._portal, "org.freedesktop.portal.FileChooser")
+        self._request_path = iface.OpenFile(
+            "", "test open file", dbus.Dictionary(signature="sv"))
+        self._main_loop.run()
+        if self._response == 0:
+            for uri in self._results["uris"]:
+                parsed = urlparse(uri)
+                assert parsed.scheme == "file"
+                with open(parsed.path, "r") as fp:
+                    sys.stdout.write(fp.read())
+        elif self._response == 1:
+            # user cancelled
+            sys.stderr.write("request cancelled\n")
+            return 1
+        else:
+            sys.stderr.write("request failed\n")
+            return 1
+
+    def cmd_save_file(self, content):
+        iface = dbus.Interface(
+            self._portal, "org.freedesktop.portal.FileChooser")
+        self._request_path = iface.SaveFile(
+            "", "test save file", dbus.Dictionary(signature="sv"))
+        self._main_loop.run()
+        if self._response == 0:
+            uris = self._results["uris"]
+            assert len(uris) == 1
+            parsed = urlparse(uris[0])
+            assert parsed.scheme == "file"
+            with open(parsed.path, "w") as fp:
+                fp.write(content)
+        elif self._response == 1:
+            # user cancelled
+            sys.stderr.write("request cancelled\n")
+            return 1
+        else:
+            sys.stderr.write("request failed\n")
+            return 1
+
+
+def main(argv):
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    main_loop = GLib.MainLoop()
+    bus = dbus.SessionBus()
+
+    client = Client(bus, main_loop)
+    return client.run(argv[1:])
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/lib/snaps/test-snapd-portal-client/setup.py
+++ b/tests/lib/snaps/test-snapd-portal-client/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import setuptools
+
+setuptools.setup(
+    name="test-snapd-portal-client",
+    version="1.0",
+    scripts=[
+        "client.py"
+    ],
+)

--- a/tests/lib/snaps/test-snapd-portal-client/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-portal-client/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: test-snapd-portal-client
+version: 1.0
+summary: Python based test client for xdg-desktop-portal
+description: ...
+apps:
+  test-snapd-portal-client:
+    command: bin/client.py
+    environment:
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/girepository-1.0
+    plugs:
+      - desktop
+
+parts:
+  client:
+    source: .
+    plugin: python
+    stage-packages:
+      - python3-dbus
+      - python3-gi
+      - gir1.2-glib-2.0

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -14,7 +14,7 @@ description: |
     xdg-document-portal services.
 
 # Only enable the test on systems we know portals to function on.
-# Expand as 
+# Expand as needed.
 systems:
   - ubuntu-18.04-*
   - ubuntu-18.10-*
@@ -23,79 +23,31 @@ environment:
     USER_RUNTIME_DIR: /run/user/$(id -u test)
 
 prepare: |
-    #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB"/pkgdb.sh
-    distro_install_package python3-dbus python3-gi xdg-desktop-portal
-    snap install --edge test-snapd-portal-client
-
-    systemctl stop user@"$(id -u test)".service
-    cat << EOF > /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
-    [D-BUS Service]
-    Name=org.freedesktop.impl.portal.spread
-    Exec=/usr/bin/python3 $TESTSLIB/fakeportalui/portalui.py
-    SystemdService=spread-portal-ui.service
-    EOF
-    cat << EOF > /usr/lib/systemd/user/spread-portal-ui.service
-    [Unit]
-    Description=Fake portal UI
-    [Service]
-    Type=dbus
-    BusName=org.freedesktop.impl.portal.spread
-    ExecStart=/usr/bin/python3 $TESTSLIB/fakeportalui/portalui.py
-    EOF
-    mkdir -p /usr/share/xdg-desktop-portal/portals
-    cat << EOF > /usr/share/xdg-desktop-portal/portals/spread.portal
-    [portal]
-    DBusName=org.freedesktop.impl.portal.spread
-    Interfaces=org.freedesktop.impl.portal.FileChooser
-    UseIn=spread
-    EOF
-
-    mkdir -p "$USER_RUNTIME_DIR"
-    umount --lazy  "${USER_RUNTIME_DIR}/doc" || :
-    rm -rf "${USER_RUNTIME_DIR:?}"/*
-    chmod u=rwX,go= "$USER_RUNTIME_DIR"
-    chown test:test "$USER_RUNTIME_DIR"
-
-    rm -f /tmp/file-to-read.txt
-    rm -f /tmp/file-to-write.txt
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    setup_portals
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
-    . "$TESTSLIB"/pkgdb.sh
-
-    systemctl stop user@"$(id -u test)".service
-    rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
-    rm -f /usr/lib/systemd/user/spread-portal-ui.service
-    rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
-    distro_purge_package python3-dbus python3-gi xdg-desktop-portal
-    distro_auto_remove_packages
-    umount --lazy  "${USER_RUNTIME_DIR}/doc" || :
-    rm -rf "${USER_RUNTIME_DIR:?}/*" "${USER_RUNTIME_DIR:?}/.[!.]*"
-
-    rm -f /tmp/file-to-read.txt
-    rm -f /tmp/file-to-write.txt
+    . "$TESTSLIB"/desktop-portal.sh
+    teardown_portals
 
 execute: |
-    systemctl start user@"$(id -u test)".service
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
 
-    # This isn't quote-safe, but is good enough for our tests.
-    function as_user() {
-      su -l -c "XDG_RUNTIME_DIR=\"${USER_RUNTIME_DIR}\" $*" test
-    }
-    function as_user_session() {
-      as_user systemd-run --user --pipe --wait "$@"
-    }
-
-    as_user systemctl --user set-environment XDG_CURRENT_DESKTOP=spread
+    echo "Install the portals test client"
+    snap install --edge test-snapd-portal-client
 
     echo "The confined application can run open files via the portal"
     echo "from-host-system" > /tmp/file-to-read.txt
+    # file ownership is exposed through the document portal, and our
+    # AppArmor policy uses the @owner restriction.
     chown test:test /tmp/file-to-read.txt
-    as_user_session test-snapd-portal-client open-file | MATCH "from-host-system"
+    as_user test-snapd-portal-client open-file | MATCH "from-host-system"
 
     echo "The confined application can write files via the portal"
     [ ! -f /tmp/file-to-write.txt ]
-    as_user_session test-snapd-portal-client save-file "from-sandbox"
+    as_user test-snapd-portal-client save-file "from-sandbox"
     [ -f /tmp/file-to-write.txt ]
     MATCH "from-sandbox" < /tmp/file-to-write.txt

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -33,12 +33,14 @@ prepare: |
     setup_portals
 
 restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
+    rm -f /tmp/file-to-read.txt
+    rm -f /tmp/file-to-write.txt
 
 execute: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
 
     echo "Install the portals test client"

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -19,12 +19,10 @@ systems:
     # Ships xdg-desktop-portal 0.11
     - ubuntu-18.04-*
 
-    # Ships xdg-desktop-portal 1.0.2-1ubuntu1.
-    # Fails on the safe-file portion of the test.
-    # https://bugs.launchpad.net/ubuntu/+source/xdg-desktop-portal/+bug/1810757
-    #- ubuntu-18.10-*
-
     # Ships xdg-desktop-portal 1.0.3
+    - ubuntu-18.10-*
+
+    # Ships xdg-desktop-portal 1.2.0
     - ubuntu-19.04-*
 
 prepare: |

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -16,14 +16,16 @@ description: |
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
 systems:
-  # Ships xdg-desktop-portal 0.11
-  - ubuntu-18.04-*
+    # Ships xdg-desktop-portal 0.11
+    - ubuntu-18.04-*
 
-  # Ships xdg-desktop-portal 1.0.2-1ubuntu1.
-  # Fails on the safe-file portion of the test.  1.0.3 appears to work though.
-  # https://bugs.launchpad.net/ubuntu/+source/xdg-desktop-portal/+bug/1810757
+    # Ships xdg-desktop-portal 1.0.2-1ubuntu1.
+    # Fails on the safe-file portion of the test.
+    # https://bugs.launchpad.net/ubuntu/+source/xdg-desktop-portal/+bug/1810757
+    #- ubuntu-18.10-*
 
-  #- ubuntu-18.10-*
+    # Ships xdg-desktop-portal 1.0.3
+    - ubuntu-19.04-*
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -16,11 +16,14 @@ description: |
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
 systems:
+  # Ships xdg-desktop-portal 0.11
   - ubuntu-18.04-*
-  - ubuntu-18.10-*
 
-environment:
-    USER_RUNTIME_DIR: /run/user/$(id -u test)
+  # Ships xdg-desktop-portal 1.0.2-1ubuntu1.
+  # Fails on the safe-file portion of the test.  1.0.3 appears to work though.
+  # https://bugs.launchpad.net/ubuntu/+source/xdg-desktop-portal/+bug/1810757
+
+  #- ubuntu-18.10-*
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -1,0 +1,101 @@
+summary: the desktop portal file choosers provide access to files
+description: |
+    The xdg-desktop-portal file chooser interface provides a way for a
+    confined application to request access to any file the user can
+    read/write.
+
+    The choice of which file is handled via an out-of-process file
+    chooser running outside of confinement, and the file itself is
+    then made available to the sandbox via the xdg-document-portal
+    FUSE file system.
+
+    This test substitutes in a replacement for the file chooser UI,
+    but otherwise uses the real xdg-desktop-portal and
+    xdg-document-portal services.
+
+# Only enable the test on systems we know portals to function on.
+# Expand as 
+systems:
+  - ubuntu-18.04-*
+  - ubuntu-18.10-*
+
+environment:
+    USER_RUNTIME_DIR: /run/user/$(id -u test)
+
+prepare: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    distro_install_package python3-dbus python3-gi xdg-desktop-portal
+    snap install --edge test-snapd-portal-client
+
+    systemctl stop user@"$(id -u test)".service
+    cat << EOF > /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
+    [D-BUS Service]
+    Name=org.freedesktop.impl.portal.spread
+    Exec=/usr/bin/python3 $TESTSLIB/fakeportalui/portalui.py
+    SystemdService=spread-portal-ui.service
+    EOF
+    cat << EOF > /usr/lib/systemd/user/spread-portal-ui.service
+    [Unit]
+    Description=Fake portal UI
+    [Service]
+    Type=dbus
+    BusName=org.freedesktop.impl.portal.spread
+    ExecStart=/usr/bin/python3 $TESTSLIB/fakeportalui/portalui.py
+    EOF
+    mkdir -p /usr/share/xdg-desktop-portal/portals
+    cat << EOF > /usr/share/xdg-desktop-portal/portals/spread.portal
+    [portal]
+    DBusName=org.freedesktop.impl.portal.spread
+    Interfaces=org.freedesktop.impl.portal.FileChooser
+    UseIn=spread
+    EOF
+
+    mkdir -p "$USER_RUNTIME_DIR"
+    umount --lazy  "${USER_RUNTIME_DIR}/doc" || :
+    rm -rf "${USER_RUNTIME_DIR:?}"/*
+    chmod u=rwX,go= "$USER_RUNTIME_DIR"
+    chown test:test "$USER_RUNTIME_DIR"
+
+    rm -f /tmp/file-to-read.txt
+    rm -f /tmp/file-to-write.txt
+
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+
+    systemctl stop user@"$(id -u test)".service
+    rm -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.spread.service
+    rm -f /usr/lib/systemd/user/spread-portal-ui.service
+    rm -f /usr/share/xdg-desktop-portal/portals/spread.portal
+    distro_purge_package python3-dbus python3-gi xdg-desktop-portal
+    distro_auto_remove_packages
+    umount --lazy  "${USER_RUNTIME_DIR}/doc" || :
+    rm -rf "${USER_RUNTIME_DIR:?}/*" "${USER_RUNTIME_DIR:?}/.[!.]*"
+
+    rm -f /tmp/file-to-read.txt
+    rm -f /tmp/file-to-write.txt
+
+execute: |
+    systemctl start user@"$(id -u test)".service
+
+    # This isn't quote-safe, but is good enough for our tests.
+    function as_user() {
+      su -l -c "XDG_RUNTIME_DIR=\"${USER_RUNTIME_DIR}\" $*" test
+    }
+    function as_user_session() {
+      as_user systemd-run --user --pipe --wait "$@"
+    }
+
+    as_user systemctl --user set-environment XDG_CURRENT_DESKTOP=spread
+
+    echo "The confined application can run open files via the portal"
+    echo "from-host-system" > /tmp/file-to-read.txt
+    chown test:test /tmp/file-to-read.txt
+    as_user_session test-snapd-portal-client open-file | MATCH "from-host-system"
+
+    echo "The confined application can write files via the portal"
+    [ ! -f /tmp/file-to-write.txt ]
+    as_user_session test-snapd-portal-client save-file "from-sandbox"
+    [ -f /tmp/file-to-write.txt ]
+    MATCH "from-sandbox" < /tmp/file-to-write.txt

--- a/tests/main/desktop-portal-open-file/editor.sh
+++ b/tests/main/desktop-portal-open-file/editor.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 filename="$1"
+editor_history="$2"
+
 echo "Editing $filename"
 
-echo "$filename" >> /tmp/editor-history.txt
+echo "$filename" >> "$editor_history"

--- a/tests/main/desktop-portal-open-file/editor.sh
+++ b/tests/main/desktop-portal-open-file/editor.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+filename="$1"
+echo "Editing $filename"
+
+echo "$filename" >> /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -1,0 +1,66 @@
+summary: the desktop portal allows confined apps to open local files
+description: |
+    The xdg-desktop-portal "Open URI" interface provides a way for
+    confined applications to open local files using the associated
+    application on the host system.
+
+    The confined application proves access to the file by passing a
+    file descriptor to the desktop portal.
+
+# Only enable the test on systems we know portals to function on.
+# Expand as needed.
+systems:
+  - ubuntu-18.04-*
+  - ubuntu-18.10-*
+
+prepare: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    setup_portals
+
+    # Configure fake web browser
+    mkdir -p ~test/.local/share/applications
+    cat << EOF > ~test/.local/share/applications/test-editor.desktop
+    [Desktop Entry]
+    Type=Application
+    Name=Test Editor
+    Exec=$(pwd)/editor.sh %f
+    MimeType=text/plain;
+    EOF
+    mkdir -p ~test/.config
+    cat << EOF > ~test/.config/mimeapps.list
+    [Default Applications]
+    text/plain=test-editor.desktop
+    EOF
+    rm -f /tmp/editor-history.txt
+
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    teardown_portals
+
+    rm -f ~test/.config/mimeapps.list
+    rm -f ~test/.local/share/applications/test-editor.desktop
+    rm -f /tmp/editor-history.txt
+
+execute: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    echo "Install the portals test client"
+    snap install --edge test-snapd-portal-client
+
+    echo "Create a file that the test client can access"
+    commondir=~test/snap/test-snapd-portal-client/common
+    testfile="$commondir/test.txt"
+    mkdir -p "$commondir"
+    chown test:test "$commondir"
+    echo "Hello World" > "$testfile"
+    chown test:test "$testfile"
+
+    echo "The confined application can open URLs in the default browser"
+    as_user test-snapd-portal-client launch-file "$testfile"
+
+    echo "The test-browser process was invoked with the URL"
+    [ -f /tmp/editor-history.txt ]
+    MATCH "$testfile" < /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -57,9 +57,8 @@ execute: |
     commondir=~test/snap/test-snapd-portal-client/common
     testfile="$commondir/test.txt"
     mkdir -p "$commondir"
-    chown test:test "$commondir"
     echo "Hello World" > "$testfile"
-    chown test:test "$testfile"
+    chown -R test:test ~test/snap
 
     echo "The confined application can open URLs in the default browser"
     as_user test-snapd-portal-client launch-file "$testfile"

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -47,6 +47,8 @@ restore: |
 execute: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/desktop-portal.sh
+    #shellcheck source=tests/lib/files.sh
+    . "$TESTSLIB"/files.sh
 
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
@@ -63,5 +65,5 @@ execute: |
     as_user test-snapd-portal-client launch-file "$testfile"
 
     echo "The test-browser process was invoked with the URL"
-    [ -f /tmp/editor-history.txt ]
+    wait_for_file /tmp/editor-history.txt 4 .5
     MATCH "$testfile" < /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -14,6 +14,9 @@ systems:
   - ubuntu-18.10-*
   - ubuntu-19.04-*
 
+environment:
+    EDITOR_HISTORY: /tmp/editor-history.txt
+
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
@@ -25,7 +28,7 @@ prepare: |
     [Desktop Entry]
     Type=Application
     Name=Test Editor
-    Exec=$(pwd)/editor.sh %f
+    Exec=$(pwd)/editor.sh %f $EDITOR_HISTORY
     MimeType=text/plain;
     EOF
     mkdir -p ~test/.config
@@ -33,19 +36,18 @@ prepare: |
     [Default Applications]
     text/plain=test-editor.desktop
     EOF
-    rm -f /tmp/editor-history.txt
 
 restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
 
     rm -f ~test/.config/mimeapps.list
     rm -f ~test/.local/share/applications/test-editor.desktop
-    rm -f /tmp/editor-history.txt
+    rm -f "$EDITOR_HISTORY"
 
 execute: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     #shellcheck source=tests/lib/files.sh
     . "$TESTSLIB"/files.sh
@@ -64,5 +66,5 @@ execute: |
     as_user test-snapd-portal-client launch-file "$testfile"
 
     echo "The test-browser process was invoked with the URL"
-    wait_for_file /tmp/editor-history.txt 4 .5
-    MATCH "$testfile" < /tmp/editor-history.txt
+    wait_for_file "$EDITOR_HISTORY" 4 .5
+    MATCH "$testfile" < "$EDITOR_HISTORY"

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -12,6 +12,7 @@ description: |
 systems:
   - ubuntu-18.04-*
   - ubuntu-18.10-*
+  - ubuntu-19.04-*
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -9,6 +9,7 @@ description: |
 systems:
   - ubuntu-18.04-*
   - ubuntu-18.10-*
+  - ubuntu-19.04-*
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -1,0 +1,55 @@
+summary: the desktop portal allows confined apps to open URIs
+description: |
+    The xdg-desktop-portal "Open URI" interface provides a way for
+    confined applications to open URIs using the host system's
+    preferred browser.
+
+# Only enable the test on systems we know portals to function on.
+# Expand as needed.
+systems:
+  - ubuntu-18.04-*
+  - ubuntu-18.10-*
+
+prepare: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    setup_portals
+
+    # Configure fake web browser
+    mkdir -p ~test/.local/share/applications
+    cat << EOF > ~test/.local/share/applications/test-browser.desktop
+    [Desktop Entry]
+    Type=Application
+    Name=Test Web Browser
+    Exec=$(pwd)/web-browser.sh %u
+    MimeType=x-scheme-handler/http;
+    EOF
+    mkdir -p ~test/.config
+    cat << EOF > ~test/.config/mimeapps.list
+    [Default Applications]
+    x-scheme-handler/http=test-browser.desktop
+    EOF
+    rm -f /tmp/browser-history.txt
+
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    teardown_portals
+
+    rm -f ~test/.config/mimeapps.list
+    rm -f ~test/.local/share/applications/test-browser.desktop
+    rm -f /tmp/browser-history.txt
+
+execute: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    echo "Install the portals test client"
+    snap install --edge test-snapd-portal-client
+
+    echo "The confined application can open URLs in the default browser"
+    as_user test-snapd-portal-client open-uri http://www.example.org
+
+    echo "The test-browser process was invoked with the URL"
+    [ -f /tmp/browser-history.txt ]
+    MATCH http://www.example.org < /tmp/browser-history.txt

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -11,6 +11,9 @@ systems:
   - ubuntu-18.10-*
   - ubuntu-19.04-*
 
+environment:
+    BROWSER_HISTORY: /tmp/browser-history.txt
+
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
@@ -22,7 +25,7 @@ prepare: |
     [Desktop Entry]
     Type=Application
     Name=Test Web Browser
-    Exec=$(pwd)/web-browser.sh %u
+    Exec=$(pwd)/web-browser.sh %u $BROWSER_HISTORY
     MimeType=x-scheme-handler/http;
     EOF
     mkdir -p ~test/.config
@@ -30,19 +33,18 @@ prepare: |
     [Default Applications]
     x-scheme-handler/http=test-browser.desktop
     EOF
-    rm -f /tmp/browser-history.txt
 
 restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
 
     rm -f ~test/.config/mimeapps.list
     rm -f ~test/.local/share/applications/test-browser.desktop
-    rm -f /tmp/browser-history.txt
+    rm -f "$BROWSER_HISTORY"
 
 execute: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     #shellcheck source=tests/lib/files.sh
     . "$TESTSLIB"/files.sh
@@ -54,5 +56,5 @@ execute: |
     as_user test-snapd-portal-client open-uri http://www.example.org
 
     echo "The test-browser process was invoked with the URL"
-    wait_for_file /tmp/browser-history.txt 4 .5
-    MATCH http://www.example.org < /tmp/browser-history.txt
+    wait_for_file "$BROWSER_HISTORY" 4 .5
+    MATCH http://www.example.org < "$BROWSER_HISTORY"

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -44,6 +44,8 @@ restore: |
 execute: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/desktop-portal.sh
+    #shellcheck source=tests/lib/files.sh
+    . "$TESTSLIB"/files.sh
 
     echo "Install the portals test client"
     snap install --edge test-snapd-portal-client
@@ -52,5 +54,5 @@ execute: |
     as_user test-snapd-portal-client open-uri http://www.example.org
 
     echo "The test-browser process was invoked with the URL"
-    [ -f /tmp/browser-history.txt ]
+    wait_for_file /tmp/browser-history.txt 4 .5
     MATCH http://www.example.org < /tmp/browser-history.txt

--- a/tests/main/desktop-portal-open-uri/web-browser.sh
+++ b/tests/main/desktop-portal-open-uri/web-browser.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+url="$1"
+echo "Browsing to $url"
+
+echo "$url" >> /tmp/browser-history.txt

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -23,6 +23,7 @@ description: |
 systems:
   - ubuntu-18.04-*
   - ubuntu-18.10-*
+  - ubuntu-19.04-*
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -31,12 +31,13 @@ prepare: |
     setup_portals
 
 restore: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
     teardown_portals
+    rm -f /tmp/screenshot.txt
 
 execute: |
-    #shellcheck source=tests/lib/pkgdb.sh
+    #shellcheck source=tests/lib/desktop-portal.sh
     . "$TESTSLIB"/desktop-portal.sh
 
     echo "Install the portals test client"

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -1,0 +1,50 @@
+summary: the desktop portal screenshot API works for snap applications
+description: |
+    The xdg-desktop-portal screenshot interface provides a way for
+    confined applications to take screenshots with the consent of the
+    user.
+
+    While there is nothing preventing an X11 client from screenshot
+    other apps or the entire screen, this is not possible with
+    Wayland.  Instead, it is necessary to ask the compositor to take a
+    screenshot.
+
+    While the gnome-shell compositor offers a D-Bus API to make
+    screenshots, it is not appropriate to expose to confined
+    applications.  There is no user prompt, and it can be used to make
+    the shell write to arbitrary paths.
+
+    The xdg-desktop-portal service addresses this by providing an API
+    that prompts the user and delivers the screenshot to the app
+    securely via the document portal.
+
+# Only enable the test on systems we know portals to function on.
+# Expand as needed.
+systems:
+  - ubuntu-18.04-*
+  - ubuntu-18.10-*
+
+prepare: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    setup_portals
+
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    teardown_portals
+
+execute: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    echo "Install the portals test client"
+    snap install --edge test-snapd-portal-client
+
+    echo "The confined application can take screenshots"
+    # The fake portal UI uses this file as the screenshot
+    echo "my screenshot" > /tmp/screenshot.txt
+    # file ownership is exposed through the document portal, and our
+    # AppArmor policy uses the @owner restriction.
+    chown test:test /tmp/screenshot.txt
+    as_user test-snapd-portal-client screenshot | MATCH "my screenshot"


### PR DESCRIPTION
At present, all the tests for xdg-desktop-portal support run against a fake version of xdg-desktop-portal, or against a file system tree that resembles that presented by xdg-document-portal.

This PR adds some spread tests that run against the real xdg-desktop-portal daemon together with a stubbed out implementation of the `org.freedesktop.impl.portal.*` interfaces that can run headless.

As we don't yet have xdg-desktop-portal SRU'd to all Ubuntu releases yet, I am only enabling the test on specific distro releases for now.  I think it is more important to verify it works on some distros than leave the test out of tree until it works everywhere.

The new tests cover the following portal features:

1. out of process file choosers to open and save files the confined app can't usually access.
2. taking screenshots
3. opening URLs in the host's default web browser
4. launching the application associated on the host with a file the confined application can access.