### PR TITLE
cmd/snap: fix typo in cmd_wait.go

### DIFF
--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -43,7 +43,7 @@ type cmdWait struct {
 func init() {
 	addCommand("wait",
 		"Wait for configuration",
-		"The wait command waits until a configration becomes true.",
+		"The wait command waits until a configuration becomes true.",
 		func() flags.Commander {
 			return &cmdWait{}
 		}, nil, []argDesc{


### PR DESCRIPTION
s/configration/configuration/
