### PR TITLE
tests: not checking 'tracking channel' after refresh core on nested execution

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -200,7 +200,11 @@ del_device(){
     echo "device deleted"
 }
 
-get_nested_core_revision(){
-    ID=$1
-    execute_remote "snap info core" | awk "/${ID}: / {print(\$3)}" | sed -e 's/(\(.*\))/\1/'
+get_nested_core_revision_for_channel(){
+    local CHANNEL=$1
+    execute_remote "snap info core" | awk "/${CHANNEL}: / {print(\$4)}" | sed -e 's/(\(.*\))/\1/'
+}
+
+get_nested_core_revision_installed(){
+    execute_remote "snap info core" | awk "/installed: / {print(\$3)}" | sed -e 's/(\(.*\))/\1/'
 }

--- a/tests/nested/core/core-snap-refresh-on-core/task.yaml
+++ b/tests/nested/core/core-snap-refresh-on-core/task.yaml
@@ -43,7 +43,6 @@ execute: |
 
     # Check the initial core is installed and snaps can be executed
     test "$(get_nested_core_revision installed)" = "${INITIAL_REV}"
-    execute_remote "snap info core" | MATCH "tracking: *${CORE_CHANNEL}"
 
     # Ensure test-snapd-tools works
     execute_remote "test-snapd-tools.echo hello" | MATCH hello
@@ -55,7 +54,6 @@ execute: |
 
     # After refresh, check new core is installed  
     test "$(get_nested_core_revision installed)" = "${NEW_REV}"
-    execute_remote "snap info core" | MATCH "tracking: *${NEW_CORE_CHANNEL}"
 
     # Ensure test-snapd-tools works
     execute_remote "test-snapd-tools.echo hello" | MATCH hello
@@ -67,7 +65,6 @@ execute: |
 
     # After revert, check initial core is installed  
     test "$(get_nested_core_revision installed)" = "${INITIAL_REV}"
-    execute_remote "snap info core" | MATCH "tracking: *${CORE_CHANNEL}"
 
     # Ensure test-snapd-tools works
     execute_remote "test-snapd-tools.echo hello" | MATCH hello

--- a/tests/nested/core/core-snap-refresh-on-core/task.yaml
+++ b/tests/nested/core/core-snap-refresh-on-core/task.yaml
@@ -27,8 +27,8 @@ execute: |
         exit 1
     fi
 
-    INITIAL_REV="$(get_nested_core_revision "${CORE_CHANNEL}")"
-    NEW_REV="$(get_nested_core_revision "${NEW_CORE_CHANNEL}")"
+    INITIAL_REV="$(get_nested_core_revision_for_channel "${CORE_CHANNEL}")"
+    NEW_REV="$(get_nested_core_revision_for_channel "${NEW_CORE_CHANNEL}")"
 
     # Install test snap
     execute_remote "snap install test-snapd-tools"
@@ -42,7 +42,7 @@ execute: |
     execute_remote "snap install core_*.snap"
 
     # Check the initial core is installed and snaps can be executed
-    test "$(get_nested_core_revision installed)" = "${INITIAL_REV}"
+    test "$(get_nested_core_revision_installed)" = "${INITIAL_REV}"
 
     # Ensure test-snapd-tools works
     execute_remote "test-snapd-tools.echo hello" | MATCH hello
@@ -53,7 +53,7 @@ execute: |
     wait_for_ssh
 
     # After refresh, check new core is installed  
-    test "$(get_nested_core_revision installed)" = "${NEW_REV}"
+    test "$(get_nested_core_revision_installed)" = "${NEW_REV}"
 
     # Ensure test-snapd-tools works
     execute_remote "test-snapd-tools.echo hello" | MATCH hello
@@ -64,7 +64,7 @@ execute: |
     wait_for_ssh
 
     # After revert, check initial core is installed  
-    test "$(get_nested_core_revision installed)" = "${INITIAL_REV}"
+    test "$(get_nested_core_revision_installed)" = "${INITIAL_REV}"
 
     # Ensure test-snapd-tools works
     execute_remote "test-snapd-tools.echo hello" | MATCH hello


### PR DESCRIPTION
The test was failing but after a discussion the core is working as designed.