### PR TITLE
cmd/snap-confine: call sc_should_use_normal_mode once

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -516,7 +516,8 @@ static bool __attribute__ ((used))
 }
 
 void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const char *base_snap_name, const char *snap_name)
+			  const char *base_snap_name, const char *snap_name,
+			  bool is_normal_mode)
 {
 	// Get the current working directory before we start fiddling with
 	// mounts and possibly pivot_root.  At the end of the whole process, we
@@ -529,7 +530,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	// Classify the current distribution, as claimed by /etc/os-release.
 	sc_distro distro = sc_classify_distro();
 	// Check which mode we should run in, normal or legacy.
-	if (sc_should_use_normal_mode(distro, base_snap_name)) {
+	if (is_normal_mode) {
 		// In normal mode we use the base snap as / and set up several bind mounts.
 		const struct sc_mount mounts[] = {
 			{"/dev"},	// because it contains devices on host OS

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -51,7 +51,8 @@ int sc_open_snap_discard_ns(void);
  * this is impossible it will chdir to SC_VOID_DIR.
  **/
 void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const char *base_snap_name, const char *snap_name);
+			  const char *base_snap_name, const char *snap_name,
+			  bool is_normal_mode);
 
 /**
  * Ensure that / or /snap is mounted with the SHARED option.

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -92,7 +92,8 @@ void sc_close_mount_ns(struct sc_mount_ns *group);
  **/
 int sc_join_preserved_ns(struct sc_mount_ns *group, struct sc_apparmor
 			 *apparmor, const char *base_snap_name,
-			 const char *snap_name, int snap_discard_ns_fd);
+			 const char *snap_name, int snap_discard_ns_fd,
+			 bool is_normal_mode);
 
 /**
  * Join a preserved, per-user, mount namespace if one exists.


### PR DESCRIPTION
Historically snap-confine used two modes of operation. Initially on core
systems snap-confine would unshare the mount namespace and preform some
alterations but would otherwise run with the contents of the initial
mount namesapce. On classic systems snap-confine would pivot into the
base snap (core) and perform some more alterations.

With the introduction of multiple boot bases, per-snap bases some of
that logic seems rusty. To make it less confusing what is going on
reduce the number of places that determine if legacy (sans-pivot) or
normal mode (with pivot) to exactly one.

There is more cleanup that can be done but it will require making the
invocation structure something we can pass around to more functions.
This will be attempted in subsequent patches.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
