### PR TITLE
packaging: avoid race in snapd.postinst

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -581,7 +581,8 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 					die("cannot locate the core or legacy core snap (current symlink missing?)");
 				}
 			}
-			die("cannot locate the base snap: %s", base_snap_name);
+			if (access(rootfs_dir, F_OK) != 0)
+			        die("cannot locate the base snap: %s", base_snap_name);
 		}
 		struct sc_mount_config normal_config = {
 			.rootfs_dir = rootfs_dir,

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -581,6 +581,8 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 					die("cannot locate the core or legacy core snap (current symlink missing?)");
 				}
 			}
+			// If after the special case handling above we are
+			// still not ok, die
 			if (access(rootfs_dir, F_OK) != 0)
 			        die("cannot locate the base snap: %s", base_snap_name);
 		}

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -113,9 +113,13 @@ override_dh_fixperms:
 #
 # Because both the usual and the .real profile describe the same binary the
 # .real profile takes priority (as it is loaded later).
-override_dh_installdeb:
+#
+# We need run dh_apparmor *before* dh_systemd_enable to ensure the postinst
+# snippets are added in the right order (first the new apparmor profile
+# is loaded, then we restart the service).
+override_dh_systemd_enable:
 	dh_apparmor --profile-name=usr.lib.snapd.snap-confine.real -psnapd
-	dh_installdeb
+	dh_systemd_enable
 
 override_dh_clean:
 ifneq (,$(TEST_GITHUB_AUTOPKGTEST))

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -1,0 +1,27 @@
+summary: Ensure upgrades from snapd 2.15 work
+
+systems: [ubuntu-16.04-64]
+
+prepare: |
+    dpkg --purge snapd
+
+execute: |
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB"/systemd.sh
+
+    echo "download snapd 2.15.2ubuntu1 and the matching ubuntu-core-launcher"
+    wget https://launchpad.net/ubuntu/+source/snap-confine/1.0.38-0ubuntu0.16.04.8/+build/10606388/+files/ubuntu-core-launcher_1.0.38-0ubuntu0.16.04.8_amd64.deb
+    wget https://launchpad.net/ubuntu/+source/snap-confine/1.0.38-0ubuntu0.16.04.8/+build/10606388/+files/snap-confine_1.0.38-0ubuntu0.16.04.8_amd64.deb
+    wget https://launchpad.net/ubuntu/+source/snapd/2.15.2ubuntu1/+build/10939171/+files/snapd_2.15.2ubuntu1_amd64.deb
+    echo "Install snapd 2.15.2"
+    apt install -y ./ubuntu-core-launcher_1.0.38-0ubuntu0.16.04.8_amd64.deb ./snap-confine_1.0.38-0ubuntu0.16.04.8_amd64.deb ./snapd_2.15.2ubuntu1_amd64.deb
+
+    echo "install a service snap and check its active"
+    snap install go-example-webserver
+    wait_for_service snap.go-example-webserver.webserver.service
+
+    echo "upgrade to current snapd"
+    apt install -y "$GOHOME"/snapd*.deb
+
+    echo "and ensure the snap service is still active"
+    wait_for_service snap.go-example-webserver.webserver.service


### PR DESCRIPTION
We need to run dh_apparmor before dh_systemd_enable so that
the snapd.postinst is written in the right way.

The old code was doing things in the *wrong* order:
- it (re)starts snapd first
- it reloads the snap-confine apparmor profile *after* that
which of course means that on an upgrade there is a time window
in which snapd is available for the system-key check but
snap-confine has an old profile and will die because it tries
to do things that it cannot do with that old profile.

Together with the removal of "snapd.framework.target" this
race caused real world upgrades to stop snaps.

This bug can cause snap services to fail to start on upgrades. If snapd is
upgraded from a really old version of snapd that sill has snapd.framework.target
then the removal of snapd.framework.target will stop/restart all snap services.
However because of this race the service cannot start yet so they fail.

We need to put this in the security pocket.

This also adds a spread test to ensure the upgrade really works. 

When adding the spread test I noticed that the initial fix that just fixes the apparmor
rule loading is not sufficient, there is also a bug in snap-confine that needs a fixing.
This is the change included in snap-confine/mount-support.c - with that the spread
test works and the go-webserver is active again after the upgrade.