### PR TITLE
tests: run create-user on core devices

### DIFF
--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -1,15 +1,18 @@
 summary: Ensure create-user functionality
 
-# Disabled for Fedora, openSUSE, Arch, AMZN2 as none have all options for add user
-# the `snap create-user` command requires. Needs code rework.
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+# FIXME: enable on ubuntu-core-18-* as well once the shadow SRU
+#        https://launchpad.net/ubuntu/+source/shadow/1:4.5-1ubuntu2
+#        is available on -updates
+systems: [ubuntu-core-16-*]
 
 environment:
     USER_EMAIL: mvo@ubuntu.com
     USER_NAME: mvo
 
 restore: |
-    userdel -r "$USER_NAME" || true
+    # FIXME: use "snap delete-user" once
+    # https://github.com/snapcore/snapd/pull/6679 lands
+    userdel --extrausers -r "$USER_NAME" || true
     rm -rf "/etc/sudoers.d/create-user-$USER_NAME"
 
 execute: |
@@ -22,11 +25,11 @@ execute: |
 
     echo "snap create-user -- ensure success when run as non-root user with sudo"
     expected="created user \"$USER_NAME\""
-    obtained=$(su - test /bin/sh -c "sudo snap create-user --force-managed --sudoer $USER_EMAIL 2>&1")
+    obtained=$(su - test /bin/sh -c "sudo snap create-user --sudoer $USER_EMAIL 2>&1")
     [[ "$obtained" =~ $expected ]]
 
     echo "ensure user exists in /etc/passwd"
-    MATCH "^$USER_NAME:x:[0-9]+:[0-9]+:$USER_EMAIL" < /etc/passwd
+    MATCH "^$USER_NAME:x:[0-9]+:[0-9]+:$USER_EMAIL" < /var/lib/extrausers/passwd
 
     echo "ensure proper sudoers.d file"
     MATCH "$USER_NAME ALL=\\(ALL\\) NOPASSWD:ALL" < "/etc/sudoers.d/create-user-$USER_NAME"


### PR DESCRIPTION
The current "snap create-user" test runs on classic only. This
is bad for multiple reasons. The main use-case of this feature
are core devices and we are considering to drop support for this
on classic entirely.

So this PR changes the test to run on core16 now and once the
"shadow" package SRU pending in
https://launchpad.net/ubuntu/+source/shadow/1:4.5-1ubuntu2
is merged we can enable it on core18 too.

