### PR TITLE
spread.yaml: add qemu:centos-7-64

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -201,6 +201,9 @@ backends:
             - fedora-28-64:
                 username: fedora
                 password: fedora
+            - centos-7-64:
+                username: centos
+                password: centos
     autopkgtest:
         type: adhoc
         allocate: |


### PR DESCRIPTION
By going to https://cloud.centos.org/centos/7/images/ and using
https://blog.strandboge.com/2019/04/16/cloud-images-qemu-cloud-init-and-snapd-spread-tests/
it is possible to create a qemu:centos-7-64 VM for local testing (note,
the VM needs additional configuration, but this is all that is needed
for spread to connect, send the project data and start preparing).
