### PR TITLE
travis: bump Go version to 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ git:
 jobs:
   include:
     - stage: quick
-      name: go 1.9/xenial static and unit test suites
+      name: go 1.10/xenial static and unit test suites
       dist: xenial
-      go: "1.9"
+      go: "1.10.x"
       before_install:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
       install:
@@ -17,7 +17,7 @@ jobs:
         - ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick
-      go: "1.10"
+      go: "1.10.x"
       name: OSX build and minimal runtime sanity check
       os: osx
       addons:


### PR DESCRIPTION
Bump Go version used in Travis jobs to 1.10.x (latest tagged 1.10 release).