### PR TITLE
[RFC] cmd/snap: make 'snap list' show disabled snaps dimmed.

### DIFF
--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -128,20 +128,25 @@ func (x *cmdList) Execute(args []string) error {
 	esc := x.getEscapes()
 	w := tabWriter()
 
-	// TRANSLATORS: the %s is to insert a filler escape sequence (please keep it flush to the column header, with no extra spaces)
-	fmt.Fprintf(w, i18n.G("Name\tVersion\tRev\tTracking\tPublisher%s\tNotes\n"), fillerPublisher(esc))
+	fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\t%s%s%s\t%s%s\n",
+		esc.end,
+		i18n.G("Name"), i18n.G("Version"), i18n.G("Rev"), i18n.G("Tracking"), i18n.G("Publisher"), fillerPublisher(esc), esc.end, i18n.G("Notes"), esc.end)
 
 	for _, snap := range snaps {
-		// doing it this way because otherwise it's a sea of %s\t%s\t%s
-		line := []string{
+		e := esc.end
+		if snap.Status != client.StatusActive {
+			e = esc.dim
+		}
+		fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\t%s%s\t%s%s\n",
+			e,
 			snap.Name,
 			snap.Version,
 			snap.Revision.String(),
 			fmtChannel(snap.TrackingChannel),
-			shortPublisher(esc, snap.Publisher),
+			shortPublisher(esc, snap.Publisher), e,
 			NotesFromLocal(snap).String(),
-		}
-		fmt.Fprintln(w, strings.Join(line, "\t"))
+			esc.end,
+		)
 	}
 	w.Flush()
 

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -111,6 +111,7 @@ var colorDescs = mixinDescs{
 type escapes struct {
 	green string
 	bold  string
+	dim   string
 	end   string
 
 	tick, dash, uparrow string
@@ -120,12 +121,14 @@ var (
 	color = escapes{
 		green: "\033[32m",
 		bold:  "\033[1m",
+		dim:   "\033[2m",
 		end:   "\033[0m",
 	}
 
 	mono = escapes{
 		green: "\033[1m",
 		bold:  "\033[1m",
+		dim:   "\033[2m",
 		end:   "\033[0m",
 	}
 


### PR DESCRIPTION
This is a silly RFC PR. I haven't touched the tests so I wouldn't be surprised if they fail.

What this does is print disabled snaps in dim, in the output of `snap list`:
![image](https://user-images.githubusercontent.com/1543430/52341148-c2a24f00-2a09-11e9-9435-660d9bd25715.png)

this is particularly useful in `snap list --all`:

![image](https://user-images.githubusercontent.com/1543430/52341206-e6fe2b80-2a09-11e9-96ec-0866118a985f.png)

WDYT?