### PR TITLE
wrappers: Add an X-SnapInstanceName field to desktop files

### DIFF
--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -35,7 +35,7 @@ execute: |
     snap install --dangerous ./basic-desktop_1.0_all.snap
     diff -u <(head -n5 /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop) - <<-EOF
     	[Desktop Entry]
-    	X-SnapName=basic-desktop
+    	X-SnapInstanceName=basic-desktop
     	Name=Echo
     	Comment=It echos stuff
     	Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop.echo

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -33,8 +33,9 @@ execute: |
 
     echo "Sideload desktop snap"
     snap install --dangerous ./basic-desktop_1.0_all.snap
-    diff -u <(head -n4 /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop) - <<-EOF
+    diff -u <(head -n5 /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop) - <<-EOF
     	[Desktop Entry]
+    	X-SnapName=basic-desktop
     	Name=Echo
     	Comment=It echos stuff
     	Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop.echo

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -17,8 +17,9 @@ execute: |
         expected="^basic-desktop_$instance 1.0 installed\$"
         install_local_as basic-desktop "basic-desktop_$instance" | MATCH "$expected"
 
-        diff -u <(head -n4 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
+        diff -u <(head -n5 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
     [Desktop Entry]
+    X-SnapName=basic-desktop_${instance}
     Name=Echo
     Comment=It echos stuff
     Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -19,7 +19,7 @@ execute: |
 
         diff -u <(head -n5 "/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop") - <<-EOF
     [Desktop Entry]
-    X-SnapName=basic-desktop_${instance}
+    X-SnapInstanceName=basic-desktop_${instance}
     Name=Echo
     Comment=It echos stuff
     Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -171,6 +171,11 @@ func sanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []
 		newContent.Grow(len(bline) + 1)
 		newContent.Write(bline)
 		newContent.WriteByte('\n')
+
+		// insert snap name
+		if bytes.Equal(bline, []byte("[Desktop Entry]")) {
+			newContent.Write([]byte("X-SnapName=" + s.InstanceName() + "\n"))
+		}
 	}
 
 	return newContent.Bytes()

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -174,7 +174,7 @@ func sanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []
 
 		// insert snap name
 		if bytes.Equal(bline, []byte("[Desktop Entry]")) {
-			newContent.Write([]byte("X-SnapName=" + s.InstanceName() + "\n"))
+			newContent.Write([]byte("X-SnapInstanceName=" + s.InstanceName() + "\n"))
 		}
 	}
 

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -214,6 +214,7 @@ Icon=${SNAP}/meep
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+X-SnapName=foo
 Name=foo
 Icon=%s/foo/12/meep
 
@@ -237,6 +238,7 @@ Exec=baz
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapName=snap
 Name=foo
 `)
 }
@@ -251,12 +253,14 @@ apps:
 `))
 	c.Assert(err, IsNil)
 	desktopContent := []byte(`[Desktop Entry]
+X-SnapName=snap
 Name=foo
 Exec=snap.app.evil.evil
 `)
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapName=snap
 Name=foo
 `)
 }
@@ -271,12 +275,14 @@ apps:
 `))
 	c.Assert(err, IsNil)
 	desktopContent := []byte(`[Desktop Entry]
+X-SnapName=snap
 Name=foo
 Exec=snap.app.evil.evil
 `)
 
 	e := wrappers.SanitizeDesktopFile(snap, "app.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+X-SnapName=snap
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop %s/bin/snap.app
 `, dirs.SnapMountDir))
@@ -298,6 +304,7 @@ Exec=snap.app %U
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+X-SnapName=snap
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U
 `, dirs.SnapMountDir))
@@ -321,12 +328,13 @@ TryExec=snap.app %U
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapName=snap
 Name=foo
 `)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeWorthWithI18n(c *C) {
-	snap := &snap.Info{}
+	snap := &snap.Info{SideInfo: snap.SideInfo{RealName: "snap"}}
 	desktopContent := []byte(`[Desktop Entry]
 Name=foo
 GenericName=bar
@@ -339,6 +347,7 @@ Invalid[i18n]=key
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapName=snap
 Name=foo
 GenericName=bar
 GenericName[de]=einsehrlangeszusammengesetzteswort
@@ -356,9 +365,10 @@ func (s *sanitizeDesktopFileSuite) TestSanitizeDesktopActionsOk(c *C) {
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeDesktopFileAyatana(c *C) {
-	snap := &snap.Info{}
+	snap := &snap.Info{SideInfo: snap.SideInfo{RealName: "snap"}}
 
 	desktopContent := []byte(`[Desktop Entry]
+X-SnapName=snap
 Version=1.0
 Name=Firefox Web Browser
 X-Ayatana-Desktop-Shortcuts=NewWindow;Private
@@ -393,6 +403,7 @@ Exec=snap.app
 	df := filepath.Base(snap.Apps["app"].DesktopFile())
 	e := wrappers.SanitizeDesktopFile(snap, df, desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+X-SnapName=snap_bar
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app
 `, dirs.SnapMountDir))
@@ -416,6 +427,7 @@ Exec=snap.app %U
 	df := filepath.Base(snap.Apps["app"].DesktopFile())
 	e := wrappers.SanitizeDesktopFile(snap, df, desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+X-SnapName=snap_bar
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app %%U
 `, dirs.SnapMountDir))

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -214,7 +214,7 @@ Icon=${SNAP}/meep
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
-X-SnapName=foo
+X-SnapInstanceName=foo
 Name=foo
 Icon=%s/foo/12/meep
 
@@ -238,7 +238,7 @@ Exec=baz
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 `)
 }
@@ -253,14 +253,14 @@ apps:
 `))
 	c.Assert(err, IsNil)
 	desktopContent := []byte(`[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 Exec=snap.app.evil.evil
 `)
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 `)
 }
@@ -275,14 +275,14 @@ apps:
 `))
 	c.Assert(err, IsNil)
 	desktopContent := []byte(`[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 Exec=snap.app.evil.evil
 `)
 
 	e := wrappers.SanitizeDesktopFile(snap, "app.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop %s/bin/snap.app
 `, dirs.SnapMountDir))
@@ -304,7 +304,7 @@ Exec=snap.app %U
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U
 `, dirs.SnapMountDir))
@@ -328,7 +328,7 @@ TryExec=snap.app %U
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 `)
 }
@@ -347,7 +347,7 @@ Invalid[i18n]=key
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Name=foo
 GenericName=bar
 GenericName[de]=einsehrlangeszusammengesetzteswort
@@ -368,7 +368,7 @@ func (s *sanitizeDesktopFileSuite) TestSanitizeDesktopFileAyatana(c *C) {
 	snap := &snap.Info{SideInfo: snap.SideInfo{RealName: "snap"}}
 
 	desktopContent := []byte(`[Desktop Entry]
-X-SnapName=snap
+X-SnapInstanceName=snap
 Version=1.0
 Name=Firefox Web Browser
 X-Ayatana-Desktop-Shortcuts=NewWindow;Private
@@ -403,7 +403,7 @@ Exec=snap.app
 	df := filepath.Base(snap.Apps["app"].DesktopFile())
 	e := wrappers.SanitizeDesktopFile(snap, df, desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
-X-SnapName=snap_bar
+X-SnapInstanceName=snap_bar
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app
 `, dirs.SnapMountDir))
@@ -427,7 +427,7 @@ Exec=snap.app %U
 	df := filepath.Base(snap.Apps["app"].DesktopFile())
 	e := wrappers.SanitizeDesktopFile(snap, df, desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
-X-SnapName=snap_bar
+X-SnapInstanceName=snap_bar
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=snap_bar_app.desktop %s/bin/snap_bar.app %%U
 `, dirs.SnapMountDir))


### PR DESCRIPTION
Allow the snap that provides a .desktop file to be determined by putting the
snap name into the .desktop file (using the X-SnapInstanceName key).

This is useful for tools that scan the available .desktop files and want to get
additional snap information for that application. The particular motivation
for this change is gnome-control-center now exposes per-application
configuration and needs to determine if the .desktop file is from a Snap,
Flatpak (uses X-Flatpak key) or traditional packaging system.
