### PR TITLE
cmd/snap-update-ns: let the go parser know we are parsing -u

### DIFF
--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -31,6 +31,7 @@ import (
 var opts struct {
 	FromSnapConfine bool `long:"from-snap-confine"`
 	UserMounts      bool `long:"user-mounts"`
+	UserID          int  `short:"u"`
 	Positionals     struct {
 		SnapName string `positional-arg-name:"SNAP_NAME" required:"yes"`
 	} `positional-args:"true"`


### PR DESCRIPTION
Ironically the go side doesn't strictly care about this because the C
bootstrap code will set up everything so that existing calls to
os.Getuid are sufficient but we should let the parser know so that it
doesn't complain.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
