### PR TITLE
cmd/snap-update-ns: close internal lock on error

### DIFF
--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -47,6 +47,7 @@ func applySystemFstab(instanceName string, fromSnapConfine bool) error {
 		// namespace is locked. This is used by snap-confine to use
 		// snap-update-ns to apply mount profiles.
 		if err := lock.TryLock(); err != osutil.ErrAlreadyLocked {
+			lock.Close()
 			return fmt.Errorf("mount namespace of snap %q is not locked but --from-snap-confine was used", instanceName)
 		}
 	} else {
@@ -62,6 +63,7 @@ func applySystemFstab(instanceName string, fromSnapConfine bool) error {
 	// than what we expected).
 	logger.Debugf("freezing processes of snap %q", instanceName)
 	if err := freezeSnapProcesses(instanceName); err != nil {
+		lock.Close()
 		return err
 	}
 	defer func() {


### PR DESCRIPTION
This patch fixes an error where a lock would internally leak until the
snap-update-ns process quits in the case where we would either:

 - fail to freeze the freezer cgroup
 - fail to verify a lock was already locked

The actual error is harmless since if either of those fail we just quit
anyway. The tests for this are already covered in the bigger refactor
branch where the locking code is broken out to a dedicated method for
easier testing.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
