### PR TITLE
osutil,cmdutil: move CommandFromCore and make it use the snapd snap (if available)

### DIFF
--- a/cmd/cmd_linux.go
+++ b/cmd/cmd_linux.go
@@ -114,7 +114,7 @@ func coreSupportsReExec(corePath string) bool {
 	return true
 }
 
-// TODO: move to cmd/cmdutil.go
+// TODO: move to cmd/cmdutil/
 //
 // InternalToolPath returns the path of an internal snapd tool. The tool
 // *must* be located inside the same tree as the current binary.

--- a/cmd/cmd_linux.go
+++ b/cmd/cmd_linux.go
@@ -114,6 +114,8 @@ func coreSupportsReExec(corePath string) bool {
 	return true
 }
 
+// TODO: move to cmd/cmdutil.go
+//
 // InternalToolPath returns the path of an internal snapd tool. The tool
 // *must* be located inside the same tree as the current binary.
 //

--- a/cmd/cmdutil/cmdutil.go
+++ b/cmd/cmdutil/cmdutil.go
@@ -112,7 +112,7 @@ func CommandFromSystemSnap(name string, cmdArgs ...string) (*exec.Cmd, error) {
 	}
 	coreLdSo := filepath.Join(root, interp)
 	// we cannot use EvalSymlink here because we need to resolve
-	// relative and absolute symlinks differently. A absolute
+	// relative and an absolute symlinks differently. A absolute
 	// symlink is relative to root of the snapd/core snap.
 	seen := map[string]bool{}
 	for osutil.IsSymlink(coreLdSo) {

--- a/cmd/cmdutil/cmdutil.go
+++ b/cmd/cmdutil/cmdutil.go
@@ -1,0 +1,139 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package cmdutil
+
+import (
+	"bufio"
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+func elfInterp(cmd string) (string, error) {
+	el, err := elf.Open(cmd)
+	if err != nil {
+		return "", err
+	}
+	defer el.Close()
+
+	for _, prog := range el.Progs {
+		if prog.Type == elf.PT_INTERP {
+			r := prog.Open()
+			interp, err := ioutil.ReadAll(r)
+			if err != nil {
+				return "", nil
+			}
+
+			return string(bytes.Trim(interp, "\x00")), nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find PT_INTERP header")
+}
+
+func parseLdSoConf(root string, confPath string) []string {
+	f, err := os.Open(filepath.Join(root, confPath))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var out []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "#"):
+			// nothing
+		case strings.TrimSpace(line) == "":
+			// nothing
+		case strings.HasPrefix(line, "include "):
+			l := strings.SplitN(line, "include ", 2)
+			files, err := filepath.Glob(filepath.Join(root, l[1]))
+			if err != nil {
+				return nil
+			}
+			for _, f := range files {
+				out = append(out, parseLdSoConf(root, f[len(root):])...)
+			}
+		default:
+			out = append(out, filepath.Join(root, line))
+		}
+
+	}
+	if err := scanner.Err(); err != nil {
+		return nil
+	}
+
+	return out
+}
+
+// CommandFromSystemSnap runs a command from the snapd/core snap
+// using the proper interpreter and library paths.
+//
+// At the moment it can only run ELF files, expects a standard ld.so
+// interpreter, and can't handle RPATH.
+func CommandFromSystemSnap(name string, cmdArgs ...string) (*exec.Cmd, error) {
+	from := "snapd"
+	root := filepath.Join(dirs.SnapMountDir, "/snapd/current")
+	if !osutil.FileExists(root) {
+		from = "core"
+		root = filepath.Join(dirs.SnapMountDir, "/core/current")
+	}
+
+	cmdPath := filepath.Join(root, name)
+	interp, err := elfInterp(cmdPath)
+	if err != nil {
+		return nil, err
+	}
+	coreLdSo := filepath.Join(root, interp)
+	// we cannot use EvalSymlink here because we need to resolve
+	// relative and absolute symlinks differently. A absolute
+	// symlink is relative to root of the snapd/core snap.
+	seen := map[string]bool{}
+	for osutil.IsSymlink(coreLdSo) {
+		link, err := os.Readlink(coreLdSo)
+		if err != nil {
+			return nil, err
+		}
+		if filepath.IsAbs(link) {
+			coreLdSo = filepath.Join(root, link)
+		} else {
+			coreLdSo = filepath.Join(filepath.Dir(coreLdSo), link)
+		}
+		if seen[coreLdSo] {
+			return nil, fmt.Errorf("cannot run command from %s: symlink cycle found", from)
+		}
+		seen[coreLdSo] = true
+	}
+
+	ldLibraryPathForCore := parseLdSoConf(root, "/etc/ld.so.conf")
+
+	ldSoArgs := []string{"--library-path", strings.Join(ldLibraryPathForCore, ":"), cmdPath}
+	allArgs := append(ldSoArgs, cmdArgs...)
+	return exec.Command(coreLdSo, allArgs...), nil
+}

--- a/cmd/cmdutil/cmdutil_test.go
+++ b/cmd/cmdutil/cmdutil_test.go
@@ -1,0 +1,116 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmdutil_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/cmdutil"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+var truePath = osutil.LookPathDefault("true", "/bin/true")
+
+type cmdutilSuite struct{}
+
+var _ = Suite(&cmdutilSuite{})
+
+func (s *cmdutilSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *cmdutilSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+}
+
+func (s *cmdutilSuite) makeMockLdSoConf(c *C) {
+	ldSoConf := filepath.Join(dirs.SnapMountDir, "/core/current/etc/ld.so.conf")
+	ldSoConfD := ldSoConf + ".d"
+
+	err := os.MkdirAll(filepath.Dir(ldSoConf), 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(ldSoConfD, 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(ldSoConf, []byte("include /etc/ld.so.conf.d/*.conf"), 0644)
+	c.Assert(err, IsNil)
+
+	ldSoConf1 := filepath.Join(ldSoConfD, "x86_64-linux-gnu.conf")
+
+	err = ioutil.WriteFile(ldSoConf1, []byte(`
+# Multiarch support
+/lib/x86_64-linux-gnu
+/usr/lib/x86_64-linux-gnu`), 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *cmdutilSuite) TestCommandFromCore(c *C) {
+	s.makeMockLdSoConf(c)
+	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+
+	os.MkdirAll(filepath.Join(root, "/usr/bin"), 0755)
+	osutil.CopyFile(truePath, filepath.Join(root, "/usr/bin/xdelta3"), 0)
+	cmd, err := cmdutil.CommandFromSystemSnap("/usr/bin/xdelta3", "--some-xdelta-arg")
+	c.Assert(err, IsNil)
+
+	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("readelf -l %s |grep interpreter:|cut -f2 -d:|cut -f1 -d]", truePath)).Output()
+	c.Assert(err, IsNil)
+	interp := strings.TrimSpace(string(out))
+
+	c.Check(cmd.Args, DeepEquals, []string{
+		filepath.Join(root, interp),
+		"--library-path",
+		fmt.Sprintf("%s/lib/x86_64-linux-gnu:%s/usr/lib/x86_64-linux-gnu", root, root),
+		filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3"),
+		"--some-xdelta-arg",
+	})
+}
+
+func (s *cmdutilSuite) TestCommandFromCoreSymlinkCycle(c *C) {
+	s.makeMockLdSoConf(c)
+	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+
+	os.MkdirAll(filepath.Join(root, "/usr/bin"), 0755)
+	osutil.CopyFile(truePath, filepath.Join(root, "/usr/bin/xdelta3"), 0)
+
+	out, err := exec.Command("/bin/sh", "-c", "readelf -l /bin/true |grep interpreter:|cut -f2 -d:|cut -f1 -d]").Output()
+	c.Assert(err, IsNil)
+	interp := strings.TrimSpace(string(out))
+
+	coreInterp := filepath.Join(root, interp)
+	c.Assert(os.MkdirAll(filepath.Dir(coreInterp), 0755), IsNil)
+	c.Assert(os.Symlink(filepath.Base(coreInterp), coreInterp), IsNil)
+
+	_, err = cmdutil.CommandFromSystemSnap("/usr/bin/xdelta3", "--some-xdelta-arg")
+	c.Assert(err, ErrorMatches, "cannot run command from core: symlink cycle found")
+
+}

--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -20,16 +20,10 @@
 package osutil
 
 import (
-	"bufio"
-	"bytes"
-	"debug/elf"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -37,115 +31,6 @@ import (
 
 	"github.com/snapcore/snapd/strutil"
 )
-
-func parseCoreLdSoConf(snapMountDir string, confPath string) []string {
-	root := filepath.Join(snapMountDir, "/core/current")
-
-	f, err := os.Open(filepath.Join(root, confPath))
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	var out []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		switch {
-		case strings.HasPrefix(line, "#"):
-			// nothing
-		case strings.TrimSpace(line) == "":
-			// nothing
-		case strings.HasPrefix(line, "include "):
-			l := strings.SplitN(line, "include ", 2)
-			files, err := filepath.Glob(filepath.Join(root, l[1]))
-			if err != nil {
-				return nil
-			}
-			for _, f := range files {
-				out = append(out, parseCoreLdSoConf(snapMountDir, f[len(root):])...)
-			}
-		default:
-			out = append(out, filepath.Join(root, line))
-		}
-
-	}
-	if err := scanner.Err(); err != nil {
-		return nil
-	}
-
-	return out
-}
-
-func elfInterp(cmd string) (string, error) {
-	el, err := elf.Open(cmd)
-	if err != nil {
-		return "", err
-	}
-	defer el.Close()
-
-	for _, prog := range el.Progs {
-		if prog.Type == elf.PT_INTERP {
-			r := prog.Open()
-			interp, err := ioutil.ReadAll(r)
-			if err != nil {
-				return "", nil
-			}
-
-			return string(bytes.Trim(interp, "\x00")), nil
-		}
-	}
-
-	return "", fmt.Errorf("cannot find PT_INTERP header")
-}
-
-// TODO: rename/move to a more sensible place
-//
-// CommandFromSnapdOrCore runs a command from the snapd/core snap
-// using the proper interpreter and library paths.
-//
-// At the moment it can only run ELF files, expects a standard ld.so
-// interpreter, and can't handle RPATH.
-func CommandFromCore(snapMountDir string, name string, cmdArgs ...string) (*exec.Cmd, error) {
-	from := "snapd"
-	root := filepath.Join(snapMountDir, "/snapd/current")
-	if !FileExists(root) {
-		from = "core"
-		root = filepath.Join(snapMountDir, "/core/current")
-	}
-
-	cmdPath := filepath.Join(root, name)
-	interp, err := elfInterp(cmdPath)
-	if err != nil {
-		return nil, err
-	}
-	coreLdSo := filepath.Join(root, interp)
-	// we cannot use EvalSymlink here because we need to resolve
-	// relative and absolute symlinks differently. A absolute
-	// symlink is relative to root of the snapd/core snap.
-	seen := map[string]bool{}
-	for IsSymlink(coreLdSo) {
-		link, err := os.Readlink(coreLdSo)
-		if err != nil {
-			return nil, err
-		}
-		if filepath.IsAbs(link) {
-			coreLdSo = filepath.Join(root, link)
-		} else {
-			coreLdSo = filepath.Join(filepath.Dir(coreLdSo), link)
-		}
-		if seen[coreLdSo] {
-			return nil, fmt.Errorf("cannot run command from %s: symlink cycle found", from)
-		}
-		seen[coreLdSo] = true
-	}
-
-	ldLibraryPathForCore := parseCoreLdSoConf(snapMountDir, "/etc/ld.so.conf")
-
-	ldSoArgs := []string{"--library-path", strings.Join(ldLibraryPathForCore, ":"), cmdPath}
-	allArgs := append(ldSoArgs, cmdArgs...)
-	return exec.Command(coreLdSo, allArgs...), nil
-}
 
 var cmdWaitTimeout = 5 * time.Second
 

--- a/osutil/exec_test.go
+++ b/osutil/exec_test.go
@@ -23,11 +23,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -48,69 +45,6 @@ func (s *execSuite) SetUpTest(c *C) {
 
 func (s *execSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-}
-
-func (s *execSuite) makeMockLdSoConf(c *C) {
-	ldSoConf := filepath.Join(dirs.SnapMountDir, "/core/current/etc/ld.so.conf")
-	ldSoConfD := ldSoConf + ".d"
-
-	err := os.MkdirAll(filepath.Dir(ldSoConf), 0755)
-	c.Assert(err, IsNil)
-	err = os.MkdirAll(ldSoConfD, 0755)
-	c.Assert(err, IsNil)
-
-	err = ioutil.WriteFile(ldSoConf, []byte("include /etc/ld.so.conf.d/*.conf"), 0644)
-	c.Assert(err, IsNil)
-
-	ldSoConf1 := filepath.Join(ldSoConfD, "x86_64-linux-gnu.conf")
-
-	err = ioutil.WriteFile(ldSoConf1, []byte(`
-# Multiarch support
-/lib/x86_64-linux-gnu
-/usr/lib/x86_64-linux-gnu`), 0644)
-	c.Assert(err, IsNil)
-}
-
-func (s *execSuite) TestCommandFromCore(c *C) {
-	s.makeMockLdSoConf(c)
-	root := filepath.Join(dirs.SnapMountDir, "/core/current")
-
-	os.MkdirAll(filepath.Join(root, "/usr/bin"), 0755)
-	osutil.CopyFile(truePath, filepath.Join(root, "/usr/bin/xdelta3"), 0)
-	cmd, err := osutil.CommandFromCore(dirs.SnapMountDir, "/usr/bin/xdelta3", "--some-xdelta-arg")
-	c.Assert(err, IsNil)
-
-	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("readelf -l %s |grep interpreter:|cut -f2 -d:|cut -f1 -d]", truePath)).Output()
-	c.Assert(err, IsNil)
-	interp := strings.TrimSpace(string(out))
-
-	c.Check(cmd.Args, DeepEquals, []string{
-		filepath.Join(root, interp),
-		"--library-path",
-		fmt.Sprintf("%s/lib/x86_64-linux-gnu:%s/usr/lib/x86_64-linux-gnu", root, root),
-		filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3"),
-		"--some-xdelta-arg",
-	})
-}
-
-func (s *execSuite) TestCommandFromCoreSymlinkCycle(c *C) {
-	s.makeMockLdSoConf(c)
-	root := filepath.Join(dirs.SnapMountDir, "/core/current")
-
-	os.MkdirAll(filepath.Join(root, "/usr/bin"), 0755)
-	osutil.CopyFile(truePath, filepath.Join(root, "/usr/bin/xdelta3"), 0)
-
-	out, err := exec.Command("/bin/sh", "-c", "readelf -l /bin/true |grep interpreter:|cut -f2 -d:|cut -f1 -d]").Output()
-	c.Assert(err, IsNil)
-	interp := strings.TrimSpace(string(out))
-
-	coreInterp := filepath.Join(root, interp)
-	c.Assert(os.MkdirAll(filepath.Dir(coreInterp), 0755), IsNil)
-	c.Assert(os.Symlink(filepath.Base(coreInterp), coreInterp), IsNil)
-
-	_, err = osutil.CommandFromCore(dirs.SnapMountDir, "/usr/bin/xdelta3", "--some-xdelta-arg")
-	c.Assert(err, ErrorMatches, "cannot run command from core: symlink cycle found")
-
 }
 
 func (s *execSuite) TestRunAndWaitRunsAndWaits(c *C) {

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -36,10 +36,10 @@ func MockUpdateFontconfigCaches(f func() error) (restore func()) {
 	}
 }
 
-func MockCommandFromCore(f func(string, string, ...string) (*exec.Cmd, error)) (restore func()) {
-	old := commandFromCore
-	commandFromCore = f
+func MockCommandFromSystemSnap(f func(string, ...string) (*exec.Cmd, error)) (restore func()) {
+	old := commandFromSystemSnap
+	commandFromSystemSnap = f
 	return func() {
-		commandFromCore = old
+		commandFromSystemSnap = old
 	}
 }

--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -22,17 +22,17 @@ package backend
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/cmd/cmdutil"
 	"github.com/snapcore/snapd/osutil"
 )
 
 var updateFontconfigCaches = updateFontconfigCachesImpl
-var commandFromCore = osutil.CommandFromCore
+var commandFromSystemSnap = cmdutil.CommandFromSystemSnap
 
 // updateFontconfigCaches always update the fontconfig caches
 func updateFontconfigCachesImpl() error {
 	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
-		cmd, err := commandFromCore(dirs.SnapMountDir, "/bin/"+fc)
+		cmd, err := commandFromSystemSnap("/bin/" + fc)
 		if err != nil {
 			return fmt.Errorf("cannot get %s from core: %v", fc, err)
 		}

--- a/overlord/snapstate/backend/fontconfig.go
+++ b/overlord/snapstate/backend/fontconfig.go
@@ -32,7 +32,6 @@ var commandFromCore = osutil.CommandFromCore
 // updateFontconfigCaches always update the fontconfig caches
 func updateFontconfigCachesImpl() error {
 	for _, fc := range []string{"fc-cache-v6", "fc-cache-v7"} {
-		// FIXME: also use the snapd snap if available
 		cmd, err := commandFromCore(dirs.SnapMountDir, "/bin/"+fc)
 		if err != nil {
 			return fmt.Errorf("cannot get %s from core: %v", fc, err)

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -396,8 +396,8 @@ type: os
 	newCmdV7 := testutil.MockCommand(c, filepath.Join(mountDirNew, "bin", "fc-cache-v7"), "")
 
 	// provide our own mock, osutil.CommandFromCore expects an ELF binary
-	restore = backend.MockCommandFromCore(func(mountDir, name string, args ...string) (*exec.Cmd, error) {
-		cmd := filepath.Join(mountDir, "core", "current", name)
+	restore = backend.MockCommandFromSystemSnap(func(name string, args ...string) (*exec.Cmd, error) {
+		cmd := filepath.Join(dirs.SnapMountDir, "core", "current", name)
 		c.Logf("command from core: %v", cmd)
 		return exec.Command(cmd, args...), nil
 	})

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -43,11 +43,11 @@ func MockLink(newLink func(string, string) error) (restore func()) {
 	}
 }
 
-func MockFromCore(newFromCore func(string, string, ...string) (*exec.Cmd, error)) (restore func()) {
-	oldFromCore := osutilCommandFromCore
-	osutilCommandFromCore = newFromCore
+func MockCommandFromSystemSnap(f func(string, ...string) (*exec.Cmd, error)) (restore func()) {
+	oldCommandFromSystemSnap := cmdutilCommandFromSystemSnap
+	cmdutilCommandFromSystemSnap = f
 	return func() {
-		osutilCommandFromCore = oldFromCore
+		cmdutilCommandFromSystemSnap = oldCommandFromSystemSnap
 	}
 }
 

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -30,6 +30,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/snapcore/snapd/cmd/cmdutil"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
@@ -54,7 +55,7 @@ func New(snapPath string) *Snap {
 }
 
 var osLink = os.Link
-var osutilCommandFromCore = osutil.CommandFromCore
+var cmdutilCommandFromSystemSnap = cmdutil.CommandFromSystemSnap
 
 func (s *Snap) Install(targetPath, mountDir string) error {
 
@@ -305,7 +306,7 @@ func (s *Snap) Build(sourceDir, snapType string, excludeFiles ...string) error {
 	if err != nil {
 		return err
 	}
-	cmd, err := osutilCommandFromCore(dirs.SnapMountDir, "/usr/bin/mksquashfs")
+	cmd, err := cmdutilCommandFromSystemSnap("/usr/bin/mksquashfs")
 	if err != nil {
 		cmd = exec.Command("mksquashfs")
 	}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -412,8 +412,7 @@ squashfs-root/random/data.bin
 }
 
 func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcardsFlag(c *C) {
-	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
-		c.Check(mountDir, Equals, dirs.SnapMountDir)
+	defer squashfs.MockCommandFromSystemSnap(func(cmd string, args ...string) (*exec.Cmd, error) {
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return nil, errors.New("bzzt")
 	})()
@@ -436,9 +435,8 @@ func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcard
 
 func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 	usedFromCore := false
-	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockCommandFromSystemSnap(func(cmd string, args ...string) (*exec.Cmd, error) {
 		usedFromCore = true
-		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return &exec.Cmd{Path: "/bin/true"}, nil
 	})()
@@ -456,9 +454,8 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 
 func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(c *C) {
 	triedFromCore := false
-	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockCommandFromSystemSnap(func(cmd string, args ...string) (*exec.Cmd, error) {
 		triedFromCore = true
-		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return nil, errors.New("bzzt")
 	})()
@@ -476,9 +473,8 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(
 
 func (s *SquashfsTestSuite) TestBuildFailsIfNoMksquashfs(c *C) {
 	triedFromCore := false
-	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
+	defer squashfs.MockCommandFromSystemSnap(func(cmd string, args ...string) (*exec.Cmd, error) {
 		triedFromCore = true
-		c.Check(mountDir, Equals, dirs.SnapMountDir)
 		c.Check(cmd, Equals, "/usr/bin/mksquashfs")
 		return nil, errors.New("bzzt")
 	})()
@@ -495,8 +491,7 @@ func (s *SquashfsTestSuite) TestBuildFailsIfNoMksquashfs(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestBuildVariesArgsByType(c *C) {
-	defer squashfs.MockFromCore(func(mountDir, cmd string, args ...string) (*exec.Cmd, error) {
-		c.Check(mountDir, Equals, dirs.SnapMountDir)
+	defer squashfs.MockCommandFromSystemSnap(func(cmd string, args ...string) (*exec.Cmd, error) {
 		return nil, errors.New("bzzt")
 	})()
 	mksq := testutil.MockCommand(c, "mksquashfs", "")

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,9 +29,31 @@ parts:
     # FIXME: this should probably go upstream
     plugin: x-builddeb
     source: .
+  # xdelta is used to enable delta downloads (even if the host does not have it)
+  xdelta3:
+    plugin: nil
     stage-packages:
       - xdelta3
+    stage:
+      - usr/bin/*
+      - usr/lib/*
+      - lib/*
+  # squashfs-tools are used by `snap pack`
+  squashfs-tools:
+    plugin: nil
+    stage-packages:
       - squashfs-tools
+    stage:
+      - usr/bin/*
+      - usr/lib/*
+      - lib/*
+  # liblzma5 is part of core but the snapd snap needs to run even without core
+  liblzma5:
+    plugin: nil
+    stage-packages:
+      - liblzma5
+    stage:
+      - lib/*
   # the version in Ubuntu 16.04 (cache v6)
   fontconfig-xenial:
     plugin: nil

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,6 +29,9 @@ parts:
     # FIXME: this should probably go upstream
     plugin: x-builddeb
     source: .
+    stage-packages:
+      - xdelta3
+      - squashfs-tools
   # the version in Ubuntu 16.04 (cache v6)
   fontconfig-xenial:
     plugin: nil

--- a/store/store.go
+++ b/store/store.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/cmd/cmdutil"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
@@ -1592,7 +1593,7 @@ func getXdelta3Cmd(args ...string) (*exec.Cmd, error) {
 	case osutil.ExecutableExists("xdelta3"):
 		return exec.Command("xdelta3", args...), nil
 	case osutil.FileExists(filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3")):
-		return osutil.CommandFromCore(dirs.SnapMountDir, "/usr/bin/xdelta3", args...)
+		return cmdutil.CommandFromSystemSnap("/usr/bin/xdelta3", args...)
 	}
 	return nil, fmt.Errorf("cannot find xdelta3 binary in PATH or core snap")
 }

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -307,6 +307,16 @@ prepare_classic() {
     fi
 }
 
+repack_snapd_snap_with_deb_content() {
+    TARGET="$1"
+
+    UNPACK_DIR="./snapd-unpack"
+    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
+    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
+    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
+    snap pack "$UNPACK_DIR" "$TARGET"
+}
+
 setup_reflash_magic() {
     # install the stuff we need
     distro_install_package kpartx busybox-static
@@ -340,11 +350,7 @@ setup_reflash_magic() {
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
     if is_core18_system; then
-        # modify the snapd snap so that it has our snapd
-        UNPACK_DIR="/tmp/snapd-snap"
-        unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-        dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-        snap pack "$UNPACK_DIR" "$IMAGE_HOME"
+        repack_snapd_snap_with_deb_content "$IMAGE_HOME"
 
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -308,9 +308,9 @@ prepare_classic() {
 }
 
 repack_snapd_snap_with_deb_content() {
-    TARGET="$1"
+    local TARGET="$1"
 
-    UNPACK_DIR="./snapd-unpack"
+    local UNPACK_DIR="./snapd-unpack"
     unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
     dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
     cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -339,13 +339,13 @@ setup_reflash_magic() {
     cp /usr/bin/snap "$IMAGE_HOME"
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
-    # modify the snapd snap so that it has our snapd
-    UNPACK_DIR="/tmp/snapd-snap"
-    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-    snap pack "$UNPACK_DIR" "$IMAGE_HOME"
-    
     if is_core18_system; then
+        # modify the snapd snap so that it has our snapd
+        UNPACK_DIR="/tmp/snapd-snap"
+        unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
+        dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
+        snap pack "$UNPACK_DIR" "$IMAGE_HOME"
+
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
         IMAGE=core18-amd64.img

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -310,7 +310,7 @@ prepare_classic() {
 repack_snapd_snap_with_deb_content() {
     local TARGET="$1"
 
-    local UNPACK_DIR="./snapd-unpack"
+    local UNPACK_DIR="/tmp/snapd-unpack"
     unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
     dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
     cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -339,13 +339,13 @@ setup_reflash_magic() {
     cp /usr/bin/snap "$IMAGE_HOME"
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
+    # modify the snapd snap so that it has our snapd
+    UNPACK_DIR="/tmp/snapd-snap"
+    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
+    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
+    snap pack "$UNPACK_DIR" "$IMAGE_HOME"
+    
     if is_core18_system; then
-        # modify the snapd snap so that it has our snapd
-        UNPACK_DIR="/tmp/snapd-snap"
-        unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-        dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-        snap pack "$UNPACK_DIR" "$IMAGE_HOME"
-        
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
         IMAGE=core18-amd64.img

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -315,6 +315,7 @@ repack_snapd_snap_with_deb_content() {
     dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
     cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
     snap pack "$UNPACK_DIR" "$TARGET"
+    rm -rf "$UNPACK_DIR"
 }
 
 setup_reflash_magic() {

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -7,7 +7,10 @@ systems: [ubuntu-16.04-64]
 priority: 100
 
 restore: |
+    echo "Cleanup the installed snapcraft"
     apt autoremove -y snapcraft
+    echo "Cleanup the build snapd snap"
+    rm -f "$PROJECT_PATH"/snapd_*.snap
 
 execute: |
     echo "Installing snapscraft"
@@ -23,5 +26,6 @@ execute: |
     echo "Ensure we have xdelta3"
     unsquashfs -ll snapd_*.snap | MATCH bin/xdelta3
 
-    echo "Ensure we have mksquashfs"
+    echo "Ensure we have mksquashfs (and the dependencies)"
     unsquashfs -ll snapd_*.snap | MATCH bin/mksquashfs
+    unsquashfs -ll snapd_*.snap | MATCH liblzma.so.5

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -19,3 +19,9 @@ execute: |
     echo "Ensure we have the fc-cache binaries"
     unsquashfs -ll snapd_*.snap | MATCH bin/fc-cache-v6
     unsquashfs -ll snapd_*.snap | MATCH bin/fc-cache-v7
+
+    echo "Ensure we have xdelta3"
+    unsquashfs -ll snapd_*.snap | MATCH bin/xdelta3"
+
+    echo "Ensure we have mksquashfs"
+    unsquashfs -ll snapd_*.snap | MATCH bin/mksquashfs"

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -21,7 +21,7 @@ execute: |
     unsquashfs -ll snapd_*.snap | MATCH bin/fc-cache-v7
 
     echo "Ensure we have xdelta3"
-    unsquashfs -ll snapd_*.snap | MATCH bin/xdelta3"
+    unsquashfs -ll snapd_*.snap | MATCH bin/xdelta3
 
     echo "Ensure we have mksquashfs"
-    unsquashfs -ll snapd_*.snap | MATCH bin/mksquashfs"
+    unsquashfs -ll snapd_*.snap | MATCH bin/mksquashfs

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -1,0 +1,27 @@
+summary: Ensure the snapd works without core
+
+# we have a separate test for UC18 already, on UC16 we always have a core snap
+systems: [-ubuntu-core-*]
+
+execute: |
+    if [ "${SNAP_REEXEC:-}" = "0" ]; then
+        echo "skipping test when SNAP_REEXEC is disabled"
+        exit 0
+    fi
+
+    echo "Ensure core is gone so that we can have snapd"
+    distro_purge_package snapd
+    distro_install_build_snapd
+
+    echo "Install the snapd snap"
+    snap set core experimental.snapd-snap=true
+    snap install --dangerous $GOPATH/snapd_*.snap
+
+    echo "Now install a core18 based snap and ensure it works"
+    snap install test-snapd-tools-core18
+    test-snapd-tools-core18.echo hello | MATCH hello
+
+    echo "Ensure we re-exec to the snapd snap"
+    SNAPD_DEBUG=1 test-snapd-tools-core18.echo 2>&1 | grep 'restarting into "/snap/snapd/current'
+
+    # TODO: add test that checks that `snap pack` uses mksquashfs from snapd

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -15,12 +15,10 @@ execute: |
     fi
 
     echo "Create modified snapd snap"
-    UNPACK_DIR="./snapd-unpack"
+    #shellcheck source=tests/lib/prepare.sh
+    . "$TESTSLIB"/prepare.sh
     snap download --edge snapd
-    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
-    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
-    snap pack "$UNPACK_DIR" /tmp
+    repack_snapd_snap_with_deb_content /tmp
 
     echo "Ensure core is gone so that we can have snapd"
     #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -1,7 +1,12 @@
-summary: Ensure the snapd works without core
+summary: Ensure the snapd works without core on classic systems
 
-# we have a separate test for UC18 already, on UC16 we always have a core snap
-systems: [-ubuntu-core-*]
+# Run only on ubuntu classic because this re-execs.  We have a
+# separate test for UC18 already and on UC16 we always have a core
+# snap so we don't need to test there.
+systems: [ubuntu-1*, ubuntu-2*]
+
+restore: |
+    rm -f /tmp/snapd_*.snap
 
 execute: |
     if [ "${SNAP_REEXEC:-}" = "0" ]; then
@@ -9,19 +14,33 @@ execute: |
         exit 0
     fi
 
+    echo "Create modified snapd snap"
+    UNPACK_DIR="./snapd-unpack"
+    snap download --edge snapd
+    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
+    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
+    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
+    snap pack "$UNPACK_DIR" /tmp
+
     echo "Ensure core is gone so that we can have snapd"
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
     distro_purge_package snapd
     distro_install_build_snapd
 
     echo "Install the snapd snap"
     snap set core experimental.snapd-snap=true
-    snap install --dangerous $GOPATH/snapd_*.snap
+    snap install --dangerous /tmp/snapd_*.snap
+    echo "Ensure we restarted into the snapd snap"
+    # shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB/journalctl.sh"
+    check_journalctl_log  'restarting into "/snap/snapd/'
 
     echo "Now install a core18 based snap and ensure it works"
     snap install test-snapd-tools-core18
     test-snapd-tools-core18.echo hello | MATCH hello
+    echo "No core was installed"
+    ! snap list | grep ^"core "
 
     echo "Ensure we re-exec to the snapd snap"
-    SNAPD_DEBUG=1 test-snapd-tools-core18.echo 2>&1 | grep 'restarting into "/snap/snapd/current'
-
-    # TODO: add test that checks that `snap pack` uses mksquashfs from snapd
+    SNAPD_DEBUG=1 test-snapd-tools-core18.echo 2>&1 | MATCH 'restarting into "/snap/snapd/current'


### PR DESCRIPTION
The CommandFromCore helper is currently always looking at the
core snap. With the snapd snap we need to refactor it so that
it uses the snapd snap if available and just falls back to the
core snap. 

This PR also moves the code from osutil (it is a bit misplaced there)
to cmd/cmdutil - we cannot have it in cmd/ because there is also
cmd/snapinfo.go which will trigger an import cycle if we move it
there. We should also move cmd.InternalToolPath to cmdutil but that
should be done in a separate PR.

This should unblock #6404. 

For easier review I could split this and just do a pure rename in the
first PR and the tweak the code in the second (and third?) PR. But
its *not* that much change so maybe its ok to review in one go.
Feedback welcome.
