### PR TITLE
[RFC] snap-confine: revert "cmd/snap-confine,snap-update-ns: discard quirks"

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -213,6 +213,8 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/mount-support.h \
 	snap-confine/ns-support.c \
 	snap-confine/ns-support.h \
+	snap-confine/quirks.c \
+	snap-confine/quirks.h \
 	snap-confine/snap-confine-args.c \
 	snap-confine/snap-confine-args.h \
 	snap-confine/snap-confine.c \
@@ -300,6 +302,8 @@ snap_confine_unit_tests_SOURCES = \
 	snap-confine/cookie-support-test.c \
 	snap-confine/mount-support-test.c \
 	snap-confine/ns-support-test.c \
+	snap-confine/quirks.c \
+	snap-confine/quirks.h \
 	snap-confine/snap-confine-args-test.c \
 	snap-confine/snap-device-helper-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)

--- a/cmd/snap-confine/README.mount_namespace
+++ b/cmd/snap-confine/README.mount_namespace
@@ -80,6 +80,52 @@ mount("none", "/tmp", NULL, MS_PRIVATE, NULL) = 0
 mount("devpts", "/dev/pts", "devpts", MS_MGC_VAL, "newinstance,ptmxmode=0666,mode=0"...)
 mount("/dev/pts/ptmx", "/dev/ptmx", 0x5574dfe9a5c3, MS_BIND, NULL)
 
+# Classic only - process quirks mounts by:
+#   creating temporary quirks directory for moving /var/lib/snapd aside
+mkdir("/tmp/snapd.quirks_xKIzG3", 0700) = 0
+#   moving /var/lib/snapd aside
+mount("/var/lib/snapd", "/tmp/snapd.quirks_xKIzG3", NULL, MS_MOVE, NULL) = 0
+#   creating a tmpfs on /var/lib for our mount points
+mount("none", "/var/lib", "tmpfs", MS_NOSUID|MS_NODEV, NULL) = 0
+#   mimicking the vanilla /var/lib/* from the core snap in /var/lib in tmpfs
+#   (the directories to mimic are dynamically determined and will vary as the
+#   core snap changes. Syscalls for finding what to mount and creating the
+#   mount points are omitted)
+mount("/snap/ubuntu-core/current/var/lib/apparmor", "/var/lib/apparmor", NULL, MS_RDONLY|MS_NOSUID|MS_NODEV|MS_BIND|MS_REC|MS_SLAVE, NULL) = 0
+mount("/snap/ubuntu-core/current/var/lib/classic", "/var/lib/classic", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/console-conf", "/var/lib/console-conf", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/dbus", "/var/lib/dbus", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/dhcp", "/var/lib/dhcp", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/extrausers", "/var/lib/extrausers", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/initramfs-tools", "/var/lib/initramfs-tools", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/initscripts", "/var/lib/initscripts", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/insserv", "/var/lib/insserv", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/logrotate", "/var/lib/logrotate", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/machines", "/var/lib/machines", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/misc", "/var/lib/misc", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/pam", "/var/lib/pam", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/python", "/var/lib/python", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/resolvconf", "/var/lib/resolvconf", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/snapd", "/var/lib/snapd", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/sudo", "/var/lib/sudo", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/systemd", "/var/lib/systemd", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/ubuntu-fan", "/var/lib/ubuntu-fan", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/ucf", "/var/lib/ucf", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/update-rc.d", "/var/lib/update-rc.d", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/urandom", "/var/lib/urandom", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/vim", "/var/lib/vim", ...) = 0
+mount("/snap/ubuntu-core/current/var/lib/waagent", "/var/lib/waagent", ...) = 0
+#   unmounting the /var/lib/snapd that was just mimicked
+umount2("/var/lib/snapd", 0)
+#   moving back the /var/lib/snapd that was set aside
+mount("/tmp/snapd.quirks_xKIzG3", "/var/lib/snapd", NULL, MS_MOVE, NULL) = 0
+#   cleaning up the temporary directory
+rmdir("/tmp/snapd.quirks_xKIzG3") = 0
+#   applying the actual quirk mounts as needed (for now, lxd, but more may
+#   come). Eg:
+mount("/var/lib/snapd/hostfs/var/lib/lxd", "/var/lib/lxd", NULL, MS_REC|MS_SLAVE|MS_NODEV|MS_NOSUID|MS_NOEXEC) = 0
+# End quirk mounts on classic
+
 # Process snap-defined mounts (eg, for content interface, mount the source to
 # the target as defined in /var/lib/snapd/mount/snap.<name>.<command>.fstab)
 # Eg:

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -47,6 +47,7 @@
 #include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
 #include "mount-support-nvidia.h"
+#include "quirks.h"
 
 #define MAX_BUF 1000
 
@@ -617,6 +618,10 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	// TODO: fold this into bootstrap
 	setup_private_pts();
 
+	// setup quirks for specific snaps *only* for the old core snap
+	if (distro == SC_DISTRO_CLASSIC && sc_streq(base_snap_name, "core")) {
+		sc_setup_quirks();
+	}
 	// setup the security backend bind mounts
 	sc_call_snap_update_ns(snap_update_ns_fd, snap_name, apparmor);
 

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -45,6 +45,7 @@ int sc_open_snap_discard_ns(void);
  * - prepares and chroots into the core snap (on classic systems)
  * - creates private /tmp
  * - creates private /dev/pts
+ * - applies quirks for specific snaps (like LXD)
  * - processes mount profiles
  *
  * The function will also try to preserve the current working directory but if

--- a/cmd/snap-confine/quirks.c
+++ b/cmd/snap-confine/quirks.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+#include "quirks.h"
+
+#include <dirent.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "../libsnap-confine-private/classic.h"
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/mount-opt.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
+// XXX: for smaller patch, this should be in utils.h later
+#include "user-support.h"
+
+/**
+ * Get the path to the mounted core snap in the execution environment.
+ *
+ * The core snap may be named just "core" (preferred) or "ubuntu-core"
+ * (legacy).  The mount point does not depend on build-time configuration and
+ * does not differ from distribution to distribution.
+ **/
+static const char *sc_get_inner_core_mount_point(void)
+{
+	const char *core_path = "/snap/core/current/";
+	const char *ubuntu_core_path = "/snap/ubuntu-core/current/";
+	static const char *result = NULL;
+	if (result == NULL) {
+		if (access(core_path, F_OK) == 0) {
+			// Use the "core" snap if available.
+			result = core_path;
+		} else if (access(ubuntu_core_path, F_OK) == 0) {
+			// If not try to fall back to the "ubuntu-core" snap.
+			result = ubuntu_core_path;
+		} else {
+			die("cannot locate the core snap");
+		}
+	}
+	return result;
+}
+
+/**
+ * Mount a tmpfs at a given directory.
+ *
+ * The empty tmpfs is used as a substrate to create additional directories and
+ * then bind mounts to other destinations.
+ *
+ * It is useful to poke unexpected holes in the read-only core snap.
+ **/
+static void sc_quirk_setup_tmpfs(const char *dirname)
+{
+	debug("mounting tmpfs at %s", dirname);
+	if (mount("none", dirname, "tmpfs", MS_NODEV | MS_NOSUID, NULL) != 0) {
+		die("cannot mount tmpfs at %s", dirname);
+	};
+}
+
+/**
+ * Create an empty directory and bind mount something there.
+ *
+ * The empty directory is created at destdir. The bind mount is
+ * done from srcdir to destdir. The bind mount is performed with
+ * caller-defined flags.
+ **/
+static void sc_quirk_mkdir_bind(const char *src_dir, const char *dest_dir,
+				unsigned flags)
+{
+	flags |= MS_BIND;
+	debug("creating empty directory at %s", dest_dir);
+	if (sc_nonfatal_mkpath(dest_dir, 0755) < 0) {
+		die("cannot create empty directory at %s", dest_dir);
+	}
+	char buf[1000] = { 0 };
+	const char *flags_str = sc_mount_opt2str(buf, sizeof buf, flags);
+	debug("performing operation: mount %s %s -o %s", src_dir, dest_dir,
+	      flags_str);
+	if (mount(src_dir, dest_dir, NULL, flags, NULL) != 0) {
+		die("cannot perform operation: mount %s %s -o %s", src_dir,
+		    dest_dir, flags_str);
+	}
+}
+
+/**
+ * Create a writable mimic directory based on reference directory.
+ *
+ * The mimic directory is a tmpfs populated with bind mounts to the (possibly
+ * read only) directories in the reference directory. While all the read-only
+ * content stays read-only the actual mimic directory is writable so additional
+ * content can be placed there.
+ *
+ * Flags are forwarded to sc_quirk_mkdir_bind()
+ **/
+static void sc_quirk_create_writable_mimic(const char *mimic_dir,
+					   const char *ref_dir, unsigned flags)
+{
+	debug("creating writable mimic directory %s based on %s", mimic_dir,
+	      ref_dir);
+	sc_quirk_setup_tmpfs(mimic_dir);
+
+	// Now copy the ownership and permissions of the mimicked directory
+	struct stat stat_buf;
+	if (stat(ref_dir, &stat_buf) < 0) {
+		die("cannot stat %s", ref_dir);
+	}
+	if (chown(mimic_dir, stat_buf.st_uid, stat_buf.st_gid) < 0) {
+		die("cannot chown for %s", mimic_dir);
+	}
+	if (chmod(mimic_dir, stat_buf.st_mode) < 0) {
+		die("cannot chmod for %s", mimic_dir);
+	}
+
+	debug("bind-mounting all the files from the reference directory");
+	DIR *dirp SC_CLEANUP(sc_cleanup_closedir) = NULL;
+	dirp = opendir(ref_dir);
+	if (dirp == NULL) {
+		die("cannot open reference directory %s", ref_dir);
+	}
+	struct dirent *entryp = NULL;
+	do {
+		char src_name[PATH_MAX * 2] = { 0 };
+		char dest_name[PATH_MAX * 2] = { 0 };
+		// Set errno to zero, if readdir fails it will not only return null but
+		// set errno to a non-zero value. This is how we can differentiate
+		// end-of-directory from an actual error.
+		errno = 0;
+		entryp = readdir(dirp);
+		if (entryp == NULL && errno != 0) {
+			die("cannot read another directory entry");
+		}
+		if (entryp == NULL) {
+			break;
+		}
+		if (strcmp(entryp->d_name, ".") == 0
+		    || strcmp(entryp->d_name, "..") == 0) {
+			continue;
+		}
+		if (entryp->d_type != DT_DIR && entryp->d_type != DT_REG) {
+			die("unsupported entry type of file %s (%d)",
+			    entryp->d_name, entryp->d_type);
+		}
+		sc_must_snprintf(src_name, sizeof src_name, "%s/%s", ref_dir,
+				 entryp->d_name);
+		sc_must_snprintf(dest_name, sizeof dest_name, "%s/%s",
+				 mimic_dir, entryp->d_name);
+		sc_quirk_mkdir_bind(src_name, dest_name, flags);
+	} while (entryp != NULL);
+}
+
+/**
+ * Setup a quirk for LXD.
+ *
+ * An existing LXD snap relies on pre-chroot behavior to access /var/lib/lxd
+ * while in devmode. Since that directory doesn't exist in the core snap the
+ * quirk punches a custom hole so that this directory shows the hostfs content
+ * if such directory exists on the host.
+ *
+ * See: https://bugs.launchpad.net/snap-confine/+bug/1613845
+ **/
+static void sc_setup_lxd_quirk(void)
+{
+	const char *hostfs_lxd_dir = SC_HOSTFS_DIR "/var/lib/lxd";
+	if (access(hostfs_lxd_dir, F_OK) == 0) {
+		const char *lxd_dir = "/var/lib/lxd";
+		debug("setting up quirk for LXD (see LP: #1613845)");
+		sc_quirk_mkdir_bind(hostfs_lxd_dir, lxd_dir,
+				    MS_REC | MS_SLAVE | MS_NODEV | MS_NOSUID |
+				    MS_NOEXEC);
+	}
+}
+
+void sc_setup_quirks(void)
+{
+	// because /var/lib/snapd is essential let's move it to /tmp/snapd for a sec
+	char snapd_tmp[] = "/tmp/snapd.quirks_XXXXXX";
+	if (mkdtemp(snapd_tmp) == 0) {
+		die("cannot create temporary directory for /var/lib/snapd mount point");
+	}
+	debug("performing operation: mount --move %s %s", "/var/lib/snapd",
+	      snapd_tmp);
+	if (mount("/var/lib/snapd", snapd_tmp, NULL, MS_MOVE, NULL)
+	    != 0) {
+		die("cannot perform operation: mount --move %s %s",
+		    "/var/lib/snapd", snapd_tmp);
+	}
+	// now let's make /var/lib the vanilla /var/lib from the core snap
+	char buf[PATH_MAX] = { 0 };
+	sc_must_snprintf(buf, sizeof buf, "%s/var/lib",
+			 sc_get_inner_core_mount_point());
+	sc_quirk_create_writable_mimic("/var/lib", buf,
+				       MS_RDONLY | MS_REC | MS_SLAVE | MS_NODEV
+				       | MS_NOSUID);
+	// now let's move /var/lib/snapd (that was originally there) back
+	debug("performing operation: umount %s", "/var/lib/snapd");
+	if (umount("/var/lib/snapd") != 0) {
+		die("cannot perform operation: umount %s", "/var/lib/snapd");
+	}
+	debug("performing operation: mount --move %s %s", snapd_tmp,
+	      "/var/lib/snapd");
+	if (mount(snapd_tmp, "/var/lib/snapd", NULL, MS_MOVE, NULL)
+	    != 0) {
+		die("cannot perform operation: mount --move %s %s", snapd_tmp,
+		    "/var/lib/snapd");
+	}
+	debug("performing operation: rmdir %s", snapd_tmp);
+	if (rmdir(snapd_tmp) != 0) {
+		die("cannot perform operation: rmdir %s", snapd_tmp);
+	}
+	// We are now ready to apply any quirks that relate to /var/lib
+	sc_setup_lxd_quirk();
+}

--- a/cmd/snap-confine/quirks.h
+++ b/cmd/snap-confine/quirks.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_QUIRKS_H
+#define SNAP_QUIRKS_H
+
+/**
+ * Setup various quirks that have to exists for now.
+ *
+ * This function applies non-standard tweaks that are required
+ * because of requirement to stay compatible with certain snaps
+ * that were tested with pre-chroot layout.
+ **/
+void sc_setup_quirks(void);
+
+#endif

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -122,6 +122,9 @@
     # reading seccomp filters
     /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/bpf/*.bin r,
 
+    # ensuring correct permissions in sc_quirk_create_writable_mimic
+    /{tmp/snap.rootfs_*/,}var/lib/ rw,
+
     # LP: #1668659
     mount options=(rw rbind) /snap/ -> /snap/,
     mount options=(rw rshared) -> /snap/,
@@ -343,6 +346,31 @@
     # Required to correctly unmount bound mount namespace.
     # See LP: #1735459 for details.
     umount /,
+
+    # Support for the quirk system
+    /var/ r,
+    /var/lib/ r,
+    /var/lib/** rw,
+    /tmp/ r,
+    /tmp/snapd.quirks_*/ rw,
+    mount options=(move) /var/lib/snapd/ -> /tmp/snapd.quirks_*/,
+    mount fstype=tmpfs options=(rw nodev nosuid) none -> /var/lib/,
+    mount options=(ro rbind) /snap/{,ubuntu-}core/*/var/lib/** -> /var/lib/**,
+    umount /var/lib/snapd/,
+    mount options=(move) /tmp/snapd.quirks_*/ -> /var/lib/snapd/,
+    # On classic systems with a setuid root snap-confine when run by non-root
+    # user, the mimic_dir is created with the gid of the calling user (ie,
+    # not '0') so when setting the permissions (chmod) of the mimicked
+    # directory to that of the reference directory, a CAP_FSETID is triggered.
+    # snap-confine sets the directory up correctly, so simply silence the
+    # denial since we don't want to grant the capability as a whole to
+    # snap-confine.
+    deny capability fsetid,
+
+    # support for the LXD quirk
+    mount options=(rw rbind nodev nosuid noexec) /var/lib/snapd/hostfs/var/lib/lxd/ -> /var/lib/lxd/,
+    /var/lib/lxd/ w,
+    /var/lib/snapd/hostfs/var/lib/lxd r,
 
     # support for locking
     /run/snapd/lock/ rw,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -40,6 +40,7 @@
 #include "../libsnap-confine-private/utils.h"
 #include "mount-support.h"
 #include "ns-support.h"
+#include "quirks.h"
 #include "udev-support.h"
 #include "user-support.h"
 #include "cookie-support.h"

--- a/cmd/snap-confine/snap-confine.rst
+++ b/cmd/snap-confine/snap-confine.rst
@@ -92,6 +92,18 @@ options prefixed with `x-snapd-`.
 
 As a security precaution only `bind` mounts are supported at this time.
 
+Quirks
+------
+
+`snap-confine` contains a quirk system that emulates some or the behavior of
+the older versions of snap-confine that certain snaps (still in devmode but
+useful and important) have grown to rely on. This section documents the list of
+quirks:
+
+- The `/var/lib/lxd` directory, if it exists on the host, is made available in
+  the execution environment. This allows various snaps, while running in
+  devmode, to access the LXD socket. LP: #1613845
+
 Sharing of the mount namespace
 ------------------------------
 

--- a/cmd/snap-update-ns/trespassing.go
+++ b/cmd/snap-update-ns/trespassing.go
@@ -251,5 +251,10 @@ func isPrivateTmpfsCreatedBySnapd(dirName string, fsData *syscall.Statfs_t, file
 			return change.Action == Mount
 		}
 	}
-	return false
+	// TODO: As a special exception, assume that a tmpfs over /var/lib is
+	// trusted. This tmpfs is created by snap-confine as a "quirk" to support
+	// a particular behavior of LXD.  Once the quirk is migrated to a mount
+	// profile (or removed entirely if no longer necessary) the following code
+	// fragment can go away.
+	return dirName == "/var/lib"
 }

--- a/cmd/snap-update-ns/trespassing_test.go
+++ b/cmd/snap-update-ns/trespassing_test.go
@@ -426,3 +426,13 @@ func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdDeeper(c *C) {
 	})
 	c.Assert(result, Equals, false)
 }
+
+func (s *trespassingSuite) TestIsPrivateTmpfsCreatedBySnapdViaVarLib(c *C) {
+	path := "/var/lib"
+	// A tmpfs in /var/lib is private because it is a special
+	// quirk applied by snap-confine, without having a change record.
+	statfs := &syscall.Statfs_t{Type: update.TmpfsMagic}
+	stat := &syscall.Stat_t{}
+	result := update.IsPrivateTmpfsCreatedBySnapd(path, statfs, stat, nil)
+	c.Assert(result, Equals, true)
+}

--- a/tests/regression/lp-1613845/task.yaml
+++ b/tests/regression/lp-1613845/task.yaml
@@ -1,0 +1,28 @@
+summary: Check that /var/lib/lxd is bind mounted to the real thing if one exists
+
+details: |
+    After switching to the chroot-based snap-confine the LXD snap stopped
+    working (even in devmode) because it relied on access to /var/lib/lxd from
+    the host filesystem. While this would never work in an all-snap image it is
+    still important to ensure that it works in classic devmode environment.
+
+# This test only applies to classic systems
+systems: [-ubuntu-core-*, -fedora-*, -arch-*]
+
+prepare: |
+    echo "Having installed the test snap in devmode"
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local_devmode test-snapd-tools
+    echo "Having created a canary file in /var/lib/lxd"
+    mkdir -p /var/lib/lxd
+    echo "test" > /var/lib/lxd/canary
+
+execute: |
+    echo "We can see the canary file in /var/lib/lxd"
+    [ "$(test-snapd-tools.cmd cat /var/lib/lxd/canary)" = "test" ]
+
+restore: |
+    rm -f /var/lib/lxd/canary
+    # When the host already has LXD installed we cannot just remove this
+    rmdir /var/lib/lxd || :


### PR DESCRIPTION
This reverts commit 1da9316e717d119852b827becb5a17b33713d032.

This will unbreak people using jenkins which uses /var/lib/jenkins as its HOME. The quirks system made this HOME work (by luck/accient) and removing it broke all jenkins users. 