### PR TITLE
interface: avahi-observe: Fixing socket permissions on 4.15 kernels (2.38)

### DIFF
--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -47,7 +47,7 @@ network netlink,
 
 # Allow access to daemon to create socket
 /{,var/}run/avahi-daemon/  w,
-/{,var/}run/avahi-daemon/{pid,socket} rw,
+/{,var/}run/avahi-daemon/{pid,socket} rwk,
 
 # Description: Allow operating as the avahi service. This gives
 # privileged access to the system.

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -18,7 +18,8 @@ priority: 1000
 prepare: |
     # using apt here is ok because this test only runs on ubuntu
     echo "Remove any installed debs (some images carry them) to ensure we test the snap"
-    if command -v apt; then
+    # apt -v to test if apt is usable (its not on ubuntu-core)
+    if command -v apt && apt -v; then
         apt autoremove -y lxd
     fi
 

--- a/tests/main/ubuntu-core-apt/task.yaml
+++ b/tests/main/ubuntu-core-apt/task.yaml
@@ -4,8 +4,11 @@ systems: [ubuntu-core-16-*]
 
 execute: |
     expected="Ubuntu Core does not use apt-get, see 'snap --help'!"
-    output=$(apt-get update)
-    if [ "$output" != "$expected" ]; then
-        echo "Unexpected apt output: $output"
+    if apt-get update > output.txt; then
+        echo "apt should exit 1 but did not"
+        exit 1
+    fi
+    if [ "$(cat output.txt)" != "$expected" ]; then
+        echo "Unexpected apt output: $(cat output.txt)"
         exit 1
     fi


### PR DESCRIPTION
PR #6324 for 2.38
