### PR TITLE
tests: fix NFS home mocking

### DIFF
--- a/cmd/snapd/main_test.go
+++ b/cmd/snapd/main_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/testutil"
 
@@ -57,6 +58,8 @@ func (s *snapdSuite) SetUpTest(c *C) {
 
 func (s *snapdSuite) TestSanityFailGoesIntoDegradedMode(c *C) {
 	logbuf, restore := logger.MockLogger()
+	defer restore()
+	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
 
 	sanityErr := fmt.Errorf("foo failed")

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -624,3 +624,14 @@ func (b *Backend) SandboxFeatures() []string {
 
 	return tags
 }
+
+// MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS.
+// This is exported so that other packages that indirectly interact with AppArmor backend
+// can mock isHomeUsingNFS.
+func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
+	old := isHomeUsingNFS
+	isHomeUsingNFS = new
+	return func() {
+		isHomeUsingNFS = old
+	}
+}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1265,6 +1265,9 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyNoOverlay(c *C) {
 	restore := apparmor.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
 	defer restore()
 
+	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
+	defer restore()
+
 	// Intercept interaction with apparmor_parser
 	cmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer cmd.Restore()
@@ -1299,7 +1302,8 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 	// Make it appear as if overlay workaround was needed.
 	restore := apparmor.MockIsRootWritableOverlay(func() (string, error) { return "/upper", nil })
 	defer restore()
-
+	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
+	defer restore()
 	// Intercept interaction with apparmor_parser
 	cmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer cmd.Restore()
@@ -1355,6 +1359,9 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithOverlayAndReExec(c *C) {
 	// Make it appear as if overlay workaround was needed.
 	restore := apparmor.MockIsRootWritableOverlay(func() (string, error) { return "/upper", nil })
+	defer restore()
+
+	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
 
 	// Intercept interaction with apparmor_parser

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -35,15 +35,6 @@ var (
 	SetupSnapConfineReexec     = setupSnapConfineReexec
 )
 
-// MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS
-func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
-	old := isHomeUsingNFS
-	isHomeUsingNFS = new
-	return func() {
-		isHomeUsingNFS = old
-	}
-}
-
 // MockIsRootWritableOverlay mocks the real implementation of osutil.IsRootWritableOverlay
 func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
 	old := isRootWritableOverlay

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -104,8 +104,11 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"apparmor-parser-mtime":%s,"apparmor-parser-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s}`, buildID, apparmorFeaturesStr, apparmorParserMtime, apparmorParserFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
-func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
+func (s *systemKeySuite) TestInterfaceWriteSystemKeyNoNFS(c *C) {
 	s.testInterfaceWriteSystemKey(c, false)
+}
+
+func (s *systemKeySuite) TestInterfaceWriteSystemKeyWithNFS(c *C) {
 	s.testInterfaceWriteSystemKey(c, true)
 }
 

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -62,7 +62,6 @@ func (s *systemKeySuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.buildID = id
 
-	s.AddCleanup(interfaces.MockIsHomeUsingNFS(func() (bool, error) { return false, nil }))
 	s.AddCleanup(release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"}))
 }
 
@@ -72,7 +71,10 @@ func (s *systemKeySuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
+func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
+	restore := interfaces.MockIsHomeUsingNFS(func() (bool, error) { return nfsHome, nil })
+	defer restore()
+
 	err := interfaces.WriteSystemKey()
 	c.Assert(err, IsNil)
 
@@ -94,15 +96,17 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 	seccompActionsStr, err := json.Marshal(release.SecCompActions())
 	c.Assert(err, IsNil)
 
-	nfsHome, err := osutil.IsHomeUsingNFS()
-	c.Assert(err, IsNil)
-
 	buildID, err := osutil.ReadBuildID("/proc/self/exe")
 	c.Assert(err, IsNil)
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
 	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"apparmor-parser-mtime":%s,"apparmor-parser-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s}`, buildID, apparmorFeaturesStr, apparmorParserMtime, apparmorParserFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+}
+
+func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
+	s.testInterfaceWriteSystemKey(c, false)
+	s.testInterfaceWriteSystemKey(c, true)
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {


### PR DESCRIPTION
I've just moved my source code to a NFS-exported directory that's mounted across VMs inside home dirs. This uncovered a couple of issues with mocking of isHomeUsingNFS in tests that resulted in test failures:
-  in one case mocking was present, but the test called real `osutil.isHomeUsingNFS` method for expected system key, so with real NFS the test disagreed with mocked data.
- in other cases mocking was missing and apparmor backend decided to call apparmor_parser and snap-confine to reload the profile.
