### PR TITLE
devicestate: set "new-model" on the remodel change

### DIFF
--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -21,11 +21,9 @@ package daemon
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 )
@@ -62,23 +60,10 @@ func postModel(c *Command, r *http.Request, _ *auth.UserState) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	tss, err := devicestateRemodel(st, newModel)
+	chg, err := devicestateRemodel(st, newModel)
 	if err != nil {
 		return BadRequest("cannot remodel device: %v", err)
 	}
-	model, err := devicestate.Model(st)
-	if err != nil {
-		return InternalError("cannot get model: %v", err)
-	}
-
-	var msg string
-	if model.BrandID() == newModel.BrandID() && model.Model() == newModel.Model() {
-		msg = fmt.Sprintf(i18n.G("Refresh model assertion from revision %v to %v"), model.Revision(), newModel.Revision())
-	} else {
-		msg = fmt.Sprintf(i18n.G("Remodel device to %v/%v (%v)"), newModel.BrandID(), newModel.Model(), newModel.Revision())
-	}
-	chg := newChange(st, "remodel", msg, tss, nil)
-
 	ensureStateSoon(st)
 
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -520,7 +520,6 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	// Set the new model assertion - this *must* be the last thing done
 	// by the change.
 	setModel := st.NewTask("set-model", i18n.G("Set new model assertion"))
-	setModel.Set("new-model", asserts.Encode(new))
 	for _, tsPrev := range tss {
 		setModel.WaitAll(tsPrev)
 	}
@@ -537,6 +536,7 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	for _, ts := range tss {
 		chg.AddAll(ts)
 	}
+	chg.Set("new-model", asserts.Encode(new))
 
 	return chg, nil
 }

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -74,8 +74,9 @@ func (m *DeviceManager) doSetModel(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
+	chg := t.Change()
 	var modelass []byte
-	if err := t.Get("new-model", &modelass); err != nil {
+	if err := chg.Get("new-model", &modelass); err != nil {
 		return err
 	}
 

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -53,9 +53,9 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 
 	s.state.Lock()
 	t := s.state.NewTask("set-model", "set-model test")
-	t.Set("new-model", asserts.Encode(newModel))
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
+	chg.Set("new-model", asserts.Encode(newModel))
 
 	s.state.Unlock()
 
@@ -89,9 +89,9 @@ func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
 	c.Assert(err, IsNil)
 
 	t := s.state.NewTask("set-model", "set-model test")
-	t.Set("new-model", asserts.Encode(model))
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
+	chg.Set("new-model", asserts.Encode(model))
 
 	s.state.Unlock()
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3304,14 +3304,8 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 		"revision":       "1",
 	})
 
-	tss, err := devicestate.Remodel(st, newModel)
+	chg, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, IsNil)
-	chg := st.NewChange("remodel", "...")
-	c.Check(tss, HasLen, 4)
-	chg.AddAll(tss[0])
-	chg.AddAll(tss[1])
-	chg.AddAll(tss[2])
-	chg.AddAll(tss[3])
 
 	st.Unlock()
 	err = ms.o.Settle(settleTimeout)
@@ -3399,9 +3393,9 @@ type: base`
 		"revision":     "1",
 	})
 
-	tss, err := devicestate.Remodel(st, newModel)
+	chg, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, ErrorMatches, "cannot remodel to different bases yet")
-	c.Assert(tss, HasLen, 0)
+	c.Assert(chg, IsNil)
 }
 
 func (ms *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
@@ -3461,13 +3455,8 @@ version: 2.0`
 		"required-snaps": []interface{}{"foo"},
 	})
 
-	tss, err := devicestate.Remodel(st, newModel)
+	chg, err := devicestate.Remodel(st, newModel)
 	c.Assert(err, IsNil)
-	chg := st.NewChange("remodel", "...")
-	c.Check(tss, HasLen, 3)
-	chg.AddAll(tss[0])
-	chg.AddAll(tss[1])
-	chg.AddAll(tss[2])
 
 	st.Unlock()
 	err = ms.o.Settle(settleTimeout)


### PR DESCRIPTION
The old code was setting the "new-model" data only to the "set-model"
task. When we move to remodel to new kernels/bases we need this
data available more broadly, i.e. the install code needs to check
if the new kernel can be installed. This PR adds the new model
directly to the remodel change.

Build on top of https://github.com/snapcore/snapd/pull/6775
Relevant commit: 5e0db22