### PR TITLE
many: allow snap-update-ns to write user mount profile

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -656,6 +656,7 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # Those files are written by snap-update-ns and represent the actual
   # mount profile at a given moment.
   /run/snapd/ns/snap.###SNAP_INSTANCE_NAME###.fstab{,.*} rw,
+  /run/snapd/ns/snap.###SNAP_INSTANCE_NAME###.[0-9]*.user-fstab{,.*} rw,
 
   # NOTE: at this stage the /snap directory is stable as we have called
   # pivot_root already.


### PR DESCRIPTION
When snap-confine constructs a per-user mount namespace it delegates the
task to snap-update-ns invoked with a special option. The code in
snap-update-ns switches to the appropriate user ID while retaining some
capabilities required for mounting.

Before snap-update-ns was never saving the per-user mount profile so it
didn't need anything. Now it may start saving it (when the appropriate
feature is enabled) but it runs under a non-root UID. To allow the save
to really happen allow the file path pattern via apparmor template of
snap-update-ns and retain more capabilities to bypass filesystem checks.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>