### PR TITLE
[RFC] many: support `snap install --skip-service-start`

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -39,38 +39,46 @@ type SnapOptions struct {
 	Dangerous        bool   `json:"dangerous,omitempty"`
 	IgnoreValidation bool   `json:"ignore-validation,omitempty"`
 	Unaliased        bool   `json:"unaliased,omitempty"`
+	SkipServiceStart bool   `json:"skip-service-start,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
 
-func writeFieldBool(mw *multipart.Writer, key string, val bool) error {
+func writeBoolField(mw *multipart.Writer, key string, val bool) error {
 	if !val {
 		return nil
 	}
 	return mw.WriteField(key, "true")
 }
 
+type boolField struct {
+	name string
+	flag bool
+}
+
+func writeBoolFields(mw *multipart.Writer, fields []boolField) error {
+	for _, o := range fields {
+		if err := writeBoolField(mw, o.name, o.flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (opts *SnapOptions) writeModeFields(mw *multipart.Writer) error {
-	fields := []struct {
-		f string
-		b bool
-	}{
+	return writeBoolFields(mw, []boolField{
 		{"devmode", opts.DevMode},
 		{"classic", opts.Classic},
 		{"jailmode", opts.JailMode},
 		{"dangerous", opts.Dangerous},
-	}
-	for _, o := range fields {
-		if err := writeFieldBool(mw, o.f, o.b); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	})
 }
 
 func (opts *SnapOptions) writeOptionFields(mw *multipart.Writer) error {
-	return writeFieldBool(mw, "unaliased", opts.Unaliased)
+	return writeBoolFields(mw, []boolField{
+		{"unaliased", opts.Unaliased},
+		{"skip-service-start", opts.SkipServiceStart},
+	})
 }
 
 type actionData struct {

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -406,9 +406,9 @@ type cmdInstall struct {
 	Dangerous bool `long:"dangerous"`
 	// alias for --dangerous, deprecated but we need to support it
 	// because we released 2.14.2 with --force-dangerous
-	ForceDangerous bool `long:"force-dangerous" hidden:"yes"`
-
-	Unaliased bool `long:"unaliased"`
+	ForceDangerous   bool `long:"force-dangerous" hidden:"yes"`
+	Unaliased        bool `long:"unaliased"`
+	SkipServiceStart bool `long:"skip-service-start"`
 
 	Name string `long:"name"`
 
@@ -527,10 +527,11 @@ func (x *cmdInstall) Execute([]string) error {
 
 	dangerous := x.Dangerous || x.ForceDangerous
 	opts := &client.SnapOptions{
-		Channel:   x.Channel,
-		Revision:  x.Revision,
-		Dangerous: dangerous,
-		Unaliased: x.Unaliased,
+		Channel:          x.Channel,
+		Revision:         x.Revision,
+		Dangerous:        dangerous,
+		Unaliased:        x.Unaliased,
+		SkipServiceStart: x.SkipServiceStart,
 	}
 	x.setModes(opts)
 
@@ -1004,6 +1005,8 @@ func init() {
 			"unaliased": i18n.G("Install the given snap without enabling its automatic aliases"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"name": i18n.G("Install the snap file under the given instance name"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"skip-service-start": i18n.G("Do not attempt to start the services present in the snap"),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -900,6 +900,7 @@ type snapInstruction struct {
 	Classic          bool          `json:"classic"`
 	IgnoreValidation bool          `json:"ignore-validation"`
 	Unaliased        bool          `json:"unaliased"`
+	SkipServiceStart bool          `json:"skip-service-start"`
 	// dropping support temporarely until flag confusion is sorted,
 	// this isn't supported by client atm anyway
 	LeaveOld bool         `json:"temp-dropped-leave-old"`
@@ -922,6 +923,9 @@ func (inst *snapInstruction) installFlags() (snapstate.Flags, error) {
 	}
 	if inst.Unaliased {
 		flags.Unaliased = true
+	}
+	if inst.SkipServiceStart {
+		flags.SkipServiceStart = true
 	}
 	return flags, nil
 }

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -54,6 +54,10 @@ type Flags struct {
 	// installing the snap.
 	Unaliased bool `json:"unaliased,omitempty"`
 
+	// SkipServiceStart is set to request that services are not
+	// started automatically when installing the snap.
+	SkipServiceStart bool `json:"skip-service-start,omitempty"`
+
 	// Amend allows refreshing out of a snap unknown to the store
 	// and into one that is known.
 	Amend bool `json:"amend,omitempty"`

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -239,10 +239,12 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		prev = installHook
 	}
 
-	// run new serices
-	startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q%s services"), snapsup.InstanceName(), revisionStr))
-	addTask(startSnapServices)
-	prev = startSnapServices
+	if !snapsup.Flags.SkipServiceStart {
+		// run new services
+		startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q%s services"), snapsup.InstanceName(), revisionStr))
+		addTask(startSnapServices)
+		prev = startSnapServices
+	}
 
 	// Do not do that if we are reverting to a local revision
 	if snapst.IsInstalled() && !snapsup.Flags.Revert {


### PR DESCRIPTION
Without this change, if a service requires a connection in order to
run, there is no easy way to debug it as its install will be aborted.

This change adds `--skip-service-start`, which stops the services from
being started on install.

    ~$ snap list xkcd-webserver
    error: no matching snaps installed
    ~$ snap install xkcd-webserver
    xkcd-webserver 16.04-6 from Canonical✓ installed
    ~$ snap services xkcd-webserver
    Service                        Startup  Current  Notes
    xkcd-webserver.xkcd-webserver  enabled  active   -
    ~$ snap remove xkcd-webserver
    xkcd-webserver removed
    ~$ snap install --skip-service-start xkcd-webserver
    xkcd-webserver 16.04-6 from Canonical✓ installed
    ~$ snap services xkcd-webserver
    Service                        Startup  Current   Notes
    xkcd-webserver.xkcd-webserver  enabled  inactive  -

WDYT?
