### PR TITLE
daemon: verify snap instructions for multi-snap requests

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1381,6 +1381,9 @@ func snapsOp(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode request body into snap instruction: %v", err)
 	}
 
+	if err := verifySnapInstructions(&inst); err != nil {
+		return BadRequest("%v", err)
+	}
 	if inst.Channel != "" || !inst.Revision.Unset() || inst.DevMode || inst.JailMode {
 		return BadRequest("unsupported option provided for multi-snap operation")
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2404,7 +2404,7 @@ func (s *apiSuite) TestPostSnap(c *check.C) {
 	c.Check(soon, check.Equals, 1)
 }
 
-func (s *apiSuite) TestPostSnapVerfySnapInstruction(c *check.C) {
+func (s *apiSuite) TestPostSnapVerifySnapInstruction(c *check.C) {
 	s.daemonWithOverlordMock(c)
 
 	buf := bytes.NewBufferString(`{"action": "install"}`)
@@ -2413,6 +2413,21 @@ func (s *apiSuite) TestPostSnapVerfySnapInstruction(c *check.C) {
 	s.vars = map[string]string{"name": "ubuntu-core"}
 
 	rsp := postSnap(snapCmd, req, nil).(*resp)
+
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, `cannot install "ubuntu-core", please use "core" instead`)
+}
+
+func (s *apiSuite) TestPostSnapVerifyMultiSnapInstruction(c *check.C) {
+	s.daemonWithOverlordMock(c)
+
+	buf := strings.NewReader(`{"action": "install","snaps":["ubuntu-core"]}`)
+	req, err := http.NewRequest("POST", "/v2/snaps", buf)
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", "application/json")
+
+	rsp := postSnaps(snapsCmd, req, nil).(*resp)
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)


### PR DESCRIPTION
Without this change, the checks done in `verifySnapInstructions` were
not done for requests done by POSTing to `/v2/snaps`. This meant that
you could install `ubuntu-core`, by doing `snap install ubuntu-core
hello`.

This change makes the multi-snap operation also check the instruction,
so now that multi-snap operation properly errors out.
