### PR TITLE
cmd: typedef struct sc_error

### DIFF
--- a/cmd/libsnap-confine-private/error.c
+++ b/cmd/libsnap-confine-private/error.c
@@ -26,16 +26,6 @@
 #include <stdio.h>
 #include <string.h>
 
-struct sc_error {
-	// Error domain defines a scope for particular error codes.
-	const char *domain;
-	// Code differentiates particular errors for the programmer.
-	// The code may be zero if the particular meaning is not relevant.
-	int code;
-	// Message carries a formatted description of the problem.
-	char *msg;
-};
-
 static struct sc_error *sc_error_initv(const char *domain, int code,
 				       const char *msgfmt, va_list ap)
 {

--- a/cmd/libsnap-confine-private/error.c
+++ b/cmd/libsnap-confine-private/error.c
@@ -26,10 +26,10 @@
 #include <stdio.h>
 #include <string.h>
 
-static struct sc_error *sc_error_initv(const char *domain, int code,
-				       const char *msgfmt, va_list ap)
+static sc_error *sc_error_initv(const char *domain, int code,
+				const char *msgfmt, va_list ap)
 {
-	struct sc_error *err = calloc(1, sizeof *err);
+	sc_error *err = calloc(1, sizeof *err);
 	if (err == NULL) {
 		die("cannot allocate memory for error object");
 	}
@@ -41,28 +41,25 @@ static struct sc_error *sc_error_initv(const char *domain, int code,
 	return err;
 }
 
-struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
-			       ...)
+sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...)
 {
 	va_list ap;
 	va_start(ap, msgfmt);
-	struct sc_error *err = sc_error_initv(domain, code, msgfmt, ap);
+	sc_error *err = sc_error_initv(domain, code, msgfmt, ap);
 	va_end(ap);
 	return err;
 }
 
-struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
-					  ...)
+sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...)
 {
 	va_list ap;
 	va_start(ap, msgfmt);
-	struct sc_error *err =
-	    sc_error_initv(SC_ERRNO_DOMAIN, errno_copy, msgfmt, ap);
+	sc_error *err = sc_error_initv(SC_ERRNO_DOMAIN, errno_copy, msgfmt, ap);
 	va_end(ap);
 	return err;
 }
 
-const char *sc_error_domain(struct sc_error *err)
+const char *sc_error_domain(sc_error * err)
 {
 	if (err == NULL) {
 		die("cannot obtain error domain from NULL error");
@@ -70,7 +67,7 @@ const char *sc_error_domain(struct sc_error *err)
 	return err->domain;
 }
 
-int sc_error_code(struct sc_error *err)
+int sc_error_code(sc_error * err)
 {
 	if (err == NULL) {
 		die("cannot obtain error code from NULL error");
@@ -78,7 +75,7 @@ int sc_error_code(struct sc_error *err)
 	return err->code;
 }
 
-const char *sc_error_msg(struct sc_error *err)
+const char *sc_error_msg(sc_error * err)
 {
 	if (err == NULL) {
 		die("cannot obtain error message from NULL error");
@@ -86,7 +83,7 @@ const char *sc_error_msg(struct sc_error *err)
 	return err->msg;
 }
 
-void sc_error_free(struct sc_error *err)
+void sc_error_free(sc_error * err)
 {
 	if (err != NULL) {
 		free(err->msg);
@@ -95,13 +92,13 @@ void sc_error_free(struct sc_error *err)
 	}
 }
 
-void sc_cleanup_error(struct sc_error **ptr)
+void sc_cleanup_error(sc_error ** ptr)
 {
 	sc_error_free(*ptr);
 	*ptr = NULL;
 }
 
-void sc_die_on_error(struct sc_error *error)
+void sc_die_on_error(sc_error * error)
 {
 	if (error != NULL) {
 		if (strcmp(sc_error_domain(error), SC_ERRNO_DOMAIN) == 0) {
@@ -115,7 +112,7 @@ void sc_die_on_error(struct sc_error *error)
 	}
 }
 
-void sc_error_forward(struct sc_error **recipient, struct sc_error *error)
+void sc_error_forward(sc_error ** recipient, sc_error * error)
 {
 	if (recipient != NULL) {
 		*recipient = error;
@@ -124,7 +121,7 @@ void sc_error_forward(struct sc_error **recipient, struct sc_error *error)
 	}
 }
 
-bool sc_error_match(struct sc_error *error, const char *domain, int code)
+bool sc_error_match(sc_error * error, const char *domain, int code)
 {
 	if (domain == NULL) {
 		die("cannot match error to a NULL domain");

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -43,9 +43,17 @@
  **/
 
 /**
- * Opaque error structure.
+ * Error structure.
  **/
-struct sc_error;
+struct sc_error {
+	// Error domain defines a scope for particular error codes.
+	const char *domain;
+	// Code differentiates particular errors for the programmer.
+	// The code may be zero if the particular meaning is not relevant.
+	int code;
+	// Message carries a formatted description of the problem.
+	char *msg;
+};
 
 /**
  * Error domain for errors related to system errno.

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -45,7 +45,7 @@
 /**
  * Error structure.
  **/
-struct sc_error {
+typedef struct sc_error {
 	// Error domain defines a scope for particular error codes.
 	const char *domain;
 	// Code differentiates particular errors for the programmer.
@@ -53,7 +53,7 @@ struct sc_error {
 	int code;
 	// Message carries a formatted description of the problem.
 	char *msg;
-};
+} sc_error;
 
 /**
  * Error domain for errors related to system errno.
@@ -72,8 +72,7 @@ struct sc_error {
  **/
 __attribute__((warn_unused_result,
 	       format(printf, 3, 4) SC_APPEND_RETURNS_NONNULL))
-struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
-			       ...);
+sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...);
 
 /**
  * Initialize an errno-based error.
@@ -85,8 +84,8 @@ struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
  **/
 __attribute__((warn_unused_result,
 	       format(printf, 2, 3) SC_APPEND_RETURNS_NONNULL))
-struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
-					  ...);
+sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...);
+
 
 /**
  * Get the error domain out of an error object.
@@ -95,7 +94,7 @@ struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
  * No change of ownership takes place.
  **/
 __attribute__((warn_unused_result SC_APPEND_RETURNS_NONNULL))
-const char *sc_error_domain(struct sc_error *err);
+const char *sc_error_domain(sc_error * err);
 
 /**
  * Get the error code out of an error object.
@@ -108,7 +107,7 @@ const char *sc_error_domain(struct sc_error *err);
  * without having to allocate a distinct code for each one.
  **/
 __attribute__((warn_unused_result))
-int sc_error_code(struct sc_error *err);
+int sc_error_code(sc_error * err);
 
 /**
  * Get the error message out of an error object.
@@ -117,14 +116,14 @@ int sc_error_code(struct sc_error *err);
  * No change of ownership takes place.
  **/
 __attribute__((warn_unused_result SC_APPEND_RETURNS_NONNULL))
-const char *sc_error_msg(struct sc_error *err);
+const char *sc_error_msg(sc_error * err);
 
 /**
  * Free an error object.
  *
  * The error object can be NULL.
  **/
-void sc_error_free(struct sc_error *error);
+void sc_error_free(sc_error * error);
 
 /**
  * Cleanup an error with sc_error_free()
@@ -133,7 +132,7 @@ void sc_error_free(struct sc_error *error);
  * __attribute__((cleanup(sc_cleanup_error))).
  **/
 __attribute__((nonnull))
-void sc_cleanup_error(struct sc_error **ptr);
+void sc_cleanup_error(sc_error ** ptr);
 
 /**
  *
@@ -144,7 +143,7 @@ void sc_cleanup_error(struct sc_error **ptr);
  * The error message is derived from the data in the error, using the special
  * errno domain to provide additional information if that is available.
  **/
-void sc_die_on_error(struct sc_error *error);
+void sc_die_on_error(sc_error * error);
 
 /**
  * Forward an error to the caller.
@@ -157,7 +156,7 @@ void sc_die_on_error(struct sc_error *error);
  **/
 // NOTE: There's no nonnull(1) attribute as the recipient *can* be NULL. With
 // the attribute in place GCC optimizes some things out and tests fail.
-void sc_error_forward(struct sc_error **recipient, struct sc_error *error);
+void sc_error_forward(sc_error ** recipient, sc_error * error);
 
 /**
  * Check if a given error matches the specified domain and code.
@@ -166,6 +165,6 @@ void sc_error_forward(struct sc_error **recipient, struct sc_error *error);
  * case. The domain cannot be NULL though.
  **/
 __attribute__((warn_unused_result))
-bool sc_error_match(struct sc_error *error, const char *domain, int code);
+bool sc_error_match(sc_error * error, const char *domain, int code);
 
 #endif

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -111,13 +111,13 @@ static void test_sc_is_hook_security_tag(void)
 
 static void test_sc_snap_or_instance_name_validate(gconstpointer data)
 {
-	typedef void (*validate_func_t)(const char *, struct sc_error **);
+	typedef void (*validate_func_t)(const char *, sc_error **);
 
 	validate_func_t validate = (validate_func_t) data;
 	bool is_instance =
 	    (validate == sc_instance_name_validate) ? true : false;
 
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 
 	// Smoke test, a valid snap name
 	validate("hello-world", &err);
@@ -267,7 +267,7 @@ static void test_sc_snap_name_validate__respects_error_protocol(void)
 
 static void test_sc_instance_name_validate(void)
 {
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 
 	sc_instance_name_validate("hello-world", &err);
 	g_assert_null(err);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -99,11 +99,11 @@ static int skip_one_char(const char **p, char c)
 }
 
 void sc_instance_name_validate(const char *instance_name,
-			       struct sc_error **errorp)
+			       sc_error **errorp)
 {
 	// NOTE: This function should be synchronized with the two other
 	// implementations: validate_instance_name and snap.ValidateInstanceName.
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 
 	// Ensure that name is not NULL
 	if (instance_name == NULL) {
@@ -143,11 +143,11 @@ void sc_instance_name_validate(const char *instance_name,
 }
 
 void sc_instance_key_validate(const char *instance_key,
-			      struct sc_error **errorp)
+			      sc_error **errorp)
 {
 	// NOTE: see snap.ValidateInstanceName for reference of a valid instance key
 	// format
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 
 	// Ensure that name is not NULL
 	if (instance_key == NULL) {
@@ -186,11 +186,11 @@ void sc_instance_key_validate(const char *instance_key,
 	sc_error_forward(errorp, err);
 }
 
-void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
+void sc_snap_name_validate(const char *snap_name, sc_error **errorp)
 {
 	// NOTE: This function should be synchronized with the two other
 	// implementations: validate_snap_name and snap.ValidateName.
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 
 	// Ensure that name is not NULL
 	if (snap_name == NULL) {

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -77,7 +77,7 @@ static void test_test_argc_argv(void)
 static void test_sc_nonfatal_parse_args__typical(void)
 {
 	// Test that typical invocation of snap-confine is parsed correctly.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -110,7 +110,7 @@ static void test_sc_nonfatal_parse_args__typical(void)
 static void test_sc_cleanup_args(void)
 {
 	// Check that NULL argument parser can be cleaned up
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args = NULL;
 	sc_cleanup_args(&args);
 
@@ -131,7 +131,7 @@ static void test_sc_cleanup_args(void)
 static void test_sc_nonfatal_parse_args__typical_classic(void)
 {
 	// Test that typical invocation of snap-confine is parsed correctly.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -166,7 +166,7 @@ static void test_sc_nonfatal_parse_args__ubuntu_core_launcher(void)
 	// Test that typical legacy invocation of snap-confine via the
 	// ubuntu-core-launcher symlink, with duplicated security tag, is parsed
 	// correctly.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -199,7 +199,7 @@ static void test_sc_nonfatal_parse_args__ubuntu_core_launcher(void)
 static void test_sc_nonfatal_parse_args__version(void)
 {
 	// Test that snap-confine --version is detected.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -229,7 +229,7 @@ static void test_sc_nonfatal_parse_args__version(void)
 static void test_sc_nonfatal_parse_args__evil_input(void)
 {
 	// Check that calling without any arguments is reported as error.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	// NULL argcp/argvp attack
@@ -269,7 +269,7 @@ static void test_sc_nonfatal_parse_args__evil_input(void)
 static void test_sc_nonfatal_parse_args__nothing_to_parse(void)
 {
 	// Check that calling without any arguments is reported as error.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -288,7 +288,7 @@ static void test_sc_nonfatal_parse_args__nothing_to_parse(void)
 static void test_sc_nonfatal_parse_args__no_security_tag(void)
 {
 	// Check that lack of security tag is reported as error.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -310,7 +310,7 @@ static void test_sc_nonfatal_parse_args__no_security_tag(void)
 static void test_sc_nonfatal_parse_args__no_executable(void)
 {
 	// Check that lack of security tag is reported as error.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -332,7 +332,7 @@ static void test_sc_nonfatal_parse_args__no_executable(void)
 static void test_sc_nonfatal_parse_args__unknown_option(void)
 {
 	// Check that unrecognized option switch is reported as error.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -379,7 +379,7 @@ static void test_sc_nonfatal_parse_args__forwards_error(void)
 static void test_sc_nonfatal_parse_args__base_snap(void)
 {
 	// Check that --base specifies the name of the base snap.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -407,7 +407,7 @@ static void test_sc_nonfatal_parse_args__base_snap(void)
 static void test_sc_nonfatal_parse_args__base_snap__missing_arg(void)
 {
 	// Check that --base specifies the name of the base snap.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
@@ -429,7 +429,7 @@ static void test_sc_nonfatal_parse_args__base_snap__missing_arg(void)
 static void test_sc_nonfatal_parse_args__base_snap__twice(void)
 {
 	// Check that --base specifies the name of the base snap.
-	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;

--- a/cmd/snap-confine/snap-confine-args.c
+++ b/cmd/snap-confine/snap-confine-args.c
@@ -37,10 +37,10 @@ struct sc_args {
 };
 
 struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
-				       struct sc_error **errorp)
+				       sc_error **errorp)
 {
 	struct sc_args *args = NULL;
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 
 	if (argcp == NULL || argvp == NULL) {
 		err = sc_error_init(SC_ARGS_DOMAIN, 0,

--- a/cmd/snap-confine/snap-confine-args.h
+++ b/cmd/snap-confine/snap-confine-args.h
@@ -66,7 +66,7 @@ struct sc_args;
  **/
 __attribute__((warn_unused_result))
 struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
-				       struct sc_error **errorp);
+				       sc_error **errorp);
 
 /**
  * Free the object describing command-line arguments to snap-confine.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -297,7 +297,7 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 int main(int argc, char **argv)
 {
 	// Use our super-defensive parser to figure out what we've been asked to do.
-	struct sc_error *err = NULL;
+	sc_error *err = NULL;
 	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 	sc_preserved_process_state proc_state
 	    SC_CLEANUP(sc_cleanup_preserved_process_state) = {
@@ -355,7 +355,7 @@ int main(int argc, char **argv)
 	char *snap_context SC_CLEANUP(sc_cleanup_string) = NULL;
 	// Do no get snap context value if running a hook (we don't want to overwrite hook's SNAP_COOKIE)
 	if (!sc_is_hook_security_tag(invocation.security_tag)) {
-		struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+		sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 		snap_context =
 		    sc_cookie_get_from_snapd(invocation.snap_instance, &err);
 		if (err != NULL) {

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
         snap_instance_name = argv[1];
     }
 
-    struct sc_error* err = NULL;
+    sc_error* err = NULL;
     sc_instance_name_validate(snap_instance_name, &err);
     sc_die_on_error(err);
 


### PR DESCRIPTION
Originally snap-confine's code used struct sc_foo { ... } rather than a typedef
because that allowed to use pointers to partially defined structures just fine.

Given that indent is very annoying to work with and that the structure approach
doesn't win us much (in theory it is good to allow structure to change without
having to recompile the whole application using it only via pointers), use a public
structure behind a typedef.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>