### PR TITLE
cmd/libsnap: add cgroup-pids-support module

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -55,6 +55,8 @@ check-unit-tests:
 endif
 
 new_format = \
+	 libsnap-confine-private/cgroup-pids-support.c \
+	 libsnap-confine-private/cgroup-pids-support.h \
 	 snap-confine/seccomp-support-ext.c \
 	 snap-confine/seccomp-support-ext.h \
 	 snap-discard-ns/snap-discard-ns.c
@@ -94,6 +96,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/apparmor-support.h \
 	libsnap-confine-private/cgroup-freezer-support.c \
 	libsnap-confine-private/cgroup-freezer-support.h \
+	libsnap-confine-private/cgroup-pids-support.c \
+	libsnap-confine-private/cgroup-pids-support.h \
 	libsnap-confine-private/classic.c \
 	libsnap-confine-private/classic.h \
 	libsnap-confine-private/cleanup-funcs.c \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -57,6 +57,8 @@ endif
 new_format = \
 	 libsnap-confine-private/cgroup-pids-support.c \
 	 libsnap-confine-private/cgroup-pids-support.h \
+	 libsnap-confine-private/cgroup-support.c \
+	 libsnap-confine-private/cgroup-support.h \
 	 snap-confine/seccomp-support-ext.c \
 	 snap-confine/seccomp-support-ext.h \
 	 snap-discard-ns/snap-discard-ns.c
@@ -98,6 +100,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/cgroup-freezer-support.h \
 	libsnap-confine-private/cgroup-pids-support.c \
 	libsnap-confine-private/cgroup-pids-support.h \
+	libsnap-confine-private/cgroup-support.c \
+	libsnap-confine-private/cgroup-support.h \
 	libsnap-confine-private/classic.c \
 	libsnap-confine-private/classic.h \
 	libsnap-confine-private/cleanup-funcs.c \

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 // For AT_EMPTY_PATH and O_PATH
 #define _GNU_SOURCE
 

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "cgroup-support.h"
 #include "cleanup-funcs.h"
 #include "string-utils.h"
 #include "utils.h"
@@ -19,51 +20,9 @@ static const char *freezer_cgroup_dir = "/sys/fs/cgroup/freezer";
 
 void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 {
-	// Format the name of the cgroup hierarchy.
 	char buf[PATH_MAX] = { 0 };
 	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
-
-	// Open the freezer cgroup directory.
-	int cgroup_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	cgroup_fd = open(freezer_cgroup_dir,
-			 O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (cgroup_fd < 0) {
-		die("cannot open freezer cgroup (%s)", freezer_cgroup_dir);
-	}
-	// Create the freezer hierarchy for the given snap.
-	if (mkdirat(cgroup_fd, buf, 0755) < 0 && errno != EEXIST) {
-		die("cannot create freezer cgroup hierarchy for snap %s",
-		    snap_name);
-	}
-	// Open the hierarchy directory for the given snap.
-	int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	hierarchy_fd = openat(cgroup_fd, buf,
-			      O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-	if (hierarchy_fd < 0) {
-		die("cannot open freezer cgroup hierarchy for snap %s",
-		    snap_name);
-	}
-	// Since we may be running from a setuid but not setgid executable, ensure
-	// that the group and owner of the hierarchy directory is root.root.
-	if (fchownat(hierarchy_fd, "", 0, 0, AT_EMPTY_PATH) < 0) {
-		die("cannot change owner of freezer cgroup hierarchy for snap %s to root.root", snap_name);
-	}
-	// Open the tasks file.
-	int tasks_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	tasks_fd = openat(hierarchy_fd, "tasks",
-			  O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
-	if (tasks_fd < 0) {
-		die("cannot open tasks file for freezer cgroup hierarchy for snap %s", snap_name);
-	}
-	// Write the process (task) number to the tasks file. Linux task IDs are
-	// limited to 2^29 so a long int is enough to represent it.
-	// See include/linux/threads.h in the kernel source tree for details.
-	int n = sc_must_snprintf(buf, sizeof buf, "%ld", (long)pid);
-	if (write(tasks_fd, buf, n) < n) {
-		die("cannot move process %ld to freezer cgroup hierarchy for snap %s", (long)pid, snap_name);
-	}
-	debug("moved process %ld to freezer cgroup hierarchy for snap %s",
-	      (long)pid, snap_name);
+	sc_cgroup_create_and_join(freezer_cgroup_dir, buf, pid);
 }
 
 bool sc_cgroup_freezer_occupied(const char *snap_name)

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.h
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef SC_CGROUP_FREEZER_SUPPORT_H
 #define SC_CGROUP_FREEZER_SUPPORT_H
 

--- a/cmd/libsnap-confine-private/cgroup-pids-support.c
+++ b/cmd/libsnap-confine-private/cgroup-pids-support.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #include "cgroup-pids-support.h"
 
 #include "cgroup-support.h"

--- a/cmd/libsnap-confine-private/cgroup-pids-support.c
+++ b/cmd/libsnap-confine-private/cgroup-pids-support.c
@@ -1,0 +1,57 @@
+// For AT_EMPTY_PATH and O_PATH
+#define _GNU_SOURCE
+
+#include "cgroup-pids-support.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "cleanup-funcs.h"
+#include "string-utils.h"
+#include "utils.h"
+
+static const char *pids_cgroup_dir = "/sys/fs/cgroup/pids";
+
+void sc_cgroup_pids_join(const char *snap_security_tag, pid_t pid) {
+    // Open the pids cgroup directory.
+    int cgroup_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    cgroup_fd = open(pids_cgroup_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (cgroup_fd < 0) {
+        die("cannot open pids cgroup (%s)", pids_cgroup_dir);
+    }
+    // Create the pid hierarchy for the given snap security tag.
+    if (mkdirat(cgroup_fd, snap_security_tag, 0755) < 0 && errno != EEXIST) {
+        die("cannot create pids cgroup hierarchy for snap security tag %s", snap_security_tag);
+    }
+    // Open the hierarchy directory for the given snap security tag.
+    int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    hierarchy_fd = openat(cgroup_fd, snap_security_tag, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (hierarchy_fd < 0) {
+        die("cannot open pids cgroup hierarchy for snap security tag %s", snap_security_tag);
+    }
+    // Since we may be running from a setuid but not setgid executable, ensure
+    // that the group and owner of the hierarchy directory is root.root.
+    if (fchownat(hierarchy_fd, "", 0, 0, AT_EMPTY_PATH) < 0) {
+        die("cannot change owner of pids cgroup hierarchy for snap security tag %s to root.root", snap_security_tag);
+    }
+    // Open the tasks file.
+    int tasks_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    tasks_fd = openat(hierarchy_fd, "tasks", O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (tasks_fd < 0) {
+        die("cannot open tasks file for pids cgroup hierarchy for snap security tag %s", snap_security_tag);
+    }
+    // Write the process (task) number to the tasks file. Linux task IDs are
+    // limited to 2^29 so a long int is enough to represent it.
+    // See include/linux/threads.h in the kernel source tree for details.
+    char buf[PATH_MAX] = {0};
+    int n = sc_must_snprintf(buf, sizeof buf, "%ld", (long)pid);
+    if (write(tasks_fd, buf, n) < n) {
+        die("cannot move process %ld to pids cgroup hierarchy for snap security tag %s", (long)pid, snap_security_tag);
+    }
+    debug("moved process %ld to pids cgroup hierarchy for snap security tag %s", (long)pid, snap_security_tag);
+}

--- a/cmd/libsnap-confine-private/cgroup-pids-support.c
+++ b/cmd/libsnap-confine-private/cgroup-pids-support.c
@@ -1,57 +1,9 @@
-// For AT_EMPTY_PATH and O_PATH
-#define _GNU_SOURCE
-
 #include "cgroup-pids-support.h"
 
-#include <errno.h>
-#include <fcntl.h>
-#include <limits.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include "cleanup-funcs.h"
-#include "string-utils.h"
-#include "utils.h"
+#include "cgroup-support.h"
 
 static const char *pids_cgroup_dir = "/sys/fs/cgroup/pids";
 
 void sc_cgroup_pids_join(const char *snap_security_tag, pid_t pid) {
-    // Open the pids cgroup directory.
-    int cgroup_fd SC_CLEANUP(sc_cleanup_close) = -1;
-    cgroup_fd = open(pids_cgroup_dir, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-    if (cgroup_fd < 0) {
-        die("cannot open pids cgroup (%s)", pids_cgroup_dir);
-    }
-    // Create the pid hierarchy for the given snap security tag.
-    if (mkdirat(cgroup_fd, snap_security_tag, 0755) < 0 && errno != EEXIST) {
-        die("cannot create pids cgroup hierarchy for snap security tag %s", snap_security_tag);
-    }
-    // Open the hierarchy directory for the given snap security tag.
-    int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
-    hierarchy_fd = openat(cgroup_fd, snap_security_tag, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-    if (hierarchy_fd < 0) {
-        die("cannot open pids cgroup hierarchy for snap security tag %s", snap_security_tag);
-    }
-    // Since we may be running from a setuid but not setgid executable, ensure
-    // that the group and owner of the hierarchy directory is root.root.
-    if (fchownat(hierarchy_fd, "", 0, 0, AT_EMPTY_PATH) < 0) {
-        die("cannot change owner of pids cgroup hierarchy for snap security tag %s to root.root", snap_security_tag);
-    }
-    // Open the tasks file.
-    int tasks_fd SC_CLEANUP(sc_cleanup_close) = -1;
-    tasks_fd = openat(hierarchy_fd, "tasks", O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
-    if (tasks_fd < 0) {
-        die("cannot open tasks file for pids cgroup hierarchy for snap security tag %s", snap_security_tag);
-    }
-    // Write the process (task) number to the tasks file. Linux task IDs are
-    // limited to 2^29 so a long int is enough to represent it.
-    // See include/linux/threads.h in the kernel source tree for details.
-    char buf[PATH_MAX] = {0};
-    int n = sc_must_snprintf(buf, sizeof buf, "%ld", (long)pid);
-    if (write(tasks_fd, buf, n) < n) {
-        die("cannot move process %ld to pids cgroup hierarchy for snap security tag %s", (long)pid, snap_security_tag);
-    }
-    debug("moved process %ld to pids cgroup hierarchy for snap security tag %s", (long)pid, snap_security_tag);
+    sc_cgroup_create_and_join(pids_cgroup_dir, snap_security_tag, pid);
 }

--- a/cmd/libsnap-confine-private/cgroup-pids-support.h
+++ b/cmd/libsnap-confine-private/cgroup-pids-support.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef SC_CGROUP_PIDS_SUPPORT_H
 #define SC_CGROUP_PIDS_SUPPORT_H
 

--- a/cmd/libsnap-confine-private/cgroup-pids-support.h
+++ b/cmd/libsnap-confine-private/cgroup-pids-support.h
@@ -1,0 +1,26 @@
+#ifndef SC_CGROUP_PIDS_SUPPORT_H
+#define SC_CGROUP_PIDS_SUPPORT_H
+
+#include <sys/types.h>
+
+/**
+ * Join the pid cgroup for the given snap application.
+ *
+ * This function adds the specified task to the pid cgroup specific to the
+ * given snap. The name of the cgroup is "snap.$snap_name.$app_name" for apps
+ * or "snap.$snap_name.hook.$hook_name" for hooks.
+ *
+ * The "tasks" file belonging to the cgroup contains the set of all the
+ * threads that originate from the given snap app or hook. Examining that
+ * file one can reliably determine if the set is empty or not.
+ *
+ * Similarly the "cgroup.procs" file belonging to the same directory contains
+ * the set of all the processes that originate from the given snap app or
+ * hook.
+ *
+ * For more details please review:
+ * https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt
+ **/
+void sc_cgroup_pids_join(const char *snap_security_tag, pid_t pid);
+
+#endif

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 // For AT_EMPTY_PATH and O_PATH
 #define _GNU_SOURCE
 

--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -1,0 +1,59 @@
+// For AT_EMPTY_PATH and O_PATH
+#define _GNU_SOURCE
+
+#include "cgroup-support.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "cleanup-funcs.h"
+#include "utils.h"
+
+void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid) {
+    int parent_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    parent_fd = open(parent, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (parent_fd < 0) {
+        die("cannot open cgroup hierarchy %s", parent);
+    }
+    if (mkdirat(parent_fd, name, 0755) < 0 && errno != EEXIST) {
+        die("cannot create cgroup hierarchy %s/%s", parent, name);
+    }
+    int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    hierarchy_fd = openat(parent_fd, name, O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (hierarchy_fd < 0) {
+        die("cannot open cgroup hierarchy %s/%s", parent, name);
+    }
+    // Since we may be running from a setuid but not setgid executable, ensure
+    // that the group and owner of the hierarchy directory is root.root.
+    if (fchownat(hierarchy_fd, "", 0, 0, AT_EMPTY_PATH) < 0) {
+        die("cannot change owner of cgroup hierarchy %s/%s to root.root", parent, name);
+    }
+    // Open the tasks file.
+    int tasks_fd SC_CLEANUP(sc_cleanup_close) = -1;
+    tasks_fd = openat(hierarchy_fd, "tasks", O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (tasks_fd < 0) {
+        die("cannot open file %s/%s/tasks", parent, name);
+    }
+    FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
+    stream = fdopen(tasks_fd, "w");
+    if (stream == NULL) {
+        die("cannot open stream of %s/%s/tasks", parent, name);
+    }
+    // stream now owns tasks_fd
+    tasks_fd = -1;
+    // Write the process (task) number to the tasks file. Linux task IDs are
+    // limited to 2^29 so a long int is enough to represent it.
+    // See include/linux/threads.h in the kernel source tree for details.
+    int n = fprintf(stream, "%ld", (long)pid);
+    if (n < 0) {
+        die("cannot move process %ld to cgroup hierarchy %s/%s", (long)pid, parent, name);
+    }
+    if (fflush(stream) == EOF) {
+        die("cannot flush buffer");
+    }
+    debug("moved process %ld to cgroup hierarchy %s/%s", (long)pid, parent, name);
+}

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #ifndef SC_CGROUP_SUPPORT_H
 #define SC_CGROUP_SUPPORT_H
 

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -1,0 +1,16 @@
+#ifndef SC_CGROUP_SUPPORT_H
+#define SC_CGROUP_SUPPORT_H
+
+#include <fcntl.h>
+
+/**
+ * sc_cgroup_create_and_join joins, perhaps creating, a cgroup hierarchy.
+ *
+ * The code assumes that an existing hierarchy rooted at "parent". It follows
+ * up with a sub-hierarchy called "name", creating it if necessary. The created
+ * sub-hierarchy is made to belong to root.root and the specified process is
+ * moved there.
+ **/
+void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid);
+
+#endif


### PR DESCRIPTION
As a part of refresh app awareness work snapd needs to differentiate snap
services from other snap commands as well as snap hooks. Services can be
reliably stopped and restarted during a refresh process but apps have no such
capability. To know that a refresh can proceed, before stopping services, snapd
can compute the set of PIDs associated to a given snap and subtract the subset
of PIDs associated with each service. If any processes remain then some
non-service processes must be running (and one can determine which as well).

To track per-app and per-hook processes we can use the PID control group
without enabling any resource allocation constraints.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
