### PR TITLE
cmd/snap-update-ns: move locking to the common layer

### DIFF
--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -22,12 +22,19 @@ package main
 import (
 	"fmt"
 
+	"github.com/snapcore/snapd/cmd/snaplock"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 )
 
 type CommonProfileUpdateContext struct {
 	// instanceName is the name of the snap instance to update.
 	instanceName string
+
+	// fromSnapConfine indicates that the update is triggered by snap-confine
+	// and not from snapd. When set, snap-confine is still constructing the user
+	// mount namespace and is delegating mount profile application to snap-update-ns.
+	fromSnapConfine bool
 
 	currentProfilePath string
 	desiredProfilePath string
@@ -38,8 +45,52 @@ func (ctx *CommonProfileUpdateContext) InstanceName() string {
 	return ctx.instanceName
 }
 
-func (ctx *CommonProfileUpdateContext) Lock() (unlock func(), err error) {
-	return func() {}, nil
+// Lock acquires locks / freezes needed to synchronize mount namespace changes.
+func (ctx *CommonProfileUpdateContext) Lock() (func(), error) {
+	instanceName := ctx.instanceName
+
+	// Lock the mount namespace so that any concurrently attempted invocations
+	// of snap-confine are synchronized and will see consistent state.
+	lock, err := snaplock.OpenLock(instanceName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open lock file for mount namespace of snap %q: %s", instanceName, err)
+	}
+
+	logger.Debugf("locking mount namespace of snap %q", instanceName)
+	if ctx.fromSnapConfine {
+		// When --from-snap-confine is passed then we just ensure that the
+		// namespace is locked. This is used by snap-confine to use
+		// snap-update-ns to apply mount profiles.
+		if err := lock.TryLock(); err != osutil.ErrAlreadyLocked {
+			// If we managed to grab the lock we should drop it.
+			lock.Close()
+			return nil, fmt.Errorf("mount namespace of snap %q is not locked but --from-snap-confine was used", instanceName)
+		}
+	} else {
+		if err := lock.Lock(); err != nil {
+			return nil, fmt.Errorf("cannot lock mount namespace of snap %q: %s", instanceName, err)
+		}
+	}
+
+	// Freeze the mount namespace and unfreeze it later. This lets us perform
+	// modifications without snap processes attempting to construct
+	// symlinks or perform other malicious activity (such as attempting to
+	// introduce a symlink that would cause us to mount something other
+	// than what we expected).
+	logger.Debugf("freezing processes of snap %q", instanceName)
+	if err := freezeSnapProcesses(instanceName); err != nil {
+		// If we cannot freeze the processes we should drop the lock.
+		lock.Close()
+		return nil, err
+	}
+
+	unlock := func() {
+		logger.Debugf("unlocking mount namespace of snap %q", instanceName)
+		lock.Close()
+		logger.Debugf("thawing processes of snap %q", instanceName)
+		thawSnapProcesses(instanceName)
+	}
+	return unlock, nil
 }
 
 func (ctx *CommonProfileUpdateContext) Assumptions() *Assumptions {

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -28,6 +28,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/cmd/snaplock"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -41,13 +43,66 @@ var _ = Suite(&commonSuite{})
 
 func (s *commonSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
-	s.ctx = update.NewCommonProfileUpdateContext("foo",
+	s.ctx = update.NewCommonProfileUpdateContext("foo", false,
 		filepath.Join(s.dir, "current.fstab"),
 		filepath.Join(s.dir, "desired.fstab"))
 }
 
 func (s *commonSuite) TestInstanceName(c *C) {
 	c.Check(s.ctx.InstanceName(), Equals, "foo")
+}
+
+func (s *commonSuite) TestLock(c *C) {
+	// Mock away real freezer code, allowing test code to return an error when freezing.
+	var freezingError error
+	restore := update.MockFreezing(func(string) error { return freezingError }, func(string) error { return nil })
+	defer restore()
+	// Mock system directories, we use the lock directory.
+	dirs.SetRootDir(s.dir)
+	defer dirs.SetRootDir("")
+
+	// We will use 2nd lock for our testing.
+	testLock, err := snaplock.OpenLock(s.ctx.InstanceName())
+	c.Assert(err, IsNil)
+	defer testLock.Close()
+
+	// When fromSnapConfine is false we acquire our own lock.
+	s.ctx.SetFromSnapConfine(false)
+	c.Check(s.ctx.FromSnapConfine(), Equals, false)
+	unlock, err := s.ctx.Lock()
+	c.Assert(err, IsNil)
+	// The lock is acquired now. We should not be able to get another lock.
+	c.Check(testLock.TryLock(), Equals, osutil.ErrAlreadyLocked)
+	// We can release the original lock now and see our test lock working.
+	unlock()
+	c.Assert(testLock.TryLock(), IsNil)
+
+	// When fromSnapConfine is true we test existing lock but don't grab one.
+	s.ctx.SetFromSnapConfine(true)
+	c.Check(s.ctx.FromSnapConfine(), Equals, true)
+	err = testLock.Lock()
+	c.Assert(err, IsNil)
+	unlock, err = s.ctx.Lock()
+	c.Assert(err, IsNil)
+	unlock()
+
+	// When the test lock is unlocked the common update helper reports an error
+	// since it was expecting the lock to be held. Oh, and the lock is not leaked.
+	testLock.Unlock()
+	unlock, err = s.ctx.Lock()
+	c.Check(err, ErrorMatches, `mount namespace of snap "foo" is not locked but --from-snap-confine was used`)
+	c.Check(unlock, IsNil)
+	c.Assert(testLock.TryLock(), IsNil)
+
+	// When freezing fails the lock acquired internally is not leaked.
+	freezingError = errTesting
+	s.ctx.SetFromSnapConfine(false)
+	c.Check(s.ctx.FromSnapConfine(), Equals, false)
+	testLock.Unlock()
+	unlock, err = s.ctx.Lock()
+	c.Check(err, Equals, errTesting)
+	c.Check(unlock, IsNil)
+	c.Check(testLock.TryLock(), IsNil)
 }
 
 func (s *commonSuite) TestLoadDesiredProfile(c *C) {

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -219,9 +219,18 @@ func (ctx *CommonProfileUpdateContext) DesiredProfilePath() string {
 	return ctx.desiredProfilePath
 }
 
-func NewCommonProfileUpdateContext(instanceName string, currentProfilePath, desiredProfilePath string) *CommonProfileUpdateContext {
+func (ctx *CommonProfileUpdateContext) FromSnapConfine() bool {
+	return ctx.fromSnapConfine
+}
+
+func (ctx *CommonProfileUpdateContext) SetFromSnapConfine(v bool) {
+	ctx.fromSnapConfine = v
+}
+
+func NewCommonProfileUpdateContext(instanceName string, fromSnapConfine bool, currentProfilePath, desiredProfilePath string) *CommonProfileUpdateContext {
 	return &CommonProfileUpdateContext{
 		instanceName:       instanceName,
+		fromSnapConfine:    fromSnapConfine,
 		currentProfilePath: currentProfilePath,
 		desiredProfilePath: desiredProfilePath,
 	}

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -79,7 +79,7 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	ctx := update.NewSystemProfileUpdateContext(snapName)
+	ctx := update.NewSystemProfileUpdateContext(snapName, false)
 	err = update.ComputeAndSaveSystemChanges(ctx, snapName, s.as)
 	c.Assert(err, IsNil)
 
@@ -147,7 +147,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	ctx := update.NewSystemProfileUpdateContext(snapName)
+	ctx := update.NewSystemProfileUpdateContext(snapName, false)
 	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
@@ -225,7 +225,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	ctx := update.NewSystemProfileUpdateContext(snapName)
+	ctx := update.NewSystemProfileUpdateContext(snapName, false)
 	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
@@ -268,7 +268,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	ctx := update.NewSystemProfileUpdateContext(snapName)
+	ctx := update.NewSystemProfileUpdateContext(snapName, false)
 	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
@@ -311,7 +311,7 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	ctx := update.NewSystemProfileUpdateContext(snapName)
+	ctx := update.NewSystemProfileUpdateContext(snapName, false)
 	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, nil), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
@@ -355,7 +355,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	defer restore()
 
 	// The error was ignored, and no mount was recorded in the profile
-	ctx := update.NewSystemProfileUpdateContext(snapName)
+	ctx := update.NewSystemProfileUpdateContext(snapName, false)
 	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -22,10 +22,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/cmd/snaplock"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -35,9 +33,10 @@ type SystemProfileUpdateContext struct {
 }
 
 // NewSystemProfileUpdateContext returns encapsulated information for performing a per-user mount namespace update.
-func NewSystemProfileUpdateContext(instanceName string) *SystemProfileUpdateContext {
+func NewSystemProfileUpdateContext(instanceName string, fromSnapConfine bool) *SystemProfileUpdateContext {
 	return &SystemProfileUpdateContext{CommonProfileUpdateContext: CommonProfileUpdateContext{
 		instanceName:       instanceName,
+		fromSnapConfine:    fromSnapConfine,
 		currentProfilePath: currentSystemProfilePath(instanceName),
 		desiredProfilePath: desiredSystemProfilePath(instanceName),
 	}}
@@ -78,46 +77,12 @@ func (ctx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 }
 
 func applySystemFstab(instanceName string, fromSnapConfine bool) error {
-	ctx := NewSystemProfileUpdateContext(instanceName)
-
-	// Lock the mount namespace so that any concurrently attempted invocations
-	// of snap-confine are synchronized and will see consistent state.
-	lock, err := snaplock.OpenLock(instanceName)
+	ctx := NewSystemProfileUpdateContext(instanceName, fromSnapConfine)
+	unlock, err := ctx.Lock()
 	if err != nil {
-		return fmt.Errorf("cannot open lock file for mount namespace of snap %q: %s", instanceName, err)
-	}
-	defer func() {
-		logger.Debugf("unlocking mount namespace of snap %q", instanceName)
-		lock.Close()
-	}()
-
-	logger.Debugf("locking mount namespace of snap %q", instanceName)
-	if fromSnapConfine {
-		// When --from-snap-confine is passed then we just ensure that the
-		// namespace is locked. This is used by snap-confine to use
-		// snap-update-ns to apply mount profiles.
-		if err := lock.TryLock(); err != osutil.ErrAlreadyLocked {
-			return fmt.Errorf("mount namespace of snap %q is not locked but --from-snap-confine was used", instanceName)
-		}
-	} else {
-		if err := lock.Lock(); err != nil {
-			return fmt.Errorf("cannot lock mount namespace of snap %q: %s", instanceName, err)
-		}
-	}
-
-	// Freeze the mount namespace and unfreeze it later. This lets us perform
-	// modifications without snap processes attempting to construct
-	// symlinks or perform other malicious activity (such as attempting to
-	// introduce a symlink that would cause us to mount something other
-	// than what we expected).
-	logger.Debugf("freezing processes of snap %q", instanceName)
-	if err := freezeSnapProcesses(instanceName); err != nil {
 		return err
 	}
-	defer func() {
-		logger.Debugf("thawing processes of snap %q", instanceName)
-		thawSnapProcesses(instanceName)
-	}()
+	defer unlock()
 
 	as := ctx.Assumptions()
 	return computeAndSaveSystemChanges(ctx, instanceName, as)

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -37,14 +37,25 @@ type systemSuite struct{}
 
 var _ = Suite(&systemSuite{})
 
+func (s *systemSuite) TestLock(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	ctx := update.NewSystemProfileUpdateContext("foo", false)
+	unlock, err := ctx.Lock()
+	c.Assert(err, IsNil)
+	c.Check(unlock, NotNil)
+	unlock()
+}
+
 func (s *systemSuite) TestAssumptions(c *C) {
 	// Non-instances can access /tmp, /var/snap and /snap/$SNAP_NAME
-	ctx := update.NewSystemProfileUpdateContext("foo")
+	ctx := update.NewSystemProfileUpdateContext("foo", false)
 	as := ctx.Assumptions()
 	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo"})
 
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
-	ctx = update.NewSystemProfileUpdateContext("foo_instance")
+	ctx = update.NewSystemProfileUpdateContext("foo_instance", false)
 	as = ctx.Assumptions()
 	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/snap/foo"})
 }
@@ -54,7 +65,7 @@ func (s *systemSuite) TestLoadDesiredProfile(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	ctx := update.NewSystemProfileUpdateContext("foo")
+	ctx := update.NewSystemProfileUpdateContext("foo", false)
 	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
 
 	// Write a desired system mount profile for snap "foo".
@@ -76,7 +87,7 @@ func (s *systemSuite) TestLoadCurrentProfile(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	ctx := update.NewSystemProfileUpdateContext("foo")
+	ctx := update.NewSystemProfileUpdateContext("foo", false)
 	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
 
 	// Write a current system mount profile for snap "foo".
@@ -100,7 +111,7 @@ func (s *systemSuite) TestSaveCurrentProfile(c *C) {
 	defer dirs.SetRootDir("/")
 	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
 
-	ctx := update.NewSystemProfileUpdateContext("foo")
+	ctx := update.NewSystemProfileUpdateContext("foo", false)
 	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
 
 	// Prepare a mount profile to be saved.

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -35,8 +35,22 @@ type userSuite struct{}
 
 var _ = Suite(&userSuite{})
 
+func (s *userSuite) TestLock(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
+
+	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+
+	// Locking is a no-op.
+	unlock, err := ctx.Lock()
+	c.Assert(err, IsNil)
+	c.Check(unlock, NotNil)
+	unlock()
+}
+
 func (s *userSuite) TestAssumptions(c *C) {
-	ctx := update.NewUserProfileUpdateContext("foo", 1234)
+	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
 	as := ctx.Assumptions()
 	c.Check(as.UnrestrictedPaths(), IsNil)
 }
@@ -47,7 +61,7 @@ func (s *userSuite) TestLoadDesiredProfile(c *C) {
 	defer dirs.SetRootDir("/")
 	dirs.XdgRuntimeDirBase = "/run/user"
 
-	ctx := update.NewUserProfileUpdateContext("foo", 1234)
+	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
 
 	input := "$XDG_RUNTIME_DIR/doc/by-app/snap.foo $XDG_RUNTIME_DIR/doc none bind,rw 0 0\n"
 	output := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"


### PR DESCRIPTION
The locking was, so far, only performed for system-wide updates.
This property is retained since this is simply a refactoring at this
stage. Locking is now fully tested and documented.

The common layer is now aware if snap-update-ns is invoked from
snap-confine or from snapd. When invoked from snapd locking is handled
entirely by snap-update-ns. When invoked from snap-confine (during
the namespace bootstrap process) locking is verified. In both cases
the snap processes are frozen.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>