### PR TITLE
cmd/snap-confine: make sc_args helpers const-correct

### DIFF
--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -214,7 +214,7 @@ void sc_cleanup_args(struct sc_args **ptr)
 	*ptr = NULL;
 }
 
-bool sc_args_is_version_query(struct sc_args *args)
+bool sc_args_is_version_query(const struct sc_args *args)
 {
 	if (args == NULL) {
 		die("cannot obtain version query flag from NULL argument parser");
@@ -222,7 +222,7 @@ bool sc_args_is_version_query(struct sc_args *args)
 	return args->is_version_query;
 }
 
-bool sc_args_is_classic_confinement(struct sc_args * args)
+bool sc_args_is_classic_confinement(const struct sc_args * args)
 {
 	if (args == NULL) {
 		die("cannot obtain classic confinement flag from NULL argument parser");
@@ -230,7 +230,7 @@ bool sc_args_is_classic_confinement(struct sc_args * args)
 	return args->is_classic_confinement;
 }
 
-const char *sc_args_security_tag(struct sc_args *args)
+const char *sc_args_security_tag(const struct sc_args *args)
 {
 	if (args == NULL) {
 		die("cannot obtain security tag from NULL argument parser");
@@ -238,7 +238,7 @@ const char *sc_args_security_tag(struct sc_args *args)
 	return args->security_tag;
 }
 
-const char *sc_args_executable(struct sc_args *args)
+const char *sc_args_executable(const struct sc_args *args)
 {
 	if (args == NULL) {
 		die("cannot obtain executable from NULL argument parser");
@@ -246,7 +246,7 @@ const char *sc_args_executable(struct sc_args *args)
 	return args->executable;
 }
 
-const char *sc_args_base_snap(struct sc_args *args)
+const char *sc_args_base_snap(const struct sc_args *args)
 {
 	if (args == NULL) {
 		die("cannot obtain base snap name from NULL argument parser");

--- a/cmd/snap-confine/snap-confine-args.h
+++ b/cmd/snap-confine/snap-confine-args.h
@@ -84,12 +84,12 @@ void sc_cleanup_args(struct sc_args **ptr);
 /**
  * Check if snap-confine was invoked with the --version switch.
  **/
-bool sc_args_is_version_query(struct sc_args *args);
+bool sc_args_is_version_query(const struct sc_args *args);
 
 /**
  * Check if snap-confine was invoked with the --classic switch.
  **/
-bool sc_args_is_classic_confinement(struct sc_args *args);
+bool sc_args_is_classic_confinement(const struct sc_args *args);
 
 /**
  * Get the security tag passed to snap-confine.
@@ -100,7 +100,7 @@ bool sc_args_is_classic_confinement(struct sc_args *args);
  * The return value must not be freed(). It is bound to the lifetime of
  * the argument parser.
  **/
-const char *sc_args_security_tag(struct sc_args *args);
+const char *sc_args_security_tag(const struct sc_args *args);
 
 /**
  * Get the executable name passed to snap-confine.
@@ -111,7 +111,7 @@ const char *sc_args_security_tag(struct sc_args *args);
  * The return value must not be freed(). It is bound to the lifetime of
  * the argument parser.
  **/
-const char *sc_args_executable(struct sc_args *args);
+const char *sc_args_executable(const struct sc_args *args);
 
 /**
  * Get the name of the base snap to use.
@@ -119,6 +119,6 @@ const char *sc_args_executable(struct sc_args *args);
  * The return value must not be freed(). It is bound to the lifetime of
  * the argument parser.
  **/
-const char *sc_args_base_snap(struct sc_args *args);
+const char *sc_args_base_snap(const struct sc_args *args);
 
 #endif


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
