### PR TITLE
vendor: pin golang.org/x/sys/unix to a revision before SYS_CLOCK_GETTIME on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ jobs:
           packages: [squashfs]
       install:
         - ./get-deps.sh
-        # extra dependency on darwin:
-        - go get golang.org/x/sys/unix
       before_script:
         - ./mkversion.sh
         - go build -o /tmp/snp ./cmd/snap

--- a/get-deps.sh
+++ b/get-deps.sh
@@ -23,7 +23,7 @@ if ! command -v govendor >/dev/null;then
 fi
 
 echo Obtaining dependencies
-govendor sync
+govendor sync -v
 
 
 if [ "$1" != "--skip-unused-check" ]; then

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,7 +171,7 @@
 			"revisionTime": "2017-06-28T23:42:41Z"
 		},
 		{
-			"checksumSHA1": "vYYwyICPulixLe5cJS04LaY66aU=",
+			"checksumSHA1": "FuXoNYVqeJARuYkOmPhreYmTf2M=",
 			"comment": "using revision before x/sys/unix/ introduced SYS_CLOCK_GETTIME on OSX",
 			"path": "golang.org/x/sys/unix",
 			"revision": "9eb1bfa1ce65ae8a6ff3114b0aaf9a41a6cf3560",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,6 +171,13 @@
 			"revisionTime": "2017-06-28T23:42:41Z"
 		},
 		{
+			"checksumSHA1": "vYYwyICPulixLe5cJS04LaY66aU=",
+			"comment": "using revision before x/sys/unix/ introduced SYS_CLOCK_GETTIME on OSX",
+			"path": "golang.org/x/sys/unix",
+			"revision": "9eb1bfa1ce65ae8a6ff3114b0aaf9a41a6cf3560",
+			"revisionTime": "2019-03-29T02:42:46Z"
+		},
+		{
 			"checksumSHA1": "9gypWnVZJEaH3jMK9KqOp4xgQD4=",
 			"path": "gopkg.in/check.v1",
 			"revision": "788fd78401277ebd861206a03c884797c6ec5541",


### PR DESCRIPTION
Otherwise it breaks:
```
 ../../../golang.org/x/sys/unix/zsyscall_darwin_amd64.1_11.go:687:22: undefined: SYS_CLOCK_GETTIME
```

Replaces #6676 
