### PR TITLE
snap,store,daemon,client: send new "Snap-Client-User-Agent" header in Search()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -71,7 +71,7 @@ type Config struct {
 	// alive for later reuse
 	DisableKeepAlive bool
 
-	// Sent custom user agent
+	// User-Agent to sent to the snapd daemon
 	UserAgent string
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -70,6 +70,9 @@ type Config struct {
 	// DisableKeepAlive indicates whether the connections should not be kept
 	// alive for later reuse
 	DisableKeepAlive bool
+
+	// Sent custom user agent
+	UserAgent string
 }
 
 // A Client knows how to talk to the snappy daemon.
@@ -84,6 +87,8 @@ type Client struct {
 
 	warningCount     int
 	warningTimestamp time.Time
+
+	userAgent string
 }
 
 // New returns a new instance of Client
@@ -103,6 +108,7 @@ func New(config *Config) *Client {
 			doer:        &http.Client{Transport: transport},
 			disableAuth: config.DisableAuth,
 			interactive: config.Interactive,
+			userAgent:   config.UserAgent,
 		}
 	}
 
@@ -115,6 +121,7 @@ func New(config *Config) *Client {
 		doer:        &http.Client{Transport: &http.Transport{DisableKeepAlives: config.DisableKeepAlive}},
 		disableAuth: config.DisableAuth,
 		interactive: config.Interactive,
+		userAgent:   config.UserAgent,
 	}
 }
 
@@ -193,6 +200,9 @@ func (client *Client) raw(method, urlpath string, query url.Values, headers map[
 	req, err := http.NewRequest(method, u.String(), body)
 	if err != nil {
 		return nil, RequestError{err}
+	}
+	if client.userAgent != "" {
+		req.Header.Set("User-Agent", client.userAgent)
 	}
 
 	for key, value := range headers {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -458,6 +458,16 @@ func (cs *clientSuite) TestClientCreateUser(c *C) {
 	})
 }
 
+func (cs *clientSuite) TestUserAgent(c *C) {
+	cli := client.New(&client.Config{UserAgent: "some-agent/9.87"})
+	cli.SetDoer(cs)
+
+	var v string
+	_ = cli.Do("GET", "/", nil, nil, &v)
+	c.Assert(cs.req, NotNil)
+	c.Check(cs.req.Header.Get("User-Agent"), Equals, "some-agent/9.87")
+}
+
 var createUsersTests = []struct {
 	options   []*client.CreateUserOptions
 	bodies    []string

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -350,14 +350,17 @@ var ClientConfig = client.Config{
 	Socket: dirs.SnapdSocket,
 	// Allow interactivity if we have a terminal
 	Interactive: isStdinTTY,
-	// Custom user agent
-	UserAgent: "snap/" + cmd.Version,
 }
 
 // Client returns a new client using ClientConfig as configuration.
 // commands should (in general) not use this, and instead use clientMixin.
 func mkClient() *client.Client {
-	cli := client.New(&ClientConfig)
+	cfg := &ClientConfig
+	// Set client user-agent when talking to the snapd daemon to the
+	// same value as when talking to the store.
+	cfg.UserAgent = httputil.UserAgent()
+
+	cli := client.New(cfg)
 	goos := runtime.GOOS
 	if release.OnWSL {
 		goos = "Windows Subsystem for Linux"

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -350,6 +350,8 @@ var ClientConfig = client.Config{
 	Socket: dirs.SnapdSocket,
 	// Allow interactivity if we have a terminal
 	Interactive: isStdinTTY,
+	// Custom user agent
+	UserAgent: "snap/" + cmd.Version,
 }
 
 // Client returns a new client using ClientConfig as configuration.

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -404,3 +404,18 @@ func (s *SnapSuite) TestFixupArg(c *C) {
 	// Trailing ">s" is fixed to just >.
 	c.Check(snap.FixupArg("<option>s"), Equals, "<option>")
 }
+
+func (s *SnapSuite) TestSetsUserAgent(c *C) {
+	testServerHit := false
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("User-Agent"), Matches, "snapd/.*")
+		testServerHit = true
+
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "cannot do something"}}`)
+	})
+	restore := mockArgs("snap", "install", "foo")
+	defer restore()
+
+	_ = snap.RunMain()
+	c.Assert(testServerHit, Equals, true)
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -664,10 +664,7 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	theStore := getStore(c)
-	// TODO: ultimately we want the common layer that calls the
-	// handlers to create a Background context and this to operate
-	// on that
-	ctx := store.WithClientUserAgent(context.TODO(), r.Header.Get("User-Agent"))
+	ctx := store.WithClientUserAgent(r.Context(), r)
 	found, err := theStore.Find(ctx, &store.Search{
 		Query:    q,
 		Prefix:   prefix,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -664,7 +664,10 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	theStore := getStore(c)
-	ctx := store.ClientUserAgentContext(r.Header.Get("User-Agent"))
+	// TODO: ultimately we want the common layer that calls the
+	// handlers to create a Background context and this to operate
+	// on that
+	ctx := store.WithClientUserAgent(context.TODO(), r.Header.Get("User-Agent"))
 	found, err := theStore.Find(ctx, &store.Search{
 		Query:    q,
 		Prefix:   prefix,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -611,11 +611,6 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 	return SyncResponse(sections, nil)
 }
 
-// extractUserAgent extract the product from the user agent string
-func extractProductFromUserAgent(ua string) string {
-	return strings.Split(ua, " ")[0]
-}
-
 func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	route := c.d.router.Get(snapCmd.Path)
 	if route == nil {
@@ -669,16 +664,14 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	theStore := getStore(c)
-	found, err := theStore.Find(&store.Search{
+	ctx := store.ClientUserAgentContext(r.Header.Get("User-Agent"))
+	found, err := theStore.Find(ctx, &store.Search{
 		Query:    q,
 		Prefix:   prefix,
 		CommonID: commonID,
 		Section:  section,
 		Private:  private,
 		Scope:    scope,
-		// XXX: or add context to theStore.Find() and use that
-		//      to transmit user-agent?
-		ExtraUserAgent: extractProductFromUserAgent(r.Header.Get("User-Agent")),
 	}, user)
 	switch err {
 	case nil:

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -611,6 +611,11 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 	return SyncResponse(sections, nil)
 }
 
+// extractUserAgent extract the product from the user agent string
+func extractProductFromUserAgent(ua string) string {
+	return strings.Split(ua, " ")[0]
+}
+
 func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	route := c.d.router.Get(snapCmd.Path)
 	if route == nil {
@@ -671,6 +676,9 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 		Section:  section,
 		Private:  private,
 		Scope:    scope,
+		// XXX: or add context to theStore.Find() and use that
+		//      to transmit user-agent?
+		ExtraUserAgent: extractProductFromUserAgent(r.Header.Get("User-Agent")),
 	}, user)
 	switch err {
 	case nil:

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -36,7 +36,7 @@ import (
 // A StoreService can find, list available updates and download snaps.
 type StoreService interface {
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
-	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
+	Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 
 	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error)
 

--- a/store/store.go
+++ b/store/store.go
@@ -2518,19 +2518,3 @@ func (s *Store) CreateCohorts(ctx context.Context, snaps []string) (map[string]s
 
 	return remote.CohortKeys, nil
 }
-
-type userAgentContextKey struct{}
-
-// ClientUserAgentContext carries the client user agent that talks to snapd
-func ClientUserAgentContext(ua string) context.Context {
-	return context.WithValue(context.Background(), userAgentContextKey{}, ua)
-}
-
-// ClientUserAgent returns the user agent of the client that talks to snapd
-func ClientUserAgent(ctx context.Context) string {
-	ua, ok := ctx.Value(userAgentContextKey{}).(string)
-	if ok {
-		return ua
-	}
-	return ""
-}

--- a/store/store.go
+++ b/store/store.go
@@ -923,7 +923,7 @@ func (s *Store) newRequest(ctx context.Context, reqOptions *requestOptions, user
 	req.Header.Set(hdrSnapDeviceSeries[reqOptions.APILevel], s.series)
 	req.Header.Set(hdrSnapClassic[reqOptions.APILevel], strconv.FormatBool(release.OnClassic))
 	if cua := ClientUserAgent(ctx); cua != "" {
-		req.Header.Set("Client-User-Agent", cua)
+		req.Header.Set("Snap-Client-User-Agent", cua)
 	}
 	if reqOptions.APILevel == apiV1Endps {
 		req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)

--- a/store/store.go
+++ b/store/store.go
@@ -685,6 +685,9 @@ type requestOptions struct {
 	ExtraHeaders map[string]string
 	Data         []byte
 
+	// XXX: add this to the context for the request instead of here?
+	ExtraUserAgent string
+
 	// DeviceAuthNeed indicates the level of need to supply device
 	// authorization for this request, can be:
 	//  - deviceAuthPreferred: should be provided if available
@@ -917,7 +920,11 @@ func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*h
 		authenticateUser(req, user)
 	}
 
-	req.Header.Set("User-Agent", httputil.UserAgent())
+	userAgent := httputil.UserAgent()
+	if reqOptions.ExtraUserAgent != "" {
+		userAgent += " " + reqOptions.ExtraUserAgent
+	}
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", reqOptions.Accept)
 	req.Header.Set(hdrSnapDeviceArchitecture[reqOptions.APILevel], s.architecture)
 	req.Header.Set(hdrSnapDeviceSeries[reqOptions.APILevel], s.series)
@@ -1143,10 +1150,16 @@ type Search struct {
 	Section string
 	Private bool
 	Scope   string
+
+	// XXX: add this to the context for the request instead of here?
+	ExtraUserAgent string
 }
 
 // Find finds  (installable) snaps from the store, matching the
 // given Search.
+//
+// XXX: should we add a context here that carries the user-agent instead of
+//      adding it to the Search struct?
 func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error) {
 	if search.Private && user == nil {
 		return nil, ErrUnauthenticated
@@ -1198,6 +1211,8 @@ func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error)
 		Method: "GET",
 		URL:    u,
 		Accept: halJsonContentType,
+		// XXX: or via context
+		ExtraUserAgent: search.ExtraUserAgent,
 	}
 
 	var searchData searchResults

--- a/store/store.go
+++ b/store/store.go
@@ -685,9 +685,6 @@ type requestOptions struct {
 	ExtraHeaders map[string]string
 	Data         []byte
 
-	// XXX: add this to the context for the request instead of here?
-	ExtraUserAgent string
-
 	// DeviceAuthNeed indicates the level of need to supply device
 	// authorization for this request, can be:
 	//  - deviceAuthPreferred: should be provided if available
@@ -811,7 +808,7 @@ func (s *Store) retryRequestDecodeJSON(ctx context.Context, reqOptions *requestO
 func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *requestOptions, user *auth.UserState) (*http.Response, error) {
 	authRefreshes := 0
 	for {
-		req, err := s.newRequest(reqOptions, user)
+		req, err := s.newRequest(ctx, reqOptions, user)
 		if err != nil {
 			return nil, err
 		}
@@ -889,7 +886,7 @@ func (s *Store) refreshAuth(user *auth.UserState, need authRefreshNeed) error {
 }
 
 // build a new http.Request with headers for the store
-func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*http.Request, error) {
+func (s *Store) newRequest(ctx context.Context, reqOptions *requestOptions, user *auth.UserState) (*http.Request, error) {
 	var body io.Reader
 	if reqOptions.Data != nil {
 		body = bytes.NewBuffer(reqOptions.Data)
@@ -920,15 +917,14 @@ func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*h
 		authenticateUser(req, user)
 	}
 
-	userAgent := httputil.UserAgent()
-	if reqOptions.ExtraUserAgent != "" {
-		userAgent += " " + reqOptions.ExtraUserAgent
-	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", httputil.UserAgent())
 	req.Header.Set("Accept", reqOptions.Accept)
 	req.Header.Set(hdrSnapDeviceArchitecture[reqOptions.APILevel], s.architecture)
 	req.Header.Set(hdrSnapDeviceSeries[reqOptions.APILevel], s.series)
 	req.Header.Set(hdrSnapClassic[reqOptions.APILevel], strconv.FormatBool(release.OnClassic))
+	if cua := ClientUserAgent(ctx); cua != "" {
+		req.Header.Set("Client-User-Agent", cua)
+	}
 	if reqOptions.APILevel == apiV1Endps {
 		req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
 	}
@@ -1150,17 +1146,11 @@ type Search struct {
 	Section string
 	Private bool
 	Scope   string
-
-	// XXX: add this to the context for the request instead of here?
-	ExtraUserAgent string
 }
 
 // Find finds  (installable) snaps from the store, matching the
 // given Search.
-//
-// XXX: should we add a context here that carries the user-agent instead of
-//      adding it to the Search struct?
-func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error) {
+func (s *Store) Find(ctx context.Context, search *Search, user *auth.UserState) ([]*snap.Info, error) {
 	if search.Private && user == nil {
 		return nil, ErrUnauthenticated
 	}
@@ -1211,12 +1201,10 @@ func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error)
 		Method: "GET",
 		URL:    u,
 		Accept: halJsonContentType,
-		// XXX: or via context
-		ExtraUserAgent: search.ExtraUserAgent,
 	}
 
 	var searchData searchResults
-	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &searchData, nil)
+	resp, err := s.retryRequestDecodeJSON(ctx, reqOptions, user, &searchData, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2529,4 +2517,20 @@ func (s *Store) CreateCohorts(ctx context.Context, snaps []string) (map[string]s
 	}
 
 	return remote.CohortKeys, nil
+}
+
+type userAgentContextKey struct{}
+
+// ClientUserAgentContext carries the client user agent that talks to snapd
+func ClientUserAgentContext(ua string) context.Context {
+	return context.WithValue(context.Background(), userAgentContextKey{}, ua)
+}
+
+// ClientUserAgent returns the user agent of the client that talks to snapd
+func ClientUserAgent(ctx context.Context) string {
+	ua, ok := ctx.Value(userAgentContextKey{}).(string)
+	if ok {
+		return ua
+	}
+	return ""
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3200,7 +3200,7 @@ func (s *storeTestSuite) TestFindClientUserAgent(c *C) {
 		DetailFields: []string{}, // make the error less noisy
 	}
 
-	ctx := store.ClientUserAgentContext(clientUserAgent)
+	ctx := store.WithClientUserAgent(context.TODO(), clientUserAgent)
 	sto := store.New(&cfg, nil)
 	sto.Find(ctx, &store.Search{Query: "hello"}, nil)
 	c.Assert(serverWasHit, Equals, true)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2598,7 +2598,7 @@ func (s *storeTestSuite) TestFindQueries(c *C) {
 		{Section: "db"},
 		{Query: "hello", Section: "db"},
 	} {
-		sto.Find(&query, nil)
+		sto.Find(context.TODO(), &query, nil)
 	}
 }
 
@@ -2831,7 +2831,7 @@ func (s *storeTestSuite) TestFind(c *C) {
 	dauthCtx := &testDauthContext{c: c, device: s.device}
 	sto := store.New(&cfg, dauthCtx)
 
-	snaps, err := sto.Find(&store.Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(context.TODO(), &store.Search{Query: "hello"}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(snaps, HasLen, 1)
 	snp := snaps[0]
@@ -2916,22 +2916,22 @@ func (s *storeTestSuite) TestFindPrivate(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	_, err := sto.Find(&store.Search{Query: "foo", Private: true}, s.user)
+	_, err := sto.Find(context.TODO(), &store.Search{Query: "foo", Private: true}, s.user)
 	c.Check(err, IsNil)
 
-	_, err = sto.Find(&store.Search{Query: "foo", Prefix: true, Private: true}, s.user)
+	_, err = sto.Find(context.TODO(), &store.Search{Query: "foo", Prefix: true, Private: true}, s.user)
 	c.Check(err, IsNil)
 
-	_, err = sto.Find(&store.Search{Query: "foo", Private: true}, nil)
+	_, err = sto.Find(context.TODO(), &store.Search{Query: "foo", Private: true}, nil)
 	c.Check(err, Equals, store.ErrUnauthenticated)
 
-	_, err = sto.Find(&store.Search{Query: "name:foo", Private: true}, s.user)
+	_, err = sto.Find(context.TODO(), &store.Search{Query: "name:foo", Private: true}, s.user)
 	c.Check(err, Equals, store.ErrBadQuery)
 }
 
 func (s *storeTestSuite) TestFindFailures(c *C) {
 	sto := store.New(&store.Config{StoreBaseURL: new(url.URL)}, nil)
-	_, err := sto.Find(&store.Search{Query: "foo:bar"}, nil)
+	_, err := sto.Find(context.TODO(), &store.Search{Query: "foo:bar"}, nil)
 	c.Check(err, Equals, store.ErrBadQuery)
 }
 
@@ -2951,7 +2951,7 @@ func (s *storeTestSuite) TestFindFails(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	snaps, err := sto.Find(&store.Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(context.TODO(), &store.Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `cannot search: got unexpected HTTP status code 418 via GET to "http://\S+[?&]q=hello.*"`)
 	c.Check(snaps, HasLen, 0)
 }
@@ -2972,7 +2972,7 @@ func (s *storeTestSuite) TestFindBadContentType(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	snaps, err := sto.Find(&store.Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(context.TODO(), &store.Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `received an unexpected content type \("text/plain[^"]+"\) when trying to search via "http://\S+[?&]q=hello.*"`)
 	c.Check(snaps, HasLen, 0)
 }
@@ -2995,7 +2995,7 @@ func (s *storeTestSuite) TestFindBadBody(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	snaps, err := sto.Find(&store.Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(context.TODO(), &store.Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `invalid character '<' looking for beginning of value`)
 	c.Check(snaps, HasLen, 0)
 }
@@ -3017,7 +3017,7 @@ func (s *storeTestSuite) TestFind500(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	_, err := sto.Find(&store.Search{Query: "hello"}, nil)
+	_, err := sto.Find(context.TODO(), &store.Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `cannot search: got unexpected HTTP status code 500 via GET to "http://\S+[?&]q=hello.*"`)
 	c.Assert(n, Equals, 5)
 }
@@ -3045,7 +3045,7 @@ func (s *storeTestSuite) TestFind500once(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	snaps, err := sto.Find(&store.Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(context.TODO(), &store.Search{Query: "hello"}, nil)
 	c.Check(err, IsNil)
 	c.Assert(snaps, HasLen, 1)
 	c.Assert(n, Equals, 2)
@@ -3088,7 +3088,7 @@ func (s *storeTestSuite) TestFindAuthFailed(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	snaps, err := sto.Find(&store.Search{Query: "foo"}, s.user)
+	snaps, err := sto.Find(context.TODO(), &store.Search{Query: "foo"}, s.user)
 	c.Assert(err, IsNil)
 
 	// Check that we log an error.
@@ -3136,7 +3136,7 @@ func (s *storeTestSuite) TestFindCommonIDs(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	infos, err := sto.Find(&store.Search{Query: "foo"}, nil)
+	infos, err := sto.Find(context.TODO(), &store.Search{Query: "foo"}, nil)
 	c.Check(err, IsNil)
 	c.Assert(infos, HasLen, 1)
 	c.Check(infos[0].CommonIDs, DeepEquals, []string{"org.hello"})
@@ -3175,10 +3175,35 @@ func (s *storeTestSuite) TestFindByCommonID(c *C) {
 	}
 	sto := store.New(&cfg, nil)
 
-	infos, err := sto.Find(&store.Search{CommonID: "org.hello"}, nil)
+	infos, err := sto.Find(context.TODO(), &store.Search{CommonID: "org.hello"}, nil)
 	c.Check(err, IsNil)
 	c.Assert(infos, HasLen, 1)
 	c.Check(infos[0].CommonIDs, DeepEquals, []string{"org.hello"})
+}
+
+func (s *storeTestSuite) TestFindClientUserAgent(c *C) {
+	clientUserAgent := "some-client/1.0"
+
+	serverWasHit := false
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Client-User-Agent"), Equals, clientUserAgent)
+		serverWasHit = true
+
+		http.Error(w, http.StatusText(418), 418) // I'm a teapot
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+		DetailFields: []string{}, // make the error less noisy
+	}
+
+	ctx := store.ClientUserAgentContext(clientUserAgent)
+	sto := store.New(&cfg, nil)
+	sto.Find(ctx, &store.Search{Query: "hello"}, nil)
+	c.Assert(serverWasHit, Equals, true)
 }
 
 func (s *storeTestSuite) TestAuthLocationDependsOnEnviron(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3200,7 +3200,10 @@ func (s *storeTestSuite) TestFindClientUserAgent(c *C) {
 		DetailFields: []string{}, // make the error less noisy
 	}
 
-	ctx := store.WithClientUserAgent(context.TODO(), clientUserAgent)
+	req, err := http.NewRequest("GET", "/", nil)
+	c.Assert(err, IsNil)
+	req.Header.Add("User-Agent", clientUserAgent)
+	ctx := store.WithClientUserAgent(context.TODO(), req)
 	sto := store.New(&cfg, nil)
 	sto.Find(ctx, &store.Search{Query: "hello"}, nil)
 	c.Assert(serverWasHit, Equals, true)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3186,7 +3186,7 @@ func (s *storeTestSuite) TestFindClientUserAgent(c *C) {
 
 	serverWasHit := false
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Header.Get("Client-User-Agent"), Equals, clientUserAgent)
+		c.Check(r.Header.Get("Snap-Client-User-Agent"), Equals, clientUserAgent)
 		serverWasHit = true
 
 		http.Error(w, http.StatusText(418), 418) // I'm a teapot

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -45,7 +45,7 @@ func (Store) SnapInfo(store.SnapSpec, *auth.UserState) (*snap.Info, error) {
 	panic("Store.SnapInfo not expected")
 }
 
-func (Store) Find(*store.Search, *auth.UserState) ([]*snap.Info, error) {
+func (Store) Find(context.Context, *store.Search, *auth.UserState) ([]*snap.Info, error) {
 	panic("Store.Find not expected")
 }
 

--- a/store/uacontext.go
+++ b/store/uacontext.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+import (
+	"context"
+)
+
+type userAgentContextKey struct{}
+
+// ClientUserAgentContext carries the client user agent that talks to snapd
+func WithClientUserAgent(parent context.Context, ua string) context.Context {
+	return context.WithValue(parent, userAgentContextKey{}, ua)
+}
+
+// ClientUserAgent returns the user agent of the client that talks to snapd
+func ClientUserAgent(ctx context.Context) string {
+	ua, ok := ctx.Value(userAgentContextKey{}).(string)
+	if ok {
+		return ua
+	}
+	return ""
+}

--- a/store/uacontext.go
+++ b/store/uacontext.go
@@ -21,12 +21,14 @@ package store
 
 import (
 	"context"
+	"net/http"
 )
 
 type userAgentContextKey struct{}
 
 // ClientUserAgentContext carries the client user agent that talks to snapd
-func WithClientUserAgent(parent context.Context, ua string) context.Context {
+func WithClientUserAgent(parent context.Context, req *http.Request) context.Context {
+	ua := req.Header.Get("User-Agent")
 	return context.WithValue(parent, userAgentContextKey{}, ua)
 }
 

--- a/store/uacontext_test.go
+++ b/store/uacontext_test.go
@@ -21,6 +21,7 @@ package store_test
 
 import (
 	"context"
+	"net/http"
 
 	. "gopkg.in/check.v1"
 
@@ -37,6 +38,10 @@ func (s *clientUserAgentSuite) TestEmptyContext(c *C) {
 }
 
 func (s *clientUserAgentSuite) TestWithClientUserContext(c *C) {
-	cua := store.WithClientUserAgent(context.TODO(), "some-agent")
+	req, err := http.NewRequest("GET", "/", nil)
+	c.Assert(err, IsNil)
+	req.Header.Add("User-Agent", "some-agent")
+
+	cua := store.WithClientUserAgent(req.Context(), req)
 	c.Assert(store.ClientUserAgent(cua), Equals, "some-agent")
 }

--- a/store/uacontext_test.go
+++ b/store/uacontext_test.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store_test
+
+import (
+	"context"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/store"
+)
+
+type clientUserAgentSuite struct{}
+
+var _ = Suite(&clientUserAgentSuite{})
+
+func (s *clientUserAgentSuite) TestEmptyContext(c *C) {
+	cua := store.ClientUserAgent(context.TODO())
+	c.Assert(cua, Equals, "")
+}
+
+func (s *clientUserAgentSuite) TestWithClientUserContext(c *C) {
+	cua := store.WithClientUserAgent(context.TODO(), "some-agent")
+	c.Assert(store.ClientUserAgent(cua), Equals, "some-agent")
+}


### PR DESCRIPTION
This will take the first "product" from the user-agent that talks
to snapd and adds it as an extra user-agent when talking to the
store. The use-case for this is gnome-software which can set
the agent to "gnome-software" so that the store can gather data
about how many CLI vs GUI users we have.

This initial PR implements it just for "Search" but if this
approach is acceptable it will be added for Install as well.

This is a RFC mostly about if this is the right approach or if we should use a context to carry the user-agent. Once there is agreement I will add the missing tests (unit and integration).