### PR TITLE
travis: use Go 1.11 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
         - ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick
-      go: "1.10"
+      go: "1.11"
       name: OSX build and minimal runtime sanity check
       os: osx
       addons:


### PR DESCRIPTION
Otherwise golang.org/x/sys/unix breaks with:
```
../../../golang.org/x/sys/unix/zsyscall_darwin_amd64.1_11.go:687:22: undefined: SYS_CLOCK_GETTIME
```