### PR TITLE
image,cmd/snap:  simplify --classic-arch to --arch, expose prepare-image

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -189,9 +189,14 @@ var helpCategories = []helpCategory{
 		Description: i18n.G("miscellanea"),
 		Commands:    []string{"version", "warnings", "okay"},
 	}, {
+		Label:       i18n.G("Assertions"),
+		Description: i18n.G("manage assertions"),
+		Commands:    []string{"ack", "known"},
+	},
+	{
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),
-		Commands:    []string{"run", "pack", "try", "ack", "known", "download"},
+		Commands:    []string{"run", "pack", "try", "download", "prepare-image"},
 	},
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -187,13 +187,8 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("Other"),
 		Description: i18n.G("miscellanea"),
-		Commands:    []string{"version", "warnings", "okay"},
+		Commands:    []string{"version", "warnings", "okay", "ack", "known"},
 	}, {
-		Label:       i18n.G("Assertions"),
-		Description: i18n.G("manage assertions"),
-		Commands:    []string{"ack", "known"},
-	},
-	{
 		Label:       i18n.G("Development"),
 		Description: i18n.G("developer-oriented features"),
 		Commands:    []string{"run", "pack", "try", "download", "prepare-image"},

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -37,19 +37,23 @@ type cmdPrepareImage struct {
 		Rootdir          string
 	} `positional-args:"yes" required:"yes"`
 
-	ExtraSnaps []string `long:"extra-snaps"`
 	Channel    string   `long:"channel" default:"stable"`
+	ExtraSnaps []string `long:"extra-snaps"`
 }
 
 func init() {
 	addCommand("prepare-image",
 		i18n.G("Prepare a device image"),
 		i18n.G(`
-The prepare-image command performs some of the steps necessary for creating device images. For core images it is not invoked directly but usually via ubuntu-image. For preparing classic images it supports a --classic mode.
-`),
-		func() flags.Commander {
-			return &cmdPrepareImage{}
-		}, map[string]string{
+The prepare-image command performs some of the steps necessary for
+creating device images.
+
+For core images it is not invoked directly but usually via
+ubuntu-image.
+
+For preparing classic images it supports a --classic mode`),
+		func() flags.Commander { return &cmdPrepareImage{} },
+		map[string]string{
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"classic": i18n.G("Enable classic mode to prepare a classic model image"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -42,7 +42,7 @@ type cmdPrepareImage struct {
 }
 
 func init() {
-	cmd := addCommand("prepare-image",
+	addCommand("prepare-image",
 		i18n.G("Prepare a device image"),
 		i18n.G(`
 The prepare-image command performs some of the steps necessary for creating device images. For core images it is not invoked directly but usually via ubuntu-image. For preparing classic images it supports a --classic mode.
@@ -71,7 +71,6 @@ The prepare-image command performs some of the steps necessary for creating devi
 				desc: i18n.G("The output directory"),
 			},
 		})
-	cmd.hidden = true
 }
 
 func (x *cmdPrepareImage) Execute(args []string) error {

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/jessevdk/go-flags"
@@ -30,8 +29,8 @@ import (
 )
 
 type cmdPrepareImage struct {
-	Classic             bool   `long:"classic"`
-	ClassicArchitecture string `long:"classic-arch"`
+	Classic      bool   `long:"classic"`
+	Architecture string `long:"arch"`
 
 	Positional struct {
 		ModelAssertionFn string
@@ -46,7 +45,7 @@ func init() {
 	cmd := addCommand("prepare-image",
 		i18n.G("Prepare a device image"),
 		i18n.G(`
-The prepare-image command performs some of the steps necessary for creating device images.
+The prepare-image command performs some of the steps necessary for creating device images. For core images it is not invoked directly but usually via ubuntu-image. For preparing classic images it supports a --classic mode.
 `),
 		func() flags.Commander {
 			return &cmdPrepareImage{}
@@ -54,7 +53,7 @@ The prepare-image command performs some of the steps necessary for creating devi
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"classic": i18n.G("Enable classic mode to prepare a classic model image"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"classic-arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
+			"arch": i18n.G("Specify an architecture for snaps for --classic when the model does not"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"extra-snaps": i18n.G("Extra snaps to be installed"),
 			// TRANSLATORS: This should not start with a lowercase letter.
@@ -77,19 +76,16 @@ The prepare-image command performs some of the steps necessary for creating devi
 
 func (x *cmdPrepareImage) Execute(args []string) error {
 	opts := &image.Options{
-		ModelFile: x.Positional.ModelAssertionFn,
-		Channel:   x.Channel,
-		Snaps:     x.ExtraSnaps,
+		ModelFile:    x.Positional.ModelAssertionFn,
+		Channel:      x.Channel,
+		Snaps:        x.ExtraSnaps,
+		Architecture: x.Architecture,
 	}
 
 	if x.Classic {
 		opts.Classic = true
 		opts.RootDir = x.Positional.Rootdir
-		opts.ClassicArchitecture = x.ClassicArchitecture
 	} else {
-		if x.ClassicArchitecture != "" {
-			return fmt.Errorf(i18n.G("--classic-arch is meant to be used only in --classic mode to specify an architecture when the model does not"))
-		}
 		opts.RootDir = filepath.Join(x.Positional.Rootdir, "image")
 		opts.GadgetUnpackDir = filepath.Join(x.Positional.Rootdir, "gadget")
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1294,9 +1294,9 @@ func (s *imageSuite) TestPrepareClassicModelArchOverrideFails(c *C) {
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
-		Classic:             true,
-		ModelFile:           fn,
-		ClassicArchitecture: "i386",
+		Classic:      true,
+		ModelFile:    fn,
+		Architecture: "i386",
 	})
 	c.Assert(err, ErrorMatches, "cannot override model architecture: amd64")
 }
@@ -1324,7 +1324,7 @@ func (s *imageSuite) TestPrepareClassicModelSnapsButNoArchFails(c *C) {
 		Classic:   true,
 		ModelFile: fn,
 	})
-	c.Assert(err, ErrorMatches, "cannot have snaps for a classic image without an architecture in the model or from --classic-arch")
+	c.Assert(err, ErrorMatches, "cannot have snaps for a classic image without an architecture in the model or from --arch")
 }
 
 func (s *imageSuite) TestSetupSeedWithKernelAndGadgetTrack(c *C) {

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -34,7 +34,7 @@ prepare: |
     echo Running prepare-image
     #shellcheck disable=SC2086
     ARCH="$(dpkg-architecture -qDEB_HOST_ARCH)"
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --classic-arch $ARCH --channel $CORE_CHANNEL --extra-snaps basic_*.snap  --extra-snaps classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --classic --arch $ARCH --channel $CORE_CHANNEL --extra-snaps basic_*.snap  --extra-snaps classic-gadget_*.snap $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $ROOT"
 
     "$TESTSLIB/reset.sh" --keep-stopped
     cp -ar "$ROOT/$SEED_DIR" "$SEED_DIR"


### PR DESCRIPTION
* turn --classic-arch into more general --arch for simplification, though is not useful for non --classic mode and will then need to match or be not set
* expose prepare-image now that it might be invoked directly, in the process split out an "Assertions" command category