### PR TITLE
Fixing socket permissions on 4.15 kernels 

### DIFF
--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -47,7 +47,7 @@ network netlink,
 
 # Allow access to daemon to create socket
 /{,var/}run/avahi-daemon/  w,
-/{,var/}run/avahi-daemon/{pid,socket} rw,
+/{,var/}run/avahi-daemon/{pid,socket} rwk,
 
 # Description: Allow operating as the avahi service. This gives
 # privileged access to the system.


### PR DESCRIPTION
On 4.15 kernel, socket dir permissions needs to be rwk instead of rw otherwise directory creation is denied

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?