### PR TITLE
spread: show free space in debug output

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -451,6 +451,8 @@ debug-each: |
         snap interfaces || true
         echo '# tasks executed on system'
         cat "$RUNTIME_STATE_PATH/runs" || true
+        echo '# free space'
+        df -h || true
     fi
 
 rename:


### PR DESCRIPTION
Let's try to locate why 'no space left on device' pops up randomly in spread runs.