### PR TITLE
cmd/snap-update-ns: move Assumption to {System,User}ProfileUpdate

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -207,6 +207,10 @@ func (as *Assumptions) CanWriteToDirectory(dirFd int, dirName string) (bool, err
 	return as.canWriteToDirectory(dirFd, dirName)
 }
 
+func (as *Assumptions) UnrestrictedPaths() []string {
+	return as.unrestrictedPaths
+}
+
 func (ctx *CommonProfileUpdateContext) CurrentProfilePath() string {
 	return ctx.currentProfilePath
 }

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -43,8 +43,42 @@ func NewSystemProfileUpdateContext(instanceName string) *SystemProfileUpdateCont
 	}}
 }
 
+// Assumptions returns information about file system mutability rules.
+//
+// System mount profiles can write to /tmp (this is required for constructing
+// writable mimics) to /var/snap (where $SNAP_DATA is for services), /snap/$SNAP_NAME,
+// and, in case of instances, /snap/$SNAP_INSTANCE_NAME.
+func (ctx *SystemProfileUpdateContext) Assumptions() *Assumptions {
+	// Allow creating directories related to this snap name.
+	//
+	// Note that we allow /var/snap instead of /var/snap/$SNAP_NAME because
+	// content interface connections can readily create missing mount points on
+	// both sides of the interface connection.
+	//
+	// We scope /snap/$SNAP_NAME because only one side of the connection can be
+	// created, as snaps are read-only, the mimic construction will kick-in and
+	// create the missing directory but this directory is only visible from the
+	// snap that we are operating on (either plug or slot side, the point is,
+	// the mount point is not universally visible).
+	//
+	// /snap/$SNAP_NAME needs to be there as the code that creates such mount
+	// points must traverse writable host filesystem that contains /snap/*/ and
+	// normally such access is off-limits. This approach allows /snap/foo
+	// without allowing /snap/bin, for example.
+	//
+	// /snap/$SNAP_INSTANCE_NAME and /snap/$SNAP_NAME are added to allow
+	// remapping for parallel installs only when the snap has an instance key
+	as := &Assumptions{}
+	instanceName := ctx.InstanceName()
+	as.AddUnrestrictedPaths("/tmp", "/var/snap", "/snap/"+instanceName)
+	if snapName := snap.InstanceSnap(instanceName); snapName != instanceName {
+		as.AddUnrestrictedPaths("/snap/" + snapName)
+	}
+	return as
+}
+
 func applySystemFstab(instanceName string, fromSnapConfine bool) error {
-	upCtx := NewSystemProfileUpdateContext(instanceName)
+	ctx := NewSystemProfileUpdateContext(instanceName)
 
 	// Lock the mount namespace so that any concurrently attempted invocations
 	// of snap-confine are synchronized and will see consistent state.
@@ -85,31 +119,8 @@ func applySystemFstab(instanceName string, fromSnapConfine bool) error {
 		thawSnapProcesses(instanceName)
 	}()
 
-	// Allow creating directories related to this snap name.
-	//
-	// Note that we allow /var/snap instead of /var/snap/$SNAP_NAME because
-	// content interface connections can readily create missing mount points on
-	// both sides of the interface connection.
-	//
-	// We scope /snap/$SNAP_NAME because only one side of the connection can be
-	// created, as snaps are read-only, the mimic construction will kick-in and
-	// create the missing directory but this directory is only visible from the
-	// snap that we are operating on (either plug or slot side, the point is,
-	// the mount point is not universally visible).
-	//
-	// /snap/$SNAP_NAME needs to be there as the code that creates such mount
-	// points must traverse writable host filesystem that contains /snap/*/ and
-	// normally such access is off-limits. This approach allows /snap/foo
-	// without allowing /snap/bin, for example.
-	//
-	// /snap/$SNAP_INSTANCE_NAME and /snap/$SNAP_NAME are added to allow
-	// remapping for parallel installs only when the snap has an instance key
-	as := &Assumptions{}
-	as.AddUnrestrictedPaths("/tmp", "/var/snap", "/snap/"+instanceName)
-	if snapName := snap.InstanceSnap(instanceName); snapName != instanceName {
-		as.AddUnrestrictedPaths("/snap/" + snapName)
-	}
-	return computeAndSaveSystemChanges(upCtx, instanceName, as)
+	as := ctx.Assumptions()
+	return computeAndSaveSystemChanges(ctx, instanceName, as)
 }
 
 func computeAndSaveSystemChanges(upCtx MountProfileUpdateContext, snapName string, as *Assumptions) error {

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -37,6 +37,18 @@ type systemSuite struct{}
 
 var _ = Suite(&systemSuite{})
 
+func (s *systemSuite) TestAssumptions(c *C) {
+	// Non-instances can access /tmp, /var/snap and /snap/$SNAP_NAME
+	ctx := update.NewSystemProfileUpdateContext("foo")
+	as := ctx.Assumptions()
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo"})
+
+	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
+	ctx = update.NewSystemProfileUpdateContext("foo_instance")
+	as = ctx.Assumptions()
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/snap/foo"})
+}
+
 func (s *systemSuite) TestLoadDesiredProfile(c *C) {
 	// Mock directories.
 	dirs.SetRootDir(c.MkDir())

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -47,6 +47,17 @@ func NewUserProfileUpdateContext(instanceName string, uid int) *UserProfileUpdat
 	}
 }
 
+// Assumptions returns information about file system mutability rules.
+func (ctx *UserProfileUpdateContext) Assumptions() *Assumptions {
+	// TODO: configure the secure helper and inform it about directories that
+	// can be created without trespassing.
+	as := &Assumptions{}
+	// TODO: Handle /home/*/snap/* when we do per-user mount namespaces and
+	// allow defining layout items that refer to SNAP_USER_DATA and
+	// SNAP_USER_COMMON.
+	return as
+}
+
 // LoadDesiredProfile loads the desired, per-user mount profile, expanding user-specific variables.
 func (ctx *UserProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
 	profile, err := ctx.CommonProfileUpdateContext.LoadDesiredProfile()
@@ -67,13 +78,7 @@ func applyUserFstab(snapName string) error {
 		return fmt.Errorf("cannot load desired user mount profile of snap %q: %s", snapName, err)
 	}
 	debugShowProfile(desired, "desired mount profile")
-
-	// TODO: configure the secure helper and inform it about directories that
-	// can be created without trespassing.
-	as := &Assumptions{}
-	// TODO: Handle /home/*/snap/* when we do per-user mount namespaces and
-	// allow defining layout items that refer to SNAP_USER_DATA and
-	// SNAP_USER_COMMON.
+	as := ctx.Assumptions()
 	_, err = applyProfile(ctx, snapName, &osutil.MountProfile{}, desired, as)
 	return err
 }

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -35,6 +35,12 @@ type userSuite struct{}
 
 var _ = Suite(&userSuite{})
 
+func (s *userSuite) TestAssumptions(c *C) {
+	ctx := update.NewUserProfileUpdateContext("foo", 1234)
+	as := ctx.Assumptions()
+	c.Check(as.UnrestrictedPaths(), IsNil)
+}
+
 func (s *userSuite) TestLoadDesiredProfile(c *C) {
 	// Mock directories but to simplify testing use the real value for XDG.
 	dirs.SetRootDir(c.MkDir())


### PR DESCRIPTION
The common implementation has been removed, replacing it with the
two existing implementations, now graduated to proper methods, with
tests and basic documentation.

The new logic is immediately used.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
