### PR TITLE
tests: restore sbuild test

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -610,8 +610,10 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         debian-*)
             echo "
+                eatmydata
                 evolution-data-server
                 net-tools
+                sbuild
                 "
             ;;
     esac

--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -6,9 +6,6 @@ priority: 500
 systems: [debian-sid-*]
 
 execute: |
-    echo "Ensure we have sbuild"
-    apt install -y sbuild eatmydata
-
     echo "Create a sid sbuild env"
     eatmydata sbuild-createchroot --include=eatmydata,ccache,gnupg sid /srv/chroot/sid-amd64-sbuild http://deb.debian.org/debian
 
@@ -19,3 +16,7 @@ execute: |
     su -c "sbuild -d sid --run-autopkgtest $SPREAD_PATH/../*.dsc" test
     echo "..and now just 'arch: any'"
     su -c "sbuild --arch-any -d sid --run-autopkgtest $SPREAD_PATH/../*.dsc" test
+
+restore: |
+    rm --recursive --one-file-system /srv/chroot/sid-amd64-sbuild
+    rm -f /etc/schroot/chroot.d/sid-amd64-sbuild-*


### PR DESCRIPTION
This change is to restore the change done. With this is it possible to run more than once the test with no errors.