### PR TITLE
overlord/snapstate: use an ad-hoc error when no results

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4346,7 +4346,33 @@ func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
 	})
 
 	_, err := snapstate.Update(s.state, "some-snap", "channel-for-7", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, Equals, store.ErrNoUpdateAvailable)
+	c.Assert(err, Equals, snapstate.ErrStoreUnresponsive)
+}
+
+func (s *snapmgrTestSuite) TestUpdateNoStoreResultsWithChannelChange(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.ReplaceStore(s.state, noResultsStore{fakeStore: s.fakeStore})
+
+	// this is an atypical case in which the store didn't return
+	// an error nor a result, we are defensive and return
+	// a reasonable error
+	si := snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(7),
+	}
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Channel:  "channel-for-9",
+		Current:  si.Revision,
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "channel-for-7", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, Equals, snapstate.ErrStoreUnresponsive)
 }
 
 func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannel(c *C) {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -198,6 +198,8 @@ func preUpdateInfo(st *state.State, snapst *SnapState, amend bool, userID int) (
 	return curInfo, user, nil
 }
 
+var ErrStoreUnresponsive = fmt.Errorf("the store is unable to process the request at this time (try again later)")
+
 func singleActionResult(name, action string, results []*snap.Info, e error) (info *snap.Info, err error) {
 	if len(results) > 1 {
 		return nil, fmt.Errorf("internal error: multiple store results for a single snap op")
@@ -225,12 +227,7 @@ func singleActionResult(name, action string, results []*snap.Info, e error) (inf
 
 		// no result, atypical case
 		if saErr.NoResults {
-			switch action {
-			case "refresh":
-				return nil, store.ErrNoUpdateAvailable
-			case "install":
-				return nil, store.ErrSnapNotFound
-			}
+			return nil, ErrStoreUnresponsive
 		}
 	}
 


### PR DESCRIPTION
When a single action returned no results (typically because the store
was shedding load), we were handling it as a "snap not found" (when
installing) or as an "no updates available" (when refreshing).

This is bad because it can confuse the user (snaps suddenly
disappearing for install), but worse it can confuse snapd into
allowing a refresh to a non-existent channel.

This change makes it so that the user gets an error telling them to
try again later, instead. Only for the single action case; a
multi-refresh or -install retains the old behaviour (so automatic
refresh doesn't start erroring). This means multi-install or -refresh
can still be confusing, but we can dig into that one later.