### PR TITLE
snapcraft.yaml: include libc6 in snapd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -58,7 +58,7 @@ parts:
   # CommandFromSystemSnap
   libc6:
     plugin: nil
-    stage-packaes:
+    stage-packages:
       - libc6
     stage:
       - lib/*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,6 +54,16 @@ parts:
       - liblzma5
     stage:
       - lib/*
+  # libc6 is part of core but we need it in the snapd snap for
+  # CommandFromSystemSnap
+  libc6:
+    plugin: nil
+    stage-packaes:
+      - libc6
+    stage:
+      - lib/*
+      - usr/lib/*
+      - lib64/*
   # the version in Ubuntu 16.04 (cache v6)
   fontconfig-xenial:
     plugin: nil


### PR DESCRIPTION
We added some tools like xdelta3 and squashfs-tools to the snapd
snap now so that we can use those even if they are not available
on the system. Unfortunately this means that we need to also
carry their libc6 to be truely independent of the host system.

This PR adds libc6 to the snapd snap