### PR TITLE
many: collect time each task runs and display with `snap change <id>`

### DIFF
--- a/client/change.go
+++ b/client/change.go
@@ -63,8 +63,9 @@ type Task struct {
 	Log      []string     `json:"log,omitempty"`
 	Progress TaskProgress `json:"progress"`
 
-	SpawnTime time.Time `json:"spawn-time,omitempty"`
-	ReadyTime time.Time `json:"ready-time,omitempty"`
+	SpawnTime  time.Time     `json:"spawn-time,omitempty"`
+	ReadyTime  time.Time     `json:"ready-time,omitempty"`
+	ActiveTime time.Duration `json:"active-time,omitempty"`
 }
 
 type TaskProgress struct {

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"time"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
@@ -161,18 +162,22 @@ func (c *cmdTasks) showChange(chid string) error {
 
 	w := tabWriter()
 
-	fmt.Fprintf(w, i18n.G("Status\tSpawn\tReady\tSummary\n"))
+	fmt.Fprintf(w, i18n.G("Status\tSpawn\tReady\tActive\tSummary\n"))
 	for _, t := range chg.Tasks {
 		spawnTime := c.fmtTime(t.SpawnTime)
 		readyTime := c.fmtTime(t.ReadyTime)
 		if t.ReadyTime.IsZero() {
 			readyTime = "-"
 		}
+		activeTime := t.ActiveTime.Round(time.Millisecond).String()
+		if t.ActiveTime == 0 {
+			activeTime = "-"
+		}
 		summary := t.Summary
 		if t.Status == "Doing" && t.Progress.Total > 1 {
 			summary = fmt.Sprintf("%s (%.2f%%)", summary, float64(t.Progress.Done)/float64(t.Progress.Total)*100.0)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Status, spawnTime, readyTime, summary)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Status, spawnTime, readyTime, activeTime, summary)
 	}
 
 	w.Flush()

--- a/cmd/snap/cmd_changes_test.go
+++ b/cmd/snap/cmd_changes_test.go
@@ -37,7 +37,7 @@ var mockChangeJSON = `{"type": "sync", "result": {
   "ready": false,
   "spawn-time": "2016-04-21T01:02:03Z",
   "ready-time": "2016-04-21T01:02:04Z",
-  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
+  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z", "active-time": 12345678}]
 }}`
 
 func (s *SnapSuite) TestChangeSimple(c *check.C) {
@@ -53,8 +53,8 @@ func (s *SnapSuite) TestChangeSimple(c *check.C) {
 
 		n++
 	})
-	expectedChange := `(?ms)Status +Spawn +Ready +Summary
-Do +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary
+	expectedChange := `(?ms)Status +Spawn +Ready +Active +Summary
+Do +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +12ms +some summary
 `
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"change", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
@@ -226,8 +226,8 @@ func (s *SnapSuite) TestChangeProgress(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"change", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `(?ms)Status +Spawn +Ready +Summary
-Doing +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary \(50.00%\)
+	c.Check(s.Stdout(), check.Matches, `(?ms)Status +Spawn +Ready +Active +Summary
+Doing +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +- +some summary \(50.00%\)
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1989,8 +1989,9 @@ type taskInfo struct {
 	Log      []string         `json:"log,omitempty"`
 	Progress taskInfoProgress `json:"progress"`
 
-	SpawnTime time.Time  `json:"spawn-time,omitempty"`
-	ReadyTime *time.Time `json:"ready-time,omitempty"`
+	SpawnTime  time.Time     `json:"spawn-time,omitempty"`
+	ReadyTime  *time.Time    `json:"ready-time,omitempty"`
+	ActiveTime time.Duration `json:"active-time,omitempty"`
 }
 
 type taskInfoProgress struct {
@@ -2034,7 +2035,8 @@ func change2changeInfo(chg *state.Change) *changeInfo {
 				Done:  done,
 				Total: total,
 			},
-			SpawnTime: t.SpawnTime(),
+			SpawnTime:  t.SpawnTime(),
+			ActiveTime: t.ActiveTime(),
 		}
 		readyTime := t.ReadyTime()
 		if !readyTime.IsZero() {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -5135,6 +5135,7 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 	ids := setupChanges(st)
 	chg := st.Change(ids[0])
 	chg.Set("api-data", map[string]int{"n": 42})
+	chg.Tasks()[0].AccumulateActiveTime(123456)
 	st.Unlock()
 	s.vars = map[string]string{"id": ids[0]}
 
@@ -5163,13 +5164,14 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"tasks": []interface{}{
 			map[string]interface{}{
-				"id":         ids[2],
-				"kind":       "download",
-				"summary":    "1...",
-				"status":     "Do",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
-				"spawn-time": "2016-04-21T01:02:03Z",
+				"id":          ids[2],
+				"kind":        "download",
+				"summary":     "1...",
+				"status":      "Do",
+				"log":         []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":    map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"spawn-time":  "2016-04-21T01:02:03Z",
+				"active-time": 123456.0,
 			},
 			map[string]interface{}{
 				"id":         ids[3],

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -52,8 +52,9 @@ type Task struct {
 	log       []string
 	change    string
 
-	spawnTime time.Time
-	readyTime time.Time
+	spawnTime  time.Time
+	readyTime  time.Time
+	activeTime time.Duration
 
 	atTime time.Time
 }
@@ -84,8 +85,9 @@ type marshalledTask struct {
 	Log       []string                    `json:"log,omitempty"`
 	Change    string                      `json:"change"`
 
-	SpawnTime time.Time  `json:"spawn-time"`
-	ReadyTime *time.Time `json:"ready-time,omitempty"`
+	SpawnTime  time.Time     `json:"spawn-time"`
+	ReadyTime  *time.Time    `json:"ready-time,omitempty"`
+	ActiveTime time.Duration `json:"active-time,omitempty"`
 
 	AtTime *time.Time `json:"at-time,omitempty"`
 }
@@ -115,8 +117,9 @@ func (t *Task) MarshalJSON() ([]byte, error) {
 		Log:       t.log,
 		Change:    t.change,
 
-		SpawnTime: t.spawnTime,
-		ReadyTime: readyTime,
+		SpawnTime:  t.spawnTime,
+		ReadyTime:  readyTime,
+		ActiveTime: t.activeTime,
 
 		AtTime: atTime,
 	})
@@ -149,6 +152,7 @@ func (t *Task) UnmarshalJSON(data []byte) error {
 	t.log = unmarshalled.Log
 	t.change = unmarshalled.Change
 	t.spawnTime = unmarshalled.SpawnTime
+	t.activeTime = unmarshalled.ActiveTime
 	if unmarshalled.ReadyTime != nil {
 		t.readyTime = *unmarshalled.ReadyTime
 	}
@@ -274,6 +278,16 @@ func (t *Task) ReadyTime() time.Time {
 func (t *Task) AtTime() time.Time {
 	t.state.reading()
 	return t.atTime
+}
+
+func (t *Task) AccumulateActiveTime(duration time.Duration) {
+	t.state.writing()
+	t.activeTime += duration
+}
+
+func (t *Task) ActiveTime() time.Duration {
+	t.state.reading()
+	return t.activeTime
 }
 
 const (

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -67,6 +67,18 @@ func (cs *taskSuite) TestReadyTime(c *C) {
 	c.Check(t.Before(now.Add(5*time.Second)), Equals, true)
 }
 
+func (cs *taskSuite) TestActiveTime(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("download", "summary...")
+
+	task.AccumulateActiveTime(123456)
+
+	c.Assert(task.ActiveTime(), Equals, time.Duration(123456))
+}
+
 func (ts *taskSuite) TestGetSet(c *C) {
 	st := state.New(nil)
 	st.Lock()

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -188,13 +188,16 @@ func (r *TaskRunner) run(t *Task) {
 		// Capture the error result with tomb.Kill so we can
 		// use tomb.Err uniformily to consider both it or a
 		// overriding previous Kill reason.
+		perfStart := time.Now()
 		tomb.Kill(handler(t, tomb))
+		perfEnd := time.Now()
 
 		// Locks must be acquired in the same order everywhere.
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		r.state.Lock()
 		defer r.state.Unlock()
+		t.AccumulateActiveTime(perfEnd.Sub(perfStart))
 
 		delete(r.tombs, t.ID())
 

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -398,6 +398,7 @@ func (ts *taskRunnerSuite) TestStopHandlerJustFinishing(c *C) {
 	st.Lock()
 	defer st.Unlock()
 	c.Check(t.Status(), Equals, state.DoneStatus)
+	c.Check(t.ActiveTime(), Not(Equals), 0)
 }
 
 func (ts *taskRunnerSuite) TestStopKinds(c *C) {


### PR DESCRIPTION
This PR imports the changes from Maciej that measures how much time
each task taskes to run. This data is stored in the state and can
be displayed via `snap change <id>`. E.g.:
```
$ snap change 563
Status  Spawn               Ready               Active  Summary
Done    today at 09:28 CET  today at 09:29 CET  13ms    Stop snap "test-snapd-tools" (6) services
Done    today at 09:28 CET  today at 09:29 CET  39ms    Remove aliases for snap "test-snapd-tools"
Done    today at 09:28 CET  today at 09:29 CET  27ms    Make snap "test-snapd-tools" (6) unavailable to the system
Done    today at 09:28 CET  today at 09:29 CET  10ms    Remove security profiles of snap "test-snapd-tools"
```
This is a first (baby) step towards measuring where we spend time
in e.g. firstboot seeding and where we need to optimize.

As it is this changes the output of `snap change <id>` - to avoid this I can add a `--with-active-time` or similar switch.

Thanks to Maciej Borzecki and Zygmunt Krynicki who wrote most of
this code.
