### PR TITLE
overlord/snapstate: discard mount namespace when undoing 1st link snap

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1083,6 +1083,11 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	if len(snapst.Sequence) == 1 {
 		// XXX: shouldn't these two just log and carry on? this is an undo handler...
+		err = m.backend.DiscardSnapNamespace(snapsup.InstanceName())
+		if err != nil {
+			t.Errorf("cannot discard snap namespace %q, will retry in 3 mins: %s", snapsup.InstanceName(), err)
+			return &state.Retry{After: 3 * time.Minute}
+		}
 		if err := m.removeSnapCookie(st, snapsup.InstanceName()); err != nil {
 			return fmt.Errorf("cannot remove snap cookie: %v", err)
 		}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2661,6 +2661,10 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 			name: "some-snap",
 		},
 		{
+			op:   "discard-namespace",
+			name: "some-snap",
+		},
+		{
 			op:   "unlink-snap",
 			path: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
 		},

--- a/tests/regression/lp-1815722/task.yaml
+++ b/tests/regression/lp-1815722/task.yaml
@@ -1,0 +1,13 @@
+summary: regression test for https://bugs.launchpad.net/snapd/+bug/1815722
+execute: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+
+    install_local snap-hooks-bad-install || true
+
+    test ! -e /var/lib/snapd/ns/snap-hooks-bad-install.mnt
+    test ! -e /var/lib/snapd/ns/snap.snap-hooks-bad-install.fstab
+restore: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/dirs.sh"
+    "$LIBEXECDIR/snapd/snap-discard-ns" snap-hooks-bad-install


### PR DESCRIPTION
When a snap is installed for the first time but the installation fails,
e.g. because the install hook fails or because a service fails to start,
the mount namespace would remain behind, possibly messing up subsequent
attempts to install the snap.

When the undo handler for "link-snap" detects that it runs for the 1st
revision is already removes snap cookies, this is the perfect place to
add the logic to discard the mount namespace.

Thanks to Samuele for pointing this out!

Fixes: https://bugs.launchpad.net/snapd/+bug/1815722
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
