### PR TITLE
cmd/snap-update-ns: refactor of profile application (1/N)

### DIFF
--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -20,10 +20,18 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/osutil"
 )
 
-type CommonProfileUpdate struct{}
+type CommonProfileUpdate struct {
+	// instanceName is the name of the snap or instance to update.
+	instanceName string
+
+	currentProfilePath string
+	desiredProfilePath string
+}
 
 func (up *CommonProfileUpdate) Lock() (unlock func(), err error) {
 	return func() {}, nil
@@ -43,14 +51,28 @@ func (up *CommonProfileUpdate) PerformChange(change *Change, as *Assumptions) ([
 	return changePerform(change, as)
 }
 
+// LoadDesiredProfile loads the desired mount profile.
 func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
-	return nil, nil
+	profile, err := osutil.LoadMountProfile(up.desiredProfilePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load desired mount profile of snap %q: %s", up.instanceName, err)
+	}
+	return profile, nil
 }
 
+// LoadCurrentProfile loads the current mount profile.
 func (up *CommonProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
-	return nil, nil
+	profile, err := osutil.LoadMountProfile(up.currentProfilePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load current mount profile of snap %q: %s", up.instanceName, err)
+	}
+	return profile, nil
 }
 
+// SaveCurrentProfile saves the current mount profile.
 func (up *CommonProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	if err := profile.Save(up.currentProfilePath); err != nil {
+		return fmt.Errorf("cannot save current mount profile of snap %q: %s", up.instanceName, err)
+	}
 	return nil
 }

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -41,11 +41,6 @@ func (up *CommonProfileUpdate) Assumptions() *Assumptions {
 	return nil
 }
 
-// NeededChanges computes the sequence of mount changes needed to transform current profile to desired profile.
-func (up *CommonProfileUpdate) NeededChanges(current, desired *osutil.MountProfile) []*Change {
-	return NeededChanges(current, desired)
-}
-
 // LoadDesiredProfile loads the desired mount profile.
 func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	profile, err := osutil.LoadMountProfile(up.desiredProfilePath)

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -33,36 +33,36 @@ type CommonProfileUpdateContext struct {
 	desiredProfilePath string
 }
 
-func (up *CommonProfileUpdateContext) Lock() (unlock func(), err error) {
+func (ctx *CommonProfileUpdateContext) Lock() (unlock func(), err error) {
 	return func() {}, nil
 }
 
-func (up *CommonProfileUpdateContext) Assumptions() *Assumptions {
+func (ctx *CommonProfileUpdateContext) Assumptions() *Assumptions {
 	return nil
 }
 
 // LoadDesiredProfile loads the desired mount profile.
-func (up *CommonProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
-	profile, err := osutil.LoadMountProfile(up.desiredProfilePath)
+func (ctx *CommonProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
+	profile, err := osutil.LoadMountProfile(ctx.desiredProfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load desired mount profile of snap %q: %s", up.instanceName, err)
+		return nil, fmt.Errorf("cannot load desired mount profile of snap %q: %s", ctx.instanceName, err)
 	}
 	return profile, nil
 }
 
 // LoadCurrentProfile loads the current mount profile.
-func (up *CommonProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
-	profile, err := osutil.LoadMountProfile(up.currentProfilePath)
+func (ctx *CommonProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
+	profile, err := osutil.LoadMountProfile(ctx.currentProfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load current mount profile of snap %q: %s", up.instanceName, err)
+		return nil, fmt.Errorf("cannot load current mount profile of snap %q: %s", ctx.instanceName, err)
 	}
 	return profile, nil
 }
 
 // SaveCurrentProfile saves the current mount profile.
-func (up *CommonProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
-	if err := profile.Save(up.currentProfilePath); err != nil {
-		return fmt.Errorf("cannot save current mount profile of snap %q: %s", up.instanceName, err)
+func (ctx *CommonProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	if err := profile.Save(ctx.currentProfilePath); err != nil {
+		return fmt.Errorf("cannot save current mount profile of snap %q: %s", ctx.instanceName, err)
 	}
 	return nil
 }

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -46,7 +46,7 @@ func (up *TransitionalMountProfileUpdate) SaveCurrentProfile(profile *osutil.Mou
 }
 
 func (up *TransitionalMountProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
-	return nil
+	return NeededChanges(old, new)
 }
 
 func (up *TransitionalMountProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -46,11 +46,6 @@ func (up *CommonProfileUpdate) NeededChanges(current, desired *osutil.MountProfi
 	return NeededChanges(current, desired)
 }
 
-// PerformChange performs a given mount namespace change under given filesystem assumptions.
-func (up *CommonProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
-	return changePerform(change, as)
-}
-
 // LoadDesiredProfile loads the desired mount profile.
 func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	profile, err := osutil.LoadMountProfile(up.desiredProfilePath)

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -33,6 +33,14 @@ func (up *CommonProfileUpdate) Assumptions() *Assumptions {
 	return nil
 }
 
+func (up *CommonProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
+	return NeededChanges(old, new)
+}
+
+func (up *CommonProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
+	return changePerform(change, as)
+}
+
 func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	return nil, nil
 }
@@ -43,12 +51,4 @@ func (up *CommonProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error
 
 func (up *CommonProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
 	return nil
-}
-
-func (up *CommonProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
-	return NeededChanges(old, new)
-}
-
-func (up *CommonProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
-	return changePerform(change, as)
 }

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -50,5 +50,5 @@ func (up *TransitionalMountProfileUpdate) NeededChanges(old, new *osutil.MountPr
 }
 
 func (up *TransitionalMountProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
-	return nil, nil
+	return changePerform(change, as)
 }

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -23,32 +23,32 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-type TransitionalMountProfileUpdate struct{}
+type CommonProfileUpdate struct{}
 
-func (up *TransitionalMountProfileUpdate) Lock() (unlock func(), err error) {
+func (up *CommonProfileUpdate) Lock() (unlock func(), err error) {
 	return func() {}, nil
 }
 
-func (up *TransitionalMountProfileUpdate) Assumptions() *Assumptions {
+func (up *CommonProfileUpdate) Assumptions() *Assumptions {
 	return nil
 }
 
-func (up *TransitionalMountProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
+func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	return nil, nil
 }
 
-func (up *TransitionalMountProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
+func (up *CommonProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
 	return nil, nil
 }
 
-func (up *TransitionalMountProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
+func (up *CommonProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
 	return nil
 }
 
-func (up *TransitionalMountProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
+func (up *CommonProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
 	return NeededChanges(old, new)
 }
 
-func (up *TransitionalMountProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
+func (up *CommonProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
 	return changePerform(change, as)
 }

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -33,10 +33,12 @@ func (up *CommonProfileUpdate) Assumptions() *Assumptions {
 	return nil
 }
 
-func (up *CommonProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
-	return NeededChanges(old, new)
+// NeededChanges computes the sequence of mount changes needed to transform current profile to desired profile.
+func (up *CommonProfileUpdate) NeededChanges(current, desired *osutil.MountProfile) []*Change {
+	return NeededChanges(current, desired)
 }
 
+// PerformChange performs a given mount namespace change under given filesystem assumptions.
 func (up *CommonProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
 	return changePerform(change, as)
 }

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/osutil"
+)
+
+type TransitionalMountProfileUpdate struct{}
+
+func (up *TransitionalMountProfileUpdate) Lock() (unlock func(), err error) {
+	return func() {}, nil
+}
+
+func (up *TransitionalMountProfileUpdate) Assumptions() *Assumptions {
+	return nil
+}
+
+func (up *TransitionalMountProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
+	return nil, nil
+}
+
+func (up *TransitionalMountProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
+	return nil, nil
+}
+
+func (up *TransitionalMountProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	return nil
+}
+
+func (up *TransitionalMountProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*Change {
+	return nil
+}
+
+func (up *TransitionalMountProfileUpdate) PerformChange(change *Change, as *Assumptions) ([]*Change, error) {
+	return nil, nil
+}

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -26,7 +26,7 @@ import (
 )
 
 type CommonProfileUpdateContext struct {
-	// instanceName is the name of the snap or instance to update.
+	// instanceName is the name of the snap instance to update.
 	instanceName string
 
 	currentProfilePath string

--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -25,7 +25,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-type CommonProfileUpdate struct {
+type CommonProfileUpdateContext struct {
 	// instanceName is the name of the snap or instance to update.
 	instanceName string
 
@@ -33,16 +33,16 @@ type CommonProfileUpdate struct {
 	desiredProfilePath string
 }
 
-func (up *CommonProfileUpdate) Lock() (unlock func(), err error) {
+func (up *CommonProfileUpdateContext) Lock() (unlock func(), err error) {
 	return func() {}, nil
 }
 
-func (up *CommonProfileUpdate) Assumptions() *Assumptions {
+func (up *CommonProfileUpdateContext) Assumptions() *Assumptions {
 	return nil
 }
 
 // LoadDesiredProfile loads the desired mount profile.
-func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
+func (up *CommonProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	profile, err := osutil.LoadMountProfile(up.desiredProfilePath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load desired mount profile of snap %q: %s", up.instanceName, err)
@@ -51,7 +51,7 @@ func (up *CommonProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error
 }
 
 // LoadCurrentProfile loads the current mount profile.
-func (up *CommonProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
+func (up *CommonProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
 	profile, err := osutil.LoadMountProfile(up.currentProfilePath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load current mount profile of snap %q: %s", up.instanceName, err)
@@ -60,7 +60,7 @@ func (up *CommonProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error
 }
 
 // SaveCurrentProfile saves the current mount profile.
-func (up *CommonProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
+func (up *CommonProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
 	if err := profile.Save(up.currentProfilePath); err != nil {
 		return fmt.Errorf("cannot save current mount profile of snap %q: %s", up.instanceName, err)
 	}

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -34,14 +34,14 @@ import (
 
 type commonSuite struct {
 	dir string
-	up  *update.CommonProfileUpdate
+	up  *update.CommonProfileUpdateContext
 }
 
 var _ = Suite(&commonSuite{})
 
 func (s *commonSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
-	s.up = update.NewCommonProfileUpdate("foo",
+	s.up = update.NewCommonProfileUpdateContext("foo",
 		filepath.Join(s.dir, "current.fstab"),
 		filepath.Join(s.dir, "desired.fstab"))
 }

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -46,16 +46,6 @@ func (s *commonSuite) SetUpTest(c *C) {
 		filepath.Join(s.dir, "desired.fstab"))
 }
 
-func (s *commonSuite) TestNeededChanges(c *C) {
-	// Smoke test for computing needed changes.
-	// Complete tests for the algorithm are in changes_test.go
-	entry := osutil.MountEntry{Dir: "/tmp", Name: "none", Type: "tmpfs"}
-	current := &osutil.MountProfile{}
-	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{entry}}
-	changes := s.up.NeededChanges(current, desired)
-	c.Check(changes, DeepEquals, []*update.Change{{Action: update.Mount, Entry: entry}})
-}
-
 func (s *commonSuite) TestLoadDesiredProfile(c *C) {
 	up := s.up
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/osutil"
+)
+
+type commonSuite struct {
+	dir string
+	up  *update.CommonProfileUpdate
+}
+
+var _ = Suite(&commonSuite{})
+
+func (s *commonSuite) SetUpTest(c *C) {
+	s.dir = c.MkDir()
+	s.up = &update.CommonProfileUpdate{}
+}
+
+func (s *commonSuite) TestNeededChanges(c *C) {
+	// Smoke test for computing needed changes.
+	// Complete tests for the algorithm are in changes_test.go
+	entry := osutil.MountEntry{Dir: "/tmp", Name: "none", Type: "tmpfs"}
+	current := &osutil.MountProfile{}
+	desired := &osutil.MountProfile{Entries: []osutil.MountEntry{entry}}
+	changes := s.up.NeededChanges(current, desired)
+	c.Check(changes, DeepEquals, []*update.Change{{Action: update.Mount, Entry: entry}})
+}
+
+func (s *commonSuite) TestPerformChange(c *C) {
+	// Smoke test for performing mount namespace change.
+	// Complete tests for the algorithm are in changes_test.go
+	entry := osutil.MountEntry{Dir: "/tmp", Name: "none", Type: "tmpfs"}
+	change := &update.Change{Action: update.Mount, Entry: entry}
+	as := &update.Assumptions{}
+	var changeSeen *update.Change
+	var assumptionsSeen *update.Assumptions
+	restore := update.MockChangePerform(func(change *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+		changeSeen = change
+		assumptionsSeen = as
+		return nil, nil
+	})
+	defer restore()
+
+	synth, err := s.up.PerformChange(change, as)
+	c.Assert(err, IsNil)
+	c.Check(synth, HasLen, 0)
+	// NOTE: we're using Equals to check that the exact objects were passed.
+	c.Check(changeSeen, Equals, change)
+	c.Check(assumptionsSeen, Equals, as)
+}

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -56,29 +56,6 @@ func (s *commonSuite) TestNeededChanges(c *C) {
 	c.Check(changes, DeepEquals, []*update.Change{{Action: update.Mount, Entry: entry}})
 }
 
-func (s *commonSuite) TestPerformChange(c *C) {
-	// Smoke test for performing mount namespace change.
-	// Complete tests for the algorithm are in changes_test.go
-	entry := osutil.MountEntry{Dir: "/tmp", Name: "none", Type: "tmpfs"}
-	change := &update.Change{Action: update.Mount, Entry: entry}
-	as := &update.Assumptions{}
-	var changeSeen *update.Change
-	var assumptionsSeen *update.Assumptions
-	restore := update.MockChangePerform(func(change *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		changeSeen = change
-		assumptionsSeen = as
-		return nil, nil
-	})
-	defer restore()
-
-	synth, err := s.up.PerformChange(change, as)
-	c.Assert(err, IsNil)
-	c.Check(synth, HasLen, 0)
-	// NOTE: we're using Equals to check that the exact objects were passed.
-	c.Check(changeSeen, Equals, change)
-	c.Check(assumptionsSeen, Equals, as)
-}
-
 func (s *commonSuite) TestLoadDesiredProfile(c *C) {
 	up := s.up
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -54,6 +54,9 @@ var (
 	DesiredSystemProfilePath = desiredSystemProfilePath
 	CurrentSystemProfilePath = currentSystemProfilePath
 
+	// user
+	DesiredUserProfilePath = desiredUserProfilePath
+
 	// xdg
 	XdgRuntimeDir        = xdgRuntimeDir
 	ExpandPrefixVariable = expandPrefixVariable

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -207,16 +207,16 @@ func (as *Assumptions) CanWriteToDirectory(dirFd int, dirName string) (bool, err
 	return as.canWriteToDirectory(dirFd, dirName)
 }
 
-func (up *CommonProfileUpdate) CurrentProfilePath() string {
+func (up *CommonProfileUpdateContext) CurrentProfilePath() string {
 	return up.currentProfilePath
 }
 
-func (up *CommonProfileUpdate) DesiredProfilePath() string {
+func (up *CommonProfileUpdateContext) DesiredProfilePath() string {
 	return up.desiredProfilePath
 }
 
-func NewCommonProfileUpdate(instanceName string, currentProfilePath, desiredProfilePath string) *CommonProfileUpdate {
-	return &CommonProfileUpdate{
+func NewCommonProfileUpdateContext(instanceName string, currentProfilePath, desiredProfilePath string) *CommonProfileUpdateContext {
+	return &CommonProfileUpdateContext{
 		instanceName:       instanceName,
 		currentProfilePath: currentProfilePath,
 		desiredProfilePath: desiredProfilePath,

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -50,6 +50,10 @@ var (
 	IsReadOnly                   = isReadOnly
 	IsPrivateTmpfsCreatedBySnapd = isPrivateTmpfsCreatedBySnapd
 
+	// system
+	DesiredSystemProfilePath = desiredSystemProfilePath
+	CurrentSystemProfilePath = currentSystemProfilePath
+
 	// xdg
 	XdgRuntimeDir        = xdgRuntimeDir
 	ExpandPrefixVariable = expandPrefixVariable

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -206,3 +206,19 @@ func (as *Assumptions) PastChanges() []*Change {
 func (as *Assumptions) CanWriteToDirectory(dirFd int, dirName string) (bool, error) {
 	return as.canWriteToDirectory(dirFd, dirName)
 }
+
+func (up *CommonProfileUpdate) CurrentProfilePath() string {
+	return up.currentProfilePath
+}
+
+func (up *CommonProfileUpdate) DesiredProfilePath() string {
+	return up.desiredProfilePath
+}
+
+func NewCommonProfileUpdate(instanceName string, currentProfilePath, desiredProfilePath string) *CommonProfileUpdate {
+	return &CommonProfileUpdate{
+		instanceName:       instanceName,
+		currentProfilePath: currentProfilePath,
+		desiredProfilePath: desiredProfilePath,
+	}
+}

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -58,10 +58,11 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		return nil, nil
-	})
-	defer restore()
+	up := &testProfileUpdate{
+		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
+			return update.NeededChanges(old, new)
+		},
+	}
 
 	snapName := "foo"
 	desiredProfileContent := `/var/lib/snapd/hostfs/usr/share/fonts /usr/share/fonts none bind,ro 0 0
@@ -79,7 +80,7 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	err = update.ComputeAndSaveSystemChanges(snapName, s.as)
+	err = update.ComputeAndSaveSystemChanges(up, snapName, s.as)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -90,6 +91,51 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
+
+	up := &testProfileUpdate{
+		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
+			return update.NeededChanges(old, new)
+		},
+		// In order to make that work, /usr/share had to be converted to a writable
+		// mimic. Some actions were performed under the hood and now we see a
+		// subset of them as synthetic changes here.
+		//
+		// Note that if you compare this to the code that plans a writable mimic
+		// you will see that there are additional changes that are _not_
+		// represented here. The changes have only one goal: tell
+		// snap-update-ns how the mimic can be undone in case it is no longer
+		// needed.
+		performChange: func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+			// The change that we were asked to perform is to create a bind mount
+			// from within the snap to /usr/share/mysnap.
+			c.Assert(chg, DeepEquals, &update.Change{
+				Action: update.Mount, Entry: osutil.MountEntry{
+					Name: "/snap/mysnap/42/usr/share/mysnap",
+					Dir:  "/usr/share/mysnap", Type: "none",
+					Options: []string{"bind", "ro"}}})
+			synthetic := []*update.Change{
+				// The original directory (which was a part of the core snap and is
+				// read only) was hidden with a tmpfs.
+				{Action: update.Mount, Entry: osutil.MountEntry{
+					Dir: "/usr/share", Name: "tmpfs", Type: "tmpfs",
+					Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
+				// For the sake of brevity we will only represent a few of the
+				// entries typically there. Normally this list can get quite long.
+				// Also note that the entry is a little fake. In reality it was
+				// constructed using a temporary bind mount that contained the
+				// original mount entries of /usr/share but this fact was lost.
+				// Again, the only point of this entry is to correctly perform an
+				// undo operation when /usr/share/mysnap is no longer needed.
+				{Action: update.Mount, Entry: osutil.MountEntry{
+					Dir: "/usr/share/adduser", Name: "/usr/share/adduser",
+					Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
+				{Action: update.Mount, Entry: osutil.MountEntry{
+					Dir: "/usr/share/awk", Name: "/usr/share/awk",
+					Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
+			}
+			return synthetic, nil
+		},
+	}
 
 	// The snap `mysnap` wishes to export it's usr/share/mysnap directory and
 	// make it appear as if it was in /usr/share/mysnap directly.
@@ -105,48 +151,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
-	// In order to make that work, /usr/share had to be converted to a writable
-	// mimic. Some actions were performed under the hood and now we see a
-	// subset of them as synthetic changes here.
-	//
-	// Note that if you compare this to the code that plans a writable mimic
-	// you will see that there are additional changes that are _not_
-	// represented here. The changes have only one goal: tell
-	// snap-update-ns how the mimic can be undone in case it is no longer
-	// needed.
-	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		// The change that we were asked to perform is to create a bind mount
-		// from within the snap to /usr/share/mysnap.
-		c.Assert(chg, DeepEquals, &update.Change{
-			Action: update.Mount, Entry: osutil.MountEntry{
-				Name: "/snap/mysnap/42/usr/share/mysnap",
-				Dir:  "/usr/share/mysnap", Type: "none",
-				Options: []string{"bind", "ro"}}})
-		synthetic := []*update.Change{
-			// The original directory (which was a part of the core snap and is
-			// read only) was hidden with a tmpfs.
-			{Action: update.Mount, Entry: osutil.MountEntry{
-				Dir: "/usr/share", Name: "tmpfs", Type: "tmpfs",
-				Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
-			// For the sake of brevity we will only represent a few of the
-			// entries typically there. Normally this list can get quite long.
-			// Also note that the entry is a little fake. In reality it was
-			// constructed using a temporary bind mount that contained the
-			// original mount entries of /usr/share but this fact was lost.
-			// Again, the only point of this entry is to correctly perform an
-			// undo operation when /usr/share/mysnap is no longer needed.
-			{Action: update.Mount, Entry: osutil.MountEntry{
-				Dir: "/usr/share/adduser", Name: "/usr/share/adduser",
-				Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
-			{Action: update.Mount, Entry: osutil.MountEntry{
-				Dir: "/usr/share/awk", Name: "/usr/share/awk",
-				Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"}}},
-		}
-		return synthetic, nil
-	})
-	defer restore()
-
-	c.Assert(update.ComputeAndSaveSystemChanges(snapName, s.as), IsNil)
+	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -159,6 +164,54 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
+
+	n := -1
+	up := &testProfileUpdate{
+		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
+			return update.NeededChanges(old, new)
+		},
+		performChange: func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+			n++
+			switch n {
+			case 0:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Unmount,
+					Entry: osutil.MountEntry{
+						Name: "/snap/mysnap/42/usr/share/mysnap",
+						Dir:  "/usr/share/mysnap", Type: "none",
+						Options: []string{"bind", "ro"},
+					},
+				})
+			case 1:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Unmount,
+					Entry: osutil.MountEntry{
+						Name: "/usr/share/awk", Dir: "/usr/share/awk", Type: "none",
+						Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"},
+					},
+				})
+			case 2:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Unmount,
+					Entry: osutil.MountEntry{
+						Name: "/usr/share/adduser", Dir: "/usr/share/adduser", Type: "none",
+						Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"},
+					},
+				})
+			case 3:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Unmount,
+					Entry: osutil.MountEntry{
+						Name: "tmpfs", Dir: "/usr/share", Type: "tmpfs",
+						Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"},
+					},
+				})
+			default:
+				panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
+			}
+			return nil, nil
+		},
+	}
 
 	// The snap `mysnap` no longer wishes to export it's usr/share/mysnap
 	// directory. All the synthetic changes that were associated with that mount
@@ -179,51 +232,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
-	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		n++
-		switch n {
-		case 0:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Unmount,
-				Entry: osutil.MountEntry{
-					Name: "/snap/mysnap/42/usr/share/mysnap",
-					Dir:  "/usr/share/mysnap", Type: "none",
-					Options: []string{"bind", "ro"},
-				},
-			})
-		case 1:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Unmount,
-				Entry: osutil.MountEntry{
-					Name: "/usr/share/awk", Dir: "/usr/share/awk", Type: "none",
-					Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"},
-				},
-			})
-		case 2:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Unmount,
-				Entry: osutil.MountEntry{
-					Name: "/usr/share/adduser", Dir: "/usr/share/adduser", Type: "none",
-					Options: []string{"bind", "ro", "x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"},
-				},
-			})
-		case 3:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Unmount,
-				Entry: osutil.MountEntry{
-					Name: "tmpfs", Dir: "/usr/share", Type: "tmpfs",
-					Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/usr/share/mysnap"},
-				},
-			})
-		default:
-			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
-		}
-		return nil, nil
-	})
-	defer restore()
-
-	c.Assert(update.ComputeAndSaveSystemChanges(snapName, s.as), IsNil)
+	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -231,6 +240,30 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
+
+	n := -1
+	up := &testProfileUpdate{
+		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
+			return update.NeededChanges(old, new)
+		},
+		performChange: func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+			n++
+			switch n {
+			case 0:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Mount,
+					Entry: osutil.MountEntry{
+						Name: "/snap/mysnap/42/usr/share/mysnap",
+						Dir:  "/usr/share/mysnap", Type: "none",
+						Options: []string{"bind", "ro", "x-snapd.origin=layout"},
+					},
+				})
+				return nil, fmt.Errorf("testing")
+			default:
+				panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
+			}
+		},
+	}
 
 	const snapName = "mysnap"
 	const currentProfileContent = ""
@@ -244,28 +277,8 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
-	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		n++
-		switch n {
-		case 0:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Mount,
-				Entry: osutil.MountEntry{
-					Name: "/snap/mysnap/42/usr/share/mysnap",
-					Dir:  "/usr/share/mysnap", Type: "none",
-					Options: []string{"bind", "ro", "x-snapd.origin=layout"},
-				},
-			})
-			return nil, fmt.Errorf("testing")
-		default:
-			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
-		}
-	})
-	defer restore()
-
 	// The error was not ignored, we bailed out.
-	c.Assert(update.ComputeAndSaveSystemChanges(snapName, s.as), ErrorMatches, "testing")
+	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -273,6 +286,30 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
+
+	n := -1
+	up := &testProfileUpdate{
+		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
+			return update.NeededChanges(old, new)
+		},
+		performChange: func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+			n++
+			switch n {
+			case 0:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Mount,
+					Entry: osutil.MountEntry{
+						Name: "/snap/mysnap_foo",
+						Dir:  "/snap/mysnap", Type: "none",
+						Options: []string{"rbind", "x-snapd.origin=overname"},
+					},
+				})
+				return nil, fmt.Errorf("testing")
+			default:
+				panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
+			}
+		},
+	}
 
 	const snapName = "mysnap"
 	const currentProfileContent = ""
@@ -286,28 +323,8 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
-	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		n++
-		switch n {
-		case 0:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Mount,
-				Entry: osutil.MountEntry{
-					Name: "/snap/mysnap_foo",
-					Dir:  "/snap/mysnap", Type: "none",
-					Options: []string{"rbind", "x-snapd.origin=overname"},
-				},
-			})
-			return nil, fmt.Errorf("testing")
-		default:
-			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
-		}
-	})
-	defer restore()
-
 	// The error was not ignored, we bailed out.
-	c.Assert(update.ComputeAndSaveSystemChanges(snapName, nil), ErrorMatches, "testing")
+	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, nil), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -315,6 +332,31 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
+
+	n := -1
+	up := &testProfileUpdate{
+		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
+			return update.NeededChanges(old, new)
+		},
+		performChange: func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+			n++
+			switch n {
+			case 0:
+				c.Assert(chg, DeepEquals, &update.Change{
+					Action: update.Mount,
+					Entry: osutil.MountEntry{
+						Name:    "/source",
+						Dir:     "/target",
+						Type:    "none",
+						Options: []string{"bind", "x-snapd.ignore-missing"},
+					},
+				})
+				return nil, update.ErrIgnoredMissingMount
+			default:
+				panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
+			}
+		},
+	}
 
 	const snapName = "mysnap"
 	const currentProfileContent = ""
@@ -328,29 +370,8 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
 	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
-	n := -1
-	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-		n++
-		switch n {
-		case 0:
-			c.Assert(chg, DeepEquals, &update.Change{
-				Action: update.Mount,
-				Entry: osutil.MountEntry{
-					Name:    "/source",
-					Dir:     "/target",
-					Type:    "none",
-					Options: []string{"bind", "x-snapd.ignore-missing"},
-				},
-			})
-			return nil, update.ErrIgnoredMissingMount
-		default:
-			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
-		}
-	})
-	defer restore()
-
 	// The error was ignored, and no mount was recorded in the profile
-	c.Assert(update.ComputeAndSaveSystemChanges(snapName, s.as), IsNil)
+	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -79,7 +79,7 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	up := update.NewSystemProfileUpdate(snapName)
+	up := update.NewSystemProfileUpdateContext(snapName)
 	err = update.ComputeAndSaveSystemChanges(up, snapName, s.as)
 	c.Assert(err, IsNil)
 
@@ -147,7 +147,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	up := update.NewSystemProfileUpdate(snapName)
+	up := update.NewSystemProfileUpdateContext(snapName)
 	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
@@ -225,7 +225,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	up := update.NewSystemProfileUpdate(snapName)
+	up := update.NewSystemProfileUpdateContext(snapName)
 	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
@@ -268,7 +268,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	up := update.NewSystemProfileUpdate(snapName)
+	up := update.NewSystemProfileUpdateContext(snapName)
 	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
@@ -311,7 +311,7 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	up := update.NewSystemProfileUpdate(snapName)
+	up := update.NewSystemProfileUpdateContext(snapName)
 	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, nil), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
@@ -355,7 +355,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	defer restore()
 
 	// The error was ignored, and no mount was recorded in the profile
-	up := update.NewSystemProfileUpdate(snapName)
+	up := update.NewSystemProfileUpdateContext(snapName)
 	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -31,7 +31,7 @@ import (
 
 // SystemProfileUpdate contains information about update to system-wide mount namespace.
 type SystemProfileUpdate struct {
-	TransitionalMountProfileUpdate
+	CommonProfileUpdate
 }
 
 func applySystemFstab(instanceName string, fromSnapConfine bool) error {

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -107,14 +107,14 @@ func computeAndSaveSystemChanges(up MountProfileUpdate, snapName string, as *Ass
 	// Read the desired and current mount profiles. Note that missing files
 	// count as empty profiles so that we can gracefully handle a mount
 	// interface connection/disconnection.
-	desiredProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapMountPolicyDir, snapName)
+	desiredProfilePath := desiredSystemProfilePath(snapName)
 	desired, err := osutil.LoadMountProfile(desiredProfilePath)
 	if err != nil {
 		return fmt.Errorf("cannot load desired mount profile of snap %q: %s", snapName, err)
 	}
 	debugShowProfile(desired, "desired mount profile")
 
-	currentProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
+	currentProfilePath := currentSystemProfilePath(snapName)
 	currentBefore, err := osutil.LoadMountProfile(currentProfilePath)
 	if err != nil {
 		return fmt.Errorf("cannot load current mount profile of snap %q: %s", snapName, err)
@@ -135,4 +135,14 @@ func computeAndSaveSystemChanges(up MountProfileUpdate, snapName string, as *Ass
 		return fmt.Errorf("cannot save current mount profile of snap %q: %s", snapName, err)
 	}
 	return nil
+}
+
+// desiredSystemProfilePath returns the path of the fstab-like file with the desired, system-wide mount profile for a snap.
+func desiredSystemProfilePath(snapName string) string {
+	return fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapMountPolicyDir, snapName)
+}
+
+// currentSystemProfilePath returns the path of the fstab-like file with the applied, system-wide mount profile for a snap.
+func currentSystemProfilePath(snapName string) string {
+	return fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
 }

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -29,14 +29,14 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// SystemProfileUpdate contains information about update to system-wide mount namespace.
-type SystemProfileUpdate struct {
-	CommonProfileUpdate
+// SystemProfileUpdateContext contains information about update to system-wide mount namespace.
+type SystemProfileUpdateContext struct {
+	CommonProfileUpdateContext
 }
 
-// NewSystemProfileUpdate returns encapsulated information for performing a per-user mount namespace update.
-func NewSystemProfileUpdate(instanceName string) *SystemProfileUpdate {
-	return &SystemProfileUpdate{CommonProfileUpdate: CommonProfileUpdate{
+// NewSystemProfileUpdateContext returns encapsulated information for performing a per-user mount namespace update.
+func NewSystemProfileUpdateContext(instanceName string) *SystemProfileUpdateContext {
+	return &SystemProfileUpdateContext{CommonProfileUpdateContext: CommonProfileUpdateContext{
 		instanceName:       instanceName,
 		currentProfilePath: currentSystemProfilePath(instanceName),
 		desiredProfilePath: desiredSystemProfilePath(instanceName),
@@ -44,7 +44,7 @@ func NewSystemProfileUpdate(instanceName string) *SystemProfileUpdate {
 }
 
 func applySystemFstab(instanceName string, fromSnapConfine bool) error {
-	up := NewSystemProfileUpdate(instanceName)
+	up := NewSystemProfileUpdateContext(instanceName)
 
 	// Lock the mount namespace so that any concurrently attempted invocations
 	// of snap-confine are synchronized and will see consistent state.
@@ -112,7 +112,7 @@ func applySystemFstab(instanceName string, fromSnapConfine bool) error {
 	return computeAndSaveSystemChanges(up, instanceName, as)
 }
 
-func computeAndSaveSystemChanges(up MountProfileUpdate, snapName string, as *Assumptions) error {
+func computeAndSaveSystemChanges(up MountProfileUpdateContext, snapName string, as *Assumptions) error {
 	// Read the desired and current mount profiles. Note that missing files
 	// count as empty profiles so that we can gracefully handle a mount
 	// interface connection/disconnection.

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -29,6 +29,11 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// SystemProfileUpdate contains information about update to system-wide mount namespace.
+type SystemProfileUpdate struct {
+	TransitionalMountProfileUpdate
+}
+
 func applySystemFstab(instanceName string, fromSnapConfine bool) error {
 	// Lock the mount namespace so that any concurrently attempted invocations
 	// of snap-confine are synchronized and will see consistent state.

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -118,7 +118,8 @@ func computeAndSaveSystemChanges(snapName string, as *Assumptions) error {
 		as.AddChange(&Change{Action: Mount, Entry: entry})
 	}
 
-	currentAfter, err := applyProfile(snapName, currentBefore, desired, as)
+	up := &TransitionalMountProfileUpdate{}
+	currentAfter, err := applyProfile(up, snapName, currentBefore, desired, as)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+)
+
+type systemSuite struct{}
+
+var _ = Suite(&systemSuite{})
+
+func (s *systemSuite) TestDesiredSystemProfilePath(c *C) {
+	c.Check(update.DesiredSystemProfilePath("foo"), Equals, "/var/lib/snapd/mount/snap.foo.fstab")
+}
+
+func (s *systemSuite) TestCurrentSystemProfilePath(c *C) {
+	c.Check(update.CurrentSystemProfilePath("foo"), Equals, "/run/snapd/ns/snap.foo.fstab")
+}

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -37,8 +37,4 @@ type MountProfileUpdate interface {
 	SaveCurrentProfile(*osutil.MountProfile) error
 	// NeededChanges computes the set of changes between a pair of profiles.
 	NeededChanges(old, new *osutil.MountProfile) []*Change
-	// PerformChange performs a single change.
-	// The returned changes represent any additional synthesized changes that
-	// were made as a prerequisite to complete the desired operation.
-	PerformChange(*Change, *Assumptions) ([]*Change, error)
 }

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -35,6 +35,4 @@ type MountProfileUpdate interface {
 	LoadCurrentProfile() (*osutil.MountProfile, error)
 	// SaveCurrentProfile saves the mount profile that is currently applied.
 	SaveCurrentProfile(*osutil.MountProfile) error
-	// NeededChanges computes the set of changes between a pair of profiles.
-	NeededChanges(old, new *osutil.MountProfile) []*Change
 }

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -23,8 +23,11 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-// MountProfileUpdate abstracts the operations around mount namespace updates.
-type MountProfileUpdate interface {
+// MountProfileUpdateContext provides the context of a mount namespace update.
+// The context provides a way to synchronize the operation with other users of
+// the snap system, to load and save the mount profiles and to provide the file
+// system assumptions with which the mount namespace will be modified.
+type MountProfileUpdateContext interface {
 	// Lock obtains locks appropriate for the update.
 	Lock() (unlock func(), err error)
 	// Assumptions computes filesystem assumptions under which the update shall operate.

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/osutil"
+)
+
+// MountProfileUpdate abstracts the operations around mount namespace updates.
+type MountProfileUpdate interface {
+	// Lock obtains locks appropriate for the update.
+	Lock() (unlock func(), err error)
+	// Assumptions computes filesystem assumptions under which the update shall operate.
+	Assumptions() *Assumptions
+	// LoadDesiredProfile loads the mount profile that should be constructed.
+	LoadDesiredProfile() (*osutil.MountProfile, error)
+	// LoadCurrentProfile loads the mount profile that is currently applied.
+	LoadCurrentProfile() (*osutil.MountProfile, error)
+	// SaveCurrentProfile saves the mount profile that is currently applied.
+	SaveCurrentProfile(*osutil.MountProfile) error
+	// NeededChanges computes the set of changes between a pair of profiles.
+	NeededChanges(old, new *osutil.MountProfile) []*Change
+	// PerformChange performs a single change.
+	// The returned changes represent any additional synthesized changes that
+	// were made as a prerequisite to complete the desired operation.
+	PerformChange(*Change, *Assumptions) ([]*Change, error)
+}

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -24,40 +24,40 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-// testProfileUpdate implements MountProfileUpdate and is suitable for testing.
-type testProfileUpdate struct {
+// testProfileUpdateContext implements MountProfileUpdate and is suitable for testing.
+type testProfileUpdateContext struct {
 	loadCurrentProfile func() (*osutil.MountProfile, error)
 	loadDesiredProfile func() (*osutil.MountProfile, error)
 	saveCurrentProfile func(*osutil.MountProfile) error
 	assumptions        func() *update.Assumptions
 }
 
-func (up *testProfileUpdate) Lock() (unlock func(), err error) {
+func (up *testProfileUpdateContext) Lock() (unlock func(), err error) {
 	return func() {}, nil
 }
 
-func (up *testProfileUpdate) Assumptions() *update.Assumptions {
+func (up *testProfileUpdateContext) Assumptions() *update.Assumptions {
 	if up.assumptions != nil {
 		return up.assumptions()
 	}
 	return &update.Assumptions{}
 }
 
-func (up *testProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
+func (up *testProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
 	if up.loadCurrentProfile != nil {
 		return up.loadCurrentProfile()
 	}
 	return &osutil.MountProfile{}, nil
 }
 
-func (up *testProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
+func (up *testProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	if up.loadDesiredProfile != nil {
 		return up.loadDesiredProfile()
 	}
 	return &osutil.MountProfile{}, nil
 }
 
-func (up *testProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
+func (up *testProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
 	if up.saveCurrentProfile != nil {
 		return up.saveCurrentProfile(profile)
 	}

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -32,34 +32,34 @@ type testProfileUpdateContext struct {
 	assumptions        func() *update.Assumptions
 }
 
-func (up *testProfileUpdateContext) Lock() (unlock func(), err error) {
+func (upCtx *testProfileUpdateContext) Lock() (unlock func(), err error) {
 	return func() {}, nil
 }
 
-func (up *testProfileUpdateContext) Assumptions() *update.Assumptions {
-	if up.assumptions != nil {
-		return up.assumptions()
+func (upCtx *testProfileUpdateContext) Assumptions() *update.Assumptions {
+	if upCtx.assumptions != nil {
+		return upCtx.assumptions()
 	}
 	return &update.Assumptions{}
 }
 
-func (up *testProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
-	if up.loadCurrentProfile != nil {
-		return up.loadCurrentProfile()
+func (upCtx *testProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
+	if upCtx.loadCurrentProfile != nil {
+		return upCtx.loadCurrentProfile()
 	}
 	return &osutil.MountProfile{}, nil
 }
 
-func (up *testProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
-	if up.loadDesiredProfile != nil {
-		return up.loadDesiredProfile()
+func (upCtx *testProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
+	if upCtx.loadDesiredProfile != nil {
+		return upCtx.loadDesiredProfile()
 	}
 	return &osutil.MountProfile{}, nil
 }
 
-func (up *testProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
-	if up.saveCurrentProfile != nil {
-		return up.saveCurrentProfile(profile)
+func (upCtx *testProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	if upCtx.saveCurrentProfile != nil {
+		return upCtx.saveCurrentProfile(profile)
 	}
 	return nil
 }

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -29,8 +29,6 @@ type testProfileUpdate struct {
 	loadCurrentProfile func() (*osutil.MountProfile, error)
 	loadDesiredProfile func() (*osutil.MountProfile, error)
 	saveCurrentProfile func(*osutil.MountProfile) error
-	neededChanges      func(old, new *osutil.MountProfile) []*update.Change
-	performChange      func(*update.Change, *update.Assumptions) ([]*update.Change, error)
 	assumptions        func() *update.Assumptions
 }
 
@@ -57,20 +55,6 @@ func (up *testProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) 
 		return up.loadDesiredProfile()
 	}
 	return &osutil.MountProfile{}, nil
-}
-
-func (up *testProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*update.Change {
-	if up.neededChanges != nil {
-		return up.neededChanges(old, new)
-	}
-	return nil
-}
-
-func (up *testProfileUpdate) PerformChange(change *update.Change, as *update.Assumptions) ([]*update.Change, error) {
-	if up.performChange != nil {
-		return up.performChange(change, as)
-	}
-	return nil, nil
 }
 
 func (up *testProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -1,0 +1,81 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// testProfileUpdate implements MountProfileUpdate and is suitable for testing.
+type testProfileUpdate struct {
+	loadCurrentProfile func() (*osutil.MountProfile, error)
+	loadDesiredProfile func() (*osutil.MountProfile, error)
+	saveCurrentProfile func(*osutil.MountProfile) error
+	neededChanges      func(old, new *osutil.MountProfile) []*update.Change
+	performChange      func(*update.Change, *update.Assumptions) ([]*update.Change, error)
+	assumptions        func() *update.Assumptions
+}
+
+func (up *testProfileUpdate) Lock() (unlock func(), err error) {
+	return func() {}, nil
+}
+
+func (up *testProfileUpdate) Assumptions() *update.Assumptions {
+	if up.assumptions != nil {
+		return up.assumptions()
+	}
+	return &update.Assumptions{}
+}
+
+func (up *testProfileUpdate) LoadCurrentProfile() (*osutil.MountProfile, error) {
+	if up.loadCurrentProfile != nil {
+		return up.loadCurrentProfile()
+	}
+	return &osutil.MountProfile{}, nil
+}
+
+func (up *testProfileUpdate) LoadDesiredProfile() (*osutil.MountProfile, error) {
+	if up.loadDesiredProfile != nil {
+		return up.loadDesiredProfile()
+	}
+	return &osutil.MountProfile{}, nil
+}
+
+func (up *testProfileUpdate) NeededChanges(old, new *osutil.MountProfile) []*update.Change {
+	if up.neededChanges != nil {
+		return up.neededChanges(old, new)
+	}
+	return nil
+}
+
+func (up *testProfileUpdate) PerformChange(change *update.Change, as *update.Assumptions) ([]*update.Change, error) {
+	if up.performChange != nil {
+		return up.performChange(change, as)
+	}
+	return nil, nil
+}
+
+func (up *testProfileUpdate) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	if up.saveCurrentProfile != nil {
+		return up.saveCurrentProfile(profile)
+	}
+	return nil
+}

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -33,6 +33,7 @@ type UserProfileUpdate struct {
 }
 
 func applyUserFstab(snapName string) error {
+	up := &UserProfileUpdate{}
 	desiredProfilePath := fmt.Sprintf("%s/snap.%s.user-fstab", dirs.SnapMountPolicyDir, snapName)
 	desired, err := osutil.LoadMountProfile(desiredProfilePath)
 	if err != nil {
@@ -48,7 +49,6 @@ func applyUserFstab(snapName string) error {
 	// TODO: Handle /home/*/snap/* when we do per-user mount namespaces and
 	// allow defining layout items that refer to SNAP_USER_DATA and
 	// SNAP_USER_COMMON.
-	up := &TransitionalMountProfileUpdate{}
 	_, err = applyProfile(up, snapName, &osutil.MountProfile{}, desired, as)
 	return err
 }

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -27,6 +27,11 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
+// UserProfileUpdate contains information about update to per-user mount namespace.
+type UserProfileUpdate struct {
+	TransitionalMountProfileUpdate
+}
+
 func applyUserFstab(snapName string) error {
 	desiredProfilePath := fmt.Sprintf("%s/snap.%s.user-fstab", dirs.SnapMountPolicyDir, snapName)
 	desired, err := osutil.LoadMountProfile(desiredProfilePath)

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -27,13 +27,13 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-// UserProfileUpdate contains information about update to per-user mount namespace.
-type UserProfileUpdate struct {
-	CommonProfileUpdate
+// UserProfileUpdateContext contains information about update to per-user mount namespace.
+type UserProfileUpdateContext struct {
+	CommonProfileUpdateContext
 }
 
 func applyUserFstab(snapName string) error {
-	up := &UserProfileUpdate{}
+	up := &UserProfileUpdateContext{}
 	desiredProfilePath := desiredUserProfilePath(snapName)
 	desired, err := osutil.LoadMountProfile(desiredProfilePath)
 	if err != nil {

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -33,7 +33,7 @@ type UserProfileUpdateContext struct {
 }
 
 func applyUserFstab(snapName string) error {
-	up := &UserProfileUpdateContext{}
+	upCtx := &UserProfileUpdateContext{}
 	desiredProfilePath := desiredUserProfilePath(snapName)
 	desired, err := osutil.LoadMountProfile(desiredProfilePath)
 	if err != nil {
@@ -49,7 +49,7 @@ func applyUserFstab(snapName string) error {
 	// TODO: Handle /home/*/snap/* when we do per-user mount namespaces and
 	// allow defining layout items that refer to SNAP_USER_DATA and
 	// SNAP_USER_COMMON.
-	_, err = applyProfile(up, snapName, &osutil.MountProfile{}, desired, as)
+	_, err = applyProfile(upCtx, snapName, &osutil.MountProfile{}, desired, as)
 	return err
 }
 

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -29,7 +29,7 @@ import (
 
 // UserProfileUpdate contains information about update to per-user mount namespace.
 type UserProfileUpdate struct {
-	TransitionalMountProfileUpdate
+	CommonProfileUpdate
 }
 
 func applyUserFstab(snapName string) error {

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -43,6 +43,7 @@ func applyUserFstab(snapName string) error {
 	// TODO: Handle /home/*/snap/* when we do per-user mount namespaces and
 	// allow defining layout items that refer to SNAP_USER_DATA and
 	// SNAP_USER_COMMON.
-	_, err = applyProfile(snapName, &osutil.MountProfile{}, desired, as)
+	up := &TransitionalMountProfileUpdate{}
+	_, err = applyProfile(up, snapName, &osutil.MountProfile{}, desired, as)
 	return err
 }

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -34,7 +34,7 @@ type UserProfileUpdate struct {
 
 func applyUserFstab(snapName string) error {
 	up := &UserProfileUpdate{}
-	desiredProfilePath := fmt.Sprintf("%s/snap.%s.user-fstab", dirs.SnapMountPolicyDir, snapName)
+	desiredProfilePath := desiredUserProfilePath(snapName)
 	desired, err := osutil.LoadMountProfile(desiredProfilePath)
 	if err != nil {
 		return fmt.Errorf("cannot load desired user mount profile of snap %q: %s", snapName, err)
@@ -51,4 +51,9 @@ func applyUserFstab(snapName string) error {
 	// SNAP_USER_COMMON.
 	_, err = applyProfile(up, snapName, &osutil.MountProfile{}, desired, as)
 	return err
+}
+
+// desiredUserProfilePath returns the path of the fstab-like file with the desired, user-specific mount profile for a snap.
+func desiredUserProfilePath(snapName string) string {
+	return fmt.Sprintf("%s/snap.%s.user-fstab", dirs.SnapMountPolicyDir, snapName)
 }

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+)
+
+type userSuite struct{}
+
+var _ = Suite(&userSuite{})
+
+func (s *userSuite) TestDesiredUserProfilePath(c *C) {
+	c.Check(update.DesiredUserProfilePath("foo"), Equals, "/var/lib/snapd/mount/snap.foo.user-fstab")
+}

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -571,7 +571,7 @@ type FatalError struct {
 func execWritableMimic(plan []*Change, as *Assumptions) ([]*Change, error) {
 	undoChanges := make([]*Change, 0, len(plan)-2)
 	for i, change := range plan {
-		if _, err := changePerform(change, as); err != nil {
+		if _, err := change.Perform(as); err != nil {
 			// Drat, we failed! Let's undo everything according to our own undo
 			// plan, by following it in reverse order.
 
@@ -594,7 +594,7 @@ func execWritableMimic(plan []*Change, as *Assumptions) ([]*Change, error) {
 				if recoveryUndoChange.Entry.OptBool("rbind") {
 					recoveryUndoChange.Entry.Options = append(recoveryUndoChange.Entry.Options, osutil.XSnapdDetach())
 				}
-				if _, err2 := changePerform(recoveryUndoChange, as); err2 != nil {
+				if _, err2 := recoveryUndoChange.Perform(as); err2 != nil {
 					// Drat, we failed when trying to recover from an error.
 					// We cannot do anything at this stage.
 					return nil, &FatalError{error: fmt.Errorf("cannot undo change %q while recovering from earlier error %v: %v", recoveryUndoChange, err, err2)}

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -665,7 +665,7 @@ func applyProfile(up MountProfileUpdate, snapName string, currentBefore, desired
 	var changesMade []*Change
 	for _, change := range changesNeeded {
 		logger.Debugf("\t * %s", change)
-		synthesised, err := up.PerformChange(change, as)
+		synthesised, err := change.Perform(as)
 		changesMade = append(changesMade, synthesised...)
 		if len(synthesised) > 0 {
 			logger.Debugf("\tsynthesised additional mount changes:")

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -654,7 +654,7 @@ func createWritableMimic(dir, neededBy string, as *Assumptions) ([]*Change, erro
 	return changes, nil
 }
 
-func applyProfile(snapName string, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {
+func applyProfile(up MountProfileUpdate, snapName string, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {
 	// Compute the needed changes and perform each change if
 	// needed, collecting those that we managed to perform or that
 	// were performed already.

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -658,7 +658,7 @@ func applyProfile(up MountProfileUpdate, snapName string, currentBefore, desired
 	// Compute the needed changes and perform each change if
 	// needed, collecting those that we managed to perform or that
 	// were performed already.
-	changesNeeded := NeededChanges(currentBefore, desired)
+	changesNeeded := up.NeededChanges(currentBefore, desired)
 	debugShowChanges(changesNeeded, "mount changes needed")
 
 	logger.Debugf("performing mount changes:")

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -654,7 +654,7 @@ func createWritableMimic(dir, neededBy string, as *Assumptions) ([]*Change, erro
 	return changes, nil
 }
 
-func applyProfile(up MountProfileUpdate, snapName string, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {
+func applyProfile(up MountProfileUpdateContext, snapName string, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {
 	// Compute the needed changes and perform each change if
 	// needed, collecting those that we managed to perform or that
 	// were performed already.

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -658,7 +658,7 @@ func applyProfile(up MountProfileUpdate, snapName string, currentBefore, desired
 	// Compute the needed changes and perform each change if
 	// needed, collecting those that we managed to perform or that
 	// were performed already.
-	changesNeeded := up.NeededChanges(currentBefore, desired)
+	changesNeeded := NeededChanges(currentBefore, desired)
 	debugShowChanges(changesNeeded, "mount changes needed")
 
 	logger.Debugf("performing mount changes:")

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -665,7 +665,7 @@ func applyProfile(up MountProfileUpdate, snapName string, currentBefore, desired
 	var changesMade []*Change
 	for _, change := range changesNeeded {
 		logger.Debugf("\t * %s", change)
-		synthesised, err := changePerform(change, as)
+		synthesised, err := up.PerformChange(change, as)
 		changesMade = append(changesMade, synthesised...)
 		if len(synthesised) > 0 {
 			logger.Debugf("\tsynthesised additional mount changes:")

--- a/osutil/mountprofile_linux.go
+++ b/osutil/mountprofile_linux.go
@@ -53,6 +53,15 @@ func LoadMountProfileText(fstab string) (*MountProfile, error) {
 	return ReadMountProfile(strings.NewReader(fstab))
 }
 
+func SaveMountProfileText(p *MountProfile) (string, error) {
+	var buf bytes.Buffer
+	_, err := p.WriteTo(&buf)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 // Save saves a mount profile (fstab-like) to a given file.
 // The profile is saved with an atomic write+rename+sync operation.
 func (p *MountProfile) Save(fname string) error {


### PR DESCRIPTION
The system wide and per-user mount profiles share a lot of the
application logic: in both cases the system needs some kind of locking
done to avoid races, the current and desired profile needs to be loaded
from disk, the sequence of changes needs to be computed and applied,
lastly the updated current profile needs to be saved.

This branch contains the logic from https://github.com/snapcore/snapd/pull/6360
split into smaller and more targeted patches carved out of
https://github.com/zyga/snapd/tree/feature/user-mount-ns-20.9-split

The changes so far allow the system profile code path to be more in sync
with what is ultimately the unification of both system and user update logic
without making the diff too large all at once. I took a more less arbitrary cut
of the original branch so feel free to reach out to the full list of patches to see
what I'm building towards.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>