### PR TITLE
packaging: disable systemd environment generator on 18.04

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -231,6 +231,12 @@ override_dh_install:
 
 	$(MAKE) -C cmd install DESTDIR=$(CURDIR)/debian/tmp
 
+	# We have to disable the systemd generator on bionic because of
+	# the systemd bug LP: 1771858. Enabling it caused bug #1811233
+ifeq (${VERSION_ID},"18.04")
+	chmod -x ${CURDIR}/debian/tmp/usr/lib/systemd/system-environment-generators/snapd-env-generator
+endif
+
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
 

--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -18,15 +18,17 @@ execute: |
     . /etc/os-release
     # ensure /usr/local/{,s}bin is still part of the PATH, LP: 1814355
     systemd-run --pty --wait '/usr/bin/env' | MATCH 'PATH=.*/local/.*'
-    # Only 18.10+ is fully working with the systemd generator so fo
-    # 18.04 we need to stop here until LP: #1771858 is fixed.
+    systemd-run --pty --wait '/usr/bin/env' > env.out
     if [ "$VERSION_ID" = "18.04" ];then
-        # FIXME: remove this check once LP: #1771858 is fixed
+        # Only 18.10+ is fully working with the systemd generator, so for 18.04
+        # we account for /snap/bin not being in the PATH, until LP: #1771858 is
+        # fixed.
+        ! MATCH 'PATH=.*/snap/bin' < env.out
         exit 0
+    else
+        # ensure /snap/bin is part of the PATH
+        MATCH 'PATH=.*:/snap/bin.*' < env.out
     fi
-    # ensure /snap/bin is part of the PATH
-    systemd-run --pty --wait '/usr/bin/env' | MATCH 'PATH=.*:/snap/bin.*'
-
 
     # some unit tests
     SENV=/usr/lib/systemd/system-environment-generators/snapd-env-generator

--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure systemd environment generator works
 
 # systemd environment generators are only supported on 17.10+
-systems: [ubuntu-18.04-*]
+systems: [ubuntu-18.04-*, ubuntu-18.10-*, ubuntu-19.04-*]
 
 execute: |
     # integration test to ensure it works on the real system
@@ -15,14 +15,17 @@ execute: |
     fi
 
     echo "Ensure PATH is correct in systemd system units"
-    systemd-run --unit testenv env
-    for _ in $(seq 30); do
-        if journalctl -u testenv | grep -E 'PATH=.*:/snap/bin.*'; then
-            break
-        fi
-        sleep 1
-    done
-    journalctl -u testenv | MATCH 'PATH=.*:/snap/bin.*'
+    . /etc/os-release
+    # ensure /usr/local/{,s}bin is still part of the PATH, LP: 1814355
+    systemd-run --pty --wait '/usr/bin/env' | MATCH 'PATH=.*/local/.*'
+    # Only 18.10+ is fully working with the systemd generator so fo
+    # 18.04 we need to stop here until LP: #1771858 is fixed.
+    if [ "$VERSION_ID" = "18.04" ];then
+        # FIXME: remove this check once LP: #1771858 is fixed
+        exit 0
+    fi
+    # ensure /snap/bin is part of the PATH
+    systemd-run --pty --wait '/usr/bin/env' | MATCH 'PATH=.*:/snap/bin.*'
 
 
     # some unit tests


### PR DESCRIPTION
The PATH of systemd services does not contain "/snap/bin" because services
do not read /etc/environment (that's PAM) or login.defs (getty). To fix that
we added a systemd environment generator that would modify PATH
in snapd 2.35.1 and this works successfully in 18.10+ now. Unfortunately
the systemd version in 18.04 has a bug with the handling of the PATH
with the generators which leads to an undesired side effect when the
generator is used: we get a PATH that does no longer
include "/usr/local/{,s}bin which will break existing systems.

Hence the systemd environment generator we ship must be disabled 
on 18.04 because of the systemd bug #1771858. This was reported for
us as LP: 1814355.

This PR disables the generator on 18.04 (which is most unfortunate)
until we can fix systemd and adds a spread test.

A slightly simpler version of this fix was uploaded to bionic as
2.37.1.1.
