### PR TITLE
[RFC] many: add simple performance measure tool mostly for firstboot

### DIFF
--- a/cmd/snap/cmd_debug_measures.go
+++ b/cmd/snap/cmd_debug_measures.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
+)
+
+var shortMeasuresHelp = i18n.G("Print sandbox features available on the system")
+var longMeasuresHelp = i18n.G(`
+The sandbox command prints tags describing features of individual sandbox
+components used by snapd on a given system.
+`)
+
+type cmdMeasures struct {
+	clientMixin
+}
+
+func init() {
+	addDebugCommand("measures", shortMeasuresHelp, longMeasuresHelp, func() flags.Commander {
+		return &cmdMeasures{}
+	}, nil, nil)
+}
+
+func (cmd cmdMeasures) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	var resp struct {
+		Measures string `json:"measures"`
+	}
+	if err := cmd.client.Debug("get-measures", nil, &resp); err != nil {
+		return err
+	}
+	fmt.Fprintln(Stdout, "Measures:")
+	fmt.Fprintf(Stdout, "%s\n", resp.Measures)
+	return nil
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -53,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/measure"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -2526,6 +2528,12 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		sort.Strings(status.Unreachable)
 
 		return SyncResponse(status, nil)
+	case "get-measures":
+		var buf bytes.Buffer
+		measure.WriteAll(&buf)
+		return SyncResponse(map[string]interface{}{
+			"measures": buf.String(),
+		}, nil)
 	default:
 		return BadRequest("unknown debug action: %v", a.Action)
 	}

--- a/measure/measure.go
+++ b/measure/measure.go
@@ -22,6 +22,7 @@ package measure
 import (
 	"fmt"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -55,8 +56,13 @@ const maxSize = 100
 // for some nice work in this area
 var allMeasures []string
 
+var mu sync.Mutex
+
 // addMeasure is an internal helper
 func addMeasure(m *Measure) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	msg := fmt.Sprintf("%s took %v", m.action, m.end.Sub(m.start))
 	allMeasures = append(allMeasures, msg)
 	if len(allMeasures) > maxSize {

--- a/measure/measure.go
+++ b/measure/measure.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package measure
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// Measure is a single timing measurement for a given "action"
+//
+type Measure struct {
+	// TODO: we may want to add more fancy things like json
+	//       output, tags etc but YAGNI for now
+	action     string
+	start, end time.Time
+}
+
+// New creates a new timing measure for the given action
+func New(action string) *Measure {
+	return &Measure{action: action, start: time.Now()}
+}
+
+// Done indicates that the given measure is finished
+func (m *Measure) Done() {
+	if m.end.IsZero() {
+		m.end = time.Now()
+		addMeasure(m)
+	}
+}
+
+// maximum amount of measures to keep in memory
+const maxSize = 100
+
+// use something fancy like a ringbuffer here, see
+// https://github.com/zyga/snapd/commit/ce3f289c86b783486349b21c386f976133ff69aa
+// for some nice work in this area
+var allMeasures []string
+
+// addMeasure is an internal helper
+func addMeasure(m *Measure) {
+	msg := fmt.Sprintf("%s took %v", m.action, m.end.Sub(m.start))
+	allMeasures = append(allMeasures, msg)
+	if len(allMeasures) > maxSize {
+		allMeasures = allMeasures[len(allMeasures)-maxSize:]
+	}
+}
+
+func WriteAll(w io.Writer) {
+	for _, m := range allMeasures {
+		// FIXME: add timestaamps
+		fmt.Fprintln(w, m)
+	}
+}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/measure"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -43,6 +44,9 @@ import (
 var errNothingToDo = errors.New("nothing to do")
 
 func installSeedSnap(st *state.State, sn *snap.SeedSnap, flags snapstate.Flags) (*state.TaskSet, *snap.Info, error) {
+	m := measure.New(fmt.Sprintf("installing for %s", sn.File))
+	defer m.Done()
+
 	if sn.Classic {
 		flags.Classic = true
 	}
@@ -80,6 +84,9 @@ func trivialSeeding(st *state.State, markSeeded *state.Task) []*state.TaskSet {
 }
 
 func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
+	m := measure.New("populateStateFromSeed")
+	defer m.Done()
+
 	// check that the state is empty
 	var seeded bool
 	err := st.Get("seeded", &seeded)

--- a/tests/main/firstboot-measure/task.yaml
+++ b/tests/main/firstboot-measure/task.yaml
@@ -1,0 +1,14 @@
+summary: Check that we get performance data for firstboot
+
+systems: [ubuntu-core-*]
+
+prepare: |
+    systemctl stop snapd.socket snapd
+    rm -f /var/lib/snapd/state.json
+    systemctl start snapd.socket snapd
+    while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
+
+execute: |
+    echo "Check that we get first boot related measures"
+    snap debug measures | MATCH "Measures:"
+    snap debug measures | MATCH "populateStateFromSeed"


### PR DESCRIPTION
This PR adds a very simplisit "measure" module to the tree that
can be used to take measurements of things that take time.

The API is minimal, the intended use (for now) is:
```
func foo() {
   m := measure.New("things happening in foo")
   defer m.Done()
   ...
}
```
The PR adds some measures into the firstboot code but we need to
experiment a bit too see where else we need to measure.

With that there is a new `snap debug measures` command that can
be used to get the most recent measurements.

This will result in something like:
```
snap debug measures
Measures:
installing for core_x1.snap took 533.215754ms
installing for pc-kernel_184.snap took 1.076903215s
installing for pc_24.snap took 13.288668ms
populateStateFromSeed took 1.64349125s
```
Making the output more structed is probably a good idea too :)