### PR TITLE
snap-seccomp: use username regex as defined in osutil/user.go

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -176,7 +176,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -725,13 +724,9 @@ func compile(content []byte, out string) error {
 	return fout.Commit()
 }
 
-// Be very strict so usernames and groups specified in policy are widely
-// compatible. From NAME_REGEX in /etc/adduser.conf
-var userGroupNamePattern = regexp.MustCompile("^[a-z][-a-z0-9_]*$")
-
 // findUid returns the identifier of the given UNIX user name.
 func findUid(username string) (uint64, error) {
-	if !userGroupNamePattern.MatchString(username) {
+	if !osutil.IsValidUsername(username) {
 		return 0, fmt.Errorf("%q must be a valid username", username)
 	}
 	return osutil.FindUid(username)
@@ -739,7 +734,7 @@ func findUid(username string) (uint64, error) {
 
 // findGid returns the identifier of the given UNIX group name.
 func findGid(group string) (uint64, error) {
-	if !userGroupNamePattern.MatchString(group) {
+	if !osutil.IsValidUsername(group) {
 		return 0, fmt.Errorf("%q must be a valid group name", group)
 	}
 	return osutil.FindGid(group)

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -562,16 +562,16 @@ func (s *snapSeccompSuite) TestCompileBadInput(c *C) {
 		// u:<username>
 		{"setuid :root", `cannot parse line: cannot parse token ":root" .*`},
 		{"setuid u:", `cannot parse line: cannot parse token "u:" \(line "setuid u:"\): "" must be a valid username`},
-		{"setuid u:0", `cannot parse line: cannot parse token "u:0" \(line "setuid u:0"\): "0" must be a valid username`},
+		{"setuid u:!", `cannot parse line: cannot parse token "u:!" \(line "setuid u:!"\): "!" must be a valid username`},
 		{"setuid u:b@d|npu+", `cannot parse line: cannot parse token "u:b@d|npu+" \(line "setuid u:b@d|npu+"\): "b@d|npu+" must be a valid username`},
-		{"setuid u:snap.bad", `cannot parse line: cannot parse token "u:snap.bad" \(line "setuid u:snap.bad"\): "snap.bad" must be a valid username`},
+		{"setuid u:snap|bad", `cannot parse line: cannot parse token "u:snap|bad" \(line "setuid u:snap|bad"\): "snap|bad" must be a valid username`},
 		{"setuid U:root", `cannot parse line: cannot parse token "U:root" .*`},
 		{"setuid u:nonexistent", `cannot parse line: cannot parse token "u:nonexistent" \(line "setuid u:nonexistent"\): user: unknown user nonexistent`},
 		// g:<groupname>
 		{"setgid g:", `cannot parse line: cannot parse token "g:" \(line "setgid g:"\): "" must be a valid group name`},
-		{"setgid g:0", `cannot parse line: cannot parse token "g:0" \(line "setgid g:0"\): "0" must be a valid group name`},
+		{"setgid g:!", `cannot parse line: cannot parse token "g:!" \(line "setgid g:!"\): "!" must be a valid group name`},
 		{"setgid g:b@d|npu+", `cannot parse line: cannot parse token "g:b@d|npu+" \(line "setgid g:b@d|npu+"\): "b@d|npu+" must be a valid group name`},
-		{"setgid g:snap.bad", `cannot parse line: cannot parse token "g:snap.bad" \(line "setgid g:snap.bad"\): "snap.bad" must be a valid group name`},
+		{"setgid g:snap|bad", `cannot parse line: cannot parse token "g:snap|bad" \(line "setgid g:snap|bad"\): "snap|bad" must be a valid group name`},
 		{"setgid G:root", `cannot parse line: cannot parse token "G:root" .*`},
 		{"setgid g:nonexistent", `cannot parse line: cannot parse token "g:nonexistent" \(line "setgid g:nonexistent"\): group: unknown group nonexistent`},
 	} {

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -53,14 +53,14 @@ type AddUserOptions struct {
 // we check the (user)name ourselves, adduser is a bit too
 // strict (i.e. no `.`) - this regexp is in sync with that SSO
 // allows as valid usernames
-var isValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9+.-_]*$`).MatchString
+var IsValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9+._]*$`).MatchString
 
 func AddUser(name string, opts *AddUserOptions) error {
 	if opts == nil {
 		opts = &AddUserOptions{}
 	}
 
-	if !isValidUsername(name) {
+	if !IsValidUsername(name) {
 		return fmt.Errorf("cannot add user %q: name contains invalid characters", name)
 	}
 

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -251,3 +251,29 @@ func (s *createUserSuite) TestAddUserUnhappy(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "adduser failed with: some error")
 
 }
+
+func (s *createUserSuite) TestIsValidUsername(c *check.C) {
+	for k, v := range map[string]bool{
+		"a":       true,
+		"a-b":     true,
+		"a+b":     true,
+		"a.b":     true,
+		"a_b":     true,
+		"1":       true,
+		"1+":      true,
+		"1.":      true,
+		"1_":      true,
+		"-":       false,
+		"+":       false,
+		".":       false,
+		"_":       false,
+		"-a":      false,
+		"+a":      false,
+		".a":      false,
+		"_a":      false,
+		"a:b":     false,
+		"inval!d": false,
+	} {
+		c.Check(osutil.IsValidUsername(k), check.Equals, v)
+	}
+}


### PR DESCRIPTION
snap-seccomp: use username regex as defined in osutil/user.go

snapd should standardize on a single username(/groupname) regex. While
today the osutil/user.go regex is used for adding users to the system,
snap-seccomp uses a more restricted regex. Since some day we plan to
support snapd adding system, shared and private users, as well as
adjusting ACLs/udev rules for device access for users (eg, such as ones
created by snapd in the first place on Ubuntu Core), it makes sense to
standardize on one regex to avoid users being created that can't be
referenced in other parts of snapd.

Note, this PR builds upon https://github.com/snapcore/snapd/pull/6773