### PR TITLE
cmd/libsnap: remove fringe error function

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -42,16 +42,6 @@ void die(const char *msg, ...)
 	exit(1);
 }
 
-bool error(const char *msg, ...)
-{
-	va_list va;
-	va_start(va, msg);
-	vfprintf(stderr, msg, va);
-	va_end(va);
-
-	return false;
-}
-
 struct sc_bool_name {
 	const char *text;
 	bool value;

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -25,9 +25,6 @@ __attribute__((noreturn))
 void die(const char *fmt, ...);
 
 __attribute__((format(printf, 1, 2)))
-bool error(const char *fmt, ...);
-
-__attribute__((format(printf, 1, 2)))
 void debug(const char *fmt, ...);
 
 /**

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -358,7 +358,13 @@ int main(int argc, char **argv)
 		sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 		snap_context =
 		    sc_cookie_get_from_snapd(invocation.snap_instance, &err);
-		/* The error is explicitly ignored because the cookies are optional. */
+		/* While the cookie is normally present due to various protection
+		 * mechanisms ensuring its creation from snapd, we are not considering
+		 * it a critical error for snap-confine in the case it is absent. When
+		 * absent snaps attempting to utilize snapctl to interact with snapd
+		 * will fail but it is more important to run a little than break
+		 * entirely in case snapd-side code is incorrect. Therefore error
+		 * information is collected but discarded. */
 	}
 
 	struct sc_apparmor apparmor;

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -358,9 +358,7 @@ int main(int argc, char **argv)
 		sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 		snap_context =
 		    sc_cookie_get_from_snapd(invocation.snap_instance, &err);
-		if (err != NULL) {
-			error("%s\n", sc_error_msg(err));
-		}
+		/* The error is explicitly ignored because the cookies are optional. */
 	}
 
 	struct sc_apparmor apparmor;


### PR DESCRIPTION
The codebase before snap-confine had a family of functions such as
debug, error and die. The error function simply printed a message to
stderr. We have exactly one use of that function:

        sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
        snap_context =
            sc_cookie_get_from_snapd(invocation.snap_instance, &err);
        if (err != NULL) {
            error("%s\n", sc_error_msg(err));
        }

When we cannot get a cookie from snapd, we print the error and carry on.
This is not really useful, the possible errors, apart from memory
allocation and I/O, are simply the absence of the cookie.

This code was originally written this way because ancient snapd was not
writing the cookies and, when upgrading, the previously fatal error
would prevent apps from running.

The error message is confusing and doesn't help: users cannot do
anything about it. As such, don't print the error at all.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
