### PR TITLE
daemon: make ucrednetGet not loop

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -146,7 +146,7 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 		c.Check(rec.Code, check.Equals, 401, check.Commentf(method))
 
 		rec = httptest.NewRecorder()
-		req.RemoteAddr = "pid=100;uid=0;" + req.RemoteAddr
+		req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 		cmd.ServeHTTP(rec, req)
 		c.Check(mck.lastMethod, check.Equals, method)
@@ -155,7 +155,7 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 
 	req, err := http.NewRequest("POTATO", "", nil)
 	c.Assert(err, check.IsNil)
-	req.RemoteAddr = "pid=100;uid=0;" + req.RemoteAddr
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 	rec := httptest.NewRecorder()
 	cmd.ServeHTTP(rec, req)
@@ -171,7 +171,7 @@ func (s *daemonSuite) TestCommandRestartingState(c *check.C) {
 	}
 	req, err := http.NewRequest("GET", "", nil)
 	c.Assert(err, check.IsNil)
-	req.RemoteAddr = "pid=100;uid=0;" + req.RemoteAddr
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 	rec := httptest.NewRecorder()
 	cmd.ServeHTTP(rec, req)
@@ -215,7 +215,7 @@ func (s *daemonSuite) TestFillsWarnings(c *check.C) {
 	}
 	req, err := http.NewRequest("GET", "", nil)
 	c.Assert(err, check.IsNil)
-	req.RemoteAddr = "pid=100;uid=0;" + req.RemoteAddr
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 
 	rec := httptest.NewRecorder()
 	cmd.ServeHTTP(rec, req)
@@ -269,7 +269,7 @@ func (s *daemonSuite) TestGuestAccess(c *check.C) {
 }
 
 func (s *daemonSuite) TestSnapctlAccessSnapOKWithUser(c *check.C) {
-	remoteAddr := "pid=100;uid=1000;socket=" + dirs.SnapSocket
+	remoteAddr := "pid=100;uid=1000;socket=" + dirs.SnapSocket + ";"
 	get := &http.Request{Method: "GET", RemoteAddr: remoteAddr}
 	put := &http.Request{Method: "PUT", RemoteAddr: remoteAddr}
 	pst := &http.Request{Method: "POST", RemoteAddr: remoteAddr}
@@ -283,7 +283,7 @@ func (s *daemonSuite) TestSnapctlAccessSnapOKWithUser(c *check.C) {
 }
 
 func (s *daemonSuite) TestSnapctlAccessSnapOKWithRoot(c *check.C) {
-	remoteAddr := "pid=100;uid=0;socket=" + dirs.SnapSocket
+	remoteAddr := "pid=100;uid=0;socket=" + dirs.SnapSocket + ";"
 	get := &http.Request{Method: "GET", RemoteAddr: remoteAddr}
 	put := &http.Request{Method: "PUT", RemoteAddr: remoteAddr}
 	pst := &http.Request{Method: "POST", RemoteAddr: remoteAddr}
@@ -297,8 +297,8 @@ func (s *daemonSuite) TestSnapctlAccessSnapOKWithRoot(c *check.C) {
 }
 
 func (s *daemonSuite) TestUserAccess(c *check.C) {
-	get := &http.Request{Method: "GET", RemoteAddr: "pid=100;uid=42;"}
-	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=42;"}
+	get := &http.Request{Method: "GET", RemoteAddr: "pid=100;uid=42;socket=;"}
+	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=42;socket=;"}
 
 	cmd := &Command{d: newTestDaemon(c)}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
@@ -321,8 +321,8 @@ func (s *daemonSuite) TestUserAccess(c *check.C) {
 }
 
 func (s *daemonSuite) TestSuperAccess(c *check.C) {
-	get := &http.Request{Method: "GET", RemoteAddr: "pid=100;uid=0;"}
-	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=0;"}
+	get := &http.Request{Method: "GET", RemoteAddr: "pid=100;uid=0;socket=;"}
+	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=0;socket=;"}
 
 	cmd := &Command{d: newTestDaemon(c)}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
@@ -342,7 +342,7 @@ func (s *daemonSuite) TestSuperAccess(c *check.C) {
 }
 
 func (s *daemonSuite) TestPolkitAccess(c *check.C) {
-	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=42;"}
+	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=42;socket=;"}
 	cmd := &Command{d: newTestDaemon(c), PolkitOK: "polkit.action"}
 
 	// polkit says user is not authorised
@@ -363,7 +363,7 @@ func (s *daemonSuite) TestPolkitAccess(c *check.C) {
 }
 
 func (s *daemonSuite) TestPolkitAccessForGet(c *check.C) {
-	get := &http.Request{Method: "GET", RemoteAddr: "pid=100;uid=42;"}
+	get := &http.Request{Method: "GET", RemoteAddr: "pid=100;uid=42;socket=;"}
 	cmd := &Command{d: newTestDaemon(c), PolkitOK: "polkit.action"}
 
 	// polkit can grant authorisation for GET requests
@@ -379,7 +379,7 @@ func (s *daemonSuite) TestPolkitAccessForGet(c *check.C) {
 }
 
 func (s *daemonSuite) TestPolkitInteractivity(c *check.C) {
-	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=42;", Header: make(http.Header)}
+	put := &http.Request{Method: "PUT", RemoteAddr: "pid=100;uid=42;socket=;", Header: make(http.Header)}
 	cmd := &Command{d: newTestDaemon(c), PolkitOK: "polkit.action"}
 	s.authorized = true
 
@@ -950,7 +950,7 @@ func (s *daemonSuite) TestShutdownServerCanShutdown(c *check.C) {
 func doTestReq(c *check.C, cmd *Command, mth string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest(mth, "", nil)
 	c.Assert(err, check.IsNil)
-	req.RemoteAddr = "pid=100;uid=0;" + req.RemoteAddr
+	req.RemoteAddr = "pid=100;uid=0;socket=;"
 	rec := httptest.NewRecorder()
 	cmd.ServeHTTP(rec, req)
 	return rec

--- a/daemon/ucrednet_test.go
+++ b/daemon/ucrednet_test.go
@@ -144,14 +144,14 @@ func (s *ucrednetSuite) TestUcredErrors(c *check.C) {
 }
 
 func (s *ucrednetSuite) TestGetNoUid(c *check.C) {
-	pid, uid, _, err := ucrednetGet("pid=100;uid=;")
+	pid, uid, _, err := ucrednetGet("pid=100;uid=;socket=;")
 	c.Check(err, check.Equals, errNoID)
-	c.Check(pid, check.Equals, int32(100))
+	c.Check(pid, check.Equals, ucrednetNoProcess)
 	c.Check(uid, check.Equals, ucrednetNobody)
 }
 
 func (s *ucrednetSuite) TestGetBadUid(c *check.C) {
-	pid, uid, _, err := ucrednetGet("pid=100;uid=hello;")
+	pid, uid, _, err := ucrednetGet("pid=100;uid=4294967296;socket=;")
 	c.Check(err, check.NotNil)
 	c.Check(pid, check.Equals, int32(100))
 	c.Check(uid, check.Equals, ucrednetNobody)
@@ -172,9 +172,17 @@ func (s *ucrednetSuite) TestGetNothing(c *check.C) {
 }
 
 func (s *ucrednetSuite) TestGet(c *check.C) {
-	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket")
+	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;")
 	c.Check(err, check.IsNil)
 	c.Check(pid, check.Equals, int32(100))
 	c.Check(uid, check.Equals, uint32(42))
 	c.Check(socket, check.Equals, "/run/snap.socket")
+}
+
+func (s *ucrednetSuite) TestGetSneak(c *check.C) {
+	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;pid=0;uid=0;socket=/tmp/my.socket")
+	c.Check(err, check.Equals, errNoID)
+	c.Check(pid, check.Equals, ucrednetNoProcess)
+	c.Check(uid, check.Equals, ucrednetNobody)
+	c.Check(socket, check.Equals, "")
 }


### PR DESCRIPTION
This is the second half of the belts-and-suspenders fix for
[lp:1813365], which was distro-patched.

The previous change to this already made us not be vulnerable; this
change makes it nicer, and makes it easier to not mess up this way
again (ever).

[lp:1813365]: https://bugs.launchpad.net/snapd/+bug/1813365
