### PR TITLE
tests: set opensuse 15 as manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -86,6 +86,7 @@ backends:
                 manual: true
             - opensuse-15.0-64:
                 workers: 4
+                manual: true
             - opensuse-tumbleweed-64:
                 workers: 4
             - arch-linux-64:


### PR DESCRIPTION
It is because there are some conflicts in the mirror which make fail the
preparation of the test suite.
