### PR TITLE
tests: fix enable-disable-unit-gpio test on external boards

### DIFF
--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -13,6 +13,11 @@ details: |
 systems: [ubuntu-core-16-64]
 
 prepare: |
+    if ! snap interfaces|grep -q gpio-pin; then
+        echo "SKIP: this tests needs a fake 'gpio-pin' interface"
+        exit 0
+    fi
+
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
     echo "Create/enable fake gpio"
@@ -27,12 +32,22 @@ prepare: |
     snap connect gpio-consumer:gpio :gpio-pin
 
 restore: |
+    if ! snap interfaces|grep -q gpio-pin; then
+        echo "SKIP: this tests needs a fake 'gpio-pin' interface"
+        exit 0
+    fi
+
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
     system_stop_and_remove_persistent_unit fake-gpio
     umount /sys/class/gpio || true
 
 execute: |
+    if ! snap interfaces|grep -q gpio-pin; then
+        echo "SKIP: this tests needs a fake 'gpio-pin' interface"
+        exit 0
+    fi
+
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -13,6 +13,9 @@ details: |
 systems: [ubuntu-core-16-64]
 
 prepare: |
+    # Core image that were created using spread will have a fake "gpio-pin".
+    # Other (e.g. official) images will not have that and there we can't use
+    # this test.
     if ! snap interfaces|grep -q gpio-pin; then
         echo "SKIP: this tests needs a fake 'gpio-pin' interface"
         exit 0
@@ -32,6 +35,9 @@ prepare: |
     snap connect gpio-consumer:gpio :gpio-pin
 
 restore: |
+    # Core image that were created using spread will have a fake "gpio-pin".
+    # Other (e.g. official) images will not have that and there we can't use
+    # this test.
     if ! snap interfaces|grep -q gpio-pin; then
         echo "SKIP: this tests needs a fake 'gpio-pin' interface"
         exit 0
@@ -43,6 +49,9 @@ restore: |
     umount /sys/class/gpio || true
 
 execute: |
+    # Core image that were created using spread will have a fake "gpio-pin".
+    # Other (e.g. official) images will not have that and there we can't use
+    # this test.
     if ! snap interfaces|grep -q gpio-pin; then
         echo "SKIP: this tests needs a fake 'gpio-pin' interface"
         exit 0


### PR DESCRIPTION
This test requires the "gpio-pin" interface which is only availabe
when the image is created via spread. This test cannot be run on
"official" images. Hence add a check to the test to ensure the
test is skipped when it cannot run.
