### PR TITLE
daemon/api: fix error case for disconnect conflict

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1889,7 +1889,8 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 			}
 			for _, connRef := range conns {
 				var ts *state.TaskSet
-				conn, err := repo.Connection(connRef)
+				var conn *interfaces.Connection
+				conn, err = repo.Connection(connRef)
 				if err != nil {
 					break
 				}


### PR DESCRIPTION
The err variable in the "disconnect" handling is shadowed and in case of conflict error we end up with an empty Change in Hold state and no error is returned to the client. This PR fixes this.
Note, the important bit is below what's visible in the diff - the `ts, err = ifacestate.Disconnect(st, conn)` may return conflict error (but err is shadowed).
