### PR TITLE
 tests: enable debian sid as part of the main suite on travis

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -74,7 +74,6 @@ backends:
                 workers: 6
             - debian-sid-64:
                 workers: 6
-                manual: true
 
             - fedora-28-64:
                 workers: 4

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -416,6 +416,11 @@ prepare_suite_each() {
     # back test directory to be restored during the restore
     tar cf "${PWD}.tar" "$PWD"
 
+    # WORKAROUND for memleak https://github.com/systemd/systemd/issues/11502
+    if [[ "$SPREAD_SYSTEM" == debian-sid* ]]; then
+        systemctl restart systemd-journald
+    fi
+
     # save the job which is going to be executed in the system
     echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
     # shellcheck source=tests/lib/reset.sh

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -27,4 +27,4 @@ execute: |
     echo "When the snap is refreshed"
     snap refresh --beta "$SNAP_NAME"
     echo "Then deltas are successfully applied"
-    get_journalctl_log -u snapd | MATCH "Successfully applied delta"
+    check_journalctl_log "Successfully applied delta" -u snapd

--- a/tests/main/refresh-delta/task.yaml
+++ b/tests/main/refresh-delta/task.yaml
@@ -26,4 +26,4 @@ execute: |
     snap refresh --beta "$SNAP_NAME"
 
     echo "Then deltas are successfully applied"
-    get_journalctl_log -u snapd | MATCH "Successfully applied delta"
+    check_journalctl_log "Successfully applied delta" -u snapd

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -3,6 +3,9 @@ summary: Run project static and unit tests
 # Start before anything else as it takes a long time.
 priority: 1000
 
+# debian-sid will complain about incorrect formating (go1.11?)
+systems: [-debian-sid-*]
+
 restore: |
     rm -rf /tmp/static-unit-tests
 


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/6406 without the changes to `tests/lib/journalctl.sh` which are not needed AFAICT - the real issue that caused the journal problems is https://github.com/systemd/systemd/issues/11502