### PR TITLE
image,cmd/snap,tests: introduce support for modern prepare-image --snap <snap>[=<channel>]

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,6 +21,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/jessevdk/go-flags"
 
@@ -37,8 +38,10 @@ type cmdPrepareImage struct {
 		Rootdir          string
 	} `positional-args:"yes" required:"yes"`
 
-	Channel    string   `long:"channel" default:"stable"`
-	ExtraSnaps []string `long:"extra-snaps"`
+	Channel string `long:"channel" default:"stable"`
+	// TODO: introduce SnapWithChannel?
+	Snaps      []string `long:"snap"`
+	ExtraSnaps []string `long:"extra-snaps"` // DEPRECATED
 }
 
 func init() {
@@ -58,8 +61,9 @@ For preparing classic images it supports a --classic mode`),
 			"classic": i18n.G("Enable classic mode to prepare a classic model image"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
+			"snap": i18n.G("<snap>[=<channel>] specify extra snaps from store or local and optionally control their channel to track"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"extra-snaps": i18n.G("Extra snaps to be installed"),
+			"extra-snaps": i18n.G("Extra snaps to be installed (DEPRECATED)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"channel": i18n.G("The channel to use"),
 		}, []argDesc{
@@ -72,17 +76,38 @@ For preparing classic images it supports a --classic mode`),
 				// TRANSLATORS: This needs to begin with < and end with >
 				name: i18n.G("<root-dir>"),
 				// TRANSLATORS: This should not start with a lowercase letter.
-				desc: i18n.G("The output directory"),
+				desc: i18n.G("The target directory"),
 			},
 		})
 }
 
+var imagePrepare = image.Prepare
+
 func (x *cmdPrepareImage) Execute(args []string) error {
 	opts := &image.Options{
+		Snaps:        x.ExtraSnaps,
 		ModelFile:    x.Positional.ModelAssertionFn,
 		Channel:      x.Channel,
-		Snaps:        x.ExtraSnaps,
 		Architecture: x.Architecture,
+	}
+
+	snaps := make([]string, 0, len(x.Snaps)+len(x.ExtraSnaps))
+	snapChannels := make(map[string]string)
+	for _, snapWChannel := range x.Snaps {
+		snapAndChannel := strings.SplitN(snapWChannel, "=", 2)
+		snaps = append(snaps, snapAndChannel[0])
+		if len(snapAndChannel) == 2 {
+			snapChannels[snapAndChannel[0]] = snapAndChannel[1]
+		}
+	}
+
+	snaps = append(snaps, x.ExtraSnaps...)
+
+	if len(snaps) != 0 {
+		opts.Snaps = snaps
+	}
+	if len(snapChannels) != 0 {
+		opts.SnapChannels = snapChannels
 	}
 
 	if x.Classic {
@@ -93,5 +118,5 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 		opts.GadgetUnpackDir = filepath.Join(x.Positional.Rootdir, "gadget")
 	}
 
-	return image.Prepare(opts)
+	return imagePrepare(opts)
 }

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -61,7 +61,7 @@ For preparing classic images it supports a --classic mode`),
 			"classic": i18n.G("Enable classic mode to prepare a classic model image"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
-			"snap": i18n.G("<snap>[=<channel>] specify extra snaps from store or local and optionally control their channel to track"),
+			"snap": i18n.G("<snap>[=<channel>] specify extra snaps from store or local or optionally control the channel to track for a snap"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"extra-snaps": i18n.G("Extra snaps to be installed (DEPRECATED)"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -40,8 +40,8 @@ type cmdPrepareImage struct {
 
 	Channel string `long:"channel" default:"stable"`
 	// TODO: introduce SnapWithChannel?
-	Snaps      []string `long:"snap"`
-	ExtraSnaps []string `long:"extra-snaps"` // DEPRECATED
+	Snaps      []string `long:"snap" value-name:"<snap>[=<channel>]"`
+	ExtraSnaps []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
 }
 
 func init() {
@@ -61,7 +61,8 @@ For preparing classic images it supports a --classic mode`),
 			"classic": i18n.G("Enable classic mode to prepare a classic model image"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
-			"snap": i18n.G("<snap>[=<channel>] specify extra snaps from store or local or optionally control the channel to track for a snap"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"snap": i18n.G("Specify extra snaps from store or local or optionally control the channel to track for a snap"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"extra-snaps": i18n.G("Extra snaps to be installed (DEPRECATED)"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -62,7 +62,7 @@ For preparing classic images it supports a --classic mode`),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"snap": i18n.G("Specify extra snaps from store or local or optionally control the channel to track for a snap"),
+			"snap": i18n.G("Include the given snap from the store or a local file and/or specify the channel to track for the given snap"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"extra-snaps": i18n.G("Extra snaps to be installed (DEPRECATED)"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -1,0 +1,120 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/image"
+)
+
+type SnapPrepareImageSuite struct {
+	BaseSnapSuite
+}
+
+var _ = Suite(&SnapPrepareImageSuite{})
+
+func (s *SnapPrepareImageSuite) TestPrepareImageCore(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := snap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "model", "root-dir"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		ModelFile:       "model",
+		Channel:         "stable",
+		RootDir:         "root-dir/image",
+		GadgetUnpackDir: "root-dir/gadget",
+	})
+}
+
+func (s *SnapPrepareImageSuite) TestPrepareImageClassic(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := snap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "--classic", "model", "root-dir"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		Classic:   true,
+		ModelFile: "model",
+		Channel:   "stable",
+		RootDir:   "root-dir",
+	})
+}
+
+func (s *SnapPrepareImageSuite) TestPrepareImageClassicArch(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := snap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "--classic", "--arch", "i386", "model", "root-dir"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		Classic:      true,
+		Architecture: "i386",
+		ModelFile:    "model",
+		Channel:      "stable",
+		RootDir:      "root-dir",
+	})
+}
+
+func (s *SnapPrepareImageSuite) TestPrepareImageExtraSnaps(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := snap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "model", "root-dir", "--snap", "foo", "--snap", "bar=t/edge", "--snap", "local.snap", "--extra-snaps", "local2.snap", "--extra-snaps", "store-snap"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		ModelFile:       "model",
+		Channel:         "stable",
+		RootDir:         "root-dir/image",
+		GadgetUnpackDir: "root-dir/gadget",
+		Snaps:           []string{"foo", "bar", "local.snap", "local2.snap", "store-snap"},
+		SnapChannels:    map[string]string{"bar": "t/edge"},
+	})
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -26,6 +26,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/selinux"
 	"github.com/snapcore/snapd/store"
@@ -248,5 +249,13 @@ func MockTermSize(newTermSize func() (int, int)) (restore func()) {
 	termSize = newTermSize
 	return func() {
 		termSize = old
+	}
+}
+
+func MockImagePrepare(newImagePrepare func(*image.Options) error) (restore func()) {
+	old := imagePrepare
+	imagePrepare = newImagePrepare
+	return func() {
+		imagePrepare = old
 	}
 }

--- a/image/export_test.go
+++ b/image/export_test.go
@@ -33,6 +33,7 @@ var (
 	DownloadUnpackGadget = downloadUnpackGadget
 	SetupSeed            = setupSeed
 	InstallCloudConfig   = installCloudConfig
+	SnapChannel          = snapChannel
 )
 
 func (tsto *ToolingStore) User() *auth.UserState {

--- a/image/image.go
+++ b/image/image.go
@@ -291,10 +291,9 @@ func snapChannel(name string, model *asserts.Model, opts *Options, local *localI
 }
 
 func makeChannelFromTrack(what, track, snapChannel string) (string, error) {
-	errPrefix := fmt.Sprintf("cannot use track %q for %s from model assertion", track, what)
 	mch, err := snap.ParseChannel(track, "")
 	if err != nil {
-		return "", fmt.Errorf("%s: %v", errPrefix, err)
+		return "", fmt.Errorf("cannot use track %q for %s from model assertion: %v", track, what, err)
 	}
 	if snapChannel != "" {
 		ch, err := snap.ParseChannelVerbatim(snapChannel, "")

--- a/image/image.go
+++ b/image/image.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2017 Canonical Ltd
+ * Copyright (C) 2014-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -51,6 +51,7 @@ type Options struct {
 	Snaps           []string
 	RootDir         string
 	Channel         string
+	SnapChannels    map[string]string
 	ModelFile       string
 	GadgetUnpackDir string
 
@@ -260,23 +261,70 @@ func decodeModelAssertion(opts *Options) (*asserts.Model, error) {
 	return modela, nil
 }
 
+// snapChannel returns the channel to use for the given snap.
+func snapChannel(name string, model *asserts.Model, opts *Options, local *localInfos) (string, error) {
+	snapChannel := opts.SnapChannels[local.PreferLocal(name)]
+	if snapChannel == "" {
+		// fallback to default channel
+		snapChannel = opts.Channel
+	}
+	// consider snap types that can be pinned to a track by the model
+	var pinnedTrack string
+	var kind string
+	switch name {
+	case model.Gadget():
+		kind = "gadget"
+		pinnedTrack = model.GadgetTrack()
+	case model.Kernel():
+		kind = "kernel"
+		pinnedTrack = model.KernelTrack()
+	}
+	if pinnedTrack != "" {
+		ch, err := makeChannelFromTrack(kind, pinnedTrack, snapChannel)
+		if err != nil {
+			return "", err
+		}
+		snapChannel = ch
+
+	}
+	return snapChannel, nil
+}
+
+func makeChannelFromTrack(what, track, snapChannel string) (string, error) {
+	errPrefix := fmt.Sprintf("cannot use track %q for %s from model assertion", track, what)
+	mch, err := snap.ParseChannel(track, "")
+	if err != nil {
+		return "", fmt.Errorf("%s: %v", errPrefix, err)
+	}
+	if snapChannel != "" {
+		ch, err := snap.ParseChannelVerbatim(snapChannel, "")
+		if err != nil {
+			return "", fmt.Errorf("cannot parse channel %q for %s", snapChannel, what)
+		}
+		if ch.Track != "" && ch.Track != mch.Track {
+			return "", fmt.Errorf("channel %q for %s has a track incompatible with the track from model assertion: %s", snapChannel, what, track)
+		}
+		mch.Risk = ch.Risk
+	}
+	return mch.Clean().String(), nil
+}
+
 func downloadUnpackGadget(tsto *ToolingStore, model *asserts.Model, opts *Options, local *localInfos) error {
 	if err := os.MkdirAll(opts.GadgetUnpackDir, 0755); err != nil {
 		return fmt.Errorf("cannot create gadget unpack dir %q: %s", opts.GadgetUnpackDir, err)
 	}
 
+	gadgetName := model.Gadget()
+	gadgetChannel, err := snapChannel(gadgetName, model, opts, local)
+	if err != nil {
+		return err
+	}
+
 	dlOpts := &DownloadOptions{
 		TargetDir: opts.GadgetUnpackDir,
-		Channel:   opts.Channel,
+		Channel:   gadgetChannel,
 	}
-	if model.GadgetTrack() != "" {
-		gch, err := makeChannelFromTrack("gadget", model.GadgetTrack(), opts.Channel)
-		if err != nil {
-			return err
-		}
-		dlOpts.Channel = gch
-	}
-	snapFn, _, err := acquireSnap(tsto, model.Gadget(), dlOpts, local)
+	snapFn, _, err := acquireSnap(tsto, gadgetName, dlOpts, local)
 	if err != nil {
 		return err
 	}
@@ -340,22 +388,6 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	return func() {
 		trusted = prevTrusted
 	}
-}
-
-func makeChannelFromTrack(what, track, defaultChannel string) (string, error) {
-	errPrefix := fmt.Sprintf("cannot use track %q for %s from model assertion", track, what)
-	mch, err := snap.ParseChannel(track, "")
-	if err != nil {
-		return "", fmt.Errorf("%s: %v", errPrefix, err)
-	}
-	if defaultChannel != "" {
-		dch, err := snap.ParseChannel(defaultChannel, "")
-		if err != nil {
-			return "", fmt.Errorf("internal error: cannot parse channel %q", defaultChannel)
-		}
-		mch.Risk = dch.Risk
-	}
-	return mch.Clean().String(), nil
 }
 
 // neededDefaultProviders returns the names of all default-providers for
@@ -486,30 +518,20 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options, local *l
 			fmt.Fprintf(Stdout, "Fetching %s\n", snapName)
 		}
 
-		snapChannel := opts.Channel
-		if name == model.Kernel() && model.KernelTrack() != "" {
-			kch, err := makeChannelFromTrack("kernel", model.KernelTrack(), opts.Channel)
-			if err != nil {
-				return err
-			}
-			snapChannel = kch
+		snapChannel, err := snapChannel(name, model, opts, local)
+		if err != nil {
+			return err
 		}
-		if name == model.Gadget() && model.GadgetTrack() != "" {
-			gch, err := makeChannelFromTrack("gadget", model.GadgetTrack(), opts.Channel)
-			if err != nil {
-				return err
-			}
-			snapChannel = gch
-		}
+
 		dlOpts := &DownloadOptions{
 			TargetDir: snapSeedDir,
 			Channel:   snapChannel,
 		}
-
 		fn, info, err := acquireSnap(tsto, name, dlOpts, local)
 		if err != nil {
 			return err
 		}
+
 		// Sanity check, note that we could support this case
 		// if we have a use-case but it requires changes in the
 		// devicestate/firstboot.go ordering code.

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -34,7 +34,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --extra-snaps basic_*.snap  --extra-snaps classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --snap basic_*.snap  --snap classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"

--- a/tests/main/prepare-image-grub-core18/task.yaml
+++ b/tests/main/prepare-image-grub-core18/task.yaml
@@ -14,7 +14,7 @@ restore: |
     
 execute: |
     echo Running prepare-image
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/ubuntu-core-18-amd64.model $ROOT" test
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap snapweb $TESTSLIB/assertions/ubuntu-core-18-amd64.model $ROOT" test
 
     echo Verifying the result
     ls -lR "$IMAGE"

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -48,7 +48,7 @@ execute: |
 
     echo Running prepare-image
     #shellcheck disable=SC2086
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test
 
     echo Verifying the result
     ls -lR "$IMAGE"


### PR DESCRIPTION
This has been under consideration for a long time.
