### PR TITLE
cmd,tests: forcibly discard mount namespace when bases change

### DIFF
--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -188,6 +188,42 @@ static void test_should_use_normal_mode(void)
 	g_assert_true(sc_should_use_normal_mode(SC_DISTRO_CLASSIC, "core18"));
 }
 
+static void test_probe_distro(void)
+{
+	mock_os_release(os_release_custom);
+
+	/* Keys that are not found get NULL values. */
+	char *value = (void *)0xfefefefe;
+	sc_probe_distro(os_release, "UNKNOWN", &value, NULL);
+	g_assert_null(value);
+
+	/* Keys that are found get strdup-duplicated values. */
+	char *id = NULL;
+	sc_probe_distro(os_release, "ID", &id, NULL);
+	g_assert_nonnull(id);
+	g_assert_cmpstr(id, ==, "custom");
+	free(id);
+
+	/* Multiple keys can be extracted on one go. */
+	char *name;
+	sc_probe_distro(os_release, "ID", &id, "NAME", &name, NULL);
+	g_assert_nonnull(id);
+	g_assert_nonnull(name);
+	g_assert_cmpstr(id, ==, "custom");
+	g_assert_cmpstr(name, ==, "\"Custom Distribution\"");
+	free(id);
+	free(name);
+
+	/* Order in which keys are extracted does not matter. */
+	sc_probe_distro(os_release, "NAME", &name, "ID", &id, NULL);
+	g_assert_nonnull(name);
+	g_assert_nonnull(id);
+	g_assert_cmpstr(name, ==, "\"Custom Distribution\"");
+	g_assert_cmpstr(id, ==, "custom");
+	free(name);
+	free(id);
+}
+
 static void __attribute__ ((constructor)) init(void)
 {
 	g_test_add_func("/classic/on-classic", test_is_on_classic);
@@ -201,4 +237,5 @@ static void __attribute__ ((constructor)) init(void)
 	g_test_add_func("/classic/on-custom-base", test_is_on_custom_base);
 	g_test_add_func("/classic/should-use-normal-mode",
 			test_should_use_normal_mode);
+	g_test_add_func("/classic/probe_distro", test_probe_distro);
 }

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -2,7 +2,9 @@
 #include "classic.h"
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -55,6 +57,44 @@ sc_distro sc_classify_distro(void)
 	} else {
 		return SC_DISTRO_CLASSIC;
 	}
+}
+
+void sc_probe_distro(const char *os_release_path, ...)
+{
+	FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release_path, "r");
+	if (f == NULL) {
+		die("cannot open %s", os_release);
+	}
+
+	va_list ap;
+	va_start(ap, os_release_path);
+	for (;;) {
+		const char *key = va_arg(ap, const char *);
+		if (key == NULL) {
+			break;
+		}
+		char **value = va_arg(ap, char **);
+		if (value != NULL) {
+			*value = NULL;
+		}
+
+		fseek(f, 0, SEEK_SET);
+		char buf[255] = { 0 };
+		while (fgets(buf, sizeof buf, f) != NULL) {
+			size_t len = strlen(buf);
+			if (len > 0 && buf[len - 1] == '\n') {
+				buf[len - 1] = '\0';
+			}
+			if (strstr(buf, key) == buf && buf[strlen(key)] == '=') {
+				if (value != NULL) {
+					*value =
+					    sc_strdup(buf + strlen(key) + 1);
+				}
+				break;
+			}
+		}
+	}
+	va_end(ap);
 }
 
 bool sc_should_use_normal_mode(sc_distro distro, const char *base_snap_name)

--- a/cmd/libsnap-confine-private/classic.h
+++ b/cmd/libsnap-confine-private/classic.h
@@ -31,5 +31,16 @@ typedef enum sc_distro {
 sc_distro sc_classify_distro(void);
 
 bool sc_should_use_normal_mode(sc_distro distro, const char *base_snap_name);
+/**
+ * sc_probe_distro extracts specific KEY=VALUE fields from a given os-release file.
+ *
+ * The remaining arguments are:
+ *  const char *key
+ *  char **value;
+ *
+ * Argument parsing terminates when key is NULL.
+ * Each value pointer is set either the parsed value or NULL.
+**/
+void sc_probe_distro(const char *os_release_path, ...) __attribute__((sentinel));
 
 #endif

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -300,6 +300,51 @@ enum sc_discard_vote {
 	SC_DISCARD_YES = 2,
 };
 
+// is_same_base returns true if /etc/os-release ID and VERSION_ID match /snap/$base_snap_name/current/etc/os-release
+static bool is_same_base(const char *base_snap_name)
+{
+	const char *current_os_release_path = "/etc/os-release";
+	char desired_os_release_path[PATH_MAX] = { 0 };
+	sc_must_snprintf(desired_os_release_path,
+			 sizeof desired_os_release_path,
+			 "/snap/%s/current/etc/os-release", base_snap_name);
+
+	char *desired_id SC_CLEANUP(sc_cleanup_string) = NULL;
+	char *desired_version_id SC_CLEANUP(sc_cleanup_string) = NULL;
+	char *current_id SC_CLEANUP(sc_cleanup_string) = NULL;
+	char *current_version_id SC_CLEANUP(sc_cleanup_string) = NULL;
+
+	sc_probe_distro(current_os_release_path, "ID", &current_id,
+			"VERSION_ID", &current_version_id, NULL);
+	sc_probe_distro(desired_os_release_path, "ID", &desired_id,
+			"VERSION_ID", &desired_version_id, NULL);
+
+	if (current_id == NULL) {
+		die("cannot check if base snap is the same: current os-release ID= not present");
+	}
+	if (desired_id == NULL) {
+		die("cannot check if base snap is the same: desired os-release ID= not present");
+	}
+	if (!sc_streq(current_id, desired_id)) {
+		debug("os-release differs: current ID=%s vs desired ID=%s",
+		      current_id, desired_id);
+		return false;
+	}
+	if (current_version_id == NULL && desired_version_id == NULL) {
+		return false;
+	}
+	if (current_version_id == NULL || desired_version_id == NULL
+	    || !sc_streq(current_version_id, desired_version_id)) {
+		debug
+		    ("os-release differs: current VERSION_ID=%s vs desired VERSION_ID=%s (with same ID=%s)",
+		     current_version_id, desired_version_id, current_id);
+		return false;
+	}
+	debug
+	    ("os-release ID and VERSION_ID are the same in both current and desired base snap");
+	return true;
+}
+
 // The namespace may be stale. To check this we must actually switch into it
 // but then we use up our setns call (the kernel misbehaves if we setns twice).
 // To work around this we'll fork a child and use it to probe. The child will

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -297,7 +297,8 @@ static bool should_discard_current_ns(dev_t base_snap_dev)
 
 enum sc_discard_vote {
 	SC_DISCARD_NO = 1,
-	SC_DISCARD_YES = 2,
+	SC_DISCARD_SHOULD = 2,
+	SC_DISCARD_MUST = 3,
 };
 
 // is_same_base returns true if /etc/os-release ID and VERSION_ID match /snap/$base_snap_name/current/etc/os-release
@@ -428,15 +429,23 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 		// systemd. This makes us end up in a situation where the outer base
 		// snap will never match the rootfs inside the mount namespace.
 		bool should_discard =
-		    inv->
-		    is_normal_mode ? should_discard_current_ns(base_snap_dev) :
-		    false;
+		    inv->is_normal_mode ?
+		    should_discard_current_ns(base_snap_dev) : false;
 
-		// Send this back to the parent: 2 - discard, 1 - keep.
+		// The namespace is stale, let's check if we must discard it because base snap has changed.
+		bool must_discard =
+		    inv->is_normal_mode ? !is_same_base(inv->
+							base_snap_name) : false;
+
+		eventfd_t value =
+		    should_discard ? must_discard ? SC_DISCARD_MUST :
+		    SC_DISCARD_SHOULD : SC_DISCARD_NO;
+		const char *value_str =
+		    should_discard ? must_discard ? "must" : "should" : "no";
+		// Send this back to the parent: 3 - force discard 2 - prefer discard, 1 - keep.
 		// Note that we cannot just use 0 and 1 because of the semantics of eventfd(2).
-		if (eventfd_write(event_fd, should_discard ?
-				  SC_DISCARD_YES : SC_DISCARD_NO) < 0) {
-			die("cannot send information to %s preserved mount namespace", should_discard ? "discard" : "keep");
+		if (eventfd_write(event_fd, value) < 0) {
+			die("cannot send information to %s preserved mount namespace", value_str);
 		}
 		// Exit, we're done.
 		exit(0);
@@ -463,19 +472,25 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 		die("support process for mount namespace inspection exited abnormally");
 	}
 	// If the namespace is up-to-date then we are done.
-	if (value == SC_DISCARD_NO) {
-		debug("preserved mount namespace can be reused");
+	switch (value) {
+	case SC_DISCARD_NO:
+		debug("preserved mount is not stale, reusing");
 		return 0;
+	case SC_DISCARD_SHOULD:
+		if (sc_cgroup_freezer_occupied(inv->snap_instance)) {
+			// Some processes are still using the namespace so we cannot discard it
+			// as that would fracture the view that the set of processes inside
+			// have on what is mounted.
+			debug
+			    ("preserved mount namespace is stale but occupied, reusing");
+			return 0;
+		}
+		break;
+	case SC_DISCARD_MUST:
+		debug
+		    ("preserved mount namespace is stale but base snap has changed, discarding");
+		break;
 	}
-	// The namespace is stale, let's check if we can discard it.
-	if (sc_cgroup_freezer_occupied(inv->snap_instance)) {
-		// Some processes are still using the namespace so we cannot discard it
-		// as that would fracture the view that the set of processes inside
-		// have on what is mounted.
-		debug("preserved mount namespace is stale but occupied");
-		return 0;
-	}
-	// The namespace is both stale and empty. We can discard it now.
 	sc_call_snap_discard_ns(snap_discard_ns_fd, inv->snap_instance);
 	return EAGAIN;
 }

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -1,0 +1,34 @@
+summary: a snap migrates from base "core" to "core18"
+prepare: |
+  snap install core18
+  snap pack test-snapd-core-migration.base-core
+  snap pack test-snapd-core-migration.base-core18
+execute: |
+  # When we install a snap that is using (implicitly) base: core, then that
+  # snap runs on top of the core16 runtime environment. This can be seen by
+  # looking at the os-release file which will match that of ubuntu core 16.
+  snap install --dangerous test-snapd-core-migration_1_all.snap
+  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="16"'
+  # When said snap is refreshed to use "base core18" then because there are no
+  # active processes using that snap, the base will change correctly to core18.
+  # This can be again observed by looking at the os-release file.
+  snap install --dangerous test-snapd-core-migration_2_all.snap
+  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="18"'
+  # If we rewind and do the update again, this time allowing one of the apps
+  # from core16 world to keep running. We will see that the base is not
+  # updated. This is unexpected but is the behavior of snapd 2.38 and earlier.
+  snap remove test-snapd-core-migration
+  snap install --dangerous test-snapd-core-migration_1_all.snap
+  test-snapd-core-migration.sh -c "sleep 1h" &
+  pid=$!
+  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="16"'
+  snap install --dangerous test-snapd-core-migration_2_all.snap
+  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="16"'
+  kill "$pid"
+  wait -n || true
+  # Note that after the background application terminates the base snap visible
+  # for newly started processes will be the correct one.
+  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="18"'
+restore: |
+  snap remove test-snapd-core-migration
+  rm -f test-snapd-core-migration_{1,2}_all.snap

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -23,11 +23,12 @@ execute: |
   pid=$!
   test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="16"'
   snap install --dangerous test-snapd-core-migration_2_all.snap
-  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="16"'
+  # Even before the background process terminates we are now using the new base
+  # snap, processes across base snaps see different mount namespaces.
+  test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="18"'
   kill "$pid"
-  wait -n || true
-  # Note that after the background application terminates the base snap visible
-  # for newly started processes will be the correct one.
+  wait "$pid" || true  # wait returns the exit code and we kill the process
+  # Nothing changes after the background app terminates.
   test-snapd-core-migration.sh -c "cat /etc/os-release" | MATCH 'VERSION_ID="18"'
 restore: |
   snap remove test-snapd-core-migration

--- a/tests/main/base-migration/test-snapd-core-migration.base-core/bin/sh
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/base-migration/test-snapd-core-migration.base-core/meta/snap.yaml
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-core-migration
+version: 1
+# TODO: uncomment when "base: core" works.
+# base: core
+apps:
+  sh:
+    command: bin/sh

--- a/tests/main/base-migration/test-snapd-core-migration.base-core18/bin/sh
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core18/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/base-migration/test-snapd-core-migration.base-core18/meta/snap.yaml
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core18/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snapd-core-migration
+version: 2
+base: core18
+apps:
+  sh:
+    command: bin/sh


### PR DESCRIPTION
We were alerted that when an existing snap, that used to use core as the
implicit base snap, is refreshed to explicitly use core18, then sometimes
that snap would fail to start.

The problem was debugged to a case where snap-confine would reuse the old mount
namespace, even though it knew it was stale, because an application was still
running and making the mount namespace "busy".

When the refreshed snap requires updated libraries from the new base snap it
could segvfault or misbehave in some other way. As such, before we have
refresh-app-awareness ready and deployed (when refresh would be postponed until
the application quits), snap-confine now detects this situation and forcibly
re-creates the mount namespace.

Fixes: https://bugs.launchpad.net/snapd/+bug/1819875
