### PR TITLE
interfaces/apparmor: partial confinement on openSUSE

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -494,10 +494,12 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 func downgradeConfinement() bool {
 	kver := osutil.KernelVersion()
 	switch {
+	// As a special exception, for openSUSE when the kernel package is
+	// at least Linux 4.16, do not downgrade the confinement template.
+	case release.DistroLike("opensuse"):
+		fallthrough
 	case release.DistroLike("opensuse-tumbleweed"):
 		if cmp, _ := strutil.VersionCompare(kver, "4.16"); cmp >= 0 {
-			// As a special exception, for openSUSE Tumbleweed which ships Linux
-			// 4.16, do not downgrade the confinement template.
 			return false
 		}
 	case release.DistroLike("arch", "archlinux"):

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -647,6 +647,20 @@ func (s *backendSuite) TestCombineSnippetsOpenSUSETumbleweedOldKernel(c *C) {
 	c.Check(profile, testutil.FileEquals, "\n#classic"+commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\n\n}\n")
 }
 
+// On openSUSE Leap partial apparmor support doesn't change apparmor template to classic.
+// Strict confinement template, along with snippets, are used.
+func (s *backendSuite) TestCombineSnippetsOpenSUSELeap(c *C) {
+	restore := mockPartalAppArmorOnDistro(c, "4.16-10-1-default", "opensuse")
+	defer restore()
+	s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+		spec.AddSnippet("snippet")
+		return nil
+	}
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+	c.Check(profile, testutil.FileEquals, commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n")
+}
+
 func (s *backendSuite) TestCombineSnippetsArchOldIDSufficientHardened(c *C) {
 	restore := mockPartalAppArmorOnDistro(c, "4.18.2.a-1-hardened", "arch", "archlinux")
 	defer restore()


### PR DESCRIPTION
Historically snapd would fallback to "forced devmode", which is like
applying a very open and permissive confinement to all the systems that
do not implement full confinement. This is due to inability, at the
time, of ancient apparmor userspace, to even parse and compile the
regular snapd security template.

Over time we started allowing use of true partial confinement, that is
without the degradation to classic template, on openSUSE Tumblweed. That
distribution was selected due to its rolling nature and the fact that
up-to-date apparmor userspace and kernel was available.

Since Tumbleweed is used to build the rest of the SUSE family and the
required changes have since migrated to LEAP releases we can now extend
the fallback to handle both openSUSE (aka LEAP) as well as openSUSE
Tumbleweed, given the kernel version is recent enough.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
