### PR TITLE
tests: split travis spread execution in 2 jobs for ubuntu and non ubuntu systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       script:
         - ./tests/lib/cla_check.py
     - stage: integration
-      name: spread
+      name: spread on ubuntu systems
       dist: xenial
       addons:
         apt:
@@ -56,7 +56,19 @@ jobs:
         # override the default install for language:go
         - true
       script:
-        - ./run-checks --spread
+        - ./run-checks --spread-ubuntu
+    - stage: integration
+      name: spread on other systems than ubuntu
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-no-ubuntu
 env:
   global:
     # SPREAD_LINODE_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       script:
         - ./tests/lib/cla_check.py
     - stage: integration
-      name: spread on ubuntu systems
+      name: Ubuntu 14.04, 16.04, 18.04, 18.10, Core 16, Core 18
       dist: xenial
       addons:
         apt:
@@ -58,7 +58,7 @@ jobs:
       script:
         - ./run-checks --spread-ubuntu
     - stage: integration
-      name: spread on other systems than ubuntu
+      name: Debian, Fedora, CentOS, Amazon Linux 2, openSUSE, Arch
       dist: xenial
       addons:
         apt:

--- a/run-checks
+++ b/run-checks
@@ -53,7 +53,13 @@ case "${1:-all}" in
         short=1
         ;;
     --spread)
-        SPREAD=1
+        SPREAD=full
+        ;;
+    --spread-ubuntu)
+        SPREAD=ubuntu-only
+        ;;
+    --spread-no-ubuntu)
+        SPREAD=no-ubuntu
         ;;
     *)
         echo "Wrong flag ${1}. To run a single suite use --static, --unit, --spread."
@@ -258,14 +264,27 @@ if [ "$UNIT" = 1 ]; then
     fi
 fi
 
-if [ "$SPREAD" = 1 ]; then
+if [ -n "$SPREAD" ]; then
     TMP_SPREAD="$(mktemp -d)"
     addtrap "rm -rf \"$TMP_SPREAD\""
 
     export PATH=$TMP_SPREAD:$PATH
     ( cd "$TMP_SPREAD" && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    spread google: google-upgrade:tests/upgrade/
+    case "$SPREAD" in
+        full)
+            spread "google:"
+            ;;
+        ubuntu-only)
+            spread "google:[u]...:tests/..."
+            ;;
+        no-ubuntu)
+            spread "google:[^u]...:tests/..."
+            ;;
+        *)
+            echo "Spread parameter $SPREAD not supported"
+            exit 1
+    esac
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/spread.yaml
+++ b/spread.yaml
@@ -100,36 +100,6 @@ backends:
                 workers: 6
                 image: centos-7-64
 
-    google-upgrade:
-        type: google
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
-        location: computeengine/us-east1-b
-        halt-timeout: 2h
-        systems:
-            - ubuntu-14.04-64:
-                workers: 1
-            - ubuntu-16.04-32:
-                workers: 1
-            - ubuntu-16.04-64:
-                workers: 1
-            - ubuntu-18.04-64:
-                workers: 1
-            - ubuntu-18.10-64:
-                image: ubuntu-1810
-                workers: 1
-            - debian-9-64:
-                workers: 1
-            - fedora-29-64:
-                workers: 1
-            - arch-linux-64:
-                workers: 1
-            - amazon-linux-2-64:
-                workers: 1
-                storage: preserve-size
-            - centos-7-64:
-                workers: 1
-
-
     google-sru:
         type: google
         key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
@@ -688,9 +658,6 @@ suites:
         # it disabled. A later PR will enable most tests and
         # drop this blacklist.
         systems: [-ubuntu-core-*, -opensuse-*]
-        # autopkgtest runs against localhost which causes problems with
-        # this test prepare
-        backends: [google-upgrade]
         prepare-each: |
             # FIXME: this should really use prepare-restore.sh --prepare-suite-each
             # like other suites, needs more investigation


### PR DESCRIPTION
This is the same change than #6631 which was deleted.