### PR TITLE
image,cmd/snap,tests:  introduce prepare-image --classic

### DIFF
--- a/image/helpers.go
+++ b/image/helpers.go
@@ -189,8 +189,13 @@ func (tac toolingAuthContext) UpdateUserAuth(user *auth.UserState, discharges []
 	return user, nil
 }
 
-func NewToolingStoreFromModel(model *asserts.Model) (*ToolingStore, error) {
-	return newToolingStore(model.Architecture(), model.Store())
+func NewToolingStoreFromModel(model *asserts.Model, fallbackArchitecture string) (*ToolingStore, error) {
+	architecture := model.Architecture()
+	// can happen on classic
+	if architecture == "" {
+		architecture = fallbackArchitecture
+	}
+	return newToolingStore(architecture, model.Store())
 }
 
 func NewToolingStore() (*ToolingStore, error) {

--- a/image/image.go
+++ b/image/image.go
@@ -46,11 +46,14 @@ var (
 )
 
 type Options struct {
+	Classic         bool
 	Snaps           []string
 	RootDir         string
 	Channel         string
 	ModelFile       string
 	GadgetUnpackDir string
+
+	ClassicArchitecture string
 }
 
 type localInfos struct {
@@ -161,10 +164,37 @@ func validateNonLocalSnaps(snaps []string) error {
 	return validateSnapNames(nonLocalSnaps)
 }
 
+// classicHasSnaps returns whether the model or options specify any snaps for the classic case
+func classicHasSnaps(model *asserts.Model, opts *Options) bool {
+	return model.Gadget() != "" || len(model.RequiredSnaps()) != 0 || len(opts.Snaps) != 0
+}
+
 func Prepare(opts *Options) error {
 	model, err := decodeModelAssertion(opts)
 	if err != nil {
 		return err
+	}
+
+	if !opts.Classic {
+		if model.Classic() {
+			return fmt.Errorf("--classic mode is required to prepare the image for a classic model")
+		}
+		if opts.ClassicArchitecture != "" {
+			return fmt.Errorf("internal error: classic architecture specified for a core model")
+		}
+	} else {
+		if !model.Classic() {
+			return fmt.Errorf("cannot prepare the image for a core model with --classic mode specified")
+		}
+		if opts.GadgetUnpackDir != "" {
+			return fmt.Errorf("internal error: no gadget unpacking is performed for classic models but directory specified")
+		}
+		if model.Architecture() != "" && opts.ClassicArchitecture != "" && model.Architecture() != opts.ClassicArchitecture {
+			return fmt.Errorf("cannot override model architecture: %s", model.Architecture())
+		}
+		if model.Architecture() == "" && classicHasSnaps(model, opts) && opts.ClassicArchitecture == "" {
+			return fmt.Errorf("cannot have snaps for a classic image without an architecture in the model or from --classic-arch")
+		}
 	}
 
 	if err := validateNonLocalSnaps(opts.Snaps); err != nil {
@@ -174,12 +204,7 @@ func Prepare(opts *Options) error {
 		return fmt.Errorf("cannot use channel: %v", err)
 	}
 
-	// TODO: might make sense to support this later
-	if model.Classic() {
-		return fmt.Errorf("cannot prepare image of a classic model")
-	}
-
-	tsto, err := NewToolingStoreFromModel(model)
+	tsto, err := NewToolingStoreFromModel(model, opts.ClassicArchitecture)
 	if err != nil {
 		return err
 	}
@@ -194,8 +219,11 @@ func Prepare(opts *Options) error {
 		return fmt.Errorf("model with series %q != %q unsupported", model.Series(), release.Series)
 	}
 
-	if err := downloadUnpackGadget(tsto, model, opts, local); err != nil {
-		return err
+	if !opts.Classic {
+		// unpacking the gadget for core models
+		if err := downloadUnpackGadget(tsto, model, opts, local); err != nil {
+			return err
+		}
 	}
 
 	return bootstrapToRootDir(tsto, model, opts, local)
@@ -344,6 +372,10 @@ func neededDefaultProviders(info *snap.Info) (cps []string) {
 }
 
 func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options, local *localInfos) error {
+	if model.Classic() != opts.Classic {
+		return fmt.Errorf("internal error: classic model but classic mode not set")
+	}
+
 	// FIXME: try to avoid doing this
 	if opts.RootDir != "" {
 		dirs.SetRootDir(opts.RootDir)
@@ -352,7 +384,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 
 	// sanity check target
 	if osutil.FileExists(dirs.SnapStateFile) {
-		return fmt.Errorf("cannot bootstrap over existing system")
+		return fmt.Errorf("cannot bootstrap over existing system or an already booted image")
 	}
 	if snaps, _ := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*.snap")); len(snaps) > 0 {
 		return fmt.Errorf("need an empty snap dir in rootdir, got: %v", snaps)
@@ -379,10 +411,6 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 	}
 
 	// put snaps in place
-	if err := os.MkdirAll(dirs.SnapBlobDir, 0755); err != nil {
-		return err
-	}
-
 	snapSeedDir := filepath.Join(dirs.SnapSeedDir, "snaps")
 	assertSeedDir := filepath.Join(dirs.SnapSeedDir, "assertions")
 	for _, d := range []string{snapSeedDir, assertSeedDir} {
@@ -411,15 +439,34 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 			snaps = append(snaps, "core")
 		}
 	}
-	// core/base,kernel,gadget first
-	snaps = append(snaps, local.PreferLocal(baseName))
-	snaps = append(snaps, local.PreferLocal(model.Kernel()))
-	snaps = append(snaps, local.PreferLocal(model.Gadget()))
+
+	if !opts.Classic {
+		// core/base,kernel,gadget first
+		snaps = append(snaps, local.PreferLocal(baseName))
+		snaps = append(snaps, local.PreferLocal(model.Kernel()))
+		snaps = append(snaps, local.PreferLocal(model.Gadget()))
+	} else {
+		// classic image case: first core as needed and gadget
+		if classicHasSnaps(model, opts) {
+			// TODO: later use snapd+core16 or core18 if specified
+			snaps = append(snaps, local.PreferLocal("core"))
+		}
+		if model.Gadget() != "" {
+			snaps = append(snaps, local.PreferLocal(model.Gadget()))
+		}
+	}
+
 	// then required and the user requested stuff
 	for _, snapName := range model.RequiredSnaps() {
 		snaps = append(snaps, local.PreferLocal(snapName))
 	}
 	snaps = append(snaps, opts.Snaps...)
+
+	if !opts.Classic {
+		if err := os.MkdirAll(dirs.SnapBlobDir, 0755); err != nil {
+			return err
+		}
+	}
 
 	seen := make(map[string]bool)
 	var locals []string
@@ -481,6 +528,11 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		seen[name] = true
 		typ := info.Type
 
+		needsClassic := info.NeedsClassic()
+		if needsClassic && !opts.Classic {
+			return fmt.Errorf("cannot use classic snap %q in a core system", info.InstanceName())
+		}
+
 		// if it comes from the store fetch the snap assertions too
 		if info.SnapID != "" {
 			snapDecl, err := FetchAndCheckSnapAssertions(fn, info, f, db)
@@ -507,8 +559,8 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 			snapChannel = ""
 		}
 
-		// kernel/os/model.base are required for booting
-		if typ == snap.TypeKernel || local.Name(snapName) == baseName {
+		// kernel/os/model.base are required for booting on core
+		if !opts.Classic && (typ == snap.TypeKernel || local.Name(snapName) == baseName) {
 			dst := filepath.Join(dirs.SnapBlobDir, filepath.Base(fn))
 			// construct a relative symlink from the blob dir
 			// to the seed file
@@ -531,6 +583,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 			Channel: snapChannel,
 			File:    filepath.Base(fn),
 			DevMode: info.NeedsDevMode(),
+			Classic: needsClassic,
 			Contact: info.Contact,
 			// no assertions for this snap were put in the seed
 			Unasserted: info.SnapID == "",
@@ -575,18 +628,20 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		return fmt.Errorf("cannot write seed.yaml: %s", err)
 	}
 
-	// now do the bootloader stuff
-	if err := partition.InstallBootConfig(opts.GadgetUnpackDir); err != nil {
-		return err
-	}
+	if !opts.Classic {
+		// now do the bootloader stuff
+		if err := partition.InstallBootConfig(opts.GadgetUnpackDir); err != nil {
+			return err
+		}
 
-	if err := setBootvars(downloadedSnapsInfoForBootConfig, model); err != nil {
-		return err
-	}
+		if err := setBootvars(downloadedSnapsInfoForBootConfig, model); err != nil {
+			return err
+		}
 
-	// and the cloud-init things
-	if err := installCloudConfig(opts.GadgetUnpackDir); err != nil {
-		return err
+		// and the cloud-init things
+		if err := installCloudConfig(opts.GadgetUnpackDir); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/image/image.go
+++ b/image/image.go
@@ -385,7 +385,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 
 	// sanity check target
 	if osutil.FileExists(dirs.SnapStateFile) {
-		return fmt.Errorf("cannot bootstrap over existing system or an already booted image")
+		return fmt.Errorf("cannot prepare seed over existing system or an already booted image, detected state file %s", dirs.SnapStateFile)
 	}
 	if snaps, _ := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*.snap")); len(snaps) > 0 {
 		return fmt.Errorf("need an empty snap dir in rootdir, got: %v", snaps)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1893,7 +1893,7 @@ func (s *imageSuite) TestBootstrapToRootDirClassic(c *C) {
 		"snap_kernel": "",
 	})
 
-	c.Check(s.stderr.String(), Equals, "")
+	c.Check(s.stderr.String(), Matches, `WARNING: ensure that the contents under .*/var/lib/snapd/seed are owned by root:root in the \(final\) image`)
 
 	// no blob dir created
 	blobdir := filepath.Join(rootdir, "var/lib/snapd/snaps")
@@ -2015,8 +2015,6 @@ func (s *imageSuite) TestBootstrapToRootDirClassicNoSnaps(c *C) {
 		"snap_core":   "",
 		"snap_kernel": "",
 	})
-
-	c.Check(s.stderr.String(), Equals, "")
 
 	// no blob dir created
 	blobdir := filepath.Join(rootdir, "var/lib/snapd/snaps")

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -151,7 +151,7 @@ func (s *imageSuite) addSystemSnapAssertions(c *C, snapName string, publisher st
 		"publisher-id": publisher,
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
-	c.Assert(err, IsNil)
+	c.Assert(err, IsNil, Commentf("%s %s", snapName, publisher))
 	err = s.storeSigning.Add(decl)
 	c.Assert(err, IsNil)
 
@@ -223,6 +223,11 @@ version: 1.0
 type: gadget
 base: core18
 `
+const packageClassicGadget = `
+name: classic-gadget
+version: 1.0
+type: gadget
+`
 
 const packageKernel = `
 name: pc-kernel
@@ -259,6 +264,13 @@ name: devmode-snap
 version: 1.0
 type: app
 confinement: devmode
+`
+
+const classicSnap = `
+name: classic-snap
+version: 1.0
+type: app
+confinement: classic
 `
 
 const requiredSnap1 = `
@@ -545,10 +557,12 @@ func (s *imageSuite) TestDownloadUnpackGadgetFromTrack(c *C) {
 }
 
 func (s *imageSuite) setupSnaps(c *C, gadgetUnpackDir string, publishers map[string]string) {
-	err := os.MkdirAll(gadgetUnpackDir, 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(gadgetUnpackDir, "grub.conf"), nil, 0644)
-	c.Assert(err, IsNil)
+	if gadgetUnpackDir != "" {
+		err := os.MkdirAll(gadgetUnpackDir, 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(filepath.Join(gadgetUnpackDir, "grub.conf"), nil, 0644)
+		c.Assert(err, IsNil)
+	}
 
 	if _, ok := publishers["pc"]; ok {
 		s.downloadedSnaps["pc"] = snaptest.MakeTestSnapWithFiles(c, packageGadget, [][]string{{"grub.cfg", "I'm a grub.cfg"}})
@@ -561,9 +575,17 @@ func (s *imageSuite) setupSnaps(c *C, gadgetUnpackDir string, publishers map[str
 		s.addSystemSnapAssertions(c, "pc18", publishers["pc18"])
 	}
 
-	s.downloadedSnaps["pc-kernel"] = snaptest.MakeTestSnapWithFiles(c, packageKernel, nil)
-	s.storeSnapInfo["pc-kernel"] = infoFromSnapYaml(c, packageKernel, snap.R(2))
-	s.addSystemSnapAssertions(c, "pc-kernel", publishers["pc-kernel"])
+	if _, ok := publishers["classic-gadget"]; ok {
+		s.downloadedSnaps["classic-gadget"] = snaptest.MakeTestSnapWithFiles(c, packageClassicGadget, [][]string{{"some-file", "Some file"}})
+		s.storeSnapInfo["classic-gadget"] = infoFromSnapYaml(c, packageClassicGadget, snap.R(5))
+		s.addSystemSnapAssertions(c, "classic-gadget", publishers["classic-gadget"])
+	}
+
+	if _, ok := publishers["pc-kernel"]; ok {
+		s.downloadedSnaps["pc-kernel"] = snaptest.MakeTestSnapWithFiles(c, packageKernel, nil)
+		s.storeSnapInfo["pc-kernel"] = infoFromSnapYaml(c, packageKernel, snap.R(2))
+		s.addSystemSnapAssertions(c, "pc-kernel", publishers["pc-kernel"])
+	}
 
 	s.downloadedSnaps["core"] = snaptest.MakeTestSnapWithFiles(c, packageCore, nil)
 	s.storeSnapInfo["core"] = infoFromSnapYaml(c, packageCore, snap.R(3))
@@ -869,6 +891,34 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 		DevMode:    true,
 		Unasserted: true,
 	})
+}
+
+func (s *imageSuite) TestBootstrapToRootDirWithClassicSnapFails(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	rootdir := filepath.Join(c.MkDir(), "imageroot")
+	gadgetUnpackDir := c.MkDir()
+	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
+		"pc":        "canonical",
+		"pc-kernel": "canonical",
+	})
+
+	s.downloadedSnaps["classic-snap"] = snaptest.MakeTestSnapWithFiles(c, classicSnap, nil)
+	s.storeSnapInfo["classic-snap"] = infoFromSnapYaml(c, classicSnap, snap.R(0))
+
+	opts := &image.Options{
+		Snaps: []string{s.downloadedSnaps["classic-snap"]},
+
+		RootDir:         rootdir,
+		GadgetUnpackDir: gadgetUnpackDir,
+		Channel:         "beta",
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, IsNil)
+
+	err = image.BootstrapToRootDir(s.tsto, s.model, opts, local)
+	c.Assert(err, ErrorMatches, `cannot use classic snap "classic-snap" in a core system`)
 }
 
 func (s *imageSuite) TestBootstrapWithBase(c *C) {
@@ -1186,6 +1236,95 @@ func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 		Channel:   "x/x/x/x",
 	})
 	c.Assert(err, ErrorMatches, `cannot use channel: channel name has too many components: x/x/x/x`)
+}
+
+func (s *imageSuite) TestPrepareClassicModeNoClassicModel(c *C) {
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		Classic:   true,
+		ModelFile: fn,
+	})
+	c.Assert(err, ErrorMatches, "cannot prepare the image for a core model with --classic mode specified")
+}
+
+func (s *imageSuite) TestPrepareClassicModelNoClassicMode(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"classic":      "true",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err = ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		ModelFile: fn,
+	})
+	c.Assert(err, ErrorMatches, "--classic mode is required to prepare the image for a classic model")
+}
+
+func (s *imageSuite) TestPrepareClassicModelArchOverrideFails(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"classic":      "true",
+		"architecture": "amd64",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err = ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		Classic:             true,
+		ModelFile:           fn,
+		ClassicArchitecture: "i386",
+	})
+	c.Assert(err, ErrorMatches, "cannot override model architecture: amd64")
+}
+
+func (s *imageSuite) TestPrepareClassicModelSnapsButNoArchFails(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"classic":      "true",
+		"gadget":       "classic-gadget",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	fn := filepath.Join(c.MkDir(), "model.assertion")
+	err = ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	c.Assert(err, IsNil)
+
+	err = image.Prepare(&image.Options{
+		Classic:   true,
+		ModelFile: fn,
+	})
+	c.Assert(err, ErrorMatches, "cannot have snaps for a classic image without an architecture in the model or from --classic-arch")
 }
 
 func (s *imageSuite) TestBootstrapWithKernelAndGadgetTrack(c *C) {
@@ -1682,6 +1821,206 @@ func (s *imageSuite) TestMissingLocalSnaps(c *C) {
 	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, ErrorMatches, "local snap i-am-missing.snap not found")
 	c.Assert(local, IsNil)
+}
+
+func (s *imageSuite) TestBootstrapToRootDirClassic(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	// classic model with gadget etc
+	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":         "16",
+		"authority-id":   "my-brand",
+		"brand-id":       "my-brand",
+		"model":          "my-model",
+		"classic":        "true",
+		"architecture":   "amd64",
+		"gadget":         "classic-gadget",
+		"required-snaps": []interface{}{"required-snap1"},
+		"timestamp":      time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	model := rawmodel.(*asserts.Model)
+
+	rootdir := filepath.Join(c.MkDir(), "classic-image-root")
+	s.setupSnaps(c, "", map[string]string{
+		"classic-gadget": "my-brand",
+	})
+
+	opts := &image.Options{
+		Classic: true,
+		RootDir: rootdir,
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, IsNil)
+
+	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
+	c.Assert(err, IsNil)
+
+	// check seed yaml
+	seed, err := snap.ReadSeedYaml(filepath.Join(rootdir, "var/lib/snapd/seed/seed.yaml"))
+	c.Assert(err, IsNil)
+
+	c.Check(seed.Snaps, HasLen, 3)
+
+	// check the files are in place
+	for i, name := range []string{"core", "classic-gadget", "required-snap1"} {
+		unasserted := false
+		info := s.storeSnapInfo[name]
+
+		fn := filepath.Base(info.MountFile())
+		p := filepath.Join(rootdir, "var/lib/snapd/seed/snaps", fn)
+		c.Check(osutil.FileExists(p), Equals, true)
+
+		c.Check(seed.Snaps[i], DeepEquals, &snap.SeedSnap{
+			Name:       info.InstanceName(),
+			SnapID:     info.SnapID,
+			File:       fn,
+			Contact:    info.Contact,
+			Unasserted: unasserted,
+		})
+	}
+
+	l, err := ioutil.ReadDir(filepath.Join(rootdir, "var/lib/snapd/seed/snaps"))
+	c.Assert(err, IsNil)
+	c.Check(l, HasLen, 3)
+
+	// check that the  bootloader is unset
+	m, err := s.bootloader.GetBootVars("snap_kernel", "snap_core")
+	c.Assert(err, IsNil)
+	c.Check(m, DeepEquals, map[string]string{
+		"snap_core":   "",
+		"snap_kernel": "",
+	})
+
+	c.Check(s.stderr.String(), Equals, "")
+
+	// no blob dir created
+	blobdir := filepath.Join(rootdir, "var/lib/snapd/snaps")
+	c.Check(osutil.FileExists(blobdir), Equals, false)
+}
+
+func (s *imageSuite) TestBootstrapToRootDirClassicWithClassicSnap(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	// classic model
+	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"classic":      "true",
+		"architecture": "amd64",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	model := rawmodel.(*asserts.Model)
+
+	rootdir := filepath.Join(c.MkDir(), "classic-image-root")
+	s.setupSnaps(c, "", nil)
+
+	s.downloadedSnaps["classic-snap"] = snaptest.MakeTestSnapWithFiles(c, classicSnap, nil)
+	s.storeSnapInfo["classic-snap"] = infoFromSnapYaml(c, classicSnap, snap.R(0))
+
+	opts := &image.Options{
+		Classic: true,
+		Snaps:   []string{s.downloadedSnaps["classic-snap"]},
+		RootDir: rootdir,
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, IsNil)
+
+	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
+	c.Assert(err, IsNil)
+
+	// check seed yaml
+	seed, err := snap.ReadSeedYaml(filepath.Join(rootdir, "var/lib/snapd/seed/seed.yaml"))
+	c.Assert(err, IsNil)
+
+	c.Check(seed.Snaps, HasLen, 2)
+
+	p := filepath.Join(rootdir, "var/lib/snapd/seed/snaps", "core_3.snap")
+	c.Check(osutil.FileExists(p), Equals, true)
+	c.Check(seed.Snaps[0], DeepEquals, &snap.SeedSnap{
+		Name:   "core",
+		SnapID: "core-Id",
+		File:   "core_3.snap",
+	})
+
+	p = filepath.Join(rootdir, "var/lib/snapd/seed/snaps", "classic-snap_x1.snap")
+	c.Check(osutil.FileExists(p), Equals, true)
+	c.Check(seed.Snaps[1], DeepEquals, &snap.SeedSnap{
+		Name:       "classic-snap",
+		File:       "classic-snap_x1.snap",
+		Classic:    true,
+		Unasserted: true,
+	})
+
+	l, err := ioutil.ReadDir(filepath.Join(rootdir, "var/lib/snapd/seed/snaps"))
+	c.Assert(err, IsNil)
+	c.Check(l, HasLen, 2)
+
+	// check that the  bootloader is unset
+	m, err := s.bootloader.GetBootVars("snap_kernel", "snap_core")
+	c.Assert(err, IsNil)
+	c.Check(m, DeepEquals, map[string]string{
+		"snap_core":   "",
+		"snap_kernel": "",
+	})
+}
+
+func (s *imageSuite) TestBootstrapToRootDirClassicNoSnaps(c *C) {
+	restore := image.MockTrusted(s.storeSigning.Trusted)
+	defer restore()
+
+	// classic model with gadget etc
+	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"classic":      "true",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	model := rawmodel.(*asserts.Model)
+
+	rootdir := filepath.Join(c.MkDir(), "classic-image-root")
+
+	opts := &image.Options{
+		Classic: true,
+		RootDir: rootdir,
+	}
+	local, err := image.LocalSnaps(s.tsto, opts)
+	c.Assert(err, IsNil)
+
+	err = image.BootstrapToRootDir(s.tsto, model, opts, local)
+	c.Assert(err, IsNil)
+
+	// check seed yaml
+	seed, err := snap.ReadSeedYaml(filepath.Join(rootdir, "var/lib/snapd/seed/seed.yaml"))
+	c.Assert(err, IsNil)
+
+	c.Check(seed.Snaps, HasLen, 0)
+
+	l, err := ioutil.ReadDir(filepath.Join(rootdir, "var/lib/snapd/seed/snaps"))
+	c.Assert(err, IsNil)
+	c.Check(l, HasLen, 0)
+
+	// check that the  bootloader is unset
+	m, err := s.bootloader.GetBootVars("snap_kernel", "snap_core")
+	c.Assert(err, IsNil)
+	c.Check(m, DeepEquals, map[string]string{
+		"snap_core":   "",
+		"snap_kernel": "",
+	})
+
+	c.Check(s.stderr.String(), Equals, "")
+
+	// no blob dir created
+	blobdir := filepath.Join(rootdir, "var/lib/snapd/snaps")
+	c.Check(osutil.FileExists(blobdir), Equals, false)
 }
 
 type toolingAuthContextSuite struct {

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -87,6 +87,6 @@ execute: |
     snap known serial|MATCH "serial: 7777"
 
     snap list | MATCH "^basic"
-    test -f "$SEED_DIR/snaps/basic_*.snap"
+    test -f "$SEED_DIR/snaps/basic_"*.snap
     snap list | MATCH "^classic-gadget"
-    test -f "$SEED_DIR/snaps/classic-gadget_*.snap"
+    test -f "$SEED_DIR/snaps/classic-gadget_"*.snap

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -1,0 +1,87 @@
+summary: Check that prepare-image --classic works.
+
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+
+backends: [-autopkgtest]
+
+environment:
+    ROOT: /tmp/root
+    STORE_DIR: $(pwd)/fake-store-blobdir
+    STORE_ADDR: localhost:11028
+    SEED_DIR: /var/lib/snapd/seed
+
+kill-timeout: 3m
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    setup_fake_store "$STORE_DIR"
+
+    snap pack "$TESTSLIB/snaps/basic"
+    snap pack "$TESTSLIB/snaps/classic-gadget"
+
+    echo Expose the needed assertions through the fakestore
+    cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+    cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+    # have snap use the fakestore for assertions (but nothing else)
+    export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
+
+    echo Running prepare-image
+    #shellcheck disable=SC2086
+    ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --classic-arch $ARCH --channel $CORE_CHANNEL --extra-snaps basic_*.snap  --extra-snaps classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+
+    "$TESTSLIB/reset.sh" --keep-stopped
+    cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"
+
+    # start fake device svc
+    systemd_create_and_start_unit fakedevicesvc "$(command -v fakedevicesvc) localhost:11029"
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB/systemd.sh"
+    systemctl stop snapd.service snapd.socket
+    systemd_stop_and_destroy_unit fakedevicesvc
+
+    rm -rf "$SEED_DIR"
+    systemctl start snapd.socket snapd.service
+
+    #shellcheck source=tests/lib/store.sh
+    . "$TESTSLIB"/store.sh
+    teardown_fake_store "$STORE_DIR"
+    rm -f -- *.snap
+    rm -rf "$ROOT"
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # kick seeding
+    systemctl start snapd.service snapd.socket
+
+    echo "Wait for seeding to be done"
+    snap wait system seed.loaded
+
+    echo "We have a model assertion"
+    snap known model|MATCH "model: my-classic-w-gadget"
+
+    echo "Wait for device initialisation to be done"
+    while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
+
+    echo "Check we have a serial"
+    snap known serial|MATCH "authority-id: developer1"
+    snap known serial|MATCH "brand-id: developer1"
+    snap known serial|MATCH "model: my-classic-w-gadget"
+    snap known serial|MATCH "serial: 7777"

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -85,3 +85,8 @@ execute: |
     snap known serial|MATCH "brand-id: developer1"
     snap known serial|MATCH "model: my-classic-w-gadget"
     snap known serial|MATCH "serial: 7777"
+
+    snap list | MATCH "^basic"
+    test -f "$SEED_DIR/snaps/basic_*.snap"
+    snap list | MATCH "^classic-gadget"
+    test -f "$SEED_DIR/snaps/classic-gadget_*.snap"


### PR DESCRIPTION
This adds support for a classic mode to prepare-image (requires --classic to be used) which is mostly a subset of the full operations needed for the core case.  Given that for classic a gadget is optional for now there is no support or use for gadget unpacking. Other bits are made optional.

It also adds the capability in classic mode to seed classic snaps, while giving an error for them if that is attempted for a core image.

Gadget unpacking for this mode could be added back later via a dedicated option.