### PR TITLE
interfaces: add one-plus devices to adb-support

### DIFF
--- a/interfaces/builtin/adb_support.go
+++ b/interfaces/builtin/adb_support.go
@@ -119,6 +119,7 @@ var adbSupportVendors = map[int]string{
 	0x2a45: "MEIZU",
 	0x2a47: "BQ",
 	0x2a49: "UNOWHY",
+	0x2a70: "OnePlus",
 	0x2ae5: "FAIRPHONE",
 	0x413c: "DELL",
 	0x8087: "INTEL", // https://twitter.com/zygoon/status/1032233406564913152

--- a/interfaces/builtin/adb_support_test.go
+++ b/interfaces/builtin/adb_support_test.go
@@ -131,11 +131,16 @@ func (s *adbSupportSuite) TestUDevSpec(c *C) {
 
 	spec = &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 81)
+	c.Assert(spec.Snippets(), HasLen, 82)
 	c.Assert(spec.Snippets(), testutil.Contains, `# adb-support
 SUBSYSTEM=="usb", ATTR{idVendor}=="0502", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# adb-support
 SUBSYSTEM=="usb", ATTR{idVendor}=="19d2", TAG+="snap_consumer_app"`)
+
+	// One-plus devices are included.
+	// https://bugs.launchpad.net/snapd/+bug/1821474
+	c.Assert(spec.Snippets(), testutil.Contains, `# adb-support
+SUBSYSTEM=="usb", ATTR{idVendor}=="2a70", TAG+="snap_consumer_app"`)
 
 	spec = &udev.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)


### PR DESCRIPTION
The adb interface contains a list of product vendors that correspond to
popular phone makers. This patch adds one-plus vendor to the list in
response to user demand.

Note that the particular USB vendor ID is not present in
http://www.linux-usb.org/usb.ids

Fixes: https://bugs.launchpad.net/snapd/+bug/1821474
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
