### PR TITLE
cmd/snap-confine: track per-app and per-hook processes

### DIFF
--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -13,6 +13,7 @@ restore: |
     rmdir /sys/fs/cgroup/freezer/snap.test-snapd-sh || true
 
 execute: |
+    trap 'killall test-snapd-sh || true' EXIT
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
     test-snapd-sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &

--- a/tests/main/cgroup-pids/task.yaml
+++ b/tests/main/cgroup-pids/task.yaml
@@ -75,11 +75,10 @@ execute: |
     # are now two processes: the shell and sleep.
     test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 2
     kill "$pid3"
-    wait "$pid3" || true  # same as above
     test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 1
-    # Killing the shell will not kill sleep and since spread will hang if a
-    # background process is still running (that was spawned using &) we need to
-    # kill it ourselves. This is a bit heavy handed but works.
-    # NOTE: Alternatively we could kill the remaining cgroup process.
-    killall sleep
+    # Kill the remaining cgroup process.
+    while read -r pid; do
+        kill "$pid"
+    done < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    wait "$pid3" || true  # same as above
     test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 0

--- a/tests/main/cgroup-pids/task.yaml
+++ b/tests/main/cgroup-pids/task.yaml
@@ -55,3 +55,31 @@ execute: |
     kill "$pid2"
     wait "$pid2" || true  # same as above
     MATCH -v "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+
+    # If a snap command forks a child process it is also tracked.
+    #shellcheck disable=SC2016
+    test-snapd-sh -c 'touch $SNAP_DATA/3.stamp && sleep 1h' &
+    pid3=$!
+
+    # Ensure that snap-confine has finished its task and that the snap process
+    # is active. Note that we don't want to wait forever either.
+    for _ in $(seq 30); do
+        test -e /var/snap/test-snapd-sh/current/3.stamp && break
+        sleep 0.1
+    done
+    # While the process is alive its PID can be seen in the cgroup.procs file
+    # of the pid controller.
+    MATCH "$pid3" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+
+    # Because the script above used "sleep 1h" instead of "exec sleep 1h" there
+    # are now two processes: the shell and sleep.
+    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 2
+    kill "$pid3"
+    wait "$pid3" || true  # same as above
+    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 1
+    # Killing the shell will not kill sleep and since spread will hang if a
+    # background process is still running (that was spawned using &) we need to
+    # kill it ourselves. This is a bit heavy handed but works.
+    # NOTE: Alternatively we could kill the remaining cgroup process.
+    killall sleep
+    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 0

--- a/tests/main/cgroup-pids/task.yaml
+++ b/tests/main/cgroup-pids/task.yaml
@@ -20,6 +20,7 @@ restore: |
     # snap unset core experimental.refresh-app-awareness
 
 execute: |
+    trap 'killall test-snapd-sh || true' EXIT
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
     test-snapd-sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &

--- a/tests/main/cgroup-pids/task.yaml
+++ b/tests/main/cgroup-pids/task.yaml
@@ -1,0 +1,56 @@
+summary: Each snap app and hook is tracked in a pids cgroup
+
+details: |
+    This test creates a snap process that suspends itself and ensures that it
+    placed into the appropriate hierarchy under the pids cgroup.
+
+prepare: |
+    # This feature depends on the release-app-awareness feature
+    snap set core experimental.refresh-app-awareness=true
+
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-sh
+
+restore: |
+    rmdir /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh || true
+
+    # TODO: There is currently no way to unset configuration options.
+    # Once this is fixed please uncomment this line:
+    # snap unset core experimental.refresh-app-awareness
+
+execute: |
+    # Start a "sleep" process in the background
+    #shellcheck disable=SC2016
+    test-snapd-sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
+    pid1=$!
+    # Ensure that snap-confine has finished its task and that the snap process
+    # is active. Note that we don't want to wait forever either.
+    for _ in $(seq 30); do
+        test -e /var/snap/test-snapd-sh/current/1.stamp && break
+        sleep 0.1
+    done
+    # While the process is alive its PID can be seen in the cgroup.procs file
+    # of the pid controller.
+    MATCH "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+
+    # Start a second process so that we can check adding tasks to an existing
+    # control group.
+    #shellcheck disable=SC2016
+    test-snapd-sh -c 'touch $SNAP_DATA/2.stamp && exec sleep 1h' &
+    pid2=$!
+    for _ in $(seq 30); do
+        test -e /var/snap/test-snapd-sh/current/2.stamp && break
+        sleep 0.1
+    done
+    MATCH "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+
+    # When the process terminates the control group is updated and the task no
+    # longer registers there.
+    kill "$pid1"
+    wait "$pid1" || true  # wait returns the exit code and we kill the process
+    MATCH -v "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+
+    kill "$pid2"
+    wait "$pid2" || true  # same as above
+    MATCH -v "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs


### PR DESCRIPTION
When the app-refresh-awareness feature is enabled, snap-confine will
track processes in a v1 cgroup hierarchy for the pids controller. This
allows for per-app and per-hook process enumeration and tracking.

Currently nothing is using this feature, in will soon be used by snapd's
process tracking for soft and hard refresh checks, though.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
