### PR TITLE
interfaces: helpers for sorting plug/slot/connection refs

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -51,6 +51,14 @@ func (ref PlugRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
 }
 
+// SortsBefore returns true when plug should be sorted before the other
+func (ref PlugRef) SortsBefore(other PlugRef) bool {
+	if ref.Snap != other.Snap {
+		return ref.Snap < other.Snap
+	}
+	return ref.Name < other.Name
+}
+
 // Sanitize slot with a given snapd interface.
 func BeforePrepareSlot(iface Interface, slotInfo *snap.SlotInfo) error {
 	if iface.Name() != slotInfo.Interface {
@@ -73,6 +81,14 @@ type SlotRef struct {
 // String returns the "snap:slot" representation of a slot reference.
 func (ref SlotRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
+}
+
+// SortsBefore returns true when slot should be sorted before the other
+func (ref SlotRef) SortsBefore(other SlotRef) bool {
+	if ref.Snap != other.Snap {
+		return ref.Snap < other.Snap
+	}
+	return ref.Name < other.Name
 }
 
 // Interfaces holds information about a list of plugs, slots and their connections.
@@ -108,6 +124,14 @@ func NewConnRef(plug *snap.PlugInfo, slot *snap.SlotInfo) *ConnRef {
 // ID returns a string identifying a given connection.
 func (conn *ConnRef) ID() string {
 	return fmt.Sprintf("%s:%s %s:%s", conn.PlugRef.Snap, conn.PlugRef.Name, conn.SlotRef.Snap, conn.SlotRef.Name)
+}
+
+// SortsBefore returns true when connection should be sorted before the other
+func (conn *ConnRef) SortsBefore(other *ConnRef) bool {
+	if conn.PlugRef != other.PlugRef {
+		return conn.PlugRef.SortsBefore(other.PlugRef)
+	}
+	return conn.SlotRef.SortsBefore(other.SlotRef)
 }
 
 // ParseConnRef parses an ID string

--- a/interfaces/sorting.go
+++ b/interfaces/sorting.go
@@ -30,16 +30,7 @@ type byConnRef []*ConnRef
 func (c byConnRef) Len() int      { return len(c) }
 func (c byConnRef) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 func (c byConnRef) Less(i, j int) bool {
-	if c[i].PlugRef.Snap != c[j].PlugRef.Snap {
-		return c[i].PlugRef.Snap < c[j].PlugRef.Snap
-	}
-	if c[i].PlugRef.Name != c[j].PlugRef.Name {
-		return c[i].PlugRef.Name < c[j].PlugRef.Name
-	}
-	if c[i].SlotRef.Snap != c[j].SlotRef.Snap {
-		return c[i].SlotRef.Snap < c[j].SlotRef.Snap
-	}
-	return c[i].SlotRef.Name < c[j].SlotRef.Name
+	return c[i].SortsBefore(c[j])
 }
 
 type byPlugSnapAndName []*snap.PlugInfo

--- a/interfaces/sorting_test.go
+++ b/interfaces/sorting_test.go
@@ -70,3 +70,65 @@ func (s *SortingSuite) TestByConnRef(c *C) {
 		newConnRef("name-1_instance", "plug-1", "name-2", "slot-1"),
 	})
 }
+
+func newSlotRef(snap, name string) *interfaces.SlotRef {
+	return &interfaces.SlotRef{Snap: snap, Name: name}
+}
+
+type bySlotRef []*interfaces.SlotRef
+
+func (b bySlotRef) Len() int      { return len(b) }
+func (b bySlotRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b bySlotRef) Less(i, j int) bool {
+	return b[i].SortsBefore(*b[j])
+}
+
+func (s *SortingSuite) TestSortSlotRef(c *C) {
+	list := []*interfaces.SlotRef{
+		newSlotRef("name-2", "slot-3"),
+		newSlotRef("name-2_instance", "slot-1"),
+		newSlotRef("name-2", "slot-2"),
+		newSlotRef("name-2", "slot-4"),
+		newSlotRef("name-2", "slot-1"),
+	}
+	sort.Sort(bySlotRef(list))
+
+	c.Assert(list, DeepEquals, []*interfaces.SlotRef{
+		newSlotRef("name-2", "slot-1"),
+		newSlotRef("name-2", "slot-2"),
+		newSlotRef("name-2", "slot-3"),
+		newSlotRef("name-2", "slot-4"),
+		newSlotRef("name-2_instance", "slot-1"),
+	})
+}
+
+type byPlugRef []*interfaces.PlugRef
+
+func (b byPlugRef) Len() int      { return len(b) }
+func (b byPlugRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byPlugRef) Less(i, j int) bool {
+	return b[i].SortsBefore(*b[j])
+}
+
+func newPlugRef(snap, name string) *interfaces.PlugRef {
+	return &interfaces.PlugRef{Snap: snap, Name: name}
+}
+
+func (s *SortingSuite) TestSortPlugRef(c *C) {
+	list := []*interfaces.PlugRef{
+		newPlugRef("name-2", "plug-3"),
+		newPlugRef("name-2_instance", "plug-1"),
+		newPlugRef("name-2", "plug-4"),
+		newPlugRef("name-2", "plug-2"),
+		newPlugRef("name-2", "plug-1"),
+	}
+	sort.Sort(byPlugRef(list))
+
+	c.Assert(list, DeepEquals, []*interfaces.PlugRef{
+		newPlugRef("name-2", "plug-1"),
+		newPlugRef("name-2", "plug-2"),
+		newPlugRef("name-2", "plug-3"),
+		newPlugRef("name-2", "plug-4"),
+		newPlugRef("name-2_instance", "plug-1"),
+	})
+}


### PR DESCRIPTION
Add helpers for sorting slot/plug/connection refs.

Allows external packages to sort their collections without the necessity to
implement the actual ordering logic. Instead, it should be possible to directly
plug provided helpers into `sort.Interface.Less()`.

Also included in #6333 