### PR TITLE
tests: set selinux-clean test to manual for now

### DIFF
--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -7,6 +7,9 @@ description: |
     not want to cause unnecessary warnings when users are performing basic
     management tasks on snaps.
 
+# 2019-04-16: set to manual for now as it causes issues depending on test order
+manual: true
+
 systems: [fedora-*, centos-*]
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
The selinux-clean test breaks in master and in the pending PRs
depending on the test order. To ensure other PRs can land this PR
disables it for now and when its debugged we can re-enable.
