### PR TITLE
overlord/ifacestate: introduce HotplugKey type use short key in change summaries

### DIFF
--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -90,7 +90,7 @@ func MockConnectedSlot(c *C, yaml string, si *snap.SideInfo, slotName string) (*
 	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
 }
 
-func MockHotplugSlot(c *C, yaml string, si *snap.SideInfo, hotplugKey, ifaceName, slotName string, staticAttrs map[string]interface{}) *snap.SlotInfo {
+func MockHotplugSlot(c *C, yaml string, si *snap.SideInfo, hotplugKey snap.HotplugKey, ifaceName, slotName string, staticAttrs map[string]interface{}) *snap.SlotInfo {
 	info := snaptest.MockInfo(c, yaml, si)
 	if _, ok := info.Slots[slotName]; ok {
 		panic(fmt.Sprintf("slot %q already present in the snap yaml", slotName))

--- a/interfaces/hotplug/deviceinfo.go
+++ b/interfaces/hotplug/deviceinfo.go
@@ -120,7 +120,7 @@ func (h *HotplugDeviceInfo) str(maxModelOrVendorLen int) string {
 
 	modelOrVendor := h.firstAttrValueOf("ID_MODEL_FROM_DATABASE", "ID_MODEL", "ID_MODEL_ID", "ID_VENDOR_FROM_DATABASE", "ID_VENDOR", "ID_VENDOR_ID")
 	if len(modelOrVendor) > maxModelOrVendorLen {
-		modelOrVendor = modelOrVendor[0:maxModelOrVendorLen] + "..."
+		modelOrVendor = modelOrVendor[0:maxModelOrVendorLen] + "…"
 	}
 
 	var serial string

--- a/interfaces/hotplug/deviceinfo_test.go
+++ b/interfaces/hotplug/deviceinfo_test.go
@@ -140,7 +140,7 @@ func (s *hotplugSuite) TestStringFormat(c *C) {
 				"ID_SERIAL_SHORT":         "123",
 				"ACTION":                  "add",
 			},
-			out: "/sys/devices/a/b/c (very long vendor name abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV...; serial: 123)",
+			out: "/sys/devices/a/b/c (very long vendor name abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV…; serial: 123)",
 		},
 		{
 			env: map[string]string{
@@ -149,7 +149,7 @@ func (s *hotplugSuite) TestStringFormat(c *C) {
 				"ACTION":                 "add",
 				"MAJOR":                  "189", "MINOR": "1",
 			},
-			out: "/sys/devices/a/b/c (very long model name abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVW...)",
+			out: "/sys/devices/a/b/c (very long model name abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVW…)",
 		},
 		{
 			env: map[string]string{
@@ -183,5 +183,5 @@ func (s *hotplugSuite) TestShortStringFormat(c *C) {
 		"ACTION":                  "add",
 	})
 	c.Assert(err, IsNil)
-	c.Check(di.ShortString(), Equals, "/sys/devices/a (very long vendor...)")
+	c.Check(di.ShortString(), Equals, "/sys/devices/a (very long vendor…)")
 }

--- a/interfaces/hotplug/proposed_slot.go
+++ b/interfaces/hotplug/proposed_slot.go
@@ -33,7 +33,7 @@ type Definer interface {
 
 // HotplugKeyHandler can be implemented by interfaces that need to provide a non-standard key for hotplug devices.
 type HotplugKeyHandler interface {
-	HotplugKey(di *HotplugDeviceInfo) (string, error)
+	HotplugKey(di *HotplugDeviceInfo) (snap.HotplugKey, error)
 }
 
 // HandledByGadgetPredicate can be implemented by hotplug interfaces to decide whether a device is already handled by given gadget slot.

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -112,7 +112,7 @@ type TestHotplugInterface struct {
 	TestInterface
 
 	// Support for interacting with hotplug subsystem.
-	HotplugKeyCallback            func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error)
+	HotplugKeyCallback            func(deviceInfo *hotplug.HotplugDeviceInfo) (snap.HotplugKey, error)
 	HandledByGadgetCallback       func(deviceInfo *hotplug.HotplugDeviceInfo, slot *snap.SlotInfo) bool
 	HotplugDeviceDetectedCallback func(deviceInfo *hotplug.HotplugDeviceInfo) (*hotplug.ProposedSlot, error)
 }
@@ -414,7 +414,7 @@ func (t *TestInterface) SystemdPermanentPlug(spec *systemd.Specification, plug *
 
 // Support for interacting with hotplug subsystem.
 
-func (t *TestHotplugInterface) HotplugKey(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
+func (t *TestHotplugInterface) HotplugKey(deviceInfo *hotplug.HotplugDeviceInfo) (snap.HotplugKey, error) {
 	if t.HotplugKeyCallback != nil {
 		return t.HotplugKeyCallback(deviceInfo)
 	}

--- a/interfaces/ifacetest/testiface_test.go
+++ b/interfaces/ifacetest/testiface_test.go
@@ -175,7 +175,7 @@ func (s *TestInterfaceSuite) TestHotplugKeyError(c *C) {
 		TestInterface: ifacetest.TestInterface{
 			InterfaceName: "test",
 		},
-		HotplugKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
+		HotplugKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (snap.HotplugKey, error) {
 			return "", fmt.Errorf("error")
 		},
 	}
@@ -185,7 +185,7 @@ func (s *TestInterfaceSuite) TestHotplugKeyError(c *C) {
 	dev := &hotplug.HotplugDeviceInfo{}
 	key, err := iface.HotplugKey(dev)
 	c.Assert(err, ErrorMatches, "error")
-	c.Assert(key, Equals, "")
+	c.Assert(key, DeepEquals, snap.HotplugKey(""))
 }
 
 func (s *TestInterfaceSuite) TestHotplugKeyOK(c *C) {
@@ -194,7 +194,7 @@ func (s *TestInterfaceSuite) TestHotplugKeyOK(c *C) {
 		TestInterface: ifacetest.TestInterface{
 			InterfaceName: "test",
 		},
-		HotplugKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (string, error) {
+		HotplugKeyCallback: func(deviceInfo *hotplug.HotplugDeviceInfo) (snap.HotplugKey, error) {
 			return "key", nil
 		},
 	}
@@ -205,7 +205,7 @@ func (s *TestInterfaceSuite) TestHotplugKeyOK(c *C) {
 	dev := &hotplug.HotplugDeviceInfo{}
 	key, err := hotplugIface.HotplugKey(dev)
 	c.Assert(err, IsNil)
-	c.Assert(key, Equals, "key")
+	c.Assert(key, DeepEquals, snap.HotplugKey("key"))
 }
 
 func (s *TestInterfaceSuite) TestHotplugDeviceDetectedOK(c *C) {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -817,7 +817,7 @@ func (r *Repository) UpdateHotplugSlotAttrs(ifaceName string, hotplugKey snap.Ho
 	}
 
 	for _, slotInfo := range r.slots[snapName] {
-		if slotInfo.Interface == ifaceName && (slotInfo.HotplugKey == hotplugKey) {
+		if slotInfo.Interface == ifaceName && slotInfo.HotplugKey == hotplugKey {
 			if len(r.slotPlugs[slotInfo]) > 0 {
 				// slots should be updated when disconnected, and reconnected back after updating.
 				return nil, fmt.Errorf("internal error: cannot update slot %s while connected", slotInfo.Name)

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -765,7 +765,7 @@ func (r *Repository) connected(snapName, plugOrSlotName string) ([]*ConnRef, err
 }
 
 // ConnectionsForHotplugKey returns all hotplug connections for given interface name and hotplug key.
-func (r *Repository) ConnectionsForHotplugKey(ifaceName, hotplugKey string) ([]*ConnRef, error) {
+func (r *Repository) ConnectionsForHotplugKey(ifaceName string, hotplugKey snap.HotplugKey) ([]*ConnRef, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -788,7 +788,7 @@ func (r *Repository) ConnectionsForHotplugKey(ifaceName, hotplugKey string) ([]*
 
 // SlotForHotplugKey returns a hotplug slot for given interface name and hotplug key or nil
 // if there is no slot.
-func (r *Repository) SlotForHotplugKey(ifaceName, hotplugKey string) (*snap.SlotInfo, error) {
+func (r *Repository) SlotForHotplugKey(ifaceName string, hotplugKey snap.HotplugKey) (*snap.SlotInfo, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -807,7 +807,7 @@ func (r *Repository) SlotForHotplugKey(ifaceName, hotplugKey string) (*snap.Slot
 
 // UpdateHotplugSlotAttrs updates static attributes of hotplug slot associated with given hotplugkey, and returns the resulting
 // slot. Slots can only be updated if not connected to any plug.
-func (r *Repository) UpdateHotplugSlotAttrs(ifaceName, hotplugKey string, staticAttrs map[string]interface{}) (*snap.SlotInfo, error) {
+func (r *Repository) UpdateHotplugSlotAttrs(ifaceName string, hotplugKey snap.HotplugKey, staticAttrs map[string]interface{}) (*snap.SlotInfo, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -817,7 +817,7 @@ func (r *Repository) UpdateHotplugSlotAttrs(ifaceName, hotplugKey string, static
 	}
 
 	for _, slotInfo := range r.slots[snapName] {
-		if slotInfo.Interface == ifaceName && slotInfo.HotplugKey == hotplugKey {
+		if slotInfo.Interface == ifaceName && (slotInfo.HotplugKey == hotplugKey) {
 			if len(r.slotPlugs[slotInfo]) > 0 {
 				// slots should be updated when disconnected, and reconnected back after updating.
 				return nil, fmt.Errorf("internal error: cannot update slot %s while connected", slotInfo.Name)

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -200,16 +200,17 @@ func (s *helpersSuite) TestHotplugTaskHelpers(c *C) {
 
 	ifacestate.SetHotplugAttrs(t, "iface", "key")
 
-	var key, iface string
+	var iface string
+	var key snap.HotplugKey
 	c.Assert(t.Get("hotplug-key", &key), IsNil)
-	c.Assert(key, Equals, "key")
+	c.Assert(key, DeepEquals, snap.HotplugKey("key"))
 
 	c.Assert(t.Get("interface", &iface), IsNil)
 	c.Assert(iface, Equals, "iface")
 
 	iface, key, err = ifacestate.GetHotplugAttrs(t)
 	c.Assert(err, IsNil)
-	c.Assert(key, Equals, "key")
+	c.Assert(key, DeepEquals, snap.HotplugKey("key"))
 	c.Assert(iface, Equals, "iface")
 }
 
@@ -452,7 +453,7 @@ func (s *helpersSuite) TestGetHotplugChangeAttrs(c *C) {
 
 	seq, key, err := ifacestate.GetHotplugChangeAttrs(chg)
 	c.Assert(err, IsNil)
-	c.Check(key, Equals, "1234")
+	c.Check(key, DeepEquals, snap.HotplugKey("1234"))
 	c.Check(seq, Equals, 7)
 }
 
@@ -508,7 +509,7 @@ func (s *helpersSuite) TestAddHotplugSeqWaitTask(c *C) {
 	seq, key, err := ifacestate.GetHotplugChangeAttrs(chg)
 	c.Assert(err, IsNil)
 	c.Check(seq, Equals, 1)
-	c.Check(key, Equals, "1234")
+	c.Check(key, DeepEquals, snap.HotplugKey("1234"))
 
 	var seqTask *state.Task
 	for _, t := range chg.Tasks() {

--- a/overlord/ifacestate/hotplug.go
+++ b/overlord/ifacestate/hotplug.go
@@ -37,7 +37,7 @@ import (
 
 // deviceKey determines a key for given device and hotplug interface. Every interface may provide a custom HotplugDeviceKey method
 // to compute device key - if it doesn't, we fall back to defaultDeviceKey.
-func deviceKey(device *hotplug.HotplugDeviceInfo, iface interfaces.Interface, defaultDeviceKey string) (deviceKey string, err error) {
+func deviceKey(device *hotplug.HotplugDeviceInfo, iface interfaces.Interface, defaultDeviceKey snap.HotplugKey) (deviceKey snap.HotplugKey, err error) {
 	if keyhandler, ok := iface.(hotplug.HotplugKeyHandler); ok {
 		deviceKey, err = keyhandler.HotplugKey(device)
 		if err != nil {
@@ -80,7 +80,7 @@ var deviceKeyVersion = len(attrGroups) - 1
 // The resulting key returned by the function has the following format:
 // <version><checksum> where checksum is the sha256 checksum computed over
 // select attributes of the device.
-func defaultDeviceKey(devinfo *hotplug.HotplugDeviceInfo, keyVersion int) (string, error) {
+func defaultDeviceKey(devinfo *hotplug.HotplugDeviceInfo, keyVersion int) (snap.HotplugKey, error) {
 	found := 0
 	key := sha256.New()
 	if keyVersion >= 16 || keyVersion >= len(attrGroups) {
@@ -101,7 +101,7 @@ func defaultDeviceKey(devinfo *hotplug.HotplugDeviceInfo, keyVersion int) (strin
 	if found < 2 {
 		return "", nil
 	}
-	return fmt.Sprintf("%x%x", keyVersion, key.Sum(nil)), nil
+	return snap.HotplugKey(fmt.Sprintf("%x%x", keyVersion, key.Sum(nil))), nil
 }
 
 // hotplugDeviceAdded gets called when a device is added to the system.
@@ -194,7 +194,7 @@ InterfacesLoop:
 			return
 		}
 
-		logger.Debugf("adding hotplug device %s for interface %q, hotplug key %s", devinfo, iface.Name(), key)
+		logger.Debugf("adding hotplug device %s for interface %q, hotplug key %q", devinfo, iface.Name(), key)
 
 		seq, err := allocHotplugSeq(st)
 		if err != nil {
@@ -204,7 +204,7 @@ InterfacesLoop:
 
 		if !m.enumerationDone {
 			if m.enumeratedDeviceKeys[iface.Name()] == nil {
-				m.enumeratedDeviceKeys[iface.Name()] = make(map[string]bool)
+				m.enumeratedDeviceKeys[iface.Name()] = make(map[snap.HotplugKey]bool)
 			}
 			m.enumeratedDeviceKeys[iface.Name()][key] = true
 		}
@@ -214,16 +214,16 @@ InterfacesLoop:
 		// and hotplugDeviceRemoved() will remove affected path from hotplugDevicePaths.
 		m.hotplugDevicePaths[devPath] = append(m.hotplugDevicePaths[devPath], deviceData{hotplugKey: key, ifaceName: iface.Name()})
 
-		hotplugAdd := st.NewTask("hotplug-add-slot", fmt.Sprintf("Create slot for device %s with hotplug key %q", devinfo.ShortString(), key))
+		hotplugAdd := st.NewTask("hotplug-add-slot", fmt.Sprintf("Create slot for device %s with hotplug key %q", devinfo.ShortString(), key.ShortString()))
 		setHotplugAttrs(hotplugAdd, iface.Name(), key)
 		hotplugAdd.Set("device-info", devinfo)
 		hotplugAdd.Set("proposed-slot", proposedSlot)
 
-		hotplugConnect := st.NewTask("hotplug-connect", fmt.Sprintf("Recreate connections of interface %q for device %s with hotplug key %q", iface.Name(), devinfo.ShortString(), key))
+		hotplugConnect := st.NewTask("hotplug-connect", fmt.Sprintf("Recreate connections of interface %q for device %s with hotplug key %q", iface.Name(), devinfo.ShortString(), key.ShortString()))
 		setHotplugAttrs(hotplugConnect, iface.Name(), key)
 		hotplugConnect.WaitFor(hotplugAdd)
 
-		chg := st.NewChange(fmt.Sprintf("hotplug-add-slot-%s", iface), fmt.Sprintf("Add hotplug slot of interface %q for device %s with hotplug key %q", devinfo.ShortString(), iface.Name(), key))
+		chg := st.NewChange(fmt.Sprintf("hotplug-add-slot-%s", iface), fmt.Sprintf("Add hotplug slot of interface %q for device %s with hotplug key %q", devinfo.ShortString(), iface.Name(), key.ShortString()))
 		chg.AddTask(hotplugAdd)
 		chg.AddTask(hotplugConnect)
 		addHotplugSeqWaitTask(chg, key, seq)
@@ -254,7 +254,7 @@ func (m *InterfaceManager) hotplugDeviceRemoved(devinfo *hotplug.HotplugDeviceIn
 		ifaceName := dev.ifaceName
 		slot, err := m.repo.SlotForHotplugKey(ifaceName, hotplugKey)
 		if err != nil {
-			logger.Noticef("internal error: cannot obtain slot for hotplug interface %q, key %s: %v", ifaceName, hotplugKey, err)
+			logger.Noticef("internal error: cannot obtain slot for hotplug interface %q, hotplug key %q: %v", ifaceName, hotplugKey, err)
 			continue
 		}
 		if slot == nil {
@@ -266,11 +266,11 @@ func (m *InterfaceManager) hotplugDeviceRemoved(devinfo *hotplug.HotplugDeviceIn
 			return
 		}
 
-		logger.Debugf("removing hotplug device %s for interface %q, hotplug key %s", devinfo, ifaceName, hotplugKey)
+		logger.Debugf("removing hotplug device %s for interface %q, hotplug key %q", devinfo, ifaceName, hotplugKey)
 
 		seq, err := allocHotplugSeq(st)
 		if err != nil {
-			logger.Noticef("internal error: cannot handle removal of hotplug device %s: %v", devinfo, err)
+			logger.Noticef("internal error: cannot handle removal of hotplug device %s, hotplug key %q: %v", devinfo, hotplugKey, err)
 			continue
 		}
 
@@ -407,7 +407,7 @@ func suggestedSlotName(devinfo *hotplug.HotplugDeviceInfo, fallbackName string) 
 
 // hotplugSlotName returns a slot name derived from slotSpecName or device attributes, or interface name, in that priority order, depending
 // on which information is available. The chosen name is guaranteed to be unique
-func hotplugSlotName(hotplugKey, systemSnapInstanceName, slotSpecName, ifaceName string, devinfo *hotplug.HotplugDeviceInfo, repo *interfaces.Repository, stateSlots map[string]*HotplugSlotInfo) string {
+func hotplugSlotName(hotplugKey snap.HotplugKey, systemSnapInstanceName, slotSpecName, ifaceName string, devinfo *hotplug.HotplugDeviceInfo, repo *interfaces.Repository, stateSlots map[string]*HotplugSlotInfo) string {
 	proposedName := slotSpecName
 	if proposedName == "" {
 		proposedName = suggestedSlotName(devinfo, ifaceName)
@@ -422,11 +422,11 @@ func hotplugSlotName(hotplugKey, systemSnapInstanceName, slotSpecName, ifaceName
 }
 
 // updateDevice creates tasks to disconnect slots of given device and update the slot in the repository.
-func updateDevice(st *state.State, ifaceName, hotplugKey string, newAttrs map[string]interface{}) *state.TaskSet {
-	hotplugDisconnect := st.NewTask("hotplug-disconnect", fmt.Sprintf("Disable connections of interface %q, hotplug key %q", ifaceName, hotplugKey))
+func updateDevice(st *state.State, ifaceName string, hotplugKey snap.HotplugKey, newAttrs map[string]interface{}) *state.TaskSet {
+	hotplugDisconnect := st.NewTask("hotplug-disconnect", fmt.Sprintf("Disable connections of interface %q, hotplug key %q", ifaceName, hotplugKey.ShortString()))
 	setHotplugAttrs(hotplugDisconnect, ifaceName, hotplugKey)
 
-	updateSlot := st.NewTask("hotplug-update-slot", fmt.Sprintf("Update slot of interface %q, hotplug key %q", ifaceName, hotplugKey))
+	updateSlot := st.NewTask("hotplug-update-slot", fmt.Sprintf("Update slot of interface %q, hotplug key %q", ifaceName, hotplugKey.ShortString()))
 	setHotplugAttrs(updateSlot, ifaceName, hotplugKey)
 	updateSlot.Set("slot-attrs", newAttrs)
 	updateSlot.WaitFor(hotplugDisconnect)
@@ -435,13 +435,13 @@ func updateDevice(st *state.State, ifaceName, hotplugKey string, newAttrs map[st
 }
 
 // removeDevice creates tasks to disconnect slots of given device and remove affected slots.
-func removeDevice(st *state.State, ifaceName, hotplugKey string) *state.TaskSet {
+func removeDevice(st *state.State, ifaceName string, hotplugKey snap.HotplugKey) *state.TaskSet {
 	// hotplug-disconnect task will create hooks and disconnect the slot
-	hotplugDisconnect := st.NewTask("hotplug-disconnect", fmt.Sprintf("Disable connections of interface %q, hotplug key %q", ifaceName, hotplugKey))
+	hotplugDisconnect := st.NewTask("hotplug-disconnect", fmt.Sprintf("Disable connections of interface %q, hotplug key %q", ifaceName, hotplugKey.ShortString()))
 	setHotplugAttrs(hotplugDisconnect, ifaceName, hotplugKey)
 
 	// hotplug-remove-slot will remove this device's slot from the repository.
-	removeSlot := st.NewTask("hotplug-remove-slot", fmt.Sprintf("Remove slot for interface %q, hotplug key %q", ifaceName, hotplugKey))
+	removeSlot := st.NewTask("hotplug-remove-slot", fmt.Sprintf("Remove slot for interface %q, hotplug key %q", ifaceName, hotplugKey.ShortString()))
 	setHotplugAttrs(removeSlot, ifaceName, hotplugKey)
 	removeSlot.WaitFor(hotplugDisconnect)
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -5643,7 +5643,7 @@ func (s *interfaceManagerSuite) testHotplugAddNewSlot(c *C, devData map[string]s
 	slot := repo.Slot("core", expectedName)
 	c.Assert(slot, NotNil)
 	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "bar"})
-	c.Check(slot.HotplugKey, Equals, "1234")
+	c.Check(slot.HotplugKey, Equals, snap.HotplugKey("1234"))
 
 	var hotplugSlots map[string]interface{}
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
@@ -5707,7 +5707,7 @@ func (s *interfaceManagerSuite) TestHotplugAddGoneSlot(c *C) {
 	slot := repo.Slot("core", "hotplugslot-old-name")
 	c.Assert(slot, NotNil)
 	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "bar"})
-	c.Check(slot.HotplugKey, Equals, "1234")
+	c.Check(slot.HotplugKey, DeepEquals, snap.HotplugKey("1234"))
 
 	var hotplugSlots map[string]interface{}
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)
@@ -5768,7 +5768,7 @@ func (s *interfaceManagerSuite) TestHotplugAddSlotWithChangedAttrs(c *C) {
 	slot := repo.Slot("core", "hotplugslot")
 	c.Assert(slot, NotNil)
 	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"foo": "newfoo"})
-	c.Check(slot.HotplugKey, Equals, "1234")
+	c.Check(slot.HotplugKey, DeepEquals, snap.HotplugKey("1234"))
 
 	var hotplugSlots map[string]interface{}
 	c.Assert(s.state.Get("hotplug-slots", &hotplugSlots), IsNil)

--- a/overlord/ifacestate/implicit_test.go
+++ b/overlord/ifacestate/implicit_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 
 	. "gopkg.in/check.v1"
@@ -70,7 +71,7 @@ func (implicitSuite) TestAddImplicitSlotsOnCore(c *C) {
 	c.Assert(slot, NotNil)
 	c.Assert(slot.Interface, Equals, "dummy")
 	c.Assert(slot.Attrs, DeepEquals, map[string]interface{}{"attr": "value"})
-	c.Assert(slot.HotplugKey, Equals, "1234")
+	c.Assert(slot.HotplugKey, DeepEquals, snap.HotplugKey("1234"))
 }
 
 func (implicitSuite) TestAddImplicitSlotsOnClassic(c *C) {

--- a/snap/hotplug_key.go
+++ b/snap/hotplug_key.go
@@ -19,16 +19,16 @@
 
 package snap
 
+import (
+	"fmt"
+)
+
 // HotplugKey is a string key of a hotplugged device
 type HotplugKey string
 
 // ShortString returns a truncated string representation of the hotplug key
 func (h HotplugKey) ShortString() string {
 	str := string(h)
-	// this is normally never the case, but makes testing easier; hotplug keys
-	// use sha256 and are 65 characters long, output just the first 12 characters.
-	if len(str) < 12 {
-		return str
-	}
-	return str[0:12] + "..."
+	// hotplug key is sha256 (64+1 characters long), output just the first 12 characters.
+	return fmt.Sprintf("%.12s…", str)
 }

--- a/snap/hotplug_key.go
+++ b/snap/hotplug_key.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C)2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+// HotplugKey is a string key of a hotplugged device
+type HotplugKey string
+
+// ShortString returns a truncated string representation of the hotplug key
+func (h HotplugKey) ShortString() string {
+	str := string(h)
+	// this is normally never the case, but makes testing easier
+	if len(str) < 12 {
+		return str
+	}
+	return str[0:12] + "..."
+}

--- a/snap/hotplug_key.go
+++ b/snap/hotplug_key.go
@@ -25,7 +25,8 @@ type HotplugKey string
 // ShortString returns a truncated string representation of the hotplug key
 func (h HotplugKey) ShortString() string {
 	str := string(h)
-	// this is normally never the case, but makes testing easier
+	// this is normally never the case, but makes testing easier; hotplug keys
+	// use sha256 and are 65 characters long, output just the first 12 characters.
 	if len(str) < 12 {
 		return str
 	}

--- a/snap/hotplug_key_test.go
+++ b/snap/hotplug_key_test.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C)2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type hotplugKeySuite struct{}
+
+var _ = Suite(&hotplugKeySuite{})
+
+func (*hotplugKeySuite) TestShortString(c *C) {
+	var key snap.HotplugKey
+	key = "abcdefghijklmnopqrstuvwxyz"
+	c.Check(key.ShortString(), Equals, "abcdefghijkl...")
+}
+
+func (*hotplugKeySuite) TestString(c *C) {
+	// simple sanity test
+	keyStr := "abcdefghijklmnopqrstuvwxyz"
+	key := snap.HotplugKey(keyStr)
+	c.Check(fmt.Sprintf("%s", key), Equals, "abcdefghijklmnopqrstuvwxyz")
+}

--- a/snap/hotplug_key_test.go
+++ b/snap/hotplug_key_test.go
@@ -34,7 +34,7 @@ var _ = Suite(&hotplugKeySuite{})
 func (*hotplugKeySuite) TestShortString(c *C) {
 	var key snap.HotplugKey
 	key = "abcdefghijklmnopqrstuvwxyz"
-	c.Check(key.ShortString(), Equals, "abcdefghijkl...")
+	c.Check(key.ShortString(), Equals, "abcdefghijkl…")
 }
 
 func (*hotplugKeySuite) TestString(c *C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -661,7 +661,7 @@ type SlotInfo struct {
 	// using properties of a hotplugged device so that the same
 	// slot may be made available if the device is reinserted.
 	// It's empty for regular slots.
-	HotplugKey string
+	HotplugKey HotplugKey
 }
 
 // SocketInfo provides information on application sockets.


### PR DESCRIPTION
Introduce HotplugKey type based on string and use it everywhere in hotplug code instead of plain string. Provide ShortString method (similiar to recently landed ShortString method of HotplugDeviceInfo) and use it for task and change summaries; debug messages will still use full hotplug key string. Also fixed a few inconsistencies with "%s" vs "%q" in the messages.

Per one of the review comments suggesting use of unicode … for "...", I've also updated HotplugDeviceKey the same way.