### PR TITLE
data/selinux: tweak the policy for runuser and s-c, interpret audit entries

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -329,7 +329,9 @@ allow snappy_t unconfined_t:file { open read };
 # snapd executes runuser to take snapshots of user's snap data
 allow snappy_t self:capability { setuid setgid };
 allow snappy_t self:process setsched;
-# runuser also logs to audit
+# runuser uses kernel keyring
+allow snappy_t self:key { search write };
+# runuser logs to audit
 logging_send_audit_msgs(snappy_t)
 
 ########################################
@@ -432,6 +434,7 @@ kernel_getattr_proc(snappy_confine_t)
 term_getattr_pty_fs(snappy_confine_t)
 # term_getattr_generic_ptys() is not supported by core policy in RHEL7
 allow snappy_confine_t devpts_t:chr_file getattr;
+term_search_ptys(snappy_confine_t)
 
 # because /run/snapd/ns/*.mnt gets a label of the process context
 allow snappy_confine_t unconfined_t:file getattr;

--- a/spread.yaml
+++ b/spread.yaml
@@ -407,9 +407,9 @@ debug-each: |
         case "$SPREAD_SYSTEM" in
             fedora-*|centos-*|amazon-*)
                 if [ -e "$RUNTIME_STATE_PATH/audit-stamp" ]; then
-                    ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" --start checkpoint || true
+                    ausearch -i -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" --start checkpoint || true
                 else
-                    ausearch -m AVC || true
+                    ausearch -i -m AVC || true
                 fi
                 (
                     find /root/snap -printf '%Z\t%H/%P\n' || true

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -499,7 +499,7 @@ prepare_suite_each() {
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*|amazon-*)
-            ausearch -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" || true
+            ausearch -i -m AVC --checkpoint "$RUNTIME_STATE_PATH/audit-stamp" || true
             ;;
     esac
 }

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -31,7 +31,7 @@ execute: |
     test-snapd-tools.cmd echo 'hello world'
     su -c 'test-snapd-tools.cmd echo hello world' test
     snap remove test-snapd-tools
-    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
 
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
@@ -42,15 +42,15 @@ execute: |
     # TODO: enable once there is a workaround for denials caused by journalctl
     # snap logs test-snapd-service
     snap remove test-snapd-service
-    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
 
     install_local test-snapd-layout
     test-snapd-layout.sh -c 'ls /'
     su -c "test-snapd-layout.sh -c 'ls /'" test
     snap remove test-snapd-layout
-    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
 
     install_local socket-activation
     [ -S /var/snap/socket-activation/common/socket ]
     snap remove socket-activation
-    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -20,7 +20,7 @@ restore: |
 
 execute: |
     snap install lxd
-    ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
 
     echo "Create a trivial container using the lxd snap"
     snap set lxd waitready.timeout=240


### PR DESCRIPTION
Allow runuser to use the kernel keyring, similar adjustments are already present
in the core policy for logrotate: https://access.redhat.com/solutions/1240253

Allow snap-confine to search devpts.

Also, allow interpretation of audit entries. Makes an entry like this:

```
time->Thu Apr 18 07:25:33 2019
type=PROCTITLE msg=audit(1555572333.539:193):
proctitle=2F7573722F7362696E2F72756E75736572002D75006775657374002D2D00746172002D2D637265617465002D2D737061727365002D2D677A6970002D2D6469726563746F7279002F686F6D652F67756573742F736E61702F746573742D736E6170642D746F6F6C732F003600636F6D6D6F6E

type=SYSCALL msg=audit(1555572333.539:193): arch=c000003e syscall=250
success=yes exit=0 a0=8 a1=fffffffc a2=fffffffd a3=0 items=0 ppid=22643
pid=23027 auid=4294967295 uid=1000 gid=1000 euid=0 suid=0 fsuid=0 egid=0 sgid=0
fsgid=0 tty=(none) ses=4294967295 comm="runuser" exe="/usr/sbin/runuser"
subj=system_u:system_r:snappy_t:s0 key=(null)

type=AVC msg=audit(1555572333.539:193): avc:  denied  { write } for  pid=23027
comm="runuser" scontext=system_u:system_r:snappy_t:s0
tcontext=system_u:system_r:snappy_t:s0 tclass=key permissive=1
```

be printed like so:
```
type=PROCTITLE msg=audit(04/18/2019 07:25:33.539:193) :
proctitle=/usr/sbin/runuser -u guest -- tar --create --sparse --gzip --directory /home/guest/snap/test-snapd-tools/ 6 common

type=SYSCALL msg=audit(04/18/2019 07:25:33.539:193) : arch=x86_64 syscall=keyctl
success=yes exit=0 a0=0x8 a1=0xfffffffc a2=0xfffffffd a3=0x0 items=0 ppid=22643
pid=23027 auid=unset uid=guest gid=guest euid=root suid=root fsuid=root
egid=root sgid=root fsgid=root tty=(none) ses=unset comm=runuser
exe=/usr/sbin/runuser subj=system_u:system_r:snappy_t:s0 key=(null)

type=AVC msg=audit(04/18/2019 07:25:33.539:193) : avc:  denied  { write } for
pid=23027 comm=runuser scontext=system_u:system_r:snappy_t:s0
tcontext=system_u:system_r:snappy_t:s0 tclass=key permissive=1
```
