### PR TITLE
cmd/snap-update-ns: save errno from strtoul

### DIFF
--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -340,6 +340,7 @@ static int parse_arg_u(int argc, char * const *argv, int *optind, unsigned long 
 	errno = 0;
 	char *uid_text_end = NULL;
 	unsigned long parsed_uid = strtoul(uid_text, &uid_text_end, 10);
+	int saved_errno = errno;
 	if (
 			/* Reject overflow in parsed representation */
 			(parsed_uid == ULONG_MAX && errno != 0)
@@ -351,7 +352,7 @@ static int parse_arg_u(int argc, char * const *argv, int *optind, unsigned long 
 			|| (*uid_text != '\0' && uid_text_end != NULL
 				&& *uid_text_end != '\0')) {
 		bootstrap_msg = "cannot parse user id";
-		bootstrap_errno = errno;
+		bootstrap_errno = saved_errno;
 		return -1;
 	}
 	if ((long)parsed_uid < 0) {


### PR DESCRIPTION
This is not required now but it helps in someone adds printf-style
debugging messages that may clobber errno.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
