### PR TITLE
use major() and minor() in <sys/sysmacros.h> instead of MAJOR and MINOR…

### DIFF
--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -19,7 +19,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
-#include <linux/kdev_t.h>
+#include <sys/sysmacros.h>
 #include <sched.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -108,9 +108,7 @@ void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path)
 	dev_t devnum = udev_device_get_devnum(d);
 	udev_device_unref(d);
 
-	unsigned major = MAJOR(devnum);
-	unsigned minor = MINOR(devnum);
-	_run_snappy_app_dev_add_majmin(udev_s, path, major, minor);
+	_run_snappy_app_dev_add_majmin(udev_s, path, major(devnum), minor(devnum));
 }
 
 /*
@@ -264,34 +262,34 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 			break;
 		}
 		_run_snappy_app_dev_add_majmin(udev_s, nv_path,
-					       MAJOR(sbuf.st_rdev),
-					       MINOR(sbuf.st_rdev));
+					       major(sbuf.st_rdev),
+					       minor(sbuf.st_rdev));
 	}
 
 	// /dev/nvidiactl
 	if (stat(nvctl_path, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvctl_path,
-					       MAJOR(sbuf.st_rdev),
-					       MINOR(sbuf.st_rdev));
+					       major(sbuf.st_rdev),
+					       minor(sbuf.st_rdev));
 	}
 	// /dev/nvidia-uvm
 	if (stat(nvuvm_path, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvuvm_path,
-					       MAJOR(sbuf.st_rdev),
-					       MINOR(sbuf.st_rdev));
+					       major(sbuf.st_rdev),
+					       minor(sbuf.st_rdev));
 	}
 	// /dev/nvidia-modeset
 	if (stat(nvidia_modeset_path, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvidia_modeset_path,
-					       MAJOR(sbuf.st_rdev),
-					       MINOR(sbuf.st_rdev));
+					       major(sbuf.st_rdev),
+					       minor(sbuf.st_rdev));
 	}
 	// /dev/uhid isn't represented in sysfs, so add it to the device cgroup
 	// if it exists and let AppArmor handle the mediation
 	if (stat("/dev/uhid", &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, "/dev/uhid",
-					       MAJOR(sbuf.st_rdev),
-					       MINOR(sbuf.st_rdev));
+					       major(sbuf.st_rdev),
+					       minor(sbuf.st_rdev));
 	}
 	// add the assigned devices
 	while (udev_s->assigned != NULL) {


### PR DESCRIPTION
… macro in <linux/kdev_t.h>

While I'm creating a snap messing with /dev/tpmrm0 which major device id is 253 and minor id is 65536, snap-confine keep giving wrong major and minor id, that makes my snap always had wrong device id in /sys/fs/cgroup/devices/snap*/devices.list at runtime and thus un-accessible from the strict confined snap. 

The debug message when setting SNAP_CONFINE_DEBUG=1 is something like this:
```
DEBUG: run_snappy_app_dev_add: /sys/devices/platform/MSFT0101:00/tpm/tpm0 snap_tpm2-simulator_clear
DEBUG: running snap-device-helper add snap_tpm2-simulator_clear /sys/devices/platform/MSFT0101:00/tpm/tpm0 10:224
DEBUG: run_snappy_app_dev_add: /sys/devices/platform/MSFT0101:00/tpmrm/tpmrm0 snap_tpm2-simulator_clear
DEBUG: running snap-device-helper add snap_tpm2-simulator_clear /sys/devices/platform/MSFT0101:00/tpmrm/tpmrm0 1048829:0
```

After reading a bit <bits/sysmacros.h> it looks to me we should use the major() and minor() macros in <sys/sysmacros.h> instead of using <linux/kdev_t.h> directly.

Using the macros in <sys/sysmacros.h> solve my original snap udev cgroup issue.