### PR TITLE
cmd/snap-confine: drop uid from random /tmp name

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -71,8 +71,7 @@ static void setup_private_mount(const char *snap_name)
 	//
 	// Under that basedir, we put a 1777 /tmp dir that is then bind
 	// mounted for the applications to use
-	sc_must_snprintf(tmpdir, sizeof(tmpdir), "/tmp/snap.%d_%s_XXXXXX", uid,
-			 snap_name);
+	sc_must_snprintf(tmpdir, sizeof(tmpdir), "/tmp/snap.%s_XXXXXX", snap_name);
 	if (mkdtemp(tmpdir) == NULL) {
 		die("cannot create temporary directory essential for private /tmp");
 	}


### PR DESCRIPTION
Each snap gets a private /tmp directory created as a sub-directory of
the host's real /tmp directory. The pattern used to be
"/tmp/snap.%d_%s_XXXXXX" with the %d expanding to uid of the calling
user and %s expanding to snap_name. This patch drops the %d/uid
expansion.

The %d made no sense, when user a, with uid=1000 runs a snap "foo" it
will cause a /tmp directory to remain /tmp/snap.1000_foo_$random even
for user b with uid=1001.

This was picked up during a review a few months ago but I nobody filed a
patch then. Here it is.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
