### PR TITLE
cmd/snap-confine: drop unused dependency on libseccomp

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -224,6 +224,10 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/mount-support.h \
 	snap-confine/ns-support.c \
 	snap-confine/ns-support.h \
+	snap-confine/seccomp-support-ext.c \
+	snap-confine/seccomp-support-ext.h \
+	snap-confine/seccomp-support.c \
+	snap-confine/seccomp-support.h \
 	snap-confine/snap-confine-args.c \
 	snap-confine/snap-confine-args.h \
 	snap-confine/snap-confine.c \
@@ -262,20 +266,6 @@ snap-confine/snap-confine$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_confine_snap_con
 # https://en.opensuse.org/openSUSE:Packaging_checks#non-position-independent-executable
 snap_confine_snap_confine_CFLAGS += $(SUID_CFLAGS)
 snap_confine_snap_confine_LDFLAGS += $(SUID_LDFLAGS)
-
-if SECCOMP
-snap_confine_snap_confine_SOURCES += \
-	snap-confine/seccomp-support-ext.c \
-	snap-confine/seccomp-support-ext.h \
-	snap-confine/seccomp-support.c \
-	snap-confine/seccomp-support.h
-snap_confine_snap_confine_CFLAGS += $(SECCOMP_CFLAGS)
-if STATIC_LIBSECCOMP
-snap_confine_snap_confine_STATIC += $(shell $(PKG_CONFIG) --static --libs libseccomp)
-else
-snap_confine_snap_confine_extra_libs += $(SECCOMP_LIBS)
-endif  # STATIC_LIBSECCOMP
-endif  # SECCOMP
 
 if APPARMOR
 snap_confine_snap_confine_CFLAGS += $(APPARMOR_CFLAGS)

--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -33,7 +33,7 @@ case "$ID" in
 		extra_opts="--libexecdir=/usr/lib/snapd"
 		;;
 	ubuntu)
-		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
 		if [ "$(dpkg-architecture -qDEB_HOST_ARCH)" = "amd64" ]; then
 			extra_opts="$extra_opts --with-host-arch-32bit-triplet=$(dpkg-architecture -ai386 -qDEB_HOST_MULTIARCH)"
 		fi

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -64,32 +64,13 @@ AC_ARG_ENABLE([apparmor],
     esac], [enable_apparmor=yes])
 AM_CONDITIONAL([APPARMOR], [test "x$enable_apparmor" = "xyes"])
 
-# Allow to build without seccomp support by calling:
-# ./configure --disable-seccomp
-# This is separate because seccomp support is generally very good and it
-# provides useful confinement for unsafe system calls.
-AC_ARG_ENABLE([seccomp],
-    AS_HELP_STRING([--disable-seccomp], [Disable seccomp support]),
-    [case "${enableval}" in
-        yes) enable_seccomp=yes ;;
-        no)  enable_seccomp=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --disable-seccomp])
-    esac], [enable_seccomp=yes])
-AM_CONDITIONAL([SECCOMP], [test "x$enable_seccomp" = "xyes"])
-
 # Enable older tests only when confinement is enabled and we're building for PC
 # The tests are of smaller value as we port more and more tests to spread.
-AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_apparmor" = "xyes" && test "x$enable_seccomp" = "xyes" && ((test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686"))])
+AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_apparmor" = "xyes" && ((test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686"))])
 
 # Check for glib that we use for unit testing
 AS_IF([test "x$with_unit_tests" = "xyes"], [
     PKG_CHECK_MODULES([GLIB], [glib-2.0])
-])
-
-# Check if seccomp userspace library is available
-AS_IF([test "x$enable_seccomp" = "xyes"], [
-    PKG_CHECK_MODULES([SECCOMP], [libseccomp], [
-      AC_DEFINE([HAVE_SECCOMP], [1], [Build with seccomp support])])
 ])
 
 # Check if apparmor userspace library is available.
@@ -199,15 +180,6 @@ AC_ARG_ENABLE([static-libapparmor],
         *) AC_MSG_ERROR([bad value ${enableval} for --enable-static-libapparmor])
     esac], [enable_static_libapparmor=no])
 AM_CONDITIONAL([STATIC_LIBAPPARMOR], [test "x$enable_static_libapparmor" = "xyes"])
-
-AC_ARG_ENABLE([static-libseccomp],
-    AS_HELP_STRING([--enable-static-libseccomp], [Link libseccomp statically]),
-    [case "${enableval}" in
-        yes) enable_static_libseccomp=yes ;;
-        no)  enable_static_libseccomp=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --enable-static-libseccomp])
-    esac], [enable_static_libseccomp=no])
-AM_CONDITIONAL([STATIC_LIBSECCOMP], [test "x$enable_static_libseccomp" = "xyes"])
 
 LIB32_DIR="${prefix}/lib32"
 AC_ARG_WITH([32bit-libdir],

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -17,7 +17,6 @@
 #ifndef SNAP_CONFINE_SECCOMP_SUPPORT_H
 #define SNAP_CONFINE_SECCOMP_SUPPORT_H
 
-#include <seccomp.h>
 #include <stdbool.h>
 
 /** 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -38,15 +38,13 @@
 #include "../libsnap-confine-private/secure-getenv.h"
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/utils.h"
+#include "cookie-support.h"
 #include "mount-support.h"
 #include "ns-support.h"
+#include "seccomp-support.h"
+#include "snap-confine-args.h"
 #include "udev-support.h"
 #include "user-support.h"
-#include "cookie-support.h"
-#include "snap-confine-args.h"
-#ifdef HAVE_SECCOMP
-#include "seccomp-support.h"
-#endif				// ifdef HAVE_SECCOMP
 
 // sc_maybe_fixup_permissions fixes incorrect permissions
 // inside the mount namespace for /var/lib. Before 1ccce4
@@ -239,13 +237,11 @@ int main(int argc, char **argv)
 #endif
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 	sc_maybe_aa_change_onexec(aa, security_tag);
-#ifdef HAVE_SECCOMP
 	if (sc_apply_seccomp_profile_for_security_tag(security_tag)) {
 		/* If the process is not explicitly unconfined then load the global
 		 * profile as well. */
 		sc_apply_global_seccomp_profile();
 	}
-#endif				// ifdef HAVE_SECCOMP
 	if (snap_context != NULL) {
 		setenv("SNAP_COOKIE", snap_context, 1);
 		// for compatibility, if facing older snapd.

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -85,7 +85,7 @@ ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
     # for stability, predicability and easy of deployment. We need to link some
     # things dynamically though: udev has no stable IPC protocol between
     # libudev and udevd so we need to link with it dynamically.
-    VENDOR_ARGS=--enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp --with-host-arch-triplet=$(DEB_HOST_MULTIARCH)
+    VENDOR_ARGS=--enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --with-host-arch-triplet=$(DEB_HOST_MULTIARCH)
 ifeq ($(shell dpkg-architecture -qDEB_HOST_ARCH),amd64)
 		VENDOR_ARGS+= --with-host-arch-32bit-triplet=$(shell dpkg-architecture -f -ai386 -qDEB_HOST_MULTIARCH)
 endif


### PR DESCRIPTION
Historically snap-confine would use libseccomp to compile and attach a
seccomp profile on startup of each new snap application or hook.

For a number or releases however this has not been the case. Instead the
seccomp profile is compiled with snap-seccomp (which does link to
libseccomp) and is stored on disk in /var/lib/snapd/seccomp/bpf.  Since
the change all that snap-confine has do to is to load the compiled
profile from disk and pass it to a system call for attachment. Therefore
the whole dependency as well as the associated autoconf/automake
boilerplate can be discarded.

With this change we do exactly what we did before but in there is one
less variant of snap-confine that may be built that would require
testing.

packaging/ubuntu: stop passing --enable-static-libseccomp

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
