### PR TITLE
data/selinux: policy tweaks

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -449,6 +449,7 @@ gen_require(`
   type var_log_t;
 ')
 allow snappy_confine_t admin_home_t:dir mounton;
+allow snappy_confine_t bin_t:dir mounton;
 allow snappy_confine_t cert_t:dir { getattr mounton };
 allow snappy_confine_t device_t:filesystem unmount;
 allow snappy_confine_t devpts_t:dir mounton;
@@ -461,13 +462,13 @@ allow snappy_confine_t snappy_snap_t:dir { mounton read };
 allow snappy_confine_t snappy_snap_t:file mounton;
 allow snappy_confine_t snappy_snap_t:lnk_file read;
 allow snappy_confine_t snappy_var_lib_t:dir mounton;
+allow snappy_confine_t snappy_var_run_t:dir mounton;
 allow snappy_confine_t snappy_var_run_t:file mounton;
 allow snappy_confine_t snappy_var_t:dir { getattr mounton };
 allow snappy_confine_t tmp_t:dir { add_name create mounton remove_name rmdir setattr write read };
 allow snappy_confine_t usr_t:dir mounton;
 allow snappy_confine_t var_log_t:dir mounton;
 allow snappy_confine_t var_run_t:dir mounton;
-allow snappy_confine_t snappy_var_run_t:dir mounton;
 dev_mounton(snappy_confine_t)
 dev_mounton_sysfs(snappy_confine_t)
 dev_unmount_sysfs_fs(snappy_confine_t)

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -207,6 +207,8 @@ admin_pattern(snappy_t, snappy_var_lib_t)
 mmap_rw_files_pattern(snappy_t, snappy_var_lib_t, snappy_var_lib_t)
 # snap data files
 admin_pattern(snappy_t, snappy_var_t)
+# auto transition /var/snap when created at runtime
+files_var_filetrans(snappy_t, snappy_var_t, dir, "snap")
 # some snaps may create character files, eg. lxd creates /dev/full in the
 # container's rootfs
 manage_chr_files_pattern(snappy_t, snappy_var_t, snappy_var_t)


### PR DESCRIPTION
The /usr/libexec directory is of bin_t type. When snap has a base, /usr/libexec/snapd will be mounted into the snap mount namespace, what triggers this log:

```
    type=AVC msg=audit(04/26/19 06:34:22.007:1546) : avc:  denied  { mounton } for
             pid=18030 comm=snap-confine
             path=/tmp/snap.rootfs_uiQ2px/usr/lib/snapd dev="sda1"
             ino=156340
             scontext=system_u:system_r:snappy_confine_t:s0
             tcontext=system_u:object_r:bin_t:s0 tclass=dir
             permissive=1
```
    
When snapd creates /var/snap at runtime, make sure it transitions to snappy_var_t.

This is caught by tests restore checks, that list the following entries as incorrectly labeled:

```    
    + grep -v snappy_var_t
    + find /var/snap -printf '%Z\t%H/%P\n'
    system_u:object_r:var_t:s0      /var/snap/
    system_u:object_r:var_t:s0      /var/snap/core18
    system_u:object_r:var_t:s0      /var/snap/core18/current
    system_u:object_r:var_t:s0      /var/snap/core18/common
    system_u:object_r:var_t:s0      /var/snap/core18/941
    system_u:object_r:var_t:s0      /var/snap/test-snapd-with-configure-core18
    system_u:object_r:var_t:s0      /var/snap/test-snapd-with-configure-core18/current
    system_u:object_r:var_t:s0      /var/snap/test-snapd-with-configure-core18/common
    system_u:object_r:var_t:s0      /var/snap/test-snapd-with-configure-core18/common/configure-ran
    system_u:object_r:var_t:s0      /var/snap/test-snapd-with-configure-core18/x1
    system_u:object_r:var_t:s0      /var/snap/snapd
    system_u:object_r:var_t:s0      /var/snap/snapd/current
    system_u:object_r:var_t:s0      /var/snap/snapd/common
    system_u:object_r:var_t:s0      /var/snap/snapd/2827
```

cc @Conan-Kudo 