### PR TITLE
daemon/tests: fix race in the disconnect conflict test

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4769,9 +4769,6 @@ func (s *apiSuite) TestDisconnectConflict(c *check.C) {
 
 	simulateConflict(d.overlord, "consumer")
 
-	d.overlord.Loop()
-	defer d.overlord.Stop()
-
 	action := &interfaceAction{
 		Action: "disconnect",
 		Plugs:  []plugJSON{{Snap: "consumer", Name: "plug"}},

--- a/spread.yaml
+++ b/spread.yaml
@@ -88,6 +88,8 @@ backends:
                 workers: 4
             - opensuse-tumbleweed-64:
                 workers: 4
+                # tumbleweed image not available at the moment
+                manual: true
             - arch-linux-64:
                 workers: 4
 


### PR DESCRIPTION
Fix api test for disconnect conflicts - it was incorrectly starting overlord loop which doesn't make sense when we want to check conflicts as it creates a race (the conflicting link-snap task created for this test sometimes finishes before we do conflict check on disconnect). This is now consistent with other conflict-checking tests in api_test.
