### PR TITLE
tests: all the systems for google backend with 6 workers

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -85,19 +85,19 @@ backends:
                 # golang stack cannot compile anything, needs investigation
                 manual: true
             - opensuse-15.0-64:
-                workers: 4
+                workers: 6
                 manual: true
             - opensuse-tumbleweed-64:
-                workers: 4
+                workers: 6
             - arch-linux-64:
-                workers: 4
+                workers: 6
 
             - amazon-linux-2-64:
-                workers: 4
+                workers: 6
                 storage: preserve-size
 
             - centos-7-64:
-                workers: 4
+                workers: 6
                 image: centos-7-64
 
     google-upgrade:


### PR DESCRIPTION
The systems arch and opensuse are being delayed on the execution and it
is basically because those are running with 4 workers. The idea is to
run all the systems with 6 workers

Current Numbers:

4 workers
---------
arch -> 332 tests
tumbleweed -> 363 tests
amazon -> 328 tests
centos -> 329 tests

6 workers
---------
trusty: 363 tests
bionic: 397 tests
xenial-32: 378 tests
fedora-29: 327 tests
debian-9: 359 tests

8 workers
---------
xenial-64: 398 tests

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
