### PR TITLE
cmd/snap-update-ns: rename variable "up" to "ctx"

### DIFF
--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -34,36 +34,36 @@ import (
 
 type commonSuite struct {
 	dir string
-	up  *update.CommonProfileUpdateContext
+	ctx *update.CommonProfileUpdateContext
 }
 
 var _ = Suite(&commonSuite{})
 
 func (s *commonSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
-	s.up = update.NewCommonProfileUpdateContext("foo",
+	s.ctx = update.NewCommonProfileUpdateContext("foo",
 		filepath.Join(s.dir, "current.fstab"),
 		filepath.Join(s.dir, "desired.fstab"))
 }
 
 func (s *commonSuite) TestLoadDesiredProfile(c *C) {
-	up := s.up
+	ctx := s.ctx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"
 
 	// Ask the common profile update helper to read the desired profile.
-	profile, err := up.LoadCurrentProfile()
+	profile, err := ctx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 
 	// A profile that is not present on disk just reads as a valid empty profile.
 	c.Check(profile.Entries, HasLen, 0)
 
 	// Write a desired user mount profile for snap "foo".
-	path := up.DesiredProfilePath()
+	path := ctx.DesiredProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the common profile update helper to read the desired profile.
-	profile, err = up.LoadDesiredProfile()
+	profile, err = ctx.LoadDesiredProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -73,23 +73,23 @@ func (s *commonSuite) TestLoadDesiredProfile(c *C) {
 }
 
 func (s *commonSuite) TestLoadCurrentProfile(c *C) {
-	up := s.up
+	ctx := s.ctx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"
 
 	// Ask the common profile update helper to read the current profile.
-	profile, err := up.LoadCurrentProfile()
+	profile, err := ctx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 
 	// A profile that is not present on disk just reads as a valid empty profile.
 	c.Check(profile.Entries, HasLen, 0)
 
 	// Write a current user mount profile for snap "foo".
-	path := up.CurrentProfilePath()
+	path := ctx.CurrentProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the common profile update helper to read the current profile.
-	profile, err = up.LoadCurrentProfile()
+	profile, err = ctx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -99,7 +99,7 @@ func (s *commonSuite) TestLoadCurrentProfile(c *C) {
 }
 
 func (s *commonSuite) TestSaveCurrentProfile(c *C) {
-	up := s.up
+	ctx := s.ctx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"
 
 	// Prepare a mount profile to be saved.
@@ -107,10 +107,10 @@ func (s *commonSuite) TestSaveCurrentProfile(c *C) {
 	c.Assert(err, IsNil)
 
 	// Prepare the directory for saving the profile.
-	path := up.CurrentProfilePath()
+	path := ctx.CurrentProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 
 	// Ask the common profile update to write the current profile.
-	c.Assert(up.SaveCurrentProfile(profile), IsNil)
+	c.Assert(ctx.SaveCurrentProfile(profile), IsNil)
 	c.Check(path, testutil.FileEquals, text)
 }

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -207,12 +207,12 @@ func (as *Assumptions) CanWriteToDirectory(dirFd int, dirName string) (bool, err
 	return as.canWriteToDirectory(dirFd, dirName)
 }
 
-func (up *CommonProfileUpdateContext) CurrentProfilePath() string {
-	return up.currentProfilePath
+func (ctx *CommonProfileUpdateContext) CurrentProfilePath() string {
+	return ctx.currentProfilePath
 }
 
-func (up *CommonProfileUpdateContext) DesiredProfilePath() string {
-	return up.desiredProfilePath
+func (ctx *CommonProfileUpdateContext) DesiredProfilePath() string {
+	return ctx.desiredProfilePath
 }
 
 func NewCommonProfileUpdateContext(instanceName string, currentProfilePath, desiredProfilePath string) *CommonProfileUpdateContext {

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -79,8 +79,8 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	up := update.NewSystemProfileUpdateContext(snapName)
-	err = update.ComputeAndSaveSystemChanges(up, snapName, s.as)
+	ctx := update.NewSystemProfileUpdateContext(snapName)
+	err = update.ComputeAndSaveSystemChanges(ctx, snapName, s.as)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -147,8 +147,8 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	up := update.NewSystemProfileUpdateContext(snapName)
-	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
+	ctx := update.NewSystemProfileUpdateContext(snapName)
+	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -225,8 +225,8 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	up := update.NewSystemProfileUpdateContext(snapName)
-	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
+	ctx := update.NewSystemProfileUpdateContext(snapName)
+	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -268,8 +268,8 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	up := update.NewSystemProfileUpdateContext(snapName)
-	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), ErrorMatches, "testing")
+	ctx := update.NewSystemProfileUpdateContext(snapName)
+	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -311,8 +311,8 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	up := update.NewSystemProfileUpdateContext(snapName)
-	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, nil), ErrorMatches, "testing")
+	ctx := update.NewSystemProfileUpdateContext(snapName)
+	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, nil), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -355,8 +355,8 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	defer restore()
 
 	// The error was ignored, and no mount was recorded in the profile
-	up := update.NewSystemProfileUpdateContext(snapName)
-	c.Assert(update.ComputeAndSaveSystemChanges(up, snapName, s.as), IsNil)
+	ctx := update.NewSystemProfileUpdateContext(snapName)
+	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }


### PR DESCRIPTION
The up variable used to stand for "mount profile update" but during the
last review pass it was renamed to "mount update context", hence the
"ctx".

A few leftovers remained though, this patch renames them too.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
