### PR TITLE
ifacestate/tests: fix/improve udev mon test

### DIFF
--- a/overlord/ifacestate/udevmonitor/udevmon_test.go
+++ b/overlord/ifacestate/udevmonitor/udevmon_test.go
@@ -58,6 +58,8 @@ func (s *udevMonitorSuite) TestDiscovery(c *C) {
 		callbackChannel <- struct{}{}
 	}
 	removed := func(inf *hotplug.HotplugDeviceInfo) {
+		// we should see just one removal
+		c.Check(remInfo, IsNil)
 		remInfo = inf
 		callbackChannel <- struct{}{}
 	}
@@ -133,27 +135,38 @@ E: DEVTYPE=bzz
 		}
 	}()
 
-	// expect three add events - one from udev event, two from enumeration.
-	const numExpectedDevices = 3
+	calls := 0
 Loop:
 	for {
 		select {
 		case <-callbackChannel:
-			if len(addInfos) == numExpectedDevices && remInfo != nil && enumerationDone {
+			calls++
+			if calls == 5 {
 				break Loop
 			}
 		case <-time.After(3 * time.Second):
 			c.Error("Did not receive expected devices before timeout")
 			break Loop
-		default:
 		}
 	}
 
+	c.Check(calls, Equals, 5)
+	c.Check(enumerationDone, Equals, true)
+	// expect three add events - one from udev event, two from enumeration.
+	c.Assert(addInfos, HasLen, 3)
 	c.Assert(remInfo, NotNil)
-	c.Assert(addInfos, HasLen, numExpectedDevices)
-	c.Assert(enumerationDone, Equals, true)
 
-	c.Assert(udevmon.Stop(), IsNil)
+	stopChannel := make(chan struct{})
+	defer close(stopChannel)
+	go func() {
+		c.Assert(udevmon.Stop(), IsNil)
+		stopChannel <- struct{}{}
+	}()
+	select {
+	case <-stopChannel:
+	case <-time.After(3 * time.Second):
+		c.Error("udev monitor did not stop before timeout")
+	}
 
 	addInfo := addInfos[0]
 	c.Assert(addInfo.DeviceName(), Equals, "name")


### PR DESCRIPTION
The udevmon test failed in the ppa on udevmon.Stop() and eventually got killed by go test after 10 minutes. I played around this test and I could somewhat reproduce the problem by running it multiple times. This PR improves the test and hopefully fixes the issue (I got the updated test running for a long time with no failure):
- ~~one problem which I'm not totally clear about was the use of callbackChannel and related `if len(addInfos) == numExpectedDevices && remInfo != nil && enumerationDone` check, which was racy for reason I'm no clear about - it would sometimes break the loop after only 4 (out of 5 expected) calls. I simplified this logic to only rely on number of callback calls as the expected values are tested below anyway.~~
  the conditionals were racy as the values could be mutated by the callback concurrently. This was confirmed with `go test -race` (thanks Samuele).
- the `Stop()` is now happening in go routine, with a 3 seconds timeout. This fixes potential 10 min test kill timeout if there is a problem. I excercised this bit by adding artificial sleep on stop, and it worked as expected.