### PR TITLE
overlord/ifacestate: helper API to obtain the state of connections

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -99,7 +99,7 @@ func UpperCaseConnState() map[string]*connState {
 	}
 }
 
-func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.Connection, autoConnect, byGadget bool) {
+func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.Connection, autoConnect, byGadget, undesired bool) {
 	connRef := &interfaces.ConnRef{
 		PlugRef: *conn.Plug.Ref(),
 		SlotRef: *conn.Slot.Ref(),
@@ -113,6 +113,7 @@ func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.C
 		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
 		Auto:             autoConnect,
 		ByGadget:         byGadget,
+		Undesired:        undesired,
 	}
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -162,8 +162,8 @@ type ConnectionState struct {
 	ByGadget bool
 	// Interface name of the connection
 	Interface string
-	// Undesired indicates whether the connection was explicitly
-	// disconnected
+	// Undesired indicates whether the connection, otherwise established
+	// automatically, was explicitly disconnected
 	Undesired bool
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -155,6 +155,39 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 	return m.repo
 }
 
+type ConnectionState struct {
+	// Auto indicates whether the connection was established automatically
+	Auto bool
+	// ByGadget indicates whether the connection was trigged by the gadget
+	ByGadget bool
+	// Interface name of the connection
+	Interface string
+	// Undesired indicates whether the connection was explicitly
+	// disconnected
+	Undesired bool
+}
+
+// ConnectionStates return the state of connections tracked by the manager
+func (m *InterfaceManager) ConnectionStates() (connStateByRef map[string]ConnectionState, err error) {
+	m.state.Lock()
+	defer m.state.Unlock()
+	states, err := getConns(m.state)
+	if err != nil {
+		return nil, err
+	}
+
+	connStateByRef = make(map[string]ConnectionState, len(states))
+	for cref, cstate := range states {
+		connStateByRef[cref] = ConnectionState{
+			Auto:      cstate.Auto,
+			ByGadget:  cstate.ByGadget,
+			Interface: cstate.Interface,
+			Undesired: cstate.Undesired,
+		}
+	}
+	return connStateByRef, nil
+}
+
 // DisableUDevMonitor disables the instantiation of udev monitor, but has no effect
 // if udev is already created; it should be called after creating InterfaceManager, before
 // first Ensure.

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -4962,7 +4962,8 @@ func (s *interfaceManagerSuite) TestAttributesRestoredFromConns(c *C) {
 	c.Check(conn.Slot.Attr("number", &number), IsNil)
 	c.Check(number, Equals, int64(1))
 
-	ifacestate.UpdateConnectionInConnState(conns, conn, false, false, false)
+	var isAuto, byGadget, isUndesired bool
+	ifacestate.UpdateConnectionInConnState(conns, conn, isAuto, byGadget, isUndesired)
 	ifacestate.SetConns(st, conns)
 
 	// restore connection from conns state
@@ -5445,7 +5446,8 @@ func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undes
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
-	s.testConnectionStates(c, true, false, false, map[string]ifacestate.ConnectionState{
+	var isAuto, byGadget, isUndesired bool = true, false, false
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
@@ -5453,7 +5455,8 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
-	s.testConnectionStates(c, true, true, false, map[string]ifacestate.ConnectionState{
+	var isAuto, byGadget, isUndesired bool = true, true, false
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
@@ -5462,7 +5465,8 @@ func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *C) {
-	s.testConnectionStates(c, true, false, true, map[string]ifacestate.ConnectionState{
+	var isAuto, byGadget, isUndesired bool = true, false, true
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -4962,7 +4962,7 @@ func (s *interfaceManagerSuite) TestAttributesRestoredFromConns(c *C) {
 	c.Check(conn.Slot.Attr("number", &number), IsNil)
 	c.Check(number, Equals, int64(1))
 
-	ifacestate.UpdateConnectionInConnState(conns, conn, false, false)
+	ifacestate.UpdateConnectionInConnState(conns, conn, false, false, false)
 	ifacestate.SetConns(st, conns)
 
 	// restore connection from conns state
@@ -5408,4 +5408,64 @@ func (s *interfaceManagerSuite) TestHotplugSeqWaitTasks(c *C) {
 	for _, chg := range s.st.Changes() {
 		c.Assert(chg.Status(), Equals, state.DoneStatus)
 	}
+}
+
+func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undesired bool, expected map[string]ifacestate.ConnectionState) {
+	slotSnap := s.mockSnap(c, producerYaml)
+	plugSnap := s.mockSnap(c, consumerYaml)
+
+	mgr := s.manager(c)
+
+	conns, err := mgr.ConnectionStates()
+	c.Assert(err, IsNil)
+	c.Check(conns, HasLen, 0)
+
+	st := s.state
+	st.Lock()
+	sc, err := ifacestate.GetConns(st)
+	c.Assert(err, IsNil)
+
+	slot := slotSnap.Slots["slot"]
+	c.Assert(slot, NotNil)
+	plug := plugSnap.Plugs["plug"]
+	c.Assert(plug, NotNil)
+	// create connection in conns state
+	conn := &interfaces.Connection{
+		Plug: interfaces.NewConnectedPlug(plug, nil, nil),
+		Slot: interfaces.NewConnectedSlot(slot, nil, nil),
+	}
+	ifacestate.UpdateConnectionInConnState(sc, conn, auto, byGadget, undesired)
+	ifacestate.SetConns(st, sc)
+	st.Unlock()
+
+	conns, err = mgr.ConnectionStates()
+	c.Assert(err, IsNil)
+	c.Assert(conns, HasLen, 1)
+	c.Check(conns, DeepEquals, expected)
+}
+
+func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
+	s.testConnectionStates(c, true, false, false, map[string]ifacestate.ConnectionState{
+		"consumer:plug producer:slot": {
+			Interface: "test",
+			Auto:      true,
+		}})
+}
+
+func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
+	s.testConnectionStates(c, true, true, false, map[string]ifacestate.ConnectionState{
+		"consumer:plug producer:slot": {
+			Interface: "test",
+			Auto:      true,
+			ByGadget:  true,
+		}})
+}
+
+func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *C) {
+	s.testConnectionStates(c, true, false, true, map[string]ifacestate.ConnectionState{
+		"consumer:plug producer:slot": {
+			Interface: "test",
+			Auto:      true,
+			Undesired: true,
+		}})
 }


### PR DESCRIPTION
Add a helper method to query the state of connections. The API returns
connections that are currently established, as well as ones that were explicitly
disconnected. Connection state tells whether the connection was established
automtically, manually or triggered by the gadget.

The primary purpose of the change is to make the information accessible in the
daemon, to satisfy the API calls to `/v2/connections` endpoint.