### PR TITLE
tests: workaround missing go dependencies in debian-9

### DIFF
--- a/tests/lib/best_golang.py
+++ b/tests/lib/best_golang.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import apt
+import re
+
+best_golang=None
+for p in apt.Cache():
+    if re.match(r"golang-([0-9.]+)$", p.name):
+        if best_golang is None or apt.apt_pkg.version_compare(best_golang.candidate.version, p.candidate.version) < 0:
+            best_golang = p
+
+print(best_golang.name)

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -329,7 +329,7 @@ prepare_project() {
     case "$SPREAD_SYSTEM" in
         debian-*|ubuntu-*)
             # in 16.04: apt build-dep -y ./
-            if [[ "$SPREAD_SYSTEM" == debian-* ]]; then
+            if [[ "$SPREAD_SYSTEM" == debian-9-* ]]; then
                 best_golang="$(python3 ./tests/lib/best_golang.py)"
                 test -n "$best_golang"
                 sed -i -e "s/golang-1.10/$best_golang/" ./debian/control

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -303,7 +303,7 @@ prepare_project() {
 
     if [[ "$SPREAD_SYSTEM" == debian-9-* ]]; then
 	# Manually install the latest golang from -backports
-        cat best_golang.py <<'EOF'
+        cat > best_golang.py <<'EOF'
 import apt
 import re
 best_golang=None

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -301,6 +301,21 @@ prepare_project() {
         fi
     fi
 
+    if [[ "$SPREAD_SYSTEM" == debian-9-* ]]; then
+	# Manually install the latest golang from -backports
+        cat best.py <<'EOF'
+import apt
+import re
+best_golang=None
+for p in apt.Cache():
+    if re.match(r"golang-([0-9.]+)$", p.name):
+        if best_golang is None or apt.apt_pkg.version_compare(best_golang.candidate.version, p.candidate.version) < 0:
+            best_golang = p
+print(best_golang.name)
+EOF
+        apt install -y "$(python3 best.py)"
+    fi
+
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         if [ ! -d packaging/ubuntu-14.04 ]; then
             echo "no packaging/ubuntu-14.04/ directory "

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -303,7 +303,7 @@ prepare_project() {
 
     if [[ "$SPREAD_SYSTEM" == debian-9-* ]]; then
 	# Manually install the latest golang from -backports
-        cat best.py <<'EOF'
+        cat best_golang.py <<'EOF'
 import apt
 import re
 best_golang=None
@@ -313,7 +313,7 @@ for p in apt.Cache():
             best_golang = p
 print(best_golang.name)
 EOF
-        apt install -y "$(python3 best.py)"
+        apt install -y "$(python3 best_golang.py)"
     fi
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then


### PR DESCRIPTION
The debian-9 image we use has no golang-1.10 anymore. This makes
the tests fail right now. To fix this we need to install the latest
golang available via skretch-backports. This may change so there is
a small script that detects the right version.

