### PR TITLE
tests/upgrade/basic, packaging/fedoar: restore SELinux context of /var/cache/fontconfig, patch pre-2.39 mount units

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -832,7 +832,7 @@ fi
 
 # TODO: the trigger relies on a very specific snapd version that introduced SELinux
 # mount context, figure out how to update the trigger condition to run when needed
-%triggerun -- snapd < 2.38
+%triggerun -- snapd < 2.39
 # Trigger on uninstall, with one version of the package being pre 2.38 see
 # https://rpm-packaging-guide.github.io/#triggers-and-scriptlets for details
 # when triggers are run

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -840,6 +840,13 @@ fi
 if [ "$1" -eq 2 -a "$2" -eq 1 ]; then
    # Upgrade from pre 2.38 version
    %{_libexecdir}/snapd/snap-mgmt-selinux --patch-selinux-mount-context=system_u:object_r:snappy_snap_t:s0 || :
+
+   # snapd might have created fontconfig cache directory earlier, but with
+   # incorrect context due to bugs in the policy, make sure it gets the right one
+   # on upgrade when the new policy was introduced
+   if [ -d "%{_localstatedir}/cache/fontconfig" ]; then
+      restorecon -R %{_localstatedir}/cache/fontconfig || :
+   fi
 elif [ "$1" -eq 1 -a "$2" -eq 2 ]; then
    # Downgrade to a pre 2.38 version
    %{_libexecdir}/snapd/snap-mgmt-selinux --remove-selinux-mount-context=system_u:object_r:snappy_snap_t:s0 || :

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -12,7 +12,7 @@ restore: |
     rm -f /var/tmp/myevil.txt
     rm -f ./do-classic ./prevsnapdver.out
 
-    # an older version of snapd might have been missing proper context
+    # An older version of snapd might have been missing proper context
     # transitions for fontconfig cache locations, attempt to restore the context
     # to avoid breaking tests that run after this one
     case "$SPREAD_SYSTEM" in

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -12,6 +12,17 @@ restore: |
     rm -f /var/tmp/myevil.txt
     rm -f ./do-classic ./prevsnapdver.out
 
+    # an older version of snapd might have been missing proper context
+    # transitions for fontconfig cache locations, attempt to restore the context
+    # to avoid breaking tests that run after this one
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*)
+            if [ -d /var/cache/fontconfig ]; then
+                restorecon -RvF /var/cache/fontconfig
+            fi
+            ;;
+    esac
+
 execute: |
     if [ "$REMOTE_STORE" = staging ]; then
         echo "skip upgrade tests while talking to the staging store"


### PR DESCRIPTION
The test installs an older version of snapd that may be missing proper context
transitions for /var/cache/fontconfig when created in the context of snapd
daemon (snappy_t). Avoid breaking tests that run after this one and restore the
context to whatever is the default.
