### PR TITLE
cmd/snap-confine: use fixed private tmp directory

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -90,9 +90,8 @@ static void setup_private_mount(const char *snap_name)
 	char tmp_dir[MAX_BUF] = { 0 };
 	int base_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	int tmp_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	sc_must_snprintf(tmp_dir, sizeof(tmp_dir), "/tmp/snap.%s/tmp",
-			 snap_name);
 	sc_must_snprintf(base_dir, sizeof(base_dir), "/tmp/snap.%s", snap_name);
+	sc_must_snprintf(tmp_dir, sizeof(tmp_dir), "%s/tmp", base_dir);
 
 	// Create /tmp/snap.$SNAP_NAME/ 0700 root.root. Ignore EEXIST since we want
 	// to reuse and we will open with O_NOFOLLOW, below.

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -248,8 +248,8 @@
     # set up snap-specific private /tmp dir
     capability chown,
     /tmp/ rw,
-    /tmp/snap.*/ w,
-    /tmp/snap.*/tmp/ w,
+    /tmp/snap.*/ rw,
+    /tmp/snap.*/tmp/ rw,
     mount options=(rw private) ->  /tmp/,
     mount options=(rw bind) /tmp/snap.*/tmp/ -> /tmp/,
     mount fstype=devpts options=(rw) devpts -> /dev/pts/,

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -51,18 +51,12 @@ execute: |
         sleep 0.1
     done
 
-    # Create another stamp file in /tmp (which is private to the snap). We'll
-    # need it in a moment.
-    test-snapd-sh -c "touch /tmp/stamp"
-
     # Now, refresh core to our customized core snap.
     snap install --dangerous ./core-customized.snap
     snap list | MATCH customized
 
     # Now we are in a situation where the core snap is stale but our sleeper
-    # application is still alive so we cannot use it. We can ensure that this
-    # is the case by looking at our stamp file and seeing it being there.
-    test-snapd-sh -c "test -e /tmp/stamp"
+    # application is still alive so we cannot use it.
     test-snapd-sh -c "test ! -e /customized"
 
     # Kill our helper process.
@@ -70,7 +64,5 @@ execute: |
     wait -n || true
 
     # Now when the process terminates, we no longer need to hold back.
-    # The next process will use a fresh namespace and will no longer see
-    # the stamp file in /tmp because /tmp is now empty.
-    test-snapd-sh -c "test ! -e /tmp/stamp"
+    # The next process will use a fresh mount namespace.
     test-snapd-sh -c "test -e /customized"


### PR DESCRIPTION
When snap-confine prepares a fresh per-snap mount namespace
it constructs a private /tmp directory that is not shared with other
snaps.

As a part of this work snap-confine would create a randomly named
directory in /tmp/snap.$SNAP_NAME_xxxxx with the x characters replaced
by random unique name.

Those directories would never be recycled and would be re-created when
the mount namespace was to be discarded. This was accumulating data in
/tmp that would not be normally removed unless the machine had rebooted.
In addition whenever multiple temporary directories existed for a single
snap the user would be unable to easily determine which one is the right
one, presenting usability issues for applications that use data in /tmp
for whatever reason (e.g. temporary log files).

This patch changes the path to be fixed, always
/tmp/snap.$SNAP_INSTANCE_NAME/tmp. This opens the avenue towards snapd
managing that directory (e.g. to remove it on snap removal).

There is only one user-visible consequence: discarding the mount
namespace and re-running a snap application no longer gives the
application fresh /tmp directory. It is unlikely anything apart from
snapd test suite will observe this change though.

The test that was checking if the base snap for a given snap has changed
has now been updated not to rely on the re-creation of /tmp.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
Related-To: https://bugzilla.suse.com/show_bug.cgi?id=1127368