### PR TITLE
interfaces/wayland: allow wayland server snaps function on classic too

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -73,6 +73,9 @@ network netlink raw,
 /run/udev/data/c13:[0-9]* r,
 /run/udev/data/+input:input[0-9]* r,
 /run/udev/data/+platform:* r,
+
+# MESA reads this dri config file
+/etc/drirc r,
 `
 
 const waylandPermanentSlotSecComp = `
@@ -97,7 +100,7 @@ const waylandConnectedPlugAppArmor = `
 # Allow access to the Wayland compositor server socket
 owner /run/user/[0-9]*/wayland-[0-9]* rw,
 
-# Needed when using QT_QPA_PLATFORM=wayland-egl
+# Needed when using QT_QPA_PLATFORM=wayland-egl (MESA dri config)
 /etc/drirc r,
 `
 

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -24,7 +24,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 
 	"strings"
@@ -122,38 +121,30 @@ func (iface *waylandInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 }
 
 func (iface *waylandInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	if !release.OnClassic {
-		old := "###PLUG_SECURITY_TAGS###"
-		new := "snap." + plug.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
-		snippet := strings.Replace(waylandConnectedSlotAppArmor, old, new, -1)
-		spec.AddSnippet(snippet)
-	}
+	old := "###PLUG_SECURITY_TAGS###"
+	new := "snap." + plug.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
+	snippet := strings.Replace(waylandConnectedSlotAppArmor, old, new, -1)
+	spec.AddSnippet(snippet)
 	return nil
 }
 
 func (iface *waylandInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
-		spec.AddSnippet(waylandPermanentSlotSecComp)
-	}
+	spec.AddSnippet(waylandPermanentSlotSecComp)
 	return nil
 }
 
 func (iface *waylandInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
-		spec.AddSnippet(waylandPermanentSlotAppArmor)
-	}
+	spec.AddSnippet(waylandPermanentSlotAppArmor)
 	return nil
 }
 
 func (iface *waylandInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
-		spec.TriggerSubsystem("input")
-		spec.TagDevice(`KERNEL=="tty[0-9]*"`)
-		spec.TagDevice(`KERNEL=="mice"`)
-		spec.TagDevice(`KERNEL=="mouse[0-9]*"`)
-		spec.TagDevice(`KERNEL=="event[0-9]*"`)
-		spec.TagDevice(`KERNEL=="ts[0-9]*"`)
-	}
+	spec.TriggerSubsystem("input")
+	spec.TagDevice(`KERNEL=="tty[0-9]*"`)
+	spec.TagDevice(`KERNEL=="mice"`)
+	spec.TagDevice(`KERNEL=="mouse[0-9]*"`)
+	spec.TagDevice(`KERNEL=="event[0-9]*"`)
+	spec.TagDevice(`KERNEL=="ts[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -164,10 +164,6 @@ func (s *WaylandInterfaceSuite) TestSecCompOnCore(c *C) {
 }
 
 func (s *WaylandInterfaceSuite) TestUDev(c *C) {
-	// on a core system with wayland slot coming from a regular app snap.
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	spec := &udev.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 6)
@@ -183,15 +179,6 @@ KERNEL=="ts[0-9]*", TAG+="snap_wayland_app1"`)
 KERNEL=="tty[0-9]*", TAG+="snap_wayland_app1"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_wayland_app1", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_wayland_app1 $devpath $major:$minor"`)
 	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input"})
-
-	// on a classic system with wayland slot coming from the core snap.
-	restore = release.MockOnClassic(true)
-	defer restore()
-
-	spec = &udev.Specification{}
-	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 0)
-	c.Assert(spec.TriggeredSubsystems(), IsNil)
 }
 
 func (s *WaylandInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
Installing mir-kiosk on a classic system needs the same apparmor rules as if installed on core. This PR removes the branching on classic.

Fixes https://bugs.launchpad.net/snapd/+bug/1804869/