### PR TITLE
tests/main/selinux-lxd: make sure LXD from snaps works cleanly with enforcing SELinux

### DIFF
--- a/data/sysctl/rhel7-snap.conf
+++ b/data/sysctl/rhel7-snap.conf
@@ -2,3 +2,10 @@
 # Unexpected "Device or resource busy" error when removing a directory
 # see https://access.redhat.com/articles/3128691 for details
 fs.may_detach_mounts=1
+
+# RHEL 7.4+ specific:
+# A configuration change was made in the 7.4 release, the default number of user
+# namespaces is set to zero, see https://access.redhat.com/solutions/3188102 for
+# details
+# LXD specific fix
+user.max_user_namespaces=15000

--- a/data/sysctl/rhel7-snap.conf
+++ b/data/sysctl/rhel7-snap.conf
@@ -3,9 +3,9 @@
 # see https://access.redhat.com/articles/3128691 for details
 fs.may_detach_mounts=1
 
-# RHEL 7.4+ specific:
+# RHEL 7.4+ (and LXD) specific:
 # A configuration change was made in the 7.4 release, the default number of user
 # namespaces is set to zero, see https://access.redhat.com/solutions/3188102 for
-# details
-# LXD specific fix
+# details. For details about LXD side, see
+# https://discuss.linuxcontainers.org/t/lxd-on-centos-7/1250
 user.max_user_namespaces=15000

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -1,0 +1,52 @@
+summary: Check that LXD snap works on a system using SELinux in enforcing mode
+
+description: |
+    Make sure that LXD snap can be installed and used on a SELinux enable
+    system, with enforcing mode on.
+
+# Systems with SELinux enabled out of the box.
+systems: [fedora-*, centos-*]
+
+# lxd downloads can be quite slow
+kill-timeout: 25m
+
+# Start before anything else as it can take a really long time.
+priority: 1000
+
+prepare: |
+    # Enable enforcing mode, our policy is already marked as permissive, so we
+    # will get audit entries but the program will not be stopped by SELinux
+    setenforce 1
+    ausearch --checkpoint stamp -m AVC || true
+
+restore: |
+    rm -f stamp
+    setenforce 0
+
+execute: |
+    snap install lxd
+    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+
+    echo "Create a trivial container using the lxd snap"
+    snap set lxd waitready.timeout=240
+    lxd waitready
+    lxd init --auto
+
+    echo "Setting up proxy for lxc"
+    if [ -n "${http_proxy:-}" ]; then
+        lxd.lxc config set core.proxy_http "$http_proxy"
+    fi
+    if [ -n "${https_proxy:-}" ]; then
+        lxd.lxc config set core.proxy_https "$http_proxy"
+    fi
+
+    lxd.lxc launch "ubuntu:18.04" my-ubuntu
+
+    echo "Ensure we can run things inside"
+    lxd.lxc exec my-ubuntu echo hello | MATCH hello
+
+    echo "Stop the container"
+    lxd.lxc stop --force my-ubuntu
+
+    snap remove lxd
+    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -49,4 +49,10 @@ execute: |
     lxd.lxc stop --force my-ubuntu
 
     snap remove lxd
-    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+
+    # there is a known problem with the reference policy that disallows systemd
+    # from creating a BPF map for unconfined_service_t, see:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1694115
+    ! ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | \
+        grep -v -E 'avc:  denied  { map_create } for  pid=[0-9]+ comm="systemd"' | \
+        MATCH 'type=AVC'

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -7,12 +7,6 @@ description: |
 # Systems with SELinux enabled out of the box.
 systems: [fedora-*, centos-*]
 
-# lxd downloads can be quite slow
-kill-timeout: 25m
-
-# Start before anything else as it can take a really long time.
-priority: 1000
-
 prepare: |
     getenforce > enforcing.mode
     # Enable enforcing mode, our policy is already marked as permissive, so we

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -46,8 +46,9 @@ execute: |
     echo "Ensure we can run things inside"
     lxd.lxc exec my-ubuntu echo hello | MATCH hello
 
-    echo "Stop the container"
+    echo "Stop and remove the container"
     lxd.lxc stop --force my-ubuntu
+    lxd.lxc delete --force my-ubuntu
 
     snap remove lxd
 

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -14,14 +14,15 @@ kill-timeout: 25m
 priority: 1000
 
 prepare: |
+    getenforce > enforcing.mode
     # Enable enforcing mode, our policy is already marked as permissive, so we
     # will get audit entries but the program will not be stopped by SELinux
     setenforce 1
     ausearch --checkpoint stamp -m AVC || true
 
 restore: |
-    rm -f stamp
-    setenforce 0
+    setenforce "$(cat enforcing.mode)"
+    rm -f stamp enforcing.mode
 
 execute: |
     snap install lxd


### PR DESCRIPTION
Add a test that checks whether LXD from snaps works with SELinux in enforcing mode and raises no denials related to snapd policy.

Since we do not have a sysctl backend, add a workaround for a known problem with LXD on CentOS.

This should be the final PR in the SELinux series.

(cc @Conan-Kudo )