### PR TITLE
testutil: fix MockCmd for shellcheck 0.5

### DIFF
--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -68,14 +68,14 @@ type MockCmd struct {
 // - generate \0\0 to separate commands
 var scriptTpl = `#!/bin/bash
 printf "%%s" "$(basename "$0")" >> %[1]q
-printf "\0" >> %[1]q
+printf '\0' >> %[1]q
 
 for arg in "$@"; do
      printf "%%s" "$arg" >> %[1]q
-     printf "\0"  >> %[1]q
+     printf '\0'  >> %[1]q
 done
 
-printf "\0" >> %[1]q
+printf '\0' >> %[1]q
 %s
 `
 


### PR DESCRIPTION
With shellcheck 0.5 there is an error that
```
printf "\0"
```
should be use single quotes (SC1117). This PR fixes this.
