### PR TITLE
interfaces: cleanup internal tool lookup in system-key

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -268,6 +268,27 @@ func (s *cmdSuite) TestInternalToolPathWithDevLocation(c *C) {
 	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "potato"))
 }
 
+func (s *cmdSuite) TestInternalToolPathSnapdPathReexec(c *C) {
+	restore := cmd.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
+	})
+	defer restore()
+
+	p, err := cmd.InternalToolPath("snapd")
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, filepath.Join(dirs.SnapMountDir, "/core/111/usr/lib/snapd/snapd"))
+}
+
+func (s *cmdSuite) TestInternalToolPathSnapdSnap(c *C) {
+	restore := cmd.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.SnapMountDir, "snapd/22/usr/bin/snap"), nil
+	})
+	defer restore()
+	p, err := cmd.InternalToolPath("snapd")
+	c.Assert(err, IsNil)
+	c.Check(p, Equals, filepath.Join(dirs.SnapMountDir, "/snapd/22/usr/lib/snapd/snapd"))
+}
+
 func (s *cmdSuite) TestInternalToolPathWithLibexecdirLocation(c *C) {
 	defer dirs.SetRootDir(s.fakeroot)
 	restore := release.MockReleaseInfo(&release.OS{ID: "fedora"})

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -43,10 +43,6 @@ func (c ByInterfaceName) Len() int           { return byInterfaceName(c).Len() }
 func (c ByInterfaceName) Swap(i, j int)      { byInterfaceName(c).Swap(i, j) }
 func (c ByInterfaceName) Less(i, j int) bool { return byInterfaceName(c).Less(i, j) }
 
-var (
-	FindSnapdPath = findSnapdPath
-)
-
 // MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS
 func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
 	old := isHomeUsingNFS

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -55,12 +55,3 @@ func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
 		isHomeUsingNFS = old
 	}
 }
-
-// MockOsReadlink mocks the real implementation of os.Readlink
-func MockOsReadlink(new func(string) (string, error)) (restore func()) {
-	old := osReadlink
-	osReadlink = new
-	return func() {
-		osReadlink = old
-	}
-}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -82,10 +82,6 @@ var (
 	seccompCompilerVersionInfo = seccompCompilerVersionInfoImpl
 )
 
-func findSnapdPath() (string, error) {
-	return cmd.InternalToolPath("snapd")
-}
-
 func seccompCompilerVersionInfoImpl(path string) (string, error) {
 	compiler, err := seccomp_compiler.New(func(name string) (string, error) { return path, nil })
 	if err != nil {
@@ -103,7 +99,7 @@ func generateSystemKey() (*systemKey, error) {
 	sk := &systemKey{
 		Version: 1,
 	}
-	snapdPath, err := findSnapdPath()
+	snapdPath, err := cmd.InternalToolPath("snapd")
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -78,29 +78,12 @@ type systemKey struct {
 var (
 	isHomeUsingNFS  = osutil.IsHomeUsingNFS
 	mockedSystemKey *systemKey
-	osReadlink      = os.Readlink
 
 	seccompCompilerVersionInfo = seccompCompilerVersionInfoImpl
 )
 
 func findSnapdPath() (string, error) {
-	snapdPath := filepath.Join(dirs.DistroLibExecDir, "snapd")
-
-	// find the right snapdPath by looking if we are re-execing or not
-	exe, err := osReadlink("/proc/self/exe")
-	if err != nil {
-		return "", err
-	}
-
-	if strings.HasPrefix(exe, dirs.SnapMountDir) {
-		// reexecd' snapd may be coming from either 'core' or 'snapd'
-		// snaps, find the local prefix to the snap:
-		// /snap/snapd/123/usr/bin/snap       -> /snap/snapd/123
-		// /snap/core/234/usr/lib/snapd/snapd -> /snap/core/234
-		prefix := strings.Split(exe, "/usr/")[0]
-		return filepath.Join(prefix, "/usr/lib/snapd/snapd"), nil
-	}
-	return snapdPath, nil
+	return cmd.InternalToolPath("snapd")
 }
 
 func seccompCompilerVersionInfoImpl(path string) (string, error) {
@@ -120,7 +103,7 @@ func generateSystemKey() (*systemKey, error) {
 	sk := &systemKey{
 		Version: 1,
 	}
-	snapdPath, err := cmd.InternalToolPath("snapd")
+	snapdPath, err := findSnapdPath()
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -28,7 +28,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
@@ -211,28 +210,4 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
 	// when we encounter different versions we get the right error
 	_, err = interfaces.SystemKeyMismatch()
 	c.Assert(err, Equals, interfaces.ErrSystemKeyVersion)
-}
-
-func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathNormal(c *C) {
-	p, err := interfaces.FindSnapdPath()
-	c.Assert(err, IsNil)
-	c.Check(p, Equals, filepath.Join(dirs.DistroLibExecDir, "snapd"))
-}
-
-func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathReexec(c *C) {
-	s.AddCleanup(cmd.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
-	}))
-	p, err := interfaces.FindSnapdPath()
-	c.Assert(err, IsNil)
-	c.Check(p, Equals, filepath.Join(dirs.SnapMountDir, "/core/111/usr/lib/snapd/snapd"))
-}
-
-func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathSnapdSnap(c *C) {
-	s.AddCleanup(cmd.MockOsReadlink(func(string) (string, error) {
-		return filepath.Join(dirs.SnapMountDir, "snapd/22/usr/bin/snap"), nil
-	}))
-	p, err := interfaces.FindSnapdPath()
-	c.Assert(err, IsNil)
-	c.Check(p, Equals, filepath.Join(dirs.SnapMountDir, "/snapd/22/usr/lib/snapd/snapd"))
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
@@ -219,7 +220,7 @@ func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathNormal(c *C) {
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathReexec(c *C) {
-	s.AddCleanup(interfaces.MockOsReadlink(func(string) (string, error) {
+	s.AddCleanup(cmd.MockOsReadlink(func(string) (string, error) {
 		return filepath.Join(dirs.SnapMountDir, "core/111/usr/bin/snap"), nil
 	}))
 	p, err := interfaces.FindSnapdPath()
@@ -228,7 +229,7 @@ func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathReexec(c *C) {
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyFindSnapdPathSnapdSnap(c *C) {
-	s.AddCleanup(interfaces.MockOsReadlink(func(string) (string, error) {
+	s.AddCleanup(cmd.MockOsReadlink(func(string) (string, error) {
 		return filepath.Join(dirs.SnapMountDir, "snapd/22/usr/bin/snap"), nil
 	}))
 	p, err := interfaces.FindSnapdPath()


### PR DESCRIPTION
The code was refactored to use internal tool lookup helpers. Some bits were left
behind. Clean them up.
