### PR TITLE
tests:  reduce snapcraft leftovers from PROJECT_PATH,  temp disable centos

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -102,6 +102,7 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
+                manual: true
 
     google-sru:
         type: google

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -7,10 +7,13 @@ systems: [ubuntu-16.04-64]
 priority: 100
 
 restore: |
+    cd "$PROJECT_PATH"
+    echo "Cleanup build artifacts"
+    ! command -v snapcraft >/dev/null || snapcraft clean
     echo "Cleanup the installed snapcraft"
     apt autoremove -y snapcraft
     echo "Cleanup the build snapd snap"
-    rm -f "$PROJECT_PATH"/snapd_*.snap
+    rm -f snapd_*.snap
 
 execute: |
     echo "Installing snapscraft"


### PR DESCRIPTION
First commit solves some out of space issues related to copying the project into a /tmp dir after snapd-snap test has run.

Second is a temporary disabling of centos.