### PR TITLE
snap-confine: increase locking timeout to 30s 

### DIFF
--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -125,7 +125,7 @@ static void test_sc_enable_sanity_timeout(void)
 		sc_disable_sanity_timeout();
 		return;
 	}
-	g_test_trap_subprocess(NULL, 5 * G_USEC_PER_SEC,
+	g_test_trap_subprocess(NULL, 1 * G_USEC_PER_SEC,
 			       G_TEST_SUBPROCESS_INHERIT_STDERR);
 	g_test_trap_assert_failed();
 	g_test_trap_assert_stderr ("sanity timeout expired: Interrupted system call\n");

--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -128,6 +128,7 @@ static void test_sc_enable_sanity_timeout(void)
 	g_test_trap_subprocess(NULL, 5 * G_USEC_PER_SEC,
 			       G_TEST_SUBPROCESS_INHERIT_STDERR);
 	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr ("sanity timeout expired: Interrupted system call\n");
 }
 
 static void __attribute__ ((constructor)) init(void)

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -36,7 +36,7 @@
 
 // SANITY_TIMEOUT is the timeout in seconds that is used when
 // "sc_enable_sanity_timeout()" is called
-static const int SANITY_TIMEOUT=6;
+static const int SANITY_TIMEOUT=30;
 
 /**
  * Flag indicating that a sanity timeout has expired.

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -36,7 +36,7 @@
 
 // SANITY_TIMEOUT is the timeout in seconds that is used when
 // "sc_enable_sanity_timeout()" is called
-static const int SANITY_TIMEOUT=30;
+static const int SANITY_TIMEOUT = 30;
 
 /**
  * Flag indicating that a sanity timeout has expired.
@@ -66,7 +66,8 @@ void sc_enable_sanity_timeout(void)
 		die("cannot install signal handler for SIGALRM");
 	}
 	alarm(SANITY_TIMEOUT);
-	debug("sanity timeout initialized and set for %i seconds", SANITY_TIMEOUT);
+	debug("sanity timeout initialized and set for %i seconds",
+	      SANITY_TIMEOUT);
 }
 
 void sc_disable_sanity_timeout(void)

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -34,6 +34,10 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
+// SANITY_TIMEOUT is the timeout in seconds that is used when
+// "sc_enable_sanity_timeout()" is called
+static const int SANITY_TIMEOUT=6;
+
 /**
  * Flag indicating that a sanity timeout has expired.
  **/
@@ -61,8 +65,8 @@ void sc_enable_sanity_timeout(void)
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot install signal handler for SIGALRM");
 	}
-	alarm(6);
-	debug("sanity timeout initialized and set for three seconds");
+	alarm(SANITY_TIMEOUT);
+	debug("sanity timeout initialized and set for %i seconds", SANITY_TIMEOUT);
 }
 
 void sc_disable_sanity_timeout(void)


### PR DESCRIPTION
we got reports from the field that some snaps fail to start
and it appears this is because the "sanity" timeout is too
low for low-end arm devices. This PR increases it as a short
term measure to 30s.

