### PR TITLE
tests: fix install-snaps test by changing the snap info regex

### DIFF
--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -97,11 +97,11 @@ execute: |
     CHANNELS="stable candidate beta edge"
     for CHANNEL in $CHANNELS; do
         # shellcheck disable=SC2153
-        if ! CHANNEL_INFO="$(snap info "$SNAP" | grep " $CHANNEL: ")"; then
+        if ! CHANNEL_INFO="$(snap info --unicode=never "$SNAP" | grep " $CHANNEL: ")"; then
             echo "Snap $SNAP not found"
             exit
         fi
-        if echo "$CHANNEL_INFO" | MATCH "$CHANNEL:.*–"; then
+        if echo "$CHANNEL_INFO" | MATCH "$CHANNEL:.*--"; then
             continue
         fi
 


### PR DESCRIPTION
This regex is used to match the channel of the snap

google:ubuntu-16.04-64 .../tests/main/install-snaps# snap info
--unicode=never ia | grep -E "stable:.*--.*"
  stable:    --

error:
https://travis-ci.org/snapcore/spread-cron/builds/480186970#L6124
