### PR TITLE
overlord: factor out mocking of device service and gadget w. prepare-device for registration tests 

### DIFF
--- a/overlord/devicestate/devicestatetest/devicesvc.go
+++ b/overlord/devicestate/devicestatetest/devicesvc.go
@@ -1,0 +1,161 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestatetest
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/httputil"
+)
+
+type DeviceServiceBehavior struct {
+	ReqID string
+
+	RequestIDURLPath string
+	SerialURLPath    string
+
+	Head          func(c *C, bhv *DeviceServiceBehavior, w http.ResponseWriter, r *http.Request)
+	PostPreflight func(c *C, bhv *DeviceServiceBehavior, w http.ResponseWriter, r *http.Request)
+
+	SignSerial func(c *C, bhv *DeviceServiceBehavior, headers map[string]interface{}, body []byte) (asserts.Assertion, error)
+}
+
+// Request IDs for hard-coded behaviors.
+const (
+	ReqIDFailID501          = "REQID-FAIL-ID-501"
+	ReqIDBadRequest         = "REQID-BAD-REQ"
+	ReqIDPoll               = "REQID-POLL"
+	ReqIDSerialWithBadModel = "REQID-SERIAL-W-BAD-MODEL"
+)
+
+const (
+	requestIDURLPath = "/api/v1/snaps/auth/request-id"
+	serialURLPath    = "/api/v1/snaps/auth/devices"
+)
+
+func MockDeviceService(c *C, bhv *DeviceServiceBehavior) *httptest.Server {
+	expectedUserAgent := httputil.UserAgent()
+
+	// default URL paths
+	if bhv.RequestIDURLPath == "" {
+		bhv.RequestIDURLPath = requestIDURLPath
+		bhv.SerialURLPath = serialURLPath
+	}
+
+	var mu sync.Mutex
+	count := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		default:
+			c.Fatalf("unexpected verb %q", r.Method)
+		case "HEAD":
+			if r.URL.Path != "/" {
+				c.Fatalf("unexpected HEAD request %q", r.URL.String())
+			}
+			if bhv.Head != nil {
+				bhv.Head(c, bhv, w, r)
+			}
+			w.WriteHeader(200)
+			return
+		case "POST":
+			// carry on
+		}
+
+		if bhv.PostPreflight != nil {
+			bhv.PostPreflight(c, bhv, w, r)
+		}
+
+		switch r.URL.Path {
+		default:
+			c.Fatalf("unexpected POST request %q", r.URL.String())
+		case bhv.RequestIDURLPath:
+			if bhv.ReqID == ReqIDFailID501 {
+				w.WriteHeader(501)
+				return
+			}
+			w.WriteHeader(200)
+			c.Check(r.Header.Get("User-Agent"), Equals, expectedUserAgent)
+			io.WriteString(w, fmt.Sprintf(`{"request-id": "%s"}`, bhv.ReqID))
+		case bhv.SerialURLPath:
+			c.Check(r.Header.Get("User-Agent"), Equals, expectedUserAgent)
+
+			mu.Lock()
+			serialNum := 9999 + count
+			count++
+			mu.Unlock()
+
+			b, err := ioutil.ReadAll(r.Body)
+			c.Assert(err, IsNil)
+			a, err := asserts.Decode(b)
+			c.Assert(err, IsNil)
+			serialReq, ok := a.(*asserts.SerialRequest)
+			c.Assert(ok, Equals, true)
+			err = asserts.SignatureCheck(serialReq, serialReq.DeviceKey())
+			c.Assert(err, IsNil)
+			brandID := serialReq.BrandID()
+			model := serialReq.Model()
+			reqID := serialReq.RequestID()
+			if reqID == ReqIDBadRequest {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(400)
+				w.Write([]byte(`{
+  "error_list": [{"message": "bad serial-request"}]
+}`))
+				return
+			}
+			if reqID == ReqIDPoll && serialNum != 10002 {
+				w.WriteHeader(202)
+				return
+			}
+			serialStr := fmt.Sprintf("%d", serialNum)
+			if serialReq.Serial() != "" {
+				// use proposed serial
+				serialStr = serialReq.Serial()
+			}
+			serial, err := bhv.SignSerial(c, bhv, map[string]interface{}{
+				"authority-id":        "canonical",
+				"brand-id":            brandID,
+				"model":               model,
+				"serial":              serialStr,
+				"device-key":          serialReq.HeaderString("device-key"),
+				"device-key-sha3-384": serialReq.SignKeyID(),
+				"timestamp":           time.Now().Format(time.RFC3339),
+			}, serialReq.Body())
+			c.Assert(err, IsNil)
+			w.Header().Set("Content-Type", asserts.MediaType)
+			w.WriteHeader(200)
+			encoded := asserts.Encode(serial)
+			if reqID == ReqIDSerialWithBadModel {
+				encoded = bytes.Replace(encoded, []byte("model: pc"), []byte("model: bad-model-foo"), 1)
+			}
+			w.Write(encoded)
+		}
+	}))
+}

--- a/overlord/devicestate/devicestatetest/gadget.go
+++ b/overlord/devicestate/devicestatetest/gadget.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestatetest
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+	"gopkg.in/yaml.v2"
+
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+type PrepareDeviceBehavior struct {
+	DeviceSvcURL   string
+	Headers        map[string]string
+	RegBody        map[string]string
+	ProposedSerial string
+}
+
+func MockGadget(c *C, st *state.State, name string, revision snap.Revision, pDBhv *PrepareDeviceBehavior) (restore func()) {
+
+	sideInfoGadget := &snap.SideInfo{
+		RealName: name,
+		Revision: revision,
+	}
+
+	snapYaml := fmt.Sprintf(`name: %q
+type: gadget
+version: gadget
+`, name)
+
+	if pDBhv != nil {
+		snapYaml += `hooks:
+  prepare-device:
+`
+	}
+
+	snaptest.MockSnap(c, snapYaml, sideInfoGadget)
+	snapstate.Set(st, name, &snapstate.SnapState{
+		SnapType: "gadget",
+		Active:   true,
+		Sequence: []*snap.SideInfo{sideInfoGadget},
+		Current:  revision,
+	})
+
+	if pDBhv == nil {
+		// nothing to restore
+		return func() {}
+	}
+
+	// mock the prepare-device hook
+
+	return hookstate.MockRunHook(func(ctx *hookstate.Context, _ *tomb.Tomb) ([]byte, error) {
+		c.Assert(ctx.HookName(), Equals, "prepare-device")
+
+		// snapctl set the registration params
+		_, _, err := ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("device-service.url=%q", pDBhv.DeviceSvcURL)}, 0)
+		c.Assert(err, IsNil)
+
+		if len(pDBhv.Headers) != 0 {
+			h, err := json.Marshal(pDBhv.Headers)
+			c.Assert(err, IsNil)
+			_, _, err = ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("device-service.headers=%s", string(h))}, 0)
+			c.Assert(err, IsNil)
+		}
+
+		if pDBhv.ProposedSerial != "" {
+			_, _, err = ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("registration.proposed-serial=%q", pDBhv.ProposedSerial)}, 0)
+			c.Assert(err, IsNil)
+		}
+
+		if len(pDBhv.RegBody) != 0 {
+			d, err := yaml.Marshal(pDBhv.RegBody)
+			c.Assert(err, IsNil)
+			_, _, err = ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("registration.body=%q", d)}, 0)
+			c.Assert(err, IsNil)
+		}
+
+		return nil, nil
+	})
+}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
@@ -50,6 +51,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -3285,4 +3287,115 @@ type: base`
 	tss, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, ErrorMatches, "cannot remodel to different bases yet")
 	c.Assert(tss, HasLen, 0)
+}
+
+func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
+	brandAcct := assertstest.NewAccount(ms.storeSigning, "my-brand", map[string]interface{}{
+		"account-id":   "my-brand",
+		"verification": "verified",
+	}, "")
+	brandAccKey := assertstest.NewAccountKey(ms.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
+
+	brandSigning := assertstest.NewSigningDB("my-brand", brandPrivKey)
+	model := makeModelAssertion(c, brandSigning, map[string]interface{}{
+		"gadget": "gadget",
+	})
+
+	// reset as seeded but not registered
+	// shortcut: have already device key
+	kpMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)
+	c.Assert(err, IsNil)
+	err = kpMgr.Put(deviceKey)
+	c.Assert(err, IsNil)
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	err = assertstate.Add(st, brandAcct)
+	c.Assert(err, IsNil)
+	err = assertstate.Add(st, brandAccKey)
+	c.Assert(err, IsNil)
+	auth.SetDevice(st, &auth.DeviceState{
+		Brand: "my-brand",
+		Model: "my-model",
+		KeyID: deviceKey.PublicKey().ID(),
+	})
+	err = assertstate.Add(st, model)
+	c.Assert(err, IsNil)
+
+	signSerial := func(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (asserts.Assertion, error) {
+		brandID := headers["brand-id"].(string)
+		model := headers["model"].(string)
+		c.Check(brandID, Equals, "my-brand")
+		c.Check(model, Equals, "my-model")
+		headers["authority-id"] = brandID
+		return brandSigning.Sign(asserts.SerialType, headers, body, "")
+	}
+
+	bhv := &devicestatetest.DeviceServiceBehavior{
+		ReqID:            "REQID-1",
+		RequestIDURLPath: "/svc/request-id",
+		SerialURLPath:    "/svc/serial",
+		SignSerial:       signSerial,
+	}
+
+	mockServer := devicestatetest.MockDeviceService(c, bhv)
+	defer mockServer.Close()
+
+	pDBhv := &devicestatetest.PrepareDeviceBehavior{
+		DeviceSvcURL: mockServer.URL + "/svc/",
+		Headers: map[string]string{
+			"x-extra-header": "extra",
+		},
+		RegBody: map[string]string{
+			"mac": "00:00:00:00:ff:00",
+		},
+		ProposedSerial: "12000",
+	}
+
+	r := devicestatetest.MockGadget(c, st, "gadget", snap.R(2), pDBhv)
+	defer r()
+
+	// run the whole device registration process
+	st.Unlock()
+	err = ms.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	var becomeOperational *state.Change
+	for _, chg := range st.Changes() {
+		if chg.Kind() == "become-operational" {
+			becomeOperational = chg
+			break
+		}
+	}
+	c.Assert(becomeOperational, NotNil)
+
+	c.Check(becomeOperational.Status().Ready(), Equals, true)
+	c.Check(becomeOperational.Err(), IsNil)
+
+	device, err := auth.Device(st)
+	c.Assert(err, IsNil)
+	c.Check(device.Brand, Equals, "my-brand")
+	c.Check(device.Model, Equals, "my-model")
+	c.Check(device.Serial, Equals, "12000")
+
+	a, err := assertstate.DB(st).Find(asserts.SerialType, map[string]string{
+		"brand-id": "my-brand",
+		"model":    "my-model",
+		"serial":   "12000",
+	})
+	c.Assert(err, IsNil)
+	serial := a.(*asserts.Serial)
+
+	var details map[string]interface{}
+	err = yaml.Unmarshal(serial.Body(), &details)
+	c.Assert(err, IsNil)
+
+	c.Check(details, DeepEquals, map[string]interface{}{
+		"mac": "00:00:00:00:ff:00",
+	})
+
+	c.Check(serial.DeviceKey().ID(), Equals, device.KeyID)
 }


### PR DESCRIPTION
This factors out support for mocking a device service and a gadget with possibly a prepare-device hook to a devicestatetest package.

It Introduces a happy registration test at the level of managers_test.go  to exercise the refactoring. This a prerequisite to be able to write re-registration tests at that level.
