### PR TITLE
overlord/snapstate: format the refresh time for the log

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -252,7 +252,7 @@ func (m *autoRefresh) Ensure() error {
 			// immediate
 			m.nextRefresh = now
 		}
-		logger.Debugf("Next refresh scheduled for %s.", m.nextRefresh)
+		logger.Debugf("Next refresh scheduled for %s.", m.nextRefresh.Format(time.RFC3339))
 	}
 
 	// should we hold back refreshes?


### PR DESCRIPTION
This is a very trivial change, but it's annoying enough that I needed
to push it out there. Currently we just `%s` the refresh time to the
log on startup,

```
Next refresh scheduled for 2019-01-30 14:36:37.783240257 +0000 GMT m=+17709.346348484.
```

which is rather nasty. With this change,

```
Next refresh scheduled for 2019-01-30T15:11:02Z.
```
