### PR TITLE
osutil: use go build-id when no gnu build-id is available

### DIFF
--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -36,18 +36,16 @@ type elfNoteHeader struct {
 	Type   uint32
 }
 
-// ReadBuildID returns the GNU build ID note of the provided ELF executable.
-// The ErrNoBuildID error is returned when one is not found.
-//
-// Observed Go binaries presented one when built with:
-//
-//      go build -buildmode=pie
-//
-// See details at http://fedoraproject.org/wiki/Releases/FeatureBuildId
+// ReadBuildID will return the GNU build-id if available and else the
+// GO build-id (the go-buildid is only available
 func ReadBuildID(fname string) (string, error) {
-	const ELF_NOTE_GNU = "GNU\x00"
-	const NT_GNU_BUILD_ID uint32 = 3
+	if buildId, err := readGenericBuildID(fname, "GNU\x00", 3); err == nil {
+		return buildId, nil
+	}
+	return readGenericBuildID(fname, "Go\x00\x00", 4)
+}
 
+func readGenericBuildID(fname, elfNote string, hdrType uint32) (string, error) {
 	// Open the designated ELF file
 	f, err := elf.Open(fname)
 	if err != nil {
@@ -73,7 +71,7 @@ func ReadBuildID(fname string) (string, error) {
 		}
 
 		// We are looking for a specific type of note
-		if nHdr.Type != NT_GNU_BUILD_ID {
+		if nHdr.Type != hdrType {
 			continue
 		}
 
@@ -84,7 +82,7 @@ func ReadBuildID(fname string) (string, error) {
 		}
 
 		// We are only interested in GNU build IDs
-		if string(noteName) != ELF_NOTE_GNU {
+		if string(noteName) != elfNote {
 			continue
 		}
 

--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -36,13 +36,20 @@ type elfNoteHeader struct {
 	Type   uint32
 }
 
+const (
+	gnuElfNote = "GNU\x00"
+	gnuHdrType = 3
+	goElfNote  = "Go\x00\x00"
+	goHdrType  = 4
+)
+
 // ReadBuildID will return the GNU build-id if available and else the
 // GO build-id (the go-buildid is only available
 func ReadBuildID(fname string) (string, error) {
-	if buildId, err := readGenericBuildID(fname, "GNU\x00", 3); err == nil {
+	if buildId, err := readGenericBuildID(fname, gnuElfNote, gnuHdrType); err == nil {
 		return buildId, nil
 	}
-	return readGenericBuildID(fname, "Go\x00\x00", 4)
+	return readGenericBuildID(fname, goElfNote, goHdrType)
 }
 
 func readGenericBuildID(fname, elfNote string, hdrType uint32) (string, error) {

--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -43,8 +43,8 @@ const (
 	goHdrType  = 4
 )
 
-// ReadBuildID will return the GNU build-id if available and else the
-// GO build-id (the go-buildid is only available
+// ReadBuildID returns the build ID of a given binary. GNU BuildID is is
+// preferred over Go BuildID. Returns an error when neither is found.
 func ReadBuildID(fname string) (string, error) {
 	if buildId, err := readGenericBuildID(fname, gnuElfNote, gnuHdrType); err == nil {
 		return buildId, nil

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -43,6 +43,8 @@ func buildID(c *C, fname string) string {
 	output, err := exec.Command("file", fname).CombinedOutput()
 	c.Assert(err, IsNil)
 
+	c.Logf("file output: %q", string(output))
+
 	// BuildID can look like:
 	//  BuildID[sha1]=443877f9ec13c82365478130fc95cb5ff5181912
 	//  BuildID[md5/uuid]=ae38cdf243d2111064dfee99dfc30013

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -40,8 +40,8 @@ var falsePath = osutil.LookPathDefault("false", "/bin/false")
 var gccPath = osutil.LookPathDefault("gcc", "/usr/bin/gcc")
 
 func buildID(c *C, fname string) string {
-	// XXX host's 'file' command may be too old to know about Go BuildID,
-	// use with caution
+	// XXX host's 'file' command may be too old to know about Go BuildID or
+	// hexstring GNU BuildID, use with caution
 	output, err := exec.Command("file", fname).CombinedOutput()
 	c.Assert(err, IsNil)
 
@@ -111,8 +111,9 @@ func (s *buildIDSuite) TestReadBuildIDFixedELF(c *C) {
 
 	id, err := osutil.ReadBuildID(md5Truth)
 	c.Assert(err, IsNil)
+	// XXX cannot call buildID() as the host's 'file' command may be too old
+	// to know about hexstring format of GNU BuildID
 	c.Assert(id, Equals, "deadcafe")
-	c.Assert(id, Equals, buildID(c, md5Truth))
 }
 
 func (s *buildIDSuite) TestMyBuildID(c *C) {


### PR DESCRIPTION
The go compiler will only create a GNU build-id when either
build with -buildmode=pie or when we have a `import "C"`
somewhere. We do not use -buildmode=pie on 32bit systems
and with PR#6759 we will stop using cgo (`import "C"`) soon.

This means that we have no GNU build-id in our binaries
anymore on some sytems. The build-id is criticial for the
system-key generation. Fortunately go also provides a
build-id that we can use. It is available since at least
go-1.6 so should cause no problems. Its longer than the
GNU build id (~50 bytes) but not unwieldy.

We could also consider dropping the support for the GNU
build-id entirely the downside of that is that we will not be
able to take the build-id of any non-go program (which
does not matter right now).
