### PR TITLE
tests: update fedora 29 workers to speed up the whole testing time

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -80,7 +80,7 @@ backends:
                 workers: 4
                 manual: true
             - fedora-29-64:
-                workers: 4
+                workers: 6
             - opensuse-42.3-64:
                 workers: 4
                 # golang stack cannot compile anything, needs investigation


### PR DESCRIPTION
The idea is to reduce about 7 minutes the spread execution on travis.
