### PR TITLE
cmd/libsnap: rename C enum for feature flag

### DIFF
--- a/cmd/libsnap-confine-private/feature-test.c
+++ b/cmd/libsnap-confine-private/feature-test.c
@@ -54,14 +54,14 @@ static void test_feature_enabled__missing_dir(void)
 	char subd[PATH_MAX];
 	sc_must_snprintf(subd, sizeof subd, "%s/absent", d);
 	sc_mock_feature_flag_dir(subd);
-	g_assert(!sc_feature_enabled(SC_PER_USER_MOUNT_NAMESPACE));
+	g_assert(!sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
 static void test_feature_enabled__missing_file(void)
 {
 	const char *d = sc_testdir();
 	sc_mock_feature_flag_dir(d);
-	g_assert(!sc_feature_enabled(SC_PER_USER_MOUNT_NAMESPACE));
+	g_assert(!sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
 static void test_feature_enabled__present_file(void)
@@ -72,7 +72,7 @@ static void test_feature_enabled__present_file(void)
 	sc_must_snprintf(pname, sizeof pname, "%s/per-user-mount-namespace", d);
 	g_file_set_contents(pname, "", -1, NULL);
 
-	g_assert(sc_feature_enabled(SC_PER_USER_MOUNT_NAMESPACE));
+	g_assert(sc_feature_enabled(SC_FEATURE_PER_USER_MOUNT_NAMESPACE));
 }
 
 static void __attribute__ ((constructor)) init(void)

--- a/cmd/libsnap-confine-private/feature.c
+++ b/cmd/libsnap-confine-private/feature.c
@@ -34,7 +34,7 @@ bool sc_feature_enabled(sc_feature_flag flag)
 {
 	const char *file_name;
 	switch (flag) {
-	case SC_PER_USER_MOUNT_NAMESPACE:
+	case SC_FEATURE_PER_USER_MOUNT_NAMESPACE:
 		file_name = "per-user-mount-namespace";
 		break;
 	case SC_FEATURE_REFRESH_APP_AWARENESS:

--- a/cmd/libsnap-confine-private/feature.h
+++ b/cmd/libsnap-confine-private/feature.h
@@ -21,7 +21,7 @@
 #include <stdbool.h>
 
 typedef enum sc_feature_flag {
-	SC_PER_USER_MOUNT_NAMESPACE,
+	SC_FEATURE_PER_USER_MOUNT_NAMESPACE,
 	SC_FEATURE_REFRESH_APP_AWARENESS,
 } sc_feature_flag;
 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -382,7 +382,8 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 			 * entirely ephemeral. In addition the call
 			 * sc_join_preserved_user_ns() will never find a preserved mount
 			 * namespace and will always enter this code branch. */
-			if (sc_feature_enabled(SC_PER_USER_MOUNT_NAMESPACE)) {
+			if (sc_feature_enabled
+			    (SC_FEATURE_PER_USER_MOUNT_NAMESPACE)) {
 				sc_preserve_populated_per_user_mount_ns(group);
 			} else {
 				debug


### PR DESCRIPTION
The enum value SC_PER_USER_MOUNT_NAMESPACE was raised during the
original code review but I forgot to rename it to SC_FEATURE_xxx.
This patch automatically changes the enum value to
SC_FEATURE_PER_USER_MOUNT_NAMESPACE

Original review comment:
https://github.com/snapcore/snapd/pull/6116#discussion_r232254814

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
