### PR TITLE
gadget: introduce checkers for sanitizing structure updates

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -24,4 +24,7 @@ var (
 	ValidateVolumeStructure = validateVolumeStructure
 	ValidateRole            = validateRole
 	ValidateVolume          = validateVolume
+
+	ResolveVolume      = resolveVolume
+	CanUpdateStructure = canUpdateStructure
 )

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -44,6 +44,12 @@ const (
 	MBR = "mbr"
 	// GPT identifies a GUID Partition Table partitioning schema
 	GPT = "gpt"
+
+	SystemBoot = "system-boot"
+	SystemData = "system-data"
+	// ImplicitSystemDataLabel is the implicit filesystem label of structure
+	// of system-data role
+	ImplicitSystemDataLabel = "writable"
 )
 
 var (
@@ -131,8 +137,8 @@ func (vs *VolumeStructure) EffectiveRole() string {
 // EffectiveFilesystemLabel returns the effective filesystem label, either
 // explicitly provided or implied by the structure's role
 func (vs *VolumeStructure) EffectiveFilesystemLabel() string {
-	if vs.EffectiveRole() == "system-data" {
-		return "writable"
+	if vs.EffectiveRole() == SystemData {
+		return ImplicitSystemDataLabel
 	}
 	return vs.Label
 }
@@ -550,9 +556,9 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 	}
 
 	switch vsRole {
-	case "system-data":
-		if vs.Label != "" && vs.Label != "writable" {
-			return fmt.Errorf(`role of this kind must have an implicit label or "writable", not %q`, vs.Label)
+	case SystemData:
+		if vs.Label != "" && vs.Label != ImplicitSystemDataLabel {
+			return fmt.Errorf(`role of this kind must have an implicit label or %q, not %q`, ImplicitSystemDataLabel, vs.Label)
 		}
 	case MBR:
 		if vs.Size > SizeMBR {
@@ -567,7 +573,7 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 		if vs.Filesystem != "" && vs.Filesystem != "none" {
 			return errors.New("mbr structures must not specify a file system")
 		}
-	case "system-boot", "":
+	case SystemBoot, "":
 		// noop
 	default:
 		return fmt.Errorf("unsupported role")

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -128,6 +128,15 @@ func (vs *VolumeStructure) EffectiveRole() string {
 	return ""
 }
 
+// EffectiveFilesystemLabel returns the effective filesystem label, either
+// explicitly provided or implied by the structure's role
+func (vs *VolumeStructure) EffectiveFilesystemLabel() string {
+	if vs.EffectiveRole() == "system-data" {
+		return "writable"
+	}
+	return vs.Label
+}
+
 // VolumeContent defines the contents of the structure. The content can be
 // either files within a filesystem described by the structure or raw images
 // written into the area of a bare structure.
@@ -674,6 +683,13 @@ func ParseSize(gs string) (Size, error) {
 	return size, nil
 }
 
+func (s *Size) String() string {
+	if s == nil {
+		return "unspecified"
+	}
+	return fmt.Sprintf("%d", *s)
+}
+
 // RelativeOffset describes an offset where structure data is written at.
 // The position can be specified as byte-offset relative to the start of another
 // named structure.
@@ -683,6 +699,16 @@ type RelativeOffset struct {
 	RelativeTo string
 	// Offset is a 32-bit value
 	Offset Size
+}
+
+func (r *RelativeOffset) String() string {
+	if r == nil {
+		return "unspecified"
+	}
+	if r.RelativeTo != "" {
+		return fmt.Sprintf("%s+%d", r.RelativeTo, r.Offset)
+	}
+	return fmt.Sprintf("%d", r.Offset)
 }
 
 // ParseRelativeOffset parses a string describing an offset that can be

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package gadget
+
+import (
+	"errors"
+)
+
+var (
+	ErrNoUpdate = errors.New("no update needed")
+)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -28,7 +28,7 @@ var (
 )
 
 func resolveVolume(old *Info, new *Info) (oldVol, newVol *Volume, err error) {
-	// TODO: support only one volume
+	// support only one volume
 	if len(new.Volumes) != 1 || len(old.Volumes) != 1 {
 		return nil, nil, errors.New("cannot update with more than one volume")
 	}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -20,8 +20,102 @@ package gadget
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
 	ErrNoUpdate = errors.New("no update needed")
 )
+
+func resolveVolume(old *Info, new *Info) (oldVol, newVol *Volume, err error) {
+	// TODO: support only one volume
+	if len(new.Volumes) != 1 || len(old.Volumes) != 1 {
+		return nil, nil, errors.New("cannot update with more than one volume")
+	}
+
+	var name string
+	for n := range old.Volumes {
+		name = n
+		break
+	}
+	oldV := old.Volumes[name]
+
+	newV, ok := new.Volumes[name]
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot find entry for volume %q in updated gadget info", name)
+	}
+
+	return &oldV, &newV, nil
+}
+
+func isSameOffset(one *Size, two *Size) bool {
+	if one == nil && two == nil {
+		return true
+	}
+	if one != nil && two != nil {
+		return *one == *two
+	}
+	return false
+}
+
+func isSameRelativeOffset(one *RelativeOffset, two *RelativeOffset) bool {
+	if one == nil && two == nil {
+		return true
+	}
+	if one != nil && two != nil {
+		return *one == *two
+	}
+	return false
+}
+
+func isLegacyMBRTransition(from *PositionedStructure, to *PositionedStructure) bool {
+	// legacy MBR could have been specified by setting type: mbr, with no
+	// role
+	return from.Type == MBR && to.EffectiveRole() == MBR
+}
+
+func canUpdateStructure(from *PositionedStructure, to *PositionedStructure) error {
+	if from.Size != to.Size {
+		return fmt.Errorf("cannot change structure size from %v to %v", from.Size, to.Size)
+	}
+	if !isSameOffset(from.Offset, to.Offset) {
+		return fmt.Errorf("cannot change structure offset from %v to %v", from.Offset, to.Offset)
+	}
+	if from.StartOffset != to.StartOffset {
+		return fmt.Errorf("cannot change structure start offset from %v to %v", from.StartOffset, to.StartOffset)
+	}
+	// TODO: should this limitation be lifted?
+	if !isSameRelativeOffset(from.OffsetWrite, to.OffsetWrite) {
+		return fmt.Errorf("cannot change structure offset-write from %v to %v", from.OffsetWrite, to.OffsetWrite)
+	}
+	if from.EffectiveRole() != to.EffectiveRole() {
+		return fmt.Errorf("cannot change structure role from %q to %q", from.EffectiveRole(), to.EffectiveRole())
+	}
+	if from.Type != to.Type {
+		if !isLegacyMBRTransition(from, to) {
+			return fmt.Errorf("cannot change structure type from %q to %q", from.Type, to.Type)
+		}
+	}
+	if from.ID != to.ID {
+		return fmt.Errorf("cannot change structure ID from %q to %q", from.ID, to.ID)
+	}
+	if !to.IsBare() {
+		if from.IsBare() {
+			return fmt.Errorf("cannot change a bare structure to filesystem one")
+		}
+		if from.Filesystem != to.Filesystem {
+			return fmt.Errorf("cannot change filesystem from %q to %q",
+				from.Filesystem, to.Filesystem)
+		}
+		if from.EffectiveFilesystemLabel() != to.EffectiveFilesystemLabel() {
+			return fmt.Errorf("cannot change filesystem label from %q to %q",
+				from.Label, to.Label)
+		}
+	} else {
+		if !from.IsBare() {
+			return fmt.Errorf("cannot change a filesystem structure to a bare one")
+		}
+	}
+
+	return nil
+}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -1,0 +1,487 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget"
+)
+
+type updateTestSuite struct{}
+
+var _ = Suite(&updateTestSuite{})
+
+func (u *updateTestSuite) TestResolveVolumeDifferentName(c *C) {
+	oldInfo := &gadget.Info{
+		Volumes: map[string]gadget.Volume{
+			"old": gadget.Volume{},
+		},
+	}
+	noMatchInfo := &gadget.Info{
+		Volumes: map[string]gadget.Volume{
+			"not-old": gadget.Volume{},
+		},
+	}
+	oldVol, newVol, err := gadget.ResolveVolume(oldInfo, noMatchInfo)
+	c.Assert(err, ErrorMatches, `cannot find entry for volume "old" in updated gadget info`)
+	c.Assert(oldVol, IsNil)
+	c.Assert(newVol, IsNil)
+}
+
+func (u *updateTestSuite) TestResolveVolumeTooMany(c *C) {
+	oldInfo := &gadget.Info{
+		Volumes: map[string]gadget.Volume{
+			"old":         gadget.Volume{},
+			"another-one": gadget.Volume{},
+		},
+	}
+	noMatchInfo := &gadget.Info{
+		Volumes: map[string]gadget.Volume{
+			"old": gadget.Volume{},
+		},
+	}
+	oldVol, newVol, err := gadget.ResolveVolume(oldInfo, noMatchInfo)
+	c.Assert(err, ErrorMatches, `cannot update with more than one volume`)
+	c.Assert(oldVol, IsNil)
+	c.Assert(newVol, IsNil)
+}
+
+func (u *updateTestSuite) TestResolveVolumeSimple(c *C) {
+	oldInfo := &gadget.Info{
+		Volumes: map[string]gadget.Volume{
+			"old": gadget.Volume{Bootloader: "u-boot"},
+		},
+	}
+	noMatchInfo := &gadget.Info{
+		Volumes: map[string]gadget.Volume{
+			"old": gadget.Volume{Bootloader: "grub"},
+		},
+	}
+	oldVol, newVol, err := gadget.ResolveVolume(oldInfo, noMatchInfo)
+	c.Assert(err, IsNil)
+	c.Assert(oldVol, DeepEquals, &gadget.Volume{Bootloader: "u-boot"})
+	c.Assert(newVol, DeepEquals, &gadget.Volume{Bootloader: "grub"})
+}
+
+type canUpdateTestCase struct {
+	from gadget.PositionedStructure
+	to   gadget.PositionedStructure
+	err  string
+}
+
+func (u *updateTestSuite) testCanUpdate(c *C, testCases []canUpdateTestCase) {
+	for idx, tc := range testCases {
+		c.Logf("tc: %v", idx)
+		err := gadget.CanUpdateStructure(&tc.from, &tc.to)
+		if tc.err == "" {
+			c.Check(err, IsNil)
+		} else {
+			c.Check(err, ErrorMatches, tc.err)
+		}
+	}
+}
+
+func (u *updateTestSuite) TestCanUpdateSize(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			// size change
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1*gadget.SizeMiB + 1*gadget.SizeKiB},
+			},
+			err: "cannot change structure size from [0-9]+ to [0-9]+",
+		}, {
+			// size change
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB},
+			},
+			err: "",
+		},
+	}
+
+	u.testCanUpdate(c, cases)
+}
+
+func (u *updateTestSuite) TestCanUpdateOffsetWrite(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			// offset-write change
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{Offset: 1024},
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{Offset: 2048},
+				},
+			},
+			err: "cannot change structure offset-write from [0-9]+ to [0-9]+",
+		}, {
+			// offset-write, change in relative-to structure name
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{RelativeTo: "bar", Offset: 1024},
+				},
+			},
+			err: `cannot change structure offset-write from foo\+[0-9]+ to bar\+[0-9]+`,
+		}, {
+			// offset-write, unspecified in old
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: nil,
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{RelativeTo: "bar", Offset: 1024},
+				},
+			},
+			err: `cannot change structure offset-write from unspecified to bar\+[0-9]+`,
+		}, {
+			// offset-write, unspecified in new
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: nil,
+				},
+			},
+			err: `cannot change structure offset-write from foo\+[0-9]+ to unspecified`,
+		}, {
+			// all ok, both nils
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: nil,
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: nil,
+				},
+			},
+			err: ``,
+		}, {
+			// all ok, both fully specified
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				},
+			},
+			err: ``,
+		}, {
+			// all ok, both fully specified
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{Offset: 1024},
+				},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{
+					OffsetWrite: &gadget.RelativeOffset{Offset: 1024},
+				},
+			},
+			err: ``,
+		},
+	}
+	u.testCanUpdate(c, cases)
+}
+
+func (u *updateTestSuite) TestCanUpdateOffset(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			// explicitly declared start offset change
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB, Offset: asSizePtr(1024)},
+				StartOffset:     1024,
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB, Offset: asSizePtr(2048)},
+				StartOffset:     2048,
+			},
+			err: "cannot change structure offset from [0-9]+ to [0-9]+",
+		}, {
+			// explicitly declared start offset in new structure
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB, Offset: nil},
+				StartOffset:     1024,
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB, Offset: asSizePtr(2048)},
+				StartOffset:     2048,
+			},
+			err: "cannot change structure offset from unspecified to [0-9]+",
+		}, {
+			// explicitly declared start offset in old structure,
+			// missing from new
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB, Offset: asSizePtr(1024)},
+				StartOffset:     1024,
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB, Offset: nil},
+				StartOffset:     2048,
+			},
+			err: "cannot change structure offset from [0-9]+ to unspecified",
+		}, {
+			// start offset changed due to positioning
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB},
+				StartOffset:     1 * gadget.SizeMiB,
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Size: 1 * gadget.SizeMiB},
+				StartOffset:     2 * gadget.SizeMiB,
+			},
+			err: "cannot change structure start offset from [0-9]+ to [0-9]+",
+		},
+	}
+	u.testCanUpdate(c, cases)
+}
+
+func (u *updateTestSuite) TestCanUpdateRole(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			// new role
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Role: ""},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Role: "system-data"},
+			},
+			err: `cannot change structure role from "" to "system-data"`,
+		}, {
+			// explicitly set tole
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Role: "mbr"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Role: "system-data"},
+			},
+			err: `cannot change structure role from "mbr" to "system-data"`,
+		}, {
+			// implicit legacy role to proper explicit role
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "mbr"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "bare", Role: "mbr"},
+			},
+			err: "",
+		}, {
+			// but not in the opposite direction
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "bare", Role: "mbr"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "mbr"},
+			},
+			err: `cannot change structure type from "bare" to "mbr"`,
+		}, {
+			// start offset changed due to positioning
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Role: ""},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Role: ""},
+			},
+			err: "",
+		},
+	}
+	u.testCanUpdate(c, cases)
+}
+
+func (u *updateTestSuite) TestCanUpdateType(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			// from hybrid type to GUID
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			err: `cannot change structure type from "0C,00000000-0000-0000-0000-dd00deadbeef" to "00000000-0000-0000-0000-dd00deadbeef"`,
+		}, {
+			// from MBR type to GUID (would be stopped at volume update checks)
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			err: `cannot change structure type from "0C" to "00000000-0000-0000-0000-dd00deadbeef"`,
+		}, {
+			// from one MBR type to another
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0A"},
+			},
+			err: `cannot change structure type from "0C" to "0A"`,
+		}, {
+			// from one MBR type to another
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "bare"},
+			},
+			err: `cannot change structure type from "0C" to "bare"`,
+		}, {
+			// from one GUID to another
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadcafe"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			err: `cannot change structure type from "00000000-0000-0000-0000-dd00deadcafe" to "00000000-0000-0000-0000-dd00deadbeef"`,
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "bare"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "bare"},
+			},
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C"},
+			},
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef"},
+			},
+		},
+	}
+	u.testCanUpdate(c, cases)
+}
+
+func (u *updateTestSuite) TestCanUpdateID(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{ID: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{ID: "00000000-0000-0000-0000-dd00deadcafe"},
+			},
+			err: `cannot change structure ID from "00000000-0000-0000-0000-dd00deadbeef" to "00000000-0000-0000-0000-dd00deadcafe"`,
+		},
+	}
+	u.testCanUpdate(c, cases)
+}
+
+func (u *updateTestSuite) TestCanUpdateBareOrFilesystem(c *C) {
+
+	cases := []canUpdateTestCase{
+		{
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: ""},
+			},
+			err: `cannot change a filesystem structure to a bare one`,
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: ""},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4"},
+			},
+			err: `cannot change a bare structure to filesystem one`,
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "vfat"},
+			},
+			err: `cannot change filesystem from "ext4" to "vfat"`,
+		}, {
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "writable"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4"},
+			},
+			err: `cannot change filesystem label from "writable" to ""`,
+		}, {
+			// from implicit filesystem label to explicit one
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Role: "system-data"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Role: "system-data", Label: "writable"},
+			},
+			err: ``,
+		}, {
+			// all ok
+			from: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "do-not-touch"},
+			},
+			to: gadget.PositionedStructure{
+				VolumeStructure: &gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "do-not-touch"},
+			},
+			err: ``,
+		},
+	}
+	u.testCanUpdate(c, cases)
+}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -32,12 +32,12 @@ var _ = Suite(&updateTestSuite{})
 func (u *updateTestSuite) TestResolveVolumeDifferentName(c *C) {
 	oldInfo := &gadget.Info{
 		Volumes: map[string]gadget.Volume{
-			"old": gadget.Volume{},
+			"old": {},
 		},
 	}
 	noMatchInfo := &gadget.Info{
 		Volumes: map[string]gadget.Volume{
-			"not-old": gadget.Volume{},
+			"not-old": {},
 		},
 	}
 	oldVol, newVol, err := gadget.ResolveVolume(oldInfo, noMatchInfo)
@@ -49,13 +49,13 @@ func (u *updateTestSuite) TestResolveVolumeDifferentName(c *C) {
 func (u *updateTestSuite) TestResolveVolumeTooMany(c *C) {
 	oldInfo := &gadget.Info{
 		Volumes: map[string]gadget.Volume{
-			"old":         gadget.Volume{},
-			"another-one": gadget.Volume{},
+			"old":         {},
+			"another-one": {},
 		},
 	}
 	noMatchInfo := &gadget.Info{
 		Volumes: map[string]gadget.Volume{
-			"old": gadget.Volume{},
+			"old": {},
 		},
 	}
 	oldVol, newVol, err := gadget.ResolveVolume(oldInfo, noMatchInfo)
@@ -67,12 +67,12 @@ func (u *updateTestSuite) TestResolveVolumeTooMany(c *C) {
 func (u *updateTestSuite) TestResolveVolumeSimple(c *C) {
 	oldInfo := &gadget.Info{
 		Volumes: map[string]gadget.Volume{
-			"old": gadget.Volume{Bootloader: "u-boot"},
+			"old": {Bootloader: "u-boot"},
 		},
 	}
 	noMatchInfo := &gadget.Info{
 		Volumes: map[string]gadget.Volume{
-			"old": gadget.Volume{Bootloader: "grub"},
+			"old": {Bootloader: "grub"},
 		},
 	}
 	oldVol, newVol, err := gadget.ResolveVolume(oldInfo, noMatchInfo)


### PR DESCRIPTION
Introduce code for resolving which is the matching voulme description between updated gadget YAML infos, and checkers for sanitizing structure updates.

The rule is that we allow changes in structure content, be it bare, or a filesystem one. However, none of upper level changes in structure are allowed. That is, structure's position (declared and resolved) must not change, it's type or role, the filesystem/bare transition is not allowed, nor is the type of filesystem or the label.

cc @cmatsuoka