### PR TITLE
tests: add undo test with hanging stop command

### DIFF
--- a/tests/lib/snaps/test-snapd-service-v1-good/bin/good
+++ b/tests/lib/snaps/test-snapd-service-v1-good/bin/good
@@ -1,3 +1,7 @@
 #!/bin/sh
 
 echo "service v1"
+
+if [ -e "$SNAP_COMMON/should-fail" ]; then
+    exit 1
+fi

--- a/tests/lib/snaps/test-snapd-service-v3-very-bad/bin/bad
+++ b/tests/lib/snaps/test-snapd-service-v3-very-bad/bin/bad
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "service v3"
+touch "$SNAP_COMMON/should-fail"
+exit 1

--- a/tests/lib/snaps/test-snapd-service-v3-very-bad/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service-v3-very-bad/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-service
+version: 3.0
+apps:
+ service:
+  command: bin/bad
+  daemon: oneshot
+  restart-condition: never

--- a/tests/lib/snaps/test-snapd-service-v4-stop-hangs/bin/bad
+++ b/tests/lib/snaps/test-snapd-service-v4-stop-hangs/bin/bad
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "service v3"
+touch "$SNAP_COMMON/should-fail"
+exit 1

--- a/tests/lib/snaps/test-snapd-service-v4-stop-hangs/bin/hang
+++ b/tests/lib/snaps/test-snapd-service-v4-stop-hangs/bin/hang
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Hanging forever in stop"
+sleep 1h

--- a/tests/lib/snaps/test-snapd-service-v4-stop-hangs/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service-v4-stop-hangs/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-service
+version: 3.0
+apps:
+ service:
+  command: bin/bad
+  daemon: oneshot
+  restart-condition: never
+  stop-command: bin/hang

--- a/tests/main/refresh-undo-bad-snap/task.yaml
+++ b/tests/main/refresh-undo-bad-snap/task.yaml
@@ -1,0 +1,37 @@
+summary: Check that undo works even with broken services
+
+systems: [-ubuntu-14.04-*]
+
+environment:
+    SNAP_NAME: test-snapd-service
+    SNAP_NAME_GOOD: ${SNAP_NAME}-v1-good
+    SNAP_NAME_BAD: ${SNAP_NAME}-v3-very-bad
+    SNAP_FILE_GOOD: ${SNAP_NAME}_1.0_all.snap
+    SNAP_FILE_BAD: ${SNAP_NAME}_3.0_all.snap
+
+prepare: |
+    echo "Given a good (v1) and a bad (v2) snap"
+    snap pack "$TESTSLIB/snaps/$SNAP_NAME_GOOD"
+    snap pack "$TESTSLIB/snaps/$SNAP_NAME_BAD"
+
+debug: |
+    # shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB"/journalctl.sh
+    get_journalctl_log -u snap.test-snapd-service.service.service
+
+execute: |
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB"/systemd.sh
+
+    echo "When we install v1"
+    snap install --dangerous "${SNAP_FILE_GOOD}"
+    echo "The v1 service started correctly"
+    wait_for_service snap.test-snapd-service.service.service
+
+    echo "When we refresh to v3 it has a broken service and it breaks the previous service as well"
+    if snap install --dangerous "${SNAP_FILE_BAD}"; then
+       echo "The ${SNAP_FILE_BAD} snap should not install cleanly, test broken"
+       exit 1
+    fi
+    echo "and we are back to v1 (even though it is broken"
+    snap list $SNAP_NAME | grep 1.0

--- a/tests/main/refresh-undo-haning-stop-cmd/task.yaml
+++ b/tests/main/refresh-undo-haning-stop-cmd/task.yaml
@@ -1,0 +1,37 @@
+summary: Check that undo works even with a hanging stop command
+
+systems: [-ubuntu-14.04-*]
+
+environment:
+    SNAP_NAME: test-snapd-service
+    SNAP_NAME_GOOD: ${SNAP_NAME}-v1-good
+    SNAP_NAME_BAD: ${SNAP_NAME}-v4-stop-hangs
+    SNAP_FILE_GOOD: ${SNAP_NAME}_1.0_all.snap
+    SNAP_FILE_BAD: ${SNAP_NAME}_4.0_all.snap
+
+prepare: |
+    echo "Given a good (v1) and a bad (v2) snap"
+    snap pack "$TESTSLIB/snaps/$SNAP_NAME_GOOD"
+    snap pack "$TESTSLIB/snaps/$SNAP_NAME_BAD"
+
+debug: |
+    # shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB"/journalctl.sh
+    get_journalctl_log -u snap.test-snapd-service.service.service
+
+execute: |
+    #shellcheck source=tests/lib/systemd.sh
+    . "$TESTSLIB"/systemd.sh
+
+    echo "When we install v1"
+    snap install --dangerous "${SNAP_FILE_GOOD}"
+    echo "The v1 service started correctly"
+    wait_for_service snap.test-snapd-service.service.service
+
+    echo "When we refresh to v4 it has a hanging stop-command that hangs"
+    if snap install --dangerous "${SNAP_FILE_BAD}"; then
+       echo "The ${SNAP_FILE_BAD} snap should not install cleanly, test broken"
+       exit 1
+    fi
+    echo "Then v3 is rolled back and v1 is started again"
+    wait_for_service snap.test-snapd-service.service.service

--- a/tests/main/refresh-undo/task.yaml
+++ b/tests/main/refresh-undo/task.yaml
@@ -30,7 +30,7 @@ execute: |
             # retry
             retries=$((retries+1))
             if [ $retries -gt 30 ]; then
-                echo 'expected "service v1" output did not appear in systemctl status snap.test-snapd-service.service.service'
+                echo "expected \"$1\" output did not appear in systemctl status snap.test-snapd-service.service.service"
                 exit 1
             fi
             sleep 1


### PR DESCRIPTION
While debugging a hanging change I noticed that we lack some tests
related to the undo handling of bad services. This PR adds two
new tests:
1. A snap where the new snap service is broken and the refresh breaks
   the old snap service as well
2. A snap where the stop command takes forever
