### PR TITLE
snapcraft.yaml: fix links ld-linux-x86-64.so.2/ld64.so.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,6 +64,15 @@ parts:
       - lib/*
       - usr/lib/*
       - lib64/*
+    override-stage: |
+      snapcraftctl stage
+      # fix symlinks of ld.so to be relative
+      if [ "$(readlink -f lib64/ld-linux-x86-64.so.2)" = "/lib/x86_64-linux-gnu/ld-2.23.so" ]; then
+          ln -f -s ../lib/x86_64-linux-gnu/ld-2.23.so lib64/ld-linux-x86-64.so.2
+      fi
+      if [ "$(readlink -f lib64/ld64.so.2)" = "/lib/powerpc64le-linux-gnu/ld-2.23.so" ]; then
+          ln -f -s ../lib/powerpc64le-linux-gnu/ld-2.23.so lib64/ld64.so.2
+      fi
   # the version in Ubuntu 16.04 (cache v6)
   fontconfig-xenial:
     plugin: nil


### PR DESCRIPTION
The symlinks in the libc6 package for the 64 bit loaders are
absolute and point to the real system. We need symlinks relative
to the snapd rootfs. This PR fixes the links inside the snap
to be relative.
