### PR TITLE
tests/main/searching: video section got renamed to photo-and-video

### DIFF
--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -51,7 +51,10 @@ execute: |
     if [ "$(uname -m)" = "x86_64" ]; then
         snap find --section=photo-and-video vlc | MATCH vlc
     else
-        snap find --section=photo-and-video vlc 2>&1 | MATCH 'No matching snaps'
+        # actual output:
+        # Name           Version  Publisher  Notes  Summary
+        # mjpg-streamer  2.0      ogra       -      UVC webcam streaming tool
+        snap find --section=photo-and-video vlc 2>&1 | MATCH -v vlc
     fi
 
     # LP: 1740605

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -49,9 +49,9 @@ execute: |
     # TODO: discuss with the store how we can make this test stable, i.e.
     #       that section/snap changes do not break us
     if [ "$(uname -m)" = "x86_64" ]; then
-        snap find --section=video vlc | MATCH vlc
+        snap find --section=photo-and-video vlc | MATCH vlc
     else
-        snap find --section=video vlc 2>&1 | MATCH 'No matching snaps'
+        snap find --section=photo-and-video vlc 2>&1 | MATCH 'No matching snaps'
     fi
 
     # LP: 1740605


### PR DESCRIPTION
The 'video' section is no more and it has been apparently renamed to
'photo-and-video'.

