### PR TITLE
cmd/snap: produce better output for help on subcommands

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -71,7 +71,7 @@ type cmdHelp struct {
 	Manpage    bool `long:"man" hidden:"true"`
 	Positional struct {
 		// TODO: find a way to make Command tab-complete
-		Sub string `positional-arg-name:"<command>"`
+		Subs []string `positional-arg-name:"<command>"`
 	} `positional-args:"yes"`
 	parser *flags.Parser
 }
@@ -132,23 +132,30 @@ func (cmd cmdHelp) Execute(args []string) error {
 		return nil
 	}
 	if cmd.All {
-		if cmd.Positional.Sub != "" {
+		if len(cmd.Positional.Subs) > 0 {
 			return fmt.Errorf(i18n.G("help accepts a command, or '--all', but not both."))
 		}
 		printLongHelp(cmd.parser)
 		return nil
 	}
 
-	if cmd.Positional.Sub != "" {
-		subcmd := cmd.parser.Find(cmd.Positional.Sub)
+	var subcmd = cmd.parser.Command
+	for _, subname := range cmd.Positional.Subs {
+		subcmd = subcmd.Find(subname)
 		if subcmd == nil {
-			return fmt.Errorf(i18n.G("Unknown command %q. Try 'snap help'."), cmd.Positional.Sub)
+			sug := "snap help"
+			if x := cmd.parser.Command.Active; x != nil && x.Name != "help" {
+				sug = "snap help " + x.Name
+			}
+			// TRANSLATORS: %q is the command the user entered; %s is 'snap help' or 'snap help <cmd>'
+			return fmt.Errorf(i18n.G("unknown command %q, see '%s'."), subname, sug)
 		}
 		// this makes "snap help foo" work the same as "snap foo --help"
 		cmd.parser.Command.Active = subcmd
+	}
+	if subcmd != cmd.parser.Command {
 		return &flags.Error{Type: flags.ErrHelp}
 	}
-
 	return &flags.Error{Type: flags.ErrCommandRequired}
 }
 

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -186,3 +186,21 @@ func (s *SnapSuite) TestManpageNoDoubleTP(c *check.C) {
 	c.Check(s.Stdout(), check.Not(check.Matches), `(?s).*(?m-s)^\.TP\n\.TP$(?s-m).*`)
 
 }
+
+func (s *SnapSuite) TestBadSub(c *check.C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "debug", "brotato"}
+
+	err := snap.RunMain()
+	c.Assert(err, check.ErrorMatches, `unknown command "brotato", see 'snap help debug'.`)
+}
+
+func (s *SnapSuite) TestWorseSub(c *check.C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "-h", "debug", "brotato"}
+
+	err := snap.RunMain()
+	c.Assert(err, check.ErrorMatches, `unknown command "brotato", see 'snap help debug'.`)
+}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -478,7 +478,7 @@ var wrongDashes = string([]rune{
 func run() error {
 	cli := mkClient()
 	parser := Parser(cli)
-	_, err := parser.Parse()
+	xtra, err := parser.Parse()
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok {
 			switch e.Type {
@@ -489,7 +489,16 @@ func run() error {
 				parser.WriteHelp(Stdout)
 				return nil
 			case flags.ErrUnknownCommand:
-				return fmt.Errorf(i18n.G(`unknown command %q, see 'snap help'`), os.Args[1])
+				sub := os.Args[1]
+				sug := "snap help"
+				if len(xtra) > 0 {
+					sub = xtra[0]
+					if x := parser.Command.Active; x != nil && x.Name != "help" {
+						sug = "snap help " + x.Name
+					}
+				}
+				// TRANSLATORS: %q is the command the user entered; %s is 'snap help' or 'snap help <cmd>'
+				return fmt.Errorf(i18n.G("unknown command %q, see '%s'."), sub, sug)
 			}
 		}
 

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -267,7 +267,7 @@ func (s *SnapSuite) TestUnknownCommand(c *C) {
 	defer restore()
 
 	err := snap.RunMain()
-	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see 'snap help'`)
+	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see 'snap help'.`)
 }
 
 func (s *SnapSuite) TestResolveApp(c *C) {


### PR DESCRIPTION
Currently,

    ~$ snap debug pathos
    error: unknown command "debug", see 'snap help'
    ~$ snap -h pathos
    error: unknown command "-h", see 'snap help'
    ~$ snap help pathos
    error: Unknown command "pathos". Try 'snap help'.
    ~$ snap help debug pathos
    error: too many arguments for command
    ~$ snap help debug paths
    error: too many arguments for command

with this change,

    ~$ snap debug pathos
    error: unknown command "pathos", see 'snap help debug'.
    ~$ snap -h pathos
    error: unknown command "pathos", see 'snap help'.
    ~$ snap help pathos
    error: unknown command "pathos", see 'snap help'.
    ~$ snap help debug pathos
    error: unknown command "pathos", see 'snap help debug'.
    ~$ snap help debug paths
    Usage:
      snap paths

    The paths command prints the list of paths detected and used by
    snapd.

HTH, HAND!
