### PR TITLE
interfaces/builtin/udev: add spec to disable udev + device cgroup

### DIFF
--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -61,9 +61,10 @@ type commonInterface struct {
 	permanentPlugKModModules []string
 	permanentSlotKModModules []string
 
-	usesPtraceTrace     bool
-	suppressPtraceTrace bool
-	suppressHomeIx      bool
+	usesPtraceTrace      bool
+	suppressPtraceTrace  bool
+	suppressHomeIx       bool
+	controlsDeviceCgroup bool
 }
 
 // Name returns the interface name.
@@ -162,8 +163,14 @@ func (iface *commonInterface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *commonInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	for _, rule := range iface.connectedPlugUDev {
-		spec.TagDevice(rule)
+	// don't tag devices if the interface controls it's own device cgroup
+	if iface.controlsDeviceCgroup {
+		spec.SetControlsDeviceCgroup()
+	} else {
+		for _, rule := range iface.connectedPlugUDev {
+			spec.TagDevice(rule)
+		}
 	}
+
 	return nil
 }

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -20,8 +20,9 @@
 package builtin
 
 import (
-	. "gopkg.in/check.v1"
 	"os"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
@@ -195,4 +196,39 @@ slots:
 	c.Assert(spec.SuppressHomeIx(), Equals, false)
 	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
 	c.Assert(spec.SuppressHomeIx(), Equals, true)
+}
+
+func (s *commonIfaceSuite) TestControlsDeviceCgroup(c *C) {
+	plug, _ := MockConnectedPlug(c, `
+name: consumer
+version: 0
+apps:
+  app:
+    plugs: [common]
+`, nil, "common")
+	slot, _ := MockConnectedSlot(c, `
+name: producer
+version: 0
+slots:
+  common:
+`, nil, "common")
+
+	// setting nothing
+	iface := &commonInterface{
+		name:                 "common",
+		controlsDeviceCgroup: false,
+	}
+	spec := &udev.Specification{}
+	c.Assert(spec.ControlsDeviceCgroup(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.ControlsDeviceCgroup(), Equals, false)
+
+	iface = &commonInterface{
+		name:                 "common",
+		controlsDeviceCgroup: true,
+	}
+	spec = &udev.Specification{}
+	c.Assert(spec.ControlsDeviceCgroup(), Equals, false)
+	c.Assert(spec.AddConnectedPlug(iface, plug, slot), IsNil)
+	c.Assert(spec.ControlsDeviceCgroup(), Equals, true)
 }

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -201,5 +201,6 @@ func init() {
 		connectedPlugAppArmor: greengrassSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  greengrassSupportConnectedPlugSeccomp,
 		reservedForOS:         true,
+		controlsDeviceCgroup:  true,
 	})
 }

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -26,25 +26,36 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type GreengrassSupportInterfaceSuite struct {
-	iface    interfaces.Interface
-	slotInfo *snap.SlotInfo
-	slot     *interfaces.ConnectedSlot
-	plugInfo *snap.PlugInfo
-	plug     *interfaces.ConnectedPlug
+	iface         interfaces.Interface
+	slotInfo      *snap.SlotInfo
+	slot          *interfaces.ConnectedSlot
+	plugInfo      *snap.PlugInfo
+	plug          *interfaces.ConnectedPlug
+	extraSlotInfo *snap.SlotInfo
+	extraSlot     *interfaces.ConnectedSlot
+	extraPlugInfo *snap.PlugInfo
+	extraPlug     *interfaces.ConnectedPlug
 }
 
+const coreSlotYaml = `name: core
+version: 0
+type: os
+slots:
+  network-control:
+  greengrass-support:
+`
 const ggMockPlugSnapInfoYaml = `name: other
 version: 1.0
 apps:
  app2:
   command: foo
-  plugs: [greengrass-support]
+  plugs: [greengrass-support, network-control]
 `
 
 var _ = Suite(&GreengrassSupportInterfaceSuite{
@@ -52,15 +63,11 @@ var _ = Suite(&GreengrassSupportInterfaceSuite{
 })
 
 func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
-	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
-		Name:      "greengrass-support",
-		Interface: "greengrass-support",
-	}
-	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
-	plugSnap := snaptest.MockInfo(c, ggMockPlugSnapInfoYaml, nil)
-	s.plugInfo = plugSnap.Plugs["greengrass-support"]
-	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+	s.plug, s.plugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "greengrass-support")
+	s.slot, s.slotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "greengrass-support")
+	s.extraPlug, s.extraPlugInfo = MockConnectedPlug(c, ggMockPlugSnapInfoYaml, nil, "network-control")
+	s.extraSlot, s.extraSlotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "network-control")
+
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestName(c *C) {
@@ -80,19 +87,31 @@ func (s *GreengrassSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 
 func (s *GreengrassSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+
 }
 
-func (s *GreengrassSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
+func (s *GreengrassSupportInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount fstype=overlay no_source -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**,\n")
+}
 
-	apparmorSpec := &apparmor.Specification{}
-	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount fstype=overlay no_source -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**,\n")
+func (s *GreengrassSupportInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "# for overlayfs and various bind mounts\nmount\numount2\npivot_root\n")
+}
+
+func (s *GreengrassSupportInterfaceSuite) TestUdevTaggingDisabling(c *C) {
+	// make a spec with network-control that has udev tagging
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(builtin.MustInterface("network-control"), s.extraPlug, s.extraSlot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 3)
+
+	// connect the greengrass-support interface and ensure the spec is now nil
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Snippets(), HasLen, 0)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -21,7 +21,6 @@ package udev_test
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -326,15 +325,14 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippets(c *C) {
 func (s *backendSuite) TestControlsDeviceCgroup(c *C) {
 	// NOTE: Hand out a permanent snippet so that .rules file is generated.
 	s.Iface.UDevPermanentSlotCallback = func(spec *udev.Specification, slot *snap.SlotInfo) error {
-		spec.SetControlsDeviceCgroup()
 		spec.AddSnippet("dummy")
+		spec.SetControlsDeviceCgroup()
 		return nil
 	}
 	for _, opts := range testedConfinementOpts {
 		snapInfo := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
-		_, err := os.Stat(fname)
-		c.Assert(err, ErrorMatches, fmt.Sprintf("stat.*%s.*no such file or directory", fname))
+		c.Check(fname, testutil.FileAbsent)
 		s.RemoveSnap(c, snapInfo)
 	}
 }

--- a/interfaces/udev/spec.go
+++ b/interfaces/udev/spec.go
@@ -44,6 +44,21 @@ type Specification struct {
 
 	securityTags             []string
 	udevadmSubsystemTriggers []string
+	controlsDeviceCgroup     bool
+}
+
+// SetControlsDeviceCgroup marks a specification as needing to control
+// it's own device cgroup which prevents generation of any udev tagging rules
+// for this snap name
+func (spec *Specification) SetControlsDeviceCgroup() {
+	spec.controlsDeviceCgroup = true
+}
+
+// ControlsDeviceCgroup marks a specification as needing to control
+// it's own device cgroup which prevents generation of any udev tagging rules
+// for this snap name
+func (spec *Specification) ControlsDeviceCgroup() bool {
+	return spec.controlsDeviceCgroup
 }
 
 func (spec *Specification) addEntry(snippet, tag string) {
@@ -93,6 +108,14 @@ func (c byTagAndSnippet) Less(i, j int) bool {
 
 // Snippets returns a copy of all the snippets added so far.
 func (spec *Specification) Snippets() (result []string) {
+	// If the interface controls it's own device cgroup, then
+	// we don't want to enforce a device cgroup, which is only turned on if
+	// there are udev rules, and as such we don't want to generate any udev
+	// rules
+
+	if spec.ControlsDeviceCgroup() {
+		return nil
+	}
 	entries := make([]entry, len(spec.entries))
 	copy(entries, spec.entries)
 	sort.Sort(byTagAndSnippet(entries))

--- a/interfaces/udev/spec.go
+++ b/interfaces/udev/spec.go
@@ -108,7 +108,7 @@ func (c byTagAndSnippet) Less(i, j int) bool {
 
 // Snippets returns a copy of all the snippets added so far.
 func (spec *Specification) Snippets() (result []string) {
-	// If the interface controls it's own device cgroup, then
+	// If one of the interfaces controls it's own device cgroup, then
 	// we don't want to enforce a device cgroup, which is only turned on if
 	// there are udev rules, and as such we don't want to generate any udev
 	// rules

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -138,3 +138,9 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
 	c.Assert(s.spec.Snippets(), DeepEquals, []string{"connected-plug", "connected-slot", "permanent-plug", "permanent-slot"})
 }
+
+func (s *specSuite) TestControlsDeviceCgroup(c *C) {
+	c.Assert(s.spec.ControlsDeviceCgroup(), Equals, false)
+	s.spec.SetControlsDeviceCgroup()
+	c.Assert(s.spec.ControlsDeviceCgroup(), Equals, true)
+}


### PR DESCRIPTION
This enables an interface to declare that the snap plugging this interface controls it's own device cgroup. This is the case for the greengrass snap and may be the case for other container management snaps developed in the future. Ideally these snaps would be able to "stack" their cgroups inside the device cgroup enforced by snapd when a relevant interface is plugged, but that is not the case currently. 

I added some testing that is specific to the greengrass-support interface but I'm not sure what else should be tested for this feature so please let me know if I should add any more tests for this. 

~This is based on top of https://github.com/snapcore/snapd/pull/6162~ - this doesn't include the changes from #6162 anymore