### PR TITLE
snapstate: revert "overlord/snapstate: remove PlugsOnly"

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -64,6 +64,10 @@ type SnapSetup struct {
 	UserID  int       `json:"user-id,omitempty"`
 	Base    string    `json:"base,omitempty"`
 	Type    snap.Type `json:"type,omitempty"`
+	// PlugsOnly indicates whether the relevant revisions for the
+	// operation have only plugs (#plugs >= 0), and absolutely no
+	// slots (#slots == 0).
+	PlugsOnly bool `json:"plugs-only,omitempty"`
 
 	// FIXME: implement rename of this as suggested in
 	//  https://github.com/snapcore/snapd/pull/4103#discussion_r169569717

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -134,6 +134,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if err != nil {
 			return nil, err
 		}
+		snapsup.PlugsOnly = snapsup.PlugsOnly && (len(info.Slots) == 0)
 
 		if experimentalRefreshAppAwareness {
 			// Note that because we are modifying the snap state this block
@@ -620,6 +621,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		Channel:     channel,
 		Flags:       flags.ForSnapSetup(),
 		Type:        info.Type,
+		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: info.InstanceKey,
 	}
 
@@ -686,6 +688,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		DownloadInfo: &info.DownloadInfo,
 		SideInfo:     &info.SideInfo,
 		Type:         info.Type,
+		PlugsOnly:    len(info.Slots) == 0,
 		InstanceKey:  info.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
 			Media: info.Media,
@@ -744,6 +747,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			DownloadInfo: &info.DownloadInfo,
 			SideInfo:     &info.SideInfo,
 			Type:         info.Type,
+			PlugsOnly:    len(info.Slots) == 0,
 			InstanceKey:  info.InstanceKey,
 		}
 
@@ -930,6 +934,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			DownloadInfo: &update.DownloadInfo,
 			SideInfo:     &update.SideInfo,
 			Type:         update.Type,
+			PlugsOnly:    len(update.Slots) == 0,
 			InstanceKey:  update.InstanceKey,
 			auxStoreInfo: auxStoreInfo{
 				Media: update.Media,
@@ -1409,6 +1414,7 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 		SideInfo:    snapst.CurrentSideInfo(),
 		Flags:       snapst.Flags.ForSnapSetup(),
 		Type:        info.Type,
+		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 
@@ -1467,6 +1473,7 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 			Revision: snapst.Current,
 		},
 		Type:        info.Type,
+		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 
@@ -1673,6 +1680,7 @@ func Remove(st *state.State, name string, revision snap.Revision) (*state.TaskSe
 			Revision: revision,
 		},
 		Type:        info.Type,
+		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 
@@ -1862,6 +1870,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		SideInfo:    snapst.Sequence[i],
 		Flags:       flags.ForSnapSetup(),
 		Type:        info.Type,
+		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
 	return doInstall(st, &snapst, snapsup, 0, "")

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1726,6 +1726,8 @@ func (s *snapmgrTestSuite) TestDoInstallWithSlots(c *C) {
 	var snapsup snapstate.SnapSetup
 	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
+
+	c.Check(snapsup.PlugsOnly, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestDoUpdateHadSlots(c *C) {
@@ -1769,6 +1771,8 @@ func (s *snapmgrTestSuite) TestDoUpdateHadSlots(c *C) {
 	var snapsup snapstate.SnapSetup
 	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
+
+	c.Check(snapsup.PlugsOnly, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestDoInstallChannelDefault(c *C) {
@@ -2556,8 +2560,9 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeApp,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -2726,6 +2731,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 		},
 		SideInfo:    snapsup.SideInfo,
 		Type:        snap.TypeApp,
+		PlugsOnly:   true,
 		InstanceKey: "instance",
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
@@ -3044,8 +3050,9 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeApp,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -3191,9 +3198,10 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeApp,
-		Flags:    snapstate.Flags{Amend: true},
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
+		Flags:     snapstate.Flags{Amend: true},
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -3407,8 +3415,9 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeApp,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "services-snap",
@@ -3629,6 +3638,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 		},
 		SideInfo:    snapsup.SideInfo,
 		Type:        snap.TypeApp,
+		PlugsOnly:   true,
 		InstanceKey: "instance",
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
@@ -4001,8 +4011,9 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeKernel,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeKernel,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "kernel",
@@ -6305,9 +6316,10 @@ version: 1.0`)
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		SnapPath: mockSnap,
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeApp,
+		SnapPath:  mockSnap,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -6400,9 +6412,10 @@ epoch: 1*
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		SnapPath: mockSnap,
-		SideInfo: snapsup.SideInfo,
-		Type:     snap.TypeApp,
+		SnapPath:  mockSnap,
+		SideInfo:  snapsup.SideInfo,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -6579,7 +6592,8 @@ version: 1.0`)
 		Flags: snapstate.Flags{
 			Required: true,
 		},
-		Type: snap.TypeApp,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, si)
 
@@ -6711,7 +6725,8 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 					Revision: snap.R(7),
 					SnapID:   "some-snap-id",
 				},
-				Type: snap.TypeApp,
+				Type:      snap.TypeApp,
+				PlugsOnly: true,
 			}
 
 		}
@@ -6850,6 +6865,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 					Revision: snap.R(7),
 				},
 				Type:        snap.TypeApp,
+				PlugsOnly:   true,
 				InstanceKey: "instance",
 			}
 
@@ -7112,7 +7128,8 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 					RealName: "some-snap",
 					Revision: snap.R(7),
 				},
-				Type: snap.TypeApp,
+				Type:      snap.TypeApp,
+				PlugsOnly: true,
 			}
 
 		}
@@ -7294,6 +7311,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 			expSnapSetup.SideInfo.Revision = snap.R(2)
 		}
 		if t.Kind() == "auto-disconnect" {
+			expSnapSetup.PlugsOnly = true
 			expSnapSetup.Type = "app"
 		}
 
@@ -8397,9 +8415,10 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	snapsup, err := snapstate.TaskSnapSetup(first)
 	c.Assert(err, IsNil)
 	c.Check(snapsup, DeepEquals, &snapstate.SnapSetup{
-		SideInfo: &si,
-		Flags:    flags,
-		Type:     snap.TypeApp,
+		SideInfo:  &si,
+		Flags:     flags,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 }
 
@@ -8463,7 +8482,8 @@ func (s *snapmgrTestSuite) TestDisableRunThrough(c *C) {
 			RealName: "some-snap",
 			Revision: snap.R(7),
 		},
-		Type: snap.TypeApp,
+		Type:      snap.TypeApp,
+		PlugsOnly: true,
 	})
 }
 


### PR DESCRIPTION
This reverts commit f77fbff18acacd73cdc816812517b90a75d6ee0c.

It turns out that we removed PlugsOnly in PR#6763 a bit too early. While
it is not used right now it will be used in the future by a
PR that Samuele is working on. So revert the removal here
to ensure it does not slow the work on this PR down.
