### PR TITLE
spread.yaml: bump delta reference

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -34,7 +34,7 @@ environment:
     SNAPD_CHANNEL: "$(HOST: echo ${SPREAD_SNAPD_CHANNEL:-edge})"
     REMOTE_STORE: "$(HOST: echo ${SPREAD_REMOTE_STORE:-production})"
     SNAPPY_USE_STAGING_STORE: "$(HOST: if [ $SPREAD_REMOTE_STORE = staging ]; then echo 1; else echo 0; fi)"
-    DELTA_REF: 2.32.5
+    DELTA_REF: 2.37.4
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PUBLISHED_VERSION: "$(HOST: echo $SPREAD_SNAPD_PUBLISHED_VERSION)"
     HTTP_PROXY: "$(HOST: echo $SPREAD_HTTP_PROXY)"


### PR DESCRIPTION
This aids in local testing as the delta sent to test VMs is smaller.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
