### PR TITLE
snapstate: auto-install snapd when needed

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -298,8 +298,9 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 	// make interfaces work - LP: 1819318
 	var tsSnapd *state.TaskSet
 	if base != "core" && !snapdSnapInstalled(st) && !coreSnapInstalled(st) {
-		onInFlightErr := &state.Retry{After: prerequisitesRetryTimeout}
-		tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", defaultSnapdSnapsChannel(), onInFlightErr, userID)
+		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
+			tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", defaultSnapdSnapsChannel(), onInFlightErr, userID)
+		})
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -132,6 +132,14 @@ func defaultBaseSnapsChannel() string {
 	return channel
 }
 
+func defaultSnapdSnapsChannel() string {
+	channel := os.Getenv("SNAPD_SNAPD_CHANNEL")
+	if channel == "" {
+		return "stable"
+	}
+	return channel
+}
+
 func defaultPrereqSnapsChannel() string {
 	channel := os.Getenv("SNAPD_PREREQS_CHANNEL")
 	if channel == "" {
@@ -214,10 +222,8 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 
 func (m *SnapManager) installOneBaseOrRequired(st *state.State, snapName, channel string, onInFlight error, userID int) (*state.TaskSet, error) {
 	// The core snap provides everything we need for core16.
-	if snapName == "core16" {
-		if hasCore, err := isInstalled(st, "core"); hasCore && err == nil {
-			return nil, nil
-		}
+	if snapName == "core16" && coreSnapInstalled(st) {
+		return nil, nil
 	}
 
 	// installed already?
@@ -275,6 +281,17 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		return err
 	}
 
+	// on systems without core or snapd need to install snapd to
+	// make interfaces work - LP: 1819318
+	var tsSnapd *state.TaskSet
+	if base != "core" && !snapdSnapInstalled(st) && !coreSnapInstalled(st) {
+		onInFlightErr := &state.Retry{After: prerequisitesRetryTimeout}
+		tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", defaultSnapdSnapsChannel(), onInFlightErr, userID)
+		if err != nil {
+			return err
+		}
+	}
+
 	chg := t.Change()
 	// add all required snaps, no ordering, this will be done in the
 	// auto-connect task handler
@@ -282,13 +299,21 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		ts.JoinLane(st.NewLane())
 		chg.AddAll(ts)
 	}
-	// add the base if needed, everything else must wait on this
+	// add the base if needed, prereqs else must wait on this
 	if tsBase != nil {
 		tsBase.JoinLane(st.NewLane())
 		for _, t := range chg.Tasks() {
 			t.WaitAll(tsBase)
 		}
 		chg.AddAll(tsBase)
+	}
+	// add snapd if needed, everything must wait on this
+	if tsSnapd != nil {
+		tsSnapd.JoinLane(st.NewLane())
+		for _, t := range chg.Tasks() {
+			t.WaitAll(tsSnapd)
+		}
+		chg.AddAll(tsSnapd)
 	}
 
 	// make sure that the new change is committed to the state
@@ -1016,6 +1041,12 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 func snapdSnapInstalled(st *state.State) bool {
 	var snapst SnapState
 	err := Get(st, "snapd", &snapst)
+	return err == nil
+}
+
+func coreSnapInstalled(st *state.State) bool {
+	var snapst SnapState
+	err := Get(st, "core", &snapst)
 	return err == nil
 }
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -423,7 +423,7 @@ func (s *prereqSuite) TestDoPrereqCore16wCoreNothingToDo(c *C) {
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 
-func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
+func (s *prereqSuite) testDoPrereqNoCorePullsInSnaps(c *C, base string) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -435,7 +435,7 @@ func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Base: "core16",
+		Base: base,
 	})
 	s.state.NewChange("dummy", "...").AddTask(t)
 	s.state.Unlock()
@@ -453,7 +453,7 @@ func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
 			op: "storesvc-snap-action:action",
 			action: store.SnapAction{
 				Action:       "install",
-				InstanceName: "core16",
+				InstanceName: base,
 				Channel:      "stable",
 			},
 			revno: snap.R(11),
@@ -473,4 +473,16 @@ func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
 	})
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
+}
+
+func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
+	s.testDoPrereqNoCorePullsInSnaps(c, "core16")
+}
+
+func (s *prereqSuite) TestDoPrereqCore18NoCorePullsInSnapd(c *C) {
+	s.testDoPrereqNoCorePullsInSnaps(c, "core18")
+}
+
+func (s *prereqSuite) TestDoPrereqOtherBaseNoCorePullsInSnapd(c *C) {
+	s.testDoPrereqNoCorePullsInSnaps(c, "other-base")
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -94,7 +94,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			return nil, err
 		}
 		if model == nil || model.Base() == "" {
-			if !experimentalAllowSnapd {
+			// always allow the snapd snap on classic
+			if !release.OnClassic && !experimentalAllowSnapd {
 				return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
 			}
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -90,23 +90,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		return nil, fmt.Errorf("cannot install reserved snap name 'system'")
 	}
 
-	// Check if the snapd can be installed on Ubuntu Core systems, it is
-	// always ok to install on classic
-	if snapsup.InstanceName() == "snapd" && !release.OnClassic {
-		experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
-		if err != nil && !config.IsNoOption(err) {
-			return nil, err
-		}
-
-		model, err := Model(st)
-		if err != nil && err != state.ErrNoState {
-			return nil, err
-		}
-		if (model == nil || model.Base() == "") && !experimentalAllowSnapd {
-			return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
-		}
-	}
-
 	if snapst.IsInstalled() && !snapst.Active {
 		return nil, fmt.Errorf("cannot update disabled snap %q", snapsup.InstanceName())
 	}
@@ -536,7 +519,9 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 }
 
 func checkInstallPreconditions(st *state.State, info *snap.Info, flags Flags, snapst *SnapState, deviceCtx DeviceContext) error {
-	if info.InstanceName() == "snapd" {
+	// Check if the snapd can be installed on Ubuntu Core systems, it is
+	// always ok to install on classic
+	if info.InstanceName() == "snapd" && !release.OnClassic {
 		tr := config.NewTransaction(st)
 		experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
 		if err != nil && !config.IsNoOption(err) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -80,26 +80,28 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	if err != nil && !config.IsNoOption(err) {
 		return nil, err
 	}
-	experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
-	if err != nil && !config.IsNoOption(err) {
-		return nil, err
-	}
 
 	if snapsup.InstanceName() == "system" {
 		return nil, fmt.Errorf("cannot install reserved snap name 'system'")
 	}
-	if snapsup.InstanceName() == "snapd" {
+
+	// Check if the snapd can be installed on Ubuntu Core systems, it is
+	// always ok to install on classic
+	if snapsup.InstanceName() == "snapd" && !release.OnClassic {
+		experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
+		if err != nil && !config.IsNoOption(err) {
+			return nil, err
+		}
+
 		model, err := Model(st)
 		if err != nil && err != state.ErrNoState {
 			return nil, err
 		}
-		if model == nil || model.Base() == "" {
-			// always allow the snapd snap on classic
-			if !release.OnClassic && !experimentalAllowSnapd {
-				return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
-			}
+		if (model == nil || model.Base() == "") && !experimentalAllowSnapd {
+			return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
 		}
 	}
+
 	if snapst.IsInstalled() && !snapst.Active {
 		return nil, fmt.Errorf("cannot update disabled snap %q", snapsup.InstanceName())
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -13333,7 +13333,10 @@ func (s *snapmgrTestSuite) TestNoConfigureForBasesTask(c *C) {
 	c.Check(hasConfigureTask(ts), Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestNoSnapdSnapOnSystemsWithoutBase(c *C) {
+func (s *snapmgrTestSuite) TestNoSnapdSnapOnSystemsWithoutBaseOnUbuntuCore(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -1,0 +1,23 @@
+summary: Ensure the snapd gets auto installed when needed
+
+# not testing on ubuntu-core because we have core/snapd installed there
+systems: [-ubuntu-core-*]
+
+execute: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    distro_purge_package snapd
+    distro_install_build_snapd
+    snap wait system seed.loaded
+
+    echo "Ensure nothing is installed"
+    snap list | grep -c -v "^Name " | MATCH 0
+
+    echo "Install a snap that needs core18 only"
+    snap install test-snapd-tools-core18
+
+    echo "Ensure that the snapd snap got installed as well"
+    snap list | grep -c -v "^Name " | MATCH 3
+    snap list | MATCH ^snapd
+    snap list | MATCH ^core18
+    snap list | MATCH ^test-snapd-tools


### PR DESCRIPTION
When installing a snap that does not require "core" on a fresh
system, currently we do nothing special. This means however that
on such systems there is no "core" or "snapd" snap installed.

This means that no system interfaces are available. This PR
fixes this by auto-installing the snapd snap if its missing.

As a side effect, "snap install snapd" on classic is no longer
blocked (it still is on core).

This adresses https://bugs.launchpad.net/snapd/+bug/1819318

We should also land https://github.com/snapcore/snapd/pull/6741 along the way.