### PR TITLE
interfaces/docker-support: support overlayfs on ubuntu core

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -51,8 +51,8 @@ const dockerSupportConnectedPlugAppArmorCore = `
 # overlayfs mount correctly
 # the accesses show up as runc trying to read from
 # /system-data/var/snap/docker/common/var-lib-docker/overlay2/$SHA/diff/
-/system-data/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/common/{,**} rwl,
-/system-data/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/@{SNAP_REVISION}/{,**} rwl,
+/system-data/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/common/{,**/} rwl,
+/system-data/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/@{SNAP_REVISION}/{,**/} rwl,
 `
 
 const dockerSupportConnectedPlugAppArmor = `

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -603,16 +603,10 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	spec.SetSuppressHomeIx()
 	spec.AddSnippet(dockerSupportConnectedPlugAppArmor)
 	if privileged {
-		// note we don't consider classic vs core here because if we're privileged
-		// then we are unconfined and don't need to worry about apparmor overlayfs
-		// bugs
 		spec.AddSnippet(dockerSupportPrivilegedAppArmor)
-	} else {
-		if release.OnClassic {
-			spec.AddSnippet(dockerSupportConnectedPlugAppArmor)
-		} else {
-			spec.AddSnippet(dockerSupportConnectedPlugAppArmor + dockerSupportConnectedPlugAppArmorCore)
-		}
+	}
+	if !release.OnClassic {
+		spec.AddSnippet(dockerSupportConnectedPlugAppArmorCore)
 	}
 	spec.UsesPtraceTrace()
 	return nil


### PR DESCRIPTION
Aufs is being deprecated by upstream docker, new recommended storage-driver is overlayfs, but there are some bugs with overlayfs + apparmor, so add some additional accesses on ubuntu core to allow overlayfs to work there.

It would be great to get this into 2.39 if it's not too late yet... 