### PR TITLE
overlord/snapstate: fix restoring of "old-current" revision config in undoLinkSnap

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1131,8 +1131,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if len(snapst.Sequence) == 1 {
-		// XXX: why only restore when len()==1?
+	if len(snapst.Sequence) > 0 {
 		if err = config.RestoreRevisionConfig(st, snapsup.InstanceName(), oldCurrent); err != nil {
 			return err
 		}


### PR DESCRIPTION
When undoing snap update, the undoLinkSnap handler doesn't correctly restore snap configuration for the "old current" revision that we are returning to. This PR fixes it. There is some code needed for the new unit test that was already implemented in other test, so it's extracted into a helper. The new test fails without the fix in handlers.go.

Thanks for @chipaca for XXX in the code.
