### PR TITLE
snap: filter-out nil seed snaps

### DIFF
--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -68,6 +68,18 @@ func ReadSeedYaml(fn string) (*Seed, error) {
 		return nil, fmt.Errorf("cannot unmarshal %q: %s", yamlData, err)
 	}
 
+	// XXX: filter-out nil snaps
+	// For context see: https://bugs.launchpad.net/snapd/+bug/1825437
+	filtered := make([]*SeedSnap, 0, len(seed.Snaps))
+	for _, sn := range seed.Snaps {
+		if sn != nil {
+			filtered = append(filtered, sn)
+		}
+	}
+	if len(filtered) != len(seed.Snaps) {
+		seed.Snaps = filtered
+	}
+
 	// validate
 	for _, sn := range seed.Snaps {
 		if strings.Contains(sn.File, "/") {

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -68,8 +68,8 @@ func ReadSeedYaml(fn string) (*Seed, error) {
 		return nil, fmt.Errorf("cannot unmarshal %q: %s", yamlData, err)
 	}
 
-	// XXX: filter-out nil snaps
-	// For context see: https://bugs.launchpad.net/snapd/+bug/1825437
+	// Filter out nil entries. The Ubuntu 19.04 installer can sometimes create them
+	// See: https://bugs.launchpad.net/snapd/+bug/1825437
 	filtered := make([]*SeedSnap, 0, len(seed.Snaps))
 	for _, sn := range seed.Snaps {
 		if sn != nil {

--- a/snap/seed_yaml_test.go
+++ b/snap/seed_yaml_test.go
@@ -83,7 +83,10 @@ func (s *seedYamlTestSuite) TestNoPathAllowed(c *C) {
 }
 
 var nilSeedItemYaml = []byte(`
-snaps: [null]
+snaps:
+ - name: foo
+ -
+ - name: bar
 `)
 
 func (s *seedYamlTestSuite) TestNilItems(c *C) {
@@ -93,5 +96,5 @@ func (s *seedYamlTestSuite) TestNilItems(c *C) {
 
 	seed, err := snap.ReadSeedYaml(fn)
 	c.Assert(err, IsNil)
-	c.Assert(seed.Snaps, HasLen, 0)
+	c.Assert(seed.Snaps, HasLen, 2)
 }

--- a/snap/seed_yaml_test.go
+++ b/snap/seed_yaml_test.go
@@ -81,3 +81,17 @@ func (s *seedYamlTestSuite) TestNoPathAllowed(c *C) {
 	_, err = snap.ReadSeedYaml(fn)
 	c.Assert(err, ErrorMatches, `"foo/bar.snap" must be a filename, not a path`)
 }
+
+var nilSeedItemYaml = []byte(`
+snaps: [null]
+`)
+
+func (s *seedYamlTestSuite) TestNilItems(c *C) {
+	fn := filepath.Join(c.MkDir(), "seed.yaml")
+	err := ioutil.WriteFile(fn, nilSeedItemYaml, 0644)
+	c.Assert(err, IsNil)
+
+	seed, err := snap.ReadSeedYaml(fn)
+	c.Assert(err, IsNil)
+	c.Assert(seed.Snaps, HasLen, 0)
+}


### PR DESCRIPTION
We're seeing errors from fresh Ubuntu 19.04 installs where
snapd panics on a nil pointer:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x55675388c716]
    goroutine 38 [running]:
    github.com/snapcore/snapd/snap.ReadSeedYaml(0xc4207640c0, 0x1d, 0x1, 0xc4207640c0, 0x1d)
            github.com/snapcore/snapd/snap/seed_yaml.go:73 +0x236
    github.com/snapcore/snapd/overlord/devicestate.populateStateFromSeedImpl(0xc4200f3f80, 0x556753afe9ee, 0x4, 0x556753d5b700, 0xc4203bbb7f, 0x556753e9f3c0)
            github.com/snapcore/snapd/overlord/devicestate/firstboot.go:110 +0x24f
    github.com/snapcore/snapd/overlord/devicestate.(*DeviceManager).ensureSeedYaml(0xc4203685f0, 0x0, 0x0)
            github.com/snapcore/snapd/overlord/devicestate/devicemgr.go:354 +0x190
    github.com/snapcore/snapd/overlord/devicestate.(*DeviceManager).Ensure(0xc4203685f0, 0x0, 0x0)
            github.com/snapcore/snapd/overlord/devicestate/devicemgr.go:465 +0x42
    github.com/snapcore/snapd/overlord.(*StateEngine).Ensure(0xc4202fee10, 0x0, 0x0)
            github.com/snapcore/snapd/overlord/stateengine.go:100 +0x10b
    github.com/snapcore/snapd/overlord.(*Overlord).Loop.func1(0x0, 0x0)
            github.com/snapcore/snapd/overlord/overlord.go:290 +0x5e
    github.com/snapcore/snapd/vendor/gopkg.in/tomb%2ev2.(*Tomb).run(0xc4202dc320, 0xc4203d40f0)
            github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x2d
    created by github.com/snapcore/snapd/vendor/gopkg.in/tomb%2ev2.(*Tomb).Go
            github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0xbb

The only possible way to panic there if the SeedSnap pointer is nil,
that is, if reading /var/lib/snapd/seed/seed.yaml gives us an element
that is nil (a list containing a nil pointer).

This patch filters out such entries until we know more about the
problem.

Fixes: https://bugs.launchpad.net/snapd/+bug/1825437
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
