### PR TITLE
boot: move ExtractKernelAssets

### DIFF
--- a/boot/boottest/mockbootloader.go
+++ b/boot/boottest/mockbootloader.go
@@ -20,6 +20,8 @@
 package boottest
 
 import (
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/snap"
 	"path/filepath"
 )
 
@@ -69,4 +71,13 @@ func (b *MockBootloader) Name() string {
 
 func (b *MockBootloader) ConfigFile() string {
 	return filepath.Join(b.bootdir, "mockboot/mockboot.cfg")
+}
+
+func (b *MockBootloader) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
+	// do nothing, this is mockbootloader
+	return nil
+}
+
+func (b *MockBootloader) RemoveKernelAssets(s snap.PlaceInfo) error {
+	return bootloader.RemoveKernelAssetsFromBootDir(b.Dir(), s)
 }

--- a/boot/boottest/mockbootloader.go
+++ b/boot/boottest/mockbootloader.go
@@ -20,7 +20,6 @@
 package boottest
 
 import (
-	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/snap"
 	"path/filepath"
 )
@@ -34,6 +33,9 @@ type MockBootloader struct {
 
 	name    string
 	bootdir string
+
+	ExtractKernelAssetsCalls []*snap.Info
+	RemoveKernelAssetsCalls  []snap.PlaceInfo
 }
 
 func NewMockBootloader(name, bootdir string) *MockBootloader {
@@ -74,10 +76,11 @@ func (b *MockBootloader) ConfigFile() string {
 }
 
 func (b *MockBootloader) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
-	// do nothing, this is mockbootloader
+	b.ExtractKernelAssetsCalls = append(b.ExtractKernelAssetsCalls, s)
 	return nil
 }
 
 func (b *MockBootloader) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return bootloader.RemoveKernelAssetsFromBootDir(b.Dir(), s)
+	b.RemoveKernelAssetsCalls = append(b.RemoveKernelAssetsCalls, s)
+	return nil
 }

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -21,7 +21,6 @@ package boot
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/bootloader"
@@ -33,19 +32,13 @@ import (
 // RemoveKernelAssets removes the unpacked kernel/initrd for the given
 // kernel snap.
 func RemoveKernelAssets(s snap.PlaceInfo) error {
-	loader, err := bootloader.Find()
+	bootloader, err := bootloader.Find()
 	if err != nil {
 		return fmt.Errorf("no not remove kernel assets: %s", err)
 	}
 
-	// remove the kernel blob
-	blobName := filepath.Base(s.MountFile())
-	dstDir := filepath.Join(loader.Dir(), blobName)
-	if err := os.RemoveAll(dstDir); err != nil {
-		return err
-	}
-
-	return nil
+	// ask bootloader to remove the kernel assets if needed
+	return bootloader.RemoveKernelAssets(s)
 }
 
 // ExtractKernelAssets extracts kernel/initrd/dtb data from the given
@@ -56,46 +49,13 @@ func ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
 		return fmt.Errorf("cannot extract kernel assets from snap type %q", s.Type)
 	}
 
-	loader, err := bootloader.Find()
+	bootloader, err := bootloader.Find()
 	if err != nil {
 		return fmt.Errorf("cannot extract kernel assets: %s", err)
 	}
 
-	// XXX: should we use "kernel.yaml" for this?
-	var forceKernelExtraction bool
-	if _, err := snapf.ReadFile("meta/force-kernel-extraction"); err == nil {
-		forceKernelExtraction = true
-	}
-
-	if !forceKernelExtraction && loader.Name() == "grub" {
-		return nil
-	}
-
-	// now do the kernel specific bits
-	blobName := filepath.Base(s.MountFile())
-	dstDir := filepath.Join(loader.Dir(), blobName)
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
-		return err
-	}
-	dir, err := os.Open(dstDir)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	for _, src := range []string{"kernel.img", "initrd.img"} {
-		if err := snapf.Unpack(src, dstDir); err != nil {
-			return err
-		}
-		if err := dir.Sync(); err != nil {
-			return err
-		}
-	}
-	if err := snapf.Unpack("dtbs/*", dstDir); err != nil {
-		return err
-	}
-
-	return dir.Sync()
+	// ask bootloader to extract the kernel assets if needed
+	return bootloader.ExtractKernelAssets(s, snapf)
 }
 
 // SetNextBoot will schedule the given OS or base or kernel snap to be

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -300,10 +300,18 @@ func (s *ubootKernelOSSuite) TestExtractKernelAssetsAndRemoveOnUboot(c *C) {
 		c.Check(fullFn, testutil.FileEquals, def[1])
 	}
 
+	// it's idempotent
+	err = boot.ExtractKernelAssets(info, snapf)
+	c.Assert(err, IsNil)
+
 	// remove
 	err = boot.RemoveKernelAssets(info)
 	c.Assert(err, IsNil)
 	c.Check(osutil.FileExists(kernelAssetsDir), Equals, false)
+
+	// it's idempotent
+	err = boot.RemoveKernelAssets(info)
+	c.Assert(err, IsNil)
 }
 
 // grubKernelOSSuite tests the GRUB specific code in the bootloader handling
@@ -361,6 +369,10 @@ func (s *grubKernelOSSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) 
 	// kernel is *not* here
 	kernimg := filepath.Join(loader.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, false)
+
+	// it's idempotent
+	err = boot.ExtractKernelAssets(info, snapf)
+	c.Assert(err, IsNil)
 }
 
 func (s *grubKernelOSSuite) TestExtractKernelForceWorks(c *C) {
@@ -393,10 +405,18 @@ func (s *grubKernelOSSuite) TestExtractKernelForceWorks(c *C) {
 	initrdimg := filepath.Join(loader.Dir(), "ubuntu-kernel_42.snap", "initrd.img")
 	c.Assert(osutil.FileExists(initrdimg), Equals, true)
 
+	// it's idempotent
+	err = boot.ExtractKernelAssets(info, snapf)
+	c.Assert(err, IsNil)
+
 	// ensure that removal of assets also works
 	err = boot.RemoveKernelAssets(info)
 	c.Assert(err, IsNil)
 	exists, _, err := osutil.DirExists(filepath.Dir(kernimg))
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, false)
+
+	// it's idempotent
+	err = boot.RemoveKernelAssets(info)
+	c.Assert(err, IsNil)
 }

--- a/bootloader/androidboot.go
+++ b/bootloader/androidboot.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/androidbootenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 type androidboot struct{}
@@ -74,4 +75,13 @@ func (a *androidboot) SetBootVars(values map[string]string) error {
 		env.Set(k, v)
 	}
 	return env.Save()
+}
+
+func (a *androidboot) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
+	return nil
+
+}
+
+func (a *androidboot) RemoveKernelAssets(s snap.PlaceInfo) error {
+	return nil
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -200,6 +200,7 @@ func extractKernelAssetsToBootDir(bootDir string, s *snap.Info, snapf snap.Conta
 	return dir.Sync()
 }
 
+// FIXME: unexport
 func RemoveKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
 	// remove the kernel blob
 	blobName := filepath.Base(s.MountFile())

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -200,8 +200,7 @@ func extractKernelAssetsToBootDir(bootDir string, s *snap.Info, snapf snap.Conta
 	return dir.Sync()
 }
 
-// FIXME: unexport
-func RemoveKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
+func removeKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
 	// remove the kernel blob
 	blobName := filepath.Base(s.MountFile())
 	dstDir := filepath.Join(bootDir, blobName)

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 const (
@@ -62,6 +63,12 @@ type Bootloader interface {
 
 	// ConfigFile returns the name of the config file
 	ConfigFile() string
+
+	// ExtractKernelAssets extracts kernel assets from the given kernel snap
+	ExtractKernelAssets(s *snap.Info, snapf snap.Container) error
+
+	// RemoveKernelAssets removes the assets for the given kernel snap.
+	RemoveKernelAssets(s snap.PlaceInfo) error
 }
 
 // InstallBootConfig installs the bootloader config from the gadget
@@ -163,4 +170,43 @@ func MarkBootSuccessful(bootloader Bootloader) error {
 	m["snap_mode"] = modeSuccess
 
 	return bootloader.SetBootVars(m)
+}
+
+func extractKernelAssetsToBootDir(bootDir string, s *snap.Info, snapf snap.Container) error {
+	// now do the kernel specific bits
+	blobName := filepath.Base(s.MountFile())
+	dstDir := filepath.Join(bootDir, blobName)
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return err
+	}
+	dir, err := os.Open(dstDir)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	for _, src := range []string{"kernel.img", "initrd.img"} {
+		if err := snapf.Unpack(src, dstDir); err != nil {
+			return err
+		}
+		if err := dir.Sync(); err != nil {
+			return err
+		}
+	}
+	if err := snapf.Unpack("dtbs/*", dstDir); err != nil {
+		return err
+	}
+
+	return dir.Sync()
+}
+
+func RemoveKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {
+	// remove the kernel blob
+	blobName := filepath.Base(s.MountFile())
+	dstDir := filepath.Join(bootDir, blobName)
+	if err := os.RemoveAll(dstDir); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -31,22 +31,39 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
+const packageKernel = `
+name: ubuntu-kernel
+version: 4.0-1
+type: kernel
+vendor: Someone
+`
+
 // partition specific testsuite
-type PartitionTestSuite struct{}
+type PartitionTestSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&PartitionTestSuite{})
 
 func (s *PartitionTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 	dirs.SetRootDir(c.MkDir())
 	err := os.MkdirAll((&grub{}).Dir(), 0755)
 	c.Assert(err, IsNil)
 	err = os.MkdirAll((&uboot{}).Dir(), 0755)
 	c.Assert(err, IsNil)
+}
+
+func (s *PartitionTestSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *PartitionTestSuite) TestForceBootloader(c *C) {

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -92,5 +92,5 @@ func (g *grub) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
 }
 
 func (g *grub) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return RemoveKernelAssetsFromBootDir(g.Dir(), s)
+	return removeKernelAssetsFromBootDir(g.Dir(), s)
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/grubenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 type grub struct{}
@@ -80,4 +81,16 @@ func (g *grub) SetBootVars(values map[string]string) error {
 		env.Set(k, v)
 	}
 	return env.Save()
+}
+
+func (g *grub) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
+	// XXX: should we use "kernel.yaml" for this?
+	if _, err := snapf.ReadFile("meta/force-kernel-extraction"); err == nil {
+		return extractKernelAssetsToBootDir(g.Dir(), s, snapf)
+	}
+	return nil
+}
+
+func (g *grub) RemoveKernelAssets(s snap.PlaceInfo) error {
+	return RemoveKernelAssetsFromBootDir(g.Dir(), s)
 }

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/ubootenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 type uboot struct{}
@@ -91,4 +92,12 @@ func (u *uboot) GetBootVars(names ...string) (map[string]string, error) {
 	}
 
 	return out, nil
+}
+
+func (u *uboot) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
+	return extractKernelAssetsToBootDir(u.Dir(), s, snapf)
+}
+
+func (u *uboot) RemoveKernelAssets(s snap.PlaceInfo) error {
+	return RemoveKernelAssetsFromBootDir(u.Dir(), s)
 }

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -99,5 +99,5 @@ func (u *uboot) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
 }
 
 func (u *uboot) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return RemoveKernelAssetsFromBootDir(u.Dir(), s)
+	return removeKernelAssetsFromBootDir(u.Dir(), s)
 }

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -21,7 +21,6 @@ package backend_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,16 +143,10 @@ func (s *setupSuite) TestSetupDoUndoInstance(c *C) {
 	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, false)
 }
 
-func (s *setupSuite) TestSetupDoUndoKernelUboot(c *C) {
-	// setup uboot config, so we can get uboot bootloader
-	mockGadgetDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), nil, 0644)
-	c.Assert(err, IsNil)
-	err = bootloader.InstallBootConfig(mockGadgetDir)
-	c.Assert(err, IsNil)
-	loader, _ := bootloader.Find()
-	c.Assert(loader, NotNil)
+func (s *setupSuite) TestSetupDoUndoKernel(c *C) {
+	loader := boottest.NewMockBootloader("mock", c.MkDir())
 	bootloader.Force(loader)
+
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
 	defer os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
@@ -178,17 +171,15 @@ type: kernel
 	snapType, err := s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
 	c.Assert(err, IsNil)
 	c.Check(snapType, Equals, snap.TypeKernel)
-	l, _ := filepath.Glob(filepath.Join(loader.Dir(), "*"))
-	c.Assert(l, HasLen, 2) // kernel + uboot.conf
-
+	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 1)
+	c.Assert(loader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
 
 	// undo deletes the kernel assets again
 	err = s.be.UndoSetupSnap(minInfo, "kernel", progress.Null)
 	c.Assert(err, IsNil)
-
-	l, _ = filepath.Glob(filepath.Join(loader.Dir(), "*"))
-	c.Assert(l, HasLen, 1) // uboot.conf
+	c.Assert(loader.RemoveKernelAssetsCalls, HasLen, 1)
+	c.Assert(loader.RemoveKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 }
 
 func (s *setupSuite) TestSetupDoIdempotent(c *C) {
@@ -197,14 +188,7 @@ func (s *setupSuite) TestSetupDoIdempotent(c *C) {
 
 	// this cannot check systemd own behavior though around mounts!
 
-	// setup uboot config, so we can get uboot bootloader
-	mockGadgetDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), nil, 0644)
-	c.Assert(err, IsNil)
-	err = bootloader.InstallBootConfig(mockGadgetDir)
-	c.Assert(err, IsNil)
-	loader, _ := bootloader.Find()
-	c.Assert(loader, NotNil)
+	loader := boottest.NewMockBootloader("mock", c.MkDir())
 	bootloader.Force(loader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
@@ -227,13 +211,16 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	_, err = s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 1)
+	c.Assert(loader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 
 	// retry run
 	_, err = s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
 	c.Assert(err, IsNil)
-
+	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 2)
+	c.Assert(loader.ExtractKernelAssetsCalls[1].InstanceName(), Equals, "kernel")
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
 
 	// sanity checks
@@ -242,9 +229,6 @@ type: kernel
 	c.Assert(osutil.FileExists(minInfo.MountDir()), Equals, true)
 
 	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, true)
-
-	l, _ = filepath.Glob(filepath.Join(loader.Dir(), "*"))
-	c.Assert(l, HasLen, 2) // kernel snap + uboot.env
 }
 
 func (s *setupSuite) TestSetupUndoIdempotent(c *C) {


### PR DESCRIPTION
Move ExtractKernelAssets to bootloader implementation kernel assets are used by
bootloader, each bootloader has different requirements how/if boot assets
should be extracted. So best fitting place is to move implementation to
bootloader itself. This is foundation for adding support for other bootloaders,
which would otherwise make ExtractKernelAssets implementation function littered
with if statements handling different bootloader types.
