### PR TITLE
tests: add workaround for missing cache reset on older snapd

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -355,7 +355,10 @@ prepare_project() {
         quiet apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite util-linux
     fi
 
-    distro_purge_package snapd || true
+    # WORKAROUND for older postrm scripts that did not do 
+    # "rm -rf /var/cache/snapd"
+    rm -rf /var/cache/snapd/aux
+    distro_purge_package snapd
     install_pkg_dependencies
 
     # We take a special case for Debian/Ubuntu where we install additional build deps

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -358,7 +358,18 @@ prepare_project() {
     # WORKAROUND for older postrm scripts that did not do 
     # "rm -rf /var/cache/snapd"
     rm -rf /var/cache/snapd/aux
-    distro_purge_package snapd
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*)
+            # Ubuntu is the only system where snapd is preinstalled
+            distro_purge_package snapd
+            ;;
+        *)
+            # snapd state directory must not exist when the package is not
+            # installed
+            test ! -d /var/lib/snapd
+            ;;
+    esac
+
     install_pkg_dependencies
 
     # We take a special case for Debian/Ubuntu where we install additional build deps


### PR DESCRIPTION
Older versions of snapd did not do a `rm -rf /var/cache/snapd/*`.
Newer versions of snapd create /var/cache/snapd/aux which means
that `dpkg --purge snapd` may fail after a re-exec. We need to
think how to fix that.

However to unblock tests we should add this workaround.
