### PR TITLE
tests: simplify interfaces-contacts-service test

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -66,27 +66,10 @@ execute: |
     END:VCARD
     EOF
 
-    test-snapd-eds.contacts load test-address-book << EOF
-    BEGIN:VCARD
-    VERSION:3.0
-    FN:John Doe
-    N:Doe;John;;;
-    EMAIL;type=WORK:john@example.com
-    END:VCARD
-    EOF
-
     echo "We can also retrieve those contacts"
     # Filter out ID and revision, which are unpredictable
     test-snapd-eds.contacts list test-address-book | sed -E 's/^(UID|REV):.*/\1:.../' > /tmp/contacts.vcf
     diff -uw - /tmp/contacts.vcf << EOF
-    BEGIN:VCARD
-    VERSION:3.0
-    FN:John Doe
-    N:Doe;John;;;
-    EMAIL;type=WORK:john@example.com
-    UID:...
-    REV:...
-    END:VCARD
     BEGIN:VCARD
     VERSION:3.0
     FN:Fred Smith


### PR DESCRIPTION
The idea is to avoid an sporadic issue when inserting 2 contacts to
fast.

The idea is to make this test similar to interfaces-calendar-service

See the error: https://paste.ubuntu.com/p/qrtCrpPYF4/
