### PR TITLE
cmd: typedef mountinfo structures

### DIFF
--- a/cmd/libsnap-confine-private/mountinfo-test.c
+++ b/cmd/libsnap-confine-private/mountinfo-test.c
@@ -24,7 +24,7 @@ static void test_parse_mountinfo_entry__sysfs(void)
 {
 	const char *line =
 	    "19 25 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 19);
@@ -48,7 +48,7 @@ static void test_parse_mountinfo_entry__snapd_ns(void)
 {
 	const char *line =
 	    "104 23 0:19 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=99840k,mode=755";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 104);
@@ -69,7 +69,7 @@ static void test_parse_mountinfo_entry__snapd_mnt(void)
 {
 	const char *line =
 	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 256);
@@ -89,7 +89,7 @@ static void test_parse_mountinfo_entry__snapd_mnt(void)
 static void test_parse_mountinfo_entry__garbage(void)
 {
 	const char *line = "256 104 0:3";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_null(entry);
 }
 
@@ -97,7 +97,7 @@ static void test_parse_mountinfo_entry__no_tags(void)
 {
 	const char *line =
 	    "1 2 3:4 root mount-dir mount-opts - fs-type mount-source super-opts";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 1);
@@ -118,7 +118,7 @@ static void test_parse_mountinfo_entry__one_tag(void)
 {
 	const char *line =
 	    "1 2 3:4 root mount-dir mount-opts tag:1 - fs-type mount-source super-opts";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 1);
@@ -139,7 +139,7 @@ static void test_parse_mountinfo_entry__many_tags(void)
 {
 	const char *line =
 	    "1 2 3:4 root mount-dir mount-opts tag:1 tag:2 tag:3 tag:4 - fs-type mount-source super-opts";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 1);
@@ -160,7 +160,7 @@ static void test_parse_mountinfo_entry__empty_source(void)
 {
 	const char *line =
 	    "304 301 0:45 / /snap/test-snapd-content-advanced-plug/x1 rw,relatime - tmpfs  rw";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
+	sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
 	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 304);

--- a/cmd/libsnap-confine-private/mountinfo.c
+++ b/cmd/libsnap-confine-private/mountinfo.c
@@ -43,35 +43,34 @@
  * (10) mount source:  filesystem specific information or "none"
  * (11) super options:  per super block options
  **/
-static struct sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
+static sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
     __attribute__ ((nonnull(1)));
 
 /**
  * Free a sc_mountinfo structure and all its entries.
  **/
-static void sc_free_mountinfo(struct sc_mountinfo *info)
+static void sc_free_mountinfo(sc_mountinfo * info)
     __attribute__ ((nonnull(1)));
 
 /**
  * Free a sc_mountinfo entry.
  **/
-static void sc_free_mountinfo_entry(struct sc_mountinfo_entry *entry)
+static void sc_free_mountinfo_entry(sc_mountinfo_entry * entry)
     __attribute__ ((nonnull(1)));
 
-struct sc_mountinfo_entry *sc_first_mountinfo_entry(struct sc_mountinfo *info)
+sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo * info)
 {
 	return info->first;
 }
 
-struct sc_mountinfo_entry *sc_next_mountinfo_entry(struct sc_mountinfo_entry
-						   *entry)
+sc_mountinfo_entry *sc_next_mountinfo_entry(sc_mountinfo_entry * entry)
 {
 	return entry->next;
 }
 
-struct sc_mountinfo *sc_parse_mountinfo(const char *fname)
+sc_mountinfo *sc_parse_mountinfo(const char *fname)
 {
-	struct sc_mountinfo *info = calloc(1, sizeof *info);
+	sc_mountinfo *info = calloc(1, sizeof *info);
 	if (info == NULL) {
 		return NULL;
 	}
@@ -86,7 +85,7 @@ struct sc_mountinfo *sc_parse_mountinfo(const char *fname)
 	}
 	char *line SC_CLEANUP(sc_cleanup_string) = NULL;
 	size_t line_size = 0;
-	struct sc_mountinfo_entry *entry, *last = NULL;
+	sc_mountinfo_entry *entry, *last = NULL;
 	for (;;) {
 		errno = 0;
 		if (getline(&line, &line_size, f) == -1) {
@@ -112,7 +111,7 @@ struct sc_mountinfo *sc_parse_mountinfo(const char *fname)
 }
 
 static void show_buffers(const char *line, int offset,
-			 struct sc_mountinfo_entry *entry)
+			 sc_mountinfo_entry * entry)
 {
 #ifdef MOUNTINFO_DEBUG
 	fprintf(stderr, "Input buffer (first), with offset arrow\n");
@@ -142,7 +141,7 @@ static void show_buffers(const char *line, int offset,
 #endif				// MOUNTINFO_DEBUG
 }
 
-static char *parse_next_string_field(struct sc_mountinfo_entry *entry,
+static char *parse_next_string_field(sc_mountinfo_entry * entry,
 				     const char *line, int *offset)
 {
 	int offset_delta = 0;
@@ -165,7 +164,7 @@ static char *parse_next_string_field(struct sc_mountinfo_entry *entry,
 	return field;
 }
 
-static struct sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
+static sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
 {
 	// NOTE: the sc_mountinfo structure is allocated along with enough extra
 	// storage to hold the whole line we are parsing. This is used as backing
@@ -189,8 +188,7 @@ static struct sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
 	//
 	// If MOUNTINFO_DEBUG is defined then extra debugging is printed to stderr
 	// and this allows for visual analysis of what is going on.
-	struct sc_mountinfo_entry *entry =
-	    calloc(1, sizeof *entry + strlen(line) + 1);
+	sc_mountinfo_entry *entry = calloc(1, sizeof *entry + strlen(line) + 1);
 	if (entry == NULL) {
 		return NULL;
 	}
@@ -250,7 +248,7 @@ static struct sc_mountinfo_entry *sc_parse_mountinfo_entry(const char *line)
 	return NULL;
 }
 
-void sc_cleanup_mountinfo(struct sc_mountinfo **ptr)
+void sc_cleanup_mountinfo(sc_mountinfo ** ptr)
 {
 	if (*ptr != NULL) {
 		sc_free_mountinfo(*ptr);
@@ -258,9 +256,9 @@ void sc_cleanup_mountinfo(struct sc_mountinfo **ptr)
 	}
 }
 
-static void sc_free_mountinfo(struct sc_mountinfo *info)
+static void sc_free_mountinfo(sc_mountinfo * info)
 {
-	struct sc_mountinfo_entry *entry, *next;
+	sc_mountinfo_entry *entry, *next;
 	for (entry = info->first; entry != NULL; entry = next) {
 		next = entry->next;
 		sc_free_mountinfo_entry(entry);
@@ -268,7 +266,7 @@ static void sc_free_mountinfo(struct sc_mountinfo *info)
 	free(info);
 }
 
-static void sc_free_mountinfo_entry(struct sc_mountinfo_entry *entry)
+static void sc_free_mountinfo_entry(sc_mountinfo_entry * entry)
 {
 	free(entry);
 }

--- a/cmd/libsnap-confine-private/mountinfo.h
+++ b/cmd/libsnap-confine-private/mountinfo.h
@@ -18,16 +18,9 @@
 #define SNAP_CONFINE_MOUNTINFO_H
 
 /**
- * Structure describing entire /proc/self/sc_mountinfo file
- **/
-struct sc_mountinfo {
-	struct sc_mountinfo_entry *first;
-};
-
-/**
  * Structure describing a single entry in /proc/self/sc_mountinfo
  **/
-struct sc_mountinfo_entry {
+typedef struct sc_mountinfo_entry {
 	/**
 	 * The mount identifier of a given mount entry.
 	 **/
@@ -91,7 +84,14 @@ struct sc_mountinfo_entry {
 	// along with the structure itself and does not need to be freed
 	// separately.
 	char line_buf[0];
-};
+} sc_mountinfo_entry;
+
+/**
+ * Structure describing entire /proc/self/sc_mountinfo file
+ **/
+typedef struct sc_mountinfo {
+	sc_mountinfo_entry *first;
+} sc_mountinfo;
 
 /**
  * Parse a file in according to sc_mountinfo syntax.
@@ -100,7 +100,7 @@ struct sc_mountinfo_entry {
  * implicitly parse /proc/self/sc_mountinfo, that is the mount information
  * associated with the current process.
  **/
-struct sc_mountinfo *sc_parse_mountinfo(const char *fname);
+sc_mountinfo *sc_parse_mountinfo(const char *fname);
 
 /**
  * Free a sc_mountinfo structure.
@@ -108,7 +108,7 @@ struct sc_mountinfo *sc_parse_mountinfo(const char *fname);
  * This function is designed to be used with __attribute__((cleanup)) so it
  * takes a pointer to the freed object (which is also a pointer).
  **/
-void sc_cleanup_mountinfo(struct sc_mountinfo **ptr)
+void sc_cleanup_mountinfo(sc_mountinfo ** ptr)
     __attribute__ ((nonnull(1)));
 
 /**
@@ -118,7 +118,7 @@ void sc_cleanup_mountinfo(struct sc_mountinfo **ptr)
  * returned value is bound to the lifecycle of the whole sc_mountinfo structure
  * and should not be freed explicitly.
  **/
-struct sc_mountinfo_entry *sc_first_mountinfo_entry(struct sc_mountinfo *info)
+sc_mountinfo_entry *sc_first_mountinfo_entry(sc_mountinfo * info)
     __attribute__ ((nonnull(1)));
 
 /**
@@ -128,8 +128,7 @@ struct sc_mountinfo_entry *sc_first_mountinfo_entry(struct sc_mountinfo *info)
  * was the last entry. The returned value is bound to the lifecycle of the
  * whole sc_mountinfo structure and should not be freed explicitly.
  **/
-struct sc_mountinfo_entry *sc_next_mountinfo_entry(struct sc_mountinfo_entry
-						   *entry)
+sc_mountinfo_entry *sc_next_mountinfo_entry(sc_mountinfo_entry * entry)
     __attribute__ ((nonnull(1)));
 
 #endif

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -638,12 +638,12 @@ static bool is_mounted_with_shared_option(const char *dir)
 
 static bool is_mounted_with_shared_option(const char *dir)
 {
-	struct sc_mountinfo *sm SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+	sc_mountinfo *sm SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	sm = sc_parse_mountinfo(NULL);
 	if (sm == NULL) {
 		die("cannot parse /proc/self/mountinfo");
 	}
-	struct sc_mountinfo_entry *entry = sc_first_mountinfo_entry(sm);
+	sc_mountinfo_entry *entry = sc_first_mountinfo_entry(sm);
 	while (entry != NULL) {
 		const char *mount_dir = entry->mount_dir;
 		if (sc_streq(mount_dir, dir)) {

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -133,7 +133,7 @@ void sc_initialize_mount_ns(void)
 
 	/* Read and analyze the mount table. We need to see whether /run/snapd/ns
 	 * is a mount point with private event propagation. */
-	struct sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+	sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	info = sc_parse_mountinfo(NULL);
 	if (info == NULL) {
 		die("cannot parse /proc/self/mountinfo");
@@ -141,7 +141,7 @@ void sc_initialize_mount_ns(void)
 
 	bool is_mnt = false;
 	bool is_private = false;
-	for (struct sc_mountinfo_entry * entry = sc_first_mountinfo_entry(info);
+	for (sc_mountinfo_entry * entry = sc_first_mountinfo_entry(info);
 	     entry != NULL; entry = sc_next_mountinfo_entry(entry)) {
 		/* Find /run/snapd/ns */
 		if (!sc_streq(entry->mount_dir, sc_ns_dir)) {
@@ -239,13 +239,13 @@ static dev_t find_base_snap_device(const char *base_snap_name,
 	sc_must_snprintf(base_squashfs_path,
 			 sizeof base_squashfs_path, "%s/%s/%s",
 			 SNAP_MOUNT_DIR, base_snap_name, base_snap_rev);
-	struct sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	mi = sc_parse_mountinfo(NULL);
 	if (mi == NULL) {
 		die("cannot parse mountinfo of the current process");
 	}
 	bool found = false;
-	for (struct sc_mountinfo_entry * mie =
+	for (sc_mountinfo_entry * mie =
 	     sc_first_mountinfo_entry(mi); mie != NULL;
 	     mie = sc_next_mountinfo_entry(mie)) {
 		if (sc_streq(mie->mount_dir, base_squashfs_path)) {
@@ -272,8 +272,8 @@ static bool should_discard_current_ns(dev_t base_snap_dev)
 	// The namespace may become "stale" when the rootfs is not the same
 	// device we found above. This will happen whenever the base snap is
 	// refreshed since the namespace was first created.
-	struct sc_mountinfo_entry *mie;
-	struct sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+	sc_mountinfo_entry *mie;
+	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 
 	mi = sc_parse_mountinfo(NULL);
 	if (mi == NULL) {

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -25,10 +25,9 @@
 #include "../libsnap-confine-private/mountinfo.h"
 #include "../libsnap-confine-private/string-utils.h"
 
-static struct sc_mountinfo_entry *find_root_mountinfo(struct sc_mountinfo
-						      *mounts)
+static sc_mountinfo_entry *find_root_mountinfo(sc_mountinfo * mounts)
 {
-	struct sc_mountinfo_entry *cur, *root = NULL;
+	sc_mountinfo_entry *cur, *root = NULL;
 	for (cur = sc_first_mountinfo_entry(mounts); cur != NULL;
 	     cur = sc_next_mountinfo_entry(cur)) {
 		// Look for the mount info entry for the root file-system.
@@ -52,14 +51,14 @@ int main(int argc, char **argv)
 	// const char *late_dir = argv[3];
 
 	// Load /proc/self/mountinfo so that we can inspect the root filesystem.
-	struct sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+	sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	mounts = sc_parse_mountinfo(NULL);
 	if (!mounts) {
 		fprintf(stderr, "cannot open or parse /proc/self/mountinfo\n");
 		return 1;
 	}
 
-	struct sc_mountinfo_entry *root = find_root_mountinfo(mounts);
+	sc_mountinfo_entry *root = find_root_mountinfo(mounts);
 	if (!root) {
 		fprintf(stderr,
 			"cannot find mountinfo entry of the root filesystem\n");

--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -111,13 +111,12 @@ bool umount_all(void)
 	bool had_writable = false;
 
 	for (int i = 0; i < 10 && did_umount; i++) {
-		struct sc_mountinfo *mounts = sc_parse_mountinfo(NULL);
+		sc_mountinfo *mounts = sc_parse_mountinfo(NULL);
 		if (!mounts) {
 			// oh dear
 			die("unable to get mount info; giving up");
 		}
-		struct sc_mountinfo_entry *cur =
-		    sc_first_mountinfo_entry(mounts);
+		sc_mountinfo_entry *cur = sc_first_mountinfo_entry(mounts);
 
 		had_writable = false;
 		did_umount = false;


### PR DESCRIPTION
I'm not sure why I didn't initially. Use of typedef helps to avoids
overly long lines whenever mountinfo is used.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
