### PR TITLE
snapcraft: build static fontconfig in the snapd snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,12 +14,6 @@ version-script: |
 #type: snapd
 grade: stable
 
-parts:
-  snapd:
-    # FIXME: this should probably go upstream
-    plugin: x-builddeb
-    source: .
-
 # Note that this snap is unusual in that it has no "apps" section.
 #
 # It is started via re-exec on classic systems and via special
@@ -30,3 +24,29 @@ parts:
 #
 # See the comments from jdstrand in
 # https://forum.snapcraft.io/t/5547/10
+parts:
+  snapd:
+    # FIXME: this should probably go upstream
+    plugin: x-builddeb
+    source: .
+  # the version in Ubuntu 16.04 (cache v6)
+  fontconfig-xenial:
+    plugin: nil
+    source: https://github.com/snapcore/fc-cache-static-builder.git
+    build: |
+      ./build-from-security.py xenial
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp -a fc-cache-xenial $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v6
+    stage:
+      - bin/fc-cache-v6
+  # the version in Ubuntu 18.04 (cache v7)
+  fontconfig-bionic:
+    plugin: nil
+    source: https://github.com/snapcore/fc-cache-static-builder.git
+    build: |
+      ./build-from-security.py bionic
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp -a fc-cache-bionic $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7
+    stage:
+      - bin/fc-cache-v7
+

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -15,3 +15,7 @@ execute: |
     # shellcheck disable=SC2164
     cd "$PROJECT_PATH"
     snapcraft
+
+    echo "Ensure we have the fc-cache binaries"
+    unsquashfs -ll snapd_*.snap | MATCH bin/fc-cache-v6
+    unsquashfs -ll snapd_*.snap | MATCH bin/fc-cache-v7


### PR DESCRIPTION
Just like for the core snap we now build a static version of
fc-cache-v{6,7} for the snapd snap.
