### PR TITLE
tests: auto-clean the test directory

### DIFF
--- a/tests/core18/snapd-failover/task.yaml
+++ b/tests/core18/snapd-failover/task.yaml
@@ -1,8 +1,5 @@
 summary: Check that snapd failure handling works
 
-restore: |
-    rm -rf ./snapd-broken
-
 debug: |
     # dump failure data
     journalctl -u snapd.failure.service

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -411,6 +411,9 @@ prepare_suite() {
 }
 
 prepare_suite_each() {
+    # back test directory to be restored during the restore
+    tar cf "${PWD}.tar" "$PWD"
+
     # save the job which is going to be executed in the system
     echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
     # shellcheck source=tests/lib/reset.sh
@@ -434,6 +437,13 @@ prepare_suite_each() {
 
 restore_suite_each() {
     rm -f "$RUNTIME_STATE_PATH/audit-stamp"
+
+    # restore test directory saved during prepare
+    if [ -f "${PWD}.tar" ]; then
+        rm -rf "$PWD"
+        tar -C/ -xf "${PWD}.tar"
+        rm -rf "${PWD}.tar"
+    fi
 }
 
 restore_suite() {

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -3,9 +3,6 @@ summary: Ensure apt hooks work
 # apt hook only available on 18.04+ and aws-cli only for amd64
 systems: [ubuntu-18.04-64, ubuntu-18.10-64]
 
-restore: |
-    rm -f expected out apt.stderr
-
 debug: |
     ls -lh /var/cache/snapd
     # low tech dump of db

--- a/tests/main/auth-errors/task.yaml
+++ b/tests/main/auth-errors/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     chown -R test:test /home/test/.snap
 
 restore: |
-    rm -rf /home/test/.snap install.output connect.output
+    rm -rf /home/test/.snap
 
 execute: |
     echo "An unauthenticated user cannot install snaps"

--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -7,10 +7,6 @@ systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 prepare: |
   go build -o toggle ./toggle.go
 
-restore: |
-    rm -f foo
-    rm -f toggle
-
 execute: |
   touch foo
   # no immutable flag:

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -13,9 +13,6 @@ backends: [-autopkgtest]
 warn-timeout: 1m
 kill-timeout: 5m
 
-restore: |
-    rm -f state.json.new
-
 debug: |
     snap list || true
     snap info core || true

--- a/tests/main/cmdline/task.yaml
+++ b/tests/main/cmdline/task.yaml
@@ -7,6 +7,3 @@ execute: |
         exit 1
     fi
     MATCH "Please specify a single channel" < err.msg
-
-restore: |
-    rm -f err.msg

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -13,9 +13,6 @@ prepare: |
     snap pack "$TESTSLIB/snaps/command-chain"
     snap install --dangerous command-chain_1.0_all.snap
 
-restore: |
-    rm -f command-chain_1.0_all.snap
-
 execute: |
     echo "Test that command-chain runs for hooks"
     [ "$(cat "$BREADCRUMB")" = "chain1 chain2 configure" ]

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -40,7 +40,7 @@ restore: |
     rm "$NAMES"
     [ -e "$NAMES.orig" ] && mv "$NAMES.orig" "$NAMES"
     systemctl start snapd.service
-    rm -f testdir/foo.snap bar.snap
+    rm -f testdir/foo.snap
     rmdir testdir
 
 debug: |

--- a/tests/main/core-snap-refresh-on-core/task.yaml
+++ b/tests/main/core-snap-refresh-on-core/task.yaml
@@ -12,10 +12,6 @@ manual: true
 prepare: |
     snap install test-snapd-tools
 
-restore: |
-    rm -f prevBoot nextBoot
-    rm -f core_*.{assert,snap}
-
 execute: |
     wait_core_pre_boot() {
         chg_id="$1"

--- a/tests/main/core-snap-refresh/task.yaml
+++ b/tests/main/core-snap-refresh/task.yaml
@@ -7,9 +7,6 @@ details: |
 
 manual: true
 
-restore: |
-    rm -f prevBoot nextBoot
-
 execute: |
     #shellcheck source=tests/lib/boot.sh
     . "$TESTSLIB"/boot.sh

--- a/tests/main/disable-autoconnect/task.yaml
+++ b/tests/main/disable-autoconnect/task.yaml
@@ -10,10 +10,6 @@ prepare: |
     snap pack "$TESTSLIB"/snaps/config-versions
     snap pack "$TESTSLIB"/snaps/config-versions-v2
 
-restore: |
-    rm -f config-versions_1.0_all.snap
-    rm -f config-versions_2.0_all.snap
-
 execute: |
     CONNECTED_PATTERN=':home .* config-versions'
     DISCONNECTED_PATTERN='\- .* config-versions:home'

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -38,8 +38,6 @@ restore: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
     [ -f dbus-launch.pid ] && kill "$(cat dbus-launch.pid)"
-    rm -f dbus-launch.pid
-    rm -f stderr.log doc-portal.log report-error.txt
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
     distro_purge_package python3-dbus python3-gi
     distro_auto_remove_packages

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -1,15 +1,4 @@
 summary: Ensure that ECONNRESET is handled
-restore: |
-    echo "Stop the snap download command"
-    kill -9 "$(pgrep -f 'snap download')" || true
-
-    echo "Remove the firewall rule again"
-    iptables -D OUTPUT -m owner --uid-owner "$(id -u test)" -j REJECT -p tcp --reject-with tcp-reset || true
-    echo "Remove ingress traffic policing rule"
-    iptables -D INPUT -p tcp --match hashlimit --hashlimit-mode srcip,dstip,srcport,dstport --hashlimit-above 512kb/s \
-             --hashlimit-name 'econnreset' -j DROP
-
-    rm -f test-snapd-huge_*
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro
@@ -27,6 +16,16 @@ debug: |
     cat snap-download.log
     echo "iptables rules and counters"
     iptables -L -n -v
+
+restore: |
+    echo "Stop the snap download command"
+    kill -9 "$(pgrep -f 'snap download')" || true
+
+    echo "Remove the firewall rule again"
+    iptables -D OUTPUT -m owner --uid-owner "$(id -u test)" -j REJECT -p tcp --reject-with tcp-reset || true
+    echo "Remove ingress traffic policing rule"
+    iptables -D INPUT -p tcp --match hashlimit --hashlimit-mode srcip,dstip,srcport,dstport --hashlimit-above 512kb/s \
+             --hashlimit-name 'econnreset' -j DROP
 
 execute: |
     echo "Downloading a large snap in the background"

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -30,7 +30,6 @@ prepare: |
     mkdir -p "$BUILD_DIR"
 
 restore: |
-    rm -f failing.snap failBoot currentBoot prevBoot
     rm -rf "$BUILD_DIR"
 
     # FIXME: remove the unset when we reset properly snap_try_{core,kernel} on rollback

--- a/tests/main/install-sideload-epochs/task.yaml
+++ b/tests/main/install-sideload-epochs/task.yaml
@@ -10,9 +10,6 @@ prepare: |
     snap pack "$TESTSLIB"/snaps/test-snapd-epoch-1
     snap pack "$TESTSLIB"/snaps/test-snapd-epoch-2
 
-restore: |
-    rm -v test-snapd-epoch_{1,2}_all.snap
-
 execute: |
     rx="cannot refresh \"[^ \"]*\" to local snap with epoch [^ ]*, because it can't read the current epoch"
     snap try "$TESTSLIB"/snaps/test-snapd-epoch-1

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -14,11 +14,6 @@ prepare: |
         snap pack "$TESTSLIB"/snaps/$snap
     done
 
-restore: |
-    for snap in basic test-snapd-tools basic-desktop; do
-        rm -f ./${snap}_1.0_all.snap
-    done
-
 execute: |
     echo "Sideloaded snap shows status"
     expected='^basic 1.0 installed$'

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -26,8 +26,6 @@ restore: |
     . "$TESTSLIB"/pkgdb.sh
     # this will also kill the "gdbus monitor" command
     kill "$(cat dbus-launch.pid)"
-    rm -f dbus-launch.pid
-    rm -f dbus.env
     rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
     # usually not needed, this should die when dbus goes down
     kill "$(cat gdbus-monitor.pid)" || true

--- a/tests/main/interfaces-alsa/task.yaml
+++ b/tests/main/interfaces-alsa/task.yaml
@@ -23,7 +23,7 @@ prepare: |
     install_generic_consumer alsa
 
 restore: |
-    rm -f ./*.error /dev/snd/mysnd-dev
+    rm -f /dev/snd/mysnd-dev
 
 execute: |
     echo "When the plug is connected"

--- a/tests/main/interfaces-autopilot-introspection/task.yaml
+++ b/tests/main/interfaces-autopilot-introspection/task.yaml
@@ -22,7 +22,6 @@ prepare: |
     start_dbus_unit $SNAP_MOUNT_DIR/bin/test-snapd-autopilot-consumer.provider
 
 restore: |
-    rm -f ./*.error
     #shellcheck source=tests/lib/dbus.sh
     . "$TESTSLIB/dbus.sh"
     stop_dbus_unit

--- a/tests/main/interfaces-avahi-observe/task.yaml
+++ b/tests/main/interfaces-avahi-observe/task.yaml
@@ -18,9 +18,6 @@ prepare: |
         systemctl restart avahi-daemon.{socket,service}
     fi
 
-restore: |
-    rm -f ./*.error
-
 execute: |
     avahi_dbus_call() {
         generic-consumer.cmd dbus-send --system --print-reply --dest=org.freedesktop.Avahi / org.freedesktop.Avahi.Server.GetHostName

--- a/tests/main/interfaces-bluetooth-control/task.yaml
+++ b/tests/main/interfaces-bluetooth-control/task.yaml
@@ -9,9 +9,6 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_generic_consumer bluetooth-control
 
-restore: |
-    rm -f ./*.error version class control
-
 execute: |
     BTDEV="$(find /sys/devices/ -type d -name bluetooth)"
 

--- a/tests/main/interfaces-broadcom-asic-control/task.yaml
+++ b/tests/main/interfaces-broadcom-asic-control/task.yaml
@@ -24,8 +24,6 @@ prepare: |
     ensure_file_exists /run/udev/data/+pci:0test
 
 restore: |
-    rm -f call.error
-
     #shellcheck source=tests/lib/files.sh
     . "$TESTSLIB"/files.sh
     clean_file /dev/linux-user-bde

--- a/tests/main/interfaces-browser-support/task.yaml
+++ b/tests/main/interfaces-browser-support/task.yaml
@@ -40,7 +40,7 @@ prepare: |
     rm -rf browser-support-consumer
 
 restore: |
-    rm -f ./*.error /var/tmp/test
+    rm -f /var/tmp/test
     for file in $OWNED_FILES $READABLE_FILES $READABLE_WITH_SANDBOX_FILES; do
         rm -f "$file"
     done

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -25,7 +25,6 @@ prepare: |
 
 restore: |
     kill "$(cat dbus-launch.pid)"
-    rm -f dbus-launch.pid
 
     # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
     # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -23,7 +23,6 @@ environment:
 restore: |
     if [ -e dbus-launch.pid ]; then
         kill "$(cat dbus-launch.pid)"
-        rm -f dbus-launch.pid
     fi
 
     # In case the process gvfsd-metadata does not finish by itself, it is manually stopped

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -39,7 +39,7 @@ prepare: |
     fi
 
 restore: |
-    rm -rf "$HOME"/PDF "$TEST_FILE" print.error
+    rm -rf "$HOME"/PDF "$TEST_FILE"
 
 debug: |
     # shellcheck source=tests/lib/journalctl.sh

--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -29,7 +29,6 @@ prepare: |
     start_dbus_unit $SNAP_MOUNT_DIR/bin/test-snapd-dbus-provider.provider
 
 restore: |
-    rm -f call.error
     #shellcheck source=tests/lib/dbus.sh
     . "$TESTSLIB/dbus.sh"
     stop_dbus_unit || true

--- a/tests/main/interfaces-device-buttons/task.yaml
+++ b/tests/main/interfaces-device-buttons/task.yaml
@@ -19,8 +19,6 @@ prepare: |
     ensure_file_exists_backup_real /dev/input/event1
 
 restore: |
-    rm -f call.error
-
     # shellcheck source=tests/lib/files.sh
     . "$TESTSLIB/files.sh"
 

--- a/tests/main/interfaces-dvb/task.yaml
+++ b/tests/main/interfaces-dvb/task.yaml
@@ -16,8 +16,6 @@ prepare: |
     ensure_file_exists_backup_real /run/udev/data/c212:9
 
 restore: |
-    rm -f call.error
-
     # shellcheck source=tests/lib/files.sh
     . "$TESTSLIB/files.sh"
 

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -50,7 +50,7 @@ restore: |
     . "$TESTSLIB/systemd.sh"
     #shellcheck disable=SC2153
     systemd_stop_and_destroy_unit "$SERVICE_NAME"
-    rm -f firewall-create.error "$SERVICE_FILE" "$REQUEST_FILE"
+    rm -f "$SERVICE_FILE" "$REQUEST_FILE"
 
 execute: |
     echo "Then the plug is disconnected by default"

--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -40,7 +40,7 @@ restore: |
     for m in $mounts; do
         nsenter "--mount=/run/snapd/ns/$NAME.mnt" umount "$m"
     done
-    rm -rf "$MOUNT_POINT_OUTSIDE" fuse.error
+    rm -rf "$MOUNT_POINT_OUTSIDE"
 
     if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
         snap set system experimental.parallel-instances=null

--- a/tests/main/interfaces-gpg-keys/task.yaml
+++ b/tests/main/interfaces-gpg-keys/task.yaml
@@ -29,7 +29,6 @@ prepare: |
     echo "testkey" > "$TESTKEY"
 
 restore: |
-    rm -f call.error
     rm -rf "$KEYSDIR"
     if [ -d "$KEYSDIR".old ]; then
         mv "$KEYSDIR".old "$KEYSDIR"

--- a/tests/main/interfaces-gpg-public-keys/task.yaml
+++ b/tests/main/interfaces-gpg-public-keys/task.yaml
@@ -28,7 +28,6 @@ prepare: |
     touch "$CONFIG" || true
 
 restore: |
-    rm -f call.error
     rm -rf "$KEYSDIR"
     if [ -d "$KEYSDIR".old ]; then
         mv "$KEYSDIR".old "$KEYSDIR"

--- a/tests/main/interfaces-gpio-memory-control/task.yaml
+++ b/tests/main/interfaces-gpio-memory-control/task.yaml
@@ -9,9 +9,6 @@ prepare: |
     echo "Given the test-snapd-gpio-memory-control snap is installed"
     snap install test-snapd-gpio-memory-control
 
-restore: |
-    rm -f call.error
-
 execute: |
     if ! [ -c /dev/gpiomem ]; then
         echo "The /dev/gpiomem device does not exist in current system"

--- a/tests/main/interfaces-hardware-observe/task.yaml
+++ b/tests/main/interfaces-hardware-observe/task.yaml
@@ -16,9 +16,6 @@ prepare: |
     echo "Given a snap declaring a plug on the hardware-observe interface is installed"
     install_local hardware-observe-consumer
 
-restore: |
-    rm -f hw.error
-
 execute: |
     echo "The interface is not connected by default"
     snap interfaces -i hardware-observe | MATCH '^- +hardware-observe-consumer:hardware-observe'

--- a/tests/main/interfaces-hardware-random-control/task.yaml
+++ b/tests/main/interfaces-hardware-random-control/task.yaml
@@ -21,9 +21,6 @@ prepare: |
     echo "Given a snap declaring a plug on the hardware-random-control interface is installed"
     install_local test-snapd-hardware-random-control
 
-restore: |
-    rm -f hw.error
-
 execute: |
     echo "The interface is not connected by default"
     snap interfaces -i hardware-random-control | MATCH '^- +test-snapd-hardware-random-control:hardware-random-control'

--- a/tests/main/interfaces-hardware-random-observe/task.yaml
+++ b/tests/main/interfaces-hardware-random-observe/task.yaml
@@ -21,9 +21,6 @@ prepare: |
     echo "Given a snap declaring a plug on the hardware-random-observe interface is installed"
     install_local test-snapd-hardware-random-observe
 
-restore: |
-    rm -f hw.error
-
 execute: |
     echo "The interface is not connected by default"
     snap interfaces -i hardware-random-observe | MATCH '^- +test-snapd-hardware-random-observe:hardware-random-observe'

--- a/tests/main/interfaces-hostname-control/task.yaml
+++ b/tests/main/interfaces-hostname-control/task.yaml
@@ -12,9 +12,6 @@ prepare: |
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-sh
 
-restore: |
-    rm -f ./*.error
-
 execute: |
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB/systems.sh"

--- a/tests/main/interfaces-joystick/task.yaml
+++ b/tests/main/interfaces-joystick/task.yaml
@@ -21,8 +21,6 @@ prepare: |
     ensure_file_exists_backup_real /dev/input/event67
 
 restore: |
-    rm -f call.error
-
     # shellcheck source=tests/lib/files.sh
     . "$TESTSLIB/files.sh"
 

--- a/tests/main/interfaces-juju-client-observe/task.yaml
+++ b/tests/main/interfaces-juju-client-observe/task.yaml
@@ -18,8 +18,6 @@ prepare: |
     ensure_file_exists_backup_real "$HOME"/.local/share/juju/juju.conf
 
 restore: |
-    rm -f call.error
-
     # shellcheck source=tests/lib/files.sh
     . "$TESTSLIB/files.sh"
 

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -26,13 +26,11 @@ prepare: |
     install_generic_consumer kernel-module-control
 
 restore: |
-    rm -f ./*.error
     if lsmod | MATCH "$MODULE" && [ ! -f module_present ]; then
         rmmod "$MODULE"
     elif [ -f module_present ] && ! lsmod | MATCH "$MODULE" ; then
         insmod "$MODULE_PATH"
     fi
-    rm -f module_present
 
 debug: |
     lsmod

--- a/tests/main/interfaces-kvm/task.yaml
+++ b/tests/main/interfaces-kvm/task.yaml
@@ -14,7 +14,6 @@ prepare: |
     touch /dev/kvm
 
 restore: |
-    rm -f call.error
     rm -f /dev/kvm
 
     if [ -e /dev/kvm.bak ]; then

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -44,7 +44,6 @@ restore: |
         fi
     fi
 
-    rm -f locale-read.error locale-write.error
     mv locale.back /etc/default/locale
 
 execute: |

--- a/tests/main/interfaces-location-control/task.yaml
+++ b/tests/main/interfaces-location-control/task.yaml
@@ -24,8 +24,6 @@ prepare: |
     start_dbus_unit $SNAP_MOUNT_DIR/bin/test-snapd-location-control-provider.provider
 
 restore: |
-    rm -f getprop.error
-
     #shellcheck source=tests/lib/dbus.sh
     . "$TESTSLIB/dbus.sh"
     stop_dbus_unit

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -40,7 +40,6 @@ restore: |
 
     #shellcheck disable=SC2153
     systemd_stop_and_destroy_unit "$SERVICE_NAME"
-    rm -f ./*.output "$SERVICE_FILE"
     arp -d "$ARP_ENTRY_ADDR" -i "$(get_default_iface)" || true
 
     ip netns delete test-ns || true

--- a/tests/main/interfaces-network-observe/task.yaml
+++ b/tests/main/interfaces-network-observe/task.yaml
@@ -37,7 +37,6 @@ restore: |
 
     #shellcheck disable=SC2153
     systemd_stop_and_destroy_unit "$SERVICE_NAME"
-    rm -f net-query.output "$SERVICE_FILE"
 
 execute: |
     echo "The interface is disconnected by default"

--- a/tests/main/interfaces-network-setup-control/task.yaml
+++ b/tests/main/interfaces-network-setup-control/task.yaml
@@ -12,7 +12,6 @@ prepare: |
     install_local test-snapd-sh
 
 restore: |
-    rm -f call.error
     rm -f /etc/network/test001 /etc/network/test002
 
 execute: |

--- a/tests/main/interfaces-network-setup-observe/task.yaml
+++ b/tests/main/interfaces-network-setup-observe/task.yaml
@@ -9,9 +9,6 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-sh
 
-restore: |
-    rm -f call.error
-
 execute: |
     dirs="/etc/netplan /etc/network"
 

--- a/tests/main/interfaces-network-status/task.yaml
+++ b/tests/main/interfaces-network-status/task.yaml
@@ -24,8 +24,6 @@ prepare: |
     start_dbus_unit $SNAP_MOUNT_DIR/bin/test-snapd-network-status-provider.provider
 
 restore: |
-    rm -f getstate.error
-
     #shellcheck source=tests/lib/dbus.sh
     . "$TESTSLIB/dbus.sh"
     stop_dbus_unit

--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -36,7 +36,6 @@ restore: |
     . "$TESTSLIB"/systemd.sh
     #shellcheck disable=SC2153
     systemd_stop_and_destroy_unit "$SERVICE_NAME"
-    rm -f "$SERVICE_FILE"
 
 execute: |
     echo "The interface is connected by default"

--- a/tests/main/interfaces-openvswitch-support/task.yaml
+++ b/tests/main/interfaces-openvswitch-support/task.yaml
@@ -11,9 +11,6 @@ systems: [-ubuntu-14.04-*,-ubuntu-core-*,-fedora-*, -arch-*, -amazon-*, -opensus
 prepare: |
     snap install test-snapd-openvswitch-support
 
-restore: |
-    rm -f call.error
-
 execute: |
     echo "The interface is not connected by default"
     #shellcheck disable=SC1117

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -46,8 +46,6 @@ restore: |
     distro_purge_package openvswitch-switch
     distro_auto_remove_packages
 
-    rm -f ./*.error
-
     ip link delete tap1 || true
 
 execute: |

--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -15,7 +15,6 @@ restore: |
     if [ -f dbus-launch.pid ]; then
         kill "$(cat dbus-launch.pid)"
     fi
-    rm -f  dbus-launch.pid
 
 execute: |
     echo "Ensure things run"

--- a/tests/main/interfaces-personal-files/task.yaml
+++ b/tests/main/interfaces-personal-files/task.yaml
@@ -30,8 +30,6 @@ prepare: |
     ensure_file_exists_backup_real /var/tmp/root/.testfile2
 
 restore: |
-    rm -f call.error
-
     # shellcheck source=tests/lib/files.sh
     . "$TESTSLIB/files.sh"
 

--- a/tests/main/interfaces-physical-memory-observe/task.yaml
+++ b/tests/main/interfaces-physical-memory-observe/task.yaml
@@ -17,9 +17,6 @@ prepare: |
     echo "Given the physical-memory-observe snap is installed"
     install_local test-snapd-physical-memory-observe
 
-restore: |
-    rm -f call.error
-
 execute: |
     config="/boot/config-$(uname -r)"
     if ([ -f "$config" ] && MATCH "CONFIG_STRICT_DEVMEM=y" < "$config") || ([ -f /proc/config.gz ] && zcat /proc/config.gz | MATCH "CONFIG_STRICT_DEVMEM=y"); then

--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -19,9 +19,6 @@ prepare: |
     echo "Given a snap declaring a plug on the process-control interface is installed"
     install_local process-control-consumer
 
-restore: |
-    rm -f process-kill.error process-nice.error
-
 execute: |
     echo "The interface is disconnected by default"
     snap interfaces -i process-control | MATCH -- '- +process-control-consumer:process-control'

--- a/tests/main/interfaces-raw-usb/task.yaml
+++ b/tests/main/interfaces-raw-usb/task.yaml
@@ -8,9 +8,6 @@ prepare: |
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-sh
 
-restore: |
-    rm -f call.error
-
 execute: |
     echo "The interface is not connected by default"
     snap interfaces -i raw-usb | MATCH -- '^- +test-snapd-sh:raw-usb'

--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -28,8 +28,6 @@ prepare: |
     echo canary > /mnt/testing/data
 
 restore: |
-    rm -f call.error
-
     rm -rf /media/testdir
     if [ -f /media/fake ]; then
         #shellcheck disable=SC2114

--- a/tests/main/interfaces-snapd-control/task.yaml
+++ b/tests/main/interfaces-snapd-control/task.yaml
@@ -18,9 +18,6 @@ prepare: |
     echo "Given a snap declaring a plug on the snapd-control interface is installed"
     snap install --edge test-snapd-control-consumer
 
-restore: |
-    rm -f snapd.error
-
 execute: |
     echo "The interface is connected by default"
     snap interfaces -i snapd-control | MATCH ":snapd-control .*test-snapd-control-consumer"

--- a/tests/main/interfaces-ssh-keys/task.yaml
+++ b/tests/main/interfaces-ssh-keys/task.yaml
@@ -22,7 +22,6 @@ prepare: |
     echo "testkey.pub" > "$TESTKEY".pub
 
 restore: |
-    rm -f call.error
     rm -rf "$KEYSDIR"
     if [ -d "$KEYSDIR".old ]; then
         mv "$KEYSDIR".old "$KEYSDIR"

--- a/tests/main/interfaces-ssh-public-keys/task.yaml
+++ b/tests/main/interfaces-ssh-public-keys/task.yaml
@@ -23,7 +23,6 @@ prepare: |
     echo "testkey.pub" > "$TESTKEY".pub
 
 restore: |
-    rm -f call.error
     rm -rf "$KEYSDIR"
     if [ -d "$KEYSDIR".old ]; then
         mv "$KEYSDIR".old "$KEYSDIR"

--- a/tests/main/interfaces-system-files/task.yaml
+++ b/tests/main/interfaces-system-files/task.yaml
@@ -32,8 +32,6 @@ prepare: |
     ensure_file_exists_backup_real /root/.testfile1
 
 restore: |
-    rm -f call.error
-
     # shellcheck source=tests/lib/files.sh
     . "$TESTSLIB/files.sh"
 

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -21,7 +21,6 @@ prepare: |
     fi
 
 restore: |
-    rm -f ./*.error
     if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
         systemctl stop systemd-hostnamed
     fi

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -19,9 +19,7 @@ restore: |
     # Restore the initial rtc configuration
     if [ -f rtc.txt ]; then
         timedatectl set-local-rtc "$(cat rtc.txt)"
-        rm -f rtc.txt
     fi
-    rm -f call.error
 
 execute: |
     # hwclock with libaudit (ie, core 16) also needs netlink-audit connected.

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -20,9 +20,7 @@ restore: |
     # Restore the initial timeserver
     if [ -s timeserver.txt ]; then
         timedatectl set-ntp "$(cat timeserver.txt)"
-        rm -f timeserver.txt
     fi
-    rm -f call.error
 
 execute: |
     echo "The interface is disconnected by default"

--- a/tests/main/interfaces-timezone-control/task.yaml
+++ b/tests/main/interfaces-timezone-control/task.yaml
@@ -21,9 +21,7 @@ restore: |
     # Restore the initial timezone
     if [ -f timezone.txt ]; then
         timedatectl set-timezone "$(cat timezone.txt)" || true
-        rm -f timezone.txt
     fi
-    rm -f call.error
 
 execute: |
     echo "The interface is disconnected by default"

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -14,7 +14,6 @@ environment:
     MMCBLK_PATH: /dev/mmcblk-fake0
 
 restore: |
-    rm -f call.error
     losetup -d "$MMCBLK_PATH" || true
     rm -f "$MMCBLK_PATH" "$FS_PATH"
 

--- a/tests/main/interfaces-uhid/task.yaml
+++ b/tests/main/interfaces-uhid/task.yaml
@@ -12,9 +12,6 @@ prepare: |
     echo "Given the uhid snap is installed"
     snap install test-snapd-uhid
 
-restore: |
-    rm -f call.error
-
 execute: |
     echo "The plug is not connected by default"
     snap interfaces -i uhid | MATCH -- '^- +test-snapd-uhid:uhid'

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -24,9 +24,6 @@ prepare: |
         snap install upower
     fi
 
-restore: |
-    rm -f upower.error
-
 execute: |
     SLOT_PROVIDER=
     SLOT_NAME=upower-observe

--- a/tests/main/kernel-snap-refresh-on-core/task.yaml
+++ b/tests/main/kernel-snap-refresh-on-core/task.yaml
@@ -13,9 +13,6 @@ environment:
     KERNEL_CHANNEL: stable
     NEW_KERNEL_CHANNEL: edge
 
-restore: |
-    rm -f prevBoot nextBoot prevKernelSignature nextKernelSiganture
-        
 prepare: |
     snap install test-snapd-tools
 

--- a/tests/main/layout-symlink-bind-revert/task.yaml
+++ b/tests/main/layout-symlink-bind-revert/task.yaml
@@ -1,4 +1,5 @@
 summary: TBD
+
 prepare: |
     echo "Ensure feature flag is enabled"
     snap set core experimental.layouts=true
@@ -6,8 +7,7 @@ prepare: |
     snap pack ./runtime .
     snap pack ./app.v1 .
     snap pack ./app.v2 .
-restore: |
-    rm -f "*.snap"
+
 execute: |
     echo "The runtime and the application are installed and connected"
     snap install --dangerous ./runtime_1_all.snap

--- a/tests/main/local-install-w-metadata/task.yaml
+++ b/tests/main/local-install-w-metadata/task.yaml
@@ -3,9 +3,6 @@ summary: Checks for local install with metadata from assertions
 # XXX we would need to bother with curl there atm
 systems: [-ubuntu-core-*]
 
-restore: |
-    rm -f test-snapd-tools_*.{snap,assert}
-
 execute: |
     echo "Get the snap"
     snap download test-snapd-tools

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -29,7 +29,6 @@ restore: |
 
     lxd.lxc stop my-ubuntu --force
     lxd.lxc delete my-ubuntu
-    rm -f conf.yaml 
 
 debug: |
     # shellcheck source=tests/lib/journalctl.sh

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -14,7 +14,6 @@ restore: |
     if [[ "$SPREAD_SYSTEM" = ubuntu-core-* ]]; then
        resolvConf=$(cat resolvConf.txt)
        mv "${resolvConf}.save" "${resolvConf}"
-       rm resolvConf.txt
     else
        mv /etc/resolv.conf.save /etc/resolv.conf
     fi

--- a/tests/main/op-remove/task.yaml
+++ b/tests/main/op-remove/task.yaml
@@ -1,9 +1,5 @@
 summary: Check snap remove operations.
 
-restore: |
-    rm -f basic_1.0_all.snap
-    rm -f stderr.out
-
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/main/parallel-install-aliases/task.yaml
+++ b/tests/main/parallel-install-aliases/task.yaml
@@ -11,7 +11,6 @@ prepare: |
 
 restore: |
     snap set system experimental.parallel-instances=null
-    rm -f aliases.out
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/parallel-install-auto-aliases/task.yaml
+++ b/tests/main/parallel-install-auto-aliases/task.yaml
@@ -5,8 +5,6 @@ prepare: |
 
 restore: |
     snap set system experimental.parallel-instances=null
-    rm -f ./*.snap
-    rm -f aliases.out
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/refresh-amend/task.yaml
+++ b/tests/main/refresh-amend/task.yaml
@@ -1,8 +1,5 @@
 summary: Ensure that refresh --amend works
 
-restore: |
-    rm -f test-snapd-just-edge_*.snap
-
 execute: |
     echo "When installing a local snap"
     snap download --edge test-snapd-just-edge

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -64,7 +64,6 @@ restore: |
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
-    rm -f stderr.out
     if [ "$STORE_TYPE" = "fake" ]; then
         if is_core_system; then
             exit

--- a/tests/main/revert-sideload/task.yaml
+++ b/tests/main/revert-sideload/task.yaml
@@ -3,9 +3,6 @@ summary: Checks for snap sideload reverts
 prepare: |
     snap pack "$TESTSLIB"/snaps/basic
 
-restore: |
-    rm -f ./basic_1.0_all.snap
-
 execute: |
     echo Installing sideloaded snap
     snap install --dangerous ./basic_1.0_all.snap

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -7,9 +7,6 @@ systems: [-ubuntu-*-ppc64el, -ubuntu-*-s390x]
 # with the distro
 backends: [-autopkgtest]
 
-restore: |
-    rm -f featured.txt
-
 execute: |
     echo "List all featured snaps"
     expected='(?s).*Name +Version +Publisher +Notes +Summary *\n(.*?\n)?.*'

--- a/tests/main/seccomp-statx/task.yaml
+++ b/tests/main/seccomp-statx/task.yaml
@@ -1,16 +1,20 @@
 summary: the statx system call is not blocked by seccomp
+
 details: |
     The statx(2) system call is a relatively new addition and is not
     available on each kernel but should not be blocked by seccomp
     when the kernel implements it
+
 # This test will only pass on Ubuntu 18.10 and on other systems with seccomp
 # 2.3.3 or newer. Eventually with some tricks we should be able to support all
 # systems but for the purpose of snapd 2.36 this is the best we can do.
 systems: [ubuntu-18.10-*]
+
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-statx
+
 execute: |
     # Notably, this doesn't print statx: blocked anymore
     test-snapd-statx | MATCH 'statx: (supported|missing)'

--- a/tests/main/security-apparmor/task.yaml
+++ b/tests/main/security-apparmor/task.yaml
@@ -6,9 +6,6 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
 
-restore: |
-    rm -f touch.error
-
 execute: |
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0

--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -21,9 +21,6 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-event
 
-restore: |
-    rm -f call.error
-
 execute: |
     if [ -z "$(find /dev/input/by-path -name '*-event-kbd')" ]; then
         if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -12,7 +12,6 @@ prepare: |
     fi
 
 restore: |
-    rm -f info.txt
     if [ -e /dev/ttyS4.spread ]; then
         rm -f /dev/ttyS4 /dev/ttyS4.spread
     fi

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -20,7 +20,7 @@ prepare: |
     snap install --dangerous not-test-snapd-tools_1.0_all.snap
 
 restore: |
-    rm -rf not-test-snapd-tools_1.0_all.snap "$SNAP_INSTALL_DIR" /tmp/foo ./*stat.error
+    rm -rf "$SNAP_INSTALL_DIR" /tmp/foo
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/security-profiles/task.yaml
+++ b/tests/main/security-profiles/task.yaml
@@ -3,9 +3,6 @@ summary: Check security profile generation for apps and hooks.
 prepare: |
     snap pack "$TESTSLIB"/snaps/basic-hooks
 
-restore: |
-    rm -f basic-hooks_1.0_all.snap
-
 execute: |
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0

--- a/tests/main/security-udev-input-subsystem/task.yaml
+++ b/tests/main/security-udev-input-subsystem/task.yaml
@@ -16,9 +16,6 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-udev-input-subsystem
 
-restore: |
-    rm -f call.error
-
 execute: |
     if [ -z "$(find /dev/input/by-path -name '*-event-kbd')" ]; then
         if [ "$SPREAD_SYSTEM" = "ubuntu-16.04-64" ]; then

--- a/tests/main/server-snap/task.yaml
+++ b/tests/main/server-snap/task.yaml
@@ -28,9 +28,6 @@ prepare: |
     . "$TESTSLIB"/network.sh
     wait_listen_port "$PORT"
 
-restore: |
-    rm -f request.txt
-
 execute: |
     response=$(nc -w 5 -"$IP_VERSION" "$LOCALHOST" "$PORT" < request.txt)
 

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -40,8 +40,6 @@ prepare: |
     init_fake_refreshes "$BLOB_DIR" "$SNAP_NAME"
 
 restore: |
-    rm -f fake.store
-    rm -f stderr.out
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -14,7 +14,6 @@ restore: |
 
     echo "Restore current symlink"
     mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current ||  true
-    rm -f snap-confine.stderr
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/snap-core-fixup/task.yaml
+++ b/tests/main/snap-core-fixup/task.yaml
@@ -4,7 +4,6 @@ systems: [ubuntu-core-16-*]
 
 restore: |
     umount /boot/uboot
-    rm -f test.img
 
 execute: |
     echo "Ensure we have a clean and writable /boot/uboot to mess around"

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -1,8 +1,6 @@
 summary: Check that snap download works
 
 restore: |
-    rm -f ./*.snap
-    rm -f ./*.assert
     rm -f ~test/*.snap
     rm -f ~test/*.assert
 

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -17,9 +17,6 @@ prepare: |
     install_local_as test-snapd-tools "$NAME"
 
 restore: |
-    rm -f ./*.snap
-    rm -f ./*-vars.txt
-
     if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
         snap set system experimental.parallel-instances=null
     fi

--- a/tests/main/snap-get/task.yaml
+++ b/tests/main/snap-get/task.yaml
@@ -11,10 +11,6 @@ prepare: |
     snap pack "$TESTSLIB"/snaps/snapctl-hooks
     snap install --dangerous snapctl-hooks_1.0_all.snap
 
-restore: |
-    rm -f basic_1.0_all.snap
-    rm -f snapctl-hooks_1.0_all.snap
-
 execute: |
     echo "Test that snap get fails on a snap without any hooks"
     if output=$(snap get basic foo); then

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -9,10 +9,6 @@ prepare: |
     snap install test-snapd-tools
     snap install --channel beta --devmode test-snapd-devmode
 
-restore: |
-    rm -f basic_1.0_all.snap
-    rm -f out
-
 execute: |
     echo "With no arguments, errors out"
     ! snap info

--- a/tests/main/snap-interface/task.yaml
+++ b/tests/main/snap-interface/task.yaml
@@ -1,6 +1,8 @@
 summary: Check that "snap interface" works as expected
+
 details: |
     The "snap interface" command displays a listing of used interfaces
+
 execute: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
@@ -13,6 +15,4 @@ execute: |
     else
         diff -u out.yaml snap-interface-network-core.yaml
     fi
-restore: |
-    rm -f out.yaml
 

--- a/tests/main/snap-logs/task.yaml
+++ b/tests/main/snap-logs/task.yaml
@@ -9,9 +9,6 @@ prepare: |
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-service
 
-restore: |
-    rm -f service.log
-
 execute: |
     echo "check the logs are displayed by service-name and service-name.app"
     snap logs test-snapd-service | MATCH "running"

--- a/tests/main/snap-run-alias/task.yaml
+++ b/tests/main/snap-run-alias/task.yaml
@@ -18,8 +18,6 @@ restore: |
     . "$TESTSLIB"/dirs.sh
     rm -f $SNAP_MOUNT_DIR/bin/test_echo
     rm -f $SNAP_MOUNT_DIR/bin/test_cat
-    rm -f orig.txt
-    rm -f new.txt
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -11,10 +11,6 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-tools
 
-restore: |
-    rm -f orig.txt
-    rm -f new.txt
-
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -10,9 +10,6 @@ prepare: |
     install_local basic-run
     install_local test-snapd-tools
 
-restore: |
-    rm -f stdout stderr
-    
 debug:
     cat stderr
 

--- a/tests/main/snap-service-refresh-mode/task.yaml
+++ b/tests/main/snap-service-refresh-mode/task.yaml
@@ -5,9 +5,6 @@ backends: [-autopkgtest]
 
 kill-timeout: 5m
 
-restore:
-    rm -f ./*.pid || true
-
 debug: |
     grep -n '' ./*.pid || true
     systemctl status snap.test-snapd-service.test-snapd-endure-service || true

--- a/tests/main/snap-service-stop-mode/task.yaml
+++ b/tests/main/snap-service-stop-mode/task.yaml
@@ -9,7 +9,6 @@ systems: [-ubuntu-14.04-*]
 backends: [-autopkgtest]
 
 restore: |
-    rm -f ./*.pid || true
     # remove to ensure all services are stopped
     snap remove test-snapd-service || true
 

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -13,9 +13,6 @@ prepare: |
     echo "Build package with hook to run snapctl set"
     install_local snapctl-hooks
 
-restore: |
-    rm -f failing-config-hooks_1.0_all.snap
-
 execute: |
     echo "Test that snap set fails without configure hook"
     if snap set basic foo=bar; then

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -11,10 +11,6 @@ prepare: |
     . "$TESTSLIB"/random.sh
     kill_gpg_agent
 
-restore: |
-    rm -f pi3.model
-    rm -f pi3-model.json
-
 debug: |
     #shellcheck source=tests/lib/random.sh
     . "$TESTSLIB"/random.sh

--- a/tests/main/snapctl-configure-core/task.yaml
+++ b/tests/main/snapctl-configure-core/task.yaml
@@ -16,7 +16,6 @@ restore: |
     systemctl enable rsyslog.service
     systemctl start rsyslog.service
     rm -f /etc/systemd/login.conf.d/00-snap-core.conf
-    rm -f config.txt.save
 
 execute: |
     echo "Check that service disable works"

--- a/tests/main/snapctl-from-snap/task.yaml
+++ b/tests/main/snapctl-from-snap/task.yaml
@@ -9,9 +9,6 @@ prepare: |
     echo "Build basic test package"
     snap pack "$TESTSLIB"/snaps/snapctl-from-snap
 
-restore: |
-    rm -f snapctl-from-snap_1.0_all.snap
-
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -9,9 +9,6 @@ prepare: |
         snap alias test-snapd-curl.curl curl
     fi
 
-restore: |
-    rm -f snapctl-hooks_1.0_all.snap
-
 execute: |
     echo "Verify that snapctl -h runs without a context"
     if ! snapctl -h; then

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -60,7 +60,6 @@ restore: |
     rm -f /var/lib/snapd/seed/assertions/developer1-pc.model
     rm -f /var/lib/snapd/seed/assertions/testrootorg-store.account-key
     cp model.bak /var/lib/snapd/seed/assertions/model
-    rm -f ./*.bak
     # kick first boot again
     systemctl start snapd.service snapd.socket
     # wait for first boot to be done

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -93,7 +93,6 @@ restore: |
     rm -f /var/lib/snapd/seed/assertions/testrootorg-store.account-key
     rm -f /var/lib/snapd/seed/assertions/test-snapd-with-configure_*.assert
     cp model.bak /var/lib/snapd/seed/assertions/model
-    rm -f ./*.bak
     # kick first boot again
     systemctl start snapd.service snapd.socket
     # wait for first boot to be done

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -18,7 +18,6 @@ restore: |
     if [ -f curChg ] ; then
         snap abort "$(cat curChg)" || true
     fi
-    rm -f prevBoot nextBoot curChg
 
 prepare: |
     snap list | awk "/^core / {print(\$3)}" > nextBoot

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -9,9 +9,6 @@ environment:
 prepare: |
     snap pack "$TESTSLIB"/snaps/data-writer
 
-restore: |
-    rm -f data-writer_1.0_all.snap
-
 execute: |
     snap install --dangerous data-writer_1.0_all.snap
 

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -12,7 +12,6 @@ restore: |
     . "$TESTSLIB/dirs.sh"
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
-    rm -f dbus.env
     umount -f /usr/bin/xdg-open || true
     rm /usr/bin/xdg-open
     if [ -e /usr/bin/xdg-open.orig ]; then

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -12,7 +12,6 @@ restore: |
     . "$TESTSLIB/dirs.sh"
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
-    rm -f dbus.env
     umount -f /usr/bin/xdg-settings || true
     umount -f /usr/bin/zenity || true
 

--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -11,8 +11,6 @@ prepare: |
     create_nested_core_vm
 
 restore: |
-    rm -rf extra-snaps
-
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     destroy_nested_vm

--- a/tests/regression/lp-1618683/task.yaml
+++ b/tests/regression/lp-1618683/task.yaml
@@ -23,7 +23,6 @@ restore: |
     if [[ "$SPREAD_SYSTEM" == centos-* ]]; then
         # RHEL/Centos 7.4+ set this to 0 by default
         cat old_max_user_ns > /proc/sys/user/max_user_namespaces
-        rm -f old_max_user_ns
     fi
 
 execute: |

--- a/tests/regression/lp-1641885/task.yaml
+++ b/tests/regression/lp-1641885/task.yaml
@@ -23,9 +23,6 @@ execute: |
     echo "Ensure that the seccomp profile doesn't use the complain mode"
     MATCH -v '@complain' < /var/lib/snapd/seccomp/bpf/snap.test-snapd-devmode.test-snapd-devmode.src
 
-restore: |
-    rm -f ./test-snapd-devmode_1.0_all.snap
-
 debug: |
     echo "Apparmor profile (first 30 lines)"
     head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode || true


### PR DESCRIPTION
The idea of this change is to clean automatically the test directory during the restore step. With this change, it is not needed anymore to clean any change done in the test directory as it is also not needed to remove any snap.