### PR TITLE
daemon/api: filter connections with hotplug-gone=true

### DIFF
--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -122,7 +122,7 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 	connsjson.Slots = make([]*slotJSON, 0, len(ifaces.Slots))
 
 	for crefStr, cstate := range connStates {
-		if cstate.Undesired && filter.connected {
+		if (cstate.Undesired && filter.connected) || cstate.HotplugGone {
 			continue
 		}
 		cref, err := interfaces.ParseConnRef(crefStr)

--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -122,9 +122,14 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 	connsjson.Slots = make([]*slotJSON, 0, len(ifaces.Slots))
 
 	for crefStr, cstate := range connStates {
-		if (cstate.Undesired && filter.connected) || cstate.HotplugGone {
+		if cstate.Undesired && filter.connected {
 			continue
 		}
+		if cstate.HotplugGone {
+			// XXX: hotplug connection - the device and slot are gone
+			continue
+		}
+
 		cref, err := interfaces.ParseConnRef(crefStr)
 		if err != nil {
 			return nil, err

--- a/daemon/api_connections_test.go
+++ b/daemon/api_connections_test.go
@@ -794,6 +794,32 @@ func (s *apiSuite) TestConnectionsOnlyUndesired(c *check.C) {
 	})
 }
 
+func (s *apiSuite) TestConnectionsHotplugGone(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	s.daemon(c)
+
+	s.mockSnap(c, consumerYaml)
+	s.mockSnap(c, producerYaml)
+
+	s.testConnectionsConnected(c, "/v2/connections", map[string]interface{}{
+		"consumer:plug producer:slot": map[string]interface{}{
+			"interface": "test",
+			"hotplug-gone": true,
+		},
+	}, map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs":       []interface{}{},
+			"slots":       []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
 func (s *apiSuite) TestConnectionsSorted(c *check.C) {
 	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer restore()

--- a/daemon/api_connections_test.go
+++ b/daemon/api_connections_test.go
@@ -805,7 +805,7 @@ func (s *apiSuite) TestConnectionsHotplugGone(c *check.C) {
 
 	s.testConnectionsConnected(c, "/v2/connections", map[string]interface{}{
 		"consumer:plug producer:slot": map[string]interface{}{
-			"interface": "test",
+			"interface":    "test",
 			"hotplug-gone": true,
 		},
 	}, map[string]interface{}{

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -101,7 +101,7 @@ func UpperCaseConnState() map[string]*connState {
 	}
 }
 
-func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.Connection, autoConnect, byGadget, undesired bool) {
+func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.Connection, autoConnect, byGadget, undesired, hotplugGone bool) {
 	connRef := &interfaces.ConnRef{
 		PlugRef: *conn.Plug.Ref(),
 		SlotRef: *conn.Slot.Ref(),
@@ -116,6 +116,7 @@ func UpdateConnectionInConnState(conns map[string]*connState, conn *interfaces.C
 		Auto:             autoConnect,
 		ByGadget:         byGadget,
 		Undesired:        undesired,
+		HotplugGone:      hotplugGone,
 	}
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -182,6 +182,7 @@ type ConnectionState struct {
 	DynamicPlugAttrs map[string]interface{}
 	StaticSlotAttrs  map[string]interface{}
 	DynamicSlotAttrs map[string]interface{}
+	HotplugGone      bool
 }
 
 // ConnectionStates return the state of connections tracked by the manager
@@ -204,6 +205,7 @@ func (m *InterfaceManager) ConnectionStates() (connStateByRef map[string]Connect
 			DynamicPlugAttrs: cstate.DynamicPlugAttrs,
 			StaticSlotAttrs:  cstate.StaticSlotAttrs,
 			DynamicSlotAttrs: cstate.DynamicSlotAttrs,
+			HotplugGone:      cstate.HotplugGone,
 		}
 	}
 	return connStateByRef, nil

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -4966,7 +4966,7 @@ func (s *interfaceManagerSuite) TestAttributesRestoredFromConns(c *C) {
 	c.Check(conn.Slot.Attr("number", &number), IsNil)
 	c.Check(number, Equals, int64(1))
 
-	var isAuto, byGadget, isUndesired,hotplugGone bool
+	var isAuto, byGadget, isUndesired, hotplugGone bool
 	ifacestate.UpdateConnectionInConnState(conns, conn, isAuto, byGadget, isUndesired, hotplugGone)
 	ifacestate.SetConns(st, conns)
 
@@ -6137,7 +6137,7 @@ func (s *interfaceManagerSuite) TestConnectionStatesHotplugGone(c *C) {
 	var isAuto, byGadget, isUndesired, hotplugGone bool = false, false, false, true
 	s.testConnectionStates(c, isAuto, byGadget, isUndesired, hotplugGone, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
-			Interface: "test",
+			Interface:   "test",
 			HotplugGone: true,
 			StaticPlugAttrs: map[string]interface{}{
 				"attr1": "value1",

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -4966,8 +4966,8 @@ func (s *interfaceManagerSuite) TestAttributesRestoredFromConns(c *C) {
 	c.Check(conn.Slot.Attr("number", &number), IsNil)
 	c.Check(number, Equals, int64(1))
 
-	var isAuto, byGadget, isUndesired bool
-	ifacestate.UpdateConnectionInConnState(conns, conn, isAuto, byGadget, isUndesired)
+	var isAuto, byGadget, isUndesired,hotplugGone bool
+	ifacestate.UpdateConnectionInConnState(conns, conn, isAuto, byGadget, isUndesired, hotplugGone)
 	ifacestate.SetConns(st, conns)
 
 	// restore connection from conns state
@@ -6032,7 +6032,7 @@ func (s *interfaceManagerSuite) TestHotplugSeqWaitTasks(c *C) {
 	}
 }
 
-func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undesired bool, expected map[string]ifacestate.ConnectionState) {
+func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undesired, hotplugGone bool, expected map[string]ifacestate.ConnectionState) {
 	slotSnap := s.mockSnap(c, producerYaml)
 	plugSnap := s.mockSnap(c, consumerYaml)
 
@@ -6058,7 +6058,7 @@ func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undes
 		Plug: interfaces.NewConnectedPlug(plug, nil, dynamicPlugAttrs),
 		Slot: interfaces.NewConnectedSlot(slot, nil, dynamicSlotAttrs),
 	}
-	ifacestate.UpdateConnectionInConnState(sc, conn, auto, byGadget, undesired)
+	ifacestate.UpdateConnectionInConnState(sc, conn, auto, byGadget, undesired, hotplugGone)
 	ifacestate.SetConns(st, sc)
 	st.Unlock()
 
@@ -6069,8 +6069,8 @@ func (s *interfaceManagerSuite) testConnectionStates(c *C, auto, byGadget, undes
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
-	var isAuto, byGadget, isUndesired bool = true, false, false
-	s.testConnectionStates(c, isAuto, byGadget, isUndesired, map[string]ifacestate.ConnectionState{
+	var isAuto, byGadget, isUndesired, hotplugGone bool = true, false, false, false
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, hotplugGone, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
@@ -6090,8 +6090,8 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
-	var isAuto, byGadget, isUndesired bool = true, true, false
-	s.testConnectionStates(c, isAuto, byGadget, isUndesired, map[string]ifacestate.ConnectionState{
+	var isAuto, byGadget, isUndesired, hotplugGone bool = true, true, false, false
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, hotplugGone, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
@@ -6112,12 +6112,33 @@ func (s *interfaceManagerSuite) TestConnectionStatesGadget(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *C) {
-	var isAuto, byGadget, isUndesired bool = true, false, true
-	s.testConnectionStates(c, isAuto, byGadget, isUndesired, map[string]ifacestate.ConnectionState{
+	var isAuto, byGadget, isUndesired, hotplugGone bool = true, false, true, false
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, hotplugGone, map[string]ifacestate.ConnectionState{
 		"consumer:plug producer:slot": {
 			Interface: "test",
 			Auto:      true,
 			Undesired: true,
+			StaticPlugAttrs: map[string]interface{}{
+				"attr1": "value1",
+			},
+			DynamicPlugAttrs: map[string]interface{}{
+				"dynamic-number": int64(7),
+			},
+			StaticSlotAttrs: map[string]interface{}{
+				"attr2": "value2",
+			},
+			DynamicSlotAttrs: map[string]interface{}{
+				"other-number": int64(9),
+			},
+		}})
+}
+
+func (s *interfaceManagerSuite) TestConnectionStatesHotplugGone(c *C) {
+	var isAuto, byGadget, isUndesired, hotplugGone bool = false, false, false, true
+	s.testConnectionStates(c, isAuto, byGadget, isUndesired, hotplugGone, map[string]ifacestate.ConnectionState{
+		"consumer:plug producer:slot": {
+			Interface: "test",
+			HotplugGone: true,
 			StaticPlugAttrs: map[string]interface{}{
 				"attr1": "value1",
 			},


### PR DESCRIPTION
Filter out connections ("snap connections") that have hotplug-gone flag set - these are connections remembered in the state (but not in the repository), so that they can be restored if same device is plugged back in the future. This aspect was overlooked as critical bits of "snap connections" and hotplug landed at about the same time, so we didn't have proper test. The problem was exposed by #6491.