### PR TITLE
data/systemd: helper service to hold refreshes when waking up from suspend

### DIFF
--- a/data/systemd/snapd.hold-after-wakeup.service.in
+++ b/data/systemd/snapd.hold-after-wakeup.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hold snapd refresh when resuming from sleep
+After=systemd-suspend.service systemd-hybrid-sleep.service systemd-hibernate.service
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c '@bindir@/snap set system refresh.hold=$(date --iso-8601=seconds -d "10 minutes")'
+
+[Install]
+WantedBy=sleep.target

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -59,7 +59,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs     snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service
+%global snappy_svcs     snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.hold-after-wakeup.service
 
 # Until we have a way to add more extldflags to gobuild macro...
 %if 0%{?fedora} >= 26

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -71,7 +71,7 @@
 %global with_multilib 1
 %endif
 
-%global systemd_services_list snapd.socket snapd.service snapd.seeded.service %{?with_apparmor:snapd.apparmor.service}
+%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.hold-after-wakeup.service %{?with_apparmor:snapd.apparmor.service}
 
 %global snap_mount_dir /snap
 


### PR DESCRIPTION
Add a helper service that will launch after the system wakes up from sleep and
hold snapd refreshes for 10 minutes.
    
This aims to address a problem when the system would wake up and start
refreshing snaps right away, what may cause some undesired load and make the
machine unresponsive.

The service is set up so that it becomes part of `sleep.target`, which is used
when the host is going to sleep via either suspend, hibernation or a combination
of both. The low level /sys/power/state manipulation is implemented by
corresponding systemd helpers. The helpers exit when the system wakes up. Using
After dependency ordering, the service should start only after relevant sleep
helpers finish, effectively making it run after the wakeup. See [1] for
discussion about systemd side of things.

The default is to hold refresh for 10 minutes, and there is no way to change it
right now. Some initial feedback in the forum is positive so far [2].

References:
1. https://github.com/systemd/systemd/issues/6364
2. https://forum.snapcraft.io/t/defer-snapd-refresh-on-wake-from-suspend/4943