### PR TITLE
snap-confine: set rootfs_dir in sc_invocation struct

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -598,16 +598,8 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/var/lib/extrausers",.is_optional = true},	// access to UID/GID of extrausers (if available)
 			{},
 		};
-		char rootfs_dir[PATH_MAX] = { 0 };
-		sc_must_snprintf(rootfs_dir, sizeof rootfs_dir,
-				 "%s/%s/current/", SNAP_MOUNT_DIR,
-				 inv->base_snap_name);
-		if (access(rootfs_dir, F_OK) != 0) {
-			die("cannot locate the base snap: %s",
-			    inv->base_snap_name);
-		}
 		struct sc_mount_config normal_config = {
-			.rootfs_dir = rootfs_dir,
+			.rootfs_dir = inv->rootfs_dir,
 			.mounts = mounts,
 			.distro = distro,
 			.normal_mode = true,

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -310,14 +310,11 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 						 int snap_discard_ns_fd)
 {
 	char base_snap_rev[PATH_MAX] = { 0 };
-	char fname[PATH_MAX] = { 0 };
 	dev_t base_snap_dev;
 	int event_fd SC_CLEANUP(sc_cleanup_close) = -1;
 
 	// Read the revision of the base snap by looking at the current symlink.
-	sc_must_snprintf(fname, sizeof fname, "%s/%s/current",
-			 SNAP_MOUNT_DIR, inv->base_snap_name);
-	if (readlink(fname, base_snap_rev, sizeof base_snap_rev) < 0) {
+	if (readlink(inv->rootfs_dir, base_snap_rev, sizeof base_snap_rev) < 0) {
 		die("cannot read current revision of snap %s",
 		    inv->snap_instance);
 	}

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -72,7 +72,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
 
     // construct rootfs_dir based on base_snap_name
     char mount_point[PATH_MAX] = {0};
-    sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current/", SNAP_MOUNT_DIR, inv->base_snap_name);
+    sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", SNAP_MOUNT_DIR, inv->base_snap_name);
     inv->rootfs_dir = sc_strdup(mount_point);
 
     debug("security tag: %s", inv->security_tag);
@@ -107,7 +107,7 @@ void sc_check_rootfs_dir(sc_invocation *inv) {
         /* For "core" we can still use the ubuntu-core snap. This is helpful in
          * the migration path when new snap-confine runs before snapd has
          * finished obtaining the core snap. */
-        sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current/", SNAP_MOUNT_DIR, "ubuntu-core");
+        sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current", SNAP_MOUNT_DIR, "ubuntu-core");
         if (access(mount_point, F_OK) == 0) {
             sc_cleanup_string(&inv->base_snap_name);
             inv->base_snap_name = sc_strdup("ubuntu-core");

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -70,6 +70,11 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
     inv->snap_instance = sc_strdup(snap_instance);
     inv->classic_confinement = sc_args_is_classic_confinement(args);
 
+    // construct rootfs_dir based on base_snap_name
+    char mount_point[PATH_MAX] = {0};
+    sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current/", SNAP_MOUNT_DIR, inv->base_snap_name);
+    inv->rootfs_dir = sc_strdup(mount_point);
+
     debug("security tag: %s", inv->security_tag);
     debug("executable:   %s", inv->executable);
     debug("confinement:  %s", inv->classic_confinement ? "classic" : "non-classic");
@@ -87,12 +92,8 @@ void sc_cleanup_invocation(sc_invocation *inv) {
     }
 }
 
-void sc_check_init_rootfs_dir(sc_invocation *inv) {
-    char mount_point[PATH_MAX] = {0};
-    sc_must_snprintf(mount_point, sizeof mount_point, "%s/%s/current/", SNAP_MOUNT_DIR, inv->base_snap_name);
-
-    if (access(mount_point, F_OK) == 0) {
-        inv->rootfs_dir = sc_strdup(mount_point);
+void sc_check_rootfs_dir(sc_invocation *inv) {
+    if (access(inv->rootfs_dir, F_OK) == 0) {
         return;
     }
 
@@ -101,6 +102,8 @@ void sc_check_init_rootfs_dir(sc_invocation *inv) {
      * ubuntu-core based systems to the new core.
      */
     if (sc_streq(inv->base_snap_name, "core")) {
+        char mount_point[PATH_MAX] = {0};
+
         /* For "core" we can still use the ubuntu-core snap. This is helpful in
          * the migration path when new snap-confine runs before snapd has
          * finished obtaining the core snap. */
@@ -108,6 +111,7 @@ void sc_check_init_rootfs_dir(sc_invocation *inv) {
         if (access(mount_point, F_OK) == 0) {
             sc_cleanup_string(&inv->base_snap_name);
             inv->base_snap_name = sc_strdup("ubuntu-core");
+            sc_cleanup_string(&inv->rootfs_dir);
             inv->rootfs_dir = sc_strdup(mount_point);
             debug("falling back to ubuntu-core instead of unavailable core snap");
             return;

--- a/cmd/snap-confine/snap-confine-invocation.h
+++ b/cmd/snap-confine/snap-confine-invocation.h
@@ -60,7 +60,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
 void sc_cleanup_invocation(sc_invocation *inv);
 
 /**
- * sc_check_rootfs_dir checks the rootfs_dir.
+ * sc_check_rootfs_dir checks the rootfs_dir and applies potential fall-backs.
  *
  * Checks that the rootfs_dir for the given base_snap exists and may apply
  * the fallback logic below. Will die() if no base_snap can be found.

--- a/cmd/snap-confine/snap-confine-invocation.h
+++ b/cmd/snap-confine/snap-confine-invocation.h
@@ -60,7 +60,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
 void sc_cleanup_invocation(sc_invocation *inv);
 
 /**
- * sc_check_init_rootfs_dir checks and initializes the rootfs_dir.
+ * sc_check_rootfs_dir checks the rootfs_dir.
  *
  * Checks that the rootfs_dir for the given base_snap exists and may apply
  * the fallback logic below. Will die() if no base_snap can be found.
@@ -74,6 +74,6 @@ void sc_cleanup_invocation(sc_invocation *inv);
  * of the init process) because it relies on the value of compile-time-choice
  * of SNAP_MOUNT_DIR.
  **/
-void sc_check_init_rootfs_dir(sc_invocation *inv);
+void sc_check_rootfs_dir(sc_invocation *inv);
 
 #endif

--- a/cmd/snap-confine/snap-confine-invocation.h
+++ b/cmd/snap-confine/snap-confine-invocation.h
@@ -36,6 +36,7 @@ typedef struct sc_invocation {
     bool classic_confinement;
     /* Things derived at runtime. */
     char *base_snap_name;
+    char *rootfs_dir;
     bool is_normal_mode;
 } sc_invocation;
 
@@ -59,7 +60,10 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
 void sc_cleanup_invocation(sc_invocation *inv);
 
 /**
- * sc_maybe_pick_alt_base_snap enables fall-back base in absence of primary.
+ * sc_check_init_rootfs_dir checks and initializes the rootfs_dir.
+ *
+ * Checks that the rootfs_dir for the given base_snap exists and may apply
+ * the fallback logic below. Will die() if no base_snap can be found.
  *
  * When performing ubuntu-core to core migration, the  snap "core" may not be
  * mounted yet. In that mode when snapd instructs us to use "core" as the base
@@ -70,6 +74,6 @@ void sc_cleanup_invocation(sc_invocation *inv);
  * of the init process) because it relies on the value of compile-time-choice
  * of SNAP_MOUNT_DIR.
  **/
-void sc_maybe_pick_alt_base_snap(sc_invocation *inv);
+void sc_check_init_rootfs_dir(sc_invocation *inv);
 
 #endif

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -348,7 +348,7 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 	group = sc_open_mount_ns(inv->snap_instance);
 
 	// Init and check rootfs_dir, apply any fallback behaviors.
-	sc_check_init_rootfs_dir(inv);
+	sc_check_rootfs_dir(inv);
 
 	/**
 	 * is_normal_mode controls if we should pivot into the base snap.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -347,8 +347,8 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 	struct sc_mount_ns *group = NULL;
 	group = sc_open_mount_ns(inv->snap_instance);
 
-	/* Apply fallback behaviors, if any apply. */
-	sc_maybe_pick_alt_base_snap(inv);
+	// Init and check rootfs_dir, apply any fallback behaviors.
+	sc_check_init_rootfs_dir(inv);
 
 	/**
 	 * is_normal_mode controls if we should pivot into the base snap.

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -24,7 +24,7 @@ execute: |
     if test-snapd-tools.echo hello 2>snap-confine.stderr; then
         echo "test-snapd-tools.echo should fail to run, test broken"
     fi
-    MATCH 'cannot proceed without base snap core: No such file or directory' < snap-confine.stderr
+    MATCH 'cannot locate base snap core: No such file or directory' < snap-confine.stderr
     mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
 
     echo "Test nvidia device fix"


### PR DESCRIPTION
As suggested by Samuele in
https://github.com/snapcore/snapd/pull/6583/files#r269986723
we can calculate and check the rootfs_dir that is derived from
the base snap early now. This also means we have one central
place for checking for the base_snap rootdir and to apply any
fallbacks.

