### PR TITLE
tests: extend timeout of sbuild test

### DIFF
--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -3,6 +3,8 @@ summary: Ensure snapd builds correctly in sbuild
 # takes a while
 priority: 500
 
+kill-timeout: 30m
+
 systems: [debian-sid-*]
 
 execute: |


### PR DESCRIPTION
We see failures of the sbuild test sometimes, this PR extends
the kill timeout from the default spread 15m to 30min.
