### PR TITLE
packaging: disable -buildmode=pie on all arches

### DIFF
--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -39,10 +39,6 @@ type elfNoteHeader struct {
 // ReadBuildID returns the GNU build ID note of the provided ELF executable.
 // The ErrNoBuildID error is returned when one is not found.
 //
-// Observed Go binaries presented one when built with:
-//
-//      go build -buildmode=pie
-//
 // See details at http://fedoraproject.org/wiki/Releases/FeatureBuildId
 func ReadBuildID(fname string) (string, error) {
 	const ELF_NOTE_GNU = "GNU\x00"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -67,8 +67,8 @@ build() {
   cd "$srcdir/go/src/${_gourl}"
   XDG_CONFIG_HOME="$srcdir" ./get-deps.sh
 
-  gobuild="go build -x -v -buildmode=pie"
-  gobuild_static="go build -x -v -buildmode=pie -ldflags=-extldflags=-static"
+  gobuild="go build -x -v"
+  gobuild_static="go build -x -v -ldflags=-extldflags=-static"
   # Build/install snap and snapd
   $gobuild -o $srcdir/go/bin/snap $GOFLAGS "${_gourl}/cmd/snap"
   $gobuild -o $srcdir/go/bin/snapd $GOFLAGS "${_gourl}/cmd/snapd"

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -58,21 +58,21 @@ go_binaries = snap snapctl snap-seccomp snap-update-ns snap-exec snapd
 all: $(go_binaries) 
 
 snap snap-seccomp:
-	go build -buildmode=pie $(import_path)/cmd/$@
+	go build $(import_path)/cmd/$@
 
 # Those three need to be built as static binaries. They run on the inside of a
 # nearly-arbitrary mount namespace that does not contain anything we can depend
 # on (no standard library, for example).
 snap-update-ns snap-exec snapctl:
-	go build -buildmode=default -ldflags '-extldflags "-static"' $(import_path)/cmd/$@
+	go build -ldflags '-extldflags "-static"' $(import_path)/cmd/$@
 
 # Snapd can be built with test keys. This is only used by the internal test
 # suite to add test assertions. Do not enable this in distribution packages.
 snapd:
 ifeq ($(with_testkeys),1)
-	go build -buildmode=pie -tags withtestkeys $(import_path)/cmd/$@
+	go build -tags withtestkeys $(import_path)/cmd/$@
 else
-	go build -buildmode=pie $(import_path)/cmd/$@
+	go build $(import_path)/cmd/$@
 endif
 
 # Know how to create certain directories.

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -35,16 +35,6 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/upstart/"
 # work around that by constructing the appropriate -I flag by hand.
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
-# Disable -buildmode=pie mode on i386 as can panics in spectacular
-# ways (LP: #1711052).
-# See also https://forum.snapcraft.io/t/artful-i386-panics/
-# Note while the panic is only on artful, that's because artful
-# detects it; the issue potentially there on older things.
-BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
-ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),i386)
-BUILDFLAGS+= -buildmode=pie
-endif
-
 GCCGOFLAGS=
 ifeq ($(GCCGO),yes)
 GOARCH := $(shell go env GOARCH)

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -40,16 +40,6 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
 # work around that by constructing the appropriate -I flag by hand.
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
-# Disable -buildmode=pie mode on i386 as can panics in spectacular
-# ways (LP: #1711052).
-# See also https://forum.snapcraft.io/t/artful-i386-panics/
-# Note while the panic is only on artful, that's because artful
-# detects it; the issue potentially there on older things.
-BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
-ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),i386)
-BUILDFLAGS+= -buildmode=pie
-endif
-
 GCCGOFLAGS=
 ifeq ($(GCCGO),yes)
 GOARCH := $(shell go env GOARCH)


### PR DESCRIPTION
Building go binaries with -buildmode=pie causes issue on ARM
32bit boards. This was originally reported by a customer and
tracked in LP #1822738.

The issue is that the new GC in 1.7+ allocates a large chunk
of memory (>150Mb in our case) on ARM systems when using
buildmode=pie on the low-memory system where this was observed.

The following happens:
1. We build snap/snapd with -buildmode=pie
2. There is a bug in the malloc.go code in 1.10
3. Because the board this runs on has too little ram the kernel
   relocates it from a relatively low memory start address to a pretty
   high one. Because the GO memory system assumes it initially owns
   all the memory from the point where it start to the start it creates
   a huge GC bitmap memory region.
4. Because the pi2 does have enough ram the kernel does not relocate it
   so we cannot observe the error there.

Using -buildmode=pie is not super important on GO according to
one of the authors:
https://groups.google.com/forum/#!topic/golang-nuts/Jd9tlNc6jUE

The relevant LP bug:
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1822738