### PR TITLE
cmd/snap-confine: remove unused sc_open_snap_{update,discard}_ns

### DIFF
--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -22,24 +22,6 @@
 #include "snap-confine-invocation.h"
 
 /**
- * Return a file descriptor referencing the snap-update-ns utility
- *
- * By calling this prior to changing the mount namespace, it is
- * possible to execute the utility even if a different version is now
- * mounted at the expected location.
- **/
-int sc_open_snap_update_ns(void);
-
-/**
- * Return a file descriptor referencing the snap-discard-ns utility
- *
- * By calling this prior to changing the mount namespace, it is
- * possible to execute the utility even if a different version is now
- * mounted at the expected location.
- **/
-int sc_open_snap_discard_ns(void);
-
-/**
  * Assuming a new mountspace, populate it accordingly.
  *
  * This function performs many internal tasks:

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -40,6 +40,7 @@
 #include "../libsnap-confine-private/secure-getenv.h"
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/tool.h"
 #include "../libsnap-confine-private/utils.h"
 #include "cookie-support.h"
 #include "mount-support.h"


### PR DESCRIPTION
Those two headers were unused and probably are leftover from
libsnap-confine-private/tool.h migration. The snap-confine.c program
compiled because it relied on the stale declarations in mount-support.h
instead of the ones in tool.h

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
