### PR TITLE
cmd/snap-update-ns: explicitly check for return value from parse_arg_u

### DIFF
--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -411,7 +411,7 @@ void process_arguments(int argc, char *const *argv, const char **snap_name_out,
 				// called from snap-confine.
 				should_setns = false;
 			} else if (!strcmp(arg, "-u")) {
-				if (parse_arg_u(argc, argv, &i, uid_out)) {
+				if (parse_arg_u(argc, argv, &i, uid_out) < 0) {
 					return;
 				}
 				// Providing an user identifier implies we are performing an


### PR DESCRIPTION
The old code was correct but I like the ` < 0` check being explicit.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
