### PR TITLE
snap: remove obsolete license-* fields in the yaml

### DIFF
--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -33,26 +33,24 @@ import (
 )
 
 type snapYaml struct {
-	Name             string                 `yaml:"name"`
-	Version          string                 `yaml:"version"`
-	Type             Type                   `yaml:"type"`
-	Architectures    []string               `yaml:"architectures,omitempty"`
-	Assumes          []string               `yaml:"assumes"`
-	Title            string                 `yaml:"title"`
-	Description      string                 `yaml:"description"`
-	Summary          string                 `yaml:"summary"`
-	License          string                 `yaml:"license,omitempty"`
-	LicenseAgreement string                 `yaml:"license-agreement,omitempty"`
-	LicenseVersion   string                 `yaml:"license-version,omitempty"`
-	Epoch            Epoch                  `yaml:"epoch,omitempty"`
-	Base             string                 `yaml:"base,omitempty"`
-	Confinement      ConfinementType        `yaml:"confinement,omitempty"`
-	Environment      strutil.OrderedMap     `yaml:"environment,omitempty"`
-	Plugs            map[string]interface{} `yaml:"plugs,omitempty"`
-	Slots            map[string]interface{} `yaml:"slots,omitempty"`
-	Apps             map[string]appYaml     `yaml:"apps,omitempty"`
-	Hooks            map[string]hookYaml    `yaml:"hooks,omitempty"`
-	Layout           map[string]layoutYaml  `yaml:"layout,omitempty"`
+	Name          string                 `yaml:"name"`
+	Version       string                 `yaml:"version"`
+	Type          Type                   `yaml:"type"`
+	Architectures []string               `yaml:"architectures,omitempty"`
+	Assumes       []string               `yaml:"assumes"`
+	Title         string                 `yaml:"title"`
+	Description   string                 `yaml:"description"`
+	Summary       string                 `yaml:"summary"`
+	License       string                 `yaml:"license,omitempty"`
+	Epoch         Epoch                  `yaml:"epoch,omitempty"`
+	Base          string                 `yaml:"base,omitempty"`
+	Confinement   ConfinementType        `yaml:"confinement,omitempty"`
+	Environment   strutil.OrderedMap     `yaml:"environment,omitempty"`
+	Plugs         map[string]interface{} `yaml:"plugs,omitempty"`
+	Slots         map[string]interface{} `yaml:"slots,omitempty"`
+	Apps          map[string]appYaml     `yaml:"apps,omitempty"`
+	Hooks         map[string]hookYaml    `yaml:"hooks,omitempty"`
+	Layout        map[string]layoutYaml  `yaml:"layout,omitempty"`
 
 	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
 	TypoLayouts typoDetector `yaml:"layouts,omitempty"`
@@ -246,8 +244,6 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 		OriginalDescription: y.Description,
 		OriginalSummary:     y.Summary,
 		License:             y.License,
-		LicenseAgreement:    y.LicenseAgreement,
-		LicenseVersion:      y.LicenseVersion,
 		Epoch:               y.Epoch,
 		Confinement:         confinement,
 		Base:                y.Base,

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1407,18 +1407,6 @@ architectures:
 	c.Assert(err, NotNil)
 }
 
-func (s *YamlSuite) TestSnapYamlLicenseParsing(c *C) {
-	y := []byte(`
-name: foo
-version: 1.0
-license-agreement: explicit
-license-version: 12`)
-	info, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, IsNil)
-	c.Assert(info.LicenseAgreement, Equals, "explicit")
-	c.Assert(info.LicenseVersion, Equals, "12")
-}
-
 // apps
 
 func (s *YamlSuite) TestSimpleAppExample(c *C) {


### PR DESCRIPTION
We do not use these license-{agreement,version}. The original purpose
was to eventually show a license agreement to the user before the
snap can be installed. However we never implemented this and it seems
now days we would do that differently (with entitlements) anyway.

So dropping these fields from the code seems to be prudent.
