### PR TITLE
tests/main/remodel: clean up before reverting the state

### DIFF
--- a/tests/main/remodel/task.yaml
+++ b/tests/main/remodel/task.yaml
@@ -69,3 +69,12 @@ execute: |
     # FIXME: check that this is the active model assertion
     echo "and we got the new model assertion"
     snap debug model|MATCH "revision: 2"
+
+    # FIXME: this fails (meaning, the remove does not fail)
+    # echo "We can't remove a required snap
+    # ! snap remove test-snapd-tools
+
+    # when the above no longer fails, this will fail, so you'll have
+    # to re-remodel:
+    echo "Remove the ex-required snap"
+    snap remove test-snapd-tools

--- a/tests/main/remodel/task.yaml
+++ b/tests/main/remodel/task.yaml
@@ -71,10 +71,12 @@ execute: |
     snap debug model|MATCH "revision: 2"
 
     # FIXME: this fails (meaning, the remove does not fail)
-    # echo "We can't remove a required snap
+    # echo "We can't remove a required snap"
     # ! snap remove test-snapd-tools
 
-    # when the above no longer fails, this will fail, so you'll have
-    # to re-remodel:
+    # when the above no longer fails, this will fail, so you'll have to
+    # re-remodel to be able to remove the snap (or clean up manually in restore
+    # -- but better to check here for the expected required -> non-required
+    # behaviour):
     echo "Remove the ex-required snap"
     snap remove test-snapd-tools


### PR DESCRIPTION
While it's cleanup, it's also things that should work, so I've added
them to the test itself and not to the restore section.
