### PR TITLE
spread: add qemu:fedora-29-64

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -201,6 +201,9 @@ backends:
             - fedora-28-64:
                 username: fedora
                 password: fedora
+            - fedora-29-64:
+                username: fedora
+                password: fedora
             - centos-7-64:
                 username: centos
                 password: centos


### PR DESCRIPTION
With this and following https://blog.strandboge.com/2019/04/16/cloud-images-qemu-cloud-init-and-snapd-spread-tests/ I'm able to launch spread tests for Fedora 29 in qemu.