### PR TITLE
cmd/snap, overlord/snapstate: silently ignore classic flag when a snap is strictly confined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     - stage: quick
       name: go 1.9/xenial static and unit test suites
       dist: xenial
-      go: 1.9
+      go: "1.9"
       before_install:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
       install:
@@ -17,7 +17,7 @@ jobs:
         - ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick
-      go: 1.10
+      go: "1.10"
       name: OSX build and minimal runtime sanity check
       os: osx
       addons:

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -317,19 +317,20 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 				needsPathWarning = false
 			}
 
-			if snap.Publisher != nil {
-				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from Alice installed")
-				fmt.Fprintf(Stdout, i18n.G("%s%s %s from %s installed\n"), snap.Name, channelStr, snap.Version, longPublisher(esc, snap.Publisher))
-			} else {
-				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
-				fmt.Fprintf(Stdout, i18n.G("%s%s %s installed\n"), snap.Name, channelStr, snap.Version)
-			}
 			if opts != nil && opts.Classic && snap.Confinement != client.ClassicConfinement {
 				// requested classic but the snap is not classic
 				head := i18n.G("Warning:")
 				// TRANSLATORS: the arg is a snap name (e.g. "some-snap")
 				warn := fill(fmt.Sprintf(i18n.G("flag --classic ignored for strictly confined snap %s"), snap.Name), utf8.RuneCountInString(head)+1) // +1 for the space
 				fmt.Fprint(Stderr, esc.bold, head, esc.end, " ", warn, "\n\n")
+			}
+
+			if snap.Publisher != nil {
+				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from Alice installed")
+				fmt.Fprintf(Stdout, i18n.G("%s%s %s from %s installed\n"), snap.Name, channelStr, snap.Version, longPublisher(esc, snap.Publisher))
+			} else {
+				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
+				fmt.Fprintf(Stdout, i18n.G("%s%s %s installed\n"), snap.Name, channelStr, snap.Version)
 			}
 		case "refresh":
 			if snap.Publisher != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -573,6 +573,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		// snap does not require classic confinement, silently drop the flag
 		flags.Classic = false
 	}
+	// TODO: integrate classic override with the helper
 	if err := checkInstallPreconditions(st, info, flags, &snapst); err != nil {
 		return nil, nil, err
 	}
@@ -640,6 +641,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		// snap does not require classic confinement, silently drop the flag
 		flags.Classic = false
 	}
+	// TODO: integrate classic override with the helper
 	if err := checkInstallPreconditions(st, info, flags, &snapst); err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -569,6 +569,10 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 	}
 	info.InstanceKey = instanceKey
 
+	if flags.Classic && !info.NeedsClassic() {
+		// snap does not require classic confinement, silently drop the flag
+		flags.Classic = false
+	}
 	if err := checkInstallPreconditions(st, info, flags, &snapst); err != nil {
 		return nil, nil, err
 	}
@@ -632,6 +636,10 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		return nil, err
 	}
 
+	if flags.Classic && !info.NeedsClassic() {
+		// snap does not require classic confinement, silently drop the flag
+		flags.Classic = false
+	}
 	if err := checkInstallPreconditions(st, info, flags, &snapst); err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -510,10 +510,9 @@ func (s *snapmgrTestSuite) TestInstallClassicConfinementFiltering(c *C) {
 	_, err = snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
 	c.Assert(err, IsNil)
 
-	// if a snap is *not* classic, you cannot install it with --classic
+	// if a snap is *not* classic, but can install it with --classic which gets ignored
 	_, err = snapstate.Install(s.state, "some-snap", "channel-for-strict", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
-	c.Assert(err, ErrorMatches, `snap "some-snap" is not a classic confined snap`)
-	c.Check(err, FitsTypeOf, &snapstate.SnapNotClassicError{})
+	c.Assert(err, IsNil)
 }
 
 func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C) {
@@ -1660,6 +1659,37 @@ func (s *snapmgrTestSuite) TestInstallAliasConflict(c *C) {
 
 	_, err := snapstate.Install(s.state, "foo", "some-channel", snap.R(0), 0, snapstate.Flags{})
 	c.Assert(err, ErrorMatches, `snap "foo" command namespace conflicts with alias "foo\.bar" for "otherfoosnap" snap`)
+}
+
+func (s *snapmgrTestSuite) TestInstallStrictIgnoresClassic(c *C) {
+	restore := maybeMockClassicSupport(c)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts, err := snapstate.Install(s.state, "some-snap", "channel-for-strict", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
+	c.Assert(err, IsNil)
+
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("install", "install snap")
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+
+	// verify snap is in classic
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, "some-snap", &snapst)
+	c.Assert(err, IsNil)
+	c.Check(snapst.Channel, Equals, "channel-for-strict")
+	c.Check(snapst.Classic, Equals, false)
 }
 
 // A sneakyStore changes the state when called

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -85,5 +85,6 @@ execute: |
     if is_classic_confinement_supported ; then
         echo "Installing a strict snap in classic works but --classic is ignored"
         snap install --classic test-snapd-busybox-static 2>stderr.out
-        MATCH 'Warning: flag --classic ignored for strictly confined snap test-snapd-busybox-static' < stderr.out
+        #shellcheck disable=SC2002
+        cat stderr.out | tr '\n' ' ' | tr -s ' ' | MATCH 'Warning: flag --classic ignored for strictly confined snap test-snapd-busybox-static'
     fi

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -83,10 +83,7 @@ execute: |
     . "$TESTSLIB"/strings.sh
 
     if is_classic_confinement_supported ; then
-        echo "Installing a strict snap in classic mode does not work"
-        if snap install --classic test-snapd-busybox-static 2>stderr.out; then
-            echo "snap install ––classic test-snapd-busybox-static should have failed but did not"
-            exit 1
-        fi
-        MATCH 'error: snap "test-snapd-busybox-static" is not compatible with --classic' < stderr.out
+        echo "Installing a strict snap in classic works but --classic is ignored"
+        snap install --classic test-snapd-busybox-static 2>stderr.out
+        MATCH 'Warning: flag --classic ignored for strictly confined snap test-snapd-busybox-static' < stderr.out
     fi


### PR DESCRIPTION
Do not fail when attempting to `snap install --classic` a snap that does not require classic confinement. Instead, silently ignore a flag and raise a warning.

This is what it looks like locally:

```
$ snap install test-snapd-tools --classic
test-snapd-tools 1.0 from Canonical✓ installed
Warning: flag --classic ignored for strictly confined snap test-snapd-tools

```