### PR TITLE
snap-confine: provide proper error message on sc_sanity_timeout

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -651,6 +651,12 @@ static void helper_main(struct sc_mount_ns *group, struct sc_apparmor *apparmor,
 		debug("helper process waiting for command");
 		sc_enable_sanity_timeout();
 		if (read(group->pipe_master[0], &command, sizeof command) < 0) {
+			int saved_errno = errno;
+			// This will ensure we get the correct error message
+			// if there is a read error because the timeout
+			// expired.
+			sc_disable_sanity_timeout();
+			errno = saved_errno;
 			die("cannot read command from the pipe");
 		}
 		sc_disable_sanity_timeout();


### PR DESCRIPTION
The code that communicates with the helper process does setup
a "sanity" timeout currently. If that timeout is reached then
snap-confine dies. Unfortunately the error message is misleading
and says "interrupted system call" which does not help finding
the underlying issue.

This PR changes the code so that the timeout is checked before
the read error is printed. This will lead to the slightly better:
```
error: sanity timeout expired
```
which is still not great but it helps to see that this is not
an error in the code but something with the interaction of
snap-confine and its helpers.

