### PR TITLE
store: undo workaround for timezone-less released-at

### DIFF
--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -20,7 +20,6 @@
 package store
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -86,32 +85,11 @@ type storeSnapMedia struct {
 
 // storeInfoChannel is the channel description included in info results
 type storeInfoChannel struct {
-	Architecture string `json:"architecture"`
-	Name         string `json:"name"`
-	Risk         string `json:"risk"`
-	Track        string `json:"track"`
-	ReleasedAt   xTime  `json:"released-at"`
-}
-
-// time.Time but also try without a timezone -- this is a workaround
-// for a store-side issue that already has a fix, that should get
-// deployed today (2019-01-09)
-type xTime time.Time
-
-func (tp *xTime) UnmarshalJSON(buf []byte) error {
-	var str string
-	if err := json.Unmarshal(buf, &str); err != nil {
-		return err
-	}
-	t, err := time.Parse(time.RFC3339, str)
-	if err != nil {
-		t, err = time.Parse("2006-01-02T15:04:05", str)
-		if err != nil {
-			return err
-		}
-	}
-	*tp = xTime(t)
-	return nil
+	Architecture string    `json:"architecture"`
+	Name         string    `json:"name"`
+	Risk         string    `json:"risk"`
+	Track        string    `json:"track"`
+	ReleasedAt   time.Time `json:"released-at"`
 }
 
 // storeInfoChannelSnap is the snap-in-a-channel of which the channel map is made
@@ -160,7 +138,7 @@ func infoFromStoreInfo(si *storeInfo) (*snap.Info, error) {
 			Channel:     ch.Name,
 			Epoch:       s.Epoch,
 			Size:        s.Download.Size,
-			ReleasedAt:  time.Time(ch.ReleasedAt).UTC(),
+			ReleasedAt:  ch.ReleasedAt.UTC(),
 		}
 		if !seen[ch.Track] {
 			seen[ch.Track] = true


### PR DESCRIPTION
the store rolled out the fix \o/
