### PR TITLE
cmd,sandbox: tweak seccomp version info handling

### DIFF
--- a/cmd/snap-seccomp/export_test.go
+++ b/cmd/snap-seccomp/export_test.go
@@ -20,9 +20,10 @@
 package main
 
 var (
-	Compile         = compile
-	SeccompResolver = seccompResolver
-	VersionInfo     = versionInfo
+	Compile           = compile
+	SeccompResolver   = seccompResolver
+	VersionInfo       = versionInfo
+	GoSeccompFeatures = goSeccompFeatures
 )
 
 func MockArchUbuntuArchitecture(f func() string) (restore func()) {

--- a/cmd/snap-seccomp/versioninfo.go
+++ b/cmd/snap-seccomp/versioninfo.go
@@ -53,7 +53,7 @@ func versionInfo() (string, error) {
 	}
 
 	major, minor, micro := seccomp.GetLibraryVersion()
-	features := GoSeccompFeatures()
+	features := goSeccompFeatures()
 
 	return fmt.Sprintf("%s %d.%d.%d %x %s", myBuildID, major, minor, micro, sh.Sum(nil), features), nil
 }
@@ -67,7 +67,7 @@ func showVersionInfo() error {
 	return nil
 }
 
-func GoSeccompFeatures() string {
+func goSeccompFeatures() string {
 	features := "-"
 	// as more features are added, make this colon-separated
 	if actLogSupported() {

--- a/cmd/snap-seccomp/versioninfo.go
+++ b/cmd/snap-seccomp/versioninfo.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mvo5/libseccomp-golang"
 
@@ -68,10 +69,13 @@ func showVersionInfo() error {
 }
 
 func goSeccompFeatures() string {
-	features := "-"
-	// as more features are added, make this colon-separated
+	var features []string
 	if actLogSupported() {
-		features = "bpf-actlog"
+		features = append(features, "bpf-actlog")
 	}
-	return features
+
+	if len(features) == 0 {
+		return "-"
+	}
+	return strings.Join(features, ":")
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -323,7 +323,7 @@ func (b *Backend) SandboxFeatures() []string {
 	}
 	tags = append(tags, "bpf-argument-filtering")
 
-	if res, err := seccomp_compiler.HasGoSeccompFeature(b.versionInfo, "bpf-actlog"); err == nil && res {
+	if res, err := seccomp_compiler.VersionInfo(b.versionInfo).HasFeature("bpf-actlog"); err == nil && res {
 		tags = append(tags, "bpf-actlog")
 	}
 

--- a/packaging/debian-sid/patches/0001-cmd-snap-seccomp-use-upstream-seccomp-package.patch
+++ b/packaging/debian-sid/patches/0001-cmd-snap-seccomp-use-upstream-seccomp-package.patch
@@ -21,11 +21,11 @@ Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>
  cmd/snap-seccomp/versioninfo_test.go | 2 +-
  4 files changed, 4 insertions(+), 7 deletions(-)
 
-diff --git a/cmd/snap-seccomp/main.go b/cmd/snap-seccomp/main.go
-index 7056c0309dbcc1b6bf9f3b69e6adf454bed4fcbd..dce0f086bde290839a108d90945c880d5f387e5d 100644
---- a/cmd/snap-seccomp/main.go
-+++ b/cmd/snap-seccomp/main.go
-@@ -181,10 +181,7 @@ import (
+Index: snapd/cmd/snap-seccomp/main.go
+===================================================================
+--- snapd.orig/cmd/snap-seccomp/main.go
++++ snapd/cmd/snap-seccomp/main.go
+@@ -180,10 +180,7 @@ import (
  	"strings"
  	"syscall"
  
@@ -37,10 +37,10 @@ index 7056c0309dbcc1b6bf9f3b69e6adf454bed4fcbd..dce0f086bde290839a108d90945c880d
  
  	"github.com/snapcore/snapd/arch"
  	"github.com/snapcore/snapd/osutil"
-diff --git a/cmd/snap-seccomp/main_test.go b/cmd/snap-seccomp/main_test.go
-index 9a8a28fbfbbf733bcc31963c4b90f2385bd801b6..5c64abf52e006ad25da5de2897d68cf73cb849d6 100644
---- a/cmd/snap-seccomp/main_test.go
-+++ b/cmd/snap-seccomp/main_test.go
+Index: snapd/cmd/snap-seccomp/main_test.go
+===================================================================
+--- snapd.orig/cmd/snap-seccomp/main_test.go
++++ snapd/cmd/snap-seccomp/main_test.go
 @@ -32,7 +32,7 @@ import (
  
  	. "gopkg.in/check.v1"
@@ -50,23 +50,23 @@ index 9a8a28fbfbbf733bcc31963c4b90f2385bd801b6..5c64abf52e006ad25da5de2897d68cf7
  
  	"github.com/snapcore/snapd/arch"
  	main "github.com/snapcore/snapd/cmd/snap-seccomp"
-diff --git a/cmd/snap-seccomp/versioninfo.go b/cmd/snap-seccomp/versioninfo.go
-index e60b26363c39355f95a8ad2878bc672528cc1f5b..a2840f04830c24692539d8b7b4467a007fbbd537 100644
---- a/cmd/snap-seccomp/versioninfo.go
-+++ b/cmd/snap-seccomp/versioninfo.go
-@@ -24,7 +24,7 @@ import (
- 	"fmt"
+Index: snapd/cmd/snap-seccomp/versioninfo.go
+===================================================================
+--- snapd.orig/cmd/snap-seccomp/versioninfo.go
++++ snapd/cmd/snap-seccomp/versioninfo.go
+@@ -25,7 +25,7 @@ import (
  	"os"
+ 	"strings"
  
 -	"github.com/mvo5/libseccomp-golang"
 +	"github.com/seccomp/libseccomp-golang"
  
  	"github.com/snapcore/snapd/cmd/snap-seccomp/syscalls"
  	"github.com/snapcore/snapd/osutil"
-diff --git a/cmd/snap-seccomp/versioninfo_test.go b/cmd/snap-seccomp/versioninfo_test.go
-index 0fb23757019c517a3881cd4c9325b6ec864da3f6..f55f7cf6ff7508bb7fae3a5389341a1a01e46630 100644
---- a/cmd/snap-seccomp/versioninfo_test.go
-+++ b/cmd/snap-seccomp/versioninfo_test.go
+Index: snapd/cmd/snap-seccomp/versioninfo_test.go
+===================================================================
+--- snapd.orig/cmd/snap-seccomp/versioninfo_test.go
++++ snapd/cmd/snap-seccomp/versioninfo_test.go
 @@ -25,7 +25,7 @@ import (
  
  	. "gopkg.in/check.v1"
@@ -76,6 +76,3 @@ index 0fb23757019c517a3881cd4c9325b6ec864da3f6..f55f7cf6ff7508bb7fae3a5389341a1a
  
  	main "github.com/snapcore/snapd/cmd/snap-seccomp"
  	"github.com/snapcore/snapd/osutil"
--- 
-2.21.0
-

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -78,28 +78,31 @@ func (c *Compiler) VersionInfo() (string, error) {
 	return string(raw), nil
 }
 
-// GetLibseccompVersion parses the output of VersionInfo and provides the
+// VersionInfo represents information about the seccomp compilter
+type VersionInfo string
+
+// LibseccompVersion parses VersionInfo and provides the
 // libseccomp version
-func GetLibseccompVersion(versionInfo string) (string, error) {
-	if match := validVersionInfo.Match([]byte(versionInfo)); !match {
-		return "", fmt.Errorf("invalid format of version-info: %q", versionInfo)
+func (vi VersionInfo) LibseccompVersion() (string, error) {
+	if match := validVersionInfo.Match([]byte(vi)); !match {
+		return "", fmt.Errorf("invalid format of version-info: %q", vi)
 	}
-	return strings.Split(versionInfo, " ")[1], nil
+	return strings.Split(string(vi), " ")[1], nil
 }
 
-// GetGoSeccompFeatures parses the output of VersionInfo and provides the
+// Features parses the output of VersionInfo and provides the
 // golang seccomp features
-func GetGoSeccompFeatures(versionInfo string) (string, error) {
-	if match := validVersionInfo.Match([]byte(versionInfo)); !match {
-		return "", fmt.Errorf("invalid format of version-info: %q", versionInfo)
+func (vi VersionInfo) Features() (string, error) {
+	if match := validVersionInfo.Match([]byte(vi)); !match {
+		return "", fmt.Errorf("invalid format of version-info: %q", vi)
 	}
-	return strings.Split(versionInfo, " ")[3], nil
+	return strings.Split(string(vi), " ")[3], nil
 }
 
 // HasGoSeccompFeature parses the output of VersionInfo and answers whether or
 // not golang-seccomp supports the feature
-func HasGoSeccompFeature(versionInfo string, feature string) (bool, error) {
-	features, err := GetGoSeccompFeatures(versionInfo)
+func (vi VersionInfo) HasFeature(feature string) (bool, error) {
+	features, err := vi.Features()
 	if err != nil {
 		return false, err
 	}

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -90,9 +90,9 @@ func (s *compilerSuite) TestVersionInfoValidate(c *C) {
 		} else {
 			c.Check(err, IsNil)
 			c.Check(v, Equals, tc.exp)
-			_, err := seccomp.GetLibseccompVersion(v)
+			_, err := seccomp.VersionInfo(v).LibseccompVersion()
 			c.Check(err, IsNil)
-			_, err = seccomp.GetGoSeccompFeatures(v)
+			_, err = seccomp.VersionInfo(v).Features()
 			c.Check(err, IsNil)
 		}
 		c.Check(cmd.Calls(), DeepEquals, [][]string{
@@ -160,11 +160,11 @@ func (s *compilerSuite) TestCompilerNewUnhappy(c *C) {
 }
 
 func (s *compilerSuite) TestGetLibseccompVersion(c *C) {
-	v, err := seccomp.GetLibseccompVersion("a 2.4.1 b -")
+	v, err := seccomp.VersionInfo("a 2.4.1 b -").LibseccompVersion()
 	c.Assert(err, IsNil)
 	c.Check(v, Equals, "2.4.1")
 
-	v, err = seccomp.GetLibseccompVersion("a phooey b -")
+	v, err = seccomp.VersionInfo("a phooey b -").LibseccompVersion()
 	c.Assert(err, ErrorMatches, "invalid format of version-info: .*")
 	c.Check(v, Equals, "")
 }
@@ -182,7 +182,7 @@ func (s *compilerSuite) TestGetGoSeccompFeatures(c *C) {
 		// invalid
 		{"a 2.4.1 b b@rf", "", "invalid format of version-info: .*"},
 	} {
-		v, err := seccomp.GetGoSeccompFeatures(tc.v)
+		v, err := seccomp.VersionInfo(tc.v).Features()
 		if err == nil {
 			c.Assert(err, IsNil)
 			c.Check(v, Equals, tc.exp)
@@ -210,7 +210,7 @@ func (s *compilerSuite) TestHasGoSeccompFeature(c *C) {
 		// invalid
 		{"a 1.2.3 b b@rf", "b@rf", false, "invalid format of version-info: .*"},
 	} {
-		v, err := seccomp.HasGoSeccompFeature(tc.v, tc.f)
+		v, err := seccomp.VersionInfo(tc.v).HasFeature(tc.f)
 		if err == nil {
 			c.Assert(err, IsNil)
 			c.Check(v, Equals, tc.exp)


### PR DESCRIPTION
Some ideas from the review of https://github.com/snapcore/snapd/pull/6787 - all cosmetic but (IMO) nice to have.

1. Unexport GoSeccompFeatures in cmd/snap-seccomp (its only used internally)
2. Make VersionInfo a type with methods
3. Tweak goSeccompFeatures helper to include the fact that we need to use ":" as separator (this is what the other side already implements).