### PR TITLE
run-checks: stop running HEAD of staticcheck

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -217,6 +217,8 @@ if [ "$STATIC" = 1 ]; then
 
     echo Checking all interfaces have minimal spread test
     missing_interface_spread_test
+
+    # FIXME: re-add staticcheck with a matching version for the used go-version
 fi
 
 if [ "$UNIT" = 1 ]; then

--- a/run-checks
+++ b/run-checks
@@ -217,19 +217,6 @@ if [ "$STATIC" = 1 ]; then
 
     echo Checking all interfaces have minimal spread test
     missing_interface_spread_test
-
-    if command -v staticcheck >/dev/null || ( go version | grep -E 'go1\.(9|1[0-9])(\.[0-9]| )' ); then
-        # either you already have staticcheck on your path, or you're on a new enough go
-        echo Running staticcheck
-        if ! command -v staticcheck >/dev/null; then
-            go get -u honnef.co/go/tools/cmd/staticcheck
-        fi
-        # SA1019 https://github.com/dominikh/go-tools/blob/master/cmd/staticcheck/docs/checks/SA1019
-        # complains about using os.SEEK_* instead of io.Seek*, when the latter don't exist in 1.6 yet
-        # SA1012 https://github.com/dominikh/go-tools/blob/master/cmd/staticcheck/docs/checks/SA1012
-        # complains about tomb.Context(nil), which is wrong -- that is, tomb.Context(nil) is right.
-        go list ./... | grep -v '/vendor/' | xargs staticcheck -tests=false -ignore '*:SA1019,SA1012'
-    fi
 fi
 
 if [ "$UNIT" = 1 ]; then


### PR DESCRIPTION
The run-checks script runs a go static analysis tool staticcheck. The
tool was always fetched from master via "go get". Recently we found that
it complains about unused code (which is fine) but also about cgo and a
lot of little things that need to be inspected one by one.

I initially started fixing all of the issues but we should not have
broken master for long periods so let's start by nuking staticcheck.
We need a way to run a released version (and switch to another released
version explicitly). Ideally we'd also run some sort of meta-checker
that includes staticcheck internally.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
