### PR TITLE
cmd/snap-confine: chown private /tmp to root.root

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -62,8 +62,6 @@
 // TODO: fold this into bootstrap
 static void setup_private_mount(const char *snap_name)
 {
-	uid_t uid = getuid();
-	gid_t gid = getgid();
 	char tmpdir[MAX_BUF] = { 0 };
 
 	// Create a 0700 base directory, this is the base dir that is
@@ -98,7 +96,7 @@ static void setup_private_mount(const char *snap_name)
 	// MS_PRIVATE needs linux > 2.6.11
 	sc_do_mount("none", "/tmp", NULL, MS_PRIVATE, NULL);
 	// do the chown after the bind mount to avoid potential shenanigans
-	if (chown("/tmp/", uid, gid) < 0) {
+	if (chown("/tmp/", 0, 0) < 0) {
 		die("cannot change ownership of /tmp");
 	}
 	// chdir to original directory

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -71,8 +71,7 @@ static void setup_private_mount(const char *snap_name)
 	//
 	// Under that basedir, we put a 1777 /tmp dir that is then bind
 	// mounted for the applications to use
-	sc_must_snprintf(tmpdir, sizeof(tmpdir), "/tmp/snap.%d_%s_XXXXXX", uid,
-			 snap_name);
+	sc_must_snprintf(tmpdir, sizeof(tmpdir), "/tmp/snap.%s_XXXXXX", snap_name);
 	if (mkdtemp(tmpdir) == NULL) {
 		die("cannot create temporary directory essential for private /tmp");
 	}


### PR DESCRIPTION
When snap-confine creates a private /tmp directory for a given snap it
first creates a temporary directory in /tmp/ named after the snap, along
with a random name. Inside that directory it creates a /tmp directory
with permissions appropriate for a future /tmp, namely 1777.

Up until recently the that directory was owned by the user who first
invoked snap-confine. Since the directory is reused by all the users on
the system this logic makes no sense.

This patch changes the related logic so that the private /tmp directory
is owned by root, just like the real one.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
