### PR TITLE
interfaces/apparmor: deny inet/inet6 in snap-update-ns profile

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -640,6 +640,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
 
   # Allow reading somaxconn, required in newer distro releases
   @{PROC}/sys/net/core/somaxconn r,
+  # but silence noisy denial of inet/inet6
+  deny network inet,
+  deny network inet6,
 
   # Allow reading the os-release file (possibly a symlink to /usr/lib).
   /{etc/,usr/lib/}os-release r,


### PR DESCRIPTION
Sometimes snap-update-ns triggers inet and inet6 stream denials. This is
related to LP: #1595993. The denials are harmless in the case of
snap-update-ns and we don't want to allow it network access anyway.
Importantly, this would conflict with nfsSnippet, but nfsSnippet is not
added to snap-update-ns profiles, so there is no problem.
