### PR TITLE
tests/main/nfs-support: temporarily disable for Fedora and CentOS

### DIFF
--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -7,7 +7,9 @@ details: |
 
 # ubuntu-core: nfs service not available on core
 # opensuse: the test is failing after retry several times the snapd service reaching the systemd start-limit.
-systems: [-ubuntu-core-*, -opensuse-*]
+# fedora, centos: disable until we figure out how to handle NFS and SELinux
+#                 labels, labels can only be exported for NFSv4.2+ with security_label option
+systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -centos-*]
 
 # takes >1.5min to run
 backends: [-autopkgtest]


### PR DESCRIPTION
The test is broken with SELinux. Labels are only exported for NFS4.2+ and the
export entry must use security_label option. Disable the test until we figure out
a way around this.

See: https://selinuxproject.org/page/Labeled_NFS and nfs(5)
