### PR TITLE
sandbox/seccomp: a helper package wrapping calls to snap-seccomp

### DIFF
--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -116,7 +116,6 @@ func (s *backendSuite) TestInstallingSnapWritesHookProfiles(c *C) {
 }
 
 func (s *backendSuite) TestInstallingSnapWritesProfilesWithReexec(c *C) {
-
 	restore := seccomp.MockOsReadlink(func(string) (string, error) {
 		// simulate that we run snapd from core
 		return filepath.Join(dirs.SnapMountDir, "core/42/usr/lib/snapd/snapd"), nil

--- a/interfaces/seccomp/export_test.go
+++ b/interfaces/seccomp/export_test.go
@@ -77,6 +77,14 @@ func MockReleaseInfoVersionId(s string) (restore func()) {
 	}
 }
 
+func MockSeccompCompilerLookup(f func(string) (string, error)) (restore func()) {
+	old := seccompCompilerLookup
+	seccompCompilerLookup = f
+	return func() {
+		seccompCompilerLookup = old
+	}
+}
+
 var (
 	RequiresSocketcall = requiresSocketcall
 

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -54,6 +54,9 @@ func (c *Compiler) VersionInfo() (string, error) {
 		return "", osutil.OutputErr(output, err)
 	}
 	raw := bytes.TrimSpace(output)
+	// Example valid output:
+	// 7ac348ac9c934269214b00d1692dfa50d5d4a157 2.3.3 03e996919907bc7163bc83b95bca0ecab31300f20dfa365ea14047c698340e7c
+	// 111 chars + wiggle room
 	if len(raw) > 120 {
 		return "", fmt.Errorf("invalid version-info length: %q", raw)
 	}

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -39,8 +39,19 @@ type Compiler struct {
 	snapSeccomp string
 }
 
-func NewAtPath(path string) *Compiler {
-	return &Compiler{snapSeccomp: path}
+// New returns a wrapper for the compiler binary. The path to the binary is
+// looked up using the lookupTool helper.
+func New(lookupTool func(name string) (string, error)) (*Compiler, error) {
+	if lookupTool == nil {
+		panic("lookup tool func not provided")
+	}
+
+	path, err := lookupTool("snap-seccomp")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Compiler{snapSeccomp: path}, nil
 }
 
 // VersionInfo returns the version information of the compiler. The format of

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package seccomp
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+var (
+	// The format of version-info: <build-id> <libseccomp-version> <hash>
+	// Where, the hash is calculated over all syscall names supported by the
+	// libseccomp library.
+	// Ex: 7ac348ac9c934269214b00d1692dfa50d5d4a157 2.3.3 03e996919907bc7163bc83b95bca0ecab31300f20dfa365ea14047c698340e7c
+	validVersionInfo = regexp.MustCompile(`^[0-9a-f]+ [0-9]+\.[0-9]+\.[0-9]+ [0-9a-f]+$`)
+)
+
+type Compiler struct {
+	snapSeccomp string
+}
+
+func NewAtPath(path string) *Compiler {
+	return &Compiler{snapSeccomp: path}
+}
+
+// VersionInfo returns the version information of the compiler. The format of
+// version information is: <build-id> <libseccomp-version> <hash>. Where, the
+// hash is calculated over all syscall names supported by the libseccomp
+// library.
+func (c *Compiler) VersionInfo() (string, error) {
+	cmd := exec.Command(c.snapSeccomp, "version-info")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", osutil.OutputErr(output, err)
+	}
+	raw := bytes.TrimSpace(output)
+	if len(raw) > 120 {
+		return "", fmt.Errorf("invalid version-info length: %q", raw)
+	}
+	if match := validVersionInfo.Match(raw); !match {
+		return "", fmt.Errorf("invalid format of version-info: %q", raw)
+	}
+
+	return string(raw), nil
+}
+
+// Compile compiles given source profile and saves the result to the out
+// location.
+func (c *Compiler) Compile(in, out string) error {
+	cmd := exec.Command(c.snapSeccomp, "compile", in, out)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -1,0 +1,124 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package seccomp_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	seccomp "github.com/snapcore/snapd/sandbox/seccomp"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type compilerSuite struct{}
+
+var _ = Suite(&compilerSuite{})
+
+func TestSeccomp(t *testing.T) { TestingT(t) }
+
+func (s *compilerSuite) TestVersionInfoValidate(c *C) {
+
+	for i, tc := range []struct {
+		v   string
+		exp string
+		err string
+	}{
+		// valid
+		{"7ac348ac9c934269214b00d1692dfa50d5d4a157 2.3.3 03e996919907bc7163bc83b95bca0ecab31300f20dfa365ea14047c698340e7c", "7ac348ac9c934269214b00d1692dfa50d5d4a157 2.3.3 03e996919907bc7163bc83b95bca0ecab31300f20dfa365ea14047c698340e7c", ""},
+		{"abcdef 0.0.0 abcd", "abcdef 0.0.0 abcd", ""},
+
+		// invalid all the way down from here
+
+		// this is over the sane length limit
+		{"b27bacf755e589437c08c46f616d8531e6918dca44e575a597d93b538825b853 2.3.3 b27bacf755e589437c08c46f616d8531e6918dca44e575a597d93b538825b853", "", "invalid version-info length: .*"},
+		// incorrect format
+		{"abcd 0.0.0 fg", "", "invalid format of version-info: .*"},
+		{"ggg 0.0.0 abc", "", "invalid format of version-info: .*"},
+		{"foo", "", "invalid format of version-info: .*"},
+		{"1", "", "invalid format of version-info: .*"},
+		{"i\ncan\nhave\nnewlines", "", "invalid format of version-info: .*"},
+		{"# invalid", "", "invalid format of version-info: .*"},
+		{"-1", "", "invalid format of version-info: .*"},
+	} {
+		c.Logf("tc: %v", i)
+		cmd := testutil.MockCommand(c, "snap-seccomp", fmt.Sprintf("echo \"%s\"", tc.v))
+		compiler := seccomp.NewAtPath(cmd.Exe())
+
+		v, err := compiler.VersionInfo()
+		if tc.err != "" {
+			c.Check(err, ErrorMatches, tc.err)
+			c.Check(v, Equals, "")
+		} else {
+			c.Check(err, IsNil)
+			c.Check(v, Equals, tc.exp)
+		}
+		c.Check(cmd.Calls(), DeepEquals, [][]string{
+			{"snap-seccomp", "version-info"},
+		})
+		cmd.Restore()
+	}
+
+}
+
+func (s *compilerSuite) TestVersionInfoUnhappy(c *C) {
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
+if [ "$1" = "version-info" ]; then echo "unknown command version-info"; exit 1; fi
+exit 0
+`)
+	defer cmd.Restore()
+	compiler := seccomp.NewAtPath(cmd.Exe())
+
+	_, err := compiler.VersionInfo()
+	c.Assert(err, ErrorMatches, "unknown command version-info")
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"snap-seccomp", "version-info"},
+	})
+}
+
+func (s *compilerSuite) TestCompileEasy(c *C) {
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
+if [ "$1" = "compile" ]; then exit 0; fi
+exit 1
+`)
+	defer cmd.Restore()
+	compiler := seccomp.NewAtPath(cmd.Exe())
+
+	err := compiler.Compile("foo.src", "foo.bin")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"snap-seccomp", "compile", "foo.src", "foo.bin"},
+	})
+}
+
+func (s *compilerSuite) TestCompileUnhappy(c *C) {
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
+if [ "$1" = "compile" ]; then echo "i will not"; exit 1; fi
+exit 0
+`)
+	defer cmd.Restore()
+	compiler := seccomp.NewAtPath(cmd.Exe())
+
+	err := compiler.Compile("foo.src", "foo.bin")
+	c.Assert(err, ErrorMatches, "i will not")
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{"snap-seccomp", "compile", "foo.src", "foo.bin"},
+	})
+}


### PR DESCRIPTION
Another piece of #6485. The idea is to move all uses of  `os/exec.Command("snap-seccomp"..)` into a separate package for better maintainability and make the package importable without triggering cyclic dependencies.

Goes in hand with #6592 