### PR TITLE
overlord/snapstate, store: set a header when auto-refreshing

### DIFF
--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -49,6 +49,10 @@ type autoRefreshStore struct {
 }
 
 func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	if !opts.IsAutoRefresh {
+		panic("AutoRefresh snap action did not set IsAutoRefresh flag")
+	}
+
 	if ctx == nil || !auth.IsEnsureContext(ctx) {
 		panic("Ensure marked context required")
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -444,7 +444,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	meter := NewTaskProgressAdapterUnlocked(t)
 	targetFn := snapsup.MountFile()
 
-	dlOpts := &store.DownloadOptions{}
+	dlOpts := &store.DownloadOptions{IsAutoRefresh: snapsup.IsAutoRefresh}
 	if snapsup.IsAutoRefresh && rate > 0 {
 		dlOpts.RateLimit = rate
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -416,6 +416,7 @@ func autoRefreshRateLimited(st *state.State) (rate int64) {
 	if err != nil {
 		return 0
 	}
+	// NOTE ParseByteSize errors on negative rates
 	val, err := strutil.ParseByteSize(rateLimit)
 	if err != nil {
 		return 0
@@ -434,7 +435,11 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 
 	st.Lock()
 	theStore := Store(st)
-	rate := autoRefreshRateLimited(st)
+	var rate int64
+	if snapsup.IsAutoRefresh {
+		// NOTE rate is never negative
+		rate = autoRefreshRateLimited(st)
+	}
 	user, err := userFromUserID(st, snapsup.UserID)
 	st.Unlock()
 	if err != nil {
@@ -444,9 +449,9 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	meter := NewTaskProgressAdapterUnlocked(t)
 	targetFn := snapsup.MountFile()
 
-	dlOpts := &store.DownloadOptions{IsAutoRefresh: snapsup.IsAutoRefresh}
-	if snapsup.IsAutoRefresh && rate > 0 {
-		dlOpts.RateLimit = rate
+	dlOpts := &store.DownloadOptions{
+		IsAutoRefresh: snapsup.IsAutoRefresh,
+		RateLimit:     rate,
 	}
 	if snapsup.DownloadInfo == nil {
 		var storeInfo *snap.Info

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -150,6 +150,15 @@ func (s *downloadSnapSuite) TestDoDownloadSnapNormal(c *C) {
 	t.Get("snap-setup", &snapsup)
 	c.Check(snapsup.SideInfo, DeepEquals, si)
 	c.Check(t.Status(), Equals, state.DoneStatus)
+
+	// check no IsAutoRefresh was passed in
+	c.Assert(s.fakeStore.downloads, DeepEquals, []fakeDownload{
+		{
+			name:   "foo",
+			target: filepath.Join(dirs.SnapBlobDir, "foo_11.snap"),
+			opts:   nil,
+		},
+	})
 }
 
 func (s *downloadSnapSuite) TestDoUndoDownloadSnap(c *C) {
@@ -229,7 +238,8 @@ func (s *downloadSnapSuite) TestDoDownloadRateLimitedIntegration(c *C) {
 			name:   "foo",
 			target: filepath.Join(dirs.SnapBlobDir, "foo_11.snap"),
 			opts: &store.DownloadOptions{
-				RateLimit: 1234,
+				RateLimit:     1234,
+				IsAutoRefresh: true,
 			},
 		},
 	})

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -774,8 +774,8 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 		return nil, nil, err
 	}
 
-	refreshFlags := &store.RefreshOptions{IsAutoRefresh: flags.IsAutoRefresh}
-	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, user, refreshFlags)
+	refreshOpts := &store.RefreshOptions{IsAutoRefresh: flags.IsAutoRefresh}
+	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, user, refreshOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -774,7 +774,8 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 		return nil, nil, err
 	}
 
-	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, user, nil)
+	refreshFlags := &store.RefreshOptions{IsAutoRefresh: flags.IsAutoRefresh}
+	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, user, refreshFlags)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -1413,7 +1413,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 	return s.cacher.Put(downloadInfo.Sha3_384, targetPath)
 }
 
-func reqOptions(storeURL *url.URL, cdnHeader string, opts *DownloadOptions) *requestOptions {
+func downloadReqOpts(storeURL *url.URL, cdnHeader string, opts *DownloadOptions) *requestOptions {
 	reqOptions := requestOptions{
 		Method:       "GET",
 		URL:          storeURL,
@@ -1453,7 +1453,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 	var dlSize float64
 	startTime := time.Now()
 	for attempt := retry.Start(downloadRetryStrategy, nil); attempt.Next(); {
-		reqOptions := reqOptions(storeURL, cdnHeader, dlOpts)
+		reqOptions := downloadReqOpts(storeURL, cdnHeader, dlOpts)
 
 		httputil.MaybeLogRetryAttempt(reqOptions.URL.String(), attempt, startTime)
 
@@ -2410,7 +2410,7 @@ func (s *Store) snapConnCheck() ([]string, error) {
 		return hosts, err
 	}
 
-	reqOptions := reqOptions(dlURL, cdnHeader, nil)
+	reqOptions := downloadReqOpts(dlURL, cdnHeader, nil)
 	reqOptions.Method = "HEAD" // not actually a download
 
 	// TODO: We need the HEAD here so that we get redirected to the

--- a/store/store.go
+++ b/store/store.go
@@ -75,6 +75,7 @@ type RefreshOptions struct {
 	// RefreshManaged indicates to the store that the refresh is
 	// managed via snapd-control.
 	RefreshManaged bool
+	IsAutoRefresh  bool
 
 	PrivacyKey string
 }
@@ -1296,7 +1297,8 @@ func (e HashError) Error() string {
 }
 
 type DownloadOptions struct {
-	RateLimit int64
+	RateLimit     int64
+	IsAutoRefresh bool
 }
 
 // Download downloads the snap addressed by download info and returns its
@@ -1411,7 +1413,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 	return s.cacher.Put(downloadInfo.Sha3_384, targetPath)
 }
 
-func reqOptions(storeURL *url.URL, cdnHeader string) *requestOptions {
+func reqOptions(storeURL *url.URL, cdnHeader string, opts *DownloadOptions) *requestOptions {
 	reqOptions := requestOptions{
 		Method:       "GET",
 		URL:          storeURL,
@@ -1419,6 +1421,9 @@ func reqOptions(storeURL *url.URL, cdnHeader string) *requestOptions {
 	}
 	if cdnHeader != "" {
 		reqOptions.ExtraHeaders["Snap-CDN"] = cdnHeader
+	}
+	if opts != nil && opts.IsAutoRefresh {
+		reqOptions.ExtraHeaders["Snap-Refresh-Reason"] = "scheduled"
 	}
 
 	return &reqOptions
@@ -1448,7 +1453,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 	var dlSize float64
 	startTime := time.Now()
 	for attempt := retry.Start(downloadRetryStrategy, nil); attempt.Next(); {
-		reqOptions := reqOptions(storeURL, cdnHeader)
+		reqOptions := reqOptions(storeURL, cdnHeader, dlOpts)
 
 		httputil.MaybeLogRetryAttempt(reqOptions.URL.String(), attempt, startTime)
 
@@ -2228,6 +2233,11 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		APILevel:    apiV2Endps,
 	}
 
+	if opts.IsAutoRefresh {
+		logger.Debugf("Auto-refresh; adding header Snap-Refresh-Reason: scheduled")
+		reqOptions.addHeader("Snap-Refresh-Reason", "scheduled")
+	}
+
 	if useDeltas() {
 		logger.Debugf("Deltas enabled. Adding header Snap-Accept-Delta-Format: %v", s.deltaFormat)
 		reqOptions.addHeader("Snap-Accept-Delta-Format", s.deltaFormat)
@@ -2400,7 +2410,7 @@ func (s *Store) snapConnCheck() ([]string, error) {
 		return hosts, err
 	}
 
-	reqOptions := reqOptions(dlURL, cdnHeader)
+	reqOptions := reqOptions(dlURL, cdnHeader, nil)
 	reqOptions.Method = "HEAD" // not actually a download
 
 	// TODO: We need the HEAD here so that we get redirected to the


### PR DESCRIPTION
With this change, overlord/snapstate always passes in a flag to the
store when it's auto-refreshing, and the store uses this to set a
`Snap-Refresh-Reason: scheduled` header.

In future we can also use this flag to select a different retry
strategy for auto-refreshes, for example.
