### PR TITLE
tests: fix core revert test

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -123,14 +123,12 @@ add_debug_output_on_nested_core_vm(){
 StartLimitInterval=0
 [Service]
 Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1
-ExecStartPre=/bin/touch /dev/iio:device0
 EOF
     copy_remote local.conf
     execute_remote "sudo mkdir -p /etc/systemd/system/snapd.service.d"
     execute_remote "sudo mv local.conf /etc/systemd/system/snapd.service.d"
     execute_remote "sudo systemctl daemon-reload"
-    execute_remote "sudo systemctl stop snapd.socket snapd.service"
-    execute_remote "sudo systemctl start snapd.socket snapd.service"
+    execute_remote "sudo systemctl restart snapd.socket snapd.service"
     rm -f local.conf
 }
 

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -33,6 +33,13 @@ execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
 
+    wait_connection_with_store(){
+        while ! execute_remote "sudo snap find test-snapd-tools | grep 'Tools for testing the snapd application'"; do
+            echo "Waiting for api.snapcraft.io - network interface might be down..."
+            sleep 1
+        done
+    }
+
     #shellcheck disable=SC2164
     cd "$SPREAD_PATH"
     execute_remote "sudo snap install network-manager"
@@ -59,6 +66,7 @@ execute: |
     execute_remote "nmcli d" | MATCH "eth0 +ethernet +connected"
 
     # sanity check, no refresh should be done here but the command shouldn't fail
+    wait_connection_with_store
     execute_remote "sudo snap refresh"
 
     execute_remote "snap aliases" | MATCH "nmcli"
@@ -75,6 +83,6 @@ execute: |
     execute_remote "snap info core" | MATCH "tracking: +${CORE_REFRESH_CHANNEL}"
     execute_remote "ifconfig" | MATCH eth0
 
-
+    wait_connection_with_store
     execute_remote "sudo snap refresh"
     execute_remote "sudo cat /var/log/syslog" | MATCH -v "hsearch_r failed for.* No such process"


### PR DESCRIPTION
2 fixes for the core revert test:
 1. Add wait until backend can be reached  after reboot
 2. Now the snap log contains debug info

To check the test run: > SPREAD_CORE_CHANNEL=stable SPREAD_CORE_REFRESH_CHANNEL=beta spread google-nested:ubuntu-16.04-64:tests/nested/core/core-revert