### PR TITLE
overlord/snapstate: remove PlugsOnly

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -64,10 +64,6 @@ type SnapSetup struct {
 	UserID  int       `json:"user-id,omitempty"`
 	Base    string    `json:"base,omitempty"`
 	Type    snap.Type `json:"type,omitempty"`
-	// PlugsOnly indicates whether the relevant revisions for the
-	// operation have only plugs (#plugs >= 0), and absolutely no
-	// slots (#slots == 0).
-	PlugsOnly bool `json:"plugs-only,omitempty"`
 
 	// FIXME: implement rename of this as suggested in
 	//  https://github.com/snapcore/snapd/pull/4103#discussion_r169569717

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -131,7 +131,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if err != nil {
 			return nil, err
 		}
-		snapsup.PlugsOnly = snapsup.PlugsOnly && (len(info.Slots) == 0)
 
 		if experimentalRefreshAppAwareness {
 			// Note that because we are modifying the snap state this block
@@ -618,7 +617,6 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		Channel:     channel,
 		Flags:       flags.ForSnapSetup(),
 		Type:        info.Type,
-		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: info.InstanceKey,
 	}
 
@@ -685,7 +683,6 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		DownloadInfo: &info.DownloadInfo,
 		SideInfo:     &info.SideInfo,
 		Type:         info.Type,
-		PlugsOnly:    len(info.Slots) == 0,
 		InstanceKey:  info.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
 			Media: info.Media,
@@ -744,7 +741,6 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			DownloadInfo: &info.DownloadInfo,
 			SideInfo:     &info.SideInfo,
 			Type:         info.Type,
-			PlugsOnly:    len(info.Slots) == 0,
 			InstanceKey:  info.InstanceKey,
 		}
 
@@ -931,7 +927,6 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			DownloadInfo: &update.DownloadInfo,
 			SideInfo:     &update.SideInfo,
 			Type:         update.Type,
-			PlugsOnly:    len(update.Slots) == 0,
 			InstanceKey:  update.InstanceKey,
 			auxStoreInfo: auxStoreInfo{
 				Media: update.Media,
@@ -1411,7 +1406,6 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 		SideInfo:    snapst.CurrentSideInfo(),
 		Flags:       snapst.Flags.ForSnapSetup(),
 		Type:        info.Type,
-		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 
@@ -1470,7 +1464,6 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 			Revision: snapst.Current,
 		},
 		Type:        info.Type,
-		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 
@@ -1677,7 +1670,6 @@ func Remove(st *state.State, name string, revision snap.Revision) (*state.TaskSe
 			Revision: revision,
 		},
 		Type:        info.Type,
-		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 
@@ -1864,7 +1856,6 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		SideInfo:    snapst.Sequence[i],
 		Flags:       flags.ForSnapSetup(),
 		Type:        info.Type,
-		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 	return doInstall(st, &snapst, snapsup, 0, "")

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1720,8 +1720,6 @@ func (s *snapmgrTestSuite) TestDoInstallWithSlots(c *C) {
 	var snapsup snapstate.SnapSetup
 	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
-
-	c.Check(snapsup.PlugsOnly, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestDoUpdateHadSlots(c *C) {
@@ -1765,8 +1763,6 @@ func (s *snapmgrTestSuite) TestDoUpdateHadSlots(c *C) {
 	var snapsup snapstate.SnapSetup
 	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
-
-	c.Check(snapsup.PlugsOnly, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestDoInstallChannelDefault(c *C) {
@@ -2522,9 +2518,8 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -2693,7 +2688,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 		},
 		SideInfo:    snapsup.SideInfo,
 		Type:        snap.TypeApp,
-		PlugsOnly:   true,
 		InstanceKey: "instance",
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
@@ -3012,9 +3006,8 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -3160,10 +3153,9 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
-		Flags:     snapstate.Flags{Amend: true},
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
+		Flags:    snapstate.Flags{Amend: true},
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -3377,9 +3369,8 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "services-snap",
@@ -3600,7 +3591,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 		},
 		SideInfo:    snapsup.SideInfo,
 		Type:        snap.TypeApp,
-		PlugsOnly:   true,
 		InstanceKey: "instance",
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
@@ -3973,9 +3963,8 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeKernel,
-		PlugsOnly: true,
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeKernel,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "kernel",
@@ -6278,10 +6267,9 @@ version: 1.0`)
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		SnapPath:  mockSnap,
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		SnapPath: mockSnap,
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -6374,10 +6362,9 @@ epoch: 1*
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		SnapPath:  mockSnap,
-		SideInfo:  snapsup.SideInfo,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		SnapPath: mockSnap,
+		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -6554,8 +6541,7 @@ version: 1.0`)
 		Flags: snapstate.Flags{
 			Required: true,
 		},
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		Type: snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, si)
 
@@ -6687,8 +6673,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 					Revision: snap.R(7),
 					SnapID:   "some-snap-id",
 				},
-				Type:      snap.TypeApp,
-				PlugsOnly: true,
+				Type: snap.TypeApp,
 			}
 
 		}
@@ -6827,7 +6812,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 					Revision: snap.R(7),
 				},
 				Type:        snap.TypeApp,
-				PlugsOnly:   true,
 				InstanceKey: "instance",
 			}
 
@@ -7090,8 +7074,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 					RealName: "some-snap",
 					Revision: snap.R(7),
 				},
-				Type:      snap.TypeApp,
-				PlugsOnly: true,
+				Type: snap.TypeApp,
 			}
 
 		}
@@ -7273,7 +7256,6 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 			expSnapSetup.SideInfo.Revision = snap.R(2)
 		}
 		if t.Kind() == "auto-disconnect" {
-			expSnapSetup.PlugsOnly = true
 			expSnapSetup.Type = "app"
 		}
 
@@ -8377,10 +8359,9 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	snapsup, err := snapstate.TaskSnapSetup(first)
 	c.Assert(err, IsNil)
 	c.Check(snapsup, DeepEquals, &snapstate.SnapSetup{
-		SideInfo:  &si,
-		Flags:     flags,
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		SideInfo: &si,
+		Flags:    flags,
+		Type:     snap.TypeApp,
 	})
 }
 
@@ -8444,8 +8425,7 @@ func (s *snapmgrTestSuite) TestDisableRunThrough(c *C) {
 			RealName: "some-snap",
 			Revision: snap.R(7),
 		},
-		Type:      snap.TypeApp,
-		PlugsOnly: true,
+		Type: snap.TypeApp,
 	})
 }
 


### PR DESCRIPTION
There's a property in SnapSetup that records if a snap has only plugs
and no slots. This used to be use for some logic but it's entirely
unused now (nothing reads it) so we can just remove it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
