### PR TITLE
interfaces/builtin/intel_mei: fix /dev/mei* AppArmor pattern

### DIFF
--- a/interfaces/builtin/intel_mei.go
+++ b/interfaces/builtin/intel_mei.go
@@ -34,7 +34,7 @@ const intelMEIBaseDeclarationSlots = `
 
 const intelMEIConnectedPlugAppArmor = `
 # Description: Allow access to the Intel MEI management interface.
-/dev/mei[0-9]+ rw,
+/dev/mei[0-9]* rw,
 `
 
 var intelMEIConnectedPlugUDev = []string{`SUBSYSTEM=="mei"`}

--- a/interfaces/builtin/intel_mei_test.go
+++ b/interfaces/builtin/intel_mei_test.go
@@ -85,7 +85,7 @@ func (s *IntelMEISuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/mei[0-9]+ rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/mei[0-9]* rw,`)
 }
 
 func (s *IntelMEISuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
AppArmor pattern is incorrect, `+` is not part of AARE, at least according to
apparmor.d(5). Fix the patternt to use `[]*` instead.
