### PR TITLE
tests: skip snapd snap on reset for core systems

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -123,7 +123,7 @@ reset_all_snap() {
     for snap in "$SNAP_MOUNT_DIR"/*; do
         snap="${snap:6}"
         case "$snap" in
-            "bin" | "$gadget_name" | "$kernel_name" | "$core_name" | "core" | README)
+            "bin" | "$gadget_name" | "$kernel_name" | "$core_name" | "core" | "snapd" |README)
                 ;;
             *)
                 # make sure snapd is running before we attempt to remove snaps, in case a test stopped it


### PR DESCRIPTION
It is not needed to uninstall snapd snap on core systems during reset. 

This prevents issues on arm devices after running snapd-failover and snapd-refresh test