### PR TITLE
sanity: use proper SELinux context when mounting squashfs

### DIFF
--- a/sanity/squashfs.go
+++ b/sanity/squashfs.go
@@ -100,7 +100,9 @@ func checkSquashfsMount() error {
 	}
 	options := []string{"-t", fstype}
 	if release.SELinuxLevel() != release.NoSELinux {
-		options = append(options, "-o", fmt.Sprintf("context=%s", selinux.SnapMountContext()))
+		if ctx := selinux.SnapMountContext(); ctx != "" {
+			options = append(options, "-o", "context="+ctx)
+		}
 	}
 	options = append(options, tmpSquashfsFile.Name(), tmpMountDir)
 	cmd := exec.Command("mount", options...)

--- a/sanity/squashfs.go
+++ b/sanity/squashfs.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/selinux"
 )
 
 func init() {
@@ -99,8 +100,7 @@ func checkSquashfsMount() error {
 	}
 	options := []string{"-t", fstype}
 	if release.SELinuxLevel() != release.NoSELinux {
-		// relabel the mount as snappy_tmp_t where we have full access to
-		options = append(options, "-o", "context=system_u:object_r:snappy_tmp_t:s0")
+		options = append(options, "-o", fmt.Sprintf("context=%s", selinux.SnapMountContext()))
 	}
 	options = append(options, tmpSquashfsFile.Name(), tmpMountDir)
 	cmd := exec.Command("mount", options...)

--- a/sanity/squashfs_test.go
+++ b/sanity/squashfs_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil/squashfs"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sanity"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -92,4 +93,30 @@ func (s *sanitySuite) TestCheckSquashfsMountWrongContent(c *C) {
 
 	c.Check(mockMount.Calls(), HasLen, 1)
 	c.Check(mockUmount.Calls(), HasLen, 1)
+}
+
+func (s *sanitySuite) TestCheckSquashfsMountSELinuxContext(c *C) {
+	restore := squashfs.MockUseFuse(false)
+	defer restore()
+
+	mockMount := testutil.MockCommand(c, "mount", "echo 'mock ran'")
+	defer mockMount.Restore()
+
+	mockUmount := testutil.MockCommand(c, "umount", "")
+	defer mockUmount.Restore()
+
+	mockSELinux := release.MockSELinuxIsEnabled(func() (bool, error) { return true, nil })
+	defer mockSELinux()
+
+	err := sanity.CheckSquashfsMount()
+	c.Assert(err, ErrorMatches, `squashfs mount returned no err but canary file cannot be read`)
+
+	c.Check(mockMount.Calls(), HasLen, 1)
+	c.Check(mockUmount.Calls(), HasLen, 1)
+	squashfsFile := mockMount.Calls()[0][5]
+	mountPoint := mockMount.Calls()[0][6]
+
+	c.Check(mockMount.Calls(), DeepEquals, [][]string{
+		{"mount", "-t", "squashfs", "-o", "context=system_u:object_r:snappy_snap_t:s0", squashfsFile, mountPoint},
+	})
 }


### PR DESCRIPTION
We attempt to mount a squashfs image as part of sanity checks. Make sure to use proper mount context, so that SELinux does not complain.
