### PR TITLE
miscellaneous policy updates

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -638,6 +638,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # Allow reading /proc/version. For release.go WSL detection.
   @{PROC}/version r,
 
+  # Allow reading somaxconn, required in newer distro releases
+  @{PROC}/sys/net/core/somaxconn r,
+
   # Allow reading the os-release file (possibly a symlink to /usr/lib).
   /{etc/,usr/lib/}os-release r,
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -375,6 +375,9 @@ var defaultTemplate = `
   @{PROC}/net/dev r,
   @{PROC}/@{pid}/net/dev r,
 
+  # Read-only of this snap
+  /var/lib/snapd/snaps/@{SNAP_NAME}_*.snap r,
+
   # Read-only for the install directory
   # bind mount used here (see 'parallel installs', above)
   @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/                   r,

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -43,6 +43,7 @@ const cameraConnectedPlugAppArmor = `
 /sys/devices/pci**/usb*/**/modalias r,
 /sys/devices/pci**/usb*/**/speed r,
 /run/udev/data/c81:[0-9]* r, # video4linux (/dev/video*, etc)
+/run/udev/data/+usb:* r,
 /sys/class/video4linux/ r,
 /sys/devices/pci**/usb*/**/video4linux/** r,
 `

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -78,12 +78,16 @@ dbus (bind)
     bus=###DBUS_BUS###
     name=###DBUS_NAME###,
 
-# For KDE applications, also support alternation since they use org.kde.foo-PID
-# as their 'well-known' name. snapd does not allow declaring a 'well-known'
-# name that ends with '-[0-9]+', so this is ok.
+# For KDE applications and some other cases, also support alternation for:
+# - using org.kde.foo-PID as the 'well-known' name
+# - using org.foo.cmd_<num>_<num> as the 'well-known' name
+# Note, snapd does not allow declaring a 'well-known' name that ends with
+# '-[0-9]+' or that contains '_'. Parallel installs of DBus services aren't
+# supported at this time, but if they were, this could allow a parallel
+# install'swell-known name to overlap with the normal install.
 dbus (bind)
     bus=###DBUS_BUS###
-    name=###DBUS_NAME###-[1-9]{,[0-9]}{,[0-9]}{,[0-9]}{,[0-9]}{,[0-9]},
+    name=###DBUS_NAME###{_,-}[1-9]{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9]}{,_[1-9]{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9_]}{,[0-9]}},
 
 # Allow us to talk to dbus-daemon
 dbus (receive)

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -82,7 +82,7 @@ audit deny @{HOME}/bin/{,**} wl,
 
 const homeConnectedPlugAppArmorWithAllRead = `
 # Allow non-owner read to non-hidden and non-snap files and directories
-capability dac_override,
+capability dac_read_search,
 @{HOME}/               r,
 @{HOME}/[^s.]**        r,
 @{HOME}/s[^n]**        r,

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -82,6 +82,7 @@ audit deny @{HOME}/bin/{,**} wl,
 
 const homeConnectedPlugAppArmorWithAllRead = `
 # Allow non-owner read to non-hidden and non-snap files and directories
+capability dac_override,
 @{HOME}/               r,
 @{HOME}/[^s.]**        r,
 @{HOME}/s[^n]**        r,

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -59,7 +59,7 @@ const pulseaudioConnectedPlugAppArmorDesktop = `
 # to read available client side configuration settings. On an Ubuntu Core
 # device those things will be stored inside the snap directory.
 /etc/pulse/ r,
-/etc/pulse/* r,
+/etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
 owner /{,var/}run/user/*/pulse/ rwk,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -42,6 +42,7 @@ const systemObserveConnectedPlugAppArmor = `
 ptrace (read),
 
 # Other miscellaneous accesses for observing the system
+@{PROC}/locks r,
 @{PROC}/modules r,
 @{PROC}/stat r,
 @{PROC}/vmstat r,

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -337,6 +337,8 @@ _newselect
 pselect
 pselect6
 
+# Allow use of SysV semaphores. Note that allocated resources are not freed by
+# OOM which can lead to global kernel resource leakage.
 semctl
 semget
 semop


### PR DESCRIPTION
* interfaces/system-observe: allow read on /proc/locks
* allow reading one's own snap by default
* allow reading /proc/sys/net/core/somaxconn in snap-update-ns template
* interfaces/pulseaudio: allow reading subdirectories of /etc/pulse
* add comment on SysV IPC
* interfaces/home: allow dac_read_search with 'read: all'
* interfaces/dbus: be less strict about alternations for well-known names
* interfaces/camera: allow reading vendor/etc info from /run/udev/data/+usb:*