### PR TITLE
interfaces/adb-support: account for hubs on sysfs path

### DIFF
--- a/interfaces/builtin/adb_support.go
+++ b/interfaces/builtin/adb_support.go
@@ -135,7 +135,10 @@ var adbSupportConnectedPlugAppArmor = `
 /run/udev/data/c189:* r,
 
 # Allow reading the serial number of all the USB devices.
-/sys/devices/**/usb*/*/serial r,
+# Note that this path encodes the physical connection topology (e.g. any USB
+# hubs you are using) and as such there are more recursive patterns than one
+# might otherwise see necessary on their own system.
+/sys/devices/**/usb*/**/serial r,
 `
 
 type adbSupportInterface struct {


### PR DESCRIPTION
The adb-support interface meant to allow accessing the serial number of
all USB devices. The apparmor regular expression was constructed based
on what I saw on my particular system. What I failed to take into
account were that USB hubs are represented in this path so the interface
would fail when additional paths are on the connection chain.

This patch fixes this by allowing to read serial number from any nesting
depth.

Fixes: https://bugs.launchpad.net/snapd/+bug/1821469
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
