### PR TITLE
cmd/snap-update-ns: add no-op load/save current user profile logic

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -55,6 +55,7 @@ var (
 
 	// user
 	DesiredUserProfilePath = desiredUserProfilePath
+	CurrentUserProfilePath = currentUserProfilePath
 	ApplyUserFstab         = applyUserFstab
 
 	// xdg

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -41,10 +41,16 @@ func NewUserProfileUpdateContext(instanceName string, fromSnapConfine bool, uid 
 		CommonProfileUpdateContext: CommonProfileUpdateContext{
 			instanceName:       instanceName,
 			fromSnapConfine:    fromSnapConfine,
+			currentProfilePath: currentUserProfilePath(instanceName, uid),
 			desiredProfilePath: desiredUserProfilePath(instanceName),
 		},
 		uid: uid,
 	}
+}
+
+// UID returns the user ID of the mount namespace being updated.
+func (ctx *UserProfileUpdateContext) UID() int {
+	return ctx.uid
 }
 
 // Lock acquires locks / freezes needed to synchronize mount namespace changes.
@@ -78,18 +84,44 @@ func (ctx *UserProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile,
 	return profile, nil
 }
 
+// SaveCurrentProfile does nothing at all.
+//
+// Per-user mount profiles are not persisted yet.
+func (ctx *UserProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	return nil
+}
+
+// LoadCurrentProfile returns the empty profile.
+//
+// Per-user mount profiles are not persisted yet.
+func (ctx *UserProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
+	return &osutil.MountProfile{}, nil
+}
+
 func applyUserFstab(ctx MountProfileUpdateContext) error {
 	desired, err := ctx.LoadDesiredProfile()
 	if err != nil {
 		return err
 	}
 	debugShowProfile(desired, "desired mount profile")
+
+	current, err := ctx.LoadCurrentProfile()
+	if err != nil {
+		return err
+	}
+	debugShowProfile(current, "current mount profile")
+
 	as := ctx.Assumptions()
-	_, err = applyProfile(ctx, &osutil.MountProfile{}, desired, as)
+	_, err = applyProfile(ctx, current, desired, as)
 	return err
 }
 
 // desiredUserProfilePath returns the path of the fstab-like file with the desired, user-specific mount profile for a snap.
 func desiredUserProfilePath(snapName string) string {
 	return fmt.Sprintf("%s/snap.%s.user-fstab", dirs.SnapMountPolicyDir, snapName)
+}
+
+// currentUserProfilePath returns the path of the fstab-like file with the applied, user-specific mount profile for a snap.
+func currentUserProfilePath(snapName string, uid int) string {
+	return fmt.Sprintf("%s/snap.%s.%d.user-fstab", dirs.SnapRunNsDir, snapName, uid)
 }

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -29,6 +29,8 @@ import (
 
 	update "github.com/snapcore/snapd/cmd/snap-update-ns"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type userSuite struct{}
@@ -81,6 +83,61 @@ func (s *userSuite) TestLoadDesiredProfile(c *C) {
 	c.Check(builder.String(), Equals, output)
 }
 
+func (s *userSuite) TestLoadCurrentProfile(c *C) {
+	// Mock directories.
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+
+	// Write a current user mount profile for snap "foo".
+	text := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
+	path := update.CurrentUserProfilePath(ctx.InstanceName(), ctx.UID())
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+
+	// Ask the user profile update helper to read the current profile.
+	profile, err := ctx.LoadCurrentProfile()
+	c.Assert(err, IsNil)
+	builder := &bytes.Buffer{}
+	profile.WriteTo(builder)
+
+	// Note that the profile is empty.
+	// Currently user profiles are not persisted so the presence of a profile on-disk is ignored.
+	c.Check(builder.String(), Equals, "")
+}
+
+func (s *userSuite) TestSaveCurrentProfile(c *C) {
+	// Mock directories and create directory runtime mount profiles.
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
+
+	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+
+	// Prepare a mount profile to be saved.
+	text := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
+	profile, err := osutil.LoadMountProfileText(text)
+	c.Assert(err, IsNil)
+
+	// Write a fake current user mount profile for snap "foo".
+	path := update.CurrentUserProfilePath("foo", 1234)
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(path, []byte("banana"), 0644), IsNil)
+
+	// Ask the user profile update helper to write the current profile.
+	err = ctx.SaveCurrentProfile(profile)
+	c.Assert(err, IsNil)
+
+	// Note that the profile was not modified.
+	// Currently user profiles are not persisted.
+	c.Check(path, testutil.FileEquals, "banana")
+}
+
 func (s *userSuite) TestDesiredUserProfilePath(c *C) {
 	c.Check(update.DesiredUserProfilePath("foo"), Equals, "/var/lib/snapd/mount/snap.foo.user-fstab")
+}
+
+func (s *userSuite) TestCurrentUserProfilePath(c *C) {
+	c.Check(update.CurrentUserProfilePath("foo", 12345), Equals, "/run/snapd/ns/snap.foo.12345.user-fstab")
 }


### PR DESCRIPTION
Currently user mount profiles are not persisted. To allow using
common logic across system and user update apply functions we must
ensure that loading current per-user mount profile returns the empty
profile and that saving said profile is a no-op.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
