### PR TITLE
tests: update canonical-livepatch now that -gcp kernels are supported

### DIFF
--- a/tests/main/canonical-livepatch/task.yaml
+++ b/tests/main/canonical-livepatch/task.yaml
@@ -16,13 +16,4 @@ execute: |
     done
 
     echo "And ensure we get the expected status"
-    case "$(uname -r)" in
-        *-gcp)
-            # Google compute platform kernels are not supported by Canonical Live Patch system.
-            # The error message goes to stderr, hence the extra redirect magic.
-            ( canonical-livepatch status 2>&1 ) | MATCH -- '-gcp" is not eligible for livepatch updates'
-            ;;
-        *)
-            ( canonical-livepatch status 2>&1 ) | MATCH "Machine is not enabled"
-            ;;
-    esac
+    canonical-livepatch status 2>&1 | MATCH "Machine is not enabled"


### PR DESCRIPTION
The canonical-livepatch test is now failing because -gcp kernels
are not also available for live-patch.
