### PR TITLE
tests/main/high-user-handling: fix the test for Go 1.12 (2.37)

### DIFF
--- a/tests/main/high-user-handling/task.yaml
+++ b/tests/main/high-user-handling/task.yaml
@@ -7,6 +7,8 @@ prepare: |
 
 restore: |
     userdel hightest
+    rm -f hightest
 
 execute: |
-    sudo -E -u hightest "$(command -v go)" run test.go
+    "$(command -v go)" build -o hightest test.go
+    sudo -E -u hightest ./hightest


### PR DESCRIPTION
Go 1.12 started using $HOME/.cache for keeping the built object cache. Since
we're using sudo -E, $HOME still points to /root. Instead of calling `go run`
which would build as the user, build the binary beforehand.

Chery pick of #6555 to 2.37