### PR TITLE
timings: add new helpers, Measurer interface and DurationThreshold

### DIFF
--- a/timings/helpers.go
+++ b/timings/helpers.go
@@ -23,11 +23,11 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-// NewForTask creates a new Timings tree for given task.
-// Returned Timings tree has "task-id" and "change-id"
+// NewForTask creates a new Timings tree for the given task.
+// Returned Timings tree has "task-id", "change-id" and "task-kind"
 // tags set automatically from the respective task.
 func NewForTask(task *state.Task) *Timings {
-	tags := map[string]string{"task-id": task.ID()}
+	tags := map[string]string{"task-id": task.ID(), "task-kind": task.Kind()}
 	if chg := task.Change(); chg != nil {
 		tags["change-id"] = chg.ID()
 	}

--- a/timings/helpers.go
+++ b/timings/helpers.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timings
+
+import (
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// NewForTask creates a new Timings tree for given task.
+// Returned Timings tree has "task-id" and "change-id"
+// tags set automatically from the respective task.
+func NewForTask(task *state.Task) *Timings {
+	tags := map[string]string{"task-id": task.ID()}
+	if chg := task.Change(); chg != nil {
+		tags["change-id"] = chg.ID()
+	}
+	return New(tags)
+}
+
+// Run creates, starts and then stops a nested Span under parent Measurer. The nested
+// Span is passed to the measured function and can used to create further spans.
+func Run(meas Measurer, label, summary string, f func(nestedTiming Measurer)) {
+	nested := meas.StartSpan(label, summary)
+	f(nested)
+	nested.Stop()
+}

--- a/timings/state.go
+++ b/timings/state.go
@@ -48,6 +48,7 @@ type rootTimingsJson struct {
 var MaxTimings = 100
 
 // Duration threshold - timings below the threshold will not be saved in the state.
+// It can be changed only while holding state lock.
 var DurationThreshold = 5 * time.Millisecond
 
 var timeDuration = func(start, end time.Time) time.Duration {
@@ -93,7 +94,8 @@ func flattenRecursive(data *rootTimingsJson, timings []*Span, nestLevel int, max
 }
 
 // Save appends Timings data to the "timings" list in the state and purges old timings, ensuring
-// that up to MaxTimings are kept.
+// that up to MaxTimings are kept. Timings are only stored in state if their duration is greater
+// than or equal to DurationThreshold.
 // It's responsibility of the caller to lock the state before calling this function.
 func (t *Timings) Save(st *state.State) {
 	var stateTimings []*json.RawMessage

--- a/timings/timings.go
+++ b/timings/timings.go
@@ -32,7 +32,7 @@ var timeNow = func() time.Time {
 // followed by starting at least one Span, and then saved at the end of the activity.
 //
 // Calling StartSpan on the Timings objects creates a Span and starts new
-// performance measurement. Measurer needs to be finished by calling Stop
+// performance measurement. Measurement needs to be finished by calling Stop
 // function on the Span object.
 // Nested measurements may be collected by calling StartSpan on Span objects. Similar
 // to the above, nested measurements need to be finished by calling Stop on them.
@@ -90,7 +90,7 @@ func startSpan(label, summary string) *Span {
 }
 
 // StartSpan creates a Span and initiates performance measurement.
-// Measurer needs to be stopped by calling Stop on it.
+// Measurement needs to be stopped by calling Stop on it.
 func (t *Timings) StartSpan(label, summary string) *Span {
 	tmeas := startSpan(label, summary)
 	t.timings = append(t.timings, tmeas)

--- a/timings/timings.go
+++ b/timings/timings.go
@@ -27,7 +27,7 @@ var timeNow = func() time.Time {
 	return time.Now()
 }
 
-// Timings represents a tree of Span measurements for a single execution of measured activity.
+// Timings represents a tree of Span time measurements for a single execution of measured activity.
 // A Timings tree object should be created at the beginning of the activity,
 // followed by starting at least one Span, and then saved at the end of the activity.
 //
@@ -49,13 +49,13 @@ var timeNow = func() time.Time {
 //
 // In addition, a few helpers exist to simplify typical use cases, for example the above example
 // can be reduced to:
-//   troot := timings.NewForTask(task) // tags set automatically, label and summary derived from task
+//   troot := timings.NewForTask(task) // tags set automatically from task
 //   t1 := troot.StartSpan("computation", "...")
-//   t1.Run("sub-computation", "...", func(nested *Span) {
+//   timings.Run(t1, "sub-computation", "...", func(nested *Span) {
 //          ... expensive computation
 //   })
 //   t1.Stop()
-//   troot.Save()
+//   troot.Save(task.State())
 type Timings struct {
 	tags    map[string]string
 	timings []*Span

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -49,6 +49,7 @@ func (s *timingsSuite) SetUpTest(c *C) {
 	s.duration = 0
 
 	s.mockTimeNow(c)
+	s.mockDurationThreshold(0)
 }
 
 func (s *timingsSuite) TearDownTest(c *C) {
@@ -62,6 +63,15 @@ func (s *timingsSuite) mockDuration(c *C) {
 		s.duration += time.Millisecond
 		return s.duration
 	}))
+}
+
+func (s *timingsSuite) mockDurationThreshold(threshold time.Duration) {
+	oldDurationThreshold := timings.DurationThreshold
+	timings.DurationThreshold = threshold
+	restore := func() {
+		timings.DurationThreshold = oldDurationThreshold
+	}
+	s.AddCleanup(restore)
 }
 
 func (s *timingsSuite) mockTimeNow(c *C) {
@@ -86,8 +96,11 @@ func (s *timingsSuite) TestSave(c *C) {
 		timing := timings.New(map[string]string{"task": "3", "change": "12"})
 		meas := timing.StartSpan(fmt.Sprintf("doing something-%d", i), "...")
 		nested := meas.StartSpan("nested measurement", "...")
-		nestedMore := nested.StartSpan("nested more", "...")
-		nestedMore.Stop()
+		var called bool
+		timings.Run(nested, "nested more", "...", func(span timings.Measurer) {
+			called = true
+		})
+		c.Check(called, Equals, true)
 		nested.Stop()
 		meas.Stop()
 		timing.Save(s.st)
@@ -182,6 +195,96 @@ func (s *timingsSuite) TestDuration(c *C) {
 			}}})
 }
 
+func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expected interface{}) {
+	s.mockDurationThreshold(threshold)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	timing := timings.New(nil)
+	meas := timing.StartSpan("main", "...")
+	nested := meas.StartSpan("nested", "...")
+	nestedMore := nested.StartSpan("nested more", "...")
+	nestedMore.Stop()
+	nested.Stop()
+
+	meas.Stop()
+	timing.Save(s.st)
+
+	var stateTimings []interface{}
+	if expected == nil {
+		c.Assert(s.st.Get("timings", &stateTimings), Equals, state.ErrNoState)
+		c.Assert(stateTimings, IsNil)
+		return
+	}
+	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
+	c.Check(stateTimings, DeepEquals, expected)
+}
+
+func (s *timingsSuite) TestDurationThresholdAll(c *C) {
+	s.testDurationThreshold(c, 0, []interface{}{
+		map[string]interface{}{
+			"start-time": "2019-03-11T09:01:00.001Z",
+			"stop-time":  "2019-03-11T09:01:00.006Z",
+			"timings": []interface{}{
+				map[string]interface{}{
+					"label":    "main",
+					"summary":  "...",
+					"duration": float64(5000000),
+				},
+				map[string]interface{}{
+					"level":    float64(1),
+					"label":    "nested",
+					"summary":  "...",
+					"duration": float64(3000000),
+				},
+				map[string]interface{}{
+					"level":    float64(2),
+					"label":    "nested more",
+					"summary":  "...",
+					"duration": float64(1000000),
+				},
+			}}})
+}
+
+func (s *timingsSuite) TestDurationThreshold(c *C) {
+	s.testDurationThreshold(c, 3000000, []interface{}{
+		map[string]interface{}{
+			"start-time": "2019-03-11T09:01:00.001Z",
+			"stop-time":  "2019-03-11T09:01:00.006Z",
+			"timings": []interface{}{
+				map[string]interface{}{
+					"label":    "main",
+					"summary":  "...",
+					"duration": float64(5000000),
+				},
+				map[string]interface{}{
+					"level":    float64(1),
+					"label":    "nested",
+					"summary":  "...",
+					"duration": float64(3000000),
+				},
+			}}})
+}
+
+func (s *timingsSuite) TestDurationThresholdRootOnly(c *C) {
+	s.testDurationThreshold(c, 4000000, []interface{}{
+		map[string]interface{}{
+			"start-time": "2019-03-11T09:01:00.001Z",
+			"stop-time":  "2019-03-11T09:01:00.006Z",
+			"timings": []interface{}{
+				map[string]interface{}{
+					"label":    "main",
+					"summary":  "...",
+					"duration": float64(5000000),
+				},
+			}}})
+}
+
+func (s *timingsSuite) TestDurationThresholdNone(c *C) {
+	s.testDurationThreshold(c, time.Hour, nil)
+}
+
 func (s *timingsSuite) TestPurgeOnSave(c *C) {
 	oldMaxTimings := timings.MaxTimings
 	timings.MaxTimings = 3
@@ -208,4 +311,33 @@ func (s *timingsSuite) TestPurgeOnSave(c *C) {
 	c.Check(stateTimings[0].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "7"})
 	c.Check(stateTimings[1].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "8"})
 	c.Check(stateTimings[2].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "9"})
+}
+
+func (s *timingsSuite) TestNewForTask(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	task := s.st.NewTask("...", "...")
+	chg := s.st.NewChange("change", "...")
+	chg.AddTask(task)
+
+	troot := timings.NewForTask(task)
+	span := troot.StartSpan("foo", "bar")
+	span.Stop()
+	troot.Save(s.st)
+
+	var stateTimings []interface{}
+	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
+	c.Assert(stateTimings, DeepEquals, []interface{}{
+		map[string]interface{}{
+			"tags":       map[string]interface{}{"change-id": chg.ID(), "task-id": task.ID()},
+			"start-time": "2019-03-11T09:01:00.001Z",
+			"stop-time":  "2019-03-11T09:01:00.002Z",
+			"timings": []interface{}{
+				map[string]interface{}{
+					"label":    "foo",
+					"summary":  "bar",
+					"duration": float64(1000000),
+				},
+			}}})
 }

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -317,7 +317,7 @@ func (s *timingsSuite) TestNewForTask(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	task := s.st.NewTask("...", "...")
+	task := s.st.NewTask("kind", "...")
 	chg := s.st.NewChange("change", "...")
 	chg.AddTask(task)
 
@@ -330,7 +330,7 @@ func (s *timingsSuite) TestNewForTask(c *C) {
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 	c.Assert(stateTimings, DeepEquals, []interface{}{
 		map[string]interface{}{
-			"tags":       map[string]interface{}{"change-id": chg.ID(), "task-id": task.ID()},
+			"tags":       map[string]interface{}{"change-id": chg.ID(), "task-id": task.ID(), "task-kind": "kind"},
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.002Z",
 			"timings": []interface{}{


### PR DESCRIPTION
Add some enhancements to the timings API as a result of work on #6591:
- Measurer interface with StartSpan method, to allow passing either Timings or Span objects around.
- NewForTask helper to simplify common use case of creating Timings for a task.
- Run helper to simplify common case of running a nested measurement.
- DurationThreshold to avoid storing very short timings in the state - timings/spans that are less than that are ignored.

Some docstring cleanups were also made.