### PR TITLE
systemd: allow only a single daemon-reload at the same time

### DIFF
--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -20,13 +20,7 @@
 package backend
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
-	"time"
-
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
@@ -37,57 +31,11 @@ func addMountUnit(s *snap.Info, meter progress.Meter) error {
 	whereDir := dirs.StripRootDir(s.MountDir())
 
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
-	mountUnitName, err := sysd.WriteMountUnitFile(s.InstanceName(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
-	if err != nil {
-		return err
-	}
-
-	// we need to do a daemon-reload here to ensure that systemd really
-	// knows about this new mount unit file
-	if err := sysd.DaemonReload(); err != nil {
-		return err
-	}
-
-	if err := sysd.Enable(mountUnitName); err != nil {
-		return err
-	}
-
-	return sysd.Start(mountUnitName)
+	_, err := sysd.AddMountUnitFile(s.InstanceName(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
+	return err
 }
 
-func removeMountUnit(baseDir string, meter progress.Meter) error {
+func removeMountUnit(mountDir string, meter progress.Meter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
-	unit := systemd.MountUnitPath(dirs.StripRootDir(baseDir))
-	if osutil.FileExists(unit) {
-		// use umount -d (cleanup loopback devices) -l (lazy) to ensure that even busy mount points
-		// can be unmounted.
-		// note that the long option --lazy is not supported on trusty.
-		// the explicit -d is only needed on trusty.
-		isMounted, err := osutil.IsMounted(baseDir)
-		if err != nil {
-			return err
-		}
-		if isMounted {
-			if output, err := exec.Command("umount", "-d", "-l", baseDir).CombinedOutput(); err != nil {
-				return osutil.OutputErr(output, err)
-			}
-
-			if err := sysd.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
-				return err
-			}
-		}
-		if err := sysd.Disable(filepath.Base(unit)); err != nil {
-			return err
-		}
-		if err := os.Remove(unit); err != nil {
-			return err
-		}
-		// daemon-reload to ensure that systemd actually really
-		// forgets about this mount unit
-		if err := sysd.DaemonReload(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return sysd.RemoveMountUnitFile(mountDir)
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -23,11 +23,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	_ "github.com/snapcore/squashfuse"
@@ -46,6 +48,15 @@ var (
 
 	// how much time should Stop wait between notifying the user of the waiting
 	stopNotifyDelay = 20 * time.Second
+
+	// daemonReloadLock is a package level lock to ensure that we
+	// do not run any `systemd daemon-reload` while a
+	// daemon-reload is in progress or a mount unit is
+	// generated/activated.
+	//
+	// See https://github.com/systemd/systemd/issues/10872 for the
+	// upstream systemd bug
+	daemonReloadLock sync.Mutex
 )
 
 // systemctlCmd calls systemctl with the given args, returning its standard output (and wrapped error)
@@ -133,7 +144,8 @@ type Systemd interface {
 	IsEnabled(service string) (bool, error)
 	IsActive(service string) (bool, error)
 	LogReader(services []string, n int, follow bool) (io.ReadCloser, error)
-	WriteMountUnitFile(name, revision, what, where, fstype string) (string, error)
+	AddMountUnitFile(name, revision, what, where, fstype string) (string, error)
+	RemoveMountUnitFile(baseDir string) error
 	Mask(service string) error
 	Unmask(service string) error
 }
@@ -170,7 +182,14 @@ type systemd struct {
 }
 
 // DaemonReload reloads systemd's configuration.
-func (*systemd) DaemonReload() error {
+func (s *systemd) DaemonReload() error {
+	daemonReloadLock.Lock()
+	defer daemonReloadLock.Unlock()
+
+	return s.daemonReloadNoLock()
+}
+
+func (s *systemd) daemonReloadNoLock() error {
 	_, err := systemctlCmd("daemon-reload")
 	return err
 }
@@ -486,7 +505,11 @@ func MountUnitPath(baseDir string) string {
 	return filepath.Join(dirs.SnapServicesDir, escapedPath+".mount")
 }
 
-func (s *systemd) WriteMountUnitFile(name, revision, what, where, fstype string) (string, error) {
+// AddMountUnitFile adds/enables/starts a mount unit.
+func (s *systemd) AddMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
+	daemonReloadLock.Lock()
+	defer daemonReloadLock.Unlock()
+
 	options := []string{"nodev"}
 	if fstype == "squashfs" {
 		newFsType, newOptions, err := squashfs.FsType()
@@ -513,8 +536,67 @@ Options=%s
 
 [Install]
 WantedBy=multi-user.target
-`, name, revision, what, where, fstype, strings.Join(options, ","))
+`, snapName, revision, what, where, fstype, strings.Join(options, ","))
 
 	mu := MountUnitPath(where)
-	return filepath.Base(mu), osutil.AtomicWriteFile(mu, []byte(c), 0644, 0)
+	mountUnitName, err := filepath.Base(mu), osutil.AtomicWriteFile(mu, []byte(c), 0644, 0)
+	if err != nil {
+		return "", err
+	}
+
+	// we need to do a daemon-reload here to ensure that systemd really
+	// knows about this new mount unit file
+	if err := s.daemonReloadNoLock(); err != nil {
+		return "", err
+	}
+
+	if err := s.Enable(mountUnitName); err != nil {
+		return "", err
+	}
+	if err := s.Start(mountUnitName); err != nil {
+		return "", err
+	}
+
+	return mountUnitName, nil
+}
+
+func (s *systemd) RemoveMountUnitFile(mountedDir string) error {
+	daemonReloadLock.Lock()
+	defer daemonReloadLock.Unlock()
+
+	unit := MountUnitPath(dirs.StripRootDir(mountedDir))
+	if !osutil.FileExists(unit) {
+		return nil
+	}
+
+	// use umount -d (cleanup loopback devices) -l (lazy) to ensure that even busy mount points
+	// can be unmounted.
+	// note that the long option --lazy is not supported on trusty.
+	// the explicit -d is only needed on trusty.
+	isMounted, err := osutil.IsMounted(mountedDir)
+	if err != nil {
+		return err
+	}
+	if isMounted {
+		if output, err := exec.Command("umount", "-d", "-l", mountedDir).CombinedOutput(); err != nil {
+			return osutil.OutputErr(output, err)
+		}
+
+		if err := s.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
+			return err
+		}
+	}
+	if err := s.Disable(filepath.Base(unit)); err != nil {
+		return err
+	}
+	if err := os.Remove(unit); err != nil {
+		return err
+	}
+	// daemon-reload to ensure that systemd actually really
+	// forgets about this mount unit
+	if err := s.daemonReloadNoLock(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -486,17 +486,23 @@ func (s *SystemdTestSuite) TestMountUnitPath(c *C) {
 	c.Assert(MountUnitPath("/apps/hello/1.1"), Equals, filepath.Join(dirs.SnapServicesDir, "apps-hello-1.1.mount"))
 }
 
+func makeMockFile(c *C, path string) {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(path, nil, 0644)
+	c.Assert(err, IsNil)
+}
+
 func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
+	rootDir := dirs.GlobalRootDir
+
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
-	err := os.MkdirAll(filepath.Dir(mockSnapPath), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
-	c.Assert(err, IsNil)
+	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(rootDir, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -514,6 +520,12 @@ Options=nodev,ro,x-gdu.hide
 [Install]
 WantedBy=multi-user.target
 `[1:], mockSnapPath))
+
+	c.Assert(s.argses, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--root", rootDir, "enable", "snap-snapname-123.mount"},
+		{"start", "snap-snapname-123.mount"},
+	})
 }
 
 func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
@@ -540,6 +552,12 @@ Options=nodev,ro,x-gdu.hide,bind
 [Install]
 WantedBy=multi-user.target
 `[1:], snapDir))
+
+	c.Assert(s.argses, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--root", "", "enable", "snap-snapname-x1.mount"},
+		{"start", "snap-snapname-x1.mount"},
+	})
 }
 
 func (s *SystemdTestSuite) TestFuseInContainer(c *C) {
@@ -672,4 +690,62 @@ func (s *SystemdTestSuite) TestIsActiveErr(c *C) {
 	active, err := New("xyzzy", s.rep).IsActive("foo")
 	c.Assert(active, Equals, false)
 	c.Assert(err, ErrorMatches, ".* failed with exit status 1: random-failure\n")
+}
+
+func makeMockMountUnit(c *C, mountDir string) string {
+	mountUnit := MountUnitPath(dirs.StripRootDir(mountDir))
+	err := ioutil.WriteFile(mountUnit, nil, 0644)
+	c.Assert(err, IsNil)
+	return mountUnit
+}
+
+// FIXME: also test for the "IsMounted" case
+func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
+	rootDir := dirs.GlobalRootDir
+
+	mountDir := rootDir + "/snap/foo/42"
+	mountUnit := makeMockMountUnit(c, mountDir)
+	err := New(rootDir, nil).RemoveMountUnitFile(mountDir)
+
+	c.Assert(err, IsNil)
+	// the file is gone
+	c.Check(osutil.FileExists(mountUnit), Equals, false)
+	// and the unit is disabled and the daemon reloaded
+	c.Check(s.argses, DeepEquals, [][]string{
+		{"--root", rootDir, "disable", "snap-foo-42.mount"},
+		{"daemon-reload"},
+	})
+}
+
+func (s *SystemdTestSuite) TestDaemonReloadMutex(c *C) {
+	rootDir := dirs.GlobalRootDir
+	sysd := New(rootDir, nil)
+
+	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
+	makeMockFile(c, mockSnapPath)
+
+	// create a go-routine that will try to daemon-reload like crazy
+	stopCh := make(chan bool, 1)
+	stoppedCh := make(chan bool, 1)
+	go func() {
+		for {
+			sysd.DaemonReload()
+			select {
+			case <-stopCh:
+				close(stoppedCh)
+				return
+			default:
+				//pass
+			}
+		}
+	}()
+
+	// And now add a mount unit file while the go-routine tries to
+	// daemon-reload. This will be serialized, if not this would
+	// panic because systemd.daemonReloadNoLock ensures the lock is
+	// taken when this happens.
+	_, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/foo/42", "squashfs")
+	c.Assert(err, IsNil)
+	close(stopCh)
+	<-stoppedCh
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -486,7 +486,7 @@ func (s *SystemdTestSuite) TestMountUnitPath(c *C) {
 	c.Assert(MountUnitPath("/apps/hello/1.1"), Equals, filepath.Join(dirs.SnapServicesDir, "apps-hello-1.1.mount"))
 }
 
-func (s *SystemdTestSuite) TestWriteMountUnit(c *C) {
+func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
@@ -496,7 +496,7 @@ func (s *SystemdTestSuite) TestWriteMountUnit(c *C) {
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -516,13 +516,13 @@ WantedBy=multi-user.target
 `[1:], mockSnapPath))
 }
 
-func (s *SystemdTestSuite) TestWriteMountUnitForDirs(c *C) {
+func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
+	mountUnitName, err := New("", nil).AddMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -564,7 +564,7 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -602,7 +602,7 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 

--- a/tests/main/check-mount/task.yaml
+++ b/tests/main/check-mount/task.yaml
@@ -1,0 +1,9 @@
+summary: Check mount issue
+
+backends: [-autopkgtest]
+
+execute: |
+    for _ in $(seq 50); do
+        snap install test-snapd-tools test-snapd-public
+        snap remove test-snapd-tools test-snapd-public
+    done

--- a/tests/main/check-mount/task.yaml
+++ b/tests/main/check-mount/task.yaml
@@ -1,9 +1,0 @@
-summary: Check mount issue
-
-backends: [-autopkgtest]
-
-execute: |
-    for _ in $(seq 50); do
-        snap install test-snapd-tools test-snapd-public
-        snap remove test-snapd-tools test-snapd-public
-    done

--- a/tests/main/mount-protocol-error/task.yaml
+++ b/tests/main/mount-protocol-error/task.yaml
@@ -1,0 +1,17 @@
+summary: Check mount bug https://forum.snapcraft.io/t/5682
+
+description: |
+   Regression test for systemd mount race that produces a protocol
+   error. We added a workaround to snapd for the upstream bug
+   https://github.com/systemd/systemd/issues/10872
+
+   For more discussion on the issue see
+   https://forum.snapcraft.io/t/5682
+
+backends: [-autopkgtest]
+
+execute: |
+   for _ in $(seq 50); do
+       snap install test-snapd-tools test-snapd-public
+       snap remove test-snapd-tools test-snapd-public
+   done

--- a/tests/main/mount-protocol-error/task.yaml
+++ b/tests/main/mount-protocol-error/task.yaml
@@ -7,11 +7,22 @@ description: |
 
    For more discussion on the issue see
    https://forum.snapcraft.io/t/5682
+   https://launchpad.net/bugs/1772016
 
 backends: [-autopkgtest]
 
+# only run on a subset of systems because this test takes a long time to run
+systems: [ubuntu-18.04-64, ubuntu-18.10-64, arch-linux-64]
+
 execute: |
-   for _ in $(seq 50); do
-       snap install test-snapd-tools test-snapd-public
-       snap remove test-snapd-tools test-snapd-public
-   done
+    snap set system experimental.parallel-instances=true
+
+    names=(test-snapd-tools)
+    for n in $(seq 9); do
+        names+=(test-snapd-tools_$n)
+    done
+    for i in $(seq 10); do
+       echo "Install $i"
+       snap install ${names[@]}
+       snap remove ${names[@]}
+    done

--- a/tests/main/mount-protocol-error/task.yaml
+++ b/tests/main/mount-protocol-error/task.yaml
@@ -19,10 +19,10 @@ execute: |
 
     names=(test-snapd-tools)
     for n in $(seq 9); do
-        names+=(test-snapd-tools_$n)
+        names+=("test-snapd-tools_$n")
     done
     for i in $(seq 10); do
        echo "Install $i"
-       snap install ${names[@]}
-       snap remove ${names[@]}
+       snap install "${names[@]}"
+       snap remove "${names[@]}"
     done

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -40,7 +40,7 @@ import (
 var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/lib/snapd/.*)$`)
 
 func writeSnapdToolingMountUnit(sysd systemd.Systemd, prefix string) error {
-	// Not using WriteMountUnitFile() because we need
+	// Not using AddMountUnitFile() because we need
 	// "RequiredBy=snapd.service"
 	content := []byte(fmt.Sprintf(`[Unit]
 Description=Make the snapd snap tooling available for the system


### PR DESCRIPTION
This is an RFC PR to see if the "mount protocol error" reported in
systemd/systemd#10872 can be worked around by serializing the mount unit
adding/removal. Proposing to get full spread runs.

This is similar to #6243 but it goes further by ensuring a single daemon
reload on the systemd go package level. Note that there is still a
chance that the protocol error happens if something else (like dpkg or
the user) runs "systemd daemon-reload" while we write a mount unit.
But the risk should be hugely smaller.

This is a followup/different approach to https://github.com/snapcore/snapd/pull/6243 which was tackling the issue not deep enough.
