### PR TITLE
overlord,tests: perform soft refresh check in doInstall

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -70,6 +70,16 @@ func isParallelInstallable(snapsup *SnapSetup) error {
 }
 
 func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int, fromChange string) (*state.TaskSet, error) {
+	tr := config.NewTransaction(st)
+	experimentalRefreshAppAwareness, err := config.GetFeatureFlag(tr, features.RefreshAppAwareness)
+	if err != nil && !config.IsNoOption(err) {
+		return nil, err
+	}
+	experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
+	if err != nil && !config.IsNoOption(err) {
+		return nil, err
+	}
+
 	if snapsup.InstanceName() == "system" {
 		return nil, fmt.Errorf("cannot install reserved snap name 'system'")
 	}
@@ -79,11 +89,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			return nil, err
 		}
 		if model == nil || model.Base() == "" {
-			tr := config.NewTransaction(st)
-			experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
-			if err != nil && !config.IsNoOption(err) {
-				return nil, err
-			}
 			if !experimentalAllowSnapd {
 				return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
 			}
@@ -122,6 +127,13 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			return nil, err
 		}
 		snapsup.PlugsOnly = snapsup.PlugsOnly && (len(info.Slots) == 0)
+
+		if experimentalRefreshAppAwareness {
+			if err := SoftNothingRunningRefreshCheck(info); err != nil {
+				// TODO Remember the inhibition time in snap state.
+				return nil, err
+			}
+		}
 	}
 
 	ts := state.NewTaskSet()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -754,6 +754,50 @@ func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
 }
 
+func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// With the refresh-app-awareness feature enabled.
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness", true)
+	tr.Commit()
+
+	// With a snap state indicating a snap is already installed.
+	snapst := &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+
+	// With a snap info indicating it has an application called "app"
+	snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		if name != "some-snap" {
+			return s.fakeBackend.ReadInfo(name, si)
+		}
+		info := &snap.Info{SuggestedName: name, SideInfo: *si, Type: snap.TypeApp}
+		info.Apps = map[string]*snap.AppInfo{
+			"app": {Snap: info, Name: "app"},
+		}
+		return info, nil
+	})
+	// And with cgroup v1 information indicating the app has a process with pid 1234.
+	writePids(c, filepath.Join(dirs.PidsCgroupDir, "snap.some-snap.app"), []int{1234})
+
+	// Attempt to install revision 2 of the snap.
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
+	}
+
+	// And observe that we cannot refresh because the snap is busy.
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\)`)
+}
+
 func (s snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -738,6 +738,9 @@ func (s *snapmgrTestSuite) testUpdateCreatesGCTasks(c *C, expectedDiscards int) 
 }
 
 func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	snapst := &snapstate.SnapState{
 		Active:   false,
 		Channel:  "channel",
@@ -752,6 +755,9 @@ func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 }
 
 func (s snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
 	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0, "")
 	c.Assert(err, NotNil)

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -23,8 +23,8 @@ execute: |
     test-snapd-refresh.sh -c 'exec sleep 1h' &
     pid=$!
     trap 'kill '"$pid"' || true' EXIT
-    # Try to install v2, it should fail because v1 is running.
-    snap install --dangerous test-snapd-refresh_2_all.snap || true
+    # Try to install v2, it should fail because v1 is running. Snapd is even kind enough to tell us what is preventing the install from working.
+    ! snap install --dangerous test-snapd-refresh_2_all.snap | MATCH 'error: cannot install snap file: snap "test-snapd-refresh" has running apps \(sh\)'
     test-snapd-refresh.version | MATCH v1
     # Kill the app process running from v1.
     kill "$pid"

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -1,0 +1,34 @@
+summary: Ensure that foreground applications block app refresh.
+details: |
+    When the refresh-app-awareness feature is enabled running snap processes,
+    mainly foreground applications, will block the refresh of said snap.
+prepare: |
+    # This feature depends on the release-app-awareness feature
+    snap set core experimental.refresh-app-awareness=true
+    snap pack test-snapd-refresh.v1
+    snap pack test-snapd-refresh.v2
+restore: |
+    snap remove test-snapd-refresh
+    rm -f test-snapd-refresh-{1,2}_all.snap
+    rmdir /sys/fs/cgroup/pids/snap.test-snapd-refresh.sh || true
+    rmdir /sys/fs/cgroup/pids/snap.test-snapd-refresh.version || true
+    # TODO: There is currently no way to unset configuration options.
+    # Once this is fixed please uncomment this line:
+    # snap unset core experimental.refresh-app-awareness
+execute: |
+    # Install v1 and see that it runs as expected.
+    snap install --dangerous test-snapd-refresh_1_all.snap
+    test-snapd-refresh.version | MATCH v1
+    # Run a sleeper app to keep the snap busy
+    test-snapd-refresh.sh -c 'exec sleep 1h' &
+    pid=$!
+    trap 'kill '"$pid"' || true' EXIT
+    # Try to install v2, it should fail because v1 is running.
+    snap install --dangerous test-snapd-refresh_2_all.snap || true
+    test-snapd-refresh.version | MATCH v1
+    # Kill the app process running from v1.
+    kill "$pid"
+    wait "$pid" || true  # wait returns the exit code and we kill the process
+    # Try to install v2 again, it should now work.
+    snap install --dangerous test-snapd-refresh_2_all.snap
+    test-snapd-refresh.version | MATCH v2

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v1/bin/sh
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v1/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v1/bin/version
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v1/bin/version
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo v1

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v1/meta/snap.yaml
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v1/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-refresh
+version: 1
+apps:
+    sh:
+        command: bin/sh
+    version:
+        command: bin/version

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v2/bin/version
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v2/bin/version
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo v2

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v2/meta/snap.yaml
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v2/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-refresh
+version: 2
+apps:
+    # NOTE: the v2 version of the application does not have the "sh"
+    # application anymore. This is so that we are correctly looking at the
+    # proper revision when checking for running processes.
+    version:
+        command: bin/version


### PR DESCRIPTION
When a snap is installed or refreshed, perform a soft check. That is,
see if there are any applications running that would interfere with the
refresh process.

The soft check is the first half of the feature: the hard check is next,
and verifies that the applications are still not running just before
unlinking the old snap revision.

Note that the information about the snap to be refreshed needs to be
loaded from the state because we need to know the current set of apps
and hooks that are there.

This patch also contains a simple test for the soft refresh check of the
app-refresh-awareness feature. When the feature is enabled refreshing an
application while it is running is rejected.

Two tests that were not locking the state were amended to do so since we
now need to inspect the experimental flags in doInstall.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
