### PR TITLE
tests: fix syntax error in here-doc

### DIFF
--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -22,7 +22,7 @@ restore: |
     rm -f /etc/schroot/chroot.d/sid-amd64-sbuild-*
 
 debug: |
-    cat <<<EOM
+    cat <<EOM
     Use release-tools/debian-package-builder to interactively fix build
     issues. The debug shell created there shows the true layout of the source
     code as it exists during the build inside a debian system, inside the


### PR DESCRIPTION
I'm not sure why shellcheck was not picking it up.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

