### PR TITLE
cmd/snap: fix error messages for snapshots commands if ID is not uint

### DIFF
--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -206,9 +206,9 @@ func (x *forgetCmd) Execute([]string) error {
 
 	if len(snaps) > 0 {
 		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
-		fmt.Fprintf(Stdout, i18n.NG("Snapshot #%d of snap %s forgotten.\n", "Snapshot #%d of snaps %s forgotten.\n", len(snaps)), x.Positional.ID, strutil.Quoted(snaps))
+		fmt.Fprintf(Stdout, i18n.NG("Snapshot #%s of snap %s forgotten.\n", "Snapshot #%s of snaps %s forgotten.\n", len(snaps)), x.Positional.ID, strutil.Quoted(snaps))
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("Snapshot #%d forgotten.\n"), x.Positional.ID)
+		fmt.Fprintf(Stdout, i18n.G("Snapshot #%s forgotten.\n"), x.Positional.ID)
 	}
 	return nil
 }
@@ -244,10 +244,10 @@ func (x *checkSnapshotCmd) Execute([]string) error {
 	// TODO: also mention the home archives that were actually checked
 	if len(snaps) > 0 {
 		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
-		fmt.Fprintf(Stdout, i18n.G("Snapshot #%d of snaps %s verified successfully.\n"),
+		fmt.Fprintf(Stdout, i18n.G("Snapshot #%s of snaps %s verified successfully.\n"),
 			x.Positional.ID, strutil.Quoted(snaps))
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("Snapshot #%d verified successfully.\n"), x.Positional.ID)
+		fmt.Fprintf(Stdout, i18n.G("Snapshot #%s verified successfully.\n"), x.Positional.ID)
 	}
 	return nil
 }
@@ -283,10 +283,10 @@ func (x *restoreCmd) Execute([]string) error {
 	// TODO: also mention the home archives that were actually restored
 	if len(snaps) > 0 {
 		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
-		fmt.Fprintf(Stdout, i18n.G("Restored snapshot #%d of snaps %s.\n"),
+		fmt.Fprintf(Stdout, i18n.G("Restored snapshot #%s of snaps %s.\n"),
 			x.Positional.ID, strutil.Quoted(snaps))
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("Restored snapshot #%d.\n"), x.Positional.ID)
+		fmt.Fprintf(Stdout, i18n.G("Restored snapshot #%s.\n"), x.Positional.ID)
 	}
 	return nil
 }

--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/jessevdk/go-flags"
 
@@ -173,7 +174,7 @@ func (x *saveCmd) Execute([]string) error {
 	y := &savedCmd{
 		clientMixin:   x.clientMixin,
 		durationMixin: x.durationMixin,
-		ID:            snapshotID(setID),
+		ID:            snapshotID(strconv.FormatUint(setID, 10)),
 	}
 	return y.Execute(nil)
 }

--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -106,7 +106,10 @@ type savedCmd struct {
 }
 
 func (x *savedCmd) Execute([]string) error {
-	setID := uint64(x.ID)
+	setID, err := x.ID.ToUint()
+	if err != nil {
+		return err
+	}
 	snaps := installedSnapNames(x.Positional.Snaps)
 	list, err := x.client.SnapshotSets(setID, snaps)
 	if err != nil {
@@ -184,7 +187,10 @@ type forgetCmd struct {
 }
 
 func (x *forgetCmd) Execute([]string) error {
-	setID := uint64(x.Positional.ID)
+	setID, err := x.Positional.ID.ToUint()
+	if err != nil {
+		return err
+	}
 	snaps := installedSnapNames(x.Positional.Snaps)
 	changeID, err := x.client.ForgetSnapshots(setID, snaps)
 	if err != nil {
@@ -217,7 +223,10 @@ type checkSnapshotCmd struct {
 }
 
 func (x *checkSnapshotCmd) Execute([]string) error {
-	setID := uint64(x.Positional.ID)
+	setID, err := x.Positional.ID.ToUint()
+	if err != nil {
+		return err
+	}
 	snaps := installedSnapNames(x.Positional.Snaps)
 	users := strutil.CommaSeparatedList(x.Users)
 	changeID, err := x.client.CheckSnapshots(setID, snaps, users)
@@ -253,7 +262,10 @@ type restoreCmd struct {
 }
 
 func (x *restoreCmd) Execute([]string) error {
-	setID := uint64(x.Positional.ID)
+	setID, err := x.Positional.ID.ToUint()
+	if err != nil {
+		return err
+	}
 	snaps := installedSnapNames(x.Positional.Snaps)
 	users := strutil.CommaSeparatedList(x.Users)
 	changeID, err := x.client.RestoreSnapshots(setID, snaps, users)

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/snap"
+)
+
+type snapshotCmdArgs struct {
+	args, stdout, stderr, error string
+}
+
+var snapshotsTests = []getCmdArgs{{
+	args:  "restore x",
+	error: "invalid argument for set id’: expected a non-negative integer argument",
+}, {
+	args:  "saved --id=x",
+	error: "invalid argument for set id’: expected a non-negative integer argument",
+}, {
+	args:  "forget x",
+	error: "invalid argument for set id’: expected a non-negative integer argument",
+}, {
+	args:  "check-snapshot x",
+	error: "invalid argument for set id’: expected a non-negative integer argument",
+}}
+
+func (s *SnapSuite) TestSnapSnaphotsTest(c *C) {
+	restore := main.MockIsStdinTTY(true)
+	defer restore()
+
+	for _, test := range snapshotsTests {
+		s.stdout.Truncate(0)
+		s.stderr.Truncate(0)
+
+		c.Logf("Test: %s", test.args)
+
+		_, err := main.Parser(main.Client()).ParseArgs(strings.Fields(test.args))
+		if test.error != "" {
+			c.Check(err, ErrorMatches, test.error)
+		} else {
+			c.Check(err, IsNil)
+			c.Check(s.Stderr(), Equals, test.stderr)
+			c.Check(s.Stdout(), Equals, test.stdout)
+		}
+	}
+
+}

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -35,16 +35,16 @@ type snapshotCmdArgs struct {
 
 var snapshotsTests = []getCmdArgs{{
 	args:  "restore x",
-	error: "invalid argument for set id’: expected a non-negative integer argument",
+	error: "invalid argument for set id: expected a non-negative integer argument",
 }, {
 	args:  "saved --id=x",
-	error: "invalid argument for set id’: expected a non-negative integer argument",
+	error: "invalid argument for set id: expected a non-negative integer argument",
 }, {
 	args:  "forget x",
-	error: "invalid argument for set id’: expected a non-negative integer argument",
+	error: "invalid argument for set id: expected a non-negative integer argument",
 }, {
 	args:  "check-snapshot x",
-	error: "invalid argument for set id’: expected a non-negative integer argument",
+	error: "invalid argument for set id: expected a non-negative integer argument",
 }, {
 	args:   "restore 1",
 	stdout: "Restored snapshot #1.\n",

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -500,7 +500,7 @@ func (snapshotID) Complete(match string) []flags.Completion {
 func (s snapshotID) ToUint() (uint64, error) {
 	setID, err := strconv.ParseUint((string)(s), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf(i18n.G("invalid argument for set id’: expected a non-negative integer argument"))
+		return 0, fmt.Errorf(i18n.G("invalid argument for set id: expected a non-negative integer argument"))
 	}
 	return setID, nil
 }

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -478,7 +479,7 @@ func (s aliasOrSnap) Complete(match string) []flags.Completion {
 	return ret
 }
 
-type snapshotID uint64
+type snapshotID string
 
 func (snapshotID) Complete(match string) []flags.Completion {
 	shots, err := mkClient().SnapshotSets(0, nil)
@@ -494,4 +495,12 @@ func (snapshotID) Complete(match string) []flags.Completion {
 	}
 
 	return ret
+}
+
+func (s snapshotID) ToUint() (uint64, error) {
+	setID, err := strconv.ParseUint((string)(s), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf(i18n.G("invalid argument for set id’: expected a non-negative integer argument"))
+	}
+	return setID, nil
 }


### PR DESCRIPTION
Some snapshots-related commands expect set ID (a number). This is currently defined as uint64 in the definitions for go-flags, so when a string is provided instead, we end up with an ugly error message, e.g:
$ snap restore a
error: strconv.ParseUint: parsing "a": invalid syntax

The parsing in this particular case is unfortunately handled internally by go-flags based on the command definitions, so we cannot do anything about this in Execute(). Therefore I had to change the type of of snapshotID argument to string so we can do validation ourselves. 
