### PR TITLE
daemon: support returning assertion information as JSON with the "json" query parameter

### DIFF
--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -83,13 +83,16 @@ func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response
 	for k := range q {
 		if k == "json" {
 			switch q.Get(k) {
-			case "true":
+			case "false":
+				jsonResult = false
 			case "headers":
 				headersOnly = true
+				fallthrough
+			case "true":
+				jsonResult = true
 			default:
 				return BadRequest(`"json" query parameter when used must be set to "true" or "headers"`)
 			}
-			jsonResult = true
 			continue
 		}
 		headers[k] = q.Get(k)
@@ -116,9 +119,7 @@ func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response
 				assertsJSON[i].Body = string(assertions[i].Body())
 			}
 		}
-		return SyncResponse(map[string]interface{}{
-			"assertions": assertsJSON,
-		}, nil)
+		return SyncResponse(assertsJSON, nil)
 	}
 
 	return AssertResponse(assertions, true)

--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -21,10 +21,12 @@ package daemon_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 
 	"gopkg.in/check.v1"
 
@@ -265,4 +267,160 @@ func (s *assertsSuite) TestAssertsInvalidType(c *check.C) {
 	// Verify
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rec.Body.String(), testutil.Contains, "invalid assert type")
+}
+
+func (s *assertsSuite) TestAssertsFindManyJSONFilter(c *check.C) {
+	st := s.o.State()
+	// add store key
+	daemon.AssertAdd(st, s.storeSigning.StoreAccountKey(""))
+
+	acct := assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
+	daemon.AssertAdd(st, acct)
+
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account?json=true&username=developer1", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Assert(err, check.IsNil)
+	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+		"assertions": []interface{}{
+			map[string]interface{}{
+				"headers": acct.Headers(),
+			},
+		},
+	})
+}
+
+func (s *assertsSuite) TestAssertsFindManyJSONNoResults(c *check.C) {
+	st := s.o.State()
+	// add store key
+	daemon.AssertAdd(st, s.storeSigning.StoreAccountKey(""))
+
+	acct := assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
+	daemon.AssertAdd(st, acct)
+
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account?json=true&username=xyz", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Assert(err, check.IsNil)
+	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+		"assertions": []interface{}{},
+	})
+}
+
+func (s *assertsSuite) TestAssertsFindManyJSONWithBody(c *check.C) {
+	st := s.o.State()
+	// add store key
+	daemon.AssertAdd(st, s.storeSigning.StoreAccountKey(""))
+
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account-key?json=true", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account-key"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+
+	var got []string
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Assert(err, check.IsNil)
+	for _, a := range body["result"].(map[string]interface{})["assertions"].([]interface{}) {
+		h := a.(map[string]interface{})["headers"].(map[string]interface{})
+		got = append(got, h["account-id"].(string)+"/"+h["name"].(string))
+		// check body
+		l, err := strconv.Atoi(h["body-length"].(string))
+		c.Assert(err, check.IsNil)
+		c.Check(a.(map[string]interface{})["body"], check.HasLen, l)
+	}
+	sort.Strings(got)
+	c.Check(got, check.DeepEquals, []string{"can0nical/root", "can0nical/store", "canonical/root", "generic/models"})
+}
+
+func (s *assertsSuite) TestAssertsFindManyJSONHeadersOnly(c *check.C) {
+	st := s.o.State()
+	// add store key
+	daemon.AssertAdd(st, s.storeSigning.StoreAccountKey(""))
+
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account-key?json=headers&account-id=can0nical", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account-key"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+
+	var got []string
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Assert(err, check.IsNil)
+	for _, a := range body["result"].(map[string]interface{})["assertions"].([]interface{}) {
+		h := a.(map[string]interface{})["headers"].(map[string]interface{})
+		got = append(got, h["account-id"].(string)+"/"+h["name"].(string))
+		// check body absent
+		_, ok := a.(map[string]interface{})["body"]
+		c.Assert(ok, check.Equals, false)
+	}
+	sort.Strings(got)
+	c.Check(got, check.DeepEquals, []string{"can0nical/root", "can0nical/store"})
+}
+
+func (s *assertsSuite) TestAssertsFindManyJSONInvalidParam(c *check.C) {
+	st := s.o.State()
+	// add store key
+	daemon.AssertAdd(st, s.storeSigning.StoreAccountKey(""))
+
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account-key?json=header&account-id=can0nical", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account-key"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 400, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+
+	var rsp daemon.Resp
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
+		"message": `"json" query parameter when used must be set to "true" or "headers"`,
+	})
 }


### PR DESCRIPTION
"json" can be set to:

* "true":  return  both headers and body (but not the signature, it couldn't be easily checked anyway)
* "headers":  return just headers
* "false"/absent  use assertion format

Why don't use "Accept":

* nothing uses it in v2 so far, this endpoint has so far ignored it so it would be a risky change. something to consider for v3
* it's really returning just a subset of the assertion(s) in "json" mode
* also it uses our normal result format so it wouldn't match anyway what the store does when asked for json with Accept for an assertion

Mixing "json"  with the other query param is slightly unfortunate OTOH we should have't an assertion header just called "json", that's bad form too.

