### PR TITLE
seccomp: refactor ActLog check and expose via sandbox-features

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -634,12 +634,11 @@ func preprocess(content []byte) (unrestricted, complain bool) {
 	return unrestricted, complain
 }
 
-func complainAction() seccomp.ScmpAction {
-	// XXX: Work around some distributions not having a new enough
-	// libseccomp-golang that declares ActLog. Instead, we'll guess at its
-	// value by adding one to ActAllow and then verify that the string
-	// representation is what we expect for ActLog. The value and string is
-	// defined in https://github.com/seccomp/libseccomp-golang/pull/29.
+func actLogSupported() bool {
+	// Guess at the ActLog value by adding one to ActAllow and then verify
+	// that the string representation is what we expect for ActLog. The
+	// value and string is defined in
+	// https://github.com/seccomp/libseccomp-golang/pull/29.
 	//
 	// Ultimately, the fix for this workaround is to be able to use the
 	// GetApi() function created in the PR above. It'll tell us if the
@@ -647,7 +646,16 @@ func complainAction() seccomp.ScmpAction {
 	var actLog seccomp.ScmpAction = seccomp.ActAllow + 1
 
 	if actLog.String() == "Action: Log system call" {
-		return actLog
+		return true
+	}
+	return false
+}
+
+func complainAction() seccomp.ScmpAction {
+	// XXX: Work around some distributions not having a new enough
+	// libseccomp-golang that declares ActLog.
+	if actLogSupported() {
+		return seccomp.ActLog
 	}
 
 	// Because ActLog is functionally ActAllow with logging, if we don't
@@ -771,6 +779,13 @@ func main() {
 		err = showSeccompLibraryVersion()
 	case "version-info":
 		err = showVersionInfo()
+	case "actlog-supported":
+		if actLogSupported() {
+			fmt.Printf("SCMP_ACT_LOG supported\n")
+			os.Exit(0)
+		}
+		fmt.Printf("SCMP_ACT_LOG not supported\n")
+		os.Exit(1)
 	default:
 		err = fmt.Errorf("unsupported argument %q", cmd)
 	}

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -782,10 +782,10 @@ func main() {
 	case "actlog-supported":
 		if actLogSupported() {
 			fmt.Printf("SCMP_ACT_LOG supported\n")
-			os.Exit(0)
+		} else {
+			fmt.Printf("SCMP_ACT_LOG not supported\n")
 		}
-		fmt.Printf("SCMP_ACT_LOG not supported\n")
-		os.Exit(1)
+		os.Exit(0)
 	default:
 		err = fmt.Errorf("unsupported argument %q", cmd)
 	}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -59,23 +59,30 @@ var (
 	releaseInfoVersionId     = release.ReleaseInfo.VersionID
 	requiresSocketcall       = requiresSocketcallImpl
 
-	snapSeccompVersionInfo = snapSeccompVersionInfoImpl
-	seccompCompilerLookup  = cmd.InternalToolPath
+	snapSeccompVersionInfo     = snapSeccompVersionInfoImpl
+	seccompCompilerLookup      = cmd.InternalToolPath
+	snapSeccompActLogSupported = snapSeccompActLogSupportedImpl
 )
 
 func snapSeccompVersionInfoImpl(c Compiler) (string, error) {
 	return c.VersionInfo()
 }
 
+func snapSeccompActLogSupportedImpl(c Compiler) (bool, error) {
+	return c.ActLogSupported()
+}
+
 type Compiler interface {
 	Compile(in, out string) error
 	VersionInfo() (string, error)
+	ActLogSupported() (bool, error)
 }
 
 // Backend is responsible for maintaining seccomp profiles for snap-confine.
 type Backend struct {
-	snapSeccomp Compiler
-	versionInfo string
+	snapSeccomp     Compiler
+	versionInfo     string
+	actLogSupported bool
 }
 
 var globalProfileLE = []byte{
@@ -111,10 +118,11 @@ func isBigEndian() bool {
 	return false
 }
 
-// Initialize ensures that the global profile is on disk and interrogates
+// Initialize ensures that the global profile is on disk, interrogates
 // libseccomp wrapper to generate a version string that will be used to
 // determine if we need to recompile seccomp policy due to system
-// changes outside of snapd.
+// changes outside of snapd and determines if the snap-seccomp supports
+// ActLog.
 func (b *Backend) Initialize() error {
 	dir := dirs.SnapSeccompDir
 	fname := "global.bin"
@@ -145,6 +153,9 @@ func (b *Backend) Initialize() error {
 		return fmt.Errorf("cannot obtain snap-seccomp version information: %v", err)
 	}
 	b.versionInfo = versionInfo
+
+	// ignore error since b.actLogSupported is false then too
+	b.actLogSupported, _ = snapSeccompActLogSupported(b.snapSeccomp)
 	return nil
 }
 
@@ -321,6 +332,10 @@ func (b *Backend) SandboxFeatures() []string {
 		tags = append(tags, "kernel:"+feature)
 	}
 	tags = append(tags, "bpf-argument-filtering")
+
+	if b.actLogSupported {
+		tags = append(tags, "bpf-actlog")
+	}
 	return tags
 }
 
@@ -399,5 +414,13 @@ func MockSnapSeccompVersionInfo(s func(c Compiler) (string, error)) (restore fun
 	snapSeccompVersionInfo = s
 	return func() {
 		snapSeccompVersionInfo = old
+	}
+}
+
+func MockSnapSeccompActLogSupported(s func(c Compiler) (bool, error)) (restore func()) {
+	old := snapSeccompActLogSupported
+	snapSeccompActLogSupported = s
+	return func() {
+		snapSeccompActLogSupported = old
 	}
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -80,6 +80,8 @@ func (s *backendSuite) SetUpTest(c *C) {
 	s.snapSeccomp = testutil.MockCommand(c, snapSeccompPath, `
 if [ "$1" = "version-info" ]; then
     echo "abcdef 1.2.3 1234abcd"
+elif [ "$1" = "actlog-supported" ]; then
+    echo "SCMP_ACT_LOG supported"
 fi`)
 
 	s.Backend.Initialize()
@@ -89,6 +91,7 @@ fi`)
 	// make sure initialize called version-info
 	c.Check(s.snapSeccomp.Calls(), DeepEquals, [][]string{
 		{"snap-seccomp", "version-info"},
+		{"snap-seccomp", "actlog-supported"},
 	})
 	s.snapSeccomp.ForgetCalls()
 
@@ -174,6 +177,7 @@ fi`)
 	// ensure the snap-seccomp from the core snap was used instead
 	c.Check(snapSeccompOnCore.Calls(), DeepEquals, [][]string{
 		{"snap-seccomp", "version-info"},
+		{"snap-seccomp", "actlog-supported"},
 		{"snap-seccomp", "compile", profile + ".src", profile + ".bin"},
 	})
 	raw, err := ioutil.ReadFile(profile + ".src")
@@ -471,6 +475,20 @@ func (s *backendSuite) TestSandboxFeatures(c *C) {
 	restore := seccomp.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "bpf-argument-filtering", "bpf-actlog"})
+
+	// change version reported by snap-seccomp
+	snapSeccomp := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), `
+if [ "$1" = "version-info" ]; then
+    echo "abcdef 1.2.3 1234abcd"
+elif [ "$1" = "actlog-supported" ]; then
+    echo "SCMP_ACT_LOG not supported"
+fi`)
+	defer snapSeccomp.Restore()
+
+	// reload cached version info
+	err := s.Backend.Initialize()
+	c.Assert(err, IsNil)
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "bpf-argument-filtering"})
 }
 
@@ -653,12 +671,14 @@ fi`)
 	err = s.Backend.Initialize()
 	c.Assert(err, IsNil)
 
-	c.Check(s.snapSeccomp.Calls(), HasLen, 2)
+	c.Check(s.snapSeccomp.Calls(), HasLen, 3)
 	c.Check(s.snapSeccomp.Calls(), DeepEquals, [][]string{
 		// compilation from first Setup()
 		{"snap-seccomp", "compile", profile + ".src", profile + ".bin"},
 		// initialization with new version
 		{"snap-seccomp", "version-info"},
+		// detect actlog support
+		{"snap-seccomp", "actlog-supported"},
 	})
 
 	// the profile should be rebuilt now
@@ -666,12 +686,14 @@ fi`)
 	c.Assert(err, IsNil)
 	c.Check(profile+".src", testutil.FileEquals, updatedProfileHeader+"\ndefault\n")
 
-	c.Check(s.snapSeccomp.Calls(), HasLen, 3)
+	c.Check(s.snapSeccomp.Calls(), HasLen, 4)
 	c.Check(s.snapSeccomp.Calls(), DeepEquals, [][]string{
 		// compilation from first Setup()
 		{"snap-seccomp", "compile", profile + ".src", profile + ".bin"},
 		// initialization with new version
 		{"snap-seccomp", "version-info"},
+		// detect actlog support
+		{"snap-seccomp", "actlog-supported"},
 		// compilation of profiles with new compiler version
 		{"snap-seccomp", "compile", profile + ".src", profile + ".bin"},
 	})
@@ -708,6 +730,7 @@ fi`)
 	// the one from mounted snap was used
 	c.Check(snapSeccompInMounted.Calls(), DeepEquals, [][]string{
 		{"snap-seccomp", "version-info"},
+		{"snap-seccomp", "actlog-supported"},
 	})
 
 	sb, ok := s.Backend.(*seccomp.Backend)

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -87,3 +87,16 @@ func (c *Compiler) Compile(in, out string) error {
 	}
 	return nil
 }
+
+func (c *Compiler) ActLogSupported() (bool, error) {
+	cmd := exec.Command(c.snapSeccomp, "actlog-supported")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, osutil.OutputErr(output, err)
+	}
+	s := string(bytes.TrimSpace(output))
+	if s == "SCMP_ACT_LOG supported" {
+		return true, nil
+	}
+	return false, nil
+}

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -142,3 +142,48 @@ func (s *compilerSuite) TestCompilerNewUnhappy(c *C) {
 
 	c.Assert(func() { seccomp.New(nil) }, PanicMatches, "lookup tool func not provided")
 }
+
+func (s *compilerSuite) TestSupportsActLogTrue(c *C) {
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
+echo "SCMP_ACT_LOG supported"
+exit 0
+`)
+	defer cmd.Restore()
+
+	compiler, err := seccomp.New(fromCmd(c, cmd))
+	c.Assert(err, IsNil)
+
+	res, err := compiler.ActLogSupported()
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, true)
+}
+
+func (s *compilerSuite) TestSupportsActLogFalse(c *C) {
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
+echo "SCMP_ACT_LOG not supported"
+exit 0
+`)
+	defer cmd.Restore()
+
+	compiler, err := seccomp.New(fromCmd(c, cmd))
+	c.Assert(err, IsNil)
+
+	res, err := compiler.ActLogSupported()
+	c.Assert(err, IsNil)
+	c.Assert(res, Equals, false)
+}
+
+func (s *compilerSuite) TestSupportsActLogError(c *C) {
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
+echo "i will not"
+exit 1
+`)
+	defer cmd.Restore()
+
+	compiler, err := seccomp.New(fromCmd(c, cmd))
+	c.Assert(err, IsNil)
+
+	res, err := compiler.ActLogSupported()
+	c.Assert(err, ErrorMatches, "i will not")
+	c.Assert(res, Equals, false)
+}


### PR DESCRIPTION
seccomp: add 'actlog-supported' command and expose via sandbox-features
    
snap-seccomp currently queries for ActLog support to decide if it should
be enabled or not. We want to expose this in sandbox-features and also
to other parts of snapd. Because snapd is intended to be compilable with
CGO_ENABLED=0, the simplest solution of refactoring the support check
does not work because it pulls in libseccomp. Therefore, add a new
snap-seccomp command, 'actlog-supported' and have the seccomp backend
call it on initialization so we only call this once on startup instead
of every time the query is performed.