### PR TITLE
kvm: load required kernel modules if necessary

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -102,3 +102,13 @@ func MockOsGetenv(mock func(string) string) (restore func()) {
 
 	return restore
 }
+
+func MockProcCpuinfo(filename string) (restore func()) {
+	old := procCpuinfo
+	restore = func() {
+		procCpuinfo = old
+	}
+	procCpuinfo = filename
+
+	return restore
+}

--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -81,7 +81,7 @@ func (iface *kvmInterface) KModConnectedPlug(spec *kmod.Specification, plug *int
 	m := "kvm"
 	cpu_flags, err := getCpuFlags()
 	if err != nil {
-		logger.Debugf("kvm: fetching cpu info failed:", err)
+		logger.Debugf("kvm: fetching cpu info failed: %v", err)
 	}
 
 	if strutil.ListContains(cpu_flags, "vmx") {

--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -55,6 +55,7 @@ type kvmInterface struct {
 }
 
 var procCpuinfo = "/proc/cpuinfo"
+var flagsMatcher = regexp.MustCompile(`(?m)^flags\s+:\s+(.*)$`).FindSubmatch
 
 func getCpuFlags() (flags []string, err error) {
 	buf, err := ioutil.ReadFile(procCpuinfo)
@@ -64,8 +65,7 @@ func getCpuFlags() (flags []string, err error) {
 	}
 
 	// want to capture the text after 'flags:' entry
-	pattern := regexp.MustCompile(`(?m)^flags\s+:\s+(.*)$`)
-	match := pattern.FindSubmatch(buf)
+	match := flagsMatcher(buf)
 	if len(match) == 0 {
 		return nil, fmt.Errorf("%v does not contain a 'flags:' entry", procCpuinfo)
 	}

--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,6 +18,16 @@
  */
 
 package builtin
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/kmod"
+)
 
 const kvmSummary = `allows access to the kvm device`
 
@@ -38,8 +48,60 @@ const kvmConnectedPlugAppArmor = `
 
 var kvmConnectedPlugUDev = []string{`KERNEL=="kvm"`}
 
+type kvmInterface struct {
+	commonInterface
+}
+
+var procCpuinfo = "/proc/cpuinfo"
+
+func getCpuFlags() (flags string, err error) {
+	buf, err := ioutil.ReadFile(procCpuinfo)
+	if err != nil {
+		// if we can't read cpuinfo, we want to know _why_
+		return "", fmt.Errorf("error: %v", err)
+	}
+
+	pattern := []byte("\nflags\t\t:")
+	idx := bytes.LastIndex(buf, pattern)
+	if idx >= 0 {
+		offset := idx + len(pattern)
+		endidx := bytes.Index(buf[offset:], []byte("\n"))
+		return string(buf[offset : endidx+offset]), nil
+	}
+
+	// if not found (which will happen on non-x86 architectures, which is ok
+	// because they'd typically not have the same info over and over again),
+	// return whole buffer; otherwise, return from just after the \n
+	return string(buf[idx+1:]), nil
+}
+
+func (iface *kvmInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Check CPU capabilities to load suitable module
+	// TODO: this only considering x86 CPUs, but some ARM, PPC and S390 CPUs also support KVM
+	m := "kvm"
+	cpu_flags, err := getCpuFlags()
+	if err != nil {
+		fmt.Println("kvm: fetching cpu info failed:", err)
+	}
+
+	if strings.Contains(cpu_flags, "vmx") {
+		m = "kvm_intel"
+	} else if strings.Contains(cpu_flags, "svm") {
+		m = "kvm_amd"
+	} else {
+		// CPU appears not to support KVM extensions, fall back to bare kvm module as it appears
+		// sufficient for some architectures
+		fmt.Println("kvm: failed to detect CPU specific KVM support, will attempt to modprobe generic KVM support")
+	}
+
+	if err := spec.AddModule(m); err != nil {
+		return nil
+	}
+	return nil
+}
+
 func init() {
-	registerIface(&commonInterface{
+	registerIface(&kvmInterface{commonInterface{
 		name:                  "kvm",
 		summary:               kvmSummary,
 		implicitOnCore:        true,
@@ -48,5 +110,5 @@ func init() {
 		connectedPlugAppArmor: kvmConnectedPlugAppArmor,
 		connectedPlugUDev:     kvmConnectedPlugUDev,
 		reservedForOS:         true,
-	})
+	}})
 }

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -180,3 +180,29 @@ flags           : stuff svm other
 		"kvm_amd": true,
 	})
 }
+
+func (s *kvmInterfaceSuite) TestKModSpecWithEmptyCpuinfo(c *C) {
+	mockCpuinfo := filepath.Join(s.tmpdir, "cpuinfo")
+	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
+`[1:]), 0644), IsNil)
+
+	s.AddCleanup(builtin.MockProcCpuinfo(mockCpuinfo))
+
+	spec := &kmod.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
+		"kvm": true,
+	})
+}
+
+func (s *kvmInterfaceSuite) TestKModSpecWithMissingCpuinfo(c *C) {
+	mockCpuinfo := filepath.Join(s.tmpdir, "non-existent-cpuinfo")
+
+	s.AddCleanup(builtin.MockProcCpuinfo(mockCpuinfo))
+
+	spec := &kmod.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
+		"kvm": true,
+	})
+}

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -74,13 +74,15 @@ func (s *kvmInterfaceSuite) SetUpTest(c *C) {
 	// Need to Mock output of /proc/cpuinfo
 	s.tmpdir = c.MkDir()
 	dirs.SetRootDir(s.tmpdir)
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
 	mockCpuinfo := filepath.Join(s.tmpdir, "cpuinfo")
 	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
 processor       : 0
 flags		: cpuflags without kvm support
 
 processor	: 42
-flags		: last cpu is actually consulted, also without kvm support
+flags		: another cpu also without kvm support
 `[1:]), 0644), IsNil)
 	s.AddCleanup(builtin.MockProcCpuinfo(mockCpuinfo))
 }


### PR DESCRIPTION
Have the KVM interface load the suitable KVM kernel modules.

Supports checking the required CPU capabilities for Intel and AMD CPUs and loading suitable modules if supported, falls back to generic KVM module otherwise.

Ref: https://www.linux-kvm.org/page/Processor_support