### PR TITLE
overlord/configstate/configcore: support - and _ in cloud init field names

### DIFF
--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -21,7 +21,6 @@ package configcore
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -57,10 +56,10 @@ func (c *cloudInitInstanceData) UnmarshalJSON(bs []byte) error {
 		V1 struct {
 			Region string `json:"region"`
 			// these fields can come with - or _ as separators
-			Name                string `json:"cloud-name"`
-			AltName             string `json:"cloud_name"`
-			AvailabilityZone    string `json:"availability-zone"`
-			AltAvailabilityZone string `json:"availability_zone"`
+			Name                string `json:"cloud_name"`
+			AltName             string `json:"cloud-name"`
+			AvailabilityZone    string `json:"availability_zone"`
+			AltAvailabilityZone string `json:"availability-zone"`
 		} `json:"v1"`
 	}
 
@@ -68,28 +67,15 @@ func (c *cloudInitInstanceData) UnmarshalJSON(bs []byte) error {
 		return err
 	}
 
-	if instanceDataJSON.V1.Name != "" && instanceDataJSON.V1.AltName != "" {
-		if instanceDataJSON.V1.Name != instanceDataJSON.V1.AltName {
-			return fmt.Errorf("inconsistent cloud-name/cloud_name setting: %q / %q",
-				instanceDataJSON.V1.Name, instanceDataJSON.V1.AltName)
-		}
-	}
-	if instanceDataJSON.V1.AvailabilityZone != "" && instanceDataJSON.V1.AltAvailabilityZone != "" {
-		if instanceDataJSON.V1.AvailabilityZone != instanceDataJSON.V1.AltAvailabilityZone {
-			return fmt.Errorf("inconsistent availability-zone/availability_zone setting: %q / %q",
-				instanceDataJSON.V1.AvailabilityZone, instanceDataJSON.V1.AltAvailabilityZone)
-		}
-	}
-
-	c.V1.Name = instanceDataJSON.V1.Name
-	if c.V1.Name == "" {
+	c.V1.Region = instanceDataJSON.V1.Region
+	switch {
+	case instanceDataJSON.V1.Name != "":
+		c.V1.Name = instanceDataJSON.V1.Name
+		c.V1.AvailabilityZone = instanceDataJSON.V1.AvailabilityZone
+	case instanceDataJSON.V1.AltName != "":
 		c.V1.Name = instanceDataJSON.V1.AltName
-	}
-	c.V1.AvailabilityZone = instanceDataJSON.V1.AvailabilityZone
-	if c.V1.AvailabilityZone == "" {
 		c.V1.AvailabilityZone = instanceDataJSON.V1.AltAvailabilityZone
 	}
-	c.V1.Region = instanceDataJSON.V1.Region
 	return nil
 }
 

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -125,7 +125,7 @@ func (s *cloudSuite) TestHandleCloud(c *C) {
   "region": null
  }
 }`, "openstack", "", "nova"},
-		// but the values need to be consistent
+		// cloud_name takes precedence, if set, and other fields follow
 		{`{
  "v1": {
   "availability_zone": "us-east-2b",
@@ -136,18 +136,29 @@ func (s *cloudSuite) TestHandleCloud(c *C) {
   "local-hostname": "b5",
   "region": null
  }
-}`, "", "", ""},
+}`, "aws", "", "us-east-2b"},
 		{`{
  "v1": {
-  "availability_zone": "us-east-2b",
-  "availability-zone": "us-east-2b",
+  "availability_zone": "nova",
+  "availability-zone": "gibberish",
   "cloud_name": "openstack",
   "cloud-name": "aws",
   "instance-id": "b5",
   "local-hostname": "b5",
   "region": null
  }
-}`, "", "", ""},
+}`, "openstack", "", "nova"},
+		{`{
+ "v1": {
+  "availability_zone": "gibberish",
+  "availability-zone": "nova",
+  "cloud_name": null,
+  "cloud-name": "openstack",
+  "instance-id": "b5",
+  "local-hostname": "b5",
+  "region": null
+ }
+}`, "openstack", "", "nova"},
 	}
 
 	err := os.MkdirAll(filepath.Dir(dirs.CloudInstanceDataFile), 0755)

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -104,12 +104,57 @@ func (s *cloudSuite) TestHandleCloud(c *C) {
    "cloud-name": "none"
  }
 }`, "", "", ""},
+		// both _ and - are supported
+		{`{
+ "v1": {
+  "availability_zone": "nova",
+  "cloud_name": "openstack",
+  "instance-id": "b5",
+  "local-hostname": "b5",
+  "region": null
+ }
+}`, "openstack", "", "nova"},
+		{`{
+ "v1": {
+  "availability_zone": "nova",
+  "availability-zone": "nova",
+  "cloud_name": "openstack",
+  "cloud-name": "openstack",
+  "instance-id": "b5",
+  "local-hostname": "b5",
+  "region": null
+ }
+}`, "openstack", "", "nova"},
+		// but the values need to be consistent
+		{`{
+ "v1": {
+  "availability_zone": "us-east-2b",
+  "availability-zone": "none",
+  "cloud_name": "aws",
+  "cloud_name": "aws",
+  "instance-id": "b5",
+  "local-hostname": "b5",
+  "region": null
+ }
+}`, "", "", ""},
+		{`{
+ "v1": {
+  "availability_zone": "us-east-2b",
+  "availability-zone": "us-east-2b",
+  "cloud_name": "openstack",
+  "cloud-name": "aws",
+  "instance-id": "b5",
+  "local-hostname": "b5",
+  "region": null
+ }
+}`, "", "", ""},
 	}
 
 	err := os.MkdirAll(filepath.Dir(dirs.CloudInstanceDataFile), 0755)
 	c.Assert(err, IsNil)
 
-	for _, t := range tests {
+	for i, t := range tests {
+		c.Logf("tc: %v", i)
 		os.Remove(dirs.CloudInstanceDataFile)
 		if t.instData != "" {
 			err = ioutil.WriteFile(dirs.CloudInstanceDataFile, []byte(t.instData), 0600)

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -1,0 +1,45 @@
+summary: Ensure that cloud-init integration works
+
+description: |
+    snapd picks up basic cloud information from the host and makes it available
+    to the snaps. Run the test on a live backend which sets instance data
+    properly.
+
+# GCE backend sets instance data
+backends: [google]
+
+execute: |
+    if [[ ! -e /run/cloud-init/instance-data.json ]]; then
+        echo "cloud-init instance data is required to execute the test"
+        exit 0
+    fi
+
+    # GCE sets the following:
+    # {
+    #    ...
+    #    "v1": {
+    #      "availability-zone": "us-east1-b",
+    #      "availability_zone": "us-east1-b",
+    #      "cloud-name": "gce",
+    #      "cloud_name": "gce",
+    #      "region": "us-east1"
+    #      ...
+    #   }
+    # }
+
+    # keys can be queried only using underscore names
+    cloud_name=$(cloud-init query cloud_name)
+    test -n "$cloud_name"
+    # this shouldn't happend under GCE
+    test "$cloud_name" != "nocloud"
+
+    snap_cloud_name=$(snap get core cloud.name)
+    test "$cloud_name" = "$snap_cloud_name"
+
+    cloud_avzone=$(cloud-init query availability_zone)
+    snap_cloud_avzone=$(snap get core cloud.availability-zone)
+    test "$cloud_avzone" = "$snap_cloud_avzone"
+
+    cloud_region=$(cloud-init query region)
+    snap_cloud_region=$(snap get core cloud.region)
+    test "$cloud_region" = "$snap_cloud_region"

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -11,10 +11,28 @@ backends: [google]
 execute: |
     if [[ ! -e /run/cloud-init/instance-data.json ]]; then
         echo "cloud-init instance data is required to execute the test"
+
+        if [[ "$SPREAD_SYSTEM" == ubuntu-* && "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+            # we expect the test to run on all Ubuntu images, excluding 14.04
+            echo "the test expected to run on $SPREAD_SYSTEM"
+            exit 1
+        fi
         exit 0
     fi
 
-    # GCE sets the following:
+    get_conf() {
+        # we could use cloud-init query <key>, but that requires cloud-init 18.4+
+        # which is not available in all images we use
+        local kname="$1"
+        if jq -r '.v1 | keys[]' < /run/cloud-init/instance-data.json | grep -q _; then
+            kname=${kname/-/_}
+        else
+            kname=${kname/_/-}
+        fi
+
+       jq -r ".[\"v1\"][\"$kname\"]" < /run/cloud-init/instance-data.json
+    }
+    # GCE sets the following in Ubuntu images:
     # {
     #    ...
     #    "v1": {
@@ -28,18 +46,24 @@ execute: |
     # }
 
     # keys can be queried only using underscore names
-    cloud_name=$(cloud-init query cloud_name)
+    cloud_name=$(get_conf cloud_name)
     test -n "$cloud_name"
-    # this shouldn't happend under GCE
-    test "$cloud_name" != "nocloud"
+    # this shouldn't happen under GCE
+    if [[ "$cloud_name" == "nocloud" ||  "$cloud_name" == "none" ]]; then
+        echo "not a cloud instance, config should be empty"
+
+        nocloud=$(snap get core -d | jq -r '.cloud')
+        test "$nocloud" = null
+        exit 0
+    fi
 
     snap_cloud_name=$(snap get core cloud.name)
     test "$cloud_name" = "$snap_cloud_name"
 
-    cloud_avzone=$(cloud-init query availability_zone)
+    cloud_avzone=$(get_conf availability_zone)
     snap_cloud_avzone=$(snap get core cloud.availability-zone)
     test "$cloud_avzone" = "$snap_cloud_avzone"
 
-    cloud_region=$(cloud-init query region)
+    cloud_region=$(get_conf region)
     snap_cloud_region=$(snap get core cloud.region)
     test "$cloud_region" = "$snap_cloud_region"

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -8,6 +8,11 @@ description: |
 # GCE backend sets instance data
 backends: [google]
 
+prepare: |
+    if ! command -v jq; then
+        snap install --devmode jq
+    fi
+
 execute: |
     if [[ ! -e /run/cloud-init/instance-data.json ]]; then
         echo "cloud-init instance data is required to execute the test"


### PR DESCRIPTION
cloud-init supports both underscores and hyphens as separators in field names.
Clients can use either, see the examples provided here:
https://cloudinit.readthedocs.io/en/latest/topics/instancedata.html

Make sure that snapd supports both both name formats too.
