### PR TITLE
interfaces/builtin/opengl: allow access to Tegra X1

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -113,12 +113,14 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /run/udev/data/c226:[0-9]* r,  # 226 drm
 `
 
-// The nvidia modules don't use sysfs (therefore they can't be udev tagged) and
+// Some nvidia modules don't use sysfs (therefore they can't be udev tagged) and
 // will be added by snap-confine.
 var openglConnectedPlugUDev = []string{
 	`SUBSYSTEM=="drm", KERNEL=="card[0-9]*"`,
 	`KERNEL=="vchiq"`,
 	`KERNEL=="renderD[0-9]*"`,
+	`KERNEL=="nvhost-*"`,
+	`KERNEL=="nvmap"`,
 }
 
 func init() {

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -77,8 +77,11 @@ unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
 @{PROC}/sys/vm/mmap_min_addr r,
 @{PROC}/devices r,
 /sys/devices/system/memory/block_size_bytes r,
+/sys/module/tegra_fuse/parameters/tegra_* r,
 unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /{dev,run}/shm/cuda.* rw,
+/dev/nvhost-* rw,
+/dev/nvmap rw,
 
 # OpenCL ICD files
 /etc/OpenCL/vendors/ r,

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -92,11 +92,15 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 4)
+	c.Assert(spec.Snippets(), HasLen, 6)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 KERNEL=="renderD[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+KERNEL=="nvhost-*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+KERNEL=="nvmap", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 


### PR DESCRIPTION
Allow access to fuses and devices created by the Tegra X1 drivers, so
CUDA can be used in this chip.