### PR TITLE
cmd/snap-update-ns: pass MountProfileUpdate to apply{System,User}Fstab

### DIFF
--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -78,9 +78,11 @@ func run() error {
 	if err := parseArgs(os.Args[1:]); err != nil {
 		return err
 	}
-
+	var ctx MountProfileUpdateContext
 	if opts.UserMounts {
-		return applyUserFstab(opts.Positionals.SnapName)
+		ctx = NewUserProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine, os.Getuid())
+		return applyUserFstab(ctx, opts.Positionals.SnapName)
 	}
-	return applySystemFstab(opts.Positionals.SnapName, opts.FromSnapConfine)
+	ctx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
+	return applySystemFstab(ctx, opts.Positionals.SnapName)
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -381,7 +381,8 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	err = ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
 	c.Assert(err, IsNil)
 
-	err = update.ApplyUserFstab("foo")
+	ctx := update.NewUserProfileUpdateContext(snapName, true, 1000)
+	err = update.ApplyUserFstab(ctx, "foo")
 	c.Assert(err, IsNil)
 
 	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, os.Getuid())

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -385,7 +385,7 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	err = update.ApplyUserFstab(ctx, "foo")
 	c.Assert(err, IsNil)
 
-	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, os.Getuid())
+	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, 1000)
 
 	c.Assert(changes, HasLen, 1)
 	c.Assert(changes[0].Action, Equals, update.Mount)

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -76,8 +76,7 @@ func (ctx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	return as
 }
 
-func applySystemFstab(instanceName string, fromSnapConfine bool) error {
-	ctx := NewSystemProfileUpdateContext(instanceName, fromSnapConfine)
+func applySystemFstab(ctx MountProfileUpdateContext, instanceName string) error {
 	unlock, err := ctx.Lock()
 	if err != nil {
 		return err

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -79,16 +78,14 @@ func (ctx *UserProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile,
 	return profile, nil
 }
 
-func applyUserFstab(snapName string) error {
-	fromSnapConfine := true // currently always true, no persistence yet.
-	ctx := NewUserProfileUpdateContext(snapName, fromSnapConfine, os.Getuid())
+func applyUserFstab(ctx MountProfileUpdateContext, instanceName string) error {
 	desired, err := ctx.LoadDesiredProfile()
 	if err != nil {
-		return fmt.Errorf("cannot load desired user mount profile of snap %q: %s", snapName, err)
+		return fmt.Errorf("cannot load desired user mount profile of snap %q: %s", instanceName, err)
 	}
 	debugShowProfile(desired, "desired mount profile")
 	as := ctx.Assumptions()
-	_, err = applyProfile(ctx, snapName, &osutil.MountProfile{}, desired, as)
+	_, err = applyProfile(ctx, instanceName, &osutil.MountProfile{}, desired, as)
 	return err
 }
 


### PR DESCRIPTION
This allows some de-duplication of passed arguments.
The final simplification will come after applySystemFstab merges with
computeAndSaveSystemChanges since that's the last holdout for the
extra, redundant arguments.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
