### PR TITLE
interfaces/apparmor: deny inet/inet6 in snap-update-ns profile (2.37)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -640,6 +640,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
 
   # Allow reading somaxconn, required in newer distro releases
   @{PROC}/sys/net/core/somaxconn r,
+  # but silence noisy denial of inet/inet6
+  deny network inet,
+  deny network inet6,
 
   # Allow reading the os-release file (possibly a symlink to /usr/lib).
   /{etc/,usr/lib/}os-release r,


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/6454 for 2.37.