### PR TITLE
interfaces/builtin: add dev/pts/ptmx access to docker_support (for 2.38)

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -143,6 +143,11 @@ ptrace (read, trace) peer=docker-default,
 # needed by runc for mitigation of CVE-2019-5736
 # For details see https://bugs.launchpad.net/apparmor/+bug/1820344
 / ix,
+
+# recent versions of docker make a symlink from /dev/ptmx to /dev/pts/ptmx
+# and so to allow allocating a new shell we need this
+/dev/pts/ptmx rw,
+
 `
 
 const dockerSupportConnectedPlugSecComp = `


### PR DESCRIPTION
Recent versions of docker now create a symlink from /dev/ptmx to
/dev/pts/ptmx in order to create a new interactive shell instead of
performing a bind mount. This access allows one to disconnect the
privileged interface from docker and still use the "less privileged"
version of the docker-support interface.

Duplicate of #6612 but for 2.38

It would be nice to get this into 2.38, but it's not critical so please feel free to close this if it's too late or too much. Thanks!