### PR TITLE
interfaces: add block-devices interface

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+// Only allow raw disk devices; not loop, ram, CDROM, generic SCSI, network,
+// tape, raid, etc devices or disk partitions
+const blockDevicesSummary = `allows access to disk block devices`
+
+const blockDevicesBaseDeclarationPlugs = `
+  block-devices:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const blockDevicesBaseDeclarationSlots = `
+  block-devices:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+// https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+// For now, only list common devices and skip the following:
+// /dev/mfm{a,b} rw,                        # Acorn MFM
+// /dev/ad[a-p] rw,                         # ACSI
+// /dev/pd[a-d] rw,                         # Parallel port IDE
+// /dev/pf[0-3] rw,                         # Parallel port ATAPI
+// /dev/ub[a-z] rw,                         # USB block device
+const blockDevicesConnectedPlugAppArmor = `
+# Description: Allow write access to raw disk block devices.
+
+@{PROC}/devices r,
+/run/udev/data/b[0-9]*:[0-9]* r,
+/sys/block/ r,
+/sys/devices/**/block/** r,
+
+# Access to raw devices, not individual partitions
+/dev/hd[a-t] rw,                         # IDE, MFM, RLL
+/dev/sd{,[a-h]}[a-z] rw,                 # SCSI
+/dev/sdi[a-v] rw,                        # SCSI continued
+/dev/i2o/hd{,[a-c]}[a-z] rw,             # I2O hard disk
+/dev/i2o/hdd[a-x] rw,                    # I2O hard disk continued
+/dev/mmcblk[0-9]{,[0-9],[0-9][0-9]} rw,  # MMC (up to 1000 devices)
+/dev/nvme[0-9]{,[0-9]} rw,               # NVMe (up to 100 devices)
+/dev/vd[a-z] rw,                         # virtio
+
+# SCSI device commands, et al
+capability sys_rawio,
+
+# Perform various privileged block-device ioctl operations
+capability sys_admin,
+
+# Devices for various controllers used with ioctl()
+/dev/mpt2ctl{,_wd} rw,
+/dev/megaraid_sas_ioctl_node rw,
+`
+
+var blockDevicesConnectedPlugUDev = []string{
+	`SUBSYSTEM=="block"`,
+	`KERNEL=="mpt2ctl*"`,
+	`KERNEL=="megaraid_sas_ioctl_node"`,
+}
+
+type blockDevicesInterface struct {
+	commonInterface
+}
+
+func init() {
+	registerIface(&blockDevicesInterface{commonInterface{
+		name:                  "block-devices",
+		summary:               blockDevicesSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationPlugs:  blockDevicesBaseDeclarationPlugs,
+		baseDeclarationSlots:  blockDevicesBaseDeclarationSlots,
+		connectedPlugAppArmor: blockDevicesConnectedPlugAppArmor,
+		connectedPlugUDev:     blockDevicesConnectedPlugUDev,
+		reservedForOS:         true,
+	}})
+}

--- a/interfaces/builtin/block_devices_test.go
+++ b/interfaces/builtin/block_devices_test.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type blockDevicesInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&blockDevicesInterfaceSuite{
+	iface: builtin.MustInterface("block-devices"),
+})
+
+const blockDevicesConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [block-devices]
+`
+
+const blockDevicesCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  block-devices:
+`
+
+func (s *blockDevicesInterfaceSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.plug, s.plugInfo = MockConnectedPlug(c, blockDevicesConsumerYaml, nil, "block-devices")
+	s.slot, s.slotInfo = MockConnectedSlot(c, blockDevicesCoreYaml, nil, "block-devices")
+}
+
+func (s *blockDevicesInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "block-devices")
+}
+
+func (s *blockDevicesInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "block-devices",
+		Interface: "block-devices",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"block-devices slots are reserved for the core snap")
+}
+
+func (s *blockDevicesInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *blockDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allow write access to raw disk block devices.`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/sd{,[a-h]}[a-z] rw,`)
+}
+
+func (s *blockDevicesInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 4)
+	c.Assert(spec.Snippets()[0], Equals, `# block-devices
+KERNEL=="megaraid_sas_ioctl_node", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
+}
+
+func (s *blockDevicesInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to disk block devices`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "block-devices")
+}
+
+func (s *blockDevicesInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *blockDevicesInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -471,6 +471,24 @@ plugs:
 	c.Check(err, IsNil)
 }
 
+func (s *baseDeclSuite) TestAutoConnectionBlockDevicesOverride(c *C) {
+	cand := s.connectCand(c, "block-devices", "", "")
+	err := cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"block-devices\"")
+
+	plugsSlots := `
+plugs:
+  block-devices:
+    allow-auto-connection: true
+`
+
+	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
+	cand.PlugSnapDeclaration = snapDecl
+	err = cand.CheckAutoConnect()
+	c.Check(err, IsNil)
+}
+
 func (s *baseDeclSuite) TestAutoConnectionOverrideMultiple(c *C) {
 	plugsSlots := `
 plugs:
@@ -640,6 +658,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 	all := builtin.Interfaces()
 
 	restricted := map[string]bool{
+		"block-devices":         true,
 		"classic-support":       true,
 		"docker-support":        true,
 		"greengrass-support":    true,
@@ -766,6 +785,7 @@ func (s *baseDeclSuite) TestSanity(c *C) {
 	// given how the rules work this can be delicate,
 	// listed here to make sure that was a conscious decision
 	bothSides := map[string]bool{
+		"block-devices":         true,
 		"classic-support":       true,
 		"core-support":          true,
 		"docker-support":        true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -23,6 +23,9 @@ apps:
   avahi-observe:
     command: bin/run
     plugs: [ avahi-observe ]
+  block-devices:
+    command: bin/run
+    plugs: [ block-devices ]
   bluetooth-control:
     command: bin/run
     plugs: [ bluetooth-control ]


### PR DESCRIPTION
    Some applications need access to raw disks (eg, smartctl and hdparm) or
    disks at the block level (eg, flashing tools). This interface provides
    this access. Since read access gives the snap access to all data on the
    device and write access allows changing the contents of the disk, this
    interface is considered a "super-privileged" interface since it grants
    device ownership to the snap.
    
    Tested with 'hdparm -t /dev/sda', 'smartctl --test=short /dev/sda' and
    'smartctl --all /dev/sda'.
    
    References:
    https://forum.snapcraft.io/t/request-for-classic-confinement-sas2ircu/9023
    https://forum.snapcraft.io/t/classic-confinement-review-request-for-fwup/7379
    https://forum.snapcraft.io/t/classic-confinement-request-for-the-wimlib-snap/7424