### PR TITLE
cmd/snap-discard-ns: fix name of user fstab files

### DIFF
--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
      *
      * Applied mount profiles to unlink:
      * - "snap.$SNAP_INSTANCE_NAME.fstab"
-     * - "snap.$SNAP_INSTANCE_NAME.[0-9]+.fstab"
+     * - "snap.$SNAP_INSTANCE_NAME.[0-9]+.user-fstab"
      *
      * Use PATH_MAX as the size of each buffer since those can store any file
      * name. */
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     char sys_mnt_pattern[PATH_MAX];
     char usr_mnt_pattern[PATH_MAX];
     sc_must_snprintf(sys_fstab_pattern, sizeof sys_fstab_pattern, "snap\\.%s\\.fstab", snap_instance_name);
-    sc_must_snprintf(usr_fstab_pattern, sizeof usr_fstab_pattern, "snap\\.%s\\.*\\.fstab", snap_instance_name);
+    sc_must_snprintf(usr_fstab_pattern, sizeof usr_fstab_pattern, "snap\\.%s\\.*\\.user-fstab", snap_instance_name);
     sc_must_snprintf(sys_mnt_pattern, sizeof sys_mnt_pattern, "%s\\.mnt", snap_instance_name);
     sc_must_snprintf(usr_mnt_pattern, sizeof usr_mnt_pattern, "%s\\.*\\.mnt", snap_instance_name);
 

--- a/cmd/snap-discard-ns/snap-discard-ns.rst
+++ b/cmd/snap-discard-ns/snap-discard-ns.rst
@@ -51,7 +51,7 @@ FILES
     `snap-discard-ns`. The second form is for the per-user mount namespace.
 
 `/run/snapd/ns/snap.$SNAP_INSTNACE_NAME.fstab`:
-`/run/snapd/ns/snap.$SNAP_INSTNACE_NAME.*.fstab`:
+`/run/snapd/ns/snap.$SNAP_INSTNACE_NAME.*.user-fstab`:
 
     The current mount profile of a preserved mount namespace that is removed
     by `snap-discard-ns`.

--- a/tests/main/snap-discard-ns/task.yaml
+++ b/tests/main/snap-discard-ns/task.yaml
@@ -46,7 +46,7 @@ execute: |
     echo "We can fake a current mount profile and see that it is removed too"
     test-snapd-tools.success
     touch /run/snapd/ns/snap.test-snapd-tools.fstab
-    touch /run/snapd/ns/snap.test-snapd-tools.1000.fstab
+    touch /run/snapd/ns/snap.test-snapd-tools.1000.user-fstab
     $LIBEXECDIR/snapd/snap-discard-ns test-snapd-tools
     test ! -e /run/snapd/ns/snap.test-snapd-tools.fstab
-    test ! -e /run/snapd/ns/snap.test-snapd-tools.1000.fstab
+    test ! -e /run/snapd/ns/snap.test-snapd-tools.1000.user-fstab


### PR DESCRIPTION
This patch fixes the pattern for user mount profiles to have the
.user-fstab extension, rather than the .fstab extension.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
