### PR TITLE
snap: fix hook autodiscovery for parallel installed snaps (2.37)

### DIFF
--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -59,36 +59,6 @@ type baseHookManagerSuite struct {
 	command     *testutil.MockCmd
 }
 
-type hookManagerSuite struct {
-	baseHookManagerSuite
-}
-
-var _ = Suite(&hookManagerSuite{})
-
-var snapYaml = `
-name: test-snap
-version: 1.0
-hooks:
-    configure:
-    prepare-device:
-    do-something:
-    undo-something:
-`
-
-var snapYaml1 = `
-name: test-snap-1
-version: 1.0
-hooks:
-    prepare-device:
-`
-
-var snapYaml2 = `
-name: test-snap-2
-version: 1.0
-hooks:
-    prepare-device:
-`
-
 func (s *baseHookManagerSuite) commonSetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
@@ -160,6 +130,36 @@ func (s *baseHookManagerSuite) setUpSnap(c *C, instanceName string, yaml string)
 		InstanceKey: instanceKey,
 	})
 }
+
+type hookManagerSuite struct {
+	baseHookManagerSuite
+}
+
+var _ = Suite(&hookManagerSuite{})
+
+var snapYaml = `
+name: test-snap
+version: 1.0
+hooks:
+    configure:
+    prepare-device:
+    do-something:
+    undo-something:
+`
+
+var snapYaml1 = `
+name: test-snap-1
+version: 1.0
+hooks:
+    prepare-device:
+`
+
+var snapYaml2 = `
+name: test-snap-2
+version: 1.0
+hooks:
+    prepare-device:
+`
 
 func (s *hookManagerSuite) SetUpTest(c *C) {
 	s.commonSetUpTest(c)

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -45,7 +45,7 @@ import (
 
 func TestHookManager(t *testing.T) { TestingT(t) }
 
-type hookManagerSuite struct {
+type baseHookManagerSuite struct {
 	testutil.BaseTest
 
 	o           *overlord.Overlord
@@ -57,6 +57,10 @@ type hookManagerSuite struct {
 	task        *state.Task
 	change      *state.Change
 	command     *testutil.MockCmd
+}
+
+type hookManagerSuite struct {
+	baseHookManagerSuite
 }
 
 var _ = Suite(&hookManagerSuite{})
@@ -85,7 +89,7 @@ hooks:
     prepare-device:
 `
 
-func (s *hookManagerSuite) SetUpTest(c *C) {
+func (s *baseHookManagerSuite) commonSetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	hooktype1 := snap.NewHookType(regexp.MustCompile("^do-something$"))
@@ -104,32 +108,6 @@ func (s *hookManagerSuite) SetUpTest(c *C) {
 
 	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
-	hooksup := &hookstate.HookSetup{
-		Snap:     "test-snap",
-		Hook:     "configure",
-		Revision: snap.R(1),
-	}
-
-	initialContext := map[string]interface{}{
-		"test-key": "test-value",
-	}
-
-	s.state.Lock()
-	s.task = hookstate.HookTask(s.state, "test summary", hooksup, initialContext)
-	c.Assert(s.task, NotNil, Commentf("Expected HookTask to return a task"))
-
-	s.change = s.state.NewChange("kind", "summary")
-	s.change.AddTask(s.task)
-
-	sideInfo := &snap.SideInfo{RealName: "test-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	snaptest.MockSnap(c, snapYaml, sideInfo)
-	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
-		Current:  snap.R(1),
-	})
-	s.state.Unlock()
-
 	s.command = testutil.MockCommand(c, "snap", "")
 	s.AddCleanup(s.command.Restore)
 
@@ -144,12 +122,53 @@ func (s *hookManagerSuite) SetUpTest(c *C) {
 	}))
 }
 
-func (s *hookManagerSuite) TearDownTest(c *C) {
+func (s *baseHookManagerSuite) commonTearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 
 	s.manager.StopHooks()
 	s.se.Stop()
 	dirs.SetRootDir("")
+}
+
+func (s *baseHookManagerSuite) setUpSnap(c *C, instanceName string, yaml string) {
+	hooksup := &hookstate.HookSetup{
+		Snap:     instanceName,
+		Hook:     "configure",
+		Revision: snap.R(1),
+	}
+
+	initialContext := map[string]interface{}{
+		"test-key": "test-value",
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.task = hookstate.HookTask(s.state, "test summary", hooksup, initialContext)
+	c.Assert(s.task, NotNil, Commentf("Expected HookTask to return a task"))
+
+	s.change = s.state.NewChange("kind", "summary")
+	s.change.AddTask(s.task)
+
+	snapName, instanceKey := snap.SplitInstanceName(instanceName)
+
+	sideInfo := &snap.SideInfo{RealName: snapName, SnapID: "some-snap-id", Revision: snap.R(1)}
+	snaptest.MockSnapInstance(c, instanceName, yaml, sideInfo)
+	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
+		Active:      true,
+		Sequence:    []*snap.SideInfo{sideInfo},
+		Current:     snap.R(1),
+		InstanceKey: instanceKey,
+	})
+}
+
+func (s *hookManagerSuite) SetUpTest(c *C) {
+	s.commonSetUpTest(c)
+
+	s.setUpSnap(c, "test-snap", snapYaml)
+}
+
+func (s *hookManagerSuite) TearDownTest(c *C) {
+	s.commonTearDownTest(c)
 }
 
 func (s *hookManagerSuite) settle(c *C) {
@@ -1120,4 +1139,58 @@ func (s *hookManagerSuite) TestHookHijackingNoConflict(c *C) {
 	// no conflict on hijacked hooks
 	_, err := snapstate.Disable(s.state, "test-snap")
 	c.Assert(err, IsNil)
+}
+
+type parallelInstancesHookManagerSuite struct {
+	baseHookManagerSuite
+}
+
+var _ = Suite(&parallelInstancesHookManagerSuite{})
+
+func (s *parallelInstancesHookManagerSuite) SetUpTest(c *C) {
+	s.commonSetUpTest(c)
+	s.setUpSnap(c, "test-snap_instance", snapYaml)
+}
+
+func (s *parallelInstancesHookManagerSuite) TearDownTest(c *C) {
+	s.commonTearDownTest(c)
+}
+
+func (s *parallelInstancesHookManagerSuite) TestHookTaskEnsureHookRan(c *C) {
+	didRun := make(chan bool)
+	s.mockHandler.BeforeCallback = func() {
+		c.Check(s.manager.NumRunningHooks(), Equals, 1)
+		go func() {
+			didRun <- s.manager.GracefullyWaitRunningHooks()
+		}()
+	}
+	s.se.Ensure()
+	select {
+	case ok := <-didRun:
+		c.Check(ok, Equals, true)
+	case <-time.After(5 * time.Second):
+		c.Fatal("hook run should have been done by now")
+	}
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.context.InstanceName(), Equals, "test-snap_instance")
+	c.Check(s.context.SnapRevision(), Equals, snap.R(1))
+	c.Check(s.context.HookName(), Equals, "configure")
+
+	c.Check(s.command.Calls(), DeepEquals, [][]string{{
+		"snap", "run", "--hook", "configure", "-r", "1", "test-snap_instance",
+	}})
+
+	c.Check(s.mockHandler.BeforeCalled, Equals, true)
+	c.Check(s.mockHandler.DoneCalled, Equals, true)
+	c.Check(s.mockHandler.ErrorCalled, Equals, false)
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.DoneStatus)
+	c.Check(s.change.Status(), Equals, state.DoneStatus)
+
+	c.Check(s.manager.NumRunningHooks(), Equals, 0)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2433,6 +2433,17 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	})
 	c.Assert(snapst.Required, Equals, false)
 	c.Assert(snapst.InstanceKey, Equals, "instance")
+
+	runHooks := tasksWithKind(ts, "run-hook")
+	// install and configure hooks
+	c.Assert(runHooks, HasLen, 2)
+	for _, hookTask := range runHooks {
+		c.Assert(hookTask.Kind(), Equals, "run-hook")
+		var hooksup hookstate.HookSetup
+		err = hookTask.Get("hook-setup", &hooksup)
+		c.Assert(err, IsNil)
+		c.Assert(hooksup.Snap, Equals, "some-snap_instance")
+	}
 }
 
 func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -1008,15 +1008,15 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 		return nil, &invalidMetaError{Snap: name, Revision: si.Revision, Msg: err.Error()}
 	}
 
+	_, instanceKey := SplitInstanceName(name)
+	info.InstanceKey = instanceKey
+
 	err = addImplicitHooks(info)
 	if err != nil {
 		return nil, &invalidMetaError{Snap: name, Revision: si.Revision, Msg: err.Error()}
 	}
 
 	bindImplicitHooks(info)
-
-	_, instanceKey := SplitInstanceName(name)
-	info.InstanceKey = instanceKey
 
 	mountFile := MountFile(name, si.Revision)
 	st, err := os.Lstat(mountFile)

--- a/tests/main/install-refresh-remove-hooks/task.yaml
+++ b/tests/main/install-refresh-remove-hooks/task.yaml
@@ -1,10 +1,26 @@
-summary: Check install, remove and pre-refresh/post-refresh hooks.
+summary: Check install, configure, remove and pre-refresh/post-refresh hooks.
 
 # slow in autopkgtest (>1m)
 backends: [-autopkgtest]
 
 environment:
-    REMOVE_HOOK_FILE: "$HOME/snap/snap-hooks/common/remove-hook-executed"
+    REMOVE_HOOK_FILE/regular: "$HOME/snap/snap-hooks/common/remove-hook-executed"
+    REMOVE_HOOK_FILE/parallel: "$HOME/snap/snap-hooks_instance/common/remove-hook-executed"
+    NAME/regular: snap-hooks
+    NAME/parallel: snap-hooks_instance
+
+prepare: |
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+
+    if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
+        snap set system experimental.parallel-instances=true
+    fi
+
+restore: |
+    if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
+        snap set system experimental.parallel-instances=null
+    fi
 
 restore: |
     rm -f "$REMOVE_HOOK_FILE"
@@ -12,11 +28,12 @@ restore: |
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local snap-hooks
+    # shellcheck disable=SC2153
+    install_local_as snap-hooks "$NAME"
 
     echo "Verify configuration value with snap get"
-    snap get snap-hooks installed | MATCH 1
-    snap get snap-hooks foo | MATCH bar
+    snap get "$NAME" installed | MATCH 1
+    snap get "$NAME" foo | MATCH bar
 
     echo "Verify that pre-refresh hook was not executed"
     if snap get snap-install-hooks prerefreshed; then
@@ -31,29 +48,29 @@ execute: |
     fi
 
     echo "Verify that install hook is run only once"
-    snap set snap-hooks installed=2
-    install_local snap-hooks
-    snap get snap-hooks installed | MATCH 2
+    snap set "$NAME" installed=2
+    install_local_as snap-hooks "$NAME"
+    snap get "$NAME" installed | MATCH 2
 
     echo "Verify that pre-refresh hook was executed"
-    snap get snap-hooks prerefreshed | MATCH "pre-refresh at revision x1"
+    snap get "$NAME" prerefreshed | MATCH "pre-refresh at revision x1"
 
     echo "Verify that post-refresh hook was executed"
-    snap get snap-hooks postrefreshed | MATCH "post-refresh at revision x2"
+    snap get "$NAME" postrefreshed | MATCH "post-refresh at revision x2"
 
-    snap connect snap-hooks:home
+    snap connect "$NAME:home"
 
     echo "Verify that remove hook is not executed when removing single revision"
-    snap set snap-hooks exitcode=0
-    snap remove --revision=x1 snap-hooks
+    snap set "$NAME" exitcode=0
+    snap remove --revision=x1 "$NAME"
     if test -f "$REMOVE_HOOK_FILE"; then
         echo "Remove hook was executed. It shouldn't."
         exit 1
     fi
 
     echo "Verify that remove hook is executed"
-    snap set snap-hooks exitcode=0
-    snap remove snap-hooks
+    snap set "$NAME" exitcode=0
+    snap remove "$NAME"
     if ! test -f "$REMOVE_HOOK_FILE"; then
         echo "Remove hook was not executed"
         exit 1
@@ -61,12 +78,12 @@ execute: |
 
     echo "Installing a snap with hooks again"
     rm -f "$REMOVE_HOOK_FILE" > /dev/null 2>&1
-    install_local snap-hooks
-    snap connect snap-hooks:home
+    install_local_as snap-hooks "$NAME"
+    snap connect "$NAME:home"
 
     echo "Forcing remove script to fail"
-    snap set snap-hooks exitcode=1
-    snap remove snap-hooks
+    snap set "$NAME" exitcode=1
+    snap remove "$NAME"
     EXITCODE_VALUE=$(cat "$REMOVE_HOOK_FILE")
     if test "x$EXITCODE_VALUE" != "x1"; then
         echo "Remove hook was not executed"


### PR DESCRIPTION
Backport of https://github.com/snapcore/snapd/pull/6453 to 2.37