### PR TITLE
 cmd: fix snap-device-helper to deal correctly with hooks 

### DIFF
--- a/cmd/snap-confine/snap-device-helper
+++ b/cmd/snap-confine/snap-device-helper
@@ -25,7 +25,11 @@ NOSNAP="${APPNAME#snap_}"
 # we need to make sure we change this to:
 # - "$snap_hook.$hookname"
 # - "$snap_$instance_hook.$hookname"
-if [ -z "${NOSNAP##*_hook_*}" ]; then
+if [ -z "${NOSNAP##*_hook_hook_*}" ]; then
+    # $instance is 'hook'; $snap_hook_hook.$hookname -> $snap_hook_hook.$hookname
+    NOSNAP="${NOSNAP%_hook_*}_hook.${NOSNAP#*_hook_hook_}"
+elif [ -z "${NOSNAP##*_hook_*}" ]; then
+    # $snap_$instance_hook_$hookname -> $snap_$instance_hook.$hookname
     NOSNAP="${NOSNAP%_hook_*}_hook.${NOSNAP#*_hook_}"
 fi
 

--- a/cmd/snap-confine/snap-device-helper
+++ b/cmd/snap-confine/snap-device-helper
@@ -18,6 +18,18 @@ MAJMIN="$4"
 NOSNAP="${APPNAME#snap_}"
 [ "$NOSNAP" != "$APPNAME" ] || { echo "malformed appname $APPNAME" >&2; exit 1; }
 
+# FIXME: this will break for instances that are called "hook" :(
+# Handle hooks first, the the nosnap part looks like this:
+# - "$snap_hook_$hookname"
+# - "$snap_$instance_hook_$hookname
+# we need to make sure we change this to:
+# - "$snap_hook.$hookname"
+# - "$snap_$instance_hook.$hookname"
+if [ -z "${NOSNAP##*_hook_*}" ]; then
+    NOSNAP="${NOSNAP%_hook_*}_hook.${NOSNAP#*_hook_}"
+fi
+
+# Now deal with app/instance untangling
 if [ "${NOSNAP#*_*_}" = "${NOSNAP}" ]; then
     # snap_<snap>_<app> -> snap.<snap>.<app>
     SNAPAPP="snap.${NOSNAP%_*}.${NOSNAP#*_}"

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -98,7 +98,10 @@ static int run_sdh(gchar * action,
 
 struct sdh_test_data {
 	char *action;
+        // snap.foo.bar
 	char *app;
+        // snap_foo_bar
+        char *mangled_appname;
 	char *file_with_data;
 	char *file_with_no_data;
 };
@@ -141,7 +144,7 @@ static void test_sdh_action(gconstpointer test_data)
 
 	g_assert_false(g_file_get_contents(without_data, &data, NULL, NULL));
 
-	ret = run_sdh(td->action, td->app, "/devices/foo/tty/ttyS0", "4:64");
+	ret = run_sdh(td->action, td->mangled_appname, "/devices/foo/tty/ttyS0", "4:64");
 	g_assert_cmpint(ret, ==, 0);
 	g_assert_true(g_file_get_contents(with_data, &data, NULL, NULL));
 	g_assert_cmpstr(data, ==, "c 4:64 rwm\n");
@@ -188,17 +191,21 @@ static void test_sdh_err(void)
 }
 
 static struct sdh_test_data add_data =
-    { "add", "snap.foo.bar", "devices.allow", "devices.deny" };
+    { "add", "snap.foo.bar", "snap_foo_bar", "devices.allow", "devices.deny" };
 static struct sdh_test_data change_data =
-    { "change", "snap.foo.bar", "devices.allow", "devices.deny" };
+    { "change", "snap.foo.bar", "snap_foo_bar", "devices.allow", "devices.deny" };
 static struct sdh_test_data remove_data =
-    { "remove", "snap.foo.bar", "devices.deny", "devices.allow" };
+    { "remove", "snap.foo.bar", "snap_foo_bar", "devices.deny", "devices.allow" };
 static struct sdh_test_data instance_add_data =
-    { "add", "snap.foo_bar.baz", "devices.allow", "devices.deny" };
+    { "add", "snap.foo_bar.baz", "snap_foo_bar_baz", "devices.allow", "devices.deny" };
 static struct sdh_test_data instance_change_data =
-    { "change", "snap.foo_bar.baz", "devices.allow", "devices.deny" };
+    { "change", "snap.foo_bar.baz", "snap_foo_bar_baz", "devices.allow", "devices.deny" };
 static struct sdh_test_data instance_remove_data =
-    { "remove", "snap.foo_bar.baz", "devices.deny", "devices.allow" };
+    { "remove", "snap.foo_bar.baz", "snap_foo_bar_baz", "devices.deny", "devices.allow" };
+static struct sdh_test_data add_hook_data =
+    { "add", "snap.foo.hook.configure", "snap_foo_hook_configure", "devices.allow", "devices.deny" };
+static struct sdh_test_data instance_add_hook_data =
+    { "add", "snap.foo_bar.hook.configure", "snap_foo_bar_hook_configure", "devices.allow", "devices.deny" };
 
 static void __attribute__ ((constructor)) init(void)
 {
@@ -216,4 +223,9 @@ static void __attribute__ ((constructor)) init(void)
 			     &instance_change_data, test_sdh_action);
 	g_test_add_data_func("/snap-device-helper/parallel/remove",
 			     &instance_remove_data, test_sdh_action);
+        // hooks
+	g_test_add_data_func("/snap-device-helper/hook/add",
+			     &add_hook_data, test_sdh_action);
+	g_test_add_data_func("/snap-device-helper/hook/parallel/add",
+			     &instance_add_hook_data, test_sdh_action);
 }

--- a/cmd/snap-confine/snap-device-helper-test.c
+++ b/cmd/snap-confine/snap-device-helper-test.c
@@ -206,6 +206,8 @@ static struct sdh_test_data add_hook_data =
     { "add", "snap.foo.hook.configure", "snap_foo_hook_configure", "devices.allow", "devices.deny" };
 static struct sdh_test_data instance_add_hook_data =
     { "add", "snap.foo_bar.hook.configure", "snap_foo_bar_hook_configure", "devices.allow", "devices.deny" };
+static struct sdh_test_data instance_add_instance_name_is_hook_data =
+    { "add", "snap.foo_hook.hook.configure", "snap_foo_hook_hook_configure", "devices.allow", "devices.deny" };
 
 static void __attribute__ ((constructor)) init(void)
 {
@@ -228,4 +230,6 @@ static void __attribute__ ((constructor)) init(void)
 			     &add_hook_data, test_sdh_action);
 	g_test_add_data_func("/snap-device-helper/hook/parallel/add",
 			     &instance_add_hook_data, test_sdh_action);
+	g_test_add_data_func("/snap-device-helper/hook-name-hook/parallel/add",
+			     &instance_add_instance_name_is_hook_data, test_sdh_action);
 }

--- a/tests/lib/snaps/test-snapd-with-configure-nc/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-with-configure-nc/meta/hooks/configure
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+echo "The hook can write to /dev/null" > /dev/null
+
+touch "$SNAP_COMMON"/configure-ran
+

--- a/tests/lib/snaps/test-snapd-with-configure-nc/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-with-configure-nc/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-with-configure-nc
+version: 1.0
+summary: Basic snap with a configure hook with network control
+description: A basic snap with a configure hook with network-control
+
+hooks:
+  configure:
+    plugs: [network-control]

--- a/tests/main/configure-hook-with-network-control/task.yaml
+++ b/tests/main/configure-hook-with-network-control/task.yaml
@@ -1,0 +1,23 @@
+summary: Check that snaps with configure work with network control
+
+description: |
+    Test for https://forum.snapcraft.io/t/9452
+
+execute: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    echo "Install test snap with configure hook and network-control"
+    install_local test-snapd-with-configure-nc
+
+    echo "Ensure configure was run fully"
+    test -e /var/snap/test-snapd-with-configure-nc/common/configure-ran
+    rm -f  /var/snap/test-snapd-with-configure-nc/common/configure-ran
+
+
+    echo "Now with the network-control plug"
+    snap connect test-snapd-with-configure-nc:network-control
+    snap set test-snapd-with-configure-nc foo=bar
+    
+    echo "Ensure configure was run fully"
+    test -e /var/snap/test-snapd-with-configure-nc/common/configure-ran


### PR DESCRIPTION
Our current snap-device-helper code does not correctly handle
hooks. The input for the snap-device-helper is an "APPANME"
that looks like "snap_$snapname_$appname". There are no "."
allowed in a udev tag. So this appname needs to be translated
back into the correct security tag, like: "snap.$snapname.$appname".

This works most of the time, however it does not for hooks. They
have the form "snap_$snapname_hook_$hookname" and the script
cannot transform them correctly. This PR fixes this in a simple
way.

One open question is what about instances that are called "hook".
Those will now be handled incorrectly.

This also adds a spread test for the bug that was mentioned in the
forum.