### PR TITLE
cmd: tweak internal tool lookup to accept more possible locations

### DIFF
--- a/cmd/cmd_linux.go
+++ b/cmd/cmd_linux.go
@@ -144,11 +144,13 @@ func InternalToolPath(tool string) (string, error) {
 			prefix := exe[:idx]
 			return filepath.Join(prefix, "/usr/lib/snapd", tool), nil
 		}
-		// or perhaps some other random location, make sure the tool
-		// exists there first
-		maybeTool := filepath.Join(filepath.Dir(exe), tool)
-		if osutil.FileExists(maybeTool) {
-			return maybeTool, nil
+		if idx == -1 {
+			// or perhaps some other random location, make sure the tool
+			// exists there and is an executable
+			maybeTool := filepath.Join(filepath.Dir(exe), tool)
+			if osutil.IsExecutable(maybeTool) {
+				return maybeTool, nil
+			}
 		}
 	}
 

--- a/cmd/cmd_linux.go
+++ b/cmd/cmd_linux.go
@@ -144,6 +144,12 @@ func InternalToolPath(tool string) (string, error) {
 			prefix := exe[:idx]
 			return filepath.Join(prefix, "/usr/lib/snapd", tool), nil
 		}
+		// or perhaps some other random location, make sure the tool
+		// exists there first
+		maybeTool := filepath.Join(filepath.Dir(exe), tool)
+		if osutil.FileExists(maybeTool) {
+			return maybeTool, nil
+		}
 	}
 
 	// fallback to distro tool

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -257,7 +257,7 @@ func (s *cmdSuite) TestInternalToolPathWithOtherCrazyLocation(c *C) {
 	c.Check(path, Equals, "/usr/foo/usr/tmp/tmp.foo_1234/usr/lib/snapd/potato")
 }
 
-func (s *cmdSuite) TestInternalToolPathWithDevLocation(c *C) {
+func (s *cmdSuite) TestInternalToolPathWithDevLocationFallback(c *C) {
 	restore := cmd.MockOsReadlink(func(string) (string, error) {
 		return filepath.Join("/home/dev/snapd/snapd"), nil
 	})
@@ -266,6 +266,23 @@ func (s *cmdSuite) TestInternalToolPathWithDevLocation(c *C) {
 	path, err := cmd.InternalToolPath("potato")
 	c.Check(err, IsNil)
 	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "potato"))
+}
+
+func (s *cmdSuite) TestInternalToolPathWithOtherDevLocation(c *C) {
+	restore := cmd.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.GlobalRootDir, "/tmp/snapd"), nil
+	})
+	defer restore()
+
+	devTool := filepath.Join(dirs.GlobalRootDir, "/tmp/potato")
+	err := os.MkdirAll(filepath.Dir(devTool), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(devTool, []byte(""), 0644)
+	c.Assert(err, IsNil)
+
+	path, err := cmd.InternalToolPath("potato")
+	c.Check(err, IsNil)
+	c.Check(path, Equals, filepath.Join(dirs.GlobalRootDir, "/tmp/potato"))
 }
 
 func (s *cmdSuite) TestInternalToolPathWithLibexecdirLocation(c *C) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -268,7 +268,7 @@ func (s *cmdSuite) TestInternalToolPathWithDevLocationFallback(c *C) {
 	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "potato"))
 }
 
-func (s *cmdSuite) TestInternalToolPathWithOtherDevLocation(c *C) {
+func (s *cmdSuite) TestInternalToolPathWithOtherDevLocationWhenExecutable(c *C) {
 	restore := cmd.MockOsReadlink(func(string) (string, error) {
 		return filepath.Join(dirs.GlobalRootDir, "/tmp/snapd"), nil
 	})
@@ -277,12 +277,29 @@ func (s *cmdSuite) TestInternalToolPathWithOtherDevLocation(c *C) {
 	devTool := filepath.Join(dirs.GlobalRootDir, "/tmp/potato")
 	err := os.MkdirAll(filepath.Dir(devTool), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(devTool, []byte(""), 0644)
+	err = ioutil.WriteFile(devTool, []byte(""), 0755)
 	c.Assert(err, IsNil)
 
 	path, err := cmd.InternalToolPath("potato")
 	c.Check(err, IsNil)
 	c.Check(path, Equals, filepath.Join(dirs.GlobalRootDir, "/tmp/potato"))
+}
+
+func (s *cmdSuite) TestInternalToolPathWithOtherDevLocationNonExecutable(c *C) {
+	restore := cmd.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.GlobalRootDir, "/tmp/snapd"), nil
+	})
+	defer restore()
+
+	devTool := filepath.Join(dirs.GlobalRootDir, "/tmp/non-executable-potato")
+	err := os.MkdirAll(filepath.Dir(devTool), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(devTool, []byte(""), 0644)
+	c.Assert(err, IsNil)
+
+	path, err := cmd.InternalToolPath("non-executable-potato")
+	c.Check(err, IsNil)
+	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "non-executable-potato"))
 }
 
 func (s *cmdSuite) TestInternalToolPathWithLibexecdirLocation(c *C) {

--- a/osutil/stat.go
+++ b/osutil/stat.go
@@ -58,6 +58,15 @@ func IsSymlink(path string) bool {
 	return (fileInfo.Mode() & os.ModeSymlink) != 0
 }
 
+// IsExecutable returns true when given path points to an executable file
+func IsExecutable(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !stat.IsDir() && (stat.Mode().Perm()&0111 != 0)
+}
+
 // ExecutableExists returns whether there an exists an executable with the given name somewhere on $PATH.
 func ExecutableExists(name string) bool {
 	_, err := exec.LookPath(name)


### PR DESCRIPTION
During development, when one builds the snapd binary and run runs it from some
random location, the internal tool lookup will fall back to using
$(libexecdir)/snapd as root directory for all other binaries.

Attempt to make it easier and try to use the tool from the directory of current
binary, provided the tool exists at that path.

See https://forum.snapcraft.io/t/cant-run-compiled-snapd/10772 for reference.
