### PR TITLE
snap-confine: fix classic snaps for users with /var/lib/* homedirs (2.37)

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -313,6 +313,18 @@
     @{HOME}/ r,
     @{HOME}/snap/{,*/,*/*/} rw,
 
+    # Special case for *classic* snaps that are used by users with existing dirs
+    # in /var/lib/. Like jenkins, postgresql, mysql, puppet, ...
+    # (see https://forum.snapcraft.io/t/9717)
+    # TODO: this can be removed once we support home-dirs outside of /home
+    #       better
+    /var/ r,
+    /var/lib/ r,
+    # These should both have 'owner' match but due to LP: #1466234, we can't
+    # yet
+    /var/lib/*/ r,
+    /var/lib/*/snap/{,*/,*/*/} rw,
+
     # for creating the user shared memory directories
     /{dev,run}/{,shm/} r,
     # This should both have 'owner' match but due to LP: #1466234, we can't yet
@@ -493,12 +505,6 @@
     /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-discard-ns rix,
     /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
     /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-discard-ns rix,
-
-    # As a special exception, allow HOME to be /var/lib/jenkins
-    /var/ r,
-    /var/lib/ r,
-    /var/lib/jenkins/ r,
-    /var/lib/jenkins/snap/{,*/,*/*/} rw,
 
     # Allow mounting /var/lib/jenkinks from the host into the snap.
     mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,

--- a/tests/lib/snaps/test-snapd-classic-confinement/bin/sh
+++ b/tests/lib/snaps/test-snapd-classic-confinement/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
@@ -6,3 +6,5 @@ apps:
         command: bin/classic-confinement
     recurse:
         command: bin/recurse
+    sh:
+        command: bin/sh

--- a/tests/main/special-home-can-run-classic-snaps/task.yaml
+++ b/tests/main/special-home-can-run-classic-snaps/task.yaml
@@ -1,0 +1,29 @@
+summary: Check that users with homes in /var/lib can run *classic* snaps
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+environment:
+    SPECIAL_USER_NAME/postgres: postgres
+prepare: |
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local_classic test-snapd-classic-confinement
+
+    # Install the corresponding package that brings the special user account.
+    # Specialize the code as required for a particular user.
+    case "$SPECIAL_USER_NAME" in
+        postgres)
+            apt install -y postgresql
+            ;;
+    esac
+restore: |
+    snap remove test-snapd-sh
+    # Remove the package we installed above.
+    case "$SPECIAL_USER_NAME" in
+        postgres)
+            apt autoremove --purge -y postgresql
+            ;;
+    esac
+execute: |
+    #shellcheck disable=SC2016
+    su -c sh -c 'echo $HOME' "$SPECIAL_USER_NAME" | MATCH "/var/lib/$SPECIAL_USER_NAME"
+    su -c 'snap run test-snapd-classic-confinement.sh -c /bin/true' "$SPECIAL_USER_NAME"


### PR DESCRIPTION
…6471)

When we removed the quirks system in commit [1da9316](https://github.com/snapcore/snapd/commit/1da9316e717d119852b827becb5a17b33713d032) we removed the following apparmor rule as well:

```
     /var/lib/** rw,
```
The unintended side-effect of this change is that we broke snaps
for users with homedirs in /var/lib/ like "postgresql", "jenkins"
and potentially more. They now get the error:

```
cannot create user data directory: /var/lib/postgresql/snap/wal-e/13: Permission denied
```
We added a special case for jenkins which unfortunately is not
enough. This PR makes the snap-confine rule more general which
will unbreak all classic snaps that use /var/lib/* as their
homedir. This will fix the wal-e snap which is classic and needs
to run as the postgresql user to perform its tasks.

We probably still need a followup that deals with confined snaps
like jenkins in a more general manner like the current targeted
jenkins fix.
