### PR TITLE
tests: exclude some more slow tests from runs in autopkgtest

### DIFF
--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -4,6 +4,9 @@ summary: Checks for snap create-key
 # amazon: requires extra gpg-agent setup
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -amazon-*, -centos-*]
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 prepare: |
     #shellcheck source=tests/lib/mkpinentry.sh
     . "$TESTSLIB"/mkpinentry.sh

--- a/tests/main/install-refresh-remove-hooks/task.yaml
+++ b/tests/main/install-refresh-remove-hooks/task.yaml
@@ -1,5 +1,8 @@
 summary: Check install, remove and pre-refresh/post-refresh hooks.
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 environment:
     REMOVE_HOOK_FILE: "$HOME/snap/snap-hooks/common/remove-hook-executed"
 

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -1,5 +1,8 @@
 summary: Checks for snap sideload install
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 environment:
     # Ensure that running purely from the deb (without re-exec) works
     # correctly

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that the content sharing interface works.
 
+# slow in autopkgtest (>4m)
+backends: [-autopkgtest]
+
 details: |
     The content-sharing interface interface allows a snap to access contents from
     other snap

--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -2,6 +2,9 @@
 # https://forum.snapcraft.io/t/its-a-little-bit-hard-to-use-daemon-notify-for-sd-notify/6366
 summary: Ensure that the daemon-notify interface works.
 
+# test is timing dependant and may fail on very slow systems
+backends: [-autopkgtest]
+
 details: |
     The daemon-notify interface allows sending notification messages 
     to systemd through the notify socket

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -1,5 +1,8 @@
 summary: Checks handling of common snap directories of parallel installed snaps
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 prepare: |
     snap set system experimental.parallel-instances=true
 

--- a/tests/main/parallel-install-interfaces/task.yaml
+++ b/tests/main/parallel-install-interfaces/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snap connect with parallel installs works
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that revert of a snap in devmode restores devmode
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 environment:
     STORE_TYPE/fake: fake
     STORE_TYPE/remote: ${REMOTE_STORE}

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -3,6 +3,9 @@ summary: Check that snap-mgmt.sh works
 # purging everything on core devices will not work
 systems: [-ubuntu-core-*]
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 prepare: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/main/snap-service-after-before-install/task.yaml
+++ b/tests/main/snap-service-after-before-install/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snap install respects after/before ordering of services
 
+# slow in autopkgtest (>3m)
+backends: [-autopkgtest]
+
 debug: |
     for name in $(snap list | grep '^test-snapd-after-before-service' | awk '{print $1}'); do
         for service in before-middle middle after-middle; do

--- a/tests/main/snap-service-stop-mode-sigkill/task.yaml
+++ b/tests/main/snap-service-stop-mode-sigkill/task.yaml
@@ -2,6 +2,9 @@ summary: "Check that refresh-modes sigkill works"
 
 kill-timeout: 5m
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 restore: |
     # remove to ensure all services are stopped
     snap remove test-snapd-service || true

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -1,5 +1,8 @@
 summary: when the base snap changes revision apps are not stuck on the stale one
 
+# slow in autopkgtest (>1m)
+backends: [-autopkgtest]
+
 details: |
     When a snap application starts running the mount namespace it inhabits is
     preserved and cached across all the applications belonging to a given snap.


### PR DESCRIPTION
The i386 autopkgtest run failed in disco with a timeout error.
This PR removes some more tests from the set of tests run in
the autopkgtest backend to bring the time below the timeout.

Note that the autopkgtest environment on i386/amd64 is
exceedingly slow in the ADT cloud, most likely because of
overcommit of resources there.
