### PR TITLE
tests: use apt via eatmydata

### DIFF
--- a/cmd/snap-confine/spread-tests/spread-prepare.sh
+++ b/cmd/snap-confine/spread-tests/spread-prepare.sh
@@ -56,7 +56,7 @@ build_debian_or_ubuntu_package() {
     git clone -b "$distro_packaging_git_branch" "$distro_packaging_git" distro-packaging
 
     # Install all the build dependencies declared by the package.
-    apt-get install --quiet -y gdebi-core
+    eatmydata apt-get install --quiet -y gdebi-core
     gdebi --quiet --apt-line ./distro-packaging/debian/control | xargs -r apt-get install --quiet -y
 
     # Generate a new upstream tarball from the current state of the tree

--- a/spread.yaml
+++ b/spread.yaml
@@ -547,8 +547,8 @@ prepare: |
         # this time when none of the test files is yet in place.
         case "$SPREAD_SYSTEM" in
             ubuntu-*|debian-*)
-                apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
-                apt-get install -y xdelta3 curl >& "$tf" || ( cat "$tf"; exit 1 )
+                eatmydata apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
+                eatmydata apt-get install -y xdelta3 curl >& "$tf" || ( cat "$tf"; exit 1 )
                 ;;
             fedora-*)
                 dnf install --refresh -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)

--- a/spread.yaml
+++ b/spread.yaml
@@ -539,6 +539,10 @@ prepare: |
         fi
     fi
 
+    if [[ "$SPREAD_SYSTEM" == debian-* ]]; then
+        apt-get update && apt-get install -y eatmydata
+    fi
+
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
     if [ -f current.delta ]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -547,8 +547,8 @@ prepare: |
         # this time when none of the test files is yet in place.
         case "$SPREAD_SYSTEM" in
             ubuntu-*|debian-*)
-                eatmydata apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
-                eatmydata apt-get install -y xdelta3 curl >& "$tf" || ( cat "$tf"; exit 1 )
+                apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
+                apt-get install -y xdelta3 curl eatmydata >& "$tf" || ( cat "$tf"; exit 1 )
                 ;;
             fedora-*)
                 dnf install --refresh -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -160,8 +160,8 @@ distro_install_local_package() {
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*|debian-*)
             # relying on dpkg as apt(-get) does not support installation from local files in trusty.
-            dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
-            apt-get -f install -y
+            eatmydata dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
+            eatmydata apt-get -f install -y
             ;;
         ubuntu-*)
             flags="-y"
@@ -233,7 +233,7 @@ distro_install_package() {
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
         if [[ "$*" =~ "libudev-dev" ]]; then
-            apt-get install -y --only-upgrade systemd
+            eatmydata apt-get install -y --only-upgrade systemd
         fi
         ;;
     esac
@@ -243,7 +243,7 @@ distro_install_package() {
     case "$SPREAD_SYSTEM" in
         debian-9-*)
         if [[ "$*" =~ "gnome-keyring" ]]; then
-            apt-get remove -y libp11-kit0
+            eatmydata apt-get remove -y libp11-kit0
         fi
         ;;
     esac
@@ -264,7 +264,7 @@ distro_install_package() {
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
             # shellcheck disable=SC2086
-            quiet apt-get install $APT_FLAGS -y "${pkg_names[@]}"
+            quiet eatmydata apt-get install $APT_FLAGS -y "${pkg_names[@]}"
             ;;
         fedora-*)
             # shellcheck disable=SC2086
@@ -314,7 +314,7 @@ distro_purge_package() {
 
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
-            quiet apt-get remove -y --purge -y "$@"
+            quiet eatmydata apt-get remove -y --purge -y "$@"
             ;;
         fedora-*)
             quiet dnf -y remove "$@"
@@ -339,7 +339,7 @@ distro_purge_package() {
 distro_update_package_db() {
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
-            quiet apt-get update
+            quiet eatmydata apt-get update
             ;;
         fedora-*)
             quiet dnf clean all
@@ -365,7 +365,7 @@ distro_update_package_db() {
 distro_clean_package_cache() {
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
-            quiet apt-get clean
+            quiet eatmydata apt-get clean
             ;;
         fedora-*)
             dnf clean all
@@ -389,7 +389,7 @@ distro_clean_package_cache() {
 distro_auto_remove_packages() {
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
-            quiet apt-get -y autoremove
+            quiet eatmydata apt-get -y autoremove
             ;;
         fedora-*)
             quiet dnf -y autoremove

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -342,17 +342,17 @@ prepare_project() {
         # 14.04 has its own packaging
         ./generate-packaging-dir
 
-        quiet apt-get install -y software-properties-common
+        quiet eatmydata apt-get install -y software-properties-common
 
 	# FIXME: trusty-proposed disabled because there is an inconsistency
 	#        in the trusty-proposed archive:
 	# linux-generic-lts-xenial : Depends: linux-image-generic-lts-xenial (= 4.4.0.143.124) but 4.4.0.141.121 is to be installed
         #echo 'deb http://archive.ubuntu.com/ubuntu/ trusty-proposed main universe' >> /etc/apt/sources.list
         quiet add-apt-repository ppa:snappy-dev/image
-        quiet apt-get update
+        quiet eatmydata apt-get update
 
-        quiet apt-get install -y --install-recommends linux-generic-lts-xenial
-        quiet apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite util-linux
+        quiet eatmydata apt-get install -y --install-recommends linux-generic-lts-xenial
+        quiet eatmydata apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite util-linux
     fi
 
     # WORKAROUND for older postrm scripts that did not do 
@@ -384,7 +384,7 @@ prepare_project() {
             else
                 best_golang=golang-1.10
             fi
-            gdebi --quiet --apt-line ./debian/control | quiet xargs -r apt-get install -y
+            gdebi --quiet --apt-line ./debian/control | quiet xargs -r eatmydata apt-get install -y
             # The go 1.10 backport is not using alternatives or anything else so
             # we need to get it on path somehow. This is not perfect but simple.
             if [ -z "$(command -v go)" ]; then


### PR DESCRIPTION
On Debian and Ubuntu we have eatmydata pre-installed and thus can use it
to speed up package installation operations.

On my local test, performed on a 1st gen core i7 running Fedora 30, with
a low-end SSD, invoked as follows:

    $ time SPREAD_HTTPS_PROXY=... SPREAD_HTTP_PROXY=...
    ~/go/bin/spread -debug -v qemu:ubuntu-16.04-64:tests/main/snap-run

The times for three consecutive runs are:

    real    11m27,168s
    user    0m14,345s
    sys     0m1,216s

    real    11m35,334s
    user    0m15,294s
    sys     0m1,145s

    real    11m38,274s
    user    0m14,240s
    sys     0m1,140s

On the same machine, with the same hot proxy, the times for vanilla
master were:

    real    13m21,811s
    user    0m13,850s
    sys     0m1,088s

    real    13m16,955s
    user    0m14,451s
    sys     0m1,130s

    real    12m52,010s
    user    0m14,443s
    sys     0m1,155s

I didn't measure any other test but the savings are expected due to
package installation overhead that is incurred when dpkg synchronizes
particular file-system operations.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
