### PR TITLE
spread: increase default kill-timeout to 30min

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -474,7 +474,7 @@ repack: |
         tar c current.delta >&4
     fi
 
-kill-timeout: 20m
+kill-timeout: 30m
 
 prepare: |
     # NOTE: This part of the code needs to be in spread.yaml as it runs before


### PR DESCRIPTION
On some arches like arm64 preparing the suite may take more than the
20min and the tests run into a timeout. This PR increases the
default kill time to 30min. We could also set it per backend, e.g.
just for "external" and "autopkgtest" but once we get direct spread
support for arm/arm64 we will hit this limit again so increasing
the global timeout seems best.
