### PR TITLE
cmd/snap-update-ns: merge computeAndSaveSystemChanges into applySystemFstab

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -41,10 +41,6 @@ var (
 	PlanWritableMimic = planWritableMimic
 	ExecWritableMimic = execWritableMimic
 
-	// main
-	ComputeAndSaveSystemChanges = computeAndSaveSystemChanges
-	ApplyUserFstab              = applyUserFstab
-
 	// bootstrap
 	ClearBootstrapError = clearBootstrapError
 
@@ -55,9 +51,11 @@ var (
 	// system
 	DesiredSystemProfilePath = desiredSystemProfilePath
 	CurrentSystemProfilePath = currentSystemProfilePath
+	ApplySystemFstab         = applySystemFstab
 
 	// user
 	DesiredUserProfilePath = desiredUserProfilePath
+	ApplyUserFstab         = applyUserFstab
 
 	// xdg
 	XdgRuntimeDir        = xdgRuntimeDir

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -54,7 +54,7 @@ func (s *mainSuite) SetUpTest(c *C) {
 	s.log = buf
 }
 
-func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
+func (s *mainSuite) TestApplySystemFstab(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
@@ -80,7 +80,7 @@ func (s *mainSuite) TestComputeAndSaveSystemChanges(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	err = update.ComputeAndSaveSystemChanges(ctx, snapName, s.as)
+	err = update.ApplySystemFstab(ctx, snapName)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -148,7 +148,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
+	c.Assert(update.ApplySystemFstab(ctx, snapName), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -226,7 +226,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
+	c.Assert(update.ApplySystemFstab(ctx, snapName), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -269,7 +269,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), ErrorMatches, "testing")
+	c.Assert(update.ApplySystemFstab(ctx, snapName), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -312,7 +312,7 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, nil), ErrorMatches, "testing")
+	c.Assert(update.ApplySystemFstab(ctx, snapName), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -356,7 +356,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	// The error was ignored, and no mount was recorded in the profile
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ComputeAndSaveSystemChanges(ctx, snapName, s.as), IsNil)
+	c.Assert(update.ApplySystemFstab(ctx, snapName), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -83,37 +83,33 @@ func applySystemFstab(ctx MountProfileUpdateContext, instanceName string) error 
 	}
 	defer unlock()
 
-	as := ctx.Assumptions()
-	return computeAndSaveSystemChanges(ctx, instanceName, as)
-}
-
-func computeAndSaveSystemChanges(upCtx MountProfileUpdateContext, snapName string, as *Assumptions) error {
 	// Read the desired and current mount profiles. Note that missing files
 	// count as empty profiles so that we can gracefully handle a mount
 	// interface connection/disconnection.
-	desired, err := upCtx.LoadDesiredProfile()
+	desired, err := ctx.LoadDesiredProfile()
 	if err != nil {
 		return err
 	}
 	debugShowProfile(desired, "desired mount profile")
 
-	currentBefore, err := upCtx.LoadCurrentProfile()
+	currentBefore, err := ctx.LoadCurrentProfile()
 	if err != nil {
 		return err
 	}
 	debugShowProfile(currentBefore, "current mount profile (before applying changes)")
 	// Synthesize mount changes that were applied before for the purpose of the tmpfs detector.
+	as := ctx.Assumptions()
 	for _, entry := range currentBefore.Entries {
 		as.AddChange(&Change{Action: Mount, Entry: entry})
 	}
 
-	currentAfter, err := applyProfile(upCtx, snapName, currentBefore, desired, as)
+	currentAfter, err := applyProfile(ctx, instanceName, currentBefore, desired, as)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf("saving current mount profile of snap %q", snapName)
-	return upCtx.SaveCurrentProfile(currentAfter)
+	logger.Debugf("saving current mount profile of snap %q", instanceName)
+	return ctx.SaveCurrentProfile(currentAfter)
 }
 
 // desiredSystemProfilePath returns the path of the fstab-like file with the desired, system-wide mount profile for a snap.


### PR DESCRIPTION
This allows us to stop passing around the assumption object and brings
the two apply functions (user and system) closer towards merging.

Tests are unaffected apart from the mechanical rename.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
