### PR TITLE
snap-confine: fix incorrect use "src" var in mount-support.c

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -343,7 +343,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		}
 		// this cannot happen except when the kernel is buggy
 		if (strstr(self, "/snap-confine") == NULL) {
-			die("cannot use result from readlink: %s", src);
+			die("cannot use result from readlink: %s", self);
 		}
 		src = dirname(self);
 		// dirname(path) might return '.' depending on path.


### PR DESCRIPTION
We got a bugreport from fedora that gcc-9 fails to build with current snapd:
```
snap-confine/mount-support.c: In function 'sc_bootstrap_mount_namespace':
snap-confine/mount-support.c:403:4: error: '%s' directive argument is null [-Werror=format-overflow=]
  403 |    die("cannot use result from readlink: %s", src);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:2507: snap-confine/snap_confine_debug-mount-support.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```

This PR fixes this issue. Thanks to Jeff Law  for reporting the issue!
