### PR TITLE
snap: reject layouts to /lib/{firmware,modules}

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -727,7 +727,7 @@ func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 		return fmt.Errorf("layout %q uses invalid mount point: must be absolute and clean", layout.Path)
 	}
 
-	for _, path := range []string{"/proc", "/sys", "/dev", "/run", "/boot", "/lost+found", "/media", "/var/lib/snapd", "/var/snap"} {
+	for _, path := range []string{"/proc", "/sys", "/dev", "/run", "/boot", "/lost+found", "/media", "/var/lib/snapd", "/var/snap", "/lib/firmware", "/lib/modules"} {
 		// We use the mountedTree constraint as this has the right semantics.
 		if mountedTree(path).IsOffLimits(mountPoint) {
 			return fmt.Errorf("layout %q in an off-limits area", layout.Path)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -685,6 +685,10 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/var/lib/snapd" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/lib/snapd/hostfs", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/var/lib/snapd/hostfs" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lib/firmware", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/lib/firmware" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lib/modules", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/lib/modules" in an off-limits area`)
 
 	// Several valid layouts.
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 01755}, nil), IsNil)


### PR DESCRIPTION
Using a layout on /lib/firmware might allow an application to trick the
kernel into loading a firmware blob modified by the attacker. Similar
operation may happen in /lib/modules where the kernel may load a module
on demand.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
