### PR TITLE
tests: wait for man db cache is updated before after install snapd on Fedora

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -475,6 +475,16 @@ distro_install_build_snapd(){
 
         case "$SPREAD_SYSTEM" in
             fedora-*|centos-*)
+                # We need to wait until the man db cache is updated before do daemon-reexec
+                # Otherwise the service fails and the system will be degraded during tests executions
+                for i in $(seq 20); do
+                    man_db_cache_update_service=$(systemctl list-units | grep -E 'run-.*.service' | awk '{print $1;}')
+                    if [ -z "$man_db_cache_update_service" ]; then
+                        break
+                    fi
+                    sleep .5
+                done
+
                 # systemd caches SELinux policy data and subsequently attempts
                 # to create sockets with incorrect context, this installation of
                 # socket activated snaps fails, see:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -478,8 +478,7 @@ distro_install_build_snapd(){
                 # We need to wait until the man db cache is updated before do daemon-reexec
                 # Otherwise the service fails and the system will be degraded during tests executions
                 for i in $(seq 20); do
-                    man_db_cache_update_service=$(systemctl list-units | grep -E 'run-.*.service' | awk '{print $1;}')
-                    if [ -z "$man_db_cache_update_service" ]; then
+                    if ! systemctl is-active run-*.service; then
                         break
                     fi
                     sleep .5


### PR DESCRIPTION
The service run-<id>.service which runs systemctl start
man-db-cache-update fails when we do daemon-reexec after install snpad,
leaving the system in degraded state. This is happening with the new
images for fedora.

To test this error and the fix use:
- fedora-29-64:
    image: test-fedora-1

The idea of the fix is to wait until this service finishes and then make
daemon-reexec.
