### PR TITLE
tests: do not hardcode go1.10 in travis

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -16,8 +16,10 @@ else
 fi
 COVERMODE=${COVERMODE:-atomic}
 
-# ensure we use go-1.10 by default
-export PATH=/usr/lib/go-1.10/bin:${PATH}
+if [ -z "${TRAVIS_BUILD_ID:-}" ]; then
+    # when *not* running inside travis, ensure we use go-1.10 by default
+    export PATH=/usr/lib/go-1.10/bin:${PATH}
+fi
 
 # add workaround for https://github.com/golang/go/issues/24449
 if [ "$(uname -m)" = "s390x" ]; then


### PR DESCRIPTION
In run-checks we add /usr/lib/go-1.10/bin to the PATH to ensure
that we use the right go version when building on Ubuntu systems
that use the golang-1.10 source package.

However this breaks in travis because we use go1.9 there to ensure
that RHEL (which has 1.9) works correctly. Recently travis added
go1.10 to their images so now the PATH setting actually picks up
go1.10 in the PATH but GOROOT is set to go-1.9 which causes
strange errors like `go tool asm: exit status 2`.

This PR fixes this by only setting the PATH outside of travis.

