### PR TITLE
tests: give more time until nc returns on appstream test

### DIFF
--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -9,7 +9,7 @@ prepare: |
 execute: |
     echo "Verify that search results contain common-ids"
     printf 'GET /v2/find?name=test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
-        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        nc -U -q 5 /run/snapd.socket| grep '{'| \
         jq -r ' .result[0]["common-ids"] | sort | join (",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
 
@@ -17,12 +17,12 @@ execute: |
 
     echo "Verify that installed snap info contains common-ids"
     printf 'GET /v2/snaps/test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
-        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        nc -U -q 5 /run/snapd.socket| grep '{'| \
         jq -r ' .result["common-ids"] | sort | join(",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
 
     echo "Verify that apps have their common-id set"
     printf 'GET /v2/apps?names=test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
-        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        nc -U -q 5 /run/snapd.socket| grep '{'| \
         jq -r ' .result | sort_by(.name) | [.[]."common-id"] | join(",")' | \
         MATCH 'io.snapcraft.test-snapd-appstreamid.bar,,io.snapcraft.test-snapd-appstreamid.foo'


### PR DESCRIPTION
During executions the requests done on the appstream could take more
than 2 seconds. With 3 second of timeout the error cannot be reproduced
anymore.

Error:
https://paste.ubuntu.com/p/gbfkv796F4/

Test executions:
https://paste.ubuntu.com/p/37qryMK8zg/
