### PR TITLE
overlord/snapstate: perform hard refresh check

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -464,8 +464,8 @@ func getTime(st *state.State, timeKey string) (time.Time, error) {
 // Internally the snap state is updated to remember when the inhibition first
 // took place. Apps can inhibit refreshes for up to "maxInhibition", beyond
 // that period the refresh will go ahead despite application activity.
-func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info) error {
-	if err := SoftNothingRunningRefreshCheck(info); err != nil {
+func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker func(*snap.Info) error) error {
+	if err := checker(info); err != nil {
 		now := time.Now()
 		if snapst.RefreshInhibitedTime == nil {
 			// Store the instant when the snap was first inhibited.

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -658,6 +658,13 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if experimentalRefreshAppAwareness {
+		// A process may be created after the soft refresh done upon
+		// the request to refresh a snap. If such process is alive by
+		// the time this code is reached the refresh process is stopped.
+		// In case of failure the snap state is modified to indicate
+		// when the refresh was first inhibited. If the first
+		// inhibition is outside of a grace period then refresh
+		// proceeds regardless of the existing processes.
 		if err := inhibitRefresh(st, snapst, oldInfo, HardNothingRunningRefreshCheck); err != nil {
 			return err
 		}

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -879,4 +880,67 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshInhibitedTime(c *C) {
 	err := snapstate.Get(s.state, "snap", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.RefreshInhibitedTime.Equal(instant), Equals, true)
+}
+
+func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheck(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness", true)
+	tr.Commit()
+
+	chg := s.testDoUnlinkSnapRefreshAwareness(c)
+
+	c.Check(chg.Err(), ErrorMatches, `(?ms).*^- some-change-descr \(snap "some-snap" has running apps \(some-app\)\).*`)
+}
+
+func (s *linkSnapSuite) TestDoUnlinkSnapRefreshHardCheckOff(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.testDoUnlinkSnapRefreshAwareness(c)
+
+	c.Check(chg.Err(), IsNil)
+}
+
+func (s *linkSnapSuite) testDoUnlinkSnapRefreshAwareness(c *C) *state.Change {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// mock that "some-snap" has an app and that this app has pids running
+	writePids(c, filepath.Join(dirs.PidsCgroupDir, "snap.some-snap.some-app"), []int{1234})
+	snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		info := &snap.Info{SuggestedName: name, SideInfo: *si, Type: snap.TypeApp}
+		info.Apps = map[string]*snap.AppInfo{
+			"some-app": {Snap: info, Name: "some-app"},
+		}
+		return info, nil
+	})
+
+	si1 := &snap.SideInfo{
+		RealName: "some-snap",
+		Revision: snap.R(1),
+	}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+		Active:   true,
+	})
+	t := s.state.NewTask("unlink-current-snap", "some-change-descr")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si1,
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	defer s.state.Lock()
+
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	return chg
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -136,7 +136,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if experimentalRefreshAppAwareness {
 			// Note that because we are modifying the snap state this block
 			// must be located after the conflict check done above.
-			if err := inhibitRefresh(st, snapst, info); err != nil {
+			if err := inhibitRefresh(st, snapst, info, SoftNothingRunningRefreshCheck); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
This early branch implements the hard refresh check. The hard check is done
after all services are stop and immediately before the current revision of a
snap is unlinked. After unlinking starting new applications or hooks is no
longer possible so this seems like the appropriate place.

There are no unit tests or spread tests yet. I will add those shortly.  The
patches were reviewed in private with Chipaca who confirmed that the location
of the check is correct.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
