### PR TITLE
cmd/snap-confine: refactor and cleanup of seccomp loading

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -54,7 +54,10 @@ check-unit-tests:
 	echo "unit tests are disabled (rebuild with --enable-unit-tests)"
 endif
 
-new_format = snap-discard-ns/snap-discard-ns.c
+new_format = \
+	 snap-confine/seccomp-support-ext.c \
+	 snap-confine/seccomp-support-ext.h \
+	 snap-discard-ns/snap-discard-ns.c
 .PHONY: fmt
 fmt:: $(filter     $(addprefix %,$(new_format)),$(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch])))
 	clang-format -style='{BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 120}' -i $^
@@ -254,6 +257,8 @@ snap_confine_snap_confine_LDFLAGS += $(SUID_LDFLAGS)
 
 if SECCOMP
 snap_confine_snap_confine_SOURCES += \
+	snap-confine/seccomp-support-ext.c \
+	snap-confine/seccomp-support-ext.h \
 	snap-confine/seccomp-support.c \
 	snap-confine/seccomp-support.h
 snap_confine_snap_confine_CFLAGS += $(SECCOMP_CFLAGS)

--- a/cmd/snap-confine/seccomp-support-ext.c
+++ b/cmd/snap-confine/seccomp-support-ext.c
@@ -36,9 +36,9 @@
 
 #ifndef seccomp
 // prototype because we build with -Wstrict-prototypes
-int sys_seccomp(unsigned int operation, unsigned int flags, void *args);
+int seccomp(unsigned int operation, unsigned int flags, void *args);
 
-int sys_seccomp(unsigned int operation, unsigned int flags, void *args) {
+int seccomp(unsigned int operation, unsigned int flags, void *args) {
     errno = 0;
     return syscall(__NR_seccomp, operation, flags, args);
 }
@@ -89,7 +89,7 @@ void sc_apply_seccomp_filter(struct sock_fprog *prog) {
     // adjust their sandbox if they have CAP_SYS_ADMIN or, if running on < 4.8
     // kernels, break out of the seccomp via ptrace. Both CAP_SYS_ADMIN and
     // 'ptrace (trace)' are blocked by AppArmor with typical snappy interfaces.
-    err = sys_seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, prog);
+    err = seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, prog);
     if (err != 0) {
         /* The profile may fail to load using the "modern" interface.
          * In such case use the older prctl-based interface instead. */

--- a/cmd/snap-confine/seccomp-support-ext.c
+++ b/cmd/snap-confine/seccomp-support-ext.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "seccomp-support-ext.h"
+
+#include <errno.h>
+#include <linux/seccomp.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../libsnap-confine-private/utils.h"
+
+#ifndef SECCOMP_FILTER_FLAG_LOG
+#define SECCOMP_FILTER_FLAG_LOG 2
+#endif
+
+#ifndef seccomp
+// prototype because we build with -Wstrict-prototypes
+int sys_seccomp(unsigned int operation, unsigned int flags, void *args);
+
+int sys_seccomp(unsigned int operation, unsigned int flags, void *args) {
+    errno = 0;
+    return syscall(__NR_seccomp, operation, flags, args);
+}
+#endif
+
+void sc_apply_seccomp_filter(struct sock_fprog *prog) {
+    uid_t real_uid, effective_uid, saved_uid;
+    int err;
+
+    if (getresuid(&real_uid, &effective_uid, &saved_uid) < 0) {
+        die("cannot call getresuid");
+    }
+
+    // If we can, raise privileges so that we can load the BPF into the kernel
+    // via 'prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ...)'.
+    debug("raising privileges to load seccomp profile");
+    if (effective_uid != 0 && saved_uid == 0) {
+        if (seteuid(0) != 0) {
+            die("seteuid failed");
+        }
+        if (geteuid() != 0) {
+            die("raising privs before seccomp_load did not work");
+        }
+    }
+
+    // Load filter into the kernel.
+    //
+    // Importantly we are intentionally *not* setting NO_NEW_PRIVS because it
+    // interferes with exec transitions in AppArmor with certain snappy
+    // interfaces. Not setting NO_NEW_PRIVS does mean that applications can
+    // adjust their sandbox if they have CAP_SYS_ADMIN or, if running on < 4.8
+    // kernels, break out of the seccomp via ptrace. Both CAP_SYS_ADMIN and
+    // 'ptrace (trace)' are blocked by AppArmor with typical snappy interfaces.
+    err = sys_seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, prog);
+    if (err != 0) {
+        /* The profile may fail to load using the "modern" interface.
+         * In such case use the older prctl-based interface instead. */
+        switch (errno) {
+            case ENOSYS:
+                debug("kernel doesn't support the seccomp(2) syscall");
+                break;
+            case EINVAL:
+                debug("kernel may not support the SECCOMP_FILTER_FLAG_LOG flag");
+                break;
+        }
+        debug("falling back to prctl(2) syscall to load seccomp filter");
+        err = prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+        if (err != 0) {
+            die("cannot apply seccomp profile");
+        }
+    }
+
+    /* Drop privileges again. */
+    debug("dropping privileges after loading seccomp profile");
+    if (geteuid() == 0) {
+        unsigned real_uid = getuid();
+        if (seteuid(real_uid) != 0) {
+            die("seteuid failed");
+        }
+        if (real_uid != 0 && geteuid() == 0) {
+            die("dropping privs after seccomp_load did not work");
+        }
+    }
+}

--- a/cmd/snap-confine/seccomp-support-ext.c
+++ b/cmd/snap-confine/seccomp-support-ext.c
@@ -102,7 +102,7 @@ void sc_apply_seccomp_filter(struct sock_fprog *prog) {
                 break;
         }
         debug("falling back to prctl(2) syscall to load seccomp filter");
-        err = prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+        err = prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, prog);
         if (err != 0) {
             die("cannot apply seccomp profile");
         }

--- a/cmd/snap-confine/seccomp-support-ext.h
+++ b/cmd/snap-confine/seccomp-support-ext.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef SNAP_CONFINE_SECCOMP_SUPPORT_EXT_H
+#define SNAP_CONFINE_SECCOMP_SUPPORT_EXT_H
+
+#include <linux/filter.h>
+
+/**
+ * Apply a given bpf program as a seccomp system call filter.
+ **/
+void sc_apply_seccomp_filter(struct sock_fprog *prog);
+
+#endif

--- a/cmd/snap-confine/seccomp-support-ext.h
+++ b/cmd/snap-confine/seccomp-support-ext.h
@@ -18,6 +18,9 @@
 #define SNAP_CONFINE_SECCOMP_SUPPORT_EXT_H
 
 #include <linux/filter.h>
+#include <stddef.h>
+
+size_t sc_read_seccomp_filter(const char *filename, char *buf, size_t buf_size);
 
 /**
  * Apply a given bpf program as a seccomp system call filter.

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -144,8 +144,7 @@ bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
 		sleep(1);
 	}
 
-	/* TODO: replace this with descending open/openat with validation callback
-	 * that returns a path descriptor to avoid TOCTOU */
+	// TODO: move over to open/openat as an additional hardening measure.
 
 	// validate '/' down to profile_path are root-owned and not
 	// 'other' writable to avoid possibility of privilege
@@ -173,8 +172,7 @@ void sc_apply_global_seccomp_profile(void)
 	if (access(profile_path, F_OK) != 0) {
 		return;
 	}
-	/* TODO: replace this with descending open/openat with validation callback
-	 * that returns a path descriptor to avoid TOCTOU */
+	// TODO: move over to open/openat as an additional hardening measure.
 	validate_bpfpath_is_safe(profile_path);
 
 	char bpf[MAX_BPF_SIZE + 1] = { 0 };

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -165,3 +165,23 @@ void sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
 	sc_apply_seccomp_filter(&prog);
 	return;
 }
+
+void sc_apply_global_seccomp_profile(void)
+{
+	const char *profile_path = "/var/lib/snapd/seccomp/bpf/global.bin";
+	/* The profile may be absent. */
+	if (access(profile_path, F_OK) != 0) {
+		return;
+	}
+	/* TODO: replace this with descending open/openat with validation callback
+	 * that returns a path descriptor to avoid TOCTOU */
+	validate_bpfpath_is_safe(profile_path);
+
+	char bpf[MAX_BPF_SIZE + 1] = { 0 };
+	size_t num_read = sc_read_seccomp_filter(profile_path, bpf, sizeof bpf);
+	struct sock_fprog prog = {
+		.len = num_read / sizeof(struct sock_filter),
+		.filter = (struct sock_filter *)bpf,
+	};
+	sc_apply_seccomp_filter(&prog);
+}

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -109,13 +109,13 @@ static void validate_bpfpath_is_safe(const char *path)
 	}
 }
 
-int sc_apply_seccomp_bpf(const char *filter_profile)
+void sc_apply_seccomp_bpf(const char *security_tag)
 {
-	debug("loading bpf program for security tag %s", filter_profile);
+	debug("loading bpf program for security tag %s", security_tag);
 
 	char profile_path[PATH_MAX] = { 0 };
 	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin",
-			 filter_profile_dir, filter_profile);
+			 filter_profile_dir, security_tag);
 
 	// Wait some time for the security profile to show up. When
 	// the system boots snapd will created security profiles, but
@@ -168,7 +168,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	debug("read %zu bytes from %s", num_read, profile_path);
 
 	if (sc_streq(bpf, "@unrestricted\n")) {
-		return 0;
+		return;
 	}
 
 	struct sock_fprog prog = {
@@ -176,5 +176,5 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 		.filter = (struct sock_filter *)bpf,
 	};
 	sc_apply_seccomp_filter(&prog);
-	return 0;
+	return;
 }

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -109,7 +109,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	}
 }
 
-void sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
+bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
 {
 	debug("loading bpf program for security tag %s", security_tag);
 
@@ -156,14 +156,14 @@ void sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
 	char bpf[MAX_BPF_SIZE + 1] = { 0 };	// account for EOF
 	size_t num_read = sc_read_seccomp_filter(profile_path, bpf, sizeof bpf);
 	if (sc_streq(bpf, "@unrestricted\n")) {
-		return;
+		return false;
 	}
 	struct sock_fprog prog = {
 		.len = num_read / sizeof(struct sock_filter),
 		.filter = (struct sock_filter *)bpf,
 	};
 	sc_apply_seccomp_filter(&prog);
-	return;
+	return true;
 }
 
 void sc_apply_global_seccomp_profile(void)

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -144,6 +144,9 @@ void sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
 		sleep(1);
 	}
 
+	/* TODO: replace this with descending open/openat with validation callback
+	 * that returns a path descriptor to avoid TOCTOU */
+
 	// validate '/' down to profile_path are root-owned and not
 	// 'other' writable to avoid possibility of privilege
 	// escalation via bpf program load when paths are incorrectly

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -109,7 +109,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	}
 }
 
-void sc_apply_seccomp_bpf(const char *security_tag)
+void sc_apply_seccomp_profile_for_security_tag(const char *security_tag)
 {
 	debug("loading bpf program for security tag %s", security_tag);
 

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -20,8 +20,26 @@
 #include <seccomp.h>
 
 /** 
- * Load and apply the seccomp bpf filter for the given security tag.
+ * sc_apply_seccomp_profile_for_security_tag applies a seccomp profile to the
+ * current process. The filter is loaded from a pre-compiled bpf bytecode
+ * stored in "/var/lib/snap/seccomp/bpf" using the security tag and the
+ * extension ".bin". All components along that path must be owned by root and
+ * cannot be writable by UNIX _other_.
+ *
+ * The security tag is shared with other parts of snapd.
+ * For applications it is the string "snap.${SNAP_INSTANCE_NAME}.${app}".
+ * For hooks it is "snap.${SNAP_INSTANCE_NAME}.hook.{hook_name}".
+ *
+ * Profiles must be present in the file-system. If a profile is not present
+ * then several attempts are made, each coupled with a sleep period. Up 3600
+ * seconds may elapse before the function gives up. Unless
+ * $SNAP_CONFINE_MAX_PROFILE_WAIT environment variable dictates otherwise, the
+ * default wait time is 120 seconds.
+ *
+ * A profile may contain valid BPF program or the string "@unrestricted\n".  In
+ * the former case the profile is applied to the current process using
+ * sc_apply_seccomp_filter. In the latter case no action takes place.
  **/
-void sc_apply_seccomp_bpf(const char *security_tag);
+void sc_apply_seccomp_profile_for_security_tag(const char *security_tag);
 
 #endif

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -20,9 +20,8 @@
 #include <seccomp.h>
 
 /** 
- * Load and apply the given bpf program
- *
+ * Load and apply the seccomp bpf filter for the given security tag.
  **/
-int sc_apply_seccomp_bpf(const char *filter_profile);
+void sc_apply_seccomp_bpf(const char *security_tag);
 
 #endif

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -18,6 +18,7 @@
 #define SNAP_CONFINE_SECCOMP_SUPPORT_H
 
 #include <seccomp.h>
+#include <stdbool.h>
 
 /** 
  * sc_apply_seccomp_profile_for_security_tag applies a seccomp profile to the
@@ -39,8 +40,11 @@
  * A profile may contain valid BPF program or the string "@unrestricted\n".  In
  * the former case the profile is applied to the current process using
  * sc_apply_seccomp_filter. In the latter case no action takes place.
+ *
+ * The return value indicates if the process uses confinement or runs under the
+ * special non-confining "@unrestricted" profile.
  **/
-void sc_apply_seccomp_profile_for_security_tag(const char *security_tag);
+bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag);
 
 void sc_apply_global_seccomp_profile(void);
 

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -42,4 +42,6 @@
  **/
 void sc_apply_seccomp_profile_for_security_tag(const char *security_tag);
 
+void sc_apply_global_seccomp_profile(void);
+
 #endif

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 	sc_maybe_aa_change_onexec(&apparmor, security_tag);
 #ifdef HAVE_SECCOMP
-	sc_apply_seccomp_bpf(security_tag);
+	sc_apply_seccomp_profile_for_security_tag(security_tag);
 #endif				// ifdef HAVE_SECCOMP
 	if (snap_context != NULL) {
 		setenv("SNAP_COOKIE", snap_context, 1);

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 	sc_maybe_aa_change_onexec(&apparmor, security_tag);
 #ifdef HAVE_SECCOMP
-	sc_apply_seccomp_profile_for_security_tag(security_tag);
+	(void)sc_apply_seccomp_profile_for_security_tag(security_tag);
 	sc_apply_global_seccomp_profile();
 #endif				// ifdef HAVE_SECCOMP
 	if (snap_context != NULL) {

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -374,8 +374,11 @@ int main(int argc, char **argv)
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 	sc_maybe_aa_change_onexec(&apparmor, security_tag);
 #ifdef HAVE_SECCOMP
-	(void)sc_apply_seccomp_profile_for_security_tag(security_tag);
-	sc_apply_global_seccomp_profile();
+	if (sc_apply_seccomp_profile_for_security_tag(security_tag)) {
+		/* If the process is not explicitly unconfined then load the global
+		 * profile as well. */
+		sc_apply_global_seccomp_profile();
+	}
 #endif				// ifdef HAVE_SECCOMP
 	if (snap_context != NULL) {
 		setenv("SNAP_COOKIE", snap_context, 1);

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -375,6 +375,7 @@ int main(int argc, char **argv)
 	sc_maybe_aa_change_onexec(&apparmor, security_tag);
 #ifdef HAVE_SECCOMP
 	sc_apply_seccomp_profile_for_security_tag(security_tag);
+	sc_apply_global_seccomp_profile();
 #endif				// ifdef HAVE_SECCOMP
 	if (snap_context != NULL) {
 		setenv("SNAP_COOKIE", snap_context, 1);

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -101,7 +101,7 @@ execute: |
         echo "test-snapd-tools.echo should fail with big seccomp profile"
         exit 1
     fi
-    echo "$output" | MATCH "profile .* exceeds .* bytes"
+    echo "$output" | MATCH "cannot fit .* to memory buffer"
 
     
     echo "Ensure the code cannot not run with a missing .bin profile"


### PR DESCRIPTION
This branch contains a small refactor and cleanup of parts of the seccomp loading code.
I moved some chunks of existing code into seccomp-support-ext.c, which is using the less
annoying clang-format based indenting scheme.

