### PR TITLE
tests: fix listing tests to match "snap list --unicode=never"

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -26,20 +26,20 @@ execute: |
     #shellcheck disable=SC2166
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the core snap is sideloaded"
-        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core.*$"
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core.*$'
     elif [ "$SRU_VALIDATION" = "1" ]; then
         echo "When sru validation is done the core snap is installed from the store"
-        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical\\* +core.*$"
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical\* +core.*$'
     elif [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "autopkgtest" ]; then
-        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical\\* +core.*$"
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical\* +core.*$'
     else
         expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)? +[0-9]+ +$CORE_CHANNEL +canonical\\* +core.*$"
     fi
     snap list --unicode=never | MATCH "$expected"
 
     echo "List prints installed snaps and versions"
-    snap list | MATCH "^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$"
-    snap list | MATCH "^test-snapd-tools_foo +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$"
+    snap list | MATCH '^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
+    snap list | MATCH '^test-snapd-tools_foo +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
 
     echo "Install test-snapd-tools again"
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -26,20 +26,20 @@ execute: |
     #shellcheck disable=SC2166
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core.*$'
+        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core.*$"
     elif [ "$SRU_VALIDATION" = "1" ]; then
         echo "When sru validation is done the core snap is installed from the store"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical\\* +core.*$'
+        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical\\* +core.*$"
     elif [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "autopkgtest" ]; then
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical\\* +core.*$'
+        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical\\* +core.*$"
     else
         expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)? +[0-9]+ +$CORE_CHANNEL +canonical\\* +core.*$"
     fi
     snap list --unicode=never | MATCH "$expected"
 
     echo "List prints installed snaps and versions"
-    snap list | MATCH '^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
-    snap list | MATCH '^test-snapd-tools_foo +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
+    snap list | MATCH "^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$"
+    snap list | MATCH "^test-snapd-tools_foo +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$"
 
     echo "Install test-snapd-tools again"
     #shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
Currently the test is failing when we run "snap list --unicode=never"
with external backend trying to match using single quotes:
> MATCH '^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)?
+[0-9]+ +(edge|beta|candidate|stable) +canonical\\* +core.*$'

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
