### PR TITLE
interface: raw-usb: Adding ttyACM ttyACA permissions

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -35,7 +35,7 @@ const rawusbConnectedPlugAppArmor = `
 /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
 
 # Allow access to all ttyUSB devices too
-/dev/ttyUSB[0-9]* rw,
+/dev/tty{USB|ACM}[0-9]* rw,
 
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -35,7 +35,7 @@ const rawusbConnectedPlugAppArmor = `
 /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
 
 # Allow access to all ttyUSB devices too
-/dev/tty{USB|ACM}[0-9]* rw,
+/dev/tty{USB,ACM}[0-9]* rw,
 
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,


### PR DESCRIPTION
Many z-wave, zigbee serial devices come with device node /dev/ttyACM[0-9]
some modem devices come as /dev/ttyAMA[0-9]
Adding this rule to raw-usb so those devices can be used

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?