### PR TITLE
snapd,state: improve error message on state reading failure

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -64,7 +64,7 @@ func main() {
 			// data/systemd/snapd.service.in:SuccessExitStatus=
 			os.Exit(42)
 		}
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "cannot run daemon: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -161,7 +161,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = overlord.New()
-	c.Assert(err, ErrorMatches, "cannot decode state: EOF")
+	c.Assert(err, ErrorMatches, "cannot read state: EOF")
 }
 
 func (ovs *overlordSuite) TestNewWithPatches(c *C) {

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -161,7 +161,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = overlord.New()
-	c.Assert(err, ErrorMatches, "EOF")
+	c.Assert(err, ErrorMatches, "cannot decode state: EOF")
 }
 
 func (ovs *overlordSuite) TestNewWithPatches(c *C) {

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -475,7 +475,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	d := json.NewDecoder(r)
 	err := d.Decode(&s)
 	if err != nil {
-		return nil, fmt.Errorf("cannot decode state: %s", err)
+		return nil, fmt.Errorf("cannot read state: %s", err)
 	}
 	s.backend = backend
 	s.modified = false

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -475,7 +475,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	d := json.NewDecoder(r)
 	err := d.Decode(&s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot decode state: %s", err)
 	}
 	s.backend = backend
 	s.modified = false


### PR DESCRIPTION
While running Pi2 tests I ended up with a corrupted state and
snapd would no longer start. The error message I got was:
```
error: EOF
```
This is not very helpful. So this PR improves it to amend
some more information. Now it reads:
```
cannot run daemon: cannot decode state: EOF
```
