### PR TITLE
cmd/snap-update-ns: refactor of profile application (3/N)

### DIFF
--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -33,6 +33,11 @@ type CommonProfileUpdateContext struct {
 	desiredProfilePath string
 }
 
+// InstanceName returns the snap instance name being updated.
+func (ctx *CommonProfileUpdateContext) InstanceName() string {
+	return ctx.instanceName
+}
+
 func (ctx *CommonProfileUpdateContext) Lock() (unlock func(), err error) {
 	return func() {}, nil
 }

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -46,6 +46,10 @@ func (s *commonSuite) SetUpTest(c *C) {
 		filepath.Join(s.dir, "desired.fstab"))
 }
 
+func (s *commonSuite) TestInstanceName(c *C) {
+	c.Check(s.ctx.InstanceName(), Equals, "foo")
+}
+
 func (s *commonSuite) TestLoadDesiredProfile(c *C) {
 	ctx := s.ctx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -20,14 +20,85 @@
 package main_test
 
 import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
 	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type systemSuite struct{}
 
 var _ = Suite(&systemSuite{})
+
+func (s *systemSuite) TestLoadDesiredProfile(c *C) {
+	// Mock directories.
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	ctx := update.NewSystemProfileUpdateContext("foo")
+	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
+
+	// Write a desired system mount profile for snap "foo".
+	path := update.DesiredSystemProfilePath(ctx.InstanceName())
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+
+	// Ask the system profile update helper to read the desired profile.
+	profile, err := ctx.LoadDesiredProfile()
+	c.Assert(err, IsNil)
+	builder := &bytes.Buffer{}
+	profile.WriteTo(builder)
+
+	c.Check(builder.String(), Equals, text)
+}
+
+func (s *systemSuite) TestLoadCurrentProfile(c *C) {
+	// Mock directories.
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	ctx := update.NewSystemProfileUpdateContext("foo")
+	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
+
+	// Write a current system mount profile for snap "foo".
+	path := update.CurrentSystemProfilePath(ctx.InstanceName())
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+
+	// Ask the system profile update helper to read the current profile.
+	profile, err := ctx.LoadCurrentProfile()
+	c.Assert(err, IsNil)
+	builder := &bytes.Buffer{}
+	profile.WriteTo(builder)
+
+	// The profile is returned unchanged.
+	c.Check(builder.String(), Equals, text)
+}
+
+func (s *systemSuite) TestSaveCurrentProfile(c *C) {
+	// Mock directories and create directory for runtime mount profiles.
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
+
+	ctx := update.NewSystemProfileUpdateContext("foo")
+	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
+
+	// Prepare a mount profile to be saved.
+	profile, err := osutil.LoadMountProfileText(text)
+	c.Assert(err, IsNil)
+
+	// Ask the system profile update to write the current profile.
+	c.Assert(ctx.SaveCurrentProfile(profile), IsNil)
+	c.Check(update.CurrentSystemProfilePath(ctx.InstanceName()), testutil.FileEquals, text)
+}
 
 func (s *systemSuite) TestDesiredSystemProfilePath(c *C) {
 	c.Check(update.DesiredSystemProfilePath("foo"), Equals, "/var/lib/snapd/mount/snap.foo.fstab")

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -20,14 +20,46 @@
 package main_test
 
 import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
 	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/dirs"
 )
 
 type userSuite struct{}
 
 var _ = Suite(&userSuite{})
+
+func (s *userSuite) TestLoadDesiredProfile(c *C) {
+	// Mock directories but to simplify testing use the real value for XDG.
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+	dirs.XdgRuntimeDirBase = "/run/user"
+
+	ctx := update.NewUserProfileUpdateContext("foo", 1234)
+
+	input := "$XDG_RUNTIME_DIR/doc/by-app/snap.foo $XDG_RUNTIME_DIR/doc none bind,rw 0 0\n"
+	output := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
+
+	// Write a desired user mount profile for snap "foo".
+	path := update.DesiredUserProfilePath("foo")
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(path, []byte(input), 0644), IsNil)
+
+	// Ask the user profile update helper to read the desired profile.
+	profile, err := ctx.LoadDesiredProfile()
+	c.Assert(err, IsNil)
+	builder := &bytes.Buffer{}
+	profile.WriteTo(builder)
+
+	// Note that the profile read back contains expanded $XDG_RUNTIME_DIR.
+	c.Check(builder.String(), Equals, output)
+}
 
 func (s *userSuite) TestDesiredUserProfilePath(c *C) {
 	c.Check(update.DesiredUserProfilePath("foo"), Equals, "/var/lib/snapd/mount/snap.foo.user-fstab")


### PR DESCRIPTION
The system wide and per-user mount profiles share a lot of the
application logic: in both cases the system needs some kind of locking
done to avoid races, the current and desired profile needs to be loaded
from disk, the sequence of changes needs to be computed and applied,
lastly the updated current profile needs to be saved.

This branch contains the logic from #6360
split into smaller and more targeted patches carved out of
https://github.com/zyga/snapd/tree/feature/user-mount-ns-20.9-split-rebased

The changes in this branch utilise the profile loading code for user mount
profiles. The end goal can be seen in the branch referenced above.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
