### PR TITLE
cmd/snap: only auto-enable unicode to a tty

### DIFF
--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -143,8 +143,8 @@ func (s *SnapSuite) TestFindSnapName(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical✓ +- +GNU Hello, the "hello world" snap
-hello-world +6.1 +canonical✓ +- +Hello world example
+hello +2.10 +canonical\* +- +GNU Hello, the "hello world" snap
+hello-world +6.1 +canonical\* +- +Hello world example
 hello-huge +1.0 +noise +- +a really big snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -234,7 +234,7 @@ func (s *SnapSuite) TestFindHello(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical✓ +- +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\* +- +GNU Hello, the "hello world" snap
 hello-huge +1.0 +noise +- +a really big snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -261,7 +261,7 @@ func (s *SnapSuite) TestFindHelloNarrow(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical✓ +- +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\* +- +GNU Hello, the "hello world" snap
 hello-huge +1.0 +noise +- +a really big snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -324,7 +324,7 @@ func (s *SnapSuite) TestFindPriced(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical✓ +1.99GBP +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\* +1.99GBP +GNU Hello, the "hello world" snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -385,7 +385,7 @@ func (s *SnapSuite) TestFindPricedAndBought(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical✓ +bought +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\* +bought +GNU Hello, the "hello world" snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -322,13 +322,19 @@ func maybePrintServices(w io.Writer, snapName string, allApps []client.AppInfo, 
 var channelRisks = []string{"stable", "candidate", "beta", "edge"}
 
 // displayChannels displays channels and tracks in the right order
-func (x *infoCmd) displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.Snap) {
+func (x *infoCmd) displayChannels(w io.Writer, chantpl string, esc *escapes, remote *client.Snap, revLen, sizeLen int) (maxRevLen, maxSizeLen int) {
 	fmt.Fprintln(w, "channels:")
 
 	releasedfmt := "2006-01-02"
 	if x.AbsTime {
 		releasedfmt = time.RFC3339
 	}
+
+	type chInfoT struct {
+		name, version, released, revision, size, notes string
+	}
+	var chInfos []*chInfoT
+	maxRevLen, maxSizeLen = revLen, sizeLen
 
 	// order by tracks
 	for _, tr := range remote.Tracks {
@@ -339,24 +345,36 @@ func (x *infoCmd) displayChannels(w io.Writer, chantpl string, esc *escapes, rem
 			if tr == "latest" {
 				chName = risk
 			}
-			var version, released, revision, size, notes string
+			chInfo := chInfoT{name: chName}
 			if ok {
-				version = ch.Version
-				revision = fmt.Sprintf("(%s)", ch.Revision)
-				released = ch.ReleasedAt.Format(releasedfmt)
-				size = strutil.SizeToStr(ch.Size)
-				notes = NotesFromChannelSnapInfo(ch).String()
+				chInfo.version = ch.Version
+				chInfo.revision = fmt.Sprintf("(%s)", ch.Revision)
+				if len(chInfo.revision) > maxRevLen {
+					maxRevLen = len(chInfo.revision)
+				}
+				chInfo.released = ch.ReleasedAt.Format(releasedfmt)
+				chInfo.size = strutil.SizeToStr(ch.Size)
+				if len(chInfo.size) > maxSizeLen {
+					maxSizeLen = len(chInfo.size)
+				}
+				chInfo.notes = NotesFromChannelSnapInfo(ch).String()
 				trackHasOpenChannel = true
 			} else {
 				if trackHasOpenChannel {
-					version = esc.uparrow
+					chInfo.version = esc.uparrow
 				} else {
-					version = esc.dash
+					chInfo.version = esc.dash
 				}
 			}
-			fmt.Fprintf(w, "  "+chantpl, chName, version, released, revision, size, notes)
+			chInfos = append(chInfos, &chInfo)
 		}
 	}
+
+	for _, chInfo := range chInfos {
+		fmt.Fprintf(w, "  "+chantpl, chInfo.name, chInfo.version, chInfo.released, maxRevLen, chInfo.revision, maxSizeLen, chInfo.size, chInfo.notes)
+	}
+
+	return maxRevLen, maxSizeLen
 }
 
 func formatSummary(raw string) string {
@@ -455,6 +473,8 @@ func (x *infoCmd) Execute([]string) error {
 		maybePrintType(w, both.Type)
 		maybePrintBase(w, both.Base, x.Verbose)
 		maybePrintID(w, both)
+		var localRev, localSize string
+		var revLen, sizeLen int
 		if local != nil {
 			if local.TrackingChannel != "" {
 				fmt.Fprintf(w, "tracking:\t%s\n", local.TrackingChannel)
@@ -462,19 +482,22 @@ func (x *infoCmd) Execute([]string) error {
 			if !local.InstallDate.IsZero() {
 				fmt.Fprintf(w, "refresh-date:\t%s\n", x.fmtTime(local.InstallDate))
 			}
+			localRev = fmt.Sprintf("(%s)", local.Revision)
+			revLen = len(localRev)
+			localSize = strutil.SizeToStr(local.InstalledSize)
+			sizeLen = len(localSize)
 		}
 
-		chantpl := "%s:\t%s %s%s %s %s\n"
+		chantpl := "%s:\t%s %s%*s %*s %s\n"
 		if remote != nil && remote.Channels != nil && remote.Tracks != nil {
-			chantpl = "%s:\t%s\t%s\t%s\t%s\t%s\n"
+			chantpl = "%s:\t%s\t%s\t%*s\t%*s\t%s\n"
 
 			w.Flush()
-			x.displayChannels(w, chantpl, esc, remote)
+			revLen, sizeLen = x.displayChannels(w, chantpl, esc, remote, revLen, sizeLen)
 		}
 		if local != nil {
-			revstr := fmt.Sprintf("(%s)", local.Revision)
 			fmt.Fprintf(w, chantpl,
-				"installed", local.Version, "", revstr, strutil.SizeToStr(local.InstalledSize), notes)
+				"installed", local.Version, "", revLen, localRev, sizeLen, localSize, notes)
 		}
 
 	}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -304,7 +304,7 @@ const mockInfoJSONNoLicense = `
       "name": "hello",
       "private": false,
       "resource": "/v2/snaps/hello",
-      "revision": "1",
+      "revision": "100",
       "status": "available",
       "summary": "The GNU Hello snap",
       "type": "app",
@@ -382,7 +382,7 @@ description: |
 snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
-installed:    2.10 (1) 1kB disabled
+installed:    2.10 (100) 1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -419,11 +419,11 @@ snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
 channels:
-  1/stable:    2.10 2018-12-18T15:16:56Z (1) 65kB -
-  1/candidate: ↑                                  
-  1/beta:      ↑                                  
-  1/edge:      ↑                                  
-installed:     2.10                      (1) 1kB  disabled
+  1/stable:    2.10 2018-12-18T15:16:56Z   (1) 65kB -
+  1/candidate: ↑                                    
+  1/beta:      ↑                                    
+  1/edge:      ↑                                    
+installed:     2.10                      (100)  1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 
@@ -443,11 +443,11 @@ snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02
 channels:
-  1/stable:    2.10 2018-12-18 (1) 65kB -
-  1/candidate: ↑                        
-  1/beta:      ↑                        
-  1/edge:      ↑                        
-installed:     2.10            (1) 1kB  disabled
+  1/stable:    2.10 2018-12-18   (1) 65kB -
+  1/candidate: ↑                          
+  1/beta:      ↑                          
+  1/edge:      ↑                          
+installed:     2.10            (100)  1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(n, check.Equals, 4)
@@ -488,7 +488,7 @@ description: |
 snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: TOTALLY NOT A ROBOT
-installed:    2.10 (1) 1kB disabled
+installed:    2.10 (100) 1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -120,7 +120,7 @@ func (s *infoSuite) TestInfoPriced(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   GNU Hello, the "hello world" snap
-publisher: Canonical✓
+publisher: Canonical*
 license:   Proprietary
 price:     1.99GBP
 description: |
@@ -240,7 +240,7 @@ func (s *infoSuite) TestInfoUnquoted(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical✓
+publisher: Canonical*
 license:   MIT
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -338,7 +338,7 @@ func (s *infoSuite) TestInfoWithLocalDifferentLicense(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical✓
+publisher: Canonical*
 license:   BSD-3
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -374,7 +374,7 @@ func (s *infoSuite) TestInfoWithLocalNoLicense(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical✓
+publisher: Canonical*
 license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -391,16 +391,16 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
-		case 0, 2:
+		case 0, 2, 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
 			fmt.Fprintln(w, mockInfoJSONWithChannels)
-		case 1, 3:
+		case 1, 3, 5:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
 			fmt.Fprintln(w, mockInfoJSONNoLicense)
 		default:
-			c.Fatalf("expected to get 4 requests, now on %d (%v)", n+1, r)
+			c.Fatalf("expected to get 6 requests, now on %d (%v)", n+1, r)
 		}
 
 		n++
@@ -410,7 +410,7 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical✓
+publisher: Canonical*
 license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -420,16 +420,42 @@ tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
 channels:
   1/stable:    2.10 2018-12-18T15:16:56Z   (1) 65kB -
-  1/candidate: ↑                                    
-  1/beta:      ↑                                    
-  1/edge:      ↑                                    
+  1/candidate: ^                                    
+  1/beta:      ^                                    
+  1/edge:      ^                                    
 installed:     2.10                      (100)  1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(n, check.Equals, 2)
 
 	// now the same but without abs-time
 	s.ResetStdStreams()
 	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"info", "hello"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `name:      hello
+summary:   The GNU Hello snap
+publisher: Canonical*
+license:   unset
+description: |
+  GNU hello prints a friendly greeting. This is part of the snapcraft tour at
+  https://snapcraft.io/
+snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
+tracking:     beta
+refresh-date: 2006-01-02
+channels:
+  1/stable:    2.10 2018-12-18   (1) 65kB -
+  1/candidate: ^                          
+  1/beta:      ^                          
+  1/edge:      ^                          
+installed:     2.10            (100)  1kB disabled
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(n, check.Equals, 4)
+
+	// now the same but with unicode on
+	s.ResetStdStreams()
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"info", "--unicode=always", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
@@ -450,7 +476,7 @@ channels:
 installed:     2.10            (100)  1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(n, check.Equals, 4)
+	c.Check(n, check.Equals, 6)
 }
 
 func (s *infoSuite) TestInfoHumanTimes(c *check.C) {
@@ -480,7 +506,7 @@ func (s *infoSuite) TestInfoHumanTimes(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical✓
+publisher: Canonical*
 license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -57,6 +57,9 @@ func canUnicode(mode string) bool {
 	case "never":
 		return false
 	}
+	if !isStdoutTTY {
+		return false
+	}
 	var lang string
 	for _, k := range []string{"LC_MESSAGES", "LC_ALL", "LANG"} {
 		lang = os.Getenv(k)

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -82,7 +82,11 @@ func (s *SnapSuite) TestCanUnicode(c *check.C) {
 		restore := setEnviron(map[string]string{"LANG": t.lang, "LC_ALL": t.lcAll, "LC_MESSAGES": t.lcMsg})
 		c.Check(cmdsnap.CanUnicode("never"), check.Equals, false)
 		c.Check(cmdsnap.CanUnicode("always"), check.Equals, true)
+		restoreIsTTY := cmdsnap.MockIsStdoutTTY(true)
 		c.Check(cmdsnap.CanUnicode("auto"), check.Equals, t.expected)
+		cmdsnap.MockIsStdoutTTY(false)
+		c.Check(cmdsnap.CanUnicode("auto"), check.Equals, false)
+		restoreIsTTY()
 		restore()
 	}
 }

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -13,16 +13,16 @@ environment:
 
 execute: |
     echo "Install from different channels"
-    expected="(?s)$SNAP_NAME .* from Canonical✓ installed\\n"
+    expected="(?s)$SNAP_NAME .* from Canonical\\* installed\\n"
     for channel in edge beta candidate stable
     do
-        snap install "$SNAP_NAME" --channel=$channel | grep -Pzq "$expected"
+        snap install --unicode=never "$SNAP_NAME" --channel=$channel | grep -Pzq "$expected"
         snap remove "$SNAP_NAME"
     done
 
     echo "Install non-devmode snap with devmode option"
-    expected="(?s)$SNAP_NAME .* from Canonical✓ installed\\n"
-    snap install "$SNAP_NAME" --devmode | grep -Pzq "$expected"
+    expected="(?s)$SNAP_NAME .* from Canonical\\* installed\\n"
+    snap install --unicode=never "$SNAP_NAME" --devmode | grep -Pzq "$expected"
 
     echo "Install devmode snap without devmode option"
     expected="repeat the command including --devmode"

--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -11,9 +11,9 @@ environment:
     SNAP_NAME: bluez
 
 execute: |
-    if ! snap list bluez &> /dev/null ; then
+    if ! snap list --unicode=never bluez &> /dev/null ; then
         echo "Installing bluez snap from the store ..."
-        expected="(?s)$SNAP_NAME .* from Canonical✓ installed\\n"
+        expected="(?s)$SNAP_NAME .* from Canonical\\* installed\\n"
         snap install "$SNAP_NAME" | grep -Pzq "$expected"
     fi
 

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -29,13 +29,13 @@ execute: |
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core.*$'
     elif [ "$SRU_VALIDATION" = "1" ]; then
         echo "When sru validation is done the core snap is installed from the store"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical✓ +core.*$'
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical\\* +core.*$'
     elif [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "autopkgtest" ]; then
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical✓ +core.*$'
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical\\* +core.*$'
     else
-        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)? +[0-9]+ +$CORE_CHANNEL +canonical✓ +core.*$"
+        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)? +[0-9]+ +$CORE_CHANNEL +canonical\\* +core.*$"
     fi
-    snap list | MATCH "$expected"
+    snap list --unicode=never | MATCH "$expected"
 
     echo "List prints installed snaps and versions"
     snap list | MATCH '^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -20,7 +20,15 @@ execute: |
     echo "With one non-snap argument, errors out"
     ! snap info /etc/passwd
 
-    snap info basic_1.0_all.snap "$TESTSLIB"/snaps/basic-desktop test-snapd-tools test-snapd-devmode core /etc/passwd test-snapd-python-webserver > out
+    snap info --unicode=always        \
+      basic_1.0_all.snap              \
+      "$TESTSLIB"/snaps/basic-desktop \
+      test-snapd-tools                \
+      test-snapd-devmode              \
+      core                            \
+      /etc/passwd                     \
+      test-snapd-python-webserver     \
+      > out
     PYTHONIOENCODING=utf8 python3 check.py < out
 
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -28,4 +28,4 @@ execute: |
     execute_remote "snap known model" | MATCH "series: 16"
 
     echo "Make sure core has an actual revision"
-    execute_remote "snap list" | MATCH "^core +[0-9]+\\-[0-9.]+ +[0-9]+ +$CORE_CHANNEL +canonical✓ +core"
+    execute_remote "snap list --unicode=never" | MATCH "^core +[0-9]+\\-[0-9.]+ +[0-9]+ +$CORE_CHANNEL +canonical\\* +core"


### PR DESCRIPTION
The current behaviour of `--unicode=auto` (the default) is to output
unicode depending on the contents of a few locale-related environment
variables, independenlty of whether stdout was going to a terminal or
not. This was considered a bug.

With this change, the behaviour changes to not output unicode to a
pipe unless `--unicode=always` is given.
