### PR TITLE
overlord/snapstate: validate instance names early

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -835,7 +835,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	_, _, err = snapstate.InstallPath(st, si, snapPath, "bar_invalid_instance_name", "", snapstate.Flags{DevMode: true})
-	c.Assert(err, ErrorMatches, `invalid instance key: "invalid_instance_name"`)
+	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "invalid_instance_name"`)
 }
 
 func (ms *mgrsSuite) TestCheckInterfaces(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -559,7 +559,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		return nil, nil, err
 	}
 	if err := snap.ValidateInstanceName(instanceName); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("invalid instance name: %v", err)
 	}
 
 	snapName, instanceKey := snap.SplitInstanceName(instanceName)
@@ -623,7 +623,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 	}
 
 	if err := snap.ValidateInstanceName(name); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid instance name: %v", err)
 	}
 
 	info, err := installInfo(st, name, channel, revision, userID)
@@ -666,7 +666,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 		}
 
 		if err := snap.ValidateInstanceName(name); err != nil {
-			return nil, nil, fmt.Errorf("invalid instance name: %q", name)
+			return nil, nil, fmt.Errorf("invalid instance name: %v", err)
 		}
 
 		toInstall = append(toInstall, name)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -622,6 +622,10 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		return nil, err
 	}
 
+	if err := snap.ValidateInstanceName(name); err != nil {
+		return nil, err
+	}
+
 	info, err := installInfo(st, name, channel, revision, userID)
 	if err != nil {
 		return nil, err
@@ -660,6 +664,11 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 		if snapst.IsInstalled() {
 			continue
 		}
+
+		if err := snap.ValidateInstanceName(name); err != nil {
+			return nil, nil, fmt.Errorf("invalid instance name: %q", name)
+		}
+
 		toInstall = append(toInstall, name)
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12949,16 +12949,16 @@ func (s *snapmgrTestSuite) TestInstallValidatesInstanceNames(c *C) {
 	defer s.state.Unlock()
 
 	_, err := snapstate.Install(s.state, "foo--invalid", "", snap.R(0), 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `invalid snap name: "foo--invalid"`)
+	c.Assert(err, ErrorMatches, `invalid instance name: invalid snap name: "foo--invalid"`)
 
 	_, err = snapstate.Install(s.state, "foo_123_456", "", snap.R(0), 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `invalid instance key: "123_456"`)
+	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "123_456"`)
 
 	_, _, err = snapstate.InstallMany(s.state, []string{"foo--invalid"}, 0)
-	c.Assert(err, ErrorMatches, `invalid instance name: "foo--invalid"`)
+	c.Assert(err, ErrorMatches, `invalid instance name: invalid snap name: "foo--invalid"`)
 
 	_, _, err = snapstate.InstallMany(s.state, []string{"foo_123_456"}, 0)
-	c.Assert(err, ErrorMatches, `invalid instance name: "foo_123_456"`)
+	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "123_456"`)
 
 	mockSnap := makeTestSnap(c, `name: some-snap
 version: 1.0
@@ -12966,7 +12966,7 @@ epoch: 1*
 `)
 	si := snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}
 	_, _, err = snapstate.InstallPath(s.state, &si, mockSnap, "some-snap_123_456", "", snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `invalid instance key: "123_456"`)
+	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "123_456"`)
 }
 
 type modelPastSeedSuite struct {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12944,6 +12944,31 @@ func (s *snapmgrTestSuite) TestSnapManagerCanStandby(c *C) {
 	c.Assert(s.snapmgr.CanStandby(), Equals, false)
 }
 
+func (s *snapmgrTestSuite) TestInstallValidatesInstanceNames(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err := snapstate.Install(s.state, "foo--invalid", "", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `invalid snap name: "foo--invalid"`)
+
+	_, err = snapstate.Install(s.state, "foo_123_456", "", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `invalid instance key: "123_456"`)
+
+	_, _, err = snapstate.InstallMany(s.state, []string{"foo--invalid"}, 0)
+	c.Assert(err, ErrorMatches, `invalid instance name: "foo--invalid"`)
+
+	_, _, err = snapstate.InstallMany(s.state, []string{"foo_123_456"}, 0)
+	c.Assert(err, ErrorMatches, `invalid instance name: "foo_123_456"`)
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+epoch: 1*
+`)
+	si := snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}
+	_, _, err = snapstate.InstallPath(s.state, &si, mockSnap, "some-snap_123_456", "", snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `invalid instance key: "123_456"`)
+}
+
 type modelPastSeedSuite struct {
 	st *state.State
 }


### PR DESCRIPTION
We already validate instance name when installing snap from a path, but the
store installation paths were missing similar treatment. As a result, snap
installation would fail very late in the process, reaching the mount task.

The patch introduces makes to validate the snap names early for store
installation code paths.

