### PR TITLE
packaging: make sure that /var/lib/snapd/lib/glvnd is accounted for

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -535,6 +535,7 @@ install -d -p %{buildroot}%{_sharedstatedir}/snapd/device
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/hostfs
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl32
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/glvnd
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/vulkan
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/mount
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/seccomp/bpf
@@ -723,6 +724,7 @@ popd
 %dir %{_sharedstatedir}/snapd/lib
 %dir %{_sharedstatedir}/snapd/lib/gl
 %dir %{_sharedstatedir}/snapd/lib/gl32
+%dir %{_sharedstatedir}/snapd/lib/glvnd
 %dir %{_sharedstatedir}/snapd/lib/vulkan
 %dir %{_sharedstatedir}/snapd/mount
 %dir %{_sharedstatedir}/snapd/seccomp

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -274,7 +274,7 @@ rm -f %{buildroot}%{_libexecdir}/snapd/system-shutdown
 # Install the directories that snapd creates by itself so that they can be a part of the package
 install -d %{buildroot}%{_sharedstatedir}/snapd/{assertions,cookie,desktop/applications,device,hostfs,mount,apparmor/profiles,seccomp/bpf,snaps}
 
-install -d %{buildroot}%{_sharedstatedir}/snapd/{lib/gl,lib/gl32,lib/vulkan}
+install -d %{buildroot}%{_sharedstatedir}/snapd/{lib/gl,lib/gl32,lib/glvnd,lib/vulkan}
 install -d %{buildroot}%{_localstatedir}/cache/snapd
 install -d %{buildroot}%{_datadir}/polkit-1/actions
 install -d %{buildroot}%{snap_mount_dir}/bin
@@ -372,6 +372,7 @@ fi
 %dir %{_sharedstatedir}/snapd/lib
 %dir %{_sharedstatedir}/snapd/lib/gl
 %dir %{_sharedstatedir}/snapd/lib/gl32
+%dir %{_sharedstatedir}/snapd/lib/glvnd
 %dir %{_sharedstatedir}/snapd/lib/vulkan
 %dir %{_localstatedir}/cache/snapd
 %dir %{_environmentdir}

--- a/packaging/ubuntu-14.04/snapd.dirs
+++ b/packaging/ubuntu-14.04/snapd.dirs
@@ -8,6 +8,7 @@ var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
+var/lib/snapd/lib/glvnd
 var/lib/snapd/lib/vulkan
 var/lib/snapd/snaps/partial
 var/lib/snapd/void

--- a/packaging/ubuntu-16.04/snapd.dirs
+++ b/packaging/ubuntu-16.04/snapd.dirs
@@ -8,6 +8,7 @@ var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
+var/lib/snapd/lib/glvnd
 var/lib/snapd/lib/vulkan
 var/lib/snapd/snaps/partial
 var/lib/snapd/void


### PR DESCRIPTION
`snap-confine` will automatically create `/var/lib/snapd/lib/glvnd`, so the change is merely letting the package manager know that the path is part of `snapd` package.