### PR TITLE
snap: tweak parsing errors of gadget updates

### DIFF
--- a/snap/gadget.go
+++ b/snap/gadget.go
@@ -244,7 +244,7 @@ func (e *editionNumber) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	u, err := strconv.ParseUint(es, 10, 32)
 	if err != nil {
-		return fmt.Errorf(`"edition" must be a number, not %q`, es)
+		return fmt.Errorf(`"edition" must be a positive number, not %q`, es)
 	}
 	*e = editionNumber(u)
 	return nil

--- a/snap/gadget_test.go
+++ b/snap/gadget_test.go
@@ -436,5 +436,12 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlVolumeUpdateUnhappy(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadGadgetInfo(info, false)
-	c.Check(err, ErrorMatches, `cannot read gadget snap details: "edition" must be a number, not "borked"`)
+	c.Check(err, ErrorMatches, `cannot read gadget snap details: "edition" must be a positive number, not "borked"`)
+
+	broken = bytes.Replace(mockVolumeUpdateGadgetYaml, []byte("edition: 5"), []byte("edition: -5"), 1)
+	err = ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), broken, 0644)
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadGadgetInfo(info, false)
+	c.Check(err, ErrorMatches, `cannot read gadget snap details: "edition" must be a positive number, not "-5"`)
 }


### PR DESCRIPTION
Tweak the error message to be more precise

Requested in https://github.com/snapcore/snapd/pull/6609#discussion_r267861884