### PR TITLE
run-checks: ensure we use go-1.10 if available

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -16,7 +16,7 @@ else
 fi
 COVERMODE=${COVERMODE:-atomic}
 
-# ensure we use go-1.0 by default
+# ensure we use go-1.10 by default
 export PATH=/usr/lib/go-1.10/bin:${PATH}
 
 # add workaround for https://github.com/golang/go/issues/24449

--- a/run-checks
+++ b/run-checks
@@ -16,6 +16,9 @@ else
 fi
 COVERMODE=${COVERMODE:-atomic}
 
+# ensure we use go-1.0 by default
+export PATH=/usr/lib/go-1.10/bin:${PATH}
+
 # add workaround for https://github.com/golang/go/issues/24449
 if [ "$(uname -m)" = "s390x" ]; then
     if go version | grep -q go1.10; then


### PR DESCRIPTION
The run-checks script must use go1.10 when its available. If
not it will FTBFS in the launchpad builders.
