### PR TITLE
cmd/snap,client,daemon,store: layout and sanity tweaks for find/search options

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -117,13 +117,17 @@ type ResultInfo struct {
 // - Private: return snaps that are private
 // - Query: only return snaps that match the query string
 type FindOptions struct {
-	Query    string
+	// Query is a term to search by or a prefix (if Prefix is true)
+	Query  string
+	Prefix bool
+
 	CommonID string
-	Section  string
-	Scope    string
-	Private  bool
-	Prefix   bool
-	Refresh  bool
+
+	Section string
+	Private bool
+	Scope   string
+
+	Refresh bool
 }
 
 var ErrNoSnapsInstalled = errors.New("no snaps installed")

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -106,8 +106,8 @@ func (s remoteSnapName) Complete(match string) []flags.Completion {
 		return nil
 	}
 	snaps, _, err := mkClient().Find(&client.FindOptions{
-		Prefix: true,
 		Query:  match,
+		Prefix: true,
 	})
 	if err != nil {
 		return nil

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -665,11 +665,11 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	theStore := getStore(c)
 	found, err := theStore.Find(&store.Search{
 		Query:    q,
+		Prefix:   prefix,
 		CommonID: commonID,
 		Section:  section,
-		Scope:    scope,
 		Private:  private,
-		Prefix:   prefix,
+		Scope:    scope,
 	}, user)
 	switch err {
 	case nil:

--- a/store/store.go
+++ b/store/store.go
@@ -1125,12 +1125,6 @@ func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error)
 	q := s.defaultSnapQuery()
 
 	if search.Private {
-		if search.Prefix {
-			// The store only supports "fuzzy" search for private snaps.
-			// See http://search.apps.ubuntu.com/docs/
-			return nil, ErrBadQuery
-		}
-
 		q.Set("private", "true")
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -1092,12 +1092,15 @@ func (s *Store) SnapInfo(snapSpec SnapSpec, user *auth.UserState) (*snap.Info, e
 
 // A Search is what you do in order to Find something
 type Search struct {
-	Query    string
+	// Query is a term to search by or a prefix (if Prefix is true)
+	Query  string
+	Prefix bool
+
 	CommonID string
-	Section  string
-	Scope    string
-	Private  bool
-	Prefix   bool
+
+	Section string
+	Private bool
+	Scope   string
 }
 
 // Find finds  (installable) snaps from the store, matching the

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2789,7 +2789,7 @@ func (s *storeTestSuite) TestFindFailures(c *C) {
 	sto := store.New(&store.Config{StoreBaseURL: new(url.URL)}, nil)
 	_, err := sto.Find(&store.Search{Query: "foo:bar"}, nil)
 	c.Check(err, Equals, store.ErrBadQuery)
-	_, err = sto.Find(&store.Search{Query: "foo", Private: true, Prefix: true}, s.user)
+	_, err = sto.Find(&store.Search{Query: "foo", Prefix: true, Private: true}, s.user)
 	c.Check(err, Equals, store.ErrBadQuery)
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2756,6 +2756,11 @@ func (s *storeTestSuite) TestFindPrivate(c *C) {
 			c.Check(name, Equals, "")
 			c.Check(q, Equals, "foo")
 			c.Check(query.Get("private"), Equals, "true")
+		case 1:
+			c.Check(r.URL.Path, Matches, ".*/search")
+			c.Check(name, Equals, "foo")
+			c.Check(q, Equals, "")
+			c.Check(query.Get("private"), Equals, "true")
 		default:
 			c.Fatalf("what? %d", n)
 		}
@@ -2778,6 +2783,9 @@ func (s *storeTestSuite) TestFindPrivate(c *C) {
 	_, err := sto.Find(&store.Search{Query: "foo", Private: true}, s.user)
 	c.Check(err, IsNil)
 
+	_, err = sto.Find(&store.Search{Query: "foo", Prefix: true, Private: true}, s.user)
+	c.Check(err, IsNil)
+
 	_, err = sto.Find(&store.Search{Query: "foo", Private: true}, nil)
 	c.Check(err, Equals, store.ErrUnauthenticated)
 
@@ -2788,8 +2796,6 @@ func (s *storeTestSuite) TestFindPrivate(c *C) {
 func (s *storeTestSuite) TestFindFailures(c *C) {
 	sto := store.New(&store.Config{StoreBaseURL: new(url.URL)}, nil)
 	_, err := sto.Find(&store.Search{Query: "foo:bar"}, nil)
-	c.Check(err, Equals, store.ErrBadQuery)
-	_, err = sto.Find(&store.Search{Query: "foo", Prefix: true, Private: true}, s.user)
 	c.Check(err, Equals, store.ErrBadQuery)
 }
 


### PR DESCRIPTION
This does two things:

* it tweaks the layouts of store.Search and client.FindOptions structs slightly more logically and it explains how Query and Prefix are tied  (more docs could be a added but it's a start)
* stops checking whether prefix and private are used together, because they are now supported/orthogonal since a while in the store