### PR TITLE
cmd/snap: fix regression of snap saved command

### DIFF
--- a/cmd/snap/cmd_snapshot.go
+++ b/cmd/snap/cmd_snapshot.go
@@ -107,9 +107,13 @@ type savedCmd struct {
 }
 
 func (x *savedCmd) Execute([]string) error {
-	setID, err := x.ID.ToUint()
-	if err != nil {
-		return err
+	var setID uint64
+	var err error
+	if x.ID != "" {
+		setID, err = x.ID.ToUint()
+		if err != nil {
+			return err
+		}
 	}
 	snaps := installedSnapNames(x.Positional.Snaps)
 	list, err := x.client.SnapshotSets(setID, snaps)

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -36,7 +36,7 @@ var snapshotsTests = []getCmdArgs{{
 	args:  "saved --id=x",
 	error: "invalid argument for set id: expected a non-negative integer argument",
 }, {
-	args:  "saved",
+	args:   "saved",
 	stdout: "Set  Snap  Age    Version  Rev   Size    Notes\n1    htop  .*  2        1168      1B  -\n",
 }, {
 	args:  "forget x",

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -17,8 +17,8 @@ execute: |
     SET_ID=$( snap save test-snapd-tools test-snapd-rsync | cut -d\  -f1 | tail -n1 )
 
     # check it includes both snaps
-    snap saved | grep test-snapd-tools
-    snap saved | grep test-snapd-rsync
+    snap saved | MATCH test-snapd-tools
+    snap saved | MATCH test-snapd-rsync
     snap saved --id="$SET_ID" | grep test-snapd-tools
     snap saved --id="$SET_ID" | grep test-snapd-rsync
     # and is valid

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -17,6 +17,8 @@ execute: |
     SET_ID=$( snap save test-snapd-tools test-snapd-rsync | cut -d\  -f1 | tail -n1 )
 
     # check it includes both snaps
+    snap saved | grep test-snapd-tools
+    snap saved | grep test-snapd-rsync
     snap saved --id="$SET_ID" | grep test-snapd-tools
     snap saved --id="$SET_ID" | grep test-snapd-rsync
     # and is valid


### PR DESCRIPTION
The recent fix for more readable error messages if set id argument is ommited for snapshot commands caused unexpected regression in `snap saved` command - it errors out if set ID is omitted (previously, before the fix, we would get integer set id = 0 if omitted, which means all sets). This PR fixes it.
