### PR TITLE
cmd/snap, overlord/snapstate: silently ignore classic flag when a snap is strictly confined (2.37)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     - stage: quick
       name: go 1.6/xenial static and unit test suites
       dist: xenial
-      go: 1.6
+      go: "1.6"
       before_install:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
       install:
@@ -17,7 +17,7 @@ jobs:
         - ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick
-      go: 1.10
+      go: "1.10"
       name: OSX build and minimal runtime sanity check
       os: osx
       addons:

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jessevdk/go-flags"
 
@@ -275,7 +276,7 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 				head := i18n.G("Warning:")
 				// TRANSLATORS: the arg is a snap name (e.g. "some-snap")
 				warn := fill(fmt.Sprintf(i18n.G("flag --classic ignored for strictly confined snap %s"), snap.Name), utf8.RuneCountInString(head)+1) // +1 for the space
-				fmt.Fprint(Stderr, esc.bold, head, esc.end, " ", warn, "\n\n")
+				fmt.Fprint(Stderr, head, " ", warn, "\n\n")
 			}
 
 			if snap.Publisher != nil {

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -257,7 +257,7 @@ func (mx *channelMixin) setChannelFromCommandline() error {
 }
 
 // show what has been done
-func showDone(cli *client.Client, names []string, op string, esc *escapes) error {
+func showDone(cli *client.Client, names []string, op string, opts *client.SnapOptions, esc *escapes) error {
 	snaps, err := cli.List(names, nil)
 	if err != nil {
 		return err
@@ -270,6 +270,14 @@ func showDone(cli *client.Client, names []string, op string, esc *escapes) error
 		}
 		switch op {
 		case "install":
+			if opts != nil && opts.Classic && snap.Confinement != client.ClassicConfinement {
+				// requested classic but the snap is not classic
+				head := i18n.G("Warning:")
+				// TRANSLATORS: the arg is a snap name (e.g. "some-snap")
+				warn := fill(fmt.Sprintf(i18n.G("flag --classic ignored for strictly confined snap %s"), snap.Name), utf8.RuneCountInString(head)+1) // +1 for the space
+				fmt.Fprint(Stderr, esc.bold, head, esc.end, " ", warn, "\n\n")
+			}
+
 			if snap.Publisher != nil {
 				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from Alice installed")
 				fmt.Fprintf(Stdout, i18n.G("%s%s %s from %s installed\n"), snap.Name, channelStr, snap.Version, longPublisher(esc, snap.Publisher))
@@ -400,7 +408,7 @@ func (x *cmdInstall) installOne(nameOrPath, desiredName string, opts *client.Sna
 		}
 	}
 
-	return showDone(x.client, []string{snapName}, "install", x.getEscapes())
+	return showDone(x.client, []string{snapName}, "install", opts, x.getEscapes())
 }
 
 func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error {
@@ -439,7 +447,7 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 	}
 
 	if len(installed) > 0 {
-		if err := showDone(x.client, installed, "install", x.getEscapes()); err != nil {
+		if err := showDone(x.client, installed, "install", opts, x.getEscapes()); err != nil {
 			return err
 		}
 	}
@@ -538,7 +546,7 @@ func (x *cmdRefresh) refreshMany(snaps []string, opts *client.SnapOptions) error
 	}
 
 	if len(refreshed) > 0 {
-		return showDone(x.client, refreshed, "refresh", x.getEscapes())
+		return showDone(x.client, refreshed, "refresh", opts, x.getEscapes())
 	}
 
 	fmt.Fprintln(Stderr, i18n.G("All snaps up to date."))
@@ -564,7 +572,7 @@ func (x *cmdRefresh) refreshOne(name string, opts *client.SnapOptions) error {
 		return err
 	}
 
-	return showDone(x.client, []string{name}, "refresh", x.getEscapes())
+	return showDone(x.client, []string{name}, "refresh", opts, x.getEscapes())
 }
 
 func parseSysinfoTime(s string) time.Time {
@@ -882,7 +890,7 @@ func (x *cmdRevert) Execute(args []string) error {
 		return err
 	}
 
-	return showDone(x.client, []string{name}, "revert", nil)
+	return showDone(x.client, []string{name}, "revert", nil, nil)
 }
 
 var shortSwitchHelp = i18n.G("Switches snap to a different channel")

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -44,12 +44,13 @@ import (
 type snapOpTestServer struct {
 	c *check.C
 
-	checker   func(r *http.Request)
-	n         int
-	total     int
-	channel   string
-	rebooting bool
-	snap      string
+	checker     func(r *http.Request)
+	n           int
+	total       int
+	channel     string
+	confinement string
+	rebooting   bool
+	snap        string
 }
 
 var _ = check.Suite(&SnapOpSuite{})
@@ -80,7 +81,7 @@ func (t *snapOpTestServer) handle(w http.ResponseWriter, r *http.Request) {
 	case 3:
 		t.c.Check(r.Method, check.Equals, "GET")
 		t.c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-		fmt.Fprintf(w, `{"type": "sync", "result": [{"name": "%s", "status": "active", "version": "1.0", "developer": "bar", "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar", "validation": "unproven"}, "revision":42, "channel":"%s"}]}\n`, t.snap, t.channel)
+		fmt.Fprintf(w, `{"type": "sync", "result": [{"name": "%s", "status": "active", "version": "1.0", "developer": "bar", "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar", "validation": "unproven"}, "revision":42, "channel":"%s", "confinement": "%s"}]}\n`, t.snap, t.channel, t.confinement)
 	default:
 		t.c.Fatalf("expected to get %d requests, now on %d", t.total, t.n+1)
 	}
@@ -274,6 +275,7 @@ func (s *SnapOpSuite) TestInstallClassic(c *check.C) {
 			"action":  "install",
 			"classic": true,
 		})
+		s.srv.confinement = "classic"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
@@ -282,6 +284,26 @@ func (s *SnapOpSuite) TestInstallClassic(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
 	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
+func (s *SnapOpSuite) TestInstallStrictWithClassicFlag(c *check.C) {
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":  "install",
+			"classic": true,
+		})
+		s.srv.confinement = "strict"
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar installed`)
+	c.Check(s.Stderr(), testutil.MatchesWrapped, `Warning:\s+flag --classic ignored for strictly confined snap foo.*`)
 	// ensure that the fake server api was actually hit
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
@@ -721,6 +743,8 @@ func (s *SnapOpSuite) TestInstallPathClassic(c *check.C) {
 		name, _, body := formFile(form, c)
 		c.Check(name, check.Equals, "snap")
 		c.Check(string(body), check.Equals, "snap-data")
+
+		s.srv.confinement = "classic"
 	}
 
 	snapBody := []byte("snap-data")

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -569,6 +569,11 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 	}
 	info.InstanceKey = instanceKey
 
+	if flags.Classic && !info.NeedsClassic() {
+		// snap does not require classic confinement, silently drop the flag
+		flags.Classic = false
+	}
+	// TODO: integrate classic override with the helper
 	if err := checkInstallPreconditions(st, info, flags, &snapst); err != nil {
 		return nil, nil, err
 	}
@@ -628,6 +633,11 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		return nil, err
 	}
 
+	if flags.Classic && !info.NeedsClassic() {
+		// snap does not require classic confinement, silently drop the flag
+		flags.Classic = false
+	}
+	// TODO: integrate classic override with the helper
 	if err := checkInstallPreconditions(st, info, flags, &snapst); err != nil {
 		return nil, err
 	}

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -83,10 +83,8 @@ execute: |
     . "$TESTSLIB"/strings.sh
 
     if is_classic_confinement_supported ; then
-        echo "Installing a strict snap in classic mode does not work"
-        if snap install --classic test-snapd-busybox-static 2>stderr.out; then
-            echo "snap install ––classic test-snapd-busybox-static should have failed but did not"
-            exit 1
-        fi
-        MATCH 'error: snap "test-snapd-busybox-static" is not compatible with --classic' < stderr.out
+        echo "Installing a strict snap in classic works but --classic is ignored"
+        snap install --classic test-snapd-busybox-static 2>stderr.out
+        #shellcheck disable=SC2002
+        cat stderr.out | tr '\n' ' ' | tr -s ' ' | MATCH 'Warning: flag --classic ignored for strictly confined snap test-snapd-busybox-static'
     fi


### PR DESCRIPTION
When installing a strict snap withthe --classic snap like:

    snap install strict-snap --classic

this should be allowed because the user expresses that he/she is willing to install a classic snap.
If the snap is not classic that is even better and no reason to error (a warning is appropriate to
ensure the user is not under the misconception that the snap gets installed with classic confinement).

* overlord/snapstate: silently ignore classic flag when installing a non classic snap

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* cmd/snap: warn when --classic flag was ignored

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* overlord/snapstate: review feedback

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* tests/main/install-errors: verify --classic flag for non-classic snaps

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* cmd/snap: display warning before snap install summary

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* tests/main/install-errors: fix error match

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* travis: quote Go version

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
