### PR TITLE
interfaces: add yubikey interface and allow reading /run/udev/data/+power_supply:*

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -57,6 +57,7 @@ capability sys_admin,
 
 # power information
 /sys/power/{,**} r,
+/run/udev/data/+power_supply:* r,
 
 # interrupts
 @{PROC}/interrupts r,

--- a/interfaces/builtin/yubikey.go
+++ b/interfaces/builtin/yubikey.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/udev"
+)
+
+const yubikeySummary = `allows access to yubikey devices`
+
+const yubikeyBaseDeclarationSlots = `
+  yubikey:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+type yubikeyDevice struct {
+	VendorId, ProductId string
+}
+
+// https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules
+var yubikeyDevices = map[string]yubikeyDevice{
+	"Yubico YubiKey": {VendorId: "1050",
+		ProductId: "0113|0114|0115|0116|0120|0200|0402|0403|0406|0407|0410",
+	},
+	"Happlink (formerly Plug-Up) Security KEY": {VendorId: "2581",
+		ProductId: "f1d0",
+	},
+	"Neowave Keydo and Keydo AES": {VendorId: "1e0d",
+		ProductId: "f1d0|f1ae",
+	},
+	"HyperSecu HyperFIDO": {VendorId: "096e|2ccf",
+		ProductId: "0880",
+	},
+	"Feitian ePass FIDO, BioPass FIDO2": {VendorId: "096e",
+		ProductId: "0850|0852|0853|0854|0856|0858|085a|085b|085d",
+	},
+	"JaCarta U2F": {VendorId: "24dc",
+		ProductId: "0101",
+	},
+	"U2F Zero": {VendorId: "10c4",
+		ProductId: "8acf",
+	},
+	"VASCO SeccureClick": {VendorId: "1a44",
+		ProductId: "00bb",
+	},
+	"Bluink Key": {VendorId: "2abe",
+		ProductId: "1002",
+	},
+	"Thetis Key": {VendorId: "1ea8",
+		ProductId: "f025",
+	},
+	"Nitrokey FIDO U2F": {VendorId: "20a0",
+		ProductId: "4287",
+	},
+	"Google Titan U2F": {VendorId: "18d1",
+		ProductId: "5026",
+	},
+	"Tomu board + chopstx U2F": {VendorId: "0483",
+		ProductId: "cdab",
+	},
+}
+
+const yubikeyConnectedPlugAppArmor = `
+# Description: Allow write access to yubikey hidraw devices.
+
+# Use a glob rule and rely on device cgroup for mediation.
+/dev/hidraw* rw,
+
+# char 234-254 are used for dynamic assignment, which yubikeys are
+/run/udev/data/c23[4-9]:* r,
+/run/udev/data/c24[0-9]:* r,
+/run/udev/data/c25[0-4]:* r,
+
+# misc required accesses
+/run/udev/data/+power_supply:hid* r,
+/run/udev/data/c14:[0-9]* r,
+/sys/devices/**/usb*/**/report_descriptor r,
+`
+
+type yubikeyInterface struct {
+	commonInterface
+}
+
+func (iface *yubikeyInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	for name := range yubikeyDevices {
+		spec.TagDevice(fmt.Sprintf("# %s\nSUBSYSTEM==\"hidraw\", KERNEL==\"hidraw*\", ATTRS{idVendor}==\"%s\", ATTRS{idProduct}==\"%s\"", name, yubikeyDevices[name].VendorId, yubikeyDevices[name].ProductId))
+	}
+	return nil
+}
+
+func init() {
+	registerIface(&yubikeyInterface{commonInterface{
+		name:                  "yubikey",
+		summary:               yubikeySummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  yubikeyBaseDeclarationSlots,
+		connectedPlugAppArmor: yubikeyConnectedPlugAppArmor,
+		reservedForOS:         true,
+	}})
+}

--- a/interfaces/builtin/yubikey_test.go
+++ b/interfaces/builtin/yubikey_test.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type yubikeyInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&yubikeyInterfaceSuite{
+	iface: builtin.MustInterface("yubikey"),
+})
+
+const yubikeyConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [yubikey]
+`
+
+const yubikeyCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  yubikey:
+`
+
+func (s *yubikeyInterfaceSuite) SetUpTest(c *C) {
+	//s.BaseTest.SetUpTest(c)
+
+	s.plug, s.plugInfo = MockConnectedPlug(c, yubikeyConsumerYaml, nil, "yubikey")
+	s.slot, s.slotInfo = MockConnectedSlot(c, yubikeyCoreYaml, nil, "yubikey")
+}
+
+func (s *yubikeyInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "yubikey")
+}
+
+func (s *yubikeyInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "yubikey",
+		Interface: "yubikey",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, "yubikey slots are reserved for the core snap")
+}
+
+func (s *yubikeyInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *yubikeyInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allow write access to yubikey hidraw devices.`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/hidraw* rw,`)
+}
+
+func (s *yubikeyInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 14)
+	c.Assert(spec.Snippets(), testutil.Contains, `# yubikey
+# Yubico YubiKey
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
+}
+
+func (s *yubikeyInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to yubikey devices`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "yubikey")
+}
+
+func (s *yubikeyInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *yubikeyInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -356,6 +356,9 @@ apps:
   x11:
     command: bin/run
     plugs: [ x11 ]
+  yubikey:
+    command: bin/run
+    plugs: [ yubikey ]
 
 plugs:
   browser-sandbox:


### PR DESCRIPTION
* interfaces: add yubikey interface
    
    Yubikey devices either show up as hidraw devices or keyboard devices.
    This adds support for hidraw devices based on the list of hardware from:
    
    https://support.yubico.com/support/solutions/articles/15000006449-using-your-u2f-yubikey-with-linux
    
    Since there are many different kinds of hidraw devices, use an apparmor
    glob rule but selectively udev tag devices based on the list of upstream
    vendor and product IDs. In this manner, connected snaps only have access
    to the yubikey hidraw devices. A future PR may add support for yubikey
    keyboard devices (which simply show up as a evdev keyboards).

* interfaces/hardware-observe: allow reading /run/udev/data/+power_supply:*

Note the change to hardware-observe is the general rule for `+power_supply` whereas the the one in yubikey is a hid device rule for `+power_supply`. I could split the hardware-observe into a separate PR, but it was so small I just did it here.