### PR TITLE
testutil: run mocked commands through shellcheck

### DIFF
--- a/overlord/ifacestate/udevmonitor/udevmon_test.go
+++ b/overlord/ifacestate/udevmonitor/udevmon_test.go
@@ -90,6 +90,7 @@ E: MINOR=3
 E: MAJOR=0
 E: DEVNAME=ghi
 E: DEVTYPE=bzz
+__END__
 `)
 	defer cmd.Restore()
 

--- a/sanity/squashfs_test.go
+++ b/sanity/squashfs_test.go
@@ -33,7 +33,7 @@ func (s *sanitySuite) TestCheckSquashfsMountHappy(c *C) {
 	defer restore()
 
 	// we create a canary.txt with the same prefix as the real one
-	mockMount := testutil.MockCommand(c, "mount", "echo 'This file is used to check that snapd can read a squashfs image.' > $4/canary.txt")
+	mockMount := testutil.MockCommand(c, "mount", `echo 'This file is used to check that snapd can read a squashfs image.' > "$4"/canary.txt`)
 	defer mockMount.Restore()
 
 	mockUmount := testutil.MockCommand(c, "umount", "")
@@ -82,7 +82,7 @@ func (s *sanitySuite) TestCheckSquashfsMountWrongContent(c *C) {
 	restore := squashfs.MockUseFuse(false)
 	defer restore()
 
-	mockMount := testutil.MockCommand(c, "mount", "echo 'wrong content' > $4/canary.txt")
+	mockMount := testutil.MockCommand(c, "mount", `echo 'wrong content' > "$4"/canary.txt`)
 	defer mockMount.Restore()
 
 	mockUmount := testutil.MockCommand(c, "umount", "")

--- a/testutil/export_test.go
+++ b/testutil/export_test.go
@@ -26,3 +26,11 @@ import (
 func UnexpectedIntChecker(relation string) *intChecker {
 	return &intChecker{CheckerInfo: &check.CheckerInfo{Name: "unexpected", Params: []string{"a", "b"}}, rel: relation}
 }
+
+func MockShellcheckPath(p string) (restore func()) {
+	old := shellcheckPath
+	shellcheckPath = p
+	return func() {
+		shellcheckPath = old
+	}
+}

--- a/userd/settings_test.go
+++ b/userd/settings_test.go
@@ -59,7 +59,7 @@ elif [ "$1" = "set" ] && [ "$2" = "default-web-browser" ]; then
   # nothing to do
   exit 0
 else
-  echo "mock called with unsupported arguments $@"
+  echo "mock called with unsupported arguments $*"
   exit 1
 fi
 `)


### PR DESCRIPTION
Shell is deceivingly easy to write. It's best that we run the test snippets
through shellcheck.

This adds ~2s to whole suite execution time on my box.
