### PR TITLE
tests: add spread test for system dbus interface

### DIFF
--- a/tests/lib/snaps/test-snapd-dbus-consumer/consumer.py
+++ b/tests/lib/snaps/test-snapd-dbus-consumer/consumer.py
@@ -2,9 +2,12 @@
 import dbus
 import sys
 
-def run():
-    obj = dbus.SessionBus().get_object("com.dbustest.HelloWorld", "/com/dbustest/HelloWorld")
+def run(bus):
+    obj = bus.get_object("com.dbustest.HelloWorld", "/com/dbustest/HelloWorld")
     print(obj.SayHello(dbus_interface="com.dbustest.HelloWorld"))
 
 if __name__ == "__main__":
-    sys.exit(run())
+    bus = dbus.SessionBus()
+    if sys.argv[1] == "system":
+        bus = dbus.SystemBus()
+    run(bus)

--- a/tests/lib/snaps/test-snapd-dbus-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-dbus-consumer/snapcraft.yaml
@@ -6,12 +6,19 @@ description: A basic snap declaring a plug on dbus
 apps:
     dbus-consumer:
         plugs: [dbus-test]
-        command: bin/consumer
+        command: bin/consumer session
+    dbus-system-consumer:
+        plugs: [dbus-system-test]
+        command: bin/consumer system
 
 plugs:
     dbus-test:
         interface: dbus
         bus: session
+        name: com.dbustest.HelloWorld
+    dbus-system-test:
+        interface: dbus
+        bus: system
         name: com.dbustest.HelloWorld
 
 parts:

--- a/tests/lib/snaps/test-snapd-dbus-provider/provider.py
+++ b/tests/lib/snaps/test-snapd-dbus-provider/provider.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import sys
 from gi.repository import GLib
 import dbus
 import dbus.service
@@ -8,8 +9,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
 
 class DBusProvider(dbus.service.Object):
-    def __init__(self):
-        bus = dbus.SessionBus()
+    def __init__(self, bus):
         bus_name = dbus.service.BusName("com.dbustest.HelloWorld", bus=bus)
         dbus.service.Object.__init__(self, bus_name, "/com/dbustest/HelloWorld")
 
@@ -19,6 +19,9 @@ class DBusProvider(dbus.service.Object):
         return "hello world"
 
 if __name__ == "__main__":
-    DBusProvider()
+    bus = dbus.SessionBus()
+    if sys.argv[1] == "system":
+        bus = dbus.SystemBus()
+    DBusProvider(bus)
     loop = GLib.MainLoop()
     loop.run()

--- a/tests/lib/snaps/test-snapd-dbus-provider/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-dbus-provider/snapcraft.yaml
@@ -7,11 +7,19 @@ apps:
     provider:
         command: wrapper
         slots: [dbus-test]
+    system-provider:
+        command: wrapper
+        daemon: simple
+        slots: [dbus-system-test]
 
 slots:
     dbus-test:
         interface: dbus
         bus: session
+        name: com.dbustest.HelloWorld
+    dbus-system-test:
+        interface: dbus
+        bus: system
         name: com.dbustest.HelloWorld
 
 parts:

--- a/tests/lib/snaps/test-snapd-dbus-provider/wrapper
+++ b/tests/lib/snaps/test-snapd-dbus-provider/wrapper
@@ -1,3 +1,7 @@
+#!/bin/sh
+
+set -e
+
 export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$(ls -d $SNAP/usr/lib/*/girepository-1.0)
 
-$SNAP/usr/bin/python3 $SNAP/provider.py
+$SNAP/usr/bin/python3 $SNAP/provider.py $@

--- a/tests/main/interfaces-system-dbus/task.yaml
+++ b/tests/main/interfaces-system-dbus/task.yaml
@@ -1,0 +1,37 @@
+summary: Ensure that the dbus interface works on the system bus.
+
+execute: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB/dirs.sh"
+
+    echo "Install dbus system test snaps"
+    snap install --edge test-snapd-dbus-provider
+    snap install --edge test-snapd-dbus-consumer
+
+    echo "Wait for dbus service to auto-start"
+    for _ in $(seq 60); do
+        if dbus-send --system --print-reply --dest=com.dbustest.HelloWorld /com/dbustest/HelloWorld com.dbustest.HelloWorld.SayHello | MATCH "hello world"; then
+            break
+        fi
+        sleep 1
+    done
+
+    echo "The dbus consumer plug is disconnected by default"
+    snap interfaces -i dbus | MATCH '^- +test-snapd-dbus-consumer:dbus-system-test'
+
+    if [ "$(snap debug confinement)" = partial ]; then
+        exit 0
+    fi
+
+    echo "And the consumer is not able to access the provided method"
+    if test-snapd-dbus-consumer.dbus-system-consumer 2> call.error; then
+        echo "Expected permission error calling dbus method with disconnected plug"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error
+
+    echo "When the plug is connected"
+    snap connect test-snapd-dbus-consumer:dbus-system-test test-snapd-dbus-provider:dbus-system-test
+
+    echo "Then the consumer is able to call the provided method"
+    test-snapd-dbus-consumer.dbus-system-consumer | MATCH "hello world"


### PR DESCRIPTION
We currently only test the dbus interface on the session bus and
also not on Ubuntu Core devices. There was a recent bugreport by
a customer about this interface and while we sort out the details
this should fill the gap in the testing we have.

