### PR TITLE
spread: enable upgrade suite on fedora

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -117,8 +117,6 @@ backends:
                 workers: 1
             - fedora-29-64:
                 workers: 1
-                # https://twitter.com/zygoon/status/1073629342884864000
-                manual: true
             - arch-linux-64:
                 workers: 1
             - amazon-linux-2-64:


### PR DESCRIPTION
The split to `google-upgrade` backend must have been opened right before we reenabled the main suite to run on Fedora 29.
