### PR TITLE
cmd/snap-confine: add special case for Jenkins

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -538,6 +538,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/dev"},	// because it contains devices on host OS
 			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
 			{"/home"},	// to support /home/*/snap and home interface
+			{"/var/lib/jenkins", .is_optional=true}, // to support jenkins's HOME directory
 			{"/root"},	// because that is $HOME for services
 			{"/proc"},	// fundamental filesystem
 			{"/sys"},	// fundamental filesystem

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -494,4 +494,13 @@
     /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
     /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
 
+    # As a special exception, allow HOME to be /var/lib/jenkins
+    /var/ r,
+    /var/lib/ r,
+    /var/lib/jenkins/ r,
+    /var/lib/jenkins/snap/{,*/,*/*/} rw,
+
+    # Allow mounting /var/lib/jenkinks from the host into the snap.
+    mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
 }

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -495,6 +495,7 @@
     /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
 
     # As a special exception, allow HOME to be /var/lib/jenkins
+    # This is required for snap-confine to create SNAP_USER_DATA and similar.
     /var/ r,
     /var/lib/ r,
     /var/lib/jenkins/ r,

--- a/tests/main/special-home/task.yaml
+++ b/tests/main/special-home/task.yaml
@@ -9,13 +9,25 @@ prepare: |
     # Install the corresponding package that brings the special user account.
     # Specialize the code as required for a particular user.
     case "$SPECIAL_USER_NAME" in
-        *) apt install "$SPECIAL_USER_NAME" ;;
+        jenkins)
+            wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | apt-key add -
+            echo 'deb http://pkg.jenkins.io/debian-stable binary/' > /etc/apt/sources.list.d/jenkins.list
+            apt-get update
+            apt-get install -y jenkins
+            apt install jenkins
+            ;;
     esac
 restore: |
-    snap remove test-snapd-sh 
+    snap remove test-snapd-sh
     # Remove the package we installed above.
     case "$SPECIAL_USER_NAME" in
-        *) apt remove --purge "$SPECIAL_USER_NAME" ;;
+        jenkins)
+            apt-get remove --purge -y jenkins
+            apt-get autoremove --purge -y
+            rm -f /etc/apt/sources.list.d/jenkins.list
+            apt-get update
+            # TODO: remove the apt key added above, but how?
+            ;;
     esac
 execute: |
     #shellcheck disable=SC2016

--- a/tests/main/special-home/task.yaml
+++ b/tests/main/special-home/task.yaml
@@ -7,14 +7,15 @@ prepare: |
     . "$TESTSLIB/snaps.sh"
     install_local test-snapd-sh
     # Install the corresponding package that brings the special user account.
+    # Specialize the code as required for a particular user.
     case "$SPECIAL_USER_NAME" in
-        jenkins) apt install jenkins ;;
+        *) apt install "$SPECIAL_USER_NAME" ;;
     esac
 restore: |
     snap remove test-snapd-sh 
     # Remove the package we installed above.
     case "$SPECIAL_USER_NAME" in
-        jenkins) apt remove --purge jenkins ;;
+        *) apt remove --purge "$SPECIAL_USER_NAME" ;;
     esac
 execute: |
     #shellcheck disable=SC2016

--- a/tests/main/special-home/task.yaml
+++ b/tests/main/special-home/task.yaml
@@ -10,6 +10,8 @@ prepare: |
     # Specialize the code as required for a particular user.
     case "$SPECIAL_USER_NAME" in
         jenkins)
+            # Jenkins depends on java but not in the Debian sense.
+            apt-get install -y default-jre-headless
             wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | apt-key add -
             echo 'deb http://pkg.jenkins.io/debian-stable binary/' > /etc/apt/sources.list.d/jenkins.list
             apt-get update
@@ -22,7 +24,7 @@ restore: |
     # Remove the package we installed above.
     case "$SPECIAL_USER_NAME" in
         jenkins)
-            apt-get remove --purge -y jenkins
+            apt-get remove --purge -y jenkins default-jre-headless
             apt-get autoremove --purge -y
             rm -f /etc/apt/sources.list.d/jenkins.list
             apt-get update
@@ -32,4 +34,4 @@ restore: |
 execute: |
     #shellcheck disable=SC2016
     su -c sh -c 'echo $HOME' "$SPECIAL_USER_NAME" | MATCH "/var/lib/$SPECIAL_USER_NAME"
-    su -c 'snap run test-snapd-sh /bin/true' "$SPECIAL_USER_NAME"
+    su -c 'snap run test-snapd-sh -c /bin/true' "$SPECIAL_USER_NAME"

--- a/tests/main/special-home/task.yaml
+++ b/tests/main/special-home/task.yaml
@@ -1,0 +1,22 @@
+summary: Check that Jenkins user can run snaps
+systems: [ubuntu-16.04-64]
+environment:
+    SPECIAL_USER_NAME/jenkins: jenkins
+prepare: |
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-sh
+    # Install the corresponding package that brings the special user account.
+    case "$SPECIAL_USER_NAME" in
+        jenkins) apt install jenkins ;;
+    esac
+restore: |
+    snap remove test-snapd-sh 
+    # Remove the package we installed above.
+    case "$SPECIAL_USER_NAME" in
+        jenkins) apt remove --purge jenkins ;;
+    esac
+execute: |
+    #shellcheck disable=SC2016
+    su -c sh -c 'echo $HOME' "$SPECIAL_USER_NAME" | MATCH "/var/lib/$SPECIAL_USER_NAME"
+    su -c 'snap run test-snapd-sh /bin/true' "$SPECIAL_USER_NAME"


### PR DESCRIPTION
The 2.37 release has dropped the "quirk" system responsible for the
special layout of /var/lib. The /var/lib directory was a tmpfs, with
empty directories and bind mount re-creating the original contents of
/var/lib from the base snap. This feature made it possible to mkdir
/var/lib/lxd, which was *not* present in the core snap, and bind mount
it to /var/lib/lxd from the host.

This used to be a part of a backwards compatibility fix for the time
when LXD was installed as a classic package on the host. LXD has since
moved over to a snap and that directory lost any relevance, culminating
with the removal of the quirk system in the 2.37 development cycle.

The removal of the quirk system also removed permissions that
snap-confine used to have, that gave it wide access to /var/lib.
The Jenkins system is often packaged using classic packages. The classic
package adds a "jenkins" user and sets its home directory to
/var/lib/jenkins. A system using Jenkins CI that internally uses snap
commands would invoke snap applications from the context of that user.

This brings us to the problem: snapd doesn't fully support users with
their home directories outside of /home. Due to complexity of the mount
namespace handling and the apparmor based sandbox with path-based
permissions, adding support for arbitrary home directories is
challenging. It was also untested in the snapd CI system.

In 2.36 and earlier, using snaps from the Jenkins user and its home
directory of /var/lib/jenkins only worked by accident, because the quirk
system granted relevant permissions to snap-confine, enabling it to
create $SNAP_USER_DATA directories. With the release of 2.37 we started
observing users reporting that their Jenkins CI systems can no longer
use snap applications.

While support for arbitrary home directories is desirable, it it needs
much more code to enable properly. An isolated special-case for Jenkins
is manageable and allows us to buy more time to explore proper support
for more cases in subsequent releases.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
