### PR TITLE
interfaces/apparmor: allow running /usr/bin/od

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -183,6 +183,7 @@ var defaultTemplate = `
   /{,usr/}bin/mv ixr,
   /{,usr/}bin/nice ixr,
   /{,usr/}bin/nohup ixr,
+  /{,usr/}bin/od ixr,
   /{,usr/}bin/openssl ixr, # may cause harmless capability block_suspend denial
   /{,usr/}bin/pgrep ixr,
   /{,usr/}bin/printenv ixr,


### PR DESCRIPTION
The tool has legitimate use.

See https://forum.snapcraft.io/t/which-stage-package-is-od-command-part-of/11067/6 for details.
