### PR TITLE
overlord/snapstate: during refresh, re-refresh on epoch bump

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -386,21 +386,28 @@ func checkEpochs(_ *state.State, snapInfo, curInfo *snap.Info, _ Flags) error {
 
 // check that the snap installed in the system (via snapst) can be
 // upgraded to info (i.e. that info's epoch can read sanpst's epoch)
-func earlyEpochCheck(info *snap.Info, snapst *SnapState) error {
+// also return whether the epoch has changed
+func earlyEpochCheck(info *snap.Info, snapst *SnapState) (changed bool, err error) {
 	if snapst == nil {
 		// no snapst, no problem
-		return nil
+		return false, nil
 	}
 	cur, err := snapst.CurrentInfo()
 	if err == ErrNoCurrent {
 		// refreshing a disabled snap (maybe via InstallPath)
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	return checkEpochs(nil, info, cur, Flags{})
+	if err := checkEpochs(nil, info, cur, Flags{}); err != nil {
+		return false, err
+	}
+
+	changed = !info.Epoch.Equal(&cur.Epoch)
+
+	return changed, nil
 }
 
 func init() {

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -143,7 +143,11 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 // progress. It also ensures that snapst (if not nil) did not get
 // modified. If a conflict is detected an error is returned.
 func CheckChangeConflict(st *state.State, instanceName string, snapst *SnapState) error {
-	if err := CheckChangeConflictMany(st, []string{instanceName}, ""); err != nil {
+	return checkChangeConflictIgnoringOneChange(st, instanceName, snapst, "")
+}
+
+func checkChangeConflictIgnoringOneChange(st *state.State, instanceName string, snapst *SnapState, ignoreChangeID string) error {
+	if err := CheckChangeConflictMany(st, []string{instanceName}, ignoreChangeID); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -22,6 +22,8 @@ package snapstate
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -199,5 +201,13 @@ func setModel(override map[string]string) {
 
 	Model = func(*state.State) (*asserts.Model, error) {
 		return a.(*asserts.Model), nil
+	}
+}
+
+func MockReRefreshUpdater(f func(context.Context, *state.State, string, []string, int, *Flags) ([]string, []*state.TaskSet, error)) (restore func()) {
+	old := reRefreshUpdater
+	reRefreshUpdater = f
+	return func() {
+		reRefreshUpdater = old
 	}
 }

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -1,0 +1,168 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"errors"
+	"strings"
+
+	"golang.org/x/net/context"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	. "github.com/snapcore/snapd/testutil"
+)
+
+type reRefreshSuite struct {
+	baseHandlerSuite
+}
+
+var _ = Suite(&reRefreshSuite{})
+
+func logstr(task *state.Task) string {
+	return strings.Join(task.Log(), "\n")
+}
+
+func (s *reRefreshSuite) TestDoReRefreshFailsWithoutReRefreshSetup(c *C) {
+	s.state.Lock()
+	task := s.state.NewTask("rerefresh", "test")
+	s.state.NewChange("dummy", "...").AddTask(task)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(logstr(task), Contains, `no state entry for key`)
+}
+
+func (s *reRefreshSuite) TestDoReRefreshFailsIfUpdateFails(c *C) {
+	defer snapstate.MockReRefreshUpdater(func(context.Context, *state.State, string, []string, int, *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+		return nil, nil, errors.New("bzzt")
+	})()
+
+	s.state.Lock()
+	task := s.state.NewTask("rerefresh", "test")
+	task.Set("rerefresh-setup", map[string]interface{}{})
+	s.state.NewChange("dummy", "...").AddTask(task)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(logstr(task), Contains, `bzzt`)
+}
+
+func (s *reRefreshSuite) TestDoReRefreshNoReRefreshes(c *C) {
+	defer snapstate.MockReRefreshUpdater(func(context.Context, *state.State, string, []string, int, *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+		return nil, nil, nil
+	})()
+
+	s.state.Lock()
+	task := s.state.NewTask("rerefresh", "test")
+	task.Set("rerefresh-setup", map[string]interface{}{})
+	s.state.NewChange("dummy", "...").AddTask(task)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(logstr(task), Contains, `no re-refreshes found`)
+}
+
+func (s *reRefreshSuite) TestDoReRefreshPassesReRefreshSetupData(c *C) {
+	var chgID string
+	defer snapstate.MockReRefreshUpdater(func(ctx context.Context, st *state.State, changeID string, snaps []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+		c.Check(changeID, Equals, chgID)
+		c.Check(snaps, DeepEquals, []string{"won", "too", "tree"})
+		c.Check(userID, Equals, 42)
+		c.Check(flags, DeepEquals, &snapstate.Flags{
+			DevMode:  true,
+			JailMode: true,
+		})
+		return nil, nil, nil
+	})()
+
+	s.state.Lock()
+	task := s.state.NewTask("rerefresh", "test")
+	task.Set("rerefresh-setup", map[string]interface{}{
+		"snaps":    []string{"won", "too", "tree"},
+		"user-id":  42,
+		"devmode":  true,
+		"jailmode": true,
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(task)
+	chgID = chg.ID()
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(logstr(task), Contains, `no re-refreshes found`)
+}
+
+func (s *reRefreshSuite) TestDoReRefreshAddsNewTasks(c *C) {
+	defer snapstate.MockReRefreshUpdater(func(ctx context.Context, st *state.State, changeID string, snaps []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+		c.Check(snaps, DeepEquals, []string{"won", "too", "tree"})
+
+		task := st.NewTask("witness", "...")
+
+		return []string{"won"}, []*state.TaskSet{state.NewTaskSet(task)}, nil
+	})()
+
+	s.state.Lock()
+	task := s.state.NewTask("rerefresh", "test")
+	task.Set("rerefresh-setup", map[string]interface{}{
+		"snaps": []string{"won", "too", "tree"},
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(task)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(logstr(task), Contains, `found re-refresh for "won"`)
+
+	tasks := chg.Tasks()
+	c.Assert(tasks, HasLen, 2)
+	c.Check(tasks[1].Kind(), Equals, "witness")
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -357,6 +357,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddHandler("start-snap-services", m.startSnapServices, m.stopSnapServices)
 	runner.AddHandler("switch-snap-channel", m.doSwitchSnapChannel, nil)
 	runner.AddHandler("toggle-snap-flags", m.doToggleSnapFlags, nil)
+	runner.AddHandler("rerefresh", m.doReRefresh, nil)
 
 	// FIXME: drop the task entirely after a while
 	// (having this wart here avoids yet-another-patch)

--- a/tests/main/refresh-with-epoch-bump/task.yaml
+++ b/tests/main/refresh-with-epoch-bump/task.yaml
@@ -1,0 +1,30 @@
+summary: Check that the refresh command works through epoch bumps.
+
+details: |
+    This test installs a snap and then refreshes it to a channel
+    that's on an incompatible epoch. The store and snapd should figure
+    this out and go through a revision that can read the curent epoch
+    before re-refreshing to the expected one.
+
+prepare: |
+    snap remove test-snapd-epoch
+    snap install test-snapd-epoch
+
+debug: |
+    snap info test-snapd-epoch
+    snap list test-snapd-epoch || true
+    snap tasks --last=install
+    snap tasks --last=refresh
+
+execute: |
+    p=/snap/test-snapd-epoch/current
+    # currently on epoch 1, revision 1
+    MATCH '^epoch: 1$' $p/meta/snap.yaml
+    test $(readlink $p) = 1
+    snap refresh --beta test-snapd-epoch
+    # after the refresh, on epoch 2 (which can't read 1!), revision 3
+    MATCH '^epoch: 2$' /snap/test-snapd-epoch/current/meta/snap.yaml
+    test $(readlink $p) = 3
+    # this was done by going through revision 2
+    snap tasks --last=refresh | MATCH 'Download snap "test-snapd-epoch" \(2\)'
+    snap tasks --last=refresh | MATCH 'Download snap "test-snapd-epoch" \(3\)'


### PR DESCRIPTION
Without this change an installed snap that went through an epoch
change with an old gatekeeper revision would not see the newer
revision until the next auto-refresh.

In other words, if a snap had epoch 0 and the refresh found the tip of
the channel to be on epoch 1, with epoch 1* available, then without
this change the snap would only refresh to epoch 1*, and would reach
epoch 1 on the next auto-refresh.

This change makes snapd notice the epoch bump, and re-refresh the
snaps that went through it.
