### PR TITLE
dirs, interfaces/builtin/desktop: system fontconfig cache path is different on Fedora

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -286,6 +286,13 @@ func SetRootDir(rootdir string) {
 	SystemFontsDir = filepath.Join(rootdir, "/usr/share/fonts")
 	SystemLocalFontsDir = filepath.Join(rootdir, "/usr/local/share/fonts")
 	SystemFontconfigCacheDir = filepath.Join(rootdir, "/var/cache/fontconfig")
+	if release.DistroLike("fedora") {
+		// see:
+		// https://fedoraproject.org/wiki/Changes/FontconfigCacheDirChange
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1416380
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1377367
+		SystemFontconfigCacheDir = filepath.Join(rootdir, "/usr/lib/fontconfig/cache")
+	}
 
 	FreezerCgroupDir = filepath.Join(rootdir, "/sys/fs/cgroup/freezer/")
 	SnapshotsDir = filepath.Join(rootdir, snappyDir, "snapshots")

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -286,7 +286,9 @@ func SetRootDir(rootdir string) {
 	SystemFontsDir = filepath.Join(rootdir, "/usr/share/fonts")
 	SystemLocalFontsDir = filepath.Join(rootdir, "/usr/local/share/fonts")
 	SystemFontconfigCacheDir = filepath.Join(rootdir, "/var/cache/fontconfig")
-	if release.DistroLike("fedora") {
+	if release.DistroLike("fedora") && !release.DistroLike("amzn") {
+		// Applies to Fedora and CentOS, Amazon Linux 2 is behind with
+		// updates to fontconfig and uses /var/cache/fontconfig instead,
 		// see:
 		// https://fedoraproject.org/wiki/Changes/FontconfigCacheDirChange
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1416380

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -283,8 +283,10 @@ func SetRootDir(rootdir string) {
 	CompletionHelper = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
 	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
 
+	// These paths agree across all supported distros
 	SystemFontsDir = filepath.Join(rootdir, "/usr/share/fonts")
 	SystemLocalFontsDir = filepath.Join(rootdir, "/usr/local/share/fonts")
+	// The cache path is true for Ubuntu, Debian, openSUSE, Arch
 	SystemFontconfigCacheDir = filepath.Join(rootdir, "/var/cache/fontconfig")
 	if release.DistroLike("fedora") && !release.DistroLike("amzn") {
 		// Applies to Fedora and CentOS, Amazon Linux 2 is behind with

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -281,16 +281,13 @@ func (iface *desktopInterface) MountConnectedPlug(spec *mount.Specification, plu
 		if !osutil.IsDirectory(dir) {
 			continue
 		}
-		target := dirs.StripRootDir(dir)
-		if dir == dirs.SystemFontconfigCacheDir {
-			// fontconfig cache directory path is a little special
-			// and varies across systems, but we always mount it at
-			// the same location
-			target = "/var/cache/fontconfig"
-		}
+		// Since /etc/fonts/fonts.conf in the snap mount ns is the same
+		// as on the host, we need to preserve the original directory
+		// paths for the fontconfig runtime to poke the correct
+		// locations
 		spec.AddMountEntry(osutil.MountEntry{
 			Name:    "/var/lib/snapd/hostfs" + dir,
-			Dir:     target,
+			Dir:     dirs.StripRootDir(dir),
 			Options: []string{"bind", "ro"},
 		})
 	}

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -281,9 +281,16 @@ func (iface *desktopInterface) MountConnectedPlug(spec *mount.Specification, plu
 		if !osutil.IsDirectory(dir) {
 			continue
 		}
+		target := dirs.StripRootDir(dir)
+		if dir == dirs.SystemFontconfigCacheDir {
+			// fontconfig cache directory path is a little special
+			// and varies across systems, but we always mount it at
+			// the same location
+			target = "/var/cache/fontconfig"
+		}
 		spec.AddMountEntry(osutil.MountEntry{
 			Name:    "/var/lib/snapd/hostfs" + dir,
-			Dir:     dirs.StripRootDir(dir),
+			Dir:     target,
 			Options: []string{"bind", "ro"},
 		})
 	}

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -185,6 +185,25 @@ func (s *DesktopInterfaceSuite) TestMountSpec(c *C) {
 	entries = spec.UserMountEntries()
 	c.Assert(entries, HasLen, 1)
 	c.Check(entries[0].Dir, Equals, "$XDG_RUNTIME_DIR/doc")
+
+	// Fedora is a little special with their fontconfig cache location
+	restore = release.MockReleaseInfo(&release.OS{ID: "fedora"})
+	defer restore()
+
+	tmpdir = c.MkDir()
+	dirs.SetRootDir(tmpdir)
+	c.Assert(dirs.SystemFontconfigCacheDir, Equals, filepath.Join(tmpdir, "/usr/lib/fontconfig/cache"))
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/fonts"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/local/share/fonts"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/lib/fontconfig/cache"), 0777), IsNil)
+	spec = &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	entries = spec.MountEntries()
+	c.Assert(entries, HasLen, 3)
+
+	c.Check(entries[2].Name, Equals, hostfs+dirs.SystemFontconfigCacheDir)
+	c.Check(entries[2].Dir, Equals, "/var/cache/fontconfig")
+	c.Check(entries[2].Options, DeepEquals, []string{"bind", "ro"})
 }
 
 func (s *DesktopInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -202,7 +202,7 @@ func (s *DesktopInterfaceSuite) TestMountSpec(c *C) {
 	c.Assert(entries, HasLen, 3)
 
 	c.Check(entries[2].Name, Equals, hostfs+dirs.SystemFontconfigCacheDir)
-	c.Check(entries[2].Dir, Equals, "/var/cache/fontconfig")
+	c.Check(entries[2].Dir, Equals, "/usr/lib/fontconfig/cache")
 	c.Check(entries[2].Options, DeepEquals, []string{"bind", "ro"})
 }
 

--- a/tests/main/interfaces-desktop-host-fonts/task.yaml
+++ b/tests/main/interfaces-desktop-host-fonts/task.yaml
@@ -7,6 +7,14 @@ details: |
 
 systems: [-ubuntu-core-*]
 
+restore: |
+    rm -f /usr/share/fonts/dist-font.txt
+    rm -f /usr/local/share/fonts/local-font.txt
+    rm -f "$HOME"/.fonts/user-font1.txt
+    rm -f "$HOME"/.local/share/fonts/user-font2.txt
+    rm -f /var/cache/fontconfig/cache.txt
+    rm -f /usr/lib/fontconfig/cache/cache.txt
+
 execute: |
     mkdir -p /usr/share/fonts
     echo "Distribution font" > /usr/share/fonts/dist-font.txt
@@ -14,8 +22,14 @@ execute: |
     mkdir -p /usr/local/share/fonts
     echo "Local font" > /usr/local/share/fonts/local-font.txt
 
-    mkdir -p /var/cache/fontconfig
-    echo "Cache file" > /var/cache/fontconfig/cache.txt
+    cache_dir=/var/cache/fontconfig
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*)
+            cache_dir=/usr/lib/fontconfig/cache
+            ;;
+    esac
+    mkdir -p "$cache_dir"
+    echo "Cache file" > "$cache_dir"/cache.txt
 
     mkdir -p "$HOME"/.fonts
     echo "User font 1" > "$HOME"/.fonts/user-font1.txt

--- a/tests/main/interfaces-desktop-host-fonts/task.yaml
+++ b/tests/main/interfaces-desktop-host-fonts/task.yaml
@@ -16,9 +16,13 @@ restore: |
     rm -f /usr/lib/fontconfig/cache/cache.txt
 
 execute: |
-    mkdir -p /usr/share/fonts
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    distro_install_package fontconfig
+
     echo "Distribution font" > /usr/share/fonts/dist-font.txt
 
+    # this may not exist across all distributions
     mkdir -p /usr/local/share/fonts
     echo "Local font" > /usr/local/share/fonts/local-font.txt
 
@@ -28,7 +32,6 @@ execute: |
             cache_dir=/usr/lib/fontconfig/cache
             ;;
     esac
-    mkdir -p "$cache_dir"
     echo "Cache file" > "$cache_dir"/cache.txt
 
     mkdir -p "$HOME"/.fonts
@@ -49,8 +52,8 @@ execute: |
     echo "Checking access to host /usr/local/share/fonts"
     test-snapd-desktop.check-files /usr/local/share/fonts/local-font.txt | MATCH "Local font"
 
-    echo "Checking access to host /var/cache/fontconfig"
-    test-snapd-desktop.check-files /var/cache/fontconfig/cache.txt | MATCH "Cache file"
+    echo "Checking access to host $cache_dir"
+    test-snapd-desktop.check-files "$cache_dir"/cache.txt | MATCH "Cache file"
 
     echo "Checking access to host ~/.fonts"
     test-snapd-desktop.check-files "$HOME"/.fonts/user-font1.txt | MATCH "User font 1"


### PR DESCRIPTION
Due to https://fedoraproject.org/wiki/Changes/FontconfigCacheDirChange the fontconfig cache is under `/usr/lib/fontconfig/cache` on Fedora. Make sure we use the right path when setting up the snap mount namespace.

cc @Conan-Kudo 