### PR TITLE
overlord/snapstate: track time of postponed refreshes

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -944,8 +944,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	t.Set("old-refresh-inhibited-time", oldRefreshInhibitedTime)
 
 	// Record the fact that the snap was refreshed successfully.
-	var zeroTime time.Time
-	snapst.RefreshInhibitedTime = zeroTime
+	snapst.RefreshInhibitedTime = nil
 
 	// Do at the end so we only preserve the new state if it worked.
 	Set(st, snapsup.InstanceName(), snapst)
@@ -1097,7 +1096,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err := t.Get("old-candidate-index", &oldCandidateIndex); err != nil {
 		return err
 	}
-	var oldRefreshInhibitedTime time.Time
+	var oldRefreshInhibitedTime *time.Time
 	if err := t.Get("old-refresh-inhibited-time", &oldRefreshInhibitedTime); err != nil && err != state.ErrNoState {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -877,7 +877,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	if snapsup.Required { // set only on install and left alone on refresh
 		snapst.Required = true
 	}
-	oldRefreshPostponedTime := snapst.RefreshPostponedTime
+	oldRefreshInhibitedTime := snapst.RefreshInhibitedTime
 	// only set userID if unset or logged out in snapst and if we
 	// actually have an associated user
 	if snapsup.UserID > 0 {
@@ -941,11 +941,11 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	t.Set("old-channel", oldChannel)
 	t.Set("old-current", oldCurrent)
 	t.Set("old-candidate-index", oldCandidateIndex)
-	t.Set("old-refresh-postponed-time", oldRefreshPostponedTime)
+	t.Set("old-refresh-inhibited-time", oldRefreshInhibitedTime)
 
 	// Record the fact that the snap was refreshed successfully.
 	var zeroTime time.Time
-	snapst.RefreshPostponedTime = zeroTime
+	snapst.RefreshInhibitedTime = zeroTime
 
 	// Do at the end so we only preserve the new state if it worked.
 	Set(st, snapsup.InstanceName(), snapst)
@@ -1097,8 +1097,8 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err := t.Get("old-candidate-index", &oldCandidateIndex); err != nil {
 		return err
 	}
-	var oldRefreshPostponedTime time.Time
-	if err := t.Get("old-refresh-postponed-time", &oldRefreshPostponedTime); err != nil && err != state.ErrNoState {
+	var oldRefreshInhibitedTime time.Time
+	if err := t.Get("old-refresh-inhibited-time", &oldRefreshInhibitedTime); err != nil && err != state.ErrNoState {
 		return err
 	}
 
@@ -1141,7 +1141,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.DevMode = oldDevMode
 	snapst.JailMode = oldJailMode
 	snapst.Classic = oldClassic
-	snapst.RefreshPostponedTime = oldRefreshPostponedTime
+	snapst.RefreshInhibitedTime = oldRefreshInhibitedTime
 
 	newInfo, err := readInfo(snapsup.InstanceName(), snapsup.SideInfo, 0)
 	if err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -877,6 +877,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	if snapsup.Required { // set only on install and left alone on refresh
 		snapst.Required = true
 	}
+	oldRefreshPostponedTime := snapst.RefreshPostponedTime
 	// only set userID if unset or logged out in snapst and if we
 	// actually have an associated user
 	if snapsup.UserID > 0 {
@@ -940,6 +941,12 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	t.Set("old-channel", oldChannel)
 	t.Set("old-current", oldCurrent)
 	t.Set("old-candidate-index", oldCandidateIndex)
+	t.Set("old-refresh-postponed-time", oldRefreshPostponedTime)
+
+	// Record the fact that the snap was refreshed successfully.
+	var zeroTime time.Time
+	snapst.RefreshPostponedTime = zeroTime
+
 	// Do at the end so we only preserve the new state if it worked.
 	Set(st, snapsup.InstanceName(), snapst)
 
@@ -1090,6 +1097,10 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err := t.Get("old-candidate-index", &oldCandidateIndex); err != nil {
 		return err
 	}
+	var oldRefreshPostponedTime time.Time
+	if err := t.Get("old-refresh-postponed-time", &oldRefreshPostponedTime); err != nil && err != state.ErrNoState {
+		return err
+	}
 
 	if len(snapst.Sequence) == 1 {
 		// XXX: shouldn't these two just log and carry on? this is an undo handler...
@@ -1130,6 +1141,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.DevMode = oldDevMode
 	snapst.JailMode = oldJailMode
 	snapst.Classic = oldClassic
+	snapst.RefreshPostponedTime = oldRefreshPostponedTime
 
 	newInfo, err := readInfo(snapsup.InstanceName(), snapsup.SideInfo, 0)
 	if err != nil {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -795,8 +795,8 @@ func (s *linkSnapSuite) TestDoLinkSnapFailureCleansUpAux(c *C) {
 	c.Check(snapstate.AuxStoreInfoFilename("foo-id"), testutil.FileAbsent)
 }
 
-func (s *linkSnapSuite) TestLinkSnapResetsRefreshPostponedTime(c *C) {
-	// When a snap is linked the refresh-postponed-time is reset to zero
+func (s *linkSnapSuite) TestLinkSnapResetsRefreshInhibitedTime(c *C) {
+	// When a snap is linked the refresh-inhibited-time is reset to zero
 	// to indicate a successful refresh. The old value is stored in task
 	// state for task undo logic.
 	s.state.Lock()
@@ -809,7 +809,7 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshPostponedTime(c *C) {
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
-		RefreshPostponedTime: instant,
+		RefreshInhibitedTime: instant,
 	})
 
 	task := s.state.NewTask("link-snap", "")
@@ -832,14 +832,14 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshPostponedTime(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.RefreshPostponedTime.IsZero(), Equals, true)
+	c.Check(snapst.RefreshInhibitedTime.IsZero(), Equals, true)
 
 	var oldTime time.Time
-	c.Assert(task.Get("old-refresh-postponed-time", &oldTime), IsNil)
+	c.Assert(task.Get("old-refresh-inhibited-time", &oldTime), IsNil)
 	c.Check(oldTime.Equal(instant), Equals, true)
 }
 
-func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshPostponedTime(c *C) {
+func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshInhibitedTime(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -850,7 +850,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshPostponedTime(c *C) {
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
-		RefreshPostponedTime: instant,
+		RefreshInhibitedTime: instant,
 	})
 
 	task := s.state.NewTask("link-snap", "")
@@ -878,5 +878,5 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshPostponedTime(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.RefreshPostponedTime.Equal(instant), Equals, true)
+	c.Check(snapst.RefreshInhibitedTime.Equal(instant), Equals, true)
 }

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -809,7 +809,7 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshInhibitedTime(c *C) {
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
-		RefreshInhibitedTime: instant,
+		RefreshInhibitedTime: &instant,
 	})
 
 	task := s.state.NewTask("link-snap", "")
@@ -832,7 +832,7 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshInhibitedTime(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.RefreshInhibitedTime.IsZero(), Equals, true)
+	c.Check(snapst.RefreshInhibitedTime, IsNil)
 
 	var oldTime time.Time
 	c.Assert(task.Get("old-refresh-inhibited-time", &oldTime), IsNil)
@@ -850,7 +850,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshInhibitedTime(c *C) {
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
-		RefreshInhibitedTime: instant,
+		RefreshInhibitedTime: &instant,
 	})
 
 	task := s.state.NewTask("link-snap", "")

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -802,12 +802,14 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshPostponedTime(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	instant := time.Now()
+
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
-		RefreshPostponedTime: time.Unix(123, 0),
+		RefreshPostponedTime: instant,
 	})
 
 	task := s.state.NewTask("link-snap", "")
@@ -834,19 +836,21 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshPostponedTime(c *C) {
 
 	var oldTime time.Time
 	c.Assert(task.Get("old-refresh-postponed-time", &oldTime), IsNil)
-	c.Check(oldTime, Equals, time.Unix(123, 0))
+	c.Check(oldTime.Equal(instant), Equals, true)
 }
 
 func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshPostponedTime(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	instant := time.Now()
+
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
-		RefreshPostponedTime: time.Unix(123, 0),
+		RefreshPostponedTime: instant,
 	})
 
 	task := s.state.NewTask("link-snap", "")
@@ -874,5 +878,5 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshPostponedTime(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.RefreshPostponedTime, Equals, time.Unix(123, 0))
+	c.Check(snapst.RefreshPostponedTime.Equal(instant), Equals, true)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -140,10 +140,10 @@ type SnapState struct {
 	// each instance of given snap
 	InstanceKey string `json:"instance-key,omitempty"`
 
-	// RefreshPostponedTime records the time when the refresh was first
-	// attempted but postponed because the snap was busy. This value is
+	// RefreshInhibitedime records the time when the refresh was first
+	// attempted but inhibited because the snap was busy. This value is
 	// reset on each successful refresh.
-	RefreshPostponedTime time.Time `json:"refresh-postponed-time,omitempty"`
+	RefreshInhibitedTime time.Time `json:"refresh-inhibited-time,omitempty"`
 }
 
 // Type returns the type of the snap or an error.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -141,7 +141,7 @@ type SnapState struct {
 	InstanceKey string `json:"instance-key,omitempty"`
 
 	// RefreshPostponedTime records the time when the refresh was first
-	// attempted but postponed for because the snap was busy. This value is
+	// attempted but postponed because the snap was busy. This value is
 	// reset on each successful refresh.
 	RefreshPostponedTime time.Time `json:"refresh-postponed-time,omitempty"`
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -143,7 +143,7 @@ type SnapState struct {
 	// RefreshInhibitedime records the time when the refresh was first
 	// attempted but inhibited because the snap was busy. This value is
 	// reset on each successful refresh.
-	RefreshInhibitedTime time.Time `json:"refresh-inhibited-time,omitempty"`
+	RefreshInhibitedTime *time.Time `json:"refresh-inhibited-time,omitempty"`
 }
 
 // Type returns the type of the snap or an error.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -139,6 +139,11 @@ type SnapState struct {
 	// InstanceKey is set by the user during installation and differs for
 	// each instance of given snap
 	InstanceKey string `json:"instance-key,omitempty"`
+
+	// RefreshPostponedTime records the time when the refresh was first
+	// attempted but postponed for because the snap was busy. This value is
+	// reset on each successful refresh.
+	RefreshPostponedTime time.Time `json:"refresh-postponed-time,omitempty"`
 }
 
 // Type returns the type of the snap or an error.


### PR DESCRIPTION
When a refresh is attempted but for skipped because a particular snap is
busy then a time-stamp is recorded under snap state (refresh postponed
time). This time-stamp can be used to determine when a refresh is
mandatory, even if a snap is busy. This can prevent snaps from running
old revisions indefinitely simply because an app is open.

The patch adds the time-stamp to SnapState and ensures it is reset on
refresh. Somewhat arbitrarily the instant that this is done was picked
to be the "link-snap" task.

The timer is set and reset regardless of the refresh-app-awareness
feature flag because otherwise the state would go out-of-sync with
reality and this aspect of the change is not complex.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>