### PR TITLE
systemd: decrease the checker counter before unlocking otherwise we can get spurious panics

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -74,8 +74,8 @@ func (m *extMutex) Lock() {
 
 // Unlock releases the mutex
 func (m *extMutex) Unlock() {
-	m.lock.Unlock()
 	atomic.AddInt32(&m.muC, -1)
+	m.lock.Unlock()
 }
 
 // Taken will panic with the given error message if the lock is not


### PR DESCRIPTION
With the other order the counter can reach 2+  and give false Taken panics.
