### PR TITLE
tests: iterate getting journal logs to support delay on boards on daemon-notify test

### DIFF
--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -29,14 +29,14 @@ execute: |
 
     denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
     echo "Then after we restart the servive there is not denials"
+    snap start test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
-        if snap start test-snapd-daemon-notify.notify; then
+        denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+        if [ "$denials_before" -eq "$denials_after" ]; then
             break
         fi
         sleep 1
     done
-    denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
-
     [ "$denials_before" -eq "$denials_after" ]
 
     if [ "$(snap debug confinement)" = partial ] ; then
@@ -51,12 +51,12 @@ execute: |
 
     echo "Then the snap is not able to send notification messages"
     denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+    snap start test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
-        if snap start test-snapd-daemon-notify.notify; then
+        denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+        if [ "$denials_before" -ne "$denials_after" ]; then
             break
         fi
         sleep 1
     done
-    denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
-
     [ "$denials_before" -ne "$denials_after" ]

--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -32,7 +32,7 @@ execute: |
     snap start test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
         denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
-        if [ "$denials_before" -eq "$denials_after" ]; then
+        if [ "$denials_before" -ne "$denials_after" ]; then
             break
         fi
         sleep 1

--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -28,7 +28,7 @@ execute: |
     snap stop test-snapd-daemon-notify.notify
 
     denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
-    echo "Then after we restart the servive there is not denials"
+    echo "Then after we restart the service there are no denials"
     snap start test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
         denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"


### PR DESCRIPTION
The interfaces-daemon-notify test is sometimes failing due to in the boards like RPI it taks more time to write the journal logs and retrieve that info, so when we get the logs the "Permission denied" logs were not written down yet.

