### PR TITLE
cmd/snap, client, daemon, ifacestate: show a leading attribute of a connection

### DIFF
--- a/client/connections.go
+++ b/client/connections.go
@@ -32,6 +32,10 @@ type Connection struct {
 	Manual bool `json:"manual"`
 	// Gadget is set for connections that were enabled by the gadget snap.
 	Gadget bool `json:"gadget"`
+	// SlotAttrs is the list of attributes of the slot side of the connection.
+	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
+	// PlugAttrs is the list of attributes of the plug side of the connection.
+	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
 }
 
 // Connections contains information about connections, as well as related plugs

--- a/cmd/snap/cmd_connections.go
+++ b/cmd/snap/cmd_connections.go
@@ -125,10 +125,10 @@ func definingAttributeValue(conn *client.Connection) string {
 			value, _ = conn.SlotAttrs["content"].(string)
 		}
 	}
-	if value != "" {
-		return fmt.Sprintf("[%v]", value)
+	if value == "" {
+		return ""
 	}
-	return value
+	return fmt.Sprintf("[%v]", value)
 }
 
 func (x *cmdConnections) Execute(args []string) error {

--- a/cmd/snap/cmd_connections.go
+++ b/cmd/snap/cmd_connections.go
@@ -78,11 +78,12 @@ func endpoint(snap, name string) string {
 }
 
 type connection struct {
-	slot          string
-	plug          string
-	interfaceName string
-	manual        bool
-	gadget        bool
+	slot              string
+	plug              string
+	interfaceName     string
+	manual            bool
+	gadget            bool
+	definingAttrValue string
 }
 
 func (cn connection) String() string {
@@ -112,6 +113,22 @@ func (b byConnectionData) Less(i, j int) bool {
 		return iCon.plug < jCon.plug
 	}
 	return iCon.slot < jCon.slot
+}
+
+func definingAttributeValue(conn *client.Connection) string {
+	var value string
+
+	switch conn.Interface {
+	case "content":
+		value, _ = conn.PlugAttrs["content"].(string)
+		if value == "" {
+			value, _ = conn.SlotAttrs["content"].(string)
+		}
+	}
+	if value != "" {
+		return fmt.Sprintf("[%v]", value)
+	}
+	return value
 }
 
 func (x *cmdConnections) Execute(args []string) error {
@@ -148,11 +165,12 @@ func (x *cmdConnections) Execute(args []string) error {
 	annotatedConns := make([]connection, 0, len(connections.Established)+len(connections.Undesired))
 	for _, conn := range connections.Established {
 		annotatedConns = append(annotatedConns, connection{
-			plug:          endpoint(conn.Plug.Snap, conn.Plug.Name),
-			slot:          endpoint(conn.Slot.Snap, conn.Slot.Name),
-			manual:        conn.Manual,
-			gadget:        conn.Gadget,
-			interfaceName: conn.Interface,
+			plug:              endpoint(conn.Plug.Snap, conn.Plug.Name),
+			slot:              endpoint(conn.Slot.Snap, conn.Slot.Name),
+			manual:            conn.Manual,
+			gadget:            conn.Gadget,
+			interfaceName:     conn.Interface,
+			definingAttrValue: definingAttributeValue(&conn),
 		})
 	}
 
@@ -186,7 +204,7 @@ func (x *cmdConnections) Execute(args []string) error {
 	sort.Sort(byConnectionData(annotatedConns))
 
 	for _, note := range annotatedConns {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", note.interfaceName, note.plug, note.slot, note)
+		fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\n", note.interfaceName, note.definingAttrValue, note.plug, note.slot, note)
 	}
 
 	if len(annotatedConns) > 0 {

--- a/cmd/snap/cmd_connections.go
+++ b/cmd/snap/cmd_connections.go
@@ -78,12 +78,12 @@ func endpoint(snap, name string) string {
 }
 
 type connection struct {
-	slot              string
-	plug              string
-	interfaceName     string
-	manual            bool
-	gadget            bool
-	definingAttrValue string
+	slot                 string
+	plug                 string
+	interfaceName        string
+	interfaceDeterminant string
+	manual               bool
+	gadget               bool
 }
 
 func (cn connection) String() string {
@@ -115,7 +115,7 @@ func (b byConnectionData) Less(i, j int) bool {
 	return iCon.slot < jCon.slot
 }
 
-func definingAttributeValue(conn *client.Connection) string {
+func interfaceDeterminant(conn *client.Connection) string {
 	var value string
 
 	switch conn.Interface {
@@ -165,12 +165,12 @@ func (x *cmdConnections) Execute(args []string) error {
 	annotatedConns := make([]connection, 0, len(connections.Established)+len(connections.Undesired))
 	for _, conn := range connections.Established {
 		annotatedConns = append(annotatedConns, connection{
-			plug:              endpoint(conn.Plug.Snap, conn.Plug.Name),
-			slot:              endpoint(conn.Slot.Snap, conn.Slot.Name),
-			manual:            conn.Manual,
-			gadget:            conn.Gadget,
-			interfaceName:     conn.Interface,
-			definingAttrValue: definingAttributeValue(&conn),
+			plug:                 endpoint(conn.Plug.Snap, conn.Plug.Name),
+			slot:                 endpoint(conn.Slot.Snap, conn.Slot.Name),
+			manual:               conn.Manual,
+			gadget:               conn.Gadget,
+			interfaceName:        conn.Interface,
+			interfaceDeterminant: interfaceDeterminant(&conn),
 		})
 	}
 
@@ -204,7 +204,7 @@ func (x *cmdConnections) Execute(args []string) error {
 	sort.Sort(byConnectionData(annotatedConns))
 
 	for _, note := range annotatedConns {
-		fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\n", note.interfaceName, note.definingAttrValue, note.plug, note.slot, note)
+		fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\n", note.interfaceName, note.interfaceDeterminant, note.plug, note.slot, note)
 	}
 
 	if len(annotatedConns) > 0 {

--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -89,6 +89,19 @@ func (b byPlugRef) Less(i, j int) bool {
 	return b[i].SortsBefore(b[j])
 }
 
+// mergeAttrs merges attributes from 2 disjoint sets of static and dynamic slot or
+// plug attributes into a single map.
+func mergeAttrs(one map[string]interface{}, other map[string]interface{}) map[string]interface{} {
+	merged := make(map[string]interface{}, len(one)+len(other))
+	for k, v := range one {
+		merged[k] = v
+	}
+	for k, v := range other {
+		merged[k] = v
+	}
+	return merged
+}
+
 func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFilter) (*connectionsJSON, error) {
 	repo := ifaceMgr.Repository()
 	ifaces := repo.Interfaces()
@@ -133,8 +146,8 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 			Manual:    cstate.Auto == false,
 			Gadget:    cstate.ByGadget,
 			Interface: cstate.Interface,
-			PlugAttrs: cstate.PlugAttrs,
-			SlotAttrs: cstate.SlotAttrs,
+			PlugAttrs: mergeAttrs(cstate.StaticPlugAttrs, cstate.DynamicPlugAttrs),
+			SlotAttrs: mergeAttrs(cstate.StaticSlotAttrs, cstate.DynamicSlotAttrs),
 		}
 		if cstate.Undesired {
 			// explicitly disconnected are always manual

--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -133,6 +133,8 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 			Manual:    cstate.Auto == false,
 			Gadget:    cstate.ByGadget,
 			Interface: cstate.Interface,
+			PlugAttrs: cstate.PlugAttrs,
+			SlotAttrs: cstate.SlotAttrs,
 		}
 		if cstate.Undesired {
 			// explicitly disconnected are always manual

--- a/daemon/api_connections_test.go
+++ b/daemon/api_connections_test.go
@@ -41,7 +41,8 @@ func (s *apiSuite) testConnectionsConnected(c *check.C, query string, connsState
 	for crefStr, cstate := range connsState {
 		cref, err := interfaces.ParseConnRef(crefStr)
 		c.Assert(err, check.IsNil)
-		if undesiredRaw, ok := cstate.(map[string]interface{})["undesired"]; ok {
+		conn := cstate.(map[string]interface{})
+		if undesiredRaw, ok := conn["undesired"]; ok {
 			undesired, ok := undesiredRaw.(bool)
 			c.Assert(ok, check.Equals, true, check.Commentf("unexpected value for key 'undesired': %v", cstate))
 			if undesired {
@@ -49,7 +50,11 @@ func (s *apiSuite) testConnectionsConnected(c *check.C, query string, connsState
 				continue
 			}
 		}
-		_, err = repo.Connect(cref, nil, nil, nil, nil, nil)
+		staticPlugAttrs, _ := conn["plug-static"].(map[string]interface{})
+		dynamicPlugAttrs, _ := conn["plug-dynamic"].(map[string]interface{})
+		staticSlotAttrs, _ := conn["slot-static"].(map[string]interface{})
+		dynamicSlotAttrs, _ := conn["slot-dynamic"].(map[string]interface{})
+		_, err = repo.Connect(cref, staticPlugAttrs, dynamicPlugAttrs, staticSlotAttrs, dynamicSlotAttrs, nil)
 		c.Assert(err, check.IsNil)
 	}
 
@@ -585,6 +590,18 @@ func (s *apiSuite) TestConnectionsDefaultAuto(c *check.C) {
 		"consumer:plug producer:slot": map[string]interface{}{
 			"interface": "test",
 			"auto":      true,
+			"plug-static": map[string]interface{}{
+				"key": "value",
+			},
+			"plug-dynamic": map[string]interface{}{
+				"foo-plug-dynamic": "bar-dynamic",
+			},
+			"slot-static": map[string]interface{}{
+				"key": "value",
+			},
+			"slot-dynamic": map[string]interface{}{
+				"foo-slot-dynamic": "bar-dynamic",
+			},
 		},
 	}, map[string]interface{}{
 		"result": map[string]interface{}{
@@ -619,6 +636,14 @@ func (s *apiSuite) TestConnectionsDefaultAuto(c *check.C) {
 					"plug":      map[string]interface{}{"snap": "consumer", "plug": "plug"},
 					"slot":      map[string]interface{}{"snap": "producer", "slot": "slot"},
 					"interface": "test",
+					"plug-attrs": map[string]interface{}{
+						"key":              "value",
+						"foo-plug-dynamic": "bar-dynamic",
+					},
+					"slot-attrs": map[string]interface{}{
+						"key":              "value",
+						"foo-slot-dynamic": "bar-dynamic",
+					},
 				},
 			},
 		},

--- a/daemon/api_json.go
+++ b/daemon/api_json.go
@@ -66,11 +66,13 @@ type interfaceAction struct {
 // connectionsJSON aids in marshalling information about a single connection
 // into JSON
 type connectionJSON struct {
-	Slot      interfaces.SlotRef `json:"slot"`
-	Plug      interfaces.PlugRef `json:"plug"`
-	Interface string             `json:"interface"`
-	Manual    bool               `json:"manual,omitempty"`
-	Gadget    bool               `json:"gadget,omitempty"`
+	Slot      interfaces.SlotRef     `json:"slot"`
+	Plug      interfaces.PlugRef     `json:"plug"`
+	Interface string                 `json:"interface"`
+	Manual    bool                   `json:"manual,omitempty"`
+	Gadget    bool                   `json:"gadget,omitempty"`
+	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
+	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
 }
 
 // legacyConnectionsJSON aids in marshaling legacy connections into JSON.

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -178,6 +178,19 @@ type ConnectionState struct {
 	// Undesired indicates whether the connection, otherwise established
 	// automatically, was explicitly disconnected
 	Undesired bool
+	PlugAttrs map[string]interface{}
+	SlotAttrs map[string]interface{}
+}
+
+func mergeAttrs(one map[string]interface{}, other map[string]interface{}) map[string]interface{} {
+	merged := make(map[string]interface{}, len(one)+len(other))
+	for k, v := range one {
+		merged[k] = v
+	}
+	for k, v := range other {
+		merged[k] = v
+	}
+	return merged
 }
 
 // ConnectionStates return the state of connections tracked by the manager
@@ -196,6 +209,8 @@ func (m *InterfaceManager) ConnectionStates() (connStateByRef map[string]Connect
 			ByGadget:  cstate.ByGadget,
 			Interface: cstate.Interface,
 			Undesired: cstate.Undesired,
+			PlugAttrs: mergeAttrs(cstate.StaticPlugAttrs, cstate.DynamicPlugAttrs),
+			SlotAttrs: mergeAttrs(cstate.StaticSlotAttrs, cstate.DynamicSlotAttrs),
 		}
 	}
 	return connStateByRef, nil

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -177,20 +177,11 @@ type ConnectionState struct {
 	Interface string
 	// Undesired indicates whether the connection, otherwise established
 	// automatically, was explicitly disconnected
-	Undesired bool
-	PlugAttrs map[string]interface{}
-	SlotAttrs map[string]interface{}
-}
-
-func mergeAttrs(one map[string]interface{}, other map[string]interface{}) map[string]interface{} {
-	merged := make(map[string]interface{}, len(one)+len(other))
-	for k, v := range one {
-		merged[k] = v
-	}
-	for k, v := range other {
-		merged[k] = v
-	}
-	return merged
+	Undesired        bool
+	StaticPlugAttrs  map[string]interface{}
+	DynamicPlugAttrs map[string]interface{}
+	StaticSlotAttrs  map[string]interface{}
+	DynamicSlotAttrs map[string]interface{}
 }
 
 // ConnectionStates return the state of connections tracked by the manager
@@ -205,12 +196,14 @@ func (m *InterfaceManager) ConnectionStates() (connStateByRef map[string]Connect
 	connStateByRef = make(map[string]ConnectionState, len(states))
 	for cref, cstate := range states {
 		connStateByRef[cref] = ConnectionState{
-			Auto:      cstate.Auto,
-			ByGadget:  cstate.ByGadget,
-			Interface: cstate.Interface,
-			Undesired: cstate.Undesired,
-			PlugAttrs: mergeAttrs(cstate.StaticPlugAttrs, cstate.DynamicPlugAttrs),
-			SlotAttrs: mergeAttrs(cstate.StaticSlotAttrs, cstate.DynamicSlotAttrs),
+			Auto:             cstate.Auto,
+			ByGadget:         cstate.ByGadget,
+			Interface:        cstate.Interface,
+			Undesired:        cstate.Undesired,
+			StaticPlugAttrs:  cstate.StaticPlugAttrs,
+			DynamicPlugAttrs: cstate.DynamicPlugAttrs,
+			StaticSlotAttrs:  cstate.StaticSlotAttrs,
+			DynamicSlotAttrs: cstate.DynamicSlotAttrs,
 		}
 	}
 	return connStateByRef, nil

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -6074,12 +6074,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
-			PlugAttrs: map[string]interface{}{
-				"attr1":          "value1",
+			StaticPlugAttrs: map[string]interface{}{
+				"attr1": "value1",
+			},
+			DynamicPlugAttrs: map[string]interface{}{
 				"dynamic-number": int64(7),
 			},
-			SlotAttrs: map[string]interface{}{
-				"attr2":        "value2",
+			StaticSlotAttrs: map[string]interface{}{
+				"attr2": "value2",
+			},
+			DynamicSlotAttrs: map[string]interface{}{
 				"other-number": int64(9),
 			},
 		}})
@@ -6092,12 +6096,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
 			Interface: "test",
 			Auto:      true,
 			ByGadget:  true,
-			PlugAttrs: map[string]interface{}{
-				"attr1":          "value1",
+			StaticPlugAttrs: map[string]interface{}{
+				"attr1": "value1",
+			},
+			DynamicPlugAttrs: map[string]interface{}{
 				"dynamic-number": int64(7),
 			},
-			SlotAttrs: map[string]interface{}{
-				"attr2":        "value2",
+			StaticSlotAttrs: map[string]interface{}{
+				"attr2": "value2",
+			},
+			DynamicSlotAttrs: map[string]interface{}{
 				"other-number": int64(9),
 			},
 		}})
@@ -6110,12 +6118,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *C) {
 			Interface: "test",
 			Auto:      true,
 			Undesired: true,
-			PlugAttrs: map[string]interface{}{
-				"attr1":          "value1",
+			StaticPlugAttrs: map[string]interface{}{
+				"attr1": "value1",
+			},
+			DynamicPlugAttrs: map[string]interface{}{
 				"dynamic-number": int64(7),
 			},
-			SlotAttrs: map[string]interface{}{
-				"attr2":        "value2",
+			StaticSlotAttrs: map[string]interface{}{
+				"attr2": "value2",
+			},
+			DynamicSlotAttrs: map[string]interface{}{
 				"other-number": int64(9),
 			},
 		}})

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -6051,10 +6051,12 @@ func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undes
 	c.Assert(slot, NotNil)
 	plug := plugSnap.Plugs["plug"]
 	c.Assert(plug, NotNil)
+	dynamicPlugAttrs := map[string]interface{}{"dynamic-number": 7}
+	dynamicSlotAttrs := map[string]interface{}{"other-number": 9}
 	// create connection in conns state
 	conn := &interfaces.Connection{
-		Plug: interfaces.NewConnectedPlug(plug, nil, nil),
-		Slot: interfaces.NewConnectedSlot(slot, nil, nil),
+		Plug: interfaces.NewConnectedPlug(plug, nil, dynamicPlugAttrs),
+		Slot: interfaces.NewConnectedSlot(slot, nil, dynamicSlotAttrs),
 	}
 	ifacestate.UpdateConnectionInConnState(sc, conn, auto, byGadget, undesired)
 	ifacestate.SetConns(st, sc)
@@ -6072,6 +6074,14 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
+			PlugAttrs: map[string]interface{}{
+				"attr1":          "value1",
+				"dynamic-number": int64(7),
+			},
+			SlotAttrs: map[string]interface{}{
+				"attr2":        "value2",
+				"other-number": int64(9),
+			},
 		}})
 }
 
@@ -6082,6 +6092,14 @@ func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
 			Interface: "test",
 			Auto:      true,
 			ByGadget:  true,
+			PlugAttrs: map[string]interface{}{
+				"attr1":          "value1",
+				"dynamic-number": int64(7),
+			},
+			SlotAttrs: map[string]interface{}{
+				"attr2":        "value2",
+				"other-number": int64(9),
+			},
 		}})
 }
 
@@ -6092,6 +6110,14 @@ func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *C) {
 			Interface: "test",
 			Auto:      true,
 			Undesired: true,
+			PlugAttrs: map[string]interface{}{
+				"attr1":          "value1",
+				"dynamic-number": int64(7),
+			},
+			SlotAttrs: map[string]interface{}{
+				"attr2":        "value2",
+				"other-number": int64(9),
+			},
 		}})
 }
 

--- a/tests/main/snap-connections/task.yaml
+++ b/tests/main/snap-connections/task.yaml
@@ -21,7 +21,7 @@ execute: |
     snap connections --all | MATCH -- "$expected"
 
     snap install test-snapd-content-plug
-    expected='content +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-'
+    expected='content\[mylib\] +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-'
     snap connections test-snapd-content-plug | MATCH "$expected"
     snap connections test-snapd-content-slot | MATCH "$expected"
 
@@ -50,13 +50,13 @@ execute: |
 
     # show connected only
     snap connections > connected.out
-    MATCH 'content +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-' < connected.out
+    MATCH 'content\[mylib\] +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-' < connected.out
     MATCH -v 'network-consumer' < connected.out
     MATCH -v 'test-snapd-daemon-notify' < connected.out
 
     # show all
     snap connections --all > all.out
-    MATCH 'content +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-' < all.out
+    MATCH 'content\[mylib\] +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-' < all.out
     MATCH 'daemon-notify +test-snapd-daemon-notify:daemon-notify +- +-' < all.out
     MATCH 'network +network-consumer:network +- +-' < all.out
 


### PR DESCRIPTION
Include a the value of a 'defining' attribute of a connection's plug/slot sides in `snap conections` output. This is part of snap connections work, described here https://forum.snapcraft.io/t/snap-connections-command/4296/20

Example outputs:

```
$ snap connections test-snapd-content-plug
Interface       Plug                                         Slot                                         Notes
content[mylib]  test-snapd-content-plug:shared-content-plug  test-snapd-content-slot:shared-content-slot  -
```

```
$ snap connections gnome-logs             
Interface                 Plug                        Slot                             Notes
content[gnome-3-26-1604]  gnome-logs:gnome-3-26-1604  gnome-3-26-1604:gnome-3-26-1604  -
content[gtk-3-themes]     gnome-logs:gtk-3-themes     gtk-common-themes:gtk-3-themes   -
content[icon-themes]      gnome-logs:icon-themes      gtk-common-themes:icon-themes    -
content[sound-themes]     gnome-logs:sound-themes     gtk-common-themes:sound-themes   -
dbus                      -                           gnome-logs:gnome-logs            -
desktop                   gnome-logs:desktop          :desktop                         -
desktop-legacy            gnome-logs:desktop-legacy   :desktop-legacy                  -
gsettings                 gnome-logs:gsettings        :gsettings                       -
home                      gnome-logs:home             :home                            -
log-observe               gnome-logs:log-observe      :log-observe                     -
network                   gnome-logs:network          :network                         -
unity7                    gnome-logs:unity7           :unity7                          -
wayland                   gnome-logs:wayland          :wayland                         -
```