### PR TITLE
cmd/snap-confine: add special case for Jenkins

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -538,6 +538,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/dev"},	// because it contains devices on host OS
 			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
 			{"/home"},	// to support /home/*/snap and home interface
+			{"/var/lib/jenkins", .is_optional=true}, // to support jenkins's HOME directory
 			{"/root"},	// because that is $HOME for services
 			{"/proc"},	// fundamental filesystem
 			{"/sys"},	// fundamental filesystem

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -494,4 +494,13 @@
     /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
     /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
 
+    # As a special exception, allow HOME to be /var/lib/jenkins
+    /var/ r,
+    /var/lib/ r,
+    /var/lib/jenkins/ r,
+    /var/lib/jenkins/snap/{,*/,*/*/} rw,
+
+    # Allow mounting /var/lib/jenkinks from the host into the snap.
+    mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
 }


### PR DESCRIPTION
The 2.37 release has dropped the "quirk" system responsible for the
special layout of /var/lib. The /var/lib directory was a tmpfs, with
empty directories and bind mount re-creating the original contents of
/var/lib from the base snap. This feature made it possible to mkdir
/var/lib/lxd, which was *not* present in the core snap, and bind mount
it to /var/lib/lxd from the host.

This used to be a part of a backwards compatibility fix for the time
when LXD was installed as a classic package on the host. LXD has since
moved over to a snap and that directory lost any relevance, culminating
with the removal of the quirk system in the 2.37 development cycle.

The removal of the quirk system also removed permissions that
snap-confine used to have, that gave it wide access to /var/lib.
The Jenkins system is often packaged using classic packages. The classic
package adds a "jenkins" user and sets its home directory to
/var/lib/jenkins. A system using Jenkins CI that internally uses snap
commands would invoke snap applications from the context of that user.

This brings us to the problem: snapd doesn't fully support users with
their home directories outside of /home. Due to complexity of the mount
namespace handling and the apparmor based sandbox with path-based
permissions, adding support for arbitrary home directories is
challenging. It was also untested in the snapd CI system.

In 2.36 and earlier, using snaps from the Jenkins user and its home
directory of /var/lib/jenkins only worked by accident, because the quirk
system granted relevant permissions to snap-confine, enabling it to
create $SNAP_USER_DATA directories. With the release of 2.37 we started
observing users reporting that their Jenkins CI systems can no longer
use snap applications.

While support for arbitrary home directories is desirable, it it needs
much more code to enable properly. An isolated special-case for Jenkins
is manageable and allows us to buy more time to explore proper support
for more cases in subsequent releases.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

