### PR TITLE
tests/prepare: prevent console-conf from running

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -536,6 +536,10 @@ EOF
     # the writeable-path sync-boot won't work
     mkdir -p /mnt/system-data/etc/systemd
 
+    # we do not need console-conf, so prevent it from running
+    mkdir -p /mnt/system-data/var/lib/console-conf
+    touch /mnt/system-data/var/lib/console-conf/complete
+
     (cd /tmp ; unsquashfs -no-progress -v  /var/lib/snapd/snaps/"$core_name"_*.snap etc/systemd/system)
     cp -avr /tmp/squashfs-root/etc/systemd/system /mnt/system-data/etc/systemd/
     umount /mnt


### PR DESCRIPTION
console-conf is started at boot but keeps on failing in core18 nodes:
```
systemd[1]: serial-console-conf@ttyS0.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: serial-console-conf@ttyS0.service: Failed with result 'exit-code'.                                                               Jan 24 09:22:42 jan240849-958063 systemd[1]: serial-console-conf@ttyS0.service: Service has no hold-off time, scheduling restart.
systemd[1]: serial-console-conf@ttyS0.service: Scheduled restart job, restart counter is at 172.                                             Jan 24 09:22:42 jan240849-958063 systemd[1]: Stopped Ubuntu Core Firstboot Configuration ttyS0.
systemd[1]: Started Ubuntu Core Firstboot Configuration ttyS0.                                                                               Jan 24 09:22:43 jan240849-958063 systemd[1]: serial-console-conf@ttyS0.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: serial-console-conf@ttyS0.service: Failed with result 'exit-code'.
systemd[1]: serial-console-conf@ttyS0.service: Service has no hold-off time, scheduling restart.
systemd[1]: serial-console-conf@ttyS0.service: Scheduled restart job, restart counter is at 173.
systemd[1]: Stopped Ubuntu Core Firstboot Configuration ttyS0.
systemd[1]: Started Ubuntu Core Firstboot Configuration ttyS0.
systemd[1]: serial-console-conf@ttyS0.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: serial-console-conf@ttyS0.service: Failed with result 'exit-code'.
systemd[1]: serial-console-conf@ttyS0.service: Service has no hold-off time, scheduling restart.
systemd[1]: serial-console-conf@ttyS0.service: Scheduled restart job, restart counter is at 174.
systemd[1]: Stopped Ubuntu Core Firstboot Configuration ttyS0.
systemd[1]: Started Ubuntu Core Firstboot Configuration ttyS0.
```
Since starting and stopping the service is already systemd activity, and the
service itself triggers more stop/start actions in ExecStart{Pre,Post}, it is
suspected that it may be causing spurious mount protocol-errors we have seen
previously.
