### PR TITLE
tests: use snap which takes 15 seconds to install on retryable-error test

### DIFF
--- a/tests/lib/snaps/test-snapd-sleep-install/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-sleep-install/meta/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sleep 15

--- a/tests/lib/snaps/test-snapd-sleep-install/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sleep-install/meta/snap.yaml
@@ -1,0 +1,3 @@
+name: test-snapd-sleep-install
+summary: A snap which takes 15 seconds to be installed
+version: 1.0

--- a/tests/main/retryable-error/task.yaml
+++ b/tests/main/retryable-error/task.yaml
@@ -4,13 +4,15 @@ summary: Ensure exit code for retryable error works
 backends: [-autopkgtest]
 
 execute: |
-    echo "Install a snap"
-    snap install test-snapd-tools &
+    echo "Install a snap which takes some time to be installed"
+    snap pack "$TESTSLIB/snaps/test-snapd-sleep-install"
+    snap install --dangerous test-snapd-sleep-install_*.snap &
 
     echo "And try to install it again which results in a change confict error"
     while true; do
-        if snap changes |grep "Doing.*Install"; then
-            if snap install test-snapd-tools; then
+        snap changes
+        if snap changes | grep "Doing.*Install"; then
+            if snap install --dangerous test-snapd-sleep-install_*.snap; then
                 echo "snap install should return a change-conflict: test broken"
                 exit 1
             else
@@ -20,9 +22,10 @@ execute: |
                     exit 1
                 fi
             fi
-        break
-    fi
-    sleep 0.1
+            break
+        fi
+        sleep 0.1
     done
-    # "Ensure background processes are finished"
+
+    # Ensure background processes are finished
     wait


### PR DESCRIPTION
This change makes sure the change is still "doing" when the error code is retrieved. 

See error: https://paste.ubuntu.com/p/q9Sr23mDq8

