### PR TITLE
strutil: make SplitUnit public, allow negative numbers

### DIFF
--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -169,13 +169,18 @@ func (ts *strutilSuite) TestParseByteSizeUnhappy(c *check.C) {
 		str    string
 		errStr string
 	}{
-		{"", `cannot parse "": need a number with a unit as input`},
+		{"", `cannot parse "": no numerical prefix`},
+		{"B", `cannot parse "B": no numerical prefix`},
 		{"1", `cannot parse "1": need a number with a unit as input`},
 		{"11", `cannot parse "11": need a number with a unit as input`},
 		{"400x", `cannot parse "400x": try 'kB' or 'MB'`},
 		{"400xx", `cannot parse "400xx": try 'kB' or 'MB'`},
 		{"1k", `cannot parse "1k": try 'kB' or 'MB'`},
 		{"200KiB", `cannot parse "200KiB": try 'kB' or 'MB'`},
+		{"-200KB", `cannot parse "-200KB": size cannot be negative`},
+		{"-200B", `cannot parse "-200B": size cannot be negative`},
+		{"-B", `cannot parse "-B": "-" is not a number`},
+		{"-", `cannot parse "-": "-" is not a number`},
 	} {
 		_, err := strutil.ParseByteSize(t.str)
 		c.Check(err, check.ErrorMatches, t.errStr, check.Commentf("incorrect error for %q", t.str))

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -169,7 +169,6 @@ func (ts *strutilSuite) TestParseByteSizeUnhappy(c *check.C) {
 		str    string
 		errStr string
 	}{
-		{"", `cannot parse "": no numerical prefix`},
 		{"B", `cannot parse "B": no numerical prefix`},
 		{"1", `cannot parse "1": need a number with a unit as input`},
 		{"11", `cannot parse "11": need a number with a unit as input`},
@@ -181,6 +180,11 @@ func (ts *strutilSuite) TestParseByteSizeUnhappy(c *check.C) {
 		{"-200B", `cannot parse "-200B": size cannot be negative`},
 		{"-B", `cannot parse "-B": "-" is not a number`},
 		{"-", `cannot parse "-": "-" is not a number`},
+		{"", `cannot parse "": "" is not a number`},
+		// Digits outside of Latin1 range
+		// ARABIC-INDIC DIGIT SEVEN
+		{"٧kB", `cannot parse "٧kB": no numerical prefix`},
+		{"1٧kB", `cannot parse "1٧kB": try 'kB' or 'MB'`},
 	} {
 		_, err := strutil.ParseByteSize(t.str)
 		c.Check(err, check.ErrorMatches, t.errStr, check.Commentf("incorrect error for %q", t.str))


### PR DESCRIPTION
Make the helper public so that it can be reused in parsing of gadget size/offset values that have the following format: `<bytes> | <bytes/2^20>M | <bytes/2^30>G`.


