### PR TITLE
ubuntu: disable -buildmode=pie on armhf to fix memory issue

### DIFF
--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -35,14 +35,19 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/upstart/"
 # work around that by constructing the appropriate -I flag by hand.
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
+BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
 # Disable -buildmode=pie mode on i386 as can panics in spectacular
 # ways (LP: #1711052).
 # See also https://forum.snapcraft.io/t/artful-i386-panics/
 # Note while the panic is only on artful, that's because artful
 # detects it; the issue potentially there on older things.
-BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
+#
+# Disable -buildmode=pie mode on armhf as this may lead to nasty
+# memory exaustion issues (LP: #1822738)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),i386)
-BUILDFLAGS+= -buildmode=pie
+ ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),armhf)
+  BUILDFLAGS+= -buildmode=pie
+ endif
 endif
 
 GCCGOFLAGS=

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -36,18 +36,11 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/upstart/"
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
 BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
-# Disable -buildmode=pie mode on i386 as can panics in spectacular
-# ways (LP: #1711052).
-# See also https://forum.snapcraft.io/t/artful-i386-panics/
-# Note while the panic is only on artful, that's because artful
-# detects it; the issue potentially there on older things.
-#
-# Disable -buildmode=pie mode on armhf as this may lead to nasty
-# memory exaustion issues (LP: #1822738)
-ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),i386)
- ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),armhf)
-  BUILDFLAGS+= -buildmode=pie
- endif
+# Disable -buildmode=pie mode on all our 32bit platforms
+# (i386 and armhf). For i386 because of LP: #1711052 and for
+# armhf because of LP: #1822738
+ifeq ($(shell dpkg-architecture -qDEB_HOST_ARCH_BITS),64)
+ BUILDFLAGS+= -buildmode=pie
 endif
 
 GCCGOFLAGS=

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -41,18 +41,11 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
 BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
-# Disable -buildmode=pie mode on i386 as can panics in spectacular
-# ways (LP: #1711052).
-# See also https://forum.snapcraft.io/t/artful-i386-panics/
-# Note while the panic is only on artful, that's because artful
-# detects it; the issue potentially there on older things.
-#
-# Disable -buildmode=pie mode on armhf as this may lead to nasty
-# memory exaustion issues (LP: #1822738)
-ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),i386)
- ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),armhf)
-  BUILDFLAGS+= -buildmode=pie
- endif
+# Disable -buildmode=pie mode on all our 32bit platforms
+# (i386 and armhf). For i386 because of LP: #1711052 and for
+# armhf because of LP: #1822738
+ifeq ($(shell dpkg-architecture -qDEB_HOST_ARCH_BITS),64)
+ BUILDFLAGS+= -buildmode=pie
 endif
 
 GCCGOFLAGS=

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -40,14 +40,19 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
 # work around that by constructing the appropriate -I flag by hand.
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
+BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
 # Disable -buildmode=pie mode on i386 as can panics in spectacular
 # ways (LP: #1711052).
 # See also https://forum.snapcraft.io/t/artful-i386-panics/
 # Note while the panic is only on artful, that's because artful
 # detects it; the issue potentially there on older things.
-BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
+#
+# Disable -buildmode=pie mode on armhf as this may lead to nasty
+# memory exaustion issues (LP: #1822738)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),i386)
-BUILDFLAGS+= -buildmode=pie
+ ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),armhf)
+  BUILDFLAGS+= -buildmode=pie
+ endif
 endif
 
 GCCGOFLAGS=

--- a/tests/main/buildmode/task.yaml
+++ b/tests/main/buildmode/task.yaml
@@ -1,0 +1,22 @@
+summary: Test that we use the right buildmode per arch
+
+systems: [ubuntu-1*, ubuntu-2*]
+
+execute: |
+    # `objdump -f` will report "DYNAMIC" for binaries build with
+    # -buildmode=pie
+    needle="DYNAMIC"
+    
+    # armhf/i386 build without -buildmode=pie as it breaks too many
+    # things if we do.
+    if [ "$(uname -m)" = armv7l ] || [ "$(uname -m)" = i686 ]; then
+        # and "EXEC_P" when the buildmode is "normal"
+        needle="EXEC_P"
+    fi
+
+    # check /usr/bin/snap
+    objdump -f /usr/bin/snap | MATCH "$needle"
+    # and the helpers in /usr/lib/snapd
+    for p in snapd snap-repair; do
+        objdump -f /usr/lib/snapd/"$p" | MATCH "$needle"
+    done

--- a/tests/main/buildmode/task.yaml
+++ b/tests/main/buildmode/task.yaml
@@ -7,9 +7,9 @@ execute: |
     # -buildmode=pie
     needle="DYNAMIC"
     
-    # armhf/i386 build without -buildmode=pie as it breaks too many
-    # things if we do.
-    if [ "$(uname -m)" = armv7l ] || [ "$(uname -m)" = i686 ]; then
+    # 32bit arches (like armhf/i386) are build without -buildmode=pie
+    # as it breaks too many things if we do.
+    if [ "$(getconf LONG_BIT)" = 32 ]; then
         # and "EXEC_P" when the buildmode is "normal"
         needle="EXEC_P"
     fi


### PR DESCRIPTION
This PR disables -buildmode=pie on ARM only and leaves it
on for the other arches (for now).

Building go binaries with -buildmode=pie causes issue on ARM
32bit boards. This was originally reported by a customer and
tracked in LP #1822738.

The issue is that the new GC in 1.7+ allocates a large chunk
of memory (>150Mb in our case) on ARM systems when using
buildmode=pie on the low-memory system where this was observed.

The following happens:
1. We build snap/snapd with -buildmode=pie
2. There is a bug in the malloc.go code in 1.10
3. Because the board this runs on has too little ram the kernel
   relocates it from a relatively low memory start address to a pretty
   high one. Because the GO memory system assumes it initially owns
   all the memory from the point where it start to the start it creates
   a huge GC bitmap memory region.
4. Because the pi2 does have enough ram the kernel does not relocate it
   so we cannot observe the error there.

Using -buildmode=pie is not super important on GO according to
one of the authors:
https://groups.google.com/forum/#!topic/golang-nuts/Jd9tlNc6jUE

The relevant LP bug:
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1822738

