### PR TITLE
osutil: make IsValidUsername public and fix regex

### DIFF
--- a/osutil/user.go
+++ b/osutil/user.go
@@ -53,14 +53,14 @@ type AddUserOptions struct {
 // we check the (user)name ourselves, adduser is a bit too
 // strict (i.e. no `.`) - this regexp is in sync with that SSO
 // allows as valid usernames
-var isValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9+.-_]*$`).MatchString
+var IsValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9+._]*$`).MatchString
 
 func AddUser(name string, opts *AddUserOptions) error {
 	if opts == nil {
 		opts = &AddUserOptions{}
 	}
 
-	if !isValidUsername(name) {
+	if !IsValidUsername(name) {
 		return fmt.Errorf("cannot add user %q: name contains invalid characters", name)
 	}
 

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -251,3 +251,29 @@ func (s *createUserSuite) TestAddUserUnhappy(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "adduser failed with: some error")
 
 }
+
+func (s *createUserSuite) TestIsValidUsername(c *check.C) {
+	for k, v := range map[string]bool{
+		"a":       true,
+		"a-b":     true,
+		"a+b":     true,
+		"a.b":     true,
+		"a_b":     true,
+		"1":       true,
+		"1+":      true,
+		"1.":      true,
+		"1_":      true,
+		"-":       false,
+		"+":       false,
+		".":       false,
+		"_":       false,
+		"-a":      false,
+		"+a":      false,
+		".a":      false,
+		"_a":      false,
+		"a:b":     false,
+		"inval!d": false,
+	} {
+		c.Check(osutil.IsValidUsername(k), check.Equals, v)
+	}
+}


### PR DESCRIPTION
The old regex, `^[a-z0-9][-a-z0-9+.-_]*$`, had a bug in it where it
would accept any character within the range of '.-_' where 'a:b'
would match since `.` &lt; `:` &lt; `_` in the ASCII table.

Make IsValidUsername public since it makes adding tests easier and
subsequent commits will use this.