### PR TITLE
cmd/snap-confine: allow moving tasks to pids cgroup

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -67,6 +67,13 @@
     /sys/fs/cgroup/freezer/snap.*/tasks w,
     /sys/fs/cgroup/freezer/snap.*/cgroup.procs r,
 
+    # cgroup: pids
+    # allow creating per snap-security-tag hierarchy and adding snap command (task)
+    # invocations to the controller.
+    /sys/fs/cgroup/pids/ r,
+    /sys/fs/cgroup/pids/snap.*/ w,
+    /sys/fs/cgroup/pids/snap.*/tasks w,
+
     # querying udev
     /etc/udev/udev.conf r,
     /sys/**/uevent r,


### PR DESCRIPTION
To potentially allow snapd to track processes per app/hook we must allow
snap-confine to move the created task to a dedicated pid cgroup. This
patch contains the apparmor permissions necessary to do so.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
