### PR TITLE
overlord: use private YAML inside several tests

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2744,6 +2744,20 @@ func (s *interfaceManagerSuite) testUndoDiscardConns(c *C, snapName string) {
 
 func (s *interfaceManagerSuite) TestDoRemove(c *C) {
 	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	var consumerYaml = `
+name: consumer
+version: 1
+plugs:
+ plug:
+  interface: test
+`
+	var producerYaml = `
+name: producer
+version: 1
+slots:
+ slot:
+  interface: test
+`
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1463,16 +1463,32 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 
 func (s *interfaceManagerSuite) TestDisconnectUndo(c *C) {
 	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	var consumerYaml = `
+name: consumer
+version: 1
+plugs:
+ plug:
+  interface: test
+  static: plug-static-value
+`
+	var producerYaml = `
+name: producer
+version: 1
+slots:
+ slot:
+  interface: test
+  static: slot-static-value
+`
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
 	connState := map[string]interface{}{
 		"consumer:plug producer:slot": map[string]interface{}{
 			"interface":    "test",
-			"slot-static":  map[string]interface{}{"attr1": "value1"},
-			"slot-dynamic": map[string]interface{}{"attr2": "value2"},
-			"plug-static":  map[string]interface{}{"attr3": "value3"},
-			"plug-dynamic": map[string]interface{}{"attr4": "value4"},
+			"slot-static":  map[string]interface{}{"static": "slot-static-value"},
+			"slot-dynamic": map[string]interface{}{"dynamic": "slot-dynamic-value"},
+			"plug-static":  map[string]interface{}{"static": "plug-static-value"},
+			"plug-dynamic": map[string]interface{}{"dynamic": "plug-dynamic-value"},
 		},
 	}
 
@@ -1495,7 +1511,7 @@ func (s *interfaceManagerSuite) TestDisconnectUndo(c *C) {
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitAll(ts)
 	change.AddTask(terr)
-	c.Assert(change.Tasks(), HasLen, 4)
+	c.Assert(change.Tasks(), HasLen, 2)
 	s.state.Unlock()
 
 	s.settle(c)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3111,8 +3111,13 @@ plugs:
 	err = s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, map[string]interface{}{
-		"consumer:plug core:slot":  map[string]interface{}{"interface": "test", "hotplug-gone": true},
-		"consumer:plug core:slot2": map[string]interface{}{"interface": "test"},
+		"consumer:plug core:hotplug-slot": map[string]interface{}{
+			"interface":    "test",
+			"hotplug-gone": true,
+		},
+		"consumer:plug core:slot2": map[string]interface{}{
+			"interface": "test",
+		},
 	})
 }
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3060,17 +3060,25 @@ func (s *interfaceManagerSuite) TestDisconnectDisablesAutoConnect(c *C) {
 
 func (s *interfaceManagerSuite) TestDisconnectByHotplug(c *C) {
 	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+	var consumerYaml = `
+name: consumer
+version: 1
+plugs:
+ plug:
+  interface: test
+  attr: plug-attr
+`
 	consumerInfo := s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, coreSnapYaml)
 
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		"consumer:plug core:slot":  map[string]interface{}{"interface": "test"},
-		"consumer:plug core:slot2": map[string]interface{}{"interface": "test"},
+		"consumer:plug core:hotplug-slot": map[string]interface{}{"interface": "test"},
+		"consumer:plug core:slot2":        map[string]interface{}{"interface": "test"},
 	})
 	s.state.Set("hotplug-slots", map[string]interface{}{
-		"slot": map[string]interface{}{
-			"name":        "slot",
+		"hotplug-slot": map[string]interface{}{
+			"name":        "hotplug-slot",
 			"interface":   "test",
 			"hotplug-key": "1234",
 		}})
@@ -3081,7 +3089,7 @@ func (s *interfaceManagerSuite) TestDisconnectByHotplug(c *C) {
 	s.state.Lock()
 	conn := &interfaces.Connection{
 		Plug: interfaces.NewConnectedPlug(consumerInfo.Plugs["plug"], nil, nil),
-		Slot: interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{SuggestedName: "core"}, Name: "slot"}, nil, nil),
+		Slot: interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{SuggestedName: "core"}, Name: "hotplug-slot"}, nil, nil),
 	}
 
 	ts, err := ifacestate.DisconnectPriv(s.state, conn, ifacestate.NewDisconnectOptsWithByHotplugSet())

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3118,6 +3118,22 @@ plugs:
 
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *C) {
 	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+	var consumerYaml = `
+name: consumer
+version: 1
+plugs:
+ plug:
+  interface: test
+  attr: plug-value
+`
+	var producerYaml = `
+name: producer
+version: 1
+slots:
+ slot:
+  interface: test
+  attr: slot-value
+`
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -3126,12 +3142,12 @@ func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *C) {
 		"consumer:plug producer:slot": map[string]interface{}{
 			"interface": "test",
 			"plug-static": map[string]interface{}{
-				"attr1": "value2",
-				"attr3": "value3",
+				"attr":       "stored-plug-value",
+				"other-attr": "irrelevant-value",
 			},
 			"slot-static": map[string]interface{}{
-				"attr2": "value4",
-				"attr4": "value6",
+				"attr":       "stored-slot-value",
+				"other-attr": "irrelevant-value",
 			},
 		},
 	})
@@ -3149,13 +3165,13 @@ func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(conn.Plug.Name(), Equals, "plug")
 	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{
-		"attr1": "value2",
-		"attr3": "value3",
+		"other-attr": "irrelevant-value",
+		"attr":       "stored-plug-value",
 	})
 	c.Assert(conn.Slot.Name(), Equals, "slot")
 	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{
-		"attr2": "value4",
-		"attr4": "value6",
+		"other-attr": "irrelevant-value",
+		"attr":       "stored-slot-value",
 	})
 }
 


### PR DESCRIPTION
A number of tests reuse a "common" set of YAML documents that grew
organically and have lots of tentacles with quirky properties. An
upcoming change would start to detect those differences. As a step
towards cleaning that up, the various YAMLs are moving towards
individual tests where their content is close to the code using it,
making the test more readable and comprehensible.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>