### PR TITLE
cmd/snap: tweak man output to have no doubled up .TP lines

### DIFF
--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -174,3 +174,15 @@ func (s *SnapSuite) TestManpageInSection8(c *check.C) {
 
 	c.Check(s.Stdout(), check.Matches, `\.TH snap 8 (?s).*`)
 }
+
+func (s *SnapSuite) TestManpageNoDoubleTP(c *check.C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "help", "--man"}
+
+	err := snap.RunMain()
+	c.Assert(err, check.IsNil)
+
+	c.Check(s.Stdout(), check.Not(check.Matches), `(?s).*(?m-s)^\.TP\n\.TP$(?s-m).*`)
+
+}


### PR DESCRIPTION
As reported in [lp:1814767], snap's manpage contains doubled up .TP
lines, which for groffs older than ~16.04 (in particular, groffs
missing [the commit] that fixes the issue) means the output is less
than ideal.

Fixing this in goflags is probably going to be tricky. I'll be trying
to do that at some point, but meanwhile this fixes the issue by
post-processing the generated manpage with a heckin' regexp.

[lp:1814767]: https://bugs.launchpad.net/snapd/+bug/1814767
[the commit]: https://git.savannah.gnu.org/cgit/groff.git/commit/?id=49abd7a9093ae903bb0032eb74d647fb481d2acb
