### PR TITLE
interfaces/builtin: add add exec "/" to docker-support

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -139,6 +139,10 @@ ptrace (read, trace) peer=docker-default,
 
 #cf bug 1502785
 / r,
+
+# needed by runc for mitigation of CVE-2019-5736
+# see apparmor bug 1820344
+/ ix,
 `
 
 const dockerSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -141,7 +141,7 @@ ptrace (read, trace) peer=docker-default,
 / r,
 
 # needed by runc for mitigation of CVE-2019-5736
-# see apparmor bug 1820344
+# For details see https://bugs.launchpad.net/apparmor/+bug/1820344
 / ix,
 `
 


### PR DESCRIPTION
This access is needed to allow recent versions of runC inside docker
18.06.3 and 18.09.3 to run properly. Note that the snap is not affected
by CVE-2019-5736 directly, but this access is needed so that the
mitigation works properly.