### PR TITLE
many: make Remodel() download everything first before installing

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -293,6 +293,26 @@ func CanManageRefreshes(st *state.State) bool {
 	return false
 }
 
+// splitTsAfterEdge takes a taskset ts and splits it into two tasksets
+// after the first occurrence of the given task kind
+func splitTsAfterEdge(edge state.TaskSetEdge, ts *state.TaskSet) (*state.TaskSet, *state.TaskSet) {
+	tsBefore := state.NewTaskSet()
+	tsAfter := state.NewTaskSet()
+	edgeTask := ts.Edge(edge)
+	found := false
+	for _, t := range ts.Tasks() {
+		if !found {
+			tsBefore.AddTask(t)
+		} else {
+			tsAfter.AddTask(t)
+		}
+		if t == edgeTask {
+			found = true
+		}
+	}
+	return tsBefore, tsAfter
+}
+
 // Remodel takes a new model assertion and generates a change that
 // takes the device from the old to the new model or an error if the
 // transition is not possible.
@@ -303,9 +323,6 @@ func CanManageRefreshes(st *state.State) bool {
 // - Need new session/serial if changing store or model
 // - Check all relevant snaps exist in new store
 //   (need to check that even unchanged snaps are accessible)
-// - Download everything in a first phase of the change and "pin" cache
-//   files (also get assertions), which means also dealing with new bases
-//   and content providers
 func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 	current, err := Model(st)
 	if err != nil {
@@ -314,9 +331,6 @@ func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 	if current.Series() != new.Series() {
 		return nil, fmt.Errorf("cannot remodel to different series yet")
 	}
-	// FIXME: we need language in the model assertion to declare what
-	// transitions are ok before we allow remodel like this.
-	//
 	// Right now we only allow "remodel" to a different revision of
 	// the same model.
 	if current.BrandID() != new.BrandID() {
@@ -350,22 +364,16 @@ func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 	}
 	userID := 0
 
+	// adjust kernel track
 	var tss []*state.TaskSet
-	addTss := func(ts *state.TaskSet) {
-		if len(tss) > 0 {
-			ts.WaitAll(tss[len(tss)-1])
-		}
-		tss = append(tss, ts)
-	}
-	// adjust tracks
 	if current.KernelTrack() != new.KernelTrack() {
 		ts, err := snapstateUpdate(st, new.Kernel(), new.KernelTrack(), snap.R(0), userID, snapstate.Flags{})
 		if err != nil {
 			return nil, err
 		}
-		addTss(ts)
+		tss = append(tss, ts)
 	}
-	// adjust snaps
+	// add new required snaps
 	for _, snapName := range new.RequiredSnaps() {
 		_, err := snapstate.CurrentInfo(st, snapName)
 		// if the snap is not installed we need to install it now
@@ -374,11 +382,53 @@ func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 			if err != nil {
 				return nil, err
 			}
-			addTss(ts)
+			tss = append(tss, ts)
 		} else if err != nil {
 			return nil, err
 		}
 	}
+	// TODO: Validate that all bases and default-providers are part
+	//       of the install tasksets and error if not. If the
+	//       prereq task handler check starts adding installs into
+	//       our remodel change our carefully constructed wait chain
+	//       breaks down.
+
+	// Ensure all download/check tasks are run *before* the install
+	// tasks. During a remodel the network may not be available so
+	// we need to ensure we have everything local.
+	var prevDownload, prevInstall *state.TaskSet
+	for _, ts := range tss {
+		// make sure all things happen sequentially:
+		// - all tasks inside ts{Download,Install} already wait for
+		//   each other
+		//   Out chains look like this:
+		//     install1 <- verify1 <- download1
+		//     install2 <- verify2 <- download2
+		// - add wait of each first ts{Download,Install} task for
+		//   the last previous ts{Download,Install} task
+		//   Our chains now looks like:
+		//     download1 (no waits)
+		//     download2 <- verify1
+		//     install1 <- verify1 <- download1
+		//     install2 <- verify2 <- install1
+		tsDownload, tsInstall := splitTsAfterEdge(snapstate.DownloadAndChecksDoneEdge, ts)
+		if prevDownload != nil {
+			tsDownload.Tasks()[0].WaitFor(prevDownload.Tasks()[len(prevDownload.Tasks())-1])
+		}
+		if prevInstall != nil {
+			tsInstall.Tasks()[0].WaitFor(prevInstall.Tasks()[len(prevInstall.Tasks())-1])
+		}
+		prevDownload = tsDownload
+		prevInstall = tsInstall
+	}
+	// Make sure the first install waits for the last download. With this
+	// our (simplified) wait chain looks like:
+	// download1 <- verify1 <- download2 <- verify2 <- install1 <- install2
+	lastTsDownload, _ := splitTsAfterEdge(snapstate.DownloadAndChecksDoneEdge, tss[len(tss)-1])
+	tLastDownload := lastTsDownload.Tasks()[len(lastTsDownload.Tasks())-1]
+	_, firstTsInstall := splitTsAfterEdge(snapstate.DownloadAndChecksDoneEdge, tss[0])
+	tFirstInstall := firstTsInstall.Tasks()[0]
+	tFirstInstall.WaitFor(tLastDownload)
 
 	// Set the new model assertion - this *must* be the last thing done
 	// by the change.

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -293,8 +293,8 @@ func CanManageRefreshes(st *state.State) bool {
 	return false
 }
 
-// extractDownloadInstallEdgesFromTs is a helper that extract the first, last
-// download phase and install phase tasks from a TaskSet
+// extractDownloadInstallEdgesFromTs extracts the first, last download
+// phase and install phase tasks from a TaskSet
 func extractDownloadInstallEdgesFromTs(ts *state.TaskSet) (firstDl, lastDl, firstInst, lastInst *state.Task) {
 	edgeTask := ts.Edge(snapstate.DownloadAndChecksDoneEdge)
 	tasks := ts.Tasks()
@@ -432,6 +432,7 @@ func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 		//     install2  <- install3 (added)
 		downloadStart, downloadLast, installFirst, installLast := extractDownloadInstallEdgesFromTs(ts)
 		if prevDownload != nil {
+			// XXX: we don't strictly need to serialize the download
 			downloadStart.WaitFor(prevDownload)
 		}
 		if prevInstall != nil {
@@ -447,7 +448,7 @@ func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 	}
 	// Make sure the first install waits for the last download. With this
 	// our (simplified) wait chain looks like:
-	// download1 <- verify1 <- download2 <- verify2 <- install1 <- install2
+	// download1 <- verify1 <- download2 <- verify2 <- download3 <- verify3 <- install1 <- install2 <- install3
 	firstInstallInChain.WaitFor(lastDownloadInChain)
 
 	// Set the new model assertion - this *must* be the last thing done

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3125,13 +3125,21 @@ func makeModelAssertion(c *C, brandSigning *assertstest.SigningDB, modelExtra ma
 	return model.(*asserts.Model)
 }
 
+// byReadyTime sorts a list of tasks by their "ready" time
+type byReadyTime []*state.Task
+
+func (a byReadyTime) Len() int           { return len(a) }
+func (a byReadyTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byReadyTime) Less(i, j int) bool { return a[i].ReadyTime().Before(a[j].ReadyTime()) }
+
 func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
-	// make "foo" snap available in the store
-	ms.prereqSnapAssertions(c)
-	snapYamlContent := `name: foo
-version: 1.0`
-	snapPath, _ := ms.makeStoreTestSnap(c, snapYamlContent, "42")
-	ms.serveSnap(snapPath, "42")
+	for _, name := range []string{"foo", "bar", "baz"} {
+		ms.prereqSnapAssertions(c, map[string]interface{}{
+			"snap-name": name,
+		})
+		snapPath, _ := ms.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", name), "1")
+		ms.serveSnap(snapPath, "1")
+	}
 
 	mockServer := ms.mockStore(c)
 	defer mockServer.Close()
@@ -3164,16 +3172,18 @@ version: 1.0`
 
 	// create a new model
 	newModel := makeModelAssertion(c, brandSigning, map[string]interface{}{
-		"required-snaps": []interface{}{"foo"},
+		"required-snaps": []interface{}{"foo", "bar", "baz"},
 		"revision":       "1",
 	})
 
 	tss, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")
-	c.Check(tss, HasLen, 2)
+	c.Check(tss, HasLen, 4)
 	chg.AddAll(tss[0])
 	chg.AddAll(tss[1])
+	chg.AddAll(tss[2])
+	chg.AddAll(tss[3])
 
 	st.Unlock()
 	err = ms.o.Settle(settleTimeout)
@@ -3184,8 +3194,46 @@ version: 1.0`
 
 	info, err := snapstate.CurrentInfo(st, "foo")
 	c.Assert(err, IsNil)
-	c.Check(info.Revision, Equals, snap.R(42))
+	c.Check(info.Revision, Equals, snap.R(1))
 	c.Check(info.Version, Equals, "1.0")
+
+	// ensure sorting is correct
+	tasks := chg.Tasks()
+	sort.Sort(byReadyTime(tasks))
+
+	var i int
+	// first all downloads/checks in sequential order
+	for _, name := range []string{"foo", "bar", "baz"} {
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Ensure prerequisites for "%s" are available`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Download snap "%s" (1) from channel "stable"`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Fetch and check assertions for snap "%s" (1)`, name))
+		i++
+	}
+	// then all installs in sequential order
+	for _, name := range []string{"foo", "bar", "baz"} {
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Mount snap "%s" (1)`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Copy snap "%s" data`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup snap "%s" (1) security profiles`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Make snap "%s" (1) available to the system`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Automatically connect eligible plugs and slots of snap "%s"`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Set automatic aliases for snap "%s"`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Setup snap "%s" aliases`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Run install hook of "%s" snap if present`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Start snap "%s" (1) services`, name))
+		i++
+		c.Check(tasks[i].Summary(), Equals, fmt.Sprintf(`Run configure hook of "%s" snap if present`, name))
+		i++
+	}
 }
 
 func (ms *mgrsSuite) TestRemodelDifferentBase(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -59,7 +59,7 @@ const (
 	UseConfigDefaults
 )
 
-var (
+const (
 	DownloadAndChecksDoneEdge = state.TaskSetEdge("download-and-checks-done")
 )
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -59,6 +59,10 @@ const (
 	UseConfigDefaults
 )
 
+var (
+	DownloadAndChecksDoneEdge = state.TaskSetEdge("download-and-checks-done")
+)
+
 func isParallelInstallable(snapsup *SnapSetup) error {
 	if snapsup.InstanceKey == "" {
 		return nil
@@ -158,9 +162,10 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	}
 	prev = prepare
 
+	var checkAsserts *state.Task
 	if fromStore {
 		// fetch and check assertions
-		checkAsserts := st.NewTask("validate-snap", fmt.Sprintf(i18n.G("Fetch and check assertions for snap %q%s"), snapsup.InstanceName(), revisionStr))
+		checkAsserts = st.NewTask("validate-snap", fmt.Sprintf(i18n.G("Fetch and check assertions for snap %q%s"), snapsup.InstanceName(), revisionStr))
 		addTask(checkAsserts)
 		prev = checkAsserts
 	}
@@ -306,6 +311,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	installSet := state.NewTaskSet(tasks...)
 	installSet.WaitAll(ts)
 	ts.AddAll(installSet)
+	if checkAsserts != nil {
+		ts.MarkEdge(checkAsserts, DownloadAndChecksDoneEdge)
+	}
 
 	if flags&skipConfigure != 0 {
 		return installSet, nil

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -466,6 +466,9 @@ func (t *Task) At(when time.Time) {
 }
 
 // TaskSetEdge designates tasks inside a TaskSet for outside reference.
+//
+// This is useful to give tasks inside TaskSets a special meaning. It
+// is used to mark e.g. the last task used for downloading a snap.
 type TaskSetEdge string
 
 // A TaskSet holds a set of tasks.
@@ -477,10 +480,11 @@ type TaskSet struct {
 
 // NewTaskSet returns a new TaskSet comprising the given tasks.
 func NewTaskSet(tasks ...*Task) *TaskSet {
+	// we init all members of TaskSet so that `go vet` will not complain
 	return &TaskSet{tasks, nil}
 }
 
-// Edge returns the task marked with the given TaskSetEdge.
+// Edge returns the task marked with the given edge name.
 func (ts TaskSet) Edge(e TaskSetEdge) *Task {
 	return ts.edges[e]
 }
@@ -511,7 +515,8 @@ func (ts *TaskSet) AddTask(task *Task) {
 	ts.tasks = append(ts.tasks, task)
 }
 
-// MarkEdge marks the given task as a specific edge.
+// MarkEdge marks the given task as a specific edge. Any pre-existing
+// edge mark will be overriden.
 func (ts *TaskSet) MarkEdge(task *Task, edge TaskSetEdge) {
 	if ts.edges == nil {
 		ts.edges = make(map[TaskSetEdge]*Task)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -516,7 +516,7 @@ func (ts *TaskSet) AddTask(task *Task) {
 }
 
 // MarkEdge marks the given task as a specific edge. Any pre-existing
-// edge mark will be overriden.
+// edge mark will be overridden.
 func (ts *TaskSet) MarkEdge(task *Task, edge TaskSetEdge) {
 	if ts.edges == nil {
 		ts.edges = make(map[TaskSetEdge]*Task)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -465,14 +465,24 @@ func (t *Task) At(when time.Time) {
 	}
 }
 
+// TaskSetEdge allows marking tasks inside a TaskSet
+type TaskSetEdge string
+
 // A TaskSet holds a set of tasks.
 type TaskSet struct {
 	tasks []*Task
+
+	edges map[TaskSetEdge]*Task
 }
 
 // NewTaskSet returns a new TaskSet comprising the given tasks.
 func NewTaskSet(tasks ...*Task) *TaskSet {
-	return &TaskSet{tasks}
+	return &TaskSet{tasks, nil}
+}
+
+// Edge returns the task marked with the given TaskSetEdge
+func (ts TaskSet) Edge(e TaskSetEdge) *Task {
+	return ts.edges[e]
 }
 
 // WaitFor registers a task as a requirement for the tasks in the set
@@ -499,6 +509,14 @@ func (ts *TaskSet) AddTask(task *Task) {
 		}
 	}
 	ts.tasks = append(ts.tasks, task)
+}
+
+// MarkEdge marks the given task as a specific edge
+func (ts *TaskSet) MarkEdge(task *Task, edge TaskSetEdge) {
+	if ts.edges == nil {
+		ts.edges = make(map[TaskSetEdge]*Task)
+	}
+	ts.edges[edge] = task
 }
 
 // AddAll adds all the tasks in the argument set to the target set ts.

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -465,7 +465,7 @@ func (t *Task) At(when time.Time) {
 	}
 }
 
-// TaskSetEdge allows marking tasks inside a TaskSet
+// TaskSetEdge designates tasks inside a TaskSet for outside reference.
 type TaskSetEdge string
 
 // A TaskSet holds a set of tasks.
@@ -480,7 +480,7 @@ func NewTaskSet(tasks ...*Task) *TaskSet {
 	return &TaskSet{tasks, nil}
 }
 
-// Edge returns the task marked with the given TaskSetEdge
+// Edge returns the task marked with the given TaskSetEdge.
 func (ts TaskSet) Edge(e TaskSetEdge) *Task {
 	return ts.edges[e]
 }
@@ -511,7 +511,7 @@ func (ts *TaskSet) AddTask(task *Task) {
 	ts.tasks = append(ts.tasks, task)
 }
 
-// MarkEdge marks the given task as a specific edge
+// MarkEdge marks the given task as a specific edge.
 func (ts *TaskSet) MarkEdge(task *Task, edge TaskSetEdge) {
 	if ts.edges == nil {
 		ts.edges = make(map[TaskSetEdge]*Task)
@@ -526,7 +526,7 @@ func (ts *TaskSet) AddAll(anotherTs *TaskSet) {
 	}
 }
 
-// JoinLane adds all the tasks in the current taskset to the given lane
+// JoinLane adds all the tasks in the current taskset to the given lane.
 func (ts *TaskSet) JoinLane(lane int) {
 	for _, t := range ts.tasks {
 		t.JoinLane(lane)

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -546,3 +546,36 @@ func (ts *taskSuite) TestLanes(c *C) {
 	t.JoinLane(2)
 	c.Assert(t.Lanes(), DeepEquals, []int{1, 2})
 }
+
+func (cs *taskSuite) TestTaskSetEdge(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	// setup an example taskset
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("verify", "2...")
+	t3 := st.NewTask("install", "3...")
+	ts := state.NewTaskSet(t1, t2, t3)
+
+	// edges are just typed strings
+	edge1 := state.TaskSetEdge("on-edge")
+	edge2 := state.TaskSetEdge("eddie")
+
+	// no edge marked yet
+	c.Assert(ts.Edge(edge1), IsNil)
+	c.Assert(ts.Edge(edge2), IsNil)
+
+	// one edge
+	ts.MarkEdge(t1, edge1)
+	c.Assert(ts.Edge(edge1), Equals, t1)
+
+	// two edges
+	ts.MarkEdge(t2, edge2)
+	c.Assert(ts.Edge(edge1), Equals, t1)
+	c.Assert(ts.Edge(edge2), Equals, t2)
+
+	// edges can be reassigned
+	ts.MarkEdge(t3, edge1)
+	c.Assert(ts.Edge(edge1), Equals, t3)
+}


### PR DESCRIPTION
For remodel we cannot assume that we have network access during
the operation. Some remodeling may switch to a different way of
managing the network or similar. This means we need to order the
wait chains in the remodel task so that all downloads and checks
for assertions happen first and the actual install operations
(that do not require network) happen after this.

This PR implements this by taking the TaskSet from Install() or
Update() and marking the "check-assertions" task with a new
TaskEdge marker. This way devicestate can split the taskset on
this marker and adjust the wait chains accordingly.
