### PR TITLE
cmd/snap-update-ns: make freezer mockable

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -146,6 +146,19 @@ func FreezerCgroupDir() string {
 	return freezerCgroupDir
 }
 
+func MockFreezing(freeze, thaw func(snapName string) error) (restore func()) {
+	oldFreeze := freezeSnapProcesses
+	oldThaw := thawSnapProcesses
+
+	freezeSnapProcesses = freeze
+	thawSnapProcesses = thaw
+
+	return func() {
+		freezeSnapProcesses = oldFreeze
+		thawSnapProcesses = oldThaw
+	}
+}
+
 func MockChangePerform(f func(chg *Change, as *Assumptions) ([]*Change, error)) func() {
 	origChangePerform := changePerform
 	changePerform = f

--- a/cmd/snap-update-ns/freezer.go
+++ b/cmd/snap-update-ns/freezer.go
@@ -30,10 +30,15 @@ import (
 
 var freezerCgroupDir = "/sys/fs/cgroup/freezer"
 
-// freezeSnapProcesses freezes all the processes originating from the given snap.
+var (
+	freezeSnapProcesses = freezeSnapProcessesImpl
+	thawSnapProcesses   = thawSnapProcessesImpl
+)
+
+// freezeSnapProcessesImpl freezes all the processes originating from the given snap.
 // Processes are frozen regardless of which particular snap application they
 // originate from.
-func freezeSnapProcesses(snapName string) error {
+func freezeSnapProcessesImpl(snapName string) error {
 	fname := filepath.Join(freezerCgroupDir, fmt.Sprintf("snap.%s", snapName), "freezer.state")
 	if err := ioutil.WriteFile(fname, []byte("FROZEN"), 0644); err != nil && os.IsNotExist(err) {
 		// When there's no freezer cgroup we don't have to freeze anything.
@@ -60,7 +65,7 @@ func freezeSnapProcesses(snapName string) error {
 	return fmt.Errorf("cannot finish freezing processes of snap %q", snapName)
 }
 
-func thawSnapProcesses(snapName string) error {
+func thawSnapProcessesImpl(snapName string) error {
 	fname := filepath.Join(freezerCgroupDir, fmt.Sprintf("snap.%s", snapName), "freezer.state")
 	if err := ioutil.WriteFile(fname, []byte("THAWED"), 0644); err != nil && os.IsNotExist(err) {
 		// When there's no freezer cgroup we don't have to thaw anything.


### PR DESCRIPTION
For testing we may want to disable the whole freezer subsystem. This
patch lets us do that quickly. The actual tests using this are part of
a larger branch that I'm shrinking.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
