### PR TITLE
many: remove .user-fstab files from /run/snapd/ns

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -125,16 +125,7 @@ purge() {
                 rm -f "$mnt"
             done
         fi
-        if [ "$(find /run/snapd/ns/ -name "*.fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.fstab; do
-                rm -f "$fstab"
-            done
-        fi
-        if [ "$(find /run/snapd/ns/ -name "*.user-fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.user-fstab; do
-                rm -f "$fstab"
-            done
-        fi
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -130,6 +130,11 @@ purge() {
                 rm -f "$fstab"
             done
         fi
+        if [ "$(find /run/snapd/ns/ -name "*.user-fstab" | wc -l)" -gt 0 ]; then
+            for fstab in /run/snapd/ns/*.user-fstab; do
+                rm -f "$fstab"
+            done
+        fi
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -104,16 +104,7 @@ if [ "$1" = "purge" ]; then
                 rm -f "$mnt"
             done
         fi
-        if [ "$(find /run/snapd/ns/ -name "*.fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.fstab; do
-                rm -f "$fstab"
-            done
-        fi
-        if [ "$(find /run/snapd/ns/ -name "*.user-fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.user-fstab; do
-                rm -f "$fstab"
-            done
-        fi
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -109,6 +109,11 @@ if [ "$1" = "purge" ]; then
                 rm -f "$fstab"
             done
         fi
+        if [ "$(find /run/snapd/ns/ -name "*.user-fstab" | wc -l)" -gt 0 ]; then
+            for fstab in /run/snapd/ns/*.user-fstab; do
+                rm -f "$fstab"
+            done
+        fi
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -112,6 +112,11 @@ if [ "$1" = "purge" ]; then
                 rm -f "$fstab"
             done
         fi
+        if [ "$(find /run/snapd/ns/ -name "*.user-fstab" | wc -l)" -gt 0 ]; then
+            for fstab in /run/snapd/ns/*.user-fstab; do
+                rm -f "$fstab"
+            done
+        fi
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -107,16 +107,7 @@ if [ "$1" = "purge" ]; then
                 rm -f "$mnt"
             done
         fi
-        if [ "$(find /run/snapd/ns/ -name "*.fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.fstab; do
-                rm -f "$fstab"
-            done
-        fi
-        if [ "$(find /run/snapd/ns/ -name "*.user-fstab" | wc -l)" -gt 0 ]; then
-            for fstab in /run/snapd/ns/*.user-fstab; do
-                rm -f "$fstab"
-            done
-        fi
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -162,6 +162,7 @@ if [ -d /run/snapd/ns ]; then
         rm -f "$mnt"
     done
     rm -f /run/snapd/ns/*.fstab
+    rm -f /run/snapd/ns/*.user-fstab
 fi
 
 if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -161,8 +161,7 @@ if [ -d /run/snapd/ns ]; then
         umount -l "$mnt" || true
         rm -f "$mnt"
     done
-    rm -f /run/snapd/ns/*.fstab
-    rm -f /run/snapd/ns/*.user-fstab
+    find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
 fi
 
 if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then


### PR DESCRIPTION
When snapd is being uninstalled or when tests are removing past state we
now need to handle the new .user-fstab files in /run/snapd/ns. Those
represent the actual state of the per-user mount namespace that is
persisted when the corresponding snapd feature is enabled.

The extension matches existing .user-fstab files placed in
/var/lib/snapd/mount, for consistency.

The files were already handled by snap-discard-ns but not by various
helper scripts so here it is.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
