### PR TITLE
store, snap, cmd/snap: channels have released-at

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -321,8 +322,13 @@ func maybePrintServices(w io.Writer, snapName string, allApps []client.AppInfo, 
 var channelRisks = []string{"stable", "candidate", "beta", "edge"}
 
 // displayChannels displays channels and tracks in the right order
-func displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.Snap) {
-	fmt.Fprintf(w, "channels:"+strings.Repeat("\t", strings.Count(chantpl, "\t"))+"\n")
+func (x *infoCmd) displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.Snap) {
+	fmt.Fprintln(w, "channels:")
+
+	releasedfmt := "2006-01-02"
+	if x.AbsTime {
+		releasedfmt = time.RFC3339
+	}
 
 	// order by tracks
 	for _, tr := range remote.Tracks {
@@ -333,10 +339,11 @@ func displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.S
 			if tr == "latest" {
 				chName = risk
 			}
-			var version, revision, size, notes string
+			var version, released, revision, size, notes string
 			if ok {
 				version = ch.Version
 				revision = fmt.Sprintf("(%s)", ch.Revision)
+				released = ch.ReleasedAt.Format(releasedfmt)
 				size = strutil.SizeToStr(ch.Size)
 				notes = NotesFromChannelSnapInfo(ch).String()
 				trackHasOpenChannel = true
@@ -347,7 +354,7 @@ func displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.S
 					version = esc.dash
 				}
 			}
-			fmt.Fprintf(w, "  "+chantpl, chName, version, revision, size, notes)
+			fmt.Fprintf(w, "  "+chantpl, chName, version, released, revision, size, notes)
 		}
 	}
 }
@@ -457,17 +464,17 @@ func (x *infoCmd) Execute([]string) error {
 			}
 		}
 
-		chantpl := "%s:\t%s %s %s %s\n"
+		chantpl := "%s:\t%s %s%s %s %s\n"
 		if remote != nil && remote.Channels != nil && remote.Tracks != nil {
-			chantpl = "%s:\t%s\t%s\t%s\t%s\n"
+			chantpl = "%s:\t%s\t%s\t%s\t%s\t%s\n"
 
 			w.Flush()
-			displayChannels(w, chantpl, esc, remote)
+			x.displayChannels(w, chantpl, esc, remote)
 		}
 		if local != nil {
 			revstr := fmt.Sprintf("(%s)", local.Revision)
 			fmt.Fprintf(w, chantpl,
-				"installed", local.Version, revstr, strutil.SizeToStr(local.InstalledSize), notes)
+				"installed", local.Version, "", revstr, strutil.SizeToStr(local.InstalledSize), notes)
 		}
 
 	}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -203,7 +203,8 @@ const mockInfoJSONWithChannels = `
           "revision": "1",
           "version": "2.10",
           "channel": "1/stable",
-          "size": 65536
+          "size": 65536,
+          "released-at": "2018-12-18T15:16:56.723501Z"
         }
       },
       "tracks": ["1"]
@@ -390,16 +391,16 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
-		case 0:
+		case 0, 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
 			fmt.Fprintln(w, mockInfoJSONWithChannels)
-		case 1:
+		case 1, 3:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
 			fmt.Fprintln(w, mockInfoJSONNoLicense)
 		default:
-			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
+			c.Fatalf("expected to get 4 requests, now on %d (%v)", n+1, r)
 		}
 
 		n++
@@ -417,14 +418,39 @@ description: |
 snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
-channels:                    
-  1/stable:    2.10 (1) 65kB -
-  1/candidate: ↑             
-  1/beta:      ↑             
-  1/edge:      ↑             
-installed:     2.10 (1) 1kB  disabled
+channels:
+  1/stable:    2.10 2018-12-18T15:16:56Z (1) 65kB -
+  1/candidate: ↑                                  
+  1/beta:      ↑                                  
+  1/edge:      ↑                                  
+installed:     2.10                      (1) 1kB  disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
+
+	// now the same but without abs-time
+	s.ResetStdStreams()
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"info", "hello"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `name:      hello
+summary:   The GNU Hello snap
+publisher: Canonical✓
+license:   unset
+description: |
+  GNU hello prints a friendly greeting. This is part of the snapcraft tour at
+  https://snapcraft.io/
+snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
+tracking:     beta
+refresh-date: 2006-01-02
+channels:
+  1/stable:    2.10 2018-12-18 (1) 65kB -
+  1/candidate: ↑                        
+  1/beta:      ↑                        
+  1/edge:      ↑                        
+installed:     2.10            (1) 1kB  disabled
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(n, check.Equals, 4)
 }
 
 func (s *infoSuite) TestInfoHumanTimes(c *check.C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -319,6 +319,7 @@ type ChannelSnapInfo struct {
 	Channel     string          `json:"channel"`
 	Epoch       Epoch           `json:"epoch"`
 	Size        int64           `json:"size"`
+	ReleasedAt  time.Time       `json:"released-at"`
 }
 
 // InstanceName returns the blessed name of the snap decorated with instance

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1586,6 +1586,8 @@ slots:
     read:
       - /
 
+- add "released-at" to something randomish
+
 */
 const mockInfoJSON = `{
     "channel-map": [
@@ -1597,6 +1599,7 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "stable",
+                "released-at": "2019-01-01T10:11:12.123456789+00:00",
                 "risk": "stable",
                 "track": "latest"
             },
@@ -1630,6 +1633,7 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "candidate",
+                "released-at": "2019-01-02T10:11:12.123456789+00:00",
                 "risk": "candidate",
                 "track": "latest"
             },
@@ -1663,6 +1667,7 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "beta",
+                "released-at": "2019-01-03T10:11:12.123456789+00:00",
                 "risk": "beta",
                 "track": "latest"
             },
@@ -1696,6 +1701,7 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "edge",
+                "released-at": "2019-01-04T10:11:12.123456789+00:00",
                 "risk": "edge",
                 "track": "latest"
             },
@@ -2046,6 +2052,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Channel:     "stable",
 			Size:        20480,
 			Epoch:       snap.E("0"),
+			ReleasedAt:  time.Date(2019, 1, 1, 10, 11, 12, 123456789, time.UTC),
 		},
 		"latest/candidate": {
 			Revision:    snap.R(27),
@@ -2054,6 +2061,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Channel:     "candidate",
 			Size:        20480,
 			Epoch:       snap.E("0"),
+			ReleasedAt:  time.Date(2019, 1, 2, 10, 11, 12, 123456789, time.UTC),
 		},
 		"latest/beta": {
 			Revision:    snap.R(27),
@@ -2062,6 +2070,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Channel:     "beta",
 			Size:        20480,
 			Epoch:       snap.E("0"),
+			ReleasedAt:  time.Date(2019, 1, 3, 10, 11, 12, 123456789, time.UTC),
 		},
 		"latest/edge": {
 			Revision:    snap.R(28),
@@ -2070,6 +2079,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 			Channel:     "edge",
 			Size:        20480,
 			Epoch:       snap.E("0"),
+			ReleasedAt:  time.Date(2019, 1, 4, 10, 11, 12, 123456789, time.UTC),
 		},
 	}
 	for k, v := range result.Channels {
@@ -2084,16 +2094,19 @@ func (s *storeTestSuite) TestInfoMoreChannels(c *C) {
 	// NB this tests more channels, but still only one architecture
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", infoPathPattern)
-		// following is just a tweaked version of:
+		// following is just an aligned version of:
 		// http https://api.snapcraft.io/v2/snaps/info/go architecture==amd64 fields==channel Snap-Device-Series:16 | jq -c '.["channel-map"] | .[]'
 		io.WriteString(w, `{"channel-map": [
-{"channel":{"name":"stable",      "risk":"stable", "track":"latest"}},
-{"channel":{"name":"edge",        "risk":"edge",   "track":"latest"}},
-{"channel":{"name":"1.10/stable", "risk":"stable", "track":"1.10"  }},
-{"channel":{"name":"1.6/stable",  "risk":"stable", "track":"1.6"   }},
-{"channel":{"name":"1.7/stable",  "risk":"stable", "track":"1.7"   }},
-{"channel":{"name":"1.8/stable",  "risk":"stable", "track":"1.8"   }},
-{"channel":{"name":"1.9/stable",  "risk":"stable", "track":"1.9"   }}
+{"channel":{"architecture":"amd64","name":"stable",        "released-at":"2018-12-17T09:17:16.288554+00:00","risk":"stable",   "track":"latest"}},
+{"channel":{"architecture":"amd64","name":"edge",          "released-at":"2018-11-06T00:46:03.348730+00:00","risk":"edge",     "track":"latest"}},
+{"channel":{"architecture":"amd64","name":"1.11/stable",   "released-at":"2018-12-17T09:17:48.847205+00:00","risk":"stable",   "track":"1.11"}},
+{"channel":{"architecture":"amd64","name":"1.11/candidate","released-at":"2018-12-17T00:10:05.864910+00:00","risk":"candidate","track":"1.11"}},
+{"channel":{"architecture":"amd64","name":"1.10/stable",   "released-at":"2018-12-17T06:53:57.915517+00:00","risk":"stable",   "track":"1.10"}},
+{"channel":{"architecture":"amd64","name":"1.10/candidate","released-at":"2018-12-17T00:04:13.413244+00:00","risk":"candidate","track":"1.10"}},
+{"channel":{"architecture":"amd64","name":"1.9/stable",    "released-at":"2018-06-13T02:23:06.338145+00:00","risk":"stable",   "track":"1.9"}},
+{"channel":{"architecture":"amd64","name":"1.8/stable",    "released-at":"2018-02-07T23:08:59.152984+00:00","risk":"stable",   "track":"1.8"}},
+{"channel":{"architecture":"amd64","name":"1.7/stable",    "released-at":"2017-06-02T01:16:52.640258+00:00","risk":"stable",   "track":"1.7"}},
+{"channel":{"architecture":"amd64","name":"1.6/stable",    "released-at":"2017-05-17T21:18:42.224979+00:00","risk":"stable",   "track":"1.6"}}
 ]}`)
 	}))
 
@@ -2111,19 +2124,22 @@ func (s *storeTestSuite) TestInfoMoreChannels(c *C) {
 	result, err := sto.SnapInfo(store.SnapSpec{Name: "eh"}, nil)
 	c.Assert(err, IsNil)
 	expected := map[string]*snap.ChannelSnapInfo{
-		"latest/stable": {Channel: "stable"},
-		"latest/edge":   {Channel: "edge"},
-		"1.6/stable":    {Channel: "1.6/stable"},
-		"1.7/stable":    {Channel: "1.7/stable"},
-		"1.8/stable":    {Channel: "1.8/stable"},
-		"1.9/stable":    {Channel: "1.9/stable"},
-		"1.10/stable":   {Channel: "1.10/stable"},
+		"latest/stable":  {Channel: "stable", ReleasedAt: time.Date(2018, 12, 17, 9, 17, 16, 288554000, time.UTC)},
+		"latest/edge":    {Channel: "edge", ReleasedAt: time.Date(2018, 11, 6, 0, 46, 3, 348730000, time.UTC)},
+		"1.6/stable":     {Channel: "1.6/stable", ReleasedAt: time.Date(2017, 5, 17, 21, 18, 42, 224979000, time.UTC)},
+		"1.7/stable":     {Channel: "1.7/stable", ReleasedAt: time.Date(2017, 6, 2, 1, 16, 52, 640258000, time.UTC)},
+		"1.8/stable":     {Channel: "1.8/stable", ReleasedAt: time.Date(2018, 2, 7, 23, 8, 59, 152984000, time.UTC)},
+		"1.9/stable":     {Channel: "1.9/stable", ReleasedAt: time.Date(2018, 6, 13, 2, 23, 6, 338145000, time.UTC)},
+		"1.10/stable":    {Channel: "1.10/stable", ReleasedAt: time.Date(2018, 12, 17, 6, 53, 57, 915517000, time.UTC)},
+		"1.10/candidate": {Channel: "1.10/candidate", ReleasedAt: time.Date(2018, 12, 17, 0, 4, 13, 413244000, time.UTC)},
+		"1.11/stable":    {Channel: "1.11/stable", ReleasedAt: time.Date(2018, 12, 17, 9, 17, 48, 847205000, time.UTC)},
+		"1.11/candidate": {Channel: "1.11/candidate", ReleasedAt: time.Date(2018, 12, 17, 0, 10, 5, 864910000, time.UTC)},
 	}
 	for k, v := range result.Channels {
 		c.Check(v, DeepEquals, expected[k], Commentf("%q", k))
 	}
 	c.Check(result.Channels, HasLen, len(expected))
-	c.Check(result.Tracks, DeepEquals, []string{"latest", "1.10", "1.6", "1.7", "1.8", "1.9"})
+	c.Check(result.Tracks, DeepEquals, []string{"latest", "1.11", "1.10", "1.9", "1.8", "1.7", "1.6"})
 }
 
 func (s *storeTestSuite) TestInfoNonDefaults(c *C) {

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -39,6 +39,9 @@ verNotesRx = re.compile(r"^\w\S*\s+-$")
 def verRevNotesRx(s):
     return re.compile(r"^\w\S*\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$")
 
+def verRelRevNotesRx(s):
+    return re.compile(r"^\w\S*\s+\d{4}-\d{2}-\d{2}\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$")
+
 if os.environ['SNAPPY_USE_STAGING_STORE'] == '1':
     snap_ids={
         "test-snapd-tools": "02AHdOomTzby7gTaiLX3M3SGMmXDfLJp",
@@ -81,10 +84,10 @@ check("test-snapd-tools", res[2],
    ("installed", matches, verRevNotesRx("-")),
    ("refresh-date", exists),
    ("channels", check,
-    ("stable", matches, verRevNotesRx("-")),
+    ("stable", matches, verRelRevNotesRx("-")),
     ("candidate", equals, "↑"),
     ("beta", equals, "↑"),
-    ("edge", matches, verRevNotesRx("-")),
+    ("edge", matches, verRelRevNotesRx("-")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-tools"]),
    ("license", matches, r"(unknown|unset)"), # TODO: update once snap.yaml contains the right license
@@ -102,8 +105,8 @@ check("test-snapd-devmode", res[3],
    ("channels", check,
     ("stable", equals, "–"),
     ("candidate", equals, "–"),
-    ("beta", matches, verRevNotesRx("devmode")),
-    ("edge", matches, verRevNotesRx("devmode")),
+    ("beta", matches, verRelRevNotesRx("devmode")),
+    ("edge", matches, verRelRevNotesRx("devmode")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-devmode"]),
    ("license", matches, r"(unknown|unset)"), # TODO: update once snap.yaml contains the right license


### PR DESCRIPTION
The store is now sending the date a revision was released into a
channel as part of the channel map.

This change makes snapd know about it, and uses it for `snap info`.

Fixes [lp:1758288].

[lp:1758288]: https://bugs.launchpad.net/snapd/+bug/1758288
