### PR TITLE
daemon, client, cmd/snap: snap debug base-declaration

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -684,3 +684,8 @@ func (client *Client) Debug(action string, params interface{}, result interface{
 	_, err = client.doSync("POST", "/v2/debug", nil, nil, bytes.NewReader(body), result)
 	return err
 }
+
+func (client *Client) DebugGet(action string, result interface{}) error {
+	_, err := client.doSync("GET", "/v2/debug", url.Values{"action": []string{action}}, nil, nil, &result)
+	return err
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -557,4 +558,17 @@ func (cs *clientSuite) TestDebugGeneric(c *C) {
 	data, err := ioutil.ReadAll(cs.reqs[0].Body)
 	c.Assert(err, IsNil)
 	c.Check(string(data), DeepEquals, `{"action":"do-something","params":["param1","param2"]}`)
+}
+
+func (cs *clientSuite) TestDebugGet(c *C) {
+	cs.rsp = `{"type": "sync", "result":["res1","res2"]}`
+
+	var result []string
+	err := cs.cli.DebugGet("do-something", &result)
+	c.Check(err, IsNil)
+	c.Check(result, DeepEquals, []string{"res1", "res2"})
+	c.Check(cs.reqs, HasLen, 1)
+	c.Check(cs.reqs[0].Method, Equals, "GET")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/debug")
+	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"action": []string{"do-something"}})
 }

--- a/cmd/snap/cmd_get_base_declaration.go
+++ b/cmd/snap/cmd_get_base_declaration.go
@@ -26,15 +26,24 @@ import (
 )
 
 type cmdGetBaseDeclaration struct {
+	get bool
 	clientMixin
 }
 
 func init() {
 	cmd := addDebugCommand("get-base-declaration",
+		"(internal) obtain the base declaration for all interfaces (deprecated)",
+		"(internal) obtain the base declaration for all interfaces (deprecated)",
+		func() flags.Commander {
+			return &cmdGetBaseDeclaration{}
+		}, nil, nil)
+	cmd.hidden = true
+
+	cmd = addDebugCommand("base-declaration",
 		"(internal) obtain the base declaration for all interfaces",
 		"(internal) obtain the base declaration for all interfaces",
 		func() flags.Commander {
-			return &cmdGetBaseDeclaration{}
+			return &cmdGetBaseDeclaration{get: true}
 		}, nil, nil)
 	cmd.hidden = true
 }
@@ -46,7 +55,13 @@ func (x *cmdGetBaseDeclaration) Execute(args []string) error {
 	var resp struct {
 		BaseDeclaration string `json:"base-declaration"`
 	}
-	if err := x.client.Debug("get-base-declaration", nil, &resp); err != nil {
+	var err error
+	if x.get {
+		err = x.client.DebugGet("base-declaration", &resp)
+	} else {
+		err = x.client.Debug("get-base-declaration", nil, &resp)
+	}
+	if err != nil {
 		return err
 	}
 	fmt.Fprintf(Stdout, "%s\n", resp.BaseDeclaration)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -213,8 +213,10 @@ var (
 	}
 
 	debugCmd = &Command{
-		Path: "/v2/debug",
-		POST: postDebug,
+		Path:   "/v2/debug",
+		UserOK: true,
+		GET:    getDebug,
+		POST:   postDebug,
 	}
 
 	createUserCmd = &Command{
@@ -2478,6 +2480,15 @@ type ConnectivityStatus struct {
 	Unreachable  []string `json:"unreachable,omitempty"`
 }
 
+func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
+	query := r.URL.Query()
+	action := query.Get("action")
+	if action != "base-declaration" {
+		return BadRequest("unknown debug action %q", action)
+	}
+	return doDebugAction(c, &debugAction{Action: action})
+}
+
 func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 	var a debugAction
 	decoder := json.NewDecoder(r.Body)
@@ -2485,6 +2496,10 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode request body into a debug action: %v", err)
 	}
 
+	return doDebugAction(c, &a)
+}
+
+func doDebugAction(c *Command, a *debugAction) Response {
 	st := c.d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -2499,7 +2514,7 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 	case "ensure-state-soon":
 		ensureStateSoon(st)
 		return SyncResponse(true, nil)
-	case "get-base-declaration":
+	case "get-base-declaration", "base-declaration":
 		bd, err := assertstate.BaseDeclaration(st)
 		if err != nil {
 			return InternalError("cannot get base declaration: %s", err)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6919,6 +6919,19 @@ func (s *postDebugSuite) TestPostDebugConnectivityUnhappy(c *check.C) {
 	})
 }
 
+func (s *postDebugSuite) TestGetDebugBaseDeclaration(c *check.C) {
+	_ = s.daemon(c)
+
+	req, err := http.NewRequest("GET", "/v2/debug?action=base-declaration", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getDebug(debugCmd, req, nil).(*resp)
+
+	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Result.(map[string]interface{})["base-declaration"],
+		testutil.Contains, "type: base-declaration")
+}
+
 type appSuite struct {
 	apiBaseSuite
 	cmd *testutil.MockCmd


### PR DESCRIPTION
This change adds GET debug requests, and makes `snap debug
base-declaration` use this. The advantage is you don't need to be
authenticated to do it, which helps its use case.
