### PR TITLE
packaging: build snapctl as a static binary

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -71,13 +71,13 @@ build() {
   gobuild_static="go build -x -v -buildmode=pie -ldflags=-extldflags=-static"
   # Build/install snap and snapd
   $gobuild -o $srcdir/go/bin/snap $GOFLAGS "${_gourl}/cmd/snap"
-  $gobuild -o $srcdir/go/bin/snapctl $GOFLAGS "${_gourl}/cmd/snapctl"
   $gobuild -o $srcdir/go/bin/snapd $GOFLAGS "${_gourl}/cmd/snapd"
   $gobuild -o $srcdir/go/bin/snap-seccomp $GOFLAGS "${_gourl}/cmd/snap-seccomp"
   $gobuild -o $srcdir/go/bin/snap-failure $GOFLAGS "${_gourl}/cmd/snap-failure"
   # build snap-exec and snap-update-ns completely static for base snaps
   $gobuild_static -o $srcdir/go/bin/snap-update-ns $GOFLAGS "${_gourl}/cmd/snap-update-ns"
   $gobuild_static -o $srcdir/go/bin/snap-exec $GOFLAGS "${_gourl}/cmd/snap-exec"
+  $gobuild_static -o $srcdir/go/bin/snapctl $GOFLAGS "${_gourl}/cmd/snapctl"
 
   # Generate data files such as real systemd units, dbus service, environment
   # setup helpers out of the available templates

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -145,15 +145,17 @@ override_dh_auto_build:
 
 	# (static linking on powerpc with cgo is broken)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
-	# Generate static snap-exec and snap-update-ns - it somehow includes CGO so
+	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
 	# we must force a static build here. We need a static snap-{exec,update-ns}
 	# inside the core snap because not all bases will have a libc
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
+	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
 
 	# ensure we generated a static build
 	$(shell	if ldd _build/bin/snap-exec; then false "need static build"; fi)
 	$(shell	if ldd _build/bin/snap-update-ns; then false "need static build"; fi)
+	$(shell	if ldd _build/bin/snapctl; then false "need static build"; fi)
 endif
 
 	# ensure snap-seccomp is build with a static libseccomp on Ubuntu

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -461,13 +461,13 @@ sed -e "s:github.com/snapcore/bolt:github.com/boltdb/bolt:g" -i advisor/*.go err
 # set tags.
 %gobuild -o bin/snapd $GOFLAGS %{import_path}/cmd/snapd
 %gobuild -o bin/snap $GOFLAGS %{import_path}/cmd/snap
-%gobuild -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
 %gobuild -o bin/snap-failure $GOFLAGS %{import_path}/cmd/snap-failure
 
 # To ensure things work correctly with base snaps,
-# snap-exec and snap-update-ns need to be built statically
+# snap-exec, snap-update-ns and snapctl need to be built statically
 %gobuild_static -o bin/snap-exec $GOFLAGS %{import_path}/cmd/snap-exec
 %gobuild_static -o bin/snap-update-ns $GOFLAGS %{import_path}/cmd/snap-update-ns
+%gobuild_static -o bin/snapctl $GOFLAGS %{import_path}/cmd/snapctl
 
 %if 0%{?rhel}
 # There's no static link library for libseccomp in RHEL/CentOS...

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -60,7 +60,7 @@ all: $(go_binaries)
 snap snap-seccomp:
 	go build -buildmode=pie $(import_path)/cmd/$@
 
-# Those tree need to be built as static binaries. They run on the inside of a
+# Those three need to be built as static binaries. They run on the inside of a
 # nearly-arbitrary mount namespace that does not contain anything we can depend
 # on (no standard library, for example).
 snap-update-ns snap-exec snapctl:

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -57,13 +57,13 @@ go_binaries = snap snapctl snap-seccomp snap-update-ns snap-exec snapd
 .PHONY: all
 all: $(go_binaries) 
 
-snap snapctl snap-seccomp:
+snap snap-seccomp:
 	go build -buildmode=pie $(import_path)/cmd/$@
 
-# Those two need to be built as static binaries. They run on the inside of a
+# Those tree need to be built as static binaries. They run on the inside of a
 # nearly-arbitrary mount namespace that does not contain anything we can depend
 # on (no standard library, for example).
-snap-update-ns snap-exec:
+snap-update-ns snap-exec snapctl:
 	go build -buildmode=default -ldflags '-extldflags "-static"' $(import_path)/cmd/$@
 
 # Snapd can be built with test keys. This is only used by the internal test

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -125,14 +125,16 @@ override_dh_auto_build:
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
 	dh_auto_build -- $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS)
-	# Generate static snap-exec - it somehow includes CGO so we must
-	# force a static build here. We need a static snap-exec inside
+	# Generate static snap-exec, snapctl and snap-udpate-ns - it somehow includes CGO so we must
+	# force a static build here. We need a static snap-{exec,update-ns}/snapctl inside
 	# the core snap because not all bases will have a libc
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
+	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
 	# ensure we generated a static build
 	$(shell	if ldd _build/bin/snap-exec; then false "need static build"; fi)
 	$(shell	if ldd _build/bin/snap-update-ns; then false "need static build"; fi)
+	$(shell	if ldd _build/bin/snapctl; then false "need static build"; fi)
 
 	# Build C bits, sadly manually
 	cd cmd && ( autoreconf -i -f )

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -152,15 +152,17 @@ override_dh_auto_build:
 
 	# (static linking on powerpc with cgo is broken)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
-	# Generate static snap-exec and snap-update-ns - it somehow includes CGO so
-	# we must force a static build here. We need a static snap-{exec,update-ns}
+	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
+	# we must force a static build here. We need a static snap-{exec,update-ns}/snapctl
 	# inside the core snap because not all bases will have a libc
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
+	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
 
 	# ensure we generated a static build
 	$(shell	if ldd _build/bin/snap-exec; then false "need static build"; fi)
 	$(shell	if ldd _build/bin/snap-update-ns; then false "need static build"; fi)
+	$(shell	if ldd _build/bin/snapctl; then false "need static build"; fi)
 endif
 
 	# ensure snap-seccomp is build with a static libseccomp on Ubuntu


### PR DESCRIPTION
The snapctl binary can be called from inside the mount ns, and thus should be
built statically to ensure it operates regardless of the base that is used.
