### PR TITLE
timings: AddTag helper

### DIFF
--- a/timings/helpers.go
+++ b/timings/helpers.go
@@ -34,6 +34,11 @@ func NewForTask(task *state.Task) *Timings {
 	return New(tags)
 }
 
+// SetTagFromChange sets "change-id" tag from the given change.
+func (t *Timings) SetTagFromChange(change *state.Change) {
+	t.SetTag("change-id", change.ID())
+}
+
 // Run creates, starts and then stops a nested Span under parent Measurer. The nested
 // Span is passed to the measured function and can used to create further spans.
 func Run(meas Measurer, label, summary string, f func(nestedTiming Measurer)) {

--- a/timings/helpers.go
+++ b/timings/helpers.go
@@ -34,11 +34,6 @@ func NewForTask(task *state.Task) *Timings {
 	return New(tags)
 }
 
-// SetTagFromChange sets "change-id" tag from the given change.
-func (t *Timings) SetTagFromChange(change *state.Change) {
-	t.SetTag("change-id", change.ID())
-}
-
 // Run creates, starts and then stops a nested Span under parent Measurer. The nested
 // Span is passed to the measured function and can used to create further spans.
 func Run(meas Measurer, label, summary string, f func(nestedTiming Measurer)) {

--- a/timings/timings.go
+++ b/timings/timings.go
@@ -80,6 +80,14 @@ func New(tags map[string]string) *Timings {
 	}
 }
 
+// SetTag sets a tag on the Timings object.
+func (t *Timings) SetTag(tag, value string) {
+	if t.tags == nil {
+		t.tags = make(map[string]string)
+	}
+	t.tags[tag] = value
+}
+
 func startSpan(label, summary string) *Span {
 	tmeas := &Span{
 		label:   label,

--- a/timings/timings.go
+++ b/timings/timings.go
@@ -80,8 +80,8 @@ func New(tags map[string]string) *Timings {
 	}
 }
 
-// SetTag sets a tag on the Timings object.
-func (t *Timings) SetTag(tag, value string) {
+// AddTag sets a tag on the Timings object.
+func (t *Timings) AddTag(tag, value string) {
 	if t.tags == nil {
 		t.tags = make(map[string]string)
 	}

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -94,7 +94,7 @@ func (s *timingsSuite) TestSave(c *C) {
 	// two timings, with 2 nested measures
 	for i := 0; i < 2; i++ {
 		timing := timings.New(map[string]string{"task": "3"})
-		timing.SetTag("change", "12")
+		timing.AddTag("change", "12")
 		meas := timing.StartSpan(fmt.Sprintf("doing something-%d", i), "...")
 		nested := meas.StartSpan("nested measurement", "...")
 		var called bool
@@ -339,34 +339,6 @@ func (s *timingsSuite) TestNewForTask(c *C) {
 				map[string]interface{}{
 					"label":    "foo",
 					"summary":  "bar",
-					"duration": float64(1000000),
-				},
-			}}})
-}
-
-func (s *timingsSuite) TestSetTagFromChange(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	chg := s.st.NewChange("change", "...")
-
-	troot := timings.New(nil)
-	troot.SetTagFromChange(chg)
-
-	span := troot.StartSpan("foo", "")
-	span.Stop()
-	troot.Save(s.st)
-
-	var stateTimings []interface{}
-	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
-	c.Assert(stateTimings, DeepEquals, []interface{}{
-		map[string]interface{}{
-			"tags":       map[string]interface{}{"change-id": chg.ID()},
-			"start-time": "2019-03-11T09:01:00.001Z",
-			"stop-time":  "2019-03-11T09:01:00.002Z",
-			"timings": []interface{}{
-				map[string]interface{}{
-					"label":    "foo",
 					"duration": float64(1000000),
 				},
 			}}})

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -93,7 +93,8 @@ func (s *timingsSuite) TestSave(c *C) {
 
 	// two timings, with 2 nested measures
 	for i := 0; i < 2; i++ {
-		timing := timings.New(map[string]string{"task": "3", "change": "12"})
+		timing := timings.New(map[string]string{"task": "3"})
+		timing.SetTag("change", "12")
 		meas := timing.StartSpan(fmt.Sprintf("doing something-%d", i), "...")
 		nested := meas.StartSpan("nested measurement", "...")
 		var called bool
@@ -338,6 +339,34 @@ func (s *timingsSuite) TestNewForTask(c *C) {
 				map[string]interface{}{
 					"label":    "foo",
 					"summary":  "bar",
+					"duration": float64(1000000),
+				},
+			}}})
+}
+
+func (s *timingsSuite) TestSetTagFromChange(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	chg := s.st.NewChange("change", "...")
+
+	troot := timings.New(nil)
+	troot.SetTagFromChange(chg)
+
+	span := troot.StartSpan("foo", "")
+	span.Stop()
+	troot.Save(s.st)
+
+	var stateTimings []interface{}
+	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
+	c.Assert(stateTimings, DeepEquals, []interface{}{
+		map[string]interface{}{
+			"tags":       map[string]interface{}{"change-id": chg.ID()},
+			"start-time": "2019-03-11T09:01:00.001Z",
+			"stop-time":  "2019-03-11T09:01:00.002Z",
+			"timings": []interface{}{
+				map[string]interface{}{
+					"label":    "foo",
 					"duration": float64(1000000),
 				},
 			}}})


### PR DESCRIPTION
Added a simple helper for setting tags on a Timings object. It is relevant for the followup PR with timings in ensure methods. Normally tags can only be set via Timings ctor, so they all must be known upfront. With this helper it is possible to add a tag e.g. at the end of Ensure, when it creates a change and we want to keep its change-id.
