### PR TITLE
cmd/snap-confine: introduce sc_invocation

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -101,7 +101,7 @@ typedef struct sc_invocation {
 	const char *snap_instance;
 } sc_invocation;
 
-static void enter_classic_execution_environment(const sc_invocation * inv);
+static void enter_classic_execution_environment(void);
 static void enter_non_classic_execution_environment(const sc_invocation * inv,
 						    struct sc_apparmor *aa,
 						    uid_t real_uid,
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
 	if (geteuid() == 0) {
 		if (classic_confinement) {
 			/* TODO: move everything into this call */
-			enter_classic_execution_environment(inv);
+			enter_classic_execution_environment();
 			/* 'classic confinement' is designed to run without the sandbox
 			 * inside the shared namespace. Specifically:
 			 * - snap-confine skips using the snap-specific mount namespace
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
 	return 1;
 }
 
-static void enter_classic_execution_environment(const sc_invocation * inv)
+static void enter_classic_execution_environment(void)
 {
 }
 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -99,11 +99,11 @@ typedef struct sc_invocation {
 	const char *base_snap_name;
 	const char *security_tag;
 	const char *snap_instance;
-	struct sc_apparmor *apparmor;
 } sc_invocation;
 
 static void enter_classic_execution_environment(const sc_invocation * inv);
 static void enter_non_classic_execution_environment(const sc_invocation * inv,
+						    struct sc_apparmor *aa,
 						    uid_t real_uid,
 						    gid_t real_gid,
 						    gid_t saved_gid);
@@ -201,10 +201,10 @@ int main(int argc, char **argv)
 		.snap_instance = snap_instance,
 		.base_snap_name = base_snap_name,
 		.security_tag = security_tag,
-		.apparmor = &apparmor,
 	};
 	/* For the ease of introducing inv to the if branch below. */
 	const sc_invocation *inv = &invocation;
+	struct sc_apparmor *aa = &apparmor;
 
 	// TODO: check for similar situation and linux capabilities.
 	if (geteuid() == 0) {
@@ -222,7 +222,8 @@ int main(int argc, char **argv)
 			    ("skipping sandbox setup, classic confinement in use");
 		} else {
 			/* TODO: move everything into this call */
-			enter_non_classic_execution_environment(inv, real_uid,
+			enter_non_classic_execution_environment(inv, aa,
+								real_uid,
 								real_gid,
 								saved_gid);
 			/* snap-confine uses privately-shared /run/snapd/ns to store
@@ -268,8 +269,8 @@ int main(int argc, char **argv)
 			/* Stale mount namespace discarded or no mount namespace to
 			   join. We need to construct a new mount namespace ourselves.
 			   To capture it we will need a helper process so make one. */
-			sc_fork_helper(group, inv->apparmor);
-			int retval = sc_join_preserved_ns(group, inv->apparmor,
+			sc_fork_helper(group, aa);
+			int retval = sc_join_preserved_ns(group, aa,
 							  inv->base_snap_name,
 							  inv->snap_instance,
 							  snap_discard_ns_fd);
@@ -283,7 +284,7 @@ int main(int argc, char **argv)
 				if (unshare(CLONE_NEWNS) < 0) {
 					die("cannot unshare the mount namespace");
 				}
-				sc_populate_mount_ns(inv->apparmor,
+				sc_populate_mount_ns(aa,
 						     snap_update_ns_fd,
 						     inv->base_snap_name,
 						     inv->snap_instance);
@@ -304,16 +305,18 @@ int main(int argc, char **argv)
 				    ("joining preserved per-user mount namespace");
 				retval =
 				    sc_join_preserved_per_user_ns(group,
-								  inv->snap_instance);
+								  inv->
+								  snap_instance);
 				if (retval == ESRCH) {
 					debug
 					    ("unsharing the mount namespace (per-user)");
 					if (unshare(CLONE_NEWNS) < 0) {
 						die("cannot unshare the mount namespace");
 					}
-					sc_setup_user_mounts(inv->apparmor,
+					sc_setup_user_mounts(aa,
 							     snap_update_ns_fd,
-							     inv->snap_instance);
+							     inv->
+							     snap_instance);
 					/* Preserve the mount per-user namespace. But only if the
 					 * experimental feature is enabled. This way if the feature is
 					 * disabled user mount namespaces will still exist but will be
@@ -401,7 +404,7 @@ int main(int argc, char **argv)
 	setup_user_xdg_runtime_dir();
 #endif
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
-	sc_maybe_aa_change_onexec(&apparmor, security_tag);
+	sc_maybe_aa_change_onexec(aa, security_tag);
 #ifdef HAVE_SECCOMP
 	if (sc_apply_seccomp_profile_for_security_tag(security_tag)) {
 		/* If the process is not explicitly unconfined then load the global
@@ -444,6 +447,7 @@ static void enter_classic_execution_environment(const sc_invocation * inv)
 }
 
 static void enter_non_classic_execution_environment(const sc_invocation * inv,
+						    struct sc_apparmor *aa,
 						    uid_t real_uid,
 						    gid_t real_gid,
 						    gid_t saved_gid)


### PR DESCRIPTION
Currently passing data around snap-confine is not very easy because of
historically organic growth of the codebase. To simplify some of that
I'd like to introduce sc_invocation. An ad-hoc structure that captures
some of the variables that participate in the essential part of
snap-confine's logic.

The purpose of this patch is to introduce this structure, switch some of
the code to use it (as opposed to accessing the local variables) and
set the stage for a subsequent patch that moves a large chunk of code
into the two new stubs: enter_{,non_}classic_execution_environment().

This should eventually allow us to make a single call to
sc_should_use_normal_mode() and simply pass the result around via the
invocation structure. There is plenty of more refactoring that can be
done after this patch is in place.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
