### PR TITLE
tests: improve snaps-system-env test

### DIFF
--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure systemd environment generator works
 
 # systemd environment generators are only supported on 17.10+
-systems: [ubuntu-18.04-*, ubuntu-18.10-*, ubuntu-19.04-*]
+systems: [ubuntu-18.04-*, ubuntu-18.10-*, ubuntu-19.04-*, ubuntu-2*]
 
 execute: |
     # integration test to ensure it works on the real system
@@ -26,8 +26,8 @@ execute: |
         ! MATCH 'PATH=.*/snap/bin' < env.out
         exit 0
     else
-        # ensure /snap/bin is part of the PATH
-        MATCH 'PATH=.*:/snap/bin.*' < env.out
+        # ensure PATH is updated (and check full PATH, see LP: #1814355)
+        MATCH 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin' < env.out
     fi
 
     # some unit tests


### PR DESCRIPTION
In 18.04 we had a regression when we installed the snapd systemd
environment generator. Installing it caused LP: #1814355 and
the PATH for systemd services looked suddently like:
```
   /sbin:/usr/sbin:/bin:/usr/bin:/snap/bin
```
instead of the expected:
```
   /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
```

A better test that checked the *full* expected PATH instead of just
the addition of :/snap/bin would have caught this regression.

This PR adds the test for the full PATH now.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
