### PR TITLE
cmd/snap-update-ns: allow switching to user mount namespace

### DIFF
--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -487,10 +487,14 @@ void bootstrap(int argc, char **argv, char **envp)
 	unsigned long uid = getuid();
 	process_arguments(argc, argv, &snap_name, &should_setns,
 			  &process_user_fstab, &uid);
+
+	// If needed, enter the snap's namespace using either the user fstab with
+	// our uid or the system wide snap fstab with uid 0
 	if (should_setns && snap_name != NULL) {
 		setns_into_snap(snap_name, process_user_fstab ? uid : 0);
 		// setns_into_snap sets bootstrap_{errno,msg}
 	}
+	// If we are processing a user fstab, then drop privileges
 	if (process_user_fstab && uid != 0) {
 		switch_to_specific_privileged_user(uid, getgid());
 		// switch_to_privileged_user sets bootstrap_{errno,msg}

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -46,8 +46,9 @@ int bootstrap_errno = 0;
 const char *bootstrap_msg = NULL;
 
 // setns_into_snap switches mount namespace into that of a given snap.
-// If the uid argument is non-zero the mount namespace of a specific user is joined.
-// Otherwise the system-wide mount namespace of the provided snap is used.
+// If the uid argument is non-zero the mount namespace of the provided snap
+// for the specific user is joined. Otherwise the system-wide mount namespace
+// of the provided snap is used.
 static int setns_into_snap(const char *snap_name, int uid)
 {
 	// Construct the name of the .mnt file to open.

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -84,9 +84,9 @@ static int setns_into_snap(const char *snap_name, int uid)
 	return err;
 }
 
-// switch_to_specific_privileged_user drops to the specific user and group ID
+// switch_to_user_with_caps drops to the specific user and group ID
 // while retaining CAP_SYS_ADMIN, for operations such as mount().
-static int switch_to_specific_privileged_user(uid_t real_uid, gid_t real_gid)
+static int switch_to_user_with_caps(uid_t real_uid, gid_t real_gid)
 {
 	// _LINUX_CAPABILITY_VERSION_3 valid for kernel >= 2.6.26. See
 	// https://github.com/torvalds/linux/blob/master/kernel/capability.c
@@ -496,7 +496,7 @@ void bootstrap(int argc, char **argv, char **envp)
 	}
 	// If we are processing a user fstab, then drop privileges
 	if (process_user_fstab && uid != 0) {
-		switch_to_specific_privileged_user(uid, getgid());
-		// switch_to_privileged_user sets bootstrap_{errno,msg}
+		switch_to_user_with_caps(uid, getgid());
+		// switch_to_user_with_caps sets bootstrap_{errno,msg}
 	}
 }

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -84,8 +84,8 @@ static int setns_into_snap(const char *snap_name, int uid)
 	return err;
 }
 
-// switch_to_privileged_user drops to the specific user and group ID while retaining
-// CAP_SYS_ADMIN, for operations such as mount().
+// switch_to_specific_privileged_user drops to the specific user and group ID
+// while retaining CAP_SYS_ADMIN, for operations such as mount().
 static int switch_to_specific_privileged_user(uid_t real_uid, gid_t real_gid)
 {
 	// _LINUX_CAPABILITY_VERSION_3 valid for kernel >= 2.6.26. See

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -46,13 +46,20 @@ int bootstrap_errno = 0;
 const char *bootstrap_msg = NULL;
 
 // setns_into_snap switches mount namespace into that of a given snap.
-static int setns_into_snap(const char *snap_name)
+// If the uid argument is non-zero the mount namespace of a specific user is joined.
+// Otherwise the system-wide mount namespace of the provided snap is used.
+static int setns_into_snap(const char *snap_name, int uid)
 {
 	// Construct the name of the .mnt file to open.
 	char buf[PATH_MAX] = {
 		0,
 	};
-	int n = snprintf(buf, sizeof buf, "/run/snapd/ns/%s.mnt", snap_name);
+	int n;
+	if (uid == 0) {
+		n = snprintf(buf, sizeof buf, "/run/snapd/ns/%s.mnt", snap_name);
+	} else {
+		n = snprintf(buf, sizeof buf, "/run/snapd/ns/%s.%d.mnt", snap_name, uid);
+	}
 	if (n >= sizeof buf || n < 0) {
 		bootstrap_errno = 0;
 		bootstrap_msg = "cannot format mount namespace file name";
@@ -76,20 +83,10 @@ static int setns_into_snap(const char *snap_name)
 	return err;
 }
 
-// switch_to_privileged_user drops to the real user ID while retaining
+// switch_to_privileged_user drops to the specific user and group ID while retaining
 // CAP_SYS_ADMIN, for operations such as mount().
-static int switch_to_privileged_user()
+static int switch_to_specific_privileged_user(uid_t real_uid, gid_t real_gid)
 {
-	uid_t real_uid;
-	gid_t real_gid;
-
-	real_uid = getuid();
-	if (real_uid == 0) {
-		// We're running as root: no need to switch IDs
-		return 0;
-	}
-	real_gid = getgid();
-
 	// _LINUX_CAPABILITY_VERSION_3 valid for kernel >= 2.6.26. See
 	// https://github.com/torvalds/linux/blob/master/kernel/capability.c
 	struct __user_cap_header_struct hdr =
@@ -486,14 +483,15 @@ void bootstrap(int argc, char **argv, char **envp)
 	const char *snap_name = NULL;
 	bool should_setns = false;
 	bool process_user_fstab = false;
-	unsigned long uid = 0;
+	unsigned long uid = getuid();
 	process_arguments(argc, argv, &snap_name, &should_setns,
 			  &process_user_fstab, &uid);
-	if (process_user_fstab) {
-		switch_to_privileged_user();
-		// switch_to_privileged_user sets bootstrap_{errno,msg}
-	} else if (snap_name != NULL && should_setns) {
-		setns_into_snap(snap_name);
+	if (should_setns && snap_name != NULL) {
+		setns_into_snap(snap_name, process_user_fstab ? uid : 0);
 		// setns_into_snap sets bootstrap_{errno,msg}
+	}
+	if (process_user_fstab && uid != 0) {
+		switch_to_specific_privileged_user(uid, getgid());
+		// switch_to_privileged_user sets bootstrap_{errno,msg}
 	}
 }


### PR DESCRIPTION
When snap-update-ns is invoked with the (currently unused by snapd)
command line option `-u` it is an indication that we are going to run as
the specified user ID. In addition the option `--from-snap-confine` is
no longer attached to `--user-fstab` and now only implies that namespace
has already been set and that lock is already established.

This allows snap-update-ns to be used from two different contexts to
achieve distinct tasks:

    1) When invoked from snap-confine, it is always paired with
    `--from-snap-confine`. This, as mentioned, indicates that the mount
    namespace is already unshared and that locks are held by
    snap-confine.

    In this mode we can be called with no further options, to initialize
    the system-wide snap mount namespace or with `--user-mounts` to
    initialize the per-user snap mount namespace. Note that at this time
    `-u` is redundant because snap-confine already runs with the
    appropriate user ID.

    2) When invoked from snapd it is invoked with or without `-u` and
    `--user-mounts`. When those options are absent `snap-update-ns` will
    acquire appropriate locks, freeze running processes of the affected
    snap and perform an update to existing system-wide mount namespace
    that is joined, as appropriate. When those options are used the same
    flow will happen with the exception that per-user mount namespace
    will be joined and updated, running as the specified user ID.

This allows using snap-update-ns to update existing, persisted per-user
mount namespaces.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
