### PR TITLE
spread: restore SELinux context when we mess with system files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -498,6 +498,10 @@ prepare: |
         echo "/etc/gai.conf is not writable, ubuntu-core system? apt update won't be affected in that case"
         rm -f gai.conf
     fi
+    if command -v restorecon ; then
+        # restore proper context otherwise SELinux may complain
+        restorecon -v /etc/gai.conf
+    fi
 
     if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
         # The Fedora archive mirror seems to be unreliable.


### PR DESCRIPTION
We drop a new version of /etc/gai.conf, first having created it in the $HOME
directory. The new file gets home_t or (home_root_t in this case) type.
Accessing of file with this by system daemons may be disallowed by the policy.

Occasionally, this would manifest as:
```
time->Wed Mar 13 10:05:18 2019
type=PROCTITLE msg=audit(1552471518.269:2577): proctitle=2F7573722F7362696E2F73736864002D44002D52
type=SYSCALL msg=audit(1552471518.269:2577): arch=c000003e syscall=2 success=no exit=-13
   a0=7f4d3001d2f8 a1=80000 a2=1b6 a3=24 items=0 ppid=3181 pid=23614
   auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0
   tty=(none) ses=4294967295 comm="sshd" exe="/usr/sbin/sshd"
   subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 key=(null)
type=AVC msg=audit(1552471518.269:2577): avc:  denied  { read } for  pid=23614
   comm="sshd" name="gai.conf" dev="sda1" ino=594389
   scontext=system_u:system_r:sshd_t:s0-s0:c0.c1023
   tcontext=unconfined_u:object_r:home_root_t:s0 tclass=file permissive=0
```