### PR TITLE
tests: review/fix the autopkgtest failures in disco

### DIFF
--- a/tests/lib/snaps/test-snapd-service-watchdog/bin/direct
+++ b/tests/lib/snaps/test-snapd-service-watchdog/bin/direct
@@ -41,7 +41,7 @@ def main(opts):
     else:
         sleep_time = watchdog_timeout / 2
 
-    logging.info('watchdog notification every %us', sleep_time)
+    logging.info('watchdog notification every %s', sleep_time)
 
     with closing(socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)) as sock:
         sock.connect(notify_addr)

--- a/tests/lib/snaps/test-snapd-service-watchdog/bin/direct
+++ b/tests/lib/snaps/test-snapd-service-watchdog/bin/direct
@@ -41,7 +41,7 @@ def main(opts):
     else:
         sleep_time = watchdog_timeout / 2
 
-    logging.info('watchdog notification every %s', sleep_time)
+    logging.info('watchdog notification every %ss', sleep_time)
 
     with closing(socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)) as sock:
         sock.connect(notify_addr)

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -3,6 +3,9 @@ summary: Check different completions
 # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
+# takes >6min to run in total
+backends: [-autopkgtest]
+
 environment:
     NAMES: /var/cache/snapd/names
 

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -3,6 +3,9 @@ summary: Checks for special cases of snap install from the store
 # run on ubuntu-14,16,18,20+ but not on ubuntu-core, fedora etc
 systems: [ubuntu-1*, ubuntu-2*, ubuntu-3*]
 
+# takes >2min to run in total
+backends: [-autopkgtest]
+
 environment:
     SNAP_NAME: test-snapd-tools
     DEVMODE_SNAP: test-snapd-devmode

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -3,9 +3,6 @@ summary: Checks for special cases of snap install from the store
 # run on ubuntu-14,16,18,20+ but not on ubuntu-core, fedora etc
 systems: [ubuntu-1*, ubuntu-2*, ubuntu-3*]
 
-# takes >2min to run in total
-backends: [-autopkgtest]
-
 environment:
     SNAP_NAME: test-snapd-tools
     DEVMODE_SNAP: test-snapd-devmode

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -20,7 +20,7 @@ restore: |
     fi
 
 execute: |
-    if [ -n "$http_proxy" ] || [ -n "$https_proxy" ]; then
+    if [ -n "${http_proxy:-}" ] || [ -n "${https_proxy:-}" ] || [ -n "${HTTPS_PROXY:-}" ] || [ -n "${HTTPS_PROXY:-}" ]; then
        # all querries will go through the proxy so breaking DNS will not work
        echo "SKIP: cannot run when there is a http proxy set"
        exit 0

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -20,6 +20,12 @@ restore: |
     fi
 
 execute: |
+    if [ -n "$http_proxy" ] || [ -n "$https_proxy" ]; then
+       # all querries will go through the proxy so breaking DNS will not work
+       echo "SKIP: cannot run when there is a http proxy set"
+       exit 0
+    fi
+
     echo "Try to install a snap with broken DNS"
     if snap install test-snapd-tools; then
         echo "Installing test-snapd-tools with broken DNS should not work"

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -20,7 +20,8 @@ restore: |
     fi
 
 execute: |
-    if [ -n "${http_proxy:-}" ] || [ -n "${https_proxy:-}" ] || [ -n "${HTTPS_PROXY:-}" ] || [ -n "${HTTPS_PROXY:-}" ]; then
+    if [ -n "${http_proxy:-}" ] || [ -n "${https_proxy:-}" ] ||
+       [ -n "${HTTPS_PROXY:-}" ] || [ -n "${HTTPS_PROXY:-}" ]; then
        # all querries will go through the proxy so breaking DNS will not work
        echo "SKIP: cannot run when there is a http proxy set"
        exit 0

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -9,6 +9,9 @@ details: |
 # opensuse: the test is failing after retry several times the snapd service reaching the systemd start-limit.
 systems: [-ubuntu-core-*, -opensuse-*]
 
+# takes >1.5min to run
+backends: [-autopkgtest]
+
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"

--- a/tests/main/parallel-install-interfaces-content/task.yaml
+++ b/tests/main/parallel-install-interfaces-content/task.yaml
@@ -1,5 +1,8 @@
 summary: check that content interface works with parallel instances
 
+# takes >1.5min to run in total
+backends: [-autopkgtest]
+
 details: |
     Use the content interface along with parallel instances of snaps. Verify
     that the content is made available to each snap instance when connected.

--- a/tests/main/parallel-install-services/task.yaml
+++ b/tests/main/parallel-install-services/task.yaml
@@ -1,5 +1,8 @@
 summary: Checks for parallel installation of sideloaded snaps containing services
 
+# takes >3min to run
+backends: [-autopkgtest]
+
 prepare: |
     snap set system experimental.parallel-instances=true
 

--- a/tests/main/proxy/task.yaml
+++ b/tests/main/proxy/task.yaml
@@ -12,6 +12,10 @@ execute: |
        echo "SKIP: need python3"
        exit 0
     fi
+    if [ -n "$http_proxy" ] || [ -n "$https_proxy" ]; then
+       echo "SKIP: cannot run when there is another http proxy"
+       exit 0
+    fi
 
     systemd-run --service-type=notify --unit tinyproxy -- python3 "$TESTSLIB/tinyproxy/tinyproxy.py"
     # shellcheck source=tests/lib/systemd.sh

--- a/tests/main/proxy/task.yaml
+++ b/tests/main/proxy/task.yaml
@@ -12,7 +12,8 @@ execute: |
        echo "SKIP: need python3"
        exit 0
     fi
-    if [ -n "$http_proxy" ] || [ -n "$https_proxy" ]; then
+    if [ -n "${http_proxy:-}" ] || [ -n "${https_proxy:-}" ] ||
+       [ -n "${HTTPS_PROXY:-}" ] || [ -n "${HTTPS_PROXY:-}" ]; then
        echo "SKIP: cannot run when there is another http proxy"
        exit 0
     fi

--- a/tests/main/snap-service-refresh-mode/task.yaml
+++ b/tests/main/snap-service-refresh-mode/task.yaml
@@ -1,5 +1,8 @@
 summary: "Check that refresh-modes works"
 
+# takes >1.5min to run
+backends: [-autopkgtest]
+
 kill-timeout: 5m
 
 restore:

--- a/tests/main/snap-service-stop-mode/task.yaml
+++ b/tests/main/snap-service-stop-mode/task.yaml
@@ -5,6 +5,9 @@ kill-timeout: 5m
 # journald in ubuntu-14.04 not reliable
 systems: [-ubuntu-14.04-*]
 
+# takes >1.5min to run
+backends: [-autopkgtest]
+
 restore: |
     rm -f ./*.pid || true
     # remove to ensure all services are stopped

--- a/tests/main/snap-service-watchdog/task.yaml
+++ b/tests/main/snap-service-watchdog/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that snaps can use service-watchdog provided by systemd
 
+# skip autopkgtest as this test is timing dependent and ADT is often
+# very slow
+backends: [-autopkgtest]
+
 debug: |
     for service in direct-watchdog-ok direct-watchdog-bad; do
         systemctl status snap.test-snapd-service-watchdog.$service || true

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -2,6 +2,9 @@ summary: Check that own services can be controlled by snapctl
 
 kill-timeout: 5m
 
+# takes >1.5min to run
+backends: [-autopkgtest]
+
 environment:
     SERVICEOPTIONFILE: /var/snap/test-snapd-service/current/service-option
 


### PR DESCRIPTION
This fixes the issues found by the latest "disco" upload:
http://people.canonical.com/~ubuntu-archive/proposed-migration/disco/update_excuses.html#snapd

The amd64 testrun runs into a timeout, so there maybe more that we need to disable in ADT to stay below this limit.