### PR TITLE
snap, wrappers: support StartTimeout

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -719,6 +719,7 @@ type AppInfo struct {
 
 	Daemon          string
 	StopTimeout     timeout.Timeout
+	StartTimeout    timeout.Timeout
 	WatchdogTimeout timeout.Timeout
 	StopCommand     string
 	ReloadCommand   string

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -78,6 +78,7 @@ type appYaml struct {
 	ReloadCommand   string          `yaml:"reload-command,omitempty"`
 	PostStopCommand string          `yaml:"post-stop-command,omitempty"`
 	StopTimeout     timeout.Timeout `yaml:"stop-timeout,omitempty"`
+	StartTimeout    timeout.Timeout `yaml:"start-timeout,omitempty"`
 	WatchdogTimeout timeout.Timeout `yaml:"watchdog-timeout,omitempty"`
 	Completer       string          `yaml:"completer,omitempty"`
 	RefreshMode     string          `yaml:"refresh-mode,omitempty"`
@@ -320,6 +321,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			LegacyAliases:   yApp.Aliases,
 			Command:         yApp.Command,
 			CommandChain:    yApp.CommandChain,
+			StartTimeout:    yApp.StartTimeout,
 			Daemon:          yApp.Daemon,
 			StopTimeout:     yApp.StopTimeout,
 			StopCommand:     yApp.StopCommand,

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1447,6 +1447,7 @@ apps:
    command: svc1
    description: svc one
    stop-timeout: 25s
+   start-timeout: 42m
    daemon: forking
    stop-command: stop-cmd
    post-stop-command: post-stop-cmd
@@ -1467,6 +1468,7 @@ apps:
 		Daemon:          "forking",
 		RestartCond:     snap.RestartOnAbnormal,
 		StopTimeout:     timeout.Timeout(25 * time.Second),
+		StartTimeout:    timeout.Timeout(42 * time.Minute),
 		StopCommand:     "stop-cmd",
 		PostStopCommand: "post-stop-cmd",
 		BusName:         "busName",

--- a/tests/lib/snaps/test-snapd-service-start-timeout/forking.sh
+++ b/tests/lib/snaps/test-snapd-service-start-timeout/forking.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+sleep 30 # @@@
+
+sleep 60 &
+

--- a/tests/lib/snaps/test-snapd-service-start-timeout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service-start-timeout/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-service-start-timeout
+version: 0.1
+apps:
+  svc:
+    daemon: forking
+    command: forking.sh
+    start-timeout: 10s

--- a/tests/lib/snaps/test-snapd-service-stop-timeout/forking.sh
+++ b/tests/lib/snaps/test-snapd-service-stop-timeout/forking.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+rm -f "$SNAP_DATA/stamp"
+
+while true; do
+    if [ -e "$SNAP_DATA/stamp" ]; then
+        echo "$SNAP_DATA/stamp found, exiting"
+        break
+    fi
+    sleep 1
+done &

--- a/tests/lib/snaps/test-snapd-service-stop-timeout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service-stop-timeout/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-service-stop-timeout
+version: 0.1
+apps:
+  svc:
+    daemon: forking
+    command: forking.sh
+    stop-timeout: 10s
+    stop-command: staaap.sh

--- a/tests/lib/snaps/test-snapd-service-stop-timeout/staaap.sh
+++ b/tests/lib/snaps/test-snapd-service-stop-timeout/staaap.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+# @@@
+
+touch "$SNAP_DATA/stamp"

--- a/tests/main/snap-service-start-timeout/task.yaml
+++ b/tests/main/snap-service-start-timeout/task.yaml
@@ -3,7 +3,7 @@ summary: Check that snaps can use start-timeout
 # this test is expected to fail once we run the tests for SELinux
 # distros in Enforce mode
 
-restore:
+restore: |
     f="$TESTSLIB/snaps/test-snapd-service-start-timeout/forking.sh"
     if [ -e "$f.bak" ]; then
         mv -v "$f.bak" "$f"

--- a/tests/main/snap-service-start-timeout/task.yaml
+++ b/tests/main/snap-service-start-timeout/task.yaml
@@ -1,0 +1,12 @@
+summary: Check that snaps can use start-timeout
+
+execute: |
+    dir="$TESTSLIB/snaps/test-snapd-service-start-timeout"
+
+    # with the 30s sleep, start-timeout stops the snap from working
+    ! snap try "$dir"
+
+    # drop the 'sleep 30'
+    sed -i -e '/@@@/d' "$dir/forking.sh"
+
+    snap try "$dir"

--- a/tests/main/snap-service-start-timeout/task.yaml
+++ b/tests/main/snap-service-start-timeout/task.yaml
@@ -1,5 +1,14 @@
 summary: Check that snaps can use start-timeout
 
+# this test is expected to fail once we run the tests for SELinux
+# distros in Enforce mode
+
+restore:
+    f="$TESTSLIB/snaps/test-snapd-service-start-timeout/forking.sh"
+    if [ -e "$f.bak" ]; then
+        mv -v "$f.bak" "$f"
+    fi
+
 execute: |
     dir="$TESTSLIB/snaps/test-snapd-service-start-timeout"
 

--- a/tests/main/snap-service-stop-timeout/task.yaml
+++ b/tests/main/snap-service-stop-timeout/task.yaml
@@ -1,0 +1,22 @@
+summary: Check that snaps can use stop-timeout
+
+execute: |
+    dir="$TESTSLIB/snaps/test-snapd-service-stop-timeout"
+    stamp="/var/snap/test-snapd-service-stop-timeout/current/stamp"
+    snap try "$dir"
+
+    # without the sleep, stop-timeout doesn't interfere with stop-command
+    test ! -e "$stamp"
+    snap stop test-snapd-service-stop-timeout
+    test -e "$stamp"
+
+    # add a 'sleep 30'
+    sed -i -e 's/^# @@@/sleep 30/' "$dir/staaap.sh"
+
+    snap start test-snapd-service-stop-timeout
+
+    # now it sleeps longer than stop-timeout, the service is killed
+    # before it gets to shut down cleanly
+    test ! -e "$stamp"
+    snap stop test-snapd-service-stop-timeout
+    test ! -e "$stamp"

--- a/tests/main/snap-service-stop-timeout/task.yaml
+++ b/tests/main/snap-service-stop-timeout/task.yaml
@@ -5,7 +5,7 @@ summary: Check that snaps can use stop-timeout
 # systemd on 14.04 does not really honour TimeoutStopSec
 systems: [-ubuntu-14*]
 
-restore:
+restore: |
     f="$TESTSLIB/snaps/test-snapd-service-stop-timeout/staaap.sh"
     if [ -e "$f.bak" ]; then
         mv -v "$f.bak" "$f"

--- a/tests/main/snap-service-stop-timeout/task.yaml
+++ b/tests/main/snap-service-stop-timeout/task.yaml
@@ -1,5 +1,16 @@
 summary: Check that snaps can use stop-timeout
 
+# this test is expected to fail once we run the tests for SELinux
+# distros in Enforce mode
+# systemd on 14.04 does not really honour TimeoutStopSec
+systems: [-ubuntu-14*]
+
+restore:
+    f="$TESTSLIB/snaps/test-snapd-service-stop-timeout/staaap.sh"
+    if [ -e "$f.bak" ]; then
+        mv -v "$f.bak" "$f"
+    fi
+
 execute: |
     dir="$TESTSLIB/snaps/test-snapd-service-stop-timeout"
     stamp="/var/snap/test-snapd-service-stop-timeout/current/stamp"
@@ -11,7 +22,7 @@ execute: |
     test -e "$stamp"
 
     # add a 'sleep 30'
-    sed -i -e 's/^# @@@/sleep 30/' "$dir/staaap.sh"
+    sed -i.bak -e 's/^# @@@/sleep 30/' "$dir/staaap.sh"
 
     snap start test-snapd-service-stop-timeout
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -423,6 +423,9 @@ ExecStopPost={{.App.LauncherPostStopCommand}}
 {{- if .StopTimeout}}
 TimeoutStopSec={{.StopTimeout.Seconds}}
 {{- end}}
+{{- if .StartTimeout}}
+TimeoutStartSec={{.StartTimeout.Seconds}}
+{{- end}}
 Type={{.App.Daemon}}
 {{- if .Remain}}
 RemainAfterExit={{.Remain}}
@@ -477,6 +480,7 @@ WantedBy={{.ServicesTarget}}
 
 		Restart            string
 		StopTimeout        time.Duration
+		StartTimeout       time.Duration
 		ServicesTarget     string
 		PrerequisiteTarget string
 		MountUnit          string
@@ -493,6 +497,7 @@ WantedBy={{.ServicesTarget}}
 
 		Restart:            restartCond,
 		StopTimeout:        serviceStopTimeout(appInfo),
+		StartTimeout:       time.Duration(appInfo.StartTimeout),
 		ServicesTarget:     systemd.ServicesTarget,
 		PrerequisiteTarget: systemd.PrerequisiteTarget,
 		MountUnit:          filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir())),

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -132,6 +132,26 @@ apps:
 	c.Check(string(generatedWrapper), Equals, expectedAppService)
 }
 
+func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithStartTimeout(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        start-timeout: 10m
+        daemon: simple
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), testutil.Contains, "\nTimeoutStartSec=600\n")
+}
+
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileRestart(c *C) {
 	yamlTextTemplate := `
 name: snap


### PR DESCRIPTION
Before this change you could specify the StopTimeout of a snap's
daemons, but not their StartTimeout. This adds that support.
