### PR TITLE
tests: run livepatch on 18.04 as well

### DIFF
--- a/tests/main/canonical-livepatch/task.yaml
+++ b/tests/main/canonical-livepatch/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure canonical-livepatch snap works
 
-# livepatch works only on 16.04 amd64 systems
-systems: [ubuntu-16.04-64]
+# livepatch works only on 16.04/18.04 amd64 systems
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
 execute: |
     echo "Ensure canonical-livepatch can be installed"


### PR DESCRIPTION
The canonical-livepatch package is available on 18.04
as well so we should test it there too.
