### PR TITLE
tests: fix spaces issue in the base snaps names to remove during reset phase

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -125,7 +125,11 @@ reset_all_snap() {
                 fi
                 if ! echo "$SKIP_REMOVE_SNAPS" | grep -w "$snap"; then
                     if snap info "$snap" | grep -E '^type: +(base|core)'; then
-                        remove_bases="$remove_bases $snap"
+                        if [ -z "$remove_bases" ]; then
+                            remove_bases="$snap"
+                        else
+                            remove_bases="$remove_bases $snap"
+                        fi
                     else
                         snap remove "$snap"
                     fi

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -7,7 +7,6 @@ set -e -x
 # shellcheck source=tests/lib/state.sh
 . "$TESTSLIB/state.sh"
 
-
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB/systemd.sh"
 

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -2,25 +2,25 @@ summary: Check that the basic snapshots functionality is ok
 
 prepare: |
     snap install test-snapd-tools
-    snap install test-snapd-rsync
+    snap install --edge test-snapd-just-edge
 
 execute: |
     # use the snaps, so they create the dirs:
     test-snapd-tools.echo
-    test-snapd-rsync.rsync --version >/dev/null
+    test-snapd-just-edge.snap-name >/dev/null
     # drop in canaries:
-    for snap in test-snapd-tools test-snapd-rsync; do
+    for snap in test-snapd-tools test-snapd-just-edge; do
        echo "hello versioned $snap"  > ~/snap/$snap/current/canary.txt
        echo "hello common $snap" > ~/snap/$snap/common/canary.txt
     done
     # create snapshot, grab its id
-    SET_ID=$( snap save test-snapd-tools test-snapd-rsync | cut -d\  -f1 | tail -n1 )
+    SET_ID=$( snap save test-snapd-tools test-snapd-just-edge | cut -d\  -f1 | tail -n1 )
 
     # check it includes both snaps
     snap saved | MATCH test-snapd-tools
-    snap saved | MATCH test-snapd-rsync
+    snap saved | MATCH test-snapd-just-edge
     snap saved --id="$SET_ID" | grep test-snapd-tools
-    snap saved --id="$SET_ID" | grep test-snapd-rsync
+    snap saved --id="$SET_ID" | grep test-snapd-just-edge
     # and is valid
     snap check-snapshot "$SET_ID"
 
@@ -32,14 +32,14 @@ execute: |
     test -e ~/snap/test-snapd-tools/current/canary.txt
     test -e ~/snap/test-snapd-tools/common/canary.txt
     # it didn't restore the other one
-    test ! -e ~/snap/test-snapd-rsync/current/canary.txt
-    test ! -e ~/snap/test-snapd-rsync/common/canary.txt
+    test ! -e ~/snap/test-snapd-just-edge/current/canary.txt
+    test ! -e ~/snap/test-snapd-just-edge/common/canary.txt
 
     # restore the other
-    snap restore "$SET_ID" test-snapd-rsync
+    snap restore "$SET_ID" test-snapd-just-edge
 
     # now check everything's as we expect
-    for snap in test-snapd-tools test-snapd-rsync; do
+    for snap in test-snapd-tools test-snapd-just-edge; do
         test "$( cat ~/snap/$snap/current/canary.txt )" = "hello versioned $snap"
         test "$( cat ~/snap/$snap/common/canary.txt )" = "hello common $snap"
     done


### PR DESCRIPTION
This will prevent this error in reset.sh like this one:

```
+ snap remove ' core16'
snap " core16" is not installed
```

To reproduce the error execute:
`spread -debug -repeat 5
google:ubuntu-core-16-64:tests/main/core16-provided-by-core`
