### PR TITLE
tests/main/desktop-portal-*: fix handling of python dependencies

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -643,6 +643,8 @@ pkg_dependencies_fedora(){
         net-tools
         nfs-utils
         python3-yaml
+        python3-dbus
+        python3-gobject
         redhat-lsb-core
         rpm-build
         udisks2
@@ -721,6 +723,8 @@ pkg_dependencies_arch(){
     openbsd-netcat
     python
     python-docutils
+    python-dbus
+    python-gobject
     python3-yaml
     squashfs-tools
     shellcheck

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -56,3 +56,11 @@ execute: |
     as_user test-snapd-portal-client save-file "from-sandbox"
     [ -f /tmp/file-to-write.txt ]
     MATCH "from-sandbox" < /tmp/file-to-write.txt
+
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$TEST_UID/" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -68,3 +68,11 @@ execute: |
     echo "The test-browser process was invoked with the URL"
     wait_for_file "$EDITOR_HISTORY" 4 .5
     MATCH "$testfile" < "$EDITOR_HISTORY"
+
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$TEST_UID/" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -58,3 +58,11 @@ execute: |
     echo "The test-browser process was invoked with the URL"
     wait_for_file "$BROWSER_HISTORY" 4 .5
     MATCH http://www.example.org < "$BROWSER_HISTORY"
+
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$TEST_UID/" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -50,3 +50,11 @@ execute: |
     # AppArmor policy uses the @owner restriction.
     chown test:test /tmp/screenshot.txt
     as_user test-snapd-portal-client screenshot | MATCH "my screenshot"
+
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$TEST_UID/" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -27,7 +27,6 @@ prepare: |
     . "$TESTSLIB"/pkgdb.sh
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    distro_install_package python3-dbus python3-gi
     install_local test-snapd-desktop
     install_local test-snapd-tools
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
@@ -39,8 +38,6 @@ restore: |
     . "$TESTSLIB"/pkgdb.sh
     [ -f dbus-launch.pid ] && kill "$(cat dbus-launch.pid)"
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
-    distro_purge_package python3-dbus python3-gi
-    distro_auto_remove_packages
     rm -rf "${XDG_RUNTIME_DIR:?}/*" "${XDG_RUNTIME_DIR:?}/.[!.]*"
 
 execute: |


### PR DESCRIPTION
The tests seem to be failing randomly. Add a debug section to try to grab more
debugging information.
