### PR TITLE
errortracker: fix panic in Report if db cannot be opened

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -238,7 +238,7 @@ func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error
 	// check if we haven't already reported this error
 	db, err := newReportsDB(dirs.ErrtrackerDbDir)
 	if err != nil {
-		logger.Noticef("cannot open error reports database: %v", err)
+		return "", fmt.Errorf("cannot open error reports database: %v", err)
 	}
 	defer db.Close()
 

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -542,3 +542,15 @@ func (s *ErrtrackerTestSuite) TestReportsDBnilDoesNotCrash(c *C) {
 	c.Check(db.AlreadyReported("dupSig"), Equals, false)
 	c.Check(db.MarkReported("dupSig"), ErrorMatches, "cannot mark error report as reported with an uninitialized reports database")
 }
+
+func (s *ErrtrackerTestSuite) TestReportsDBnilDoesNotCrashOnReport(c *C) {
+	oldDbDir := dirs.ErrtrackerDbDir
+	dirs.ErrtrackerDbDir = "/proc/1/environ"
+	defer func() {
+		dirs.ErrtrackerDbDir = oldDbDir
+	}()
+
+	id, err := errtracker.Report("some-snap", "failed to do stuff", "[failed to do stuff]", nil)
+	c.Assert(err, ErrorMatches, "cannot open error reports database: open /proc/1/environ:.*")
+	c.Assert(id, Equals, "")
+}


### PR DESCRIPTION
Report() function tries to open the database and logs an error if open fails, but then carries on and panics on `Close()`. This PR fixes it.

I hit this when running snapd manually and working on unrelated stuff - https://paste.ubuntu.com/p/xQMvDQ9hNP/