### PR TITLE
interfaces/builtin/opengl: allow access to NVIDIA VDPAU library

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -42,6 +42,7 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,GLESv1_CM,GLESv2,EGL}*nvidia.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}vdpau/libvdpau_nvidia.so{,.*} rm,
 
 # Support reading the Vulkan ICD files
 /var/lib/snapd/lib/vulkan/ r,

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -24,33 +24,41 @@ prepare: |
     # mock nvidia libraries
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
         mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls
+        mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX.so.0.0.1
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX_nvidia.so.0.0.1
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so.123.456
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls/libnvidia-tls.so.123.456
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so.123.456
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau/libvdpau_nvidia.so.123.456
         if [[ "$(uname -m)" == x86_64 ]]; then
             mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls
+            mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX.so.0.0.1
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX_nvidia.so.0.0.1
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so.123.456
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls/libnvidia-tls.so.123.456
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so.123.456
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau/libvdpau_nvidia.so.123.456
         fi
     fi
     mkdir -p /usr/lib/nvidia-123/tls
+    mkdir -p /usr/lib/nvidia-123/vdpau
     echo "canary-legacy" >> /usr/lib/nvidia-123/libGLX.so.0.0.1
     echo "canary-legacy" >> /usr/lib/nvidia-123/libGLX_nvidia.so.0.0.1
     echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-glcore.so.123.456
     echo "canary-legacy" >> /usr/lib/nvidia-123/tls/libnvidia-tls.so.123.456
     echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-tls.so.123.456
+    echo "canary-legacy" >> /usr/lib/nvidia-123/vdpau/libvdpau_nvidia.so.123.456
     if [[ "$(uname -m)" == x86_64 ]]; then
         mkdir -p /usr/lib32/nvidia-123/tls
+        mkdir -p /usr/lib32/nvidia-123/vdpau
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libGLX.so.0.0.1
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libGLX_nvidia.so.0.0.1
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libnvidia-glcore.so.123.456
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/tls/libnvidia-tls.so.123.456
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libnvidia-tls.so.123.456
+        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/vdpau/libvdpau_nvidia.so.123.456
     fi
 
 restore: |
@@ -62,17 +70,17 @@ restore: |
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
         rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls
+        rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau
         rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX.so.0.0.1
         rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX_nvidia.so.0.0.1
         rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so.123.456
-        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls/libnvidia-tls.so.123.456
         rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so.123.456
         if [[ "$(uname -m)" == x86_64 ]]; then
             rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls
+            rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau
             rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX.so.0.0.1
             rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX_nvidia.so.0.0.1
             rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so.123.456
-            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls/libnvidia-tls.so.123.456
             rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so.123.456
         fi
     fi
@@ -95,7 +103,7 @@ execute: |
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
         expected="canary-triplet"
     fi
-    files="libGLX.so.0.0.1 libGLX_nvidia.so.0.0.1 libnvidia-glcore.so.123.456 tls/libnvidia-tls.so.123.456 libnvidia-tls.so.123.456"
+    files="libGLX.so.0.0.1 libGLX_nvidia.so.0.0.1 libnvidia-glcore.so.123.456 tls/libnvidia-tls.so.123.456 libnvidia-tls.so.123.456 vdpau/libvdpau_nvidia.so.123.456"
     for f in $files; do
        snap run test-snapd-policy-app-consumer.opengl -c "cat /var/lib/snapd/lib/gl/$f" | MATCH "$expected"
     done


### PR DESCRIPTION
This fixes broken VDPAU support with the Nvidia driver on Ubuntu 18.04. From the original issue below, it appears that Ubuntu 16.04 doesn't use a symlink for libvdpau_nvidia.so, which allows it to work even without this fix (though it may also be the different Nvidia driver version too)

Without this AppArmor rule, we get denied trying to open the VDPAU library on the host FS with Moonlight and VLC snaps (both use strict confinement):
```
01:06:28 moonlight: AVC apparmor="DENIED" operation="open" profile="snap.moonlight.moonlight" name="/var/lib/snapd/hostfs/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.390.77" pid=6448 comm="moonlight" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
20:53:26 vlc: AVC apparmor="DENIED" operation="open" profile="snap.vlc.vlc" name="/var/lib/snapd/hostfs/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.390.77" pid=5892 comm="vlc" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```

This manifests in the process as an EACCES error:
`5557 openat(AT_FDCWD, "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so.1", O_RDONLY|O_CLOEXEC) = -1 EACCES (Permission denied)`

It continues to search until it runs out of possible paths and fails with:
`Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory`

Original bug report: https://github.com/maxiberta/moonlight-snap/issues/1

It also looks like someone else reported this on AskUbuntu and had to resort to the traditionally packaged VLC in order to get VDPAU working: https://askubuntu.com/questions/1097153/vlc-player-failed-to-open-vdpau-backend-libvdpau-nvidia-so/1097498

NOTE: I haven't not run my updated test locally. I'm hoping the automation will do that when I submit this PR.