### PR TITLE
tests: remove snapweb from tests

### DIFF
--- a/tests/main/prepare-image-grub-core18/task.yaml
+++ b/tests/main/prepare-image-grub-core18/task.yaml
@@ -14,11 +14,11 @@ restore: |
     
 execute: |
     echo Running prepare-image
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap snapweb $TESTSLIB/assertions/ubuntu-core-18-amd64.model $ROOT" test
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap test-snapd-tools $TESTSLIB/assertions/ubuntu-core-18-amd64.model $ROOT" test
 
     echo Verifying the result
     ls -lR "$IMAGE"
-    for f in pc pc-kernel core18 snapd snapweb; do
+    for f in pc pc-kernel core18 snapd test-snapd-tools; do
         ls "$IMAGE"/var/lib/snapd/seed/snaps/"${f}"*.snap
     done
     MATCH snap_core=core18 < "$IMAGE"/boot/grub/grubenv

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -48,11 +48,11 @@ execute: |
 
     echo Running prepare-image
     #shellcheck disable=SC2086
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --snap test-snapd-tools $TESTSLIB/assertions/developer1-pc.model $ROOT" test
 
     echo Verifying the result
     ls -lR "$IMAGE"
-    for f in pc pc-kernel core snapweb; do
+    for f in pc pc-kernel core test-snapd-tools; do
         ls "$IMAGE"/var/lib/snapd/seed/snaps/"${f}"*.snap
     done
     MATCH snap_core=core < "$IMAGE/boot/grub/grubenv"

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -38,11 +38,11 @@ execute: |
     export UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL=1
 
     echo Running prepare-image as a user
-    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps snapweb $ROOT/model.assertion $ROOT" test
+    su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps test-snapd-tools $ROOT/model.assertion $ROOT" test
 
     echo Verifying the result
     ls -lR "$IMAGE"
-    for f in pi2 pi2-kernel core snapweb; do
+    for f in pi2 pi2-kernel core test-snapd-tools; do
         ls "$IMAGE/var/lib/snapd/seed/snaps/${f}"*.snap
     done
     MATCH snap_core=core < "$IMAGE/boot/uboot/uboot.env"


### PR DESCRIPTION
We use the snapweb snap in various tests. The package is now
unpublished from the store and thus the tests break. We really
don't want this package anymore.
