### PR TITLE
tests: define new "tests/smoke" suite and use that for autopkgtests

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -44,7 +44,7 @@ snap install --classic go
 . /etc/os-release
 export GOPATH=/tmp/go
 /snap/bin/go get -u github.com/snapcore/spread/cmd/spread
-/tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)"
+/tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)"/tests/smoke
 
 # store journal info for inspectsion
 journalctl --sync

--- a/spread.yaml
+++ b/spread.yaml
@@ -594,6 +594,19 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
             "$TESTSLIB"/prepare-restore.sh --restore-suite
+    # Essential tests run inside the autopkgtest environment on each
+    # platform. Autopkgtest can be very slow so we cannot run all
+    # tests there without running into timeouts.
+    tests/smoke/:
+        summary: Essenial system level tests for snapd
+        prepare: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
+        prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+        restore: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
     tests/core18/:
         summary: Subset of core18 specific tests
         systems: [ubuntu-core-18-*]

--- a/tests/smoke/find-info/task.yaml
+++ b/tests/smoke/find-info/task.yaml
@@ -1,0 +1,9 @@
+summary: Check that find works correctly
+
+execute: |
+  echo "Ensure 'snap find' works"
+  snap find test-snapd-tools | MATCH ^test-snapd-tools
+
+  echo "Ensure we can see useful info for it"
+  snap info test-snapd-tools | MATCH '^name:\ +test-snapd-tools'
+  

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -1,0 +1,20 @@
+summary: Check that installing and running a snap works
+
+execute: |
+    echo "Ensure install from the store works"
+    snap install test-snapd-tools
+
+    echo "Ensure that the snap can be run"
+    test-snapd-tools.echo hello > stdout.log 2> stderr.log
+    MATCH "^hello$" < stdout.log
+    if [ -s stderr.log ]; then
+        echo "stderr.log must be empty but it is not:"
+        cat stderr.log
+        exit 1
+    fi
+
+    echo "Ensure the snap is listed"
+    snap list | grep ^test-snapd-tools
+
+    echo "Ensure a change was generated for the install"
+    snap changes | MATCH 'Install "test-snapd-tools" snap'

--- a/tests/smoke/remove/task.yaml
+++ b/tests/smoke/remove/task.yaml
@@ -1,0 +1,20 @@
+summary: Check that install/remove works
+
+execute: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-tools
+
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB/dirs.sh"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
+
+    echo "Ensure remove works"
+    snap remove test-snapd-tools
+    test ! -d "$SNAP_MOUNT_DIR/test-snapd-tools"
+
+    if snap list | grep -E ^test-snapd-tools; then
+        echo "test-snapd-tools should be removed but it is not"
+        snap list
+        exit 1
+    fi

--- a/tests/smoke/sandbox/task.yaml
+++ b/tests/smoke/sandbox/task.yaml
@@ -1,0 +1,69 @@
+summary: Sandboxing of the snaps works
+
+restore: |
+    rm -f /home/test/foo
+
+execute: |
+    if [ "$(snap debug confinement)" != "strict" ]; then
+        if [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
+            echo "all ubuntu systems must have strict confinement"
+            exit 1
+        fi
+        echo "SKIP: no sandboxing"
+        exit 0
+    fi
+
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-sh
+
+    ############## APPARMOR
+    echo "Ensure the apparmor sandbox for snaps works for root"
+    for p in "/root/foo" "/home/foo" "/home/test/foo"; do
+        # no writing
+        ! test-snapd-sh -c "touch $p" 2>stderr.log
+        MATCH <stderr.log 'touch: .* Permission denied'
+
+        # no reading
+        touch "$p"
+        ! test-snapd-sh -c "cat $p" 2>stderr.log
+        MATCH <stderr.log 'cat: .* Permission denied'
+        rm -f "$p"
+    done
+
+    echo "Ensure the apparmor sandbox for snaps works for users"
+    ! su -l -c 'test-snapd-sh -c "touch /home/test/foo"' test 2>stderr.log
+    MATCH <stderr.log '.* Permission denied'
+
+    echo "But with the right plug the user can put files into home"
+    su -l -c  'test-snapd-sh.with-home-plug -c "echo good >/home/test/foo"' test
+    test -e /home/test/foo
+    echo "and also read them back"
+    su -l -c  'test-snapd-sh.with-home-plug -c "cat /home/test/foo"' test | MATCH good
+
+
+    ############## SECCOMP
+    echo "Ensure seccomp sandbox works"
+    cat >sec.py <<'EOF'
+    #!/usr/bin/python3
+    from ctypes import c_long, CDLL, get_errno
+    from ctypes.util import find_library
+    import errno, sys
+    if __name__ == "__main__":
+        libc_name = find_library("c")
+        libc = CDLL(libc_name, use_errno=True)
+        retval = libc.syscall(c_long(int(sys.argv[1])), c_long(0), c_long(0), c_long(0), c_long(0), c_long(0))
+        if retval < 0:
+            print(errno.errorcode[get_errno()])
+    EOF
+    echo "Running random syscall gives ENOSYS normally"
+    python3 sec.py 22082007 | MATCH ENOSYS
+    echo "But in the sandbox we get a EPERM"
+    test-snapd-sh.with-home-plug -c "python3 $(pwd)/sec.py 22082007" | MATCH EPERM
+
+    if [ "$(uname -p)" = "x86_64" ]; then
+        echo "Ensure secondary arch works for amd64 with i386 binaries"
+        snap install --edge test-snapd-hello-multi-arch
+        # this will fail if the seccomp seconardy arch handling is broken
+        test-snapd-hello-multi-arch.hello-i386 | MATCH Hello
+    fi

--- a/tests/smoke/sandbox/task.yaml
+++ b/tests/smoke/sandbox/task.yaml
@@ -17,6 +17,11 @@ execute: |
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-sh
 
+    # home is not auto-connected on core
+    if grep -q ID=ubuntu-core /etc/os-release; then
+        snap connect test-snapd-sh:home
+    fi
+
     ############## APPARMOR
     echo "Ensure the apparmor sandbox for snaps works for root"
     for p in "/root/foo" "/home/foo" "/home/test/foo"; do


### PR DESCRIPTION
Our autopkgtest test backend runs the full "main" suite right now.
This causes issue on slow architectures or slow clouds because our
test suite with >300 integration tests regularly hits the autopkgtest
timeout of 2h46min in the amd64/i386 cloud environment.

Given that this has caused quite a few delays already when doing
snapd SRUs and that we run the full suite all the time in spread
this PR splits the main suite into a smaller "smoke" suite that
will be run inside the autopkgtest environment and that only
tests a small subset of the most important integration points.

Once we have a faster autopkgtest cloud we can switch back to
running the full tests again.

This is a bit of a dramatic step so I marked it RFC and blocked until
we discussed it some more. But OTOH the current approach of
running all the tests in ADT is not working in ADT environment.

For a perspective on ADT times (in disco):

| arch | time |
|-------|-------|
| amd64 | 2h28min (most recent) |
| amd64 | 1h08min (fastest recently) |
| amd64 | timeout about ~30%-50% of the runs |
| i386     | 2h52min (timeout), two most recent runs |
| i386     | 1h25min (fastest recently) |
| arm64 | 4h27min (success) |
| s390x | 1h20min (pretty consistent) |
| ppc64el | 1h20min (pretty consistent) |