### PR TITLE
cmd/snap-confine: umount scratch dir using UMOUNT_NOFOLLOW

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -431,7 +431,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// This way we can remove the temporary directory we created and "clean up"
 	// after ourselves nicely.
 	sc_must_snprintf(dst, sizeof dst, "%s/%s", SC_HOSTFS_DIR, scratch_dir);
-	sc_do_umount(dst, 0);
+	sc_do_umount(dst, UMOUNT_NOFOLLOW);
 	// Remove the scratch directory. Note that we are using the path that is
 	// based on the old root filesystem as after pivot_root we cannot guarantee
 	// what is present at the same location normally. (It is probably an empty


### PR DESCRIPTION
During the start-up sequence, snap-confine performs some interesting
operations to prepare for pivot root. This involves setting up a root
filesystem in scratch directory in /tmp. After the pivot that directory
is unmounted (it was earlier mounted as an unbindable bind-mount).

All in all this is not a security risk of any kind but due diligence
similar to O_NOFOLLOW for openat(2) and similar.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
Related-To: https://bugzilla.suse.com/show_bug.cgi?id=1127368
