### PR TITLE
tests: fix daemon-notify test checking denials considering all the log lines

### DIFF
--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -12,22 +12,27 @@ prepare: |
     install_local test-snapd-daemon-notify
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB/journalctl.sh"
+
     echo "The interface is not connected by default"
     snap interfaces -i daemon-notify | MATCH -- "- +test-snapd-daemon-notify:daemon-notify"
 
     echo "When the interface is connected"
     snap connect test-snapd-daemon-notify:daemon-notify
 
-    echo "Then after we restart the servive there is not denials"
-    denials_before="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    echo "And the service is stopped"
     snap stop test-snapd-daemon-notify.notify
+
+    denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+    echo "Then after we restart the servive there is not denials"
     for _ in $(seq 10); do
         if snap start test-snapd-daemon-notify.notify; then
             break
         fi
         sleep 1
     done
-    denials_after="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
 
     [ "$denials_before" -eq "$denials_after" ]
 
@@ -38,15 +43,17 @@ execute: |
     echo "When the plug is disconnected"
     snap disconnect test-snapd-daemon-notify:daemon-notify
 
-    echo "Then the snap is not able to sending notification messages"
-    denials_before="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    echo "And the service is stopped"
     snap stop test-snapd-daemon-notify.notify
+
+    echo "Then the snap is not able to send notification messages"
+    denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
     for _ in $(seq 10); do
         if snap start test-snapd-daemon-notify.notify; then
             break
         fi
         sleep 1
     done
-    denials_after="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
 
     [ "$denials_before" -ne "$denials_after" ]

--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -19,7 +19,7 @@ execute: |
     snap connect test-snapd-daemon-notify:daemon-notify
 
     echo "Then after we restart the servive there is not denials"
-    denials_before="$(snap logs -n=100 test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    denials_before="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
     snap stop test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
         if snap start test-snapd-daemon-notify.notify; then
@@ -27,7 +27,7 @@ execute: |
         fi
         sleep 1
     done
-    denials_after="$(snap logs -n=100 test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    denials_after="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
 
     [ "$denials_before" -eq "$denials_after" ]
 
@@ -39,7 +39,7 @@ execute: |
     snap disconnect test-snapd-daemon-notify:daemon-notify
 
     echo "Then the snap is not able to sending notification messages"
-    denials_before="$(snap logs -n=100 test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    denials_before="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
     snap stop test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
         if snap start test-snapd-daemon-notify.notify; then
@@ -47,6 +47,6 @@ execute: |
         fi
         sleep 1
     done
-    denials_after="$(snap logs -n=100 test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
+    denials_after="$(snap logs -n=all test-snapd-daemon-notify.notify | grep -c 'Permission denied' || true)"
 
     [ "$denials_before" -ne "$denials_after" ]


### PR DESCRIPTION
This change fixes some errors that is reproduced in boards during beta validation.

See the error:
https://paste.ubuntu.com/p/QXgPpCPZ8J/

By using all the log lines we make sure the full log is checked to count
denials.

It also fix the scenario with repeat in google:
https://paste.ubuntu.com/p/7T8g8YGdvc/
