### PR TITLE
cmd/snap-confine: join freezer only after setting up user mount

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -268,25 +268,6 @@ int main(int argc, char **argv)
 			sc_maybe_fixup_permissions();
 			sc_maybe_fixup_udev();
 
-			// Associate each snap process with a dedicated snap freezer
-			// control group. This simplifies testing if any processes
-			// belonging to a given snap are still alive.
-			// See the documentation of the function for details.
-
-			if (getegid() != 0 && saved_gid == 0) {
-				// Temporarily raise egid so we can chown the freezer cgroup
-				// under LXD.
-				if (setegid(0) != 0) {
-					die("cannot set effective group id to root");
-				}
-			}
-			sc_cgroup_freezer_join(snap_instance, getpid());
-			if (geteuid() == 0 && real_gid != 0) {
-				if (setegid(real_gid) != 0) {
-					die("cannot set effective group id to %d", real_gid);
-				}
-			}
-
 			/* User mount profiles do not apply to non-root users. */
 			if (real_uid != 0) {
 				debug
@@ -319,6 +300,25 @@ int main(int argc, char **argv)
 					}
 				}
 			}
+
+			// Associate each snap process with a dedicated snap freezer
+			// control group. This simplifies testing if any processes
+			// belonging to a given snap are still alive.
+			// See the documentation of the function for details.
+			if (getegid() != 0 && saved_gid == 0) {
+				// Temporarily raise egid so we can chown the freezer cgroup
+				// under LXD.
+				if (setegid(0) != 0) {
+					die("cannot set effective group id to root");
+				}
+			}
+			sc_cgroup_freezer_join(snap_instance, getpid());
+			if (geteuid() == 0 && real_gid != 0) {
+				if (setegid(real_gid) != 0) {
+					die("cannot set effective group id to %d", real_gid);
+				}
+			}
+
 
 			sc_unlock(snap_lock_fd);
 


### PR DESCRIPTION
This way snap-update-ns can freeze the set of snap processes without
freezing itself. Currently this is not an issue but as soon as
snap-update-ns needs to freeze running applications while updating
per-user mount namespace, it becomes relevant.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
