### PR TITLE
cmd/snap-update-ns: remove instanceName argument from applyProfile

### DIFF
--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -81,8 +81,8 @@ func run() error {
 	var ctx MountProfileUpdateContext
 	if opts.UserMounts {
 		ctx = NewUserProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine, os.Getuid())
-		return applyUserFstab(ctx, opts.Positionals.SnapName)
+		return applyUserFstab(ctx)
 	}
 	ctx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
-	return applySystemFstab(ctx, opts.Positionals.SnapName)
+	return applySystemFstab(ctx)
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -80,7 +80,7 @@ func (s *mainSuite) TestApplySystemFstab(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	err = update.ApplySystemFstab(ctx, snapName)
+	err = update.ApplySystemFstab(ctx)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -148,7 +148,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx, snapName), IsNil)
+	c.Assert(update.ApplySystemFstab(ctx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -226,7 +226,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx, snapName), IsNil)
+	c.Assert(update.ApplySystemFstab(ctx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -269,7 +269,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx, snapName), ErrorMatches, "testing")
+	c.Assert(update.ApplySystemFstab(ctx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -312,7 +312,7 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx, snapName), ErrorMatches, "testing")
+	c.Assert(update.ApplySystemFstab(ctx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -356,7 +356,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	// The error was ignored, and no mount was recorded in the profile
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx, snapName), IsNil)
+	c.Assert(update.ApplySystemFstab(ctx), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -382,7 +382,7 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewUserProfileUpdateContext(snapName, true, 1000)
-	err = update.ApplyUserFstab(ctx, "foo")
+	err = update.ApplyUserFstab(ctx)
 	c.Assert(err, IsNil)
 
 	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, 1000)

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -76,7 +75,7 @@ func (ctx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	return as
 }
 
-func applySystemFstab(ctx MountProfileUpdateContext, instanceName string) error {
+func applySystemFstab(ctx MountProfileUpdateContext) error {
 	unlock, err := ctx.Lock()
 	if err != nil {
 		return err
@@ -103,12 +102,11 @@ func applySystemFstab(ctx MountProfileUpdateContext, instanceName string) error 
 		as.AddChange(&Change{Action: Mount, Entry: entry})
 	}
 
-	currentAfter, err := applyProfile(ctx, instanceName, currentBefore, desired, as)
+	currentAfter, err := applyProfile(ctx, currentBefore, desired, as)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf("saving current mount profile of snap %q", instanceName)
 	return ctx.SaveCurrentProfile(currentAfter)
 }
 

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -78,14 +78,14 @@ func (ctx *UserProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile,
 	return profile, nil
 }
 
-func applyUserFstab(ctx MountProfileUpdateContext, instanceName string) error {
+func applyUserFstab(ctx MountProfileUpdateContext) error {
 	desired, err := ctx.LoadDesiredProfile()
 	if err != nil {
-		return fmt.Errorf("cannot load desired user mount profile of snap %q: %s", instanceName, err)
+		return err
 	}
 	debugShowProfile(desired, "desired mount profile")
 	as := ctx.Assumptions()
-	_, err = applyProfile(ctx, instanceName, &osutil.MountProfile{}, desired, as)
+	_, err = applyProfile(ctx, &osutil.MountProfile{}, desired, as)
 	return err
 }
 

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -654,7 +654,7 @@ func createWritableMimic(dir, neededBy string, as *Assumptions) ([]*Change, erro
 	return changes, nil
 }
 
-func applyProfile(up MountProfileUpdateContext, snapName string, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {
+func applyProfile(up MountProfileUpdateContext, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {
 	// Compute the needed changes and perform each change if
 	// needed, collecting those that we managed to perform or that
 	// were performed already.
@@ -681,7 +681,7 @@ func applyProfile(up MountProfileUpdateContext, snapName string, currentBefore, 
 			if origin == "layout" || origin == "overname" {
 				return nil, err
 			} else if err != ErrIgnoredMissingMount {
-				logger.Noticef("cannot change mount namespace of snap %q according to change %s: %s", snapName, change, err)
+				logger.Noticef("cannot change mount namespace according to change %s: %s", change, err)
 			}
 			continue
 		}


### PR DESCRIPTION
The argument was only used for one debug message. That message
always had the implied snap name context (that in some cases
was also added again by snapd) so showing it again is of little value.

This removes the last duplicated argument from the apply family of
functions.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
