### PR TITLE
tests: check that apt works before using it

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -18,7 +18,8 @@ priority: 1000
 prepare: |
     # using apt here is ok because this test only runs on ubuntu
     echo "Remove any installed debs (some images carry them) to ensure we test the snap"
-    if command -v apt; then
+    # apt -v to test if apt is usable (its not on ubuntu-core)
+    if command -v apt && apt -v; then
         apt autoremove -y lxd
     fi
 

--- a/tests/main/ubuntu-core-apt/task.yaml
+++ b/tests/main/ubuntu-core-apt/task.yaml
@@ -4,8 +4,11 @@ systems: [ubuntu-core-16-*]
 
 execute: |
     expected="Ubuntu Core does not use apt-get, see 'snap --help'!"
-    output=$(apt-get update)
-    if [ "$output" != "$expected" ]; then
-        echo "Unexpected apt output: $output"
+    if apt-get update > output.txt; then
+        echo "apt should exit 1 but did not"
+        exit 1
+    fi
+    if [ "$(cat output.txt)" != "$expected" ]; then
+        echo "Unexpected apt output: $(cat output.txt)"
         exit 1
     fi


### PR DESCRIPTION
The lxd test is using apt unconditionally even on core devices.

Nowdays the apt wrapper on core devices will error when run so
the lxd test needs an update to ensure it only uses apt if apt
is actually usable.
