### PR TITLE
features,cmd/libsnap: add new feature "refresh-app-awareness"

### DIFF
--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -37,6 +37,9 @@ bool sc_feature_enabled(sc_feature_flag flag)
 	case SC_PER_USER_MOUNT_NAMESPACE:
 		file_name = "per-user-mount-namespace";
 		break;
+	case SC_FEATURE_REFRESH_APP_AWARENESS:
+		file_name = "refresh-app-awareness";
+		break;
 	default:
 		die("unknown feature flag code %d", flag);
 	}

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -22,6 +22,7 @@
 
 typedef enum sc_feature_flag {
 	SC_PER_USER_MOUNT_NAMESPACE,
+	SC_FEATURE_REFRESH_APP_AWARENESS,
 } sc_feature_flag;
 
 /**

--- a/features/features.go
+++ b/features/features.go
@@ -41,6 +41,8 @@ const (
 	SnapdSnap
 	// PerUserMountNamespace controls the persistence of per-user mount namespaces.
 	PerUserMountNamespace
+	// RefreshAppAwareness controls refresh being aware of running applications.
+	RefreshAppAwareness
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -62,6 +64,7 @@ var featureNames = map[SnapdFeature]string{
 	Hotplug:               "hotplug",
 	SnapdSnap:             "snapd-snap",
 	PerUserMountNamespace: "per-user-mount-namespace",
+	RefreshAppAwareness:   "refresh-app-awareness",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -72,6 +75,7 @@ var featuresEnabledWhenUnset = map[SnapdFeature]bool{
 // featuresExported contains a set of features that are exported outside of snapd.
 var featuresExported = map[SnapdFeature]bool{
 	PerUserMountNamespace: true,
+	RefreshAppAwareness:   true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -42,6 +42,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.Hotplug.String(), Equals, "hotplug")
 	c.Check(features.SnapdSnap.String(), Equals, "snapd-snap")
 	c.Check(features.PerUserMountNamespace.String(), Equals, "per-user-mount-namespace")
+	c.Check(features.RefreshAppAwareness.String(), Equals, "refresh-app-awareness")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -60,6 +61,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.Hotplug.IsExported(), Equals, false)
 	c.Check(features.SnapdSnap.IsExported(), Equals, false)
 	c.Check(features.PerUserMountNamespace.IsExported(), Equals, true)
+	c.Check(features.RefreshAppAwareness.IsExported(), Equals, true)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -87,16 +89,24 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.Hotplug.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.SnapdSnap.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.PerUserMountNamespace.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.RefreshAppAwareness.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {
 	c.Check(features.PerUserMountNamespace.ControlFile(), Equals, "/var/lib/snapd/features/per-user-mount-namespace")
+	c.Check(features.RefreshAppAwareness.ControlFile(), Equals, "/var/lib/snapd/features/refresh-app-awareness")
 	// Features that are not exported don't have a control file.
 	c.Check(features.Layouts.ControlFile, PanicMatches, `cannot compute the control file of feature "layouts" because that feature is not exported`)
 }
 
-func (*featureSuite) TestConfigOption(c *C) {
+func (*featureSuite) TestConfigOptionLayouts(c *C) {
 	snapName, configName := features.Layouts.ConfigOption()
 	c.Check(snapName, Equals, "core")
 	c.Check(configName, Equals, "experimental.layouts")
+}
+
+func (*featureSuite) TestConfigOptionRefreshAppAwareness(c *C) {
+	snapName, configName := features.RefreshAppAwareness.ConfigOption()
+	c.Check(snapName, Equals, "core")
+	c.Check(configName, Equals, "experimental.refresh-app-awareness")
 }


### PR DESCRIPTION
This branch begins the process of teaching snapd about running apps during snap
refreshes.  Since the entire functionality needs to be behind a feature flag
that is disabled until deemed stable the first branch introduces this new
feature flag. The flag is exported so that snap-confine can use it for the
purpose of the new process accounting feature.
