### PR TITLE
tests: add deferred actions

### DIFF
--- a/tests/lib/defer.sh
+++ b/tests/lib/defer.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# defer enqueues execution of shell commands.
+#
+# synopsis: defer [--scope=SCOPE] <COMMANDS>
+#
+# Given commands are stored in a shell script called .$SCOPE_defer_$N where
+# SCOPE is a name of the group of defer statements and N is an incrementing
+# counter. The counter is stored in the file .$SCOPE_defer_count, protected
+# from concurrent access by a flock-based lock file .defer_lock.
+#
+# Scope defaults to "auto", it exists to allow the prepare and restore code
+# to use deferrals without interfering with the use in the execute section.
+#
+# For the prepare/restore sections please use --scope=prepare. For the execute
+# section please use no scope at all. It is customary to use "trap run_deferred
+# EXIT" inside the execute section, to allow deferrals to clean up background
+# processes that would otherwise interfere with spread.
+#
+# To run all deferred commands use run_deferred with the same scope argument.
+defer() {
+    scope=auto
+    case "${1:-}" in
+        --scope=*)
+            scope=$(echo "$1" | cut -d = -f 2)
+            shift
+            ;;
+    esac
+    (
+        flock -n 9 || exit 1
+        if [ -e ".${scope}_defer_count" ]; then
+            count="$(cat ".${scope}_defer_count")"
+            count="$((count + 1))"
+        else
+            count=0
+        fi
+        (
+            echo "#!/bin/sh -ex"
+            echo "$@"
+        ) > ".${scope}_defer_${count}"
+        chmod +x ".${scope}_defer_${count}"
+        echo  "$count" > ".${scope}_defer_count"
+    ) 9>.defer_lock
+}
+
+# run_deferred runs deferred commands
+#
+# synopsis: run_deferred [--scope=SCOPE]
+#
+# Deferred commands are executed in LIFO order. The scope determines the group
+# of deferred commands to execute. This allows to have separate groups for the
+# prepare/restore and for the execute sections.
+run_deferred() {
+    scope=auto
+    case "${1:-}" in
+        --scope=*)
+            scope=$(echo "$1" | cut -d = -f 2)
+            shift
+            ;;
+    esac
+    (
+        flock -n 9 || exit 1
+        if [ ! -e ".${scope}_defer_count" ]; then
+            return
+        fi
+        count="$(cat ".${scope}_defer_count")"
+        for i in $(seq "$count" -1 0); do
+            "./.${scope}_defer_${i}"
+            rm "./.${scope}_defer_${i}"
+        done
+        rm ".${scope}_defer_count"
+    ) 9>.defer_lock
+}

--- a/tests/main/testlib-defer/task.yaml
+++ b/tests/main/testlib-defer/task.yaml
@@ -1,0 +1,75 @@
+summary: tests can use reliable defer logic
+detail: |
+    The defer and run_deferred shell functions allow to closely couple commands
+    with any necessary cleanup. For details see the documentation of the
+    functions in the defer.sh file below.
+execute: |
+    #shellcheck source=tests/lib/defer.sh
+    . "$TESTSLIB/defer.sh"
+
+    # Actions can be deferred.
+    for i in 1 2 3; do
+        touch "file-$i"
+        defer rm "file-$i"
+        test -f "file-$i"
+    done
+
+    # Internally the state is stored in the following files
+    test -f .auto_defer_count
+    test -f .auto_defer_0
+    test -f .auto_defer_1
+    test -f .auto_defer_2
+    test -f .defer_lock
+
+    MATCH 2 < .auto_defer_count
+    MATCH 'rm file-1' < .auto_defer_0
+    MATCH 'rm file-2' < .auto_defer_1
+    MATCH 'rm file-3' < .auto_defer_2
+
+    # Deferred actions can be invoked as seen here.
+    run_deferred
+
+    test ! -e file-1
+    test ! -e file-1
+    test ! -e file-3
+
+    # Internal book-keeping is correct.
+    test ! -e .auto_defer_count
+    test ! -e .auto_defer_0
+    test ! -e .auto_defer_1
+    test ! -e .auto_defer_2
+    test -f .defer_lock
+
+    # Scope can maintain separate defer queues.
+    touch foo
+    defer --scope=A rm foo
+    touch bar-1 bar-2
+    defer --scope=B rm bar-1
+    defer --scope=B rm bar-2
+
+    MATCH 0 < .A_defer_count
+    MATCH 'rm foo' < .A_defer_0
+    MATCH 1 < .B_defer_count
+    MATCH 'rm bar-1' < .B_defer_0
+    MATCH 'rm bar-2' < .B_defer_1
+
+    run_deferred --scope=A
+    test ! -e .A_defer_count
+    test ! -e .A_defer_0
+    test ! -e foo
+
+    test -e .B_defer_count
+    test -e .B_defer_0
+    test -e .B_defer_1
+    test -e bar-1
+    test -e bar-2
+
+    run_deferred --scope=B
+    test ! -e .B_defer_count
+    test ! -e .B_defer_0
+    test ! -e .B_defer_1
+    test ! -e bar-1
+    test ! -e bar-2
+
+restore: |
+    rm -f .*defer*


### PR DESCRIPTION
This patch adds go-like defer function for shell.

Deferred actions allow to simplify correctness reasoning of test code by
closely coupling action with side effects with the associated cleanup
code. It also allows to stop using the "foo || true" anti-patter that
hides errors in restore logic.

Deferred commands are stored in hidden shell scripts inside the current
working directory and are executed in a LIFO order. Deferred commands
can be grouped into scopes, this allows using one scope for the entire
execute section and a separate scope for the prepare/restore sections.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
