### PR TITLE
tests/main/nfs-support: use archive mode for creating fstab backup

### DIFF
--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -174,7 +174,7 @@ execute: |
     ensure_normal_perms
 
     # Back up the /etc/fstab file and define a NFS mount mount there.
-    cp /etc/fstab fstab.orig
+    cp -a /etc/fstab fstab.orig
     echo 'localhost:/home /home nfs defaults 0 0' >> /etc/fstab
 
     # Restart snapd and ensure that we have extra permissions again.


### PR DESCRIPTION
Make sure to use cp -a to preserve permissions and *labels* when creating a
backup copy of /etc/fstab. Otherwise, on SELinux systems, upon restore,
/etc/fstab ends up with `unconfined_u:object_r:home_root_t:s0` context, which
should in fact be `system_u:object_r:etc_t:s0`.
