### PR TITLE
cmd: add `snap debug validate-seed <path>` cmd

### DIFF
--- a/cmd/snap/cmd_debug_validate_seed.go
+++ b/cmd/snap/cmd_debug_validate_seed.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type cmdValidateSeed struct {
+	Positionals struct {
+		SeedYamlPath string `positional-arg-name:"<seed-yaml-path>"`
+	} `positional-args:"true"`
+}
+
+func init() {
+	cmd := addDebugCommand("validate-seed",
+		"(internal) validate seed.yaml",
+		"(internal) validate seed.yaml",
+		func() flags.Commander {
+			return &cmdValidateSeed{}
+		}, nil, nil)
+	cmd.hidden = true
+}
+
+func (x *cmdValidateSeed) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	if _, err := snap.ReadSeedYaml(x.Positionals.SeedYamlPath); err != nil {
+		return fmt.Errorf("cannot read %q: %v", x.Positionals.SeedYamlPath, err)
+	}
+	return nil
+}

--- a/cmd/snap/cmd_debug_validate_seed.go
+++ b/cmd/snap/cmd_debug_validate_seed.go
@@ -20,8 +20,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/snap"
@@ -49,7 +47,7 @@ func (x *cmdValidateSeed) Execute(args []string) error {
 	}
 
 	if _, err := snap.ReadSeedYaml(x.Positionals.SeedYamlPath); err != nil {
-		return fmt.Errorf("cannot read %q: %v", x.Positionals.SeedYamlPath, err)
+		return err
 	}
 	return nil
 }

--- a/cmd/snap/cmd_debug_validate_seed_test.go
+++ b/cmd/snap/cmd_debug_validate_seed_test.go
@@ -34,12 +34,12 @@ func (s *SnapSuite) TestDebugValidateSeedHappy(c *C) {
 snaps:
  -
    name: core
-   channel: foo
-   file: bar
+   channel: stable
+   file: core_6673.snap
  -
-   name: gnome-foo
-   channel: foo
-   name: xxx
+   name: gtk-common-themes
+   channel: stable/ubuntu-19.04
+   file: gtk-common-themes_1198.snap
 `), 0644)
 	c.Assert(err, IsNil)
 
@@ -53,16 +53,16 @@ func (s *SnapSuite) TestDebugValidateSeedRegressionLp1825437(c *C) {
 snaps:
  -
    name: core
-   channel: foo
-   file: bar
+   channel: stable
+   file: core_6673.snap
  -
  -
    name: gnome-foo
-   channel: foo
-   name: xxx
+   channel: stable/ubuntu-19.04
+   file: gtk-common-themes_1198.snap
 `), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "validate-seed", tmpf})
-	c.Assert(err, ErrorMatches, "cannot read .*: empty element in seed")
+	c.Assert(err, ErrorMatches, "cannot read seed yaml: empty element in seed")
 }

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -70,6 +70,9 @@ func ReadSeedYaml(fn string) (*Seed, error) {
 
 	// validate
 	for _, sn := range seed.Snaps {
+		if sn == nil {
+			return nil, fmt.Errorf("empty element in seed")
+		}
 		if strings.Contains(sn.File, "/") {
 			return nil, fmt.Errorf("%q must be a filename, not a path", sn.File)
 		}

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -58,36 +58,36 @@ type Seed struct {
 }
 
 func ReadSeedYaml(fn string) (*Seed, error) {
-	errPrefix := "cannot read seed yaml: "
+	errPrefix := "cannot read seed yaml"
 
 	yamlData, err := ioutil.ReadFile(fn)
 	if err != nil {
-		return nil, fmt.Errorf(errPrefix+"%v", err)
+		return nil, fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	var seed Seed
 	if err := yaml.Unmarshal(yamlData, &seed); err != nil {
-		return nil, fmt.Errorf(errPrefix+"cannot unmarshal %q: %s", yamlData, err)
+		return nil, fmt.Errorf("%s: cannot unmarshal %q: %s", errPrefix, yamlData, err)
 	}
 
 	// validate
 	for _, sn := range seed.Snaps {
 		if sn == nil {
-			return nil, fmt.Errorf(errPrefix + "empty element in seed")
+			return nil, fmt.Errorf("%s: empty element in seed", errPrefix)
 		}
 		if err := ValidateInstanceName(sn.Name); err != nil {
-			return nil, fmt.Errorf(errPrefix+"%v", err)
+			return nil, fmt.Errorf("%s: %v", errPrefix, err)
 		}
 		if sn.Channel != "" {
 			if _, err := ParseChannel(sn.Channel, ""); err != nil {
-				return nil, fmt.Errorf(errPrefix+"%v", err)
+				return nil, fmt.Errorf("%s: %v", errPrefix, err)
 			}
 		}
 		if sn.File == "" {
-			return nil, fmt.Errorf(errPrefix+`"file" attribute for %q cannot be empty`, sn.Name)
+			return nil, fmt.Errorf(`%s: "file" attribute for %q cannot be empty`, errPrefix, sn.Name)
 		}
 		if strings.Contains(sn.File, "/") {
-			return nil, fmt.Errorf(errPrefix+"%q must be a filename, not a path", sn.File)
+			return nil, fmt.Errorf("%s: %q must be a filename, not a path", errPrefix, sn.File)
 		}
 	}
 


### PR DESCRIPTION
We had a bug where one of the recent livecd-rootfs build images
had an incorrect seed.yaml. This caused a panic of snapd on when
seeding. To prevent this here is a small helper that we can run
inside livecd-rootfs to ensure seed.yaml is good enough to not
crash snapd.

This is for https://bugs.launchpad.net/ubuntu/+source/livecd-rootfs/+bug/1825437