### PR TITLE
tests: remove -o pipefail

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -4,9 +4,6 @@ set -x
 # statements we execute stops the build. The code is not (yet) written to
 # handle errors in general.
 set -e
-# Set pipefail option so that "foo | bar" behaves with fewer surprises by
-# failing if foo fails, not just if bar fails.
-set -o pipefail
 
 # shellcheck source=tests/lib/quiet.sh
 . "$TESTSLIB/quiet.sh"


### PR DESCRIPTION
The `-o pipefail` option can have some unexpected side-effects
which are counter-intuitive and hard to debug/understand:

With SIGPIPE and "echo | grep -q" there is a race condition. If
grep exists before echo is finished writing data then echo will
get a SIGPIPE and this makes MATCH fail (which is very obscure
to the user). We use "echo | grep" e.g. in check_journalctl_log
and this failed in the new debian-sid suite.

I just spend half a morning on this, let's not waste more time
because of this very obscure "feature".