### PR TITLE
cmd/snap-confine: move privs handling code one file

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -239,6 +239,8 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/snap-confine-args.h \
 	snap-confine/snap-confine-invocation.c \
 	snap-confine/snap-confine-invocation.h \
+	snap-confine/snap-confine-privs.c \
+	snap-confine/snap-confine-privs.h \
 	snap-confine/snap-confine.c \
 	snap-confine/udev-support.c \
 	snap-confine/udev-support.h \

--- a/cmd/snap-confine/snap-confine-privs.c
+++ b/cmd/snap-confine/snap-confine-privs.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "snap-confine-privs.h"
+
+#include <unistd.h>
+
+#include "../libsnap-confine-private/utils.h"
+
+void sc_main_change_to_real_gid(gid_t effective_gid, gid_t real_gid)
+{
+	if (effective_gid == 0 && real_gid != 0) {
+		if (setegid(real_gid) != 0) {
+			die("cannot set effective group id to %d", real_gid);
+		}
+	}
+}
+
+void sc_main_temporarily_drop_to_user(uid_t real_uid, gid_t real_gid)
+{
+		if (setegid(real_gid) != 0)
+			die("setegid failed");
+		if (seteuid(real_uid) != 0)
+			die("seteuid failed");
+
+		if (real_gid != 0 && geteuid() == 0)
+			die("dropping privs did not work");
+		if (real_uid != 0 && getegid() == 0)
+			die("dropping privs did not work");
+}
+
+void sc_main_temporarily_raise_to_root_gid(gid_t saved_gid)
+{
+	if (getegid() != 0 && saved_gid == 0) {
+		// Temporarily raise egid so we can chown the freezer cgroup under LXD.
+		if (setegid(0) != 0) {
+			die("cannot set effective group id to root");
+		}
+	}
+}
+
+void sc_main_temporarily_drop_from_root_gid(gid_t real_gid)
+{
+	if (geteuid() == 0 && real_gid != 0) {
+		if (setegid(real_gid) != 0) {
+			die("cannot set effective group id to %d", real_gid);
+		}
+	}
+}
+
+void sc_udev_raise_to_root_uid(void)
+{
+		uid_t real_uid, effective_uid, saved_uid;
+		if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0)
+			die("cannot get real, effective and saved user IDs");
+		// can't update the cgroup unless the real_uid is 0, euid as
+		// 0 is not enough
+		if (real_uid != 0 && effective_uid == 0)
+			if (setuid(0) != 0)
+				die("cannot set user ID to zero");
+}
+
+void sc_seccomp_temporarily_raise_to_root_uid(uid_t saved_uid, uid_t effective_uid)
+{
+	if (effective_uid != 0 && saved_uid == 0) {
+		if (seteuid(0) != 0) {
+			die("seteuid failed");
+		}
+		if (geteuid() != 0) {
+			die("raising privs before seccomp_load did not work");
+		}
+	}
+}
+
+void sc_seccomp_temporarily_drop_from_root_uid(void)
+{
+	if (geteuid() == 0) {
+		unsigned real_uid = getuid();
+		if (seteuid(real_uid) != 0) {
+			die("seteuid failed");
+		}
+		if (real_uid != 0 && geteuid() == 0) {
+			die("dropping privs after seccomp_load did not work");
+		}
+	}
+}
+
+void sc_main_permanently_drop_to_user(uid_t real_uid, gid_t real_gid)
+{
+	if (geteuid() == 0) {
+		// Note that we do not call setgroups() here because its ok
+		// that the user keeps the groups he already belongs to
+		if (setgid(real_gid) != 0)
+			die("setgid failed");
+		if (setuid(real_uid) != 0)
+			die("setuid failed");
+
+		if (real_gid != 0 && (getuid() == 0 || geteuid() == 0))
+			die("permanently dropping privs did not work");
+		if (real_uid != 0 && (getgid() == 0 || getegid() == 0))
+			die("permanently dropping privs did not work");
+	}
+
+}

--- a/cmd/snap-confine/snap-confine-privs.h
+++ b/cmd/snap-confine/snap-confine-privs.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SC_SNAP_CONFINE_PRIVS_H
+#define SC_SNAP_CONFINE_PRIVS_H
+
+/* This header is included from various places so we need to check if they have
+ * already defined _GNU_SOURCE. We're defining it because the corresponding C
+ * source file includes <unistd.h> to get getresuid(2) but apparently merely
+ * including <sys/types.h> here, without defining _GNU_SOURCE messes up
+ * internal glibc headers enough that future definition of _GNU_SOURCE followed
+ * by the inclusion of <unistd.h> doesn't define the required function. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <unistd.h>
+
+#include <sys/types.h>
+
+/**
+ * sc_main_change_to_real_gid switches effective group ID to real ID.
+ *
+ * This reduces the surface area of snap-confine that runs with the root group
+ * ID. This feature was done after snap-confine became set-group-id executable.
+ **/
+void sc_main_change_to_real_gid(gid_t effective_gid, gid_t real_gid);
+
+/**
+ * sc_main_temporarily_drop_to_user switches effective group and user IDs.
+ *
+ * The switch "lowers" permissions to that of the user calling snap-confine.
+ * The permissions can be re-raised to perform privileged operations.
+ **/
+void sc_main_temporarily_drop_to_user(uid_t real_uid, gid_t real_gid);
+
+/**
+ * sc_main_temporarily_raise_to_root_gid raises effective group ID to root.
+ *
+ * This function needs to exist because bulk of snap-confine executes as the
+ * real group ID.  Once sc_main_change_to_real_gid is removed this function and
+ * the undo counterpart sc_main_temporarily_drop_from_root_gid can be removed.
+ **/
+void sc_main_temporarily_raise_to_root_gid(gid_t saved_gid);
+
+/**
+ * sc_main_temporarily_drop_from_root_gid drops effective group ID to real ID.
+ *
+ * The only purpose of this function is to undo changes made by
+ * sc_main_temporarily_raise_to_root_gid.
+ **/
+void sc_main_temporarily_drop_from_root_gid(gid_t real_gid);
+
+/**
+ * sc_udev_raise_to_root_uid sets real user ID to root.
+ *
+ * This function is used prior to executing snap-device-helper from a forked
+ * process. It only exists to ensure that the helper shell script runs as the
+ * real root user. This is required to manipulate cgroups.
+ **/
+void sc_udev_raise_to_root_uid(void);
+
+/**
+ * sc_seccomp_temporarily_raise_to_root_uid raises effective user ID to root.
+ *
+ * This function needs to exist because sc_apply_seccomp_filter, which is
+ * called by sc_apply_seccomp_profile_for_security_tag and by
+ * sc_apply_global_seccomp_profile are both executed after
+ * sc_main_temporarily_drop_to_user.
+ *
+ *  Once the call sequence is adjusted so that that part of snap-confine
+ *  executes as root the pair of functions (along with
+ *  sc_seccomp_temporarily_raise_to_root_uid) can be discarded.
+ **/
+void sc_seccomp_temporarily_raise_to_root_uid(uid_t saved_uid, uid_t effective_uid);
+
+/**
+ * sc_main_temporarily_drop_from_root_uid drops effective user ID to real ID.
+ *
+ * The only purpose of this function is to undo changes made by
+ * sc_main_temporarily_raise_to_root_uid.
+ **/
+void sc_seccomp_temporarily_drop_from_root_uid(void);
+
+/**
+ * sc_main_permanently_drop_to_user switches to given user and group.
+ *
+ * The switch is permanent because we set effective, real and saved the ID.
+ * After this call snap-confine can no longer perform privileged operations.
+ **/
+void sc_main_permanently_drop_to_user(uid_t real_uid, gid_t real_gid);
+
+#endif

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -30,6 +30,7 @@
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
+#include "snap-confine-privs.h"
 #include "udev-support.h"
 
 static void
@@ -42,14 +43,7 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 		die("cannot fork support process for device cgroup assignment");
 	}
 	if (pid == 0) {
-		uid_t real_uid, effective_uid, saved_uid;
-		if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0)
-			die("cannot get real, effective and saved user IDs");
-		// can't update the cgroup unless the real_uid is 0, euid as
-		// 0 is not enough
-		if (real_uid != 0 && effective_uid == 0)
-			if (setuid(0) != 0)
-				die("cannot set user ID to zero");
+		sc_udev_raise_to_root_uid();
 		char buf[64] = { 0 };
 		// pass snappy-add-dev an empty environment so the
 		// user-controlled environment can't be used to subvert


### PR DESCRIPTION
Internally snap-confine has a number of places where is temporarily
drops permissions, raises permissions and finally drops them
permanently. As I'm about to refactor that so that it participates with
the preserved-process-state system but since it's a bit complex I
thought it would help to bring it under one place for easier analysis of
the upcoming changes.

This patch adds snap-confine-privs.c with a functions containing
fragments of each of the user and group ID handling parts of snap
confine. The new functions are named after the place they were extracted
from and documented to the best of my understanding. I'm honestly doing
this to wrap *my* head around it completely and have fewer surprises
later.

The new file is temporary, once the preserved process state refactoring
is merged it can be removed as it should become empty.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
