### PR TITLE
spread: some debug info to catch /var/snap/.. not being empty

### DIFF
--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -38,6 +38,7 @@ func (b Backend) RemoveSnapData(snap *snap.Info) error {
 	if err != nil {
 		return err
 	}
+	logger.Debugf("*** going to remove %q", dirs)
 
 	return removeDirs(dirs)
 }
@@ -48,6 +49,7 @@ func (b Backend) RemoveSnapCommonData(snap *snap.Info) error {
 	if err != nil {
 		return err
 	}
+	logger.Debugf("*** going to remove %q", dirs)
 
 	return removeDirs(dirs)
 }

--- a/spread.yaml
+++ b/spread.yaml
@@ -454,6 +454,8 @@ debug-each: |
         echo '# free space'
         df -h || true
         find /var/snap -ls || true
+        snap list --all || true
+        snap changes || true
     fi
 
 rename:

--- a/spread.yaml
+++ b/spread.yaml
@@ -453,6 +453,7 @@ debug-each: |
         cat "$RUNTIME_STATE_PATH/runs" || true
         echo '# free space'
         df -h || true
+        find /var/snap -ls || true
     fi
 
 rename:


### PR DESCRIPTION
The following problem seems to come up quite often:
```
+ snap info test-snapd-tools
+ snap remove test-snapd-tools
error: cannot perform the following tasks:
- Remove data for snap "test-snapd-tools" (x1) (failed to remove snap "test-snapd-tools" base directory: remove /var/snap/test-snapd-tools: directory not empty)
```
Let's try to collect some debug information.