### PR TITLE
cmd/libsnap: pass --from-snap-confine when calling snap-update-ns as user

### DIFF
--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -115,7 +115,7 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
 	char *argv[] = {
 		"snap-update-ns",
 		/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
-		/* TODO: enable this in sync with snap-update-ns changes, "--from-snap-confine", */
+		"--from-snap-confine",
 		/* This tells snap-update-ns that we want to process the per-user profile */
 		"--user-mounts", snap_name_copy, NULL
 	};


### PR DESCRIPTION
This will allow snap-update-ns to understand proper locking semantics
when invoked from snap-confine (it will check instead of locking).

NOTE: Despite what the comment says it is harmless to enable now.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
