### PR TITLE
daemon: try to tidy up the icon stuff a little

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1618,21 +1618,29 @@ func unsafeReadSnapInfoImpl(snapPath string) (*snap.Info, error) {
 var unsafeReadSnapInfo = unsafeReadSnapInfoImpl
 
 func iconGet(st *state.State, name string) Response {
-	about, err := localSnapInfo(st, name)
+	st.Lock()
+	defer st.Unlock()
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(st, name, &snapst)
 	if err != nil {
-		if err == errNoSnap {
+		if err == state.ErrNoState {
 			return SnapNotFound(name, err)
 		}
-		return InternalError("%v", err)
+		return InternalError("cannot consult state: %v", err)
+	}
+	sideInfo := snapst.CurrentSideInfo()
+	if sideInfo == nil {
+		return NotFound("snap has no current revision")
 	}
 
-	path := filepath.Clean(snapIcon(about.info))
-	if !strings.HasPrefix(path, dirs.SnapMountDir) {
-		// XXX: how could this happen?
-		return BadRequest("requested icon is not in snap path")
+	icon := snapIcon(snap.MinimalPlaceInfo(name, sideInfo.Revision))
+
+	if icon == "" {
+		return NotFound("local snap has no icon")
 	}
 
-	return FileResponse(path)
+	return FileResponse(icon)
 }
 
 func appIconGet(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3236,7 +3236,7 @@ func (s *apiSuite) TestAppIconGetNoApp(c *check.C) {
 func (s *apiSuite) TestNotInstalledSnapIcon(c *check.C) {
 	info := &snap.Info{SuggestedName: "notInstalledSnap", Media: []snap.MediaInfo{{Type: "icon", URL: "icon.svg"}}}
 	iconfile := snapIcon(info)
-	c.Check(iconfile, testutil.Contains, "icon.svg")
+	c.Check(iconfile, check.Equals, "")
 }
 
 func (s *apiSuite) TestInstallOnNonDevModeDistro(c *check.C) {

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -39,11 +39,10 @@ import (
 var errNoSnap = errors.New("snap not installed")
 
 // snapIcon tries to find the icon inside the snap
-func snapIcon(info *snap.Info) string {
-	// XXX: copy of snap.Snap.Icon which will go away
+func snapIcon(info snap.PlaceInfo) string {
 	found, _ := filepath.Glob(filepath.Join(info.MountDir(), "meta", "gui", "icon.*"))
 	if len(found) == 0 {
-		return info.Media.IconURL()
+		return ""
 	}
 
 	return found[0]
@@ -358,7 +357,7 @@ func mapRemote(remoteSnap *snap.Info) *client.Snap {
 		Developer:    remoteSnap.Publisher.Username,
 		Publisher:    &publisher,
 		DownloadSize: remoteSnap.Size,
-		Icon:         snapIcon(remoteSnap),
+		Icon:         remoteSnap.Media.IconURL(),
 		ID:           remoteSnap.SnapID,
 		Name:         remoteSnap.InstanceName(),
 		Revision:     remoteSnap.Revision,


### PR DESCRIPTION
In looking through daemon to see about dropping some pre-1.9 support, I found some weirdness in the way we were handling icons:
* when serving the icon (for locally installed snaps), we'd glob for `.../meta/gui/icon.*` on the filesystem, which is correct, but if that was missing then we'd look in MediaInfo, and 400 if not there. MediaInfo will always be empty until something like #6034 lands, but even with that it would return a URL that's not "inside" the snap so that would 400 as well. Returning a "bad request" when the user just asked for an icon seems wrong, as well. Also, when getting the current snap we loaded the whole yaml from the snap instead of just the side info from state, when the icon isn't in the yaml (we need the state to get the revision, for installed-but-not-enabled snaps; otherwise we could just look in the filesystem and save 99% of the request time -- but the response is io-bound because we're sending an icon, so 🤷).
* when serving the icon URL for locally installed snaps we'd do the same glob-then-look-in-media-info as above. Until 6034, media info is always empty so that's unnecessary for now.
* when serving the icon URL for remote snaps, we'd first try the glob thing before looking in media info. For remote snaps, the filesystem is always the wrong place to look...

This change addresses all these.
