### PR TITLE
userd: handle help urls which requires prepending XDG_DATA_DIRS

### DIFF
--- a/tests/lib/snaps/test-snapd-desktop/bin/cmd
+++ b/tests/lib/snaps/test-snapd-desktop/bin/cmd
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+command="$1"
+shift
+
+"$command" "$@"

--- a/tests/lib/snaps/test-snapd-desktop/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-desktop/meta/snap.yaml
@@ -10,3 +10,6 @@ apps:
     check-dirs:
         command: bin/check-dirs
         plugs: [desktop]
+    cmd:
+        command: bin/cmd
+        plugs: [desktop]

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -44,7 +44,6 @@ execute: |
     x-scheme-handler/http=xdg-open.desktop
     x-scheme-handler/https=xdg-open.desktop
     x-scheme-handler/mailto=xdg-open.desktop
-    x-scheme-handler/help=xdg-open.desktop
     EOF
     cat > /usr/share/applications/xdg-open.desktop <<EOF
     [Desktop Entry]
@@ -52,7 +51,7 @@ execute: |
     Type=Application
     Exec=/usr/bin/xdg-open %u
     Terminal=false
-    MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;x-scheme-handler/help;
+    MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;
     Name=xdg-open
     EOF
     
@@ -96,11 +95,10 @@ execute: |
         test "$(cat "$XDG_OPEN_OUTPUT")" = "$1"
     }
 
-    # Ensure http, https, mailto, and help work
+    # Ensure http, https, mailto work
     ensure_xdg_open_output "https://snapcraft.io"
     ensure_xdg_open_output "http://snapcraft.io"
     ensure_xdg_open_output "mailto:talk@snapcraft.io"
-    ensure_xdg_open_output "help:snapcraft"
 
     # Ensure other schemes are not passed through
     rm "$XDG_OPEN_OUTPUT"

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -15,6 +15,11 @@ environment:
     DISPLAY: :0
     XDG_OPEN_OUTPUT: /tmp/xdg-open-output
 
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-desktop
+
 restore: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
@@ -56,8 +61,9 @@ execute: |
     EOF
     
     echo "Launch user dbus session"
+    dbus-launch > dbus.env
     #shellcheck disable=SC2046
-    export $(dbus-launch)
+    export $(xargs < dbus.env)
 
     echo "Ensure snapd-xdg-open is available"
     ping_launcher() {
@@ -80,10 +86,19 @@ execute: |
     EOF
     chmod +x /usr/bin/xdg-open
 
+    xdg_open_url() {
+        test-snapd-desktop.cmd /usr/bin/dbus-send --session \
+            --dest=com.canonical.SafeLauncher               \
+            --type=method_call                              \
+            --print-reply                                   \
+            /                                               \
+            com.canonical.SafeLauncher.OpenURL              \
+            "string:$1"
+    }
     ensure_xdg_open_output() {
         rm -f "$XDG_OPEN_OUTPUT"
         export DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
-        $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open "$1"
+        xdg_open_url "$1"
         # xdg-open is async so we need to give it a little bit of time
         for _ in $(seq 10); do
             if [ -e "$XDG_OPEN_OUTPUT" ]; then
@@ -102,7 +117,10 @@ execute: |
 
     # Ensure other schemes are not passed through
     rm "$XDG_OPEN_OUTPUT"
-    ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open ftp://snapcraft.io
+    ! xdg_open_url ftp://snapcraft.io
     test ! -e "$XDG_OPEN_OUTPUT"
-    ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open aabbcc
+    ! xdg_open_url aabbcc
+    test ! -e "$XDG_OPEN_OUTPUT"
+    # help is blocked by snapd-xdg-open
+    ! xdg_open_url help:snapcraft
     test ! -e "$XDG_OPEN_OUTPUT"

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -44,6 +44,7 @@ execute: |
     x-scheme-handler/http=xdg-open.desktop
     x-scheme-handler/https=xdg-open.desktop
     x-scheme-handler/mailto=xdg-open.desktop
+    x-scheme-handler/help=xdg-open.desktop
     EOF
     cat > /usr/share/applications/xdg-open.desktop <<EOF
     [Desktop Entry]
@@ -51,7 +52,7 @@ execute: |
     Type=Application
     Exec=/usr/bin/xdg-open %u
     Terminal=false
-    MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;
+    MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/mailto;x-scheme-handler/help;
     Name=xdg-open
     EOF
     
@@ -95,10 +96,11 @@ execute: |
         test "$(cat "$XDG_OPEN_OUTPUT")" = "$1"
     }
 
-    # Ensure http, https and mailto work
+    # Ensure http, https, mailto, and help work
     ensure_xdg_open_output "https://snapcraft.io"
     ensure_xdg_open_output "http://snapcraft.io"
     ensure_xdg_open_output "mailto:talk@snapcraft.io"
+    ensure_xdg_open_output "help:snapcraft"
 
     # Ensure other schemes are not passed through
     rm "$XDG_OPEN_OUTPUT"

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -64,7 +64,7 @@ execute: |
     mount --bind /tmp/xdg-open /usr/bin/xdg-open
 
     ensure_xdg_open_output() {
-        rm -f /tmp/xdg-open-output /tmp/xdg-open-output
+        rm -f /tmp/xdg-open-output
         export DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
         test-snapd-desktop.cmd /usr/bin/xdg-open "$1"
         test -e /tmp/xdg-open-output

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -62,11 +62,12 @@ execute: |
         test "$(cat /tmp/xdg-open-output)" = "$1"
     }
 
-    # Ensure http, https and mailto work
+    # Ensure http, https, mailto, snap and help work
     ensure_xdg_open_output "https://snapcraft.io"
     ensure_xdg_open_output "http://snapcraft.io"
     ensure_xdg_open_output "mailto:talk@snapcraft.io"
     ensure_xdg_open_output "snap://snapcraft"
+    ensure_xdg_open_output "help:snapcraft"
 
     # Ensure other schemes are not passed through
     rm /tmp/xdg-open-output

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -7,6 +7,11 @@ systems: [-ubuntu-core-*]
 environment:
     DISPLAY: :0
 
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+    install_local test-snapd-desktop
+
 restore: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
@@ -23,6 +28,9 @@ execute: |
     . "$TESTSLIB/pkgdb.sh"
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
+
+    # this will be later used by userd
+    export XDG_DATA_DIRS=/usr/share
 
     dbus-launch > dbus.env
     #shellcheck disable=SC2046
@@ -46,6 +54,7 @@ execute: |
     cat << 'EOF' > /tmp/xdg-open
     #!/bin/sh
     echo "$@" > /tmp/xdg-open-output
+    echo "XDG_DATA_DIRS=$XDG_DATA_DIRS" >> /tmp/xdg-open-output
     EOF
     chmod +x /tmp/xdg-open
     if [ -e /usr/bin/xdg-open ]; then
@@ -55,11 +64,11 @@ execute: |
     mount --bind /tmp/xdg-open /usr/bin/xdg-open
 
     ensure_xdg_open_output() {
-        rm -f /tmp/xdg-open-output
+        rm -f /tmp/xdg-open-output /tmp/xdg-open-output
         export DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
-        chroot $SNAP_MOUNT_DIR/core/current /usr/bin/xdg-open "$1"
+        test-snapd-desktop.cmd /usr/bin/xdg-open "$1"
         test -e /tmp/xdg-open-output
-        test "$(cat /tmp/xdg-open-output)" = "$1"
+        test "$(head -1 /tmp/xdg-open-output)" = "$1"
     }
 
     # Ensure http, https, mailto, snap and help work
@@ -68,10 +77,12 @@ execute: |
     ensure_xdg_open_output "mailto:talk@snapcraft.io"
     ensure_xdg_open_output "snap://snapcraft"
     ensure_xdg_open_output "help:snapcraft"
+    # Ensure XDG_DATA_DIRS was prefixed with snap specific location
+    test "$(tail -1 /tmp/xdg-open-output)" = "XDG_DATA_DIRS=$SNAP_MOUNT_DIR/test-snapd-desktop/current/usr/share:/usr/share"
 
     # Ensure other schemes are not passed through
     rm /tmp/xdg-open-output
-    ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open ftp://snapcraft.io
+    ! test-snapd-desktop.cmd /usr/bin/xdg-open ftp://snapcraft.io
     test ! -e /tmp/xdg-open-output
-    ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open aabbcc
+    ! test-snapd-desktop.cmd /usr/bin/xdg-open aabbcc
     test ! -e /tmp/xdg-open-output

--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -24,10 +24,14 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/godbus/dbus"
+
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/strutil"
@@ -53,7 +57,7 @@ const launcherIntrospectionXML = `
 </interface>`
 
 var (
-	allowedURLSchemes = []string{"http", "https", "mailto", "snap"}
+	allowedURLSchemes = []string{"http", "https", "mailto", "snap", "help"}
 )
 
 // Launcher implements the 'io.snapcraft.Launcher' DBus interface.
@@ -87,7 +91,7 @@ func makeAccessDeniedError(err error) *dbus.Error {
 // OpenURL implements the 'OpenURL' method of the 'io.snapcraft.Launcher'
 // DBus interface. Before the provided url is passed to xdg-open the scheme is
 // validated against a list of allowed schemes. All other schemes are denied.
-func (s *Launcher) OpenURL(addr string) *dbus.Error {
+func (s *Launcher) OpenURL(addr string, sender dbus.Sender) *dbus.Error {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return &dbus.ErrMsgInvalidArg
@@ -97,7 +101,22 @@ func (s *Launcher) OpenURL(addr string) *dbus.Error {
 		return makeAccessDeniedError(fmt.Errorf("Supplied URL scheme %q is not allowed", u.Scheme))
 	}
 
-	if err = exec.Command("xdg-open", addr).Run(); err != nil {
+	snap, err := snapFromSender(s.conn, sender)
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+
+	xdg_data_dirs := []string{}
+	xdg_data_dirs = append(xdg_data_dirs, fmt.Sprintf(filepath.Join(dirs.SnapMountDir, snap, "current/usr/share")))
+	for _, dir := range strings.Split(os.Getenv("XDG_DATA_DIRS"), ":") {
+		xdg_data_dirs = append(xdg_data_dirs, dir)
+	}
+
+	cmd := exec.Command("xdg-open", addr)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_DATA_DIRS=%s", strings.Join(xdg_data_dirs, ":")))
+
+	if err := cmd.Run(); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
 	}
 

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -68,15 +68,15 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 		{"aabbccdd0011", "Supplied URL scheme \"\" is not allowed"},
 		{"invälid:%url", dbus.ErrMsgInvalidArg.Error()},
 	} {
-		err := s.launcher.OpenURL(t.url)
+		err := s.launcher.OpenURL(t.url, ":some-dbus-sender")
 		c.Assert(err, ErrorMatches, t.errMatcher)
 		c.Assert(s.mockXdgOpen.Calls(), IsNil)
 	}
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto", "snap"} {
-		err := s.launcher.OpenURL(schema + "://snapcraft.io")
+	for _, schema := range []string{"http", "https", "mailto", "snap", "help"} {
+		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{
 			{"xdg-open", schema + "://snapcraft.io"},
@@ -89,7 +89,7 @@ func (s *launcherSuite) TestOpenURLWithFailingXdgOpen(c *C) {
 	cmd := testutil.MockCommand(c, "xdg-open", "false")
 	defer cmd.Restore()
 
-	err := s.launcher.OpenURL("https://snapcraft.io")
+	err := s.launcher.OpenURL("https://snapcraft.io", ":some-dbus-sender")
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "cannot open supplied URL")
 }


### PR DESCRIPTION
Pass through help urls to xdg-open as well as prepend $SNAP/usr/share to XDG_DATA_DIRS which is required to allow yelp to find the help files.

This fixes opening application help in desktop snaps that utilize yelp for user documentation.

This is #6252 cherry-picked and with fixed author email.