### PR TITLE
spread, tests: do not leave mislabeled files in restorecon test, attempt to catch similar files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -409,6 +409,11 @@ debug-each: |
                 else
                     ausearch -m AVC || true
                 fi
+                (
+                    find /root/snap -printf '%Z\t%H/%P\n' || true
+                    find /home/test/snap -printf '%Z\t%H/%P\n' || true
+                ) | grep -v snappy_home_t || true
+                find /var/snap -printf '%Z\t%H/%P' | grep -v snappy_var_t || true
                 ;;
             *)
                echo '# apparmor denials '
@@ -577,6 +582,18 @@ restore: |
 restore-each: |
     "$TESTSLIB"/prepare-restore.sh --restore-project-each
     if journalctl -u snapd.service | grep -F "signal: terminated"; then exit 1; fi
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*)
+            # Make sure that we are not leaving behind incorrectly labeled snap
+            # files on systems supporting SELinux
+            (
+                find /root/snap -printf '%Z\t%H/%P\n' || true
+                find /home/test/snap -printf '%Z\t%H/%P\n' || true
+            ) | grep -c -v snappy_home_t | MATCH "0"
+
+            find /var/snap -printf '%Z\t%H/%P' | grep -c -v snappy_var_t  | MATCH "0"
+            ;;
+    esac
 
 suites:
     tests/main/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -411,9 +411,9 @@ debug-each: |
                 fi
                 (
                     find /root/snap -printf '%Z\t%H/%P\n' || true
-                    find /home/test/snap -printf '%Z\t%H/%P\n' || true
+                    find /home -regex '/home/[^/]*/snap\(/.*\)?' -printf '%Z\t%H/%P\n' || true
                 ) | grep -v snappy_home_t || true
-                find /var/snap -printf '%Z\t%H/%P' | grep -v snappy_var_t || true
+                find /var/snap -printf '%Z\t%H/%P\n' | grep -v snappy_var_t || true
                 ;;
             *)
                echo '# apparmor denials '
@@ -588,10 +588,10 @@ restore-each: |
             # files on systems supporting SELinux
             (
                 find /root/snap -printf '%Z\t%H/%P\n' || true
-                find /home/test/snap -printf '%Z\t%H/%P\n' || true
+                find /home -regex '/home/[^/]*/snap\(/.*\)?' -printf '%Z\t%H/%P\n' || true
             ) | grep -c -v snappy_home_t | MATCH "0"
 
-            find /var/snap -printf '%Z\t%H/%P' | grep -c -v snappy_var_t  | MATCH "0"
+            find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
             ;;
     esac
 

--- a/tests/main/selinux-snap-restorecon/task.yaml
+++ b/tests/main/selinux-snap-restorecon/task.yaml
@@ -11,8 +11,8 @@ prepare: |
     fi
 
 restore: |
+    rm -rf /home/test/snap
     if [ -d /home/test/snap.old ]; then
-        rm -rf /home/test/snap
         mv /home/test/snap.old /home/test/snap
     fi
 

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -5,9 +5,10 @@ execute: |
     snap install test-snapd-tools
     rev=$(snap list test-snapd-tools|tail -n1|tr -s ' '|cut -f3 -d' ')
 
-    homes=(/root/ /home/*/)
+    homes=(/root/ /home/test/)
     echo "That has some user data"
     for h in "${homes[@]}"; do
+        test -d "$h"
         d="${h}snap/test-snapd-tools/$rev"
         mkdir -p "$d"
         touch "$d/mock-data"


### PR DESCRIPTION
The test created a ~/snap with entries that were intentionally mislabeled, but failed to remove the directory afterwards.

As part of the solution, try to catch when tests are leaving such entries behind so that we can enforce proper cleanup.
