### PR TITLE
data/selinux: allow snapd to execute runuser under snappy_t

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -228,14 +228,14 @@ allow snappy_t usr_t:lnk_file { create unlink };
 ssh_exec_keygen(snappy_t)
 
 # Allow snapd to access passwd file for lookup
-auth_read_passwd(snappy_t);
+auth_read_passwd(snappy_t)
 
 # because /run/snapd/ns/*.mnt gets a label of the process context
 gen_require(` type unconfined_t; ')
 allow snappy_t unconfined_t:file getattr;
 allow snappy_t snappy_confine_t:file getattr;
 
-logging_send_syslog_msg(snappy_t);
+logging_send_syslog_msg(snappy_t)
 
 allow snappy_t self:capability { dac_read_search dac_override fowner };
 allow snappy_t self:process { setpgid };
@@ -522,7 +522,7 @@ allow snappy_cli_t snappy_var_lib_t:file { read_file_perms };
 allow snappy_cli_t snappy_var_lib_t:lnk_file { read_lnk_file_perms };
 
 # allow reading passwd
-auth_read_passwd(snappy_cli_t);
+auth_read_passwd(snappy_cli_t)
 # allow reading sssd files
 optional_policy(`
   sssd_read_public_files(snappy_cli_t)

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -326,6 +326,12 @@ allow snappy_t var_t:sock_file unlink;
 allow snappy_t unconfined_t:dir search;
 allow snappy_t unconfined_t:file { open read };
 
+# snapd executes runuser to take snapshots of user's snap data
+allow snappy_t self:capability { setuid setgid };
+allow snappy_t self:process setsched;
+# runuser also logs to audit
+logging_send_audit_msgs(snappy_t)
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -7,9 +7,6 @@ description: |
     not want to cause unnecessary warnings when users are performing basic
     management tasks on snaps.
 
-# 2019-04-16: set to manual for now as it causes issues depending on test order
-manual: true
-
 systems: [fedora-*, centos-*]
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
Snapd executes runuser to create snapshots of user's snap data. Adjust snappy_t policy so that we account for operations performed by runuser.

Relevant denials:
```
    ----
    time->Mon Apr 15 17:54:52 2019
    
    type=AVC msg=audit(1555350892.336:1330): avc:  denied  { setgid } for  pid=19550
    comm="runuser" capability=6  scontext=system_u:system_r:snappy_t:s0
    tcontext=system_u:system_r:snappy_t:s0 tclass=capability permissive=1
    ----
    time->Mon Apr 15 17:54:52 2019
    type=AVC msg=audit(1555350892.337:1331): avc:  denied  { create } for  pid=19550
    comm="runuser" scontext=system_u:system_r:snappy_t:s0
    tcontext=system_u:system_r:snappy_t:s0 tclass=netlink_audit_socket permissive=1
    ----
    time->Mon Apr 15 17:54:52 2019
    type=AVC msg=audit(1555350892.337:1332): avc:  denied  { nlmsg_relay } for
    pid=19550 comm="runuser" scontext=system_u:system_r:snappy_t:s0
    tcontext=system_u:system_r:snappy_t:s0 tclass=netlink_audit_socket permissive=1
    ----
    time->Mon Apr 15 17:54:52 2019
    type=AVC msg=audit(1555350892.337:1333): avc:  denied  { audit_write } for
    pid=19550 comm="runuser" capability=29  scontext=system_u:system_r:snappy_t:s0
    tcontext=system_u:system_r:snappy_t:s0 tclass=capability permissive=1
    ----
    time->Mon Apr 15 17:54:52 2019
    type=AVC msg=audit(1555350892.337:1335): avc:  denied  { setuid } for  pid=19550
    comm="runuser" capability=7  scontext=system_u:system_r:snappy_t:s0
    tcontext=system_u:system_r:snappy_t:s0 tclass=capability permissive=1
    ----
    time->Mon Apr 15 17:54:52 2019
    type=AVC msg=audit(1555350892.338:1336): avc:  denied  { setsched } for
    pid=19550 comm="runuser" scontext=system_u:system_r:snappy_t:s0
    tcontext=system_u:system_r:snappy_t:s0 tclass=process permissive=1
    -----
```