### PR TITLE
cmd/snap-update-ns: manually implement isspace

### DIFF
--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -271,7 +271,11 @@ static int instance_key_validate(const char *instance_key)
 	// engine.
 	int i = 0;
 	for (i = 0; instance_key[i] != '\0'; i++) {
-		if (islower(instance_key[i]) || isdigit(instance_key[i])) {
+		char c = instance_key[i];
+		/* NOTE: We are reimplementing islower() and isdigit()
+		 * here. For context see
+		 * https://github.com/golang/go/issues/29689 */
+		if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
 			continue;
 		}
 		bootstrap_msg =
@@ -345,9 +349,8 @@ static int parse_arg_u(int argc, char * const *argv, int *optind, unsigned long 
 			/* Reject overflow in parsed representation */
 			(parsed_uid == ULONG_MAX && errno != 0)
 			/* Reject leading whitespace allowed by strtoul. */
-			/* NOTE: This is not using isspace, due to how we get
-			 * this C code to run we end up running before libc is
-			 * properly initialized. For context see
+			/* NOTE: We are reimplementing isspace() here.
+			 * For context see
 			 * https://github.com/golang/go/issues/29689 */
 			|| c == ' ' || c == '\t' || c == '\v' || c == '\r' || c == '\n'
 			/* Reject empty string. */

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -340,11 +340,14 @@ static int parse_arg_u(int argc, char * const *argv, int *optind, unsigned long 
 	errno = 0;
 	char *uid_text_end = NULL;
 	unsigned long parsed_uid = strtoul(uid_text, &uid_text_end, 10);
+	char c = *uid_text;
 	if (
 			/* Reject overflow in parsed representation */
 			(parsed_uid == ULONG_MAX && errno != 0)
 			/* Reject leading whitespace allowed by strtoul. */
-			|| (isspace(*uid_text))
+			/* NOTE: This is not using isspace, for some reason that is crashing
+			 * at runtime. Reported upstream as https://github.com/golang/go/issues/29689 */
+			|| c == ' ' || c == '\t' || c == '\v' || c == '\r' || c == '\n'
 			/* Reject empty string. */
 			|| (*uid_text == '\0')
 			/* Reject partially parsed strings. */

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -345,8 +345,10 @@ static int parse_arg_u(int argc, char * const *argv, int *optind, unsigned long 
 			/* Reject overflow in parsed representation */
 			(parsed_uid == ULONG_MAX && errno != 0)
 			/* Reject leading whitespace allowed by strtoul. */
-			/* NOTE: This is not using isspace, for some reason that is crashing
-			 * at runtime. Reported upstream as https://github.com/golang/go/issues/29689 */
+			/* NOTE: This is not using isspace, due to how we get
+			 * this C code to run we end up running before libc is
+			 * properly initialized. For context see
+			 * https://github.com/golang/go/issues/29689 */
 			|| c == ' ' || c == '\t' || c == '\v' || c == '\r' || c == '\n'
 			/* Reject empty string. */
 			|| (*uid_text == '\0')


### PR DESCRIPTION
I wasn't able to find any other cause but using the isspace macro,
outside of tests (which pass just fine), causes ./snap-update-ns -u 1000
to crash. The debugger points to issspace(*uid_text) being the culprit
despite it not being a NULL pointer. It is correctly pointing to the
string "1000" when the crash happens. I was unable to solve it with a
static function that calls isspace internally (which is probably a
macro). As such, implement isspace ourselves to avoid the crash.

Upstream bug report: https://github.com/golang/go/issues/29689
also contains a minimal reproducer https://github.com/zyga/go-bug-29689
which crashes on latest golang binary release.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
