### PR TITLE
tests: enable tests that write /etc/{hostname,timezone} on core18

### DIFF
--- a/tests/main/interfaces-hostname-control/task.yaml
+++ b/tests/main/interfaces-hostname-control/task.yaml
@@ -3,9 +3,6 @@ summary: Ensure that the hostname-control interface works
 details: |
     The hostname-control interface allows to configure the system hostname
 
-# ubuntu-core-18 is skipped until hostnamectl is fixed
-systems: [-ubuntu-core-18-*]
-
 prepare: |
     echo "Install test hostname-control snap"
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/interfaces-timezone-control/task.yaml
+++ b/tests/main/interfaces-timezone-control/task.yaml
@@ -4,12 +4,6 @@ details: |
     This test makes sure that a snap using the timezone-control interface
     can access timezone information and update it.
 
-# FIXME:
-# core18 lacks support in systemd for the /etc/writable/timezone, once
-# https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1778936 is fixed
-# we need to re-enable it.
-systems: [-ubuntu-core-18-*]
-
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh


### PR DESCRIPTION
The systemd in Ubuntu 18.04 dropped some patches to make the
"writable-path" magic in core18 work. These patches got re-added
in bionic-proposed and in ppa:canonical-foundations/ubuntu-image.

This PR enables the tests on core18 to validate that the bug
is actually fixed.

The SRU is tracked via LP: 1778936.
