### PR TITLE
many: remove unused code (mostly)

### DIFF
--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -33,6 +33,5 @@ func (r *failureSuite) TestRun(c *C) {
 	os.Args = []string{"snap-failure", "snapd"}
 	err := failure.Run()
 	c.Check(err, IsNil)
-	c.Check(r.Stdout(), HasLen, 0)
 	c.Check(r.Stderr(), HasLen, 0)
 }

--- a/cmd/snap-failure/main.go
+++ b/cmd/snap-failure/main.go
@@ -31,7 +31,6 @@ import (
 )
 
 var (
-	Stdout io.Writer = os.Stdout
 	Stderr io.Writer = os.Stderr
 
 	opts   struct{}

--- a/cmd/snap-failure/main_test.go
+++ b/cmd/snap-failure/main_test.go
@@ -38,17 +38,11 @@ type failureSuite struct {
 
 	rootdir string
 
-	stdout *bytes.Buffer
 	stderr *bytes.Buffer
 }
 
 func (r *failureSuite) SetUpTest(c *C) {
-	r.stdout = bytes.NewBuffer(nil)
 	r.stderr = bytes.NewBuffer(nil)
-
-	oldStdout := failure.Stdout
-	r.AddCleanup(func() { failure.Stdout = oldStdout })
-	failure.Stdout = r.stdout
 
 	oldStderr := failure.Stderr
 	r.AddCleanup(func() { failure.Stderr = oldStderr })
@@ -57,10 +51,6 @@ func (r *failureSuite) SetUpTest(c *C) {
 	r.rootdir = c.MkDir()
 	dirs.SetRootDir(r.rootdir)
 	r.AddCleanup(func() { dirs.SetRootDir("/") })
-}
-
-func (r *failureSuite) Stdout() string {
-	return r.stdout.String()
 }
 
 func (r *failureSuite) Stderr() string {

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -112,7 +112,6 @@ type jsonRPC struct {
 	Method  string `json:"method"`
 	Params  struct {
 		Command         string   `json:"command"`
-		SearchTerms     []string `json:"search-terms"`
 		UnknownPackages []string `json:"unknown-packages"`
 	}
 }

--- a/cmd/snap/cmd_connectivity_check.go
+++ b/cmd/snap/cmd_connectivity_check.go
@@ -44,8 +44,7 @@ func (x *cmdConnectivityCheck) Execute(args []string) error {
 	}
 
 	var status struct {
-		Connectivity bool
-		Unreachable  []string
+		Unreachable []string
 	}
 	if err := x.client.Debug("connectivity", nil, &status); err != nil {
 		return err

--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -31,7 +31,7 @@ import (
 )
 
 func fmtSize(size int64) string {
-	return quantity.FormatAmount(uint64(size), -1)
+	return quantity.FormatAmount(uint64(size), -1) + "B"
 }
 
 var (
@@ -141,8 +141,9 @@ func (x *savedCmd) Execute([]string) error {
 			if sh.Broken != "" {
 				note = "broken: " + sh.Broken
 			}
-			size := quantity.FormatAmount(uint64(sh.Size), -1) + "B"
-			fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n", sg.ID, sh.Snap, x.fmtDuration(sh.Time), sh.Version, sh.Revision, size, note)
+			size := fmtSize(sh.Size)
+			age := x.fmtDuration(sh.Time)
+			fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n", sg.ID, sh.Snap, age, sh.Version, sh.Revision, size, note)
 		}
 	}
 	return nil

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/snapcore/snapd/cmd/snap"
 )
 
-type snapshotCmdArgs struct {
-	args, stdout, stderr, error string
-}
-
 var snapshotsTests = []getCmdArgs{{
 	args:  "restore x",
 	error: "invalid argument for set id: expected a non-negative integer argument",

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -48,7 +48,6 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/jsonutil"
@@ -58,7 +57,6 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
-	"github.com/snapcore/snapd/overlord/configstate/proxyconf"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -2158,15 +2156,6 @@ var (
 	ctlcmdRun                 = ctlcmd.Run
 	osutilAddUser             = osutil.AddUser
 )
-
-func makeHttpClient(st *state.State) *http.Client {
-	proxyConf := proxyconf.New(st)
-	return httputil.NewHTTPClient(&httputil.ClientOptions{
-		Timeout:    10 * time.Second,
-		MayLogBody: true,
-		Proxy:      proxyConf.Conf,
-	})
-}
 
 func getUserDetailsFromStore(theStore snapstate.StoreService, email string) (string, *osutil.AddUserOptions, error) {
 	v, err := theStore.UserInfo(email)

--- a/daemon/api_connections_test.go
+++ b/daemon/api_connections_test.go
@@ -73,18 +73,6 @@ func (s *apiSuite) testConnections(c *check.C, query string, expected map[string
 	c.Check(body, check.DeepEquals, expected)
 }
 
-func (s *apiSuite) testConnectedConnections(c *check.C, query string, expected map[string]interface{}) {
-	req, err := http.NewRequest("GET", query, nil)
-	c.Assert(err, check.IsNil)
-	rec := httptest.NewRecorder()
-	connectionsCmd.GET(connectionsCmd, req, nil).ServeHTTP(rec, req)
-	c.Check(rec.Code, check.Equals, 200)
-	var body map[string]interface{}
-	err = json.Unmarshal(rec.Body.Bytes(), &body)
-	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, expected)
-}
-
 func (s *apiSuite) TestConnectionsUnhappy(c *check.C) {
 	s.daemon(c)
 	req, err := http.NewRequest("GET", "/v2/connections?select=bad", nil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -427,10 +427,6 @@ func (s *apiBaseSuite) waitTrivialChange(c *check.C, chg *state.Change) {
 	c.Assert(chg.IsReady(), check.Equals, true)
 }
 
-func (s *apiBaseSuite) mkInstalled(c *check.C, name, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
-	return s.mkInstalledInState(c, nil, name, developer, version, revision, active, extraYaml)
-}
-
 func (s *apiBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) string {
 	df := filepath.Join(dirs.SnapDesktopFilesDir, name)
 	err := os.MkdirAll(filepath.Dir(df), 0755)
@@ -532,16 +528,6 @@ version: %s
 	}
 
 	return snapInfo
-}
-
-func (s *apiBaseSuite) mkGadget(c *check.C, store string) {
-	yamlText := fmt.Sprintf(`name: test
-version: 1
-type: gadget
-gadget: {store: {id: %q}}
-`, store)
-	snaptest.MockSnap(c, yamlText, &snap.SideInfo{Revision: snap.R(1)})
-	c.Assert(os.Symlink("1", filepath.Join(dirs.SnapMountDir, "test", "current")), check.IsNil)
 }
 
 type apiSuite struct {

--- a/osutil/strace/timing.go
+++ b/osutil/strace/timing.go
@@ -130,11 +130,6 @@ var execveatRE = regexp.MustCompile(`([0-9]+)\ +([0-9.]+) execveat\(.*\["([^"]+)
 // 17559 1542815330.242750 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=17643, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
 var sigChldTermRE = regexp.MustCompile(`[0-9]+\ +([0-9.]+).*SIG(CHLD|TERM)\ {.*si_pid=([0-9]+),`)
 
-// all lines start with this:
-// PID   TIME
-// 21616 1542882400.198907 ....
-var timeRE = regexp.MustCompile(`[0-9]+\ +([0-9.]+).*`)
-
 func handleExecMatch(trace *ExecveTiming, pt *pidTracker, match []string) error {
 	if len(match) == 0 {
 		return nil


### PR DESCRIPTION
The mostly bit is because I couldn't resist a teeny tiny refactoring
along the way.

Anyhow, this is the result of running the `unused` static analyser on
the code. There's a bunch more, but unused doesn't know about gocheck,
so it gets confused about some things, and separating the wheat from
the chaff is tedious.