### PR TITLE
interfaces/builtin: add dev/pts/ptmx access to docker_support

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -139,6 +139,11 @@ ptrace (read, trace) peer=docker-default,
 
 #cf bug 1502785
 / r,
+
+# recent versions of docker make a symlink from /dev/ptmx to /dev/pts/ptmx
+# and so to allow allocating a new shell we need this
+/dev/pts/ptmx rw,
+
 `
 
 const dockerSupportConnectedPlugSecComp = `


### PR DESCRIPTION
Recent versions of docker now create a symlink from /dev/ptmx to
/dev/pts/ptmx in order to create a new interactive shell instead of
performing a bind mount. This access allows one to disconnect the
privileged interface from docker and still use the "less privileged"
version of the docker-support interface.