### PR TITLE
many: implement user removal

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2018 Canonical Ltd
+ * Copyright (C) 2015-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -653,6 +653,28 @@ func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserRe
 		return results, fmt.Errorf("while creating users:%s", buf.Bytes())
 	}
 	return results, nil
+}
+
+// RemoveUserOptions holds options for removing a local system user.
+type RemoveUserOptions struct {
+	Username string `json:"username,omitempty"`
+}
+
+// RemoveUser removes a local system user.
+func (client *Client) RemoveUser(options *RemoveUserOptions) error {
+	if options.Username == "" {
+		return fmt.Errorf("cannot remove a user without providing an username")
+	}
+
+	data, err := json.Marshal(options)
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.doSync("POST", "/v2/remove-user", nil, nil, bytes.NewReader(data), nil); err != nil {
+		return fmt.Errorf("while removing user: %v", err)
+	}
+	return nil
 }
 
 // Users returns the local users.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -513,6 +513,24 @@ func (cs *clientSuite) TestClientCreateUsers(c *C) {
 
 		c.Assert(bodies, DeepEquals, test.bodies)
 	}
+}
+
+func (cs *clientSuite) TestClientRemoveUser(c *C) {
+	err := cs.cli.RemoveUser(&client.RemoveUserOptions{})
+	c.Assert(err, ErrorMatches, "cannot remove a user without providing an username")
+
+	cs.rsp = `{
+		"type": "sync",
+		"result": {}
+	}`
+	err = cs.cli.RemoveUser(&client.RemoveUserOptions{Username: "karl"})
+	c.Assert(cs.req.Method, Equals, "POST")
+	c.Assert(cs.req.URL.Path, Equals, "/v2/remove-user")
+	c.Assert(err, IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, IsNil)
+	c.Assert(string(body), Equals, `{"username":"karl"}`)
 }
 
 func (cs *clientSuite) TestClientJSONError(c *C) {

--- a/cmd/snap/cmd_remove_user.go
+++ b/cmd/snap/cmd_remove_user.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+
+	"github.com/jessevdk/go-flags"
+)
+
+var shortRemoveUserHelp = i18n.G("Remove a local system user")
+var longRemoveUserHelp = i18n.G(`
+The remove-user command removes a local system user.
+`)
+
+type cmdRemoveUser struct {
+	clientMixin
+	Positional struct {
+		Username string
+	} `positional-args:"yes"`
+}
+
+func init() {
+	cmd := addCommand("remove-user", shortRemoveUserHelp, longRemoveUserHelp, func() flags.Commander { return &cmdRemoveUser{} },
+		map[string]string{}, []argDesc{{
+			// TRANSLATORS: This is a noun and it needs to begin with < and end with >
+			name: i18n.G("<username>"),
+			// TRANSLATORS: This should not start with a lowercase letter
+			desc: i18n.G("The username to remove"),
+		}})
+	cmd.hidden = true
+}
+
+func (x *cmdRemoveUser) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	username := x.Positional.Username
+
+	options := client.RemoveUserOptions{
+		Username: username,
+	}
+
+	err := x.client.RemoveUser(&options)
+	if err == nil {
+		fmt.Fprintf(Stdout, i18n.G("removed user %q\n"), username)
+	}
+
+	return err
+}

--- a/cmd/snap/cmd_remove_user_test.go
+++ b/cmd/snap/cmd_remove_user_test.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+func makeRemoveUserChecker(c *check.C, n *int, username string) func(w http.ResponseWriter, r *http.Request) {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		switch *n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/remove-user")
+			var gotBody map[string]interface{}
+			dec := json.NewDecoder(r.Body)
+			err := dec.Decode(&gotBody)
+			c.Assert(err, check.IsNil)
+
+			wantBody := make(map[string]interface{})
+			wantBody["username"] = "karl"
+			c.Check(gotBody, check.DeepEquals, wantBody)
+
+			fmt.Fprintln(w, `{"type": "sync", "result": {}}`)
+		default:
+			c.Fatalf("got too many requests (now on %d)", *n+1)
+		}
+
+		*n++
+	}
+	return f
+}
+
+func (s *SnapSuite) TestRemoveUser(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(makeRemoveUserChecker(c, &n, "karl"))
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"remove-user", "karl"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.DeepEquals, []string{})
+	c.Check(n, check.Equals, 1)
+	c.Assert(s.Stdout(), check.Equals, `removed user "karl"`+"\n")
+	c.Assert(s.Stderr(), check.Equals, "")
+}


### PR DESCRIPTION
Add the remove-user command and corresponding daemon operations to
delete an user from the system. A version of the userdel utility with
extrausers support is required, see LP #1659534 for details.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
