### PR TITLE
cmd/snap-confine: handle death of helper process

### DIFF
--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -167,10 +167,7 @@ static int sc_open_snapd_tool(const char *tool_name)
 		die("cannot open path %s", dir_name);
 	}
 	int tool_fd = -1;
-	/* Use O_CLOEXEC but not O_PATH. This allows us to determine if the file is
-	 * a binary or a script just prior to passing it to fexecve. This way we
-	 * can still undo the use of O_CLOEXEC which is a safe default. */
-	tool_fd = openat(dir_fd, tool_name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+	tool_fd = openat(dir_fd, tool_name, O_PATH | O_NOFOLLOW | O_CLOEXEC);
 	if (tool_fd < 0) {
 		die("cannot open path %s/%s", dir_name, tool_name);
 	}
@@ -213,23 +210,6 @@ static void sc_call_snapd_tool_with_apparmor(int tool_fd, const char *tool_name,
 		if (apparmor != NULL && aa_profile != NULL) {
 			sc_maybe_aa_change_onexec(apparmor, aa_profile);
 		}
-		/* As a special exception, allow the tool to be a script. */
-		char buf[2] = { 0 };
-		ssize_t num_read = pread(tool_fd, buf, sizeof buf, 0);
-		if (num_read < 0) {
-			die("cannot read program header");
-		}
-		if (buf[0] == '#' && buf[1] == '!') {
-			int flags = fcntl(tool_fd, F_GETFD);
-			if (flags < 0) {
-				die("cannot get file descriptor flags");
-			}
-			flags &= ~FD_CLOEXEC;
-			if (fcntl(tool_fd, F_SETFD, flags) < 0) {
-				die("cannot set file descriptor flags");
-			}
-		}
-		/* Execute the tool. */
 		fexecve(tool_fd, argv, envp);
 		die("cannot execute snapd tool %s", tool_name);
 	} else {

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -595,7 +595,6 @@ static void teardown_signals_for_helper(void)
 
 static void helper_fork(struct sc_mount_ns *group, struct sc_apparmor *apparmor)
 {
-	setup_signals_for_helper();
 	// Create a pipe for sending commands to the helper process.
 	if (pipe2(group->pipe_master, O_CLOEXEC | O_DIRECT) < 0) {
 		die("cannot create pipes for commanding the helper process");
@@ -620,6 +619,8 @@ static void helper_fork(struct sc_mount_ns *group, struct sc_apparmor *apparmor)
 		sc_cleanup_close(&group->pipe_helper[0]);
 		helper_main(group, apparmor, parent);
 	} else {
+		setup_signals_for_helper();
+
 		/* master */
 		sc_cleanup_close(&group->pipe_master[0]);
 		sc_cleanup_close(&group->pipe_helper[1]);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -767,8 +767,12 @@ static void sc_message_capture_helper(struct sc_mount_ns *group, int command_id)
 		die("cannot send command %d to helper process", command_id);
 	}
 	debug("waiting for response from helper");
-	if (read(group->pipe_helper[0], &ack, sizeof ack) < 0) {
+	int read_n = read(group->pipe_helper[0], &ack, sizeof ack);
+	if (read_n < 0) {
 		die("cannot receive ack from helper process");
+	}
+	if (read_n == 0) {
+		die("unexpected eof from helper process");
 	}
 }
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -713,6 +713,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # sharing and propagates mount events outside of the snap namespace.
   audit deny mount -> /media,
 
+  # Allow receiving signals from unconfined (eg, systemd)
+  signal (receive) peer=unconfined,
+
   # Commonly needed permissions for writable mimics.
   /tmp/ r,
   /tmp/.snap/{,**} rw,

--- a/tests/lib/snaps/test-snapd-simple-service/bin/service
+++ b/tests/lib/snaps/test-snapd-simple-service/bin/service
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sleep 1h

--- a/tests/lib/snaps/test-snapd-simple-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-simple-service/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-simple-service
+version: 1.0
+apps:
+    test-snapd-simple-service:
+        command: bin/service
+        daemon: simple
+        restart-delay: 0
+        restart-condition: never

--- a/tests/regression/lp-1813963/task.yaml
+++ b/tests/regression/lp-1813963/task.yaml
@@ -1,4 +1,9 @@
 summary: "regression test for LP: #1813963"
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+
+backends: [-external]
+
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
@@ -23,35 +28,8 @@ prepare: |
     # Nothing should have been denied yet.
     test "$(dmesg | grep -c DENIED)" -eq 0
 
-    # Check if we have apparmor support. When there is no apparmor we don't
-    # need special profile changes below.
-    if snap debug sandbox-features | grep -q apparmor; then
-        apparmor=yes
-    else
-        apparmor=no
-    fi
-
     systemctl stop snapd.service
     echo "snapd has been stopped" | systemd-cat
-
-    if [ "$apparmor" = yes ]; then
-        # Because we are about to replace snap-update-ns with a script we also need
-        # to adjust the per-snap apparmor profile of snap-update-ns to convey
-        # additional permissions about executing as a script.
-        for SUN_AA in /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-sh /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-simple-service; do
-            truncate --size=-2 "$SUN_AA"  # chop trailing }
-            profile="$(basename "$SUN_AA")"
-            {
-                echo '  /bin/dash mrix,'
-                echo '  /bin/sleep mrix,'
-                echo "  $(pwd)"'/real-snap-update-ns mrix,'
-                echo '  signal (send, receive) set=(int, pipe) peer='"$profile"','
-                echo '}'
-            } >> "$SUN_AA"
-            apparmor_parser -r "$SUN_AA"
-        done
-        echo "snap-update-ns profiles have been replaced" | systemd-cat
-    fi
 
     # Replace snap-update-ns with a fake version that waits for the given
     # amount of time before doing its real work. Since snap-update-ns doesn't
@@ -59,11 +37,17 @@ prepare: |
     # baked-in from the outside.
     cp "$LIBEXECDIR/snapd/snap-update-ns" ./real-snap-update-ns
 
-    echo '#!/bin/sh -x' > fake-snap-update-ns
-    # 31 seconds is one second longer than the sanity timeout.
-    echo 'sleep 31' >> fake-snap-update-ns
-    echo 'exec "'"$(pwd)/real-snap-update-ns"'" "$@"' >> fake-snap-update-ns
-    chmod 0755 fake-snap-update-ns
+    # We could install our own go here via `snap install go --classic`
+    # but instead we just run this on systems (via systems above) that
+    # already have go. Doing this as a shell script is tricky and requires
+    # modifying sc_call_snapd_tool_with_apparmor() so that ~FDCLOEXEC is
+    # cleaned which is not what we want.
+    cat >fake-snap-update-ns.go <<EOF
+    package main
+    import "time"
+    func main() { time.Sleep(31*time.Second) }
+    EOF
+    go build fake-snap-update-ns.go
 
     # Replace snap-update-ns in all the places it might exist in.
     mount --bind ./fake-snap-update-ns "$LIBEXECDIR/snapd/snap-update-ns"

--- a/tests/regression/lp-1813963/task.yaml
+++ b/tests/regression/lp-1813963/task.yaml
@@ -1,0 +1,124 @@
+summary: "regression test for LP: #1813963"
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    # Install the versatile test snap.
+    install_local test-snapd-sh
+    # Discard the mount namespace in case the snap has any hooks. We rely on
+    # the mount namespace to be absent and about to be constructed in the test
+    # below.
+    "$LIBEXECDIR"/snapd/snap-discard-ns test-snapd-sh
+
+    # Install a simple service snap. This snap has a single service that just
+    # runs for an hour and quits. The point is that it is just one service
+    # without anything special about it.
+    #
+    # For the purpose of the test we want the service to be off.
+    install_local test-snapd-simple-service
+    systemctl stop snap.test-snapd-simple-service.test-snapd-simple-service.service
+    "$LIBEXECDIR"/snapd/snap-discard-ns test-snapd-simple-service
+
+    # Nothing should have been denied yet.
+    test "$(dmesg | grep -c DENIED)" -eq 0
+
+    # Check if we have apparmor support. When there is no apparmor we don't
+    # need special profile changes below.
+    if snap debug sandbox-features | grep -q apparmor; then
+        apparmor=yes
+    else
+        apparmor=no
+    fi
+
+    systemctl stop snapd.service
+    echo "snapd has been stopped" | systemd-cat
+
+    if [ "$apparmor" = yes ]; then
+        # Because we are about to replace snap-update-ns with a script we also need
+        # to adjust the per-snap apparmor profile of snap-update-ns to convey
+        # additional permissions about executing as a script.
+        for SUN_AA in /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-sh /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-simple-service; do
+            truncate --size=-2 "$SUN_AA"  # chop trailing }
+            profile="$(basename "$SUN_AA")"
+            {
+                echo '  /bin/dash mrix,'
+                echo '  /bin/sleep mrix,'
+                echo "  $(pwd)"'/real-snap-update-ns mrix,'
+                echo '  signal (send, receive) set=(int, pipe) peer='"$profile"','
+                echo '}'
+            } >> "$SUN_AA"
+            apparmor_parser -r "$SUN_AA"
+        done
+        echo "snap-update-ns profiles have been replaced" | systemd-cat
+    fi
+
+    # Replace snap-update-ns with a fake version that waits for the given
+    # amount of time before doing its real work. Since snap-update-ns doesn't
+    # have access to real environment craft the script with appropriate paths
+    # baked-in from the outside.
+    cp "$LIBEXECDIR/snapd/snap-update-ns" ./real-snap-update-ns
+
+    echo '#!/bin/sh -x' > fake-snap-update-ns
+    # 31 seconds is one second longer than the sanity timeout.
+    echo 'sleep 31' >> fake-snap-update-ns
+    echo 'exec "'"$(pwd)/real-snap-update-ns"'" "$@"' >> fake-snap-update-ns
+    chmod 0755 fake-snap-update-ns
+
+    # Replace snap-update-ns in all the places it might exist in.
+    mount --bind ./fake-snap-update-ns "$LIBEXECDIR/snapd/snap-update-ns"
+    if [ -e "$SNAP_MOUNT_DIR/core/current/" ]; then
+        mount --bind ./fake-snap-update-ns "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-update-ns"
+    fi
+    if [ -e "$SNAP_MOUNT_DIR/snapd/current/" ]; then
+        mount --bind ./fake-snap-update-ns "$SNAP_MOUNT_DIR/snapd/current/usr/lib/snapd/snap-update-ns"
+    fi
+    echo "snap-update-ns has been replaced" | systemd-cat
+restore: |
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    umount "$LIBEXECDIR/snapd/snap-update-ns" || true
+    if [ -e "$SNAP_MOUNT_DIR/core/current/" ]; then
+        umount "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-update-ns" || true
+    fi
+    if [ -e "$SNAP_MOUNT_DIR/snapd/current/" ]; then
+        umount "$SNAP_MOUNT_DIR/snapd/current/usr/lib/snapd/snap-update-ns" || true
+    fi
+
+    rm -f real-snap-update-ns
+    rm -f fake-snap-update-ns
+    echo "snap-update-ns has been restored" | systemd-cat
+
+    systemctl start snapd.service
+    echo "snapd has been started" | systemd-cat
+
+    snap remove test-snapd-sh
+    snap remove test-snapd-simple-service
+    echo "snaps have been removed" | systemd-cat
+
+execute: |
+    # When snap-update-ns is artificially slowed down so that snap-confine
+    # starts to fail on timeout errors then the exit status from the
+    # snap-confine process is the regular "failed" rather than "failed due to
+    # signal SIGPIPE".
+    set +e
+    test-snapd-sh -c /bin/true
+    retcode=$?
+    set -e
+    test "$retcode" -eq 1
+
+    # When we start our simple service it will fail. We anticipate this and
+    # explicitly pass --wait that will otherwise wait forever.
+    set +e
+    systemctl start --wait snap.test-snapd-simple-service.test-snapd-simple-service.service
+    retcode=$?
+    set -e
+    test "$retcode" -eq 1
+
+    # Nothing should have been denied as a part of this test.
+    test "$(dmesg | grep -c DENIED)" -eq 0
+debug: |
+    echo "Status of the test service"
+    systemctl status snap.test-snapd-simple-service.test-snapd-simple-service.service || true
+    echo "Apparmor denials"
+    dmesg | grep DENIED || true


### PR DESCRIPTION
When SIGPIPE is delivered the snap-confine process it would involuntary
terminate. If snap-confine was a part of a startup chain of a systemd
service then systemd would consider the exit as _clean_, as documented
by systemd.service(5), even though the actual snap application was never
invoked. This patch corrects this in the following way.

When the snap-confine helper process terminates due to SIGARLM-based
timeout mechanism the parent would receive SIGPIPE on the attempt to
communicate with the helper.

The disposition of SIGPIPE is set to SIG_IGN, and only in the scope where we
are interacting with the helper process and are possibly using pipes for 
communication. This ensures that the helper dies for whatever reason the
parent can just deal with EPIPE (and exiting with a proper error code) instead
of dying because of SIGPIPE.

The patch also contains a regression test, for easier review:

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
