### PR TITLE
tests: Use backend: [autopkgtest] for smoke test suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -602,6 +602,7 @@ suites:
     # tests there without running into timeouts.
     tests/smoke/:
         summary: Essenial system level tests for snapd
+        backends: [autopkgtest]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |


### PR DESCRIPTION
This is to avoid running the smoke test suite as part of other runs.
