### PR TITLE
many: do without device state/assertions accessors based on state only outside of devicestate/tests

### DIFF
--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -143,7 +143,7 @@ func getDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 	case "connectivity":
 		return checkConnectivity(st)
 	case "model":
-		model, err := devicestate.Model(st)
+		model, err := c.d.overlord.DeviceManager().Model()
 		if err != nil {
 			return InternalError("cannot get model: %v", err)
 		}

--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -66,7 +66,7 @@ func postModel(c *Command, r *http.Request, _ *auth.UserState) Response {
 	if err != nil {
 		return BadRequest("cannot remodel device: %v", err)
 	}
-	model, err := devicestate.Model(st)
+	model, err := c.d.overlord.DeviceManager().Model()
 	if err != nil {
 		return InternalError("cannot get model: %v", err)
 	}

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -28,6 +28,8 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -45,6 +47,11 @@ func (s *apiSuite) TestPostRemodelUnhappy(c *check.C) {
 
 func (s *apiSuite) testPostRemodel(c *check.C, newModel map[string]interface{}, expectedChgSummary string) {
 	d := s.daemonWithOverlordMock(c)
+	hookMgr, err := hookstate.Manager(d.overlord.State(), d.overlord.TaskRunner())
+	c.Assert(err, check.IsNil)
+	deviceMgr, err := devicestate.Manager(d.overlord.State(), hookMgr, d.overlord.TaskRunner())
+	c.Assert(err, check.IsNil)
+	d.overlord.AddManager(deviceMgr)
 	st := d.overlord.State()
 	st.Lock()
 	s.mockModel(c, st)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -347,7 +348,7 @@ func (s *apiBaseSuite) mockModel(c *check.C, st *state.State) {
 	err = assertstate.Add(st, model)
 	c.Assert(err, check.IsNil)
 
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "can0nical",
 		Model:  "pc",
 		Serial: "serialserial",
@@ -5683,7 +5684,7 @@ func (s *postCreateUserSuite) TestPostCreateUser(c *check.C) {
 func (s *postCreateUserSuite) TestGetUserDetailsFromAssertionModelNotFound(c *check.C) {
 	st := s.d.overlord.State()
 	st.Lock()
-	devicestate.SetDevice(st, nil)
+	devicestatetest.SetDevice(st, nil)
 	st.Unlock()
 
 	email := "foo@example.com"
@@ -5762,7 +5763,7 @@ func (s *postCreateUserSuite) makeSystemUsers(c *check.C, systemUsers []map[stri
 	}
 	// create fake device
 	st.Lock()
-	err = devicestate.SetDevice(st, &auth.DeviceState{
+	err = devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "my-brand",
 		Model:  "my-model",
 		Serial: "serialserial",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -5688,7 +5688,7 @@ func (s *postCreateUserSuite) TestGetUserDetailsFromAssertionModelNotFound(c *ch
 
 	email := "foo@example.com"
 
-	username, opts, err := getUserDetailsFromAssertion(st, email)
+	username, opts, err := getUserDetailsFromAssertion(s.d.overlord, email)
 	c.Check(username, check.Equals, "")
 	c.Check(opts, check.IsNil)
 	c.Check(err, check.ErrorMatches, `cannot add system-user "foo@example.com": cannot get model assertion: no state entry for key`)
@@ -5829,8 +5829,7 @@ func (s *postCreateUserSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 
 	// ensure that if we query the details from the assert DB we get
 	// the expected user
-	st := s.d.overlord.State()
-	username, opts, err := getUserDetailsFromAssertion(st, "foo@bar.com")
+	username, opts, err := getUserDetailsFromAssertion(s.d.overlord, "foo@bar.com")
 	c.Check(username, check.Equals, "guy")
 	c.Check(opts, check.DeepEquals, &osutil.AddUserOptions{
 		Gecos:    "foo@bar.com,Boring Guy",

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/standby"
@@ -462,7 +462,7 @@ func (s *daemonSuite) markSeeded(d *Daemon) {
 	st := d.overlord.State()
 	st.Lock()
 	st.Set("seeded", true)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "serialserial",

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -30,7 +30,7 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if providedDeviceCtx != nil {
 		return providedDeviceCtx, nil
 	}
-	modelAs, err := Model(st)
+	modelAs, err := findModel(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -188,7 +188,7 @@ func setClassicFallbackModel(st *state.State, device *auth.DeviceState) error {
 	}
 	device.Brand = "generic"
 	device.Model = "generic-classic"
-	if err := SetDevice(st, device); err != nil {
+	if err := internal.SetDevice(st, device); err != nil {
 		return err
 	}
 	return nil
@@ -528,9 +528,9 @@ func (m *DeviceManager) device() (*auth.DeviceState, error) {
 	return internal.Device(m.state)
 }
 
-// SetDevice sets the device details in the state.
-func (m *DeviceManager) SetDevice(device *auth.DeviceState) error {
-	return SetDevice(m.state, device)
+// setDevice sets the device details in the state.
+func (m *DeviceManager) setDevice(device *auth.DeviceState) error {
+	return internal.SetDevice(m.state, device)
 }
 
 // Model returns the device model assertion.
@@ -585,6 +585,10 @@ type storeContextBackend struct {
 
 func (scb storeContextBackend) Device() (*auth.DeviceState, error) {
 	return scb.DeviceManager.device()
+}
+
+func (scb storeContextBackend) SetDevice(device *auth.DeviceState) error {
+	return scb.DeviceManager.setDevice(device)
 }
 
 func (m *DeviceManager) StoreContextBackend() storecontext.Backend {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -543,7 +543,7 @@ func (m *DeviceManager) Model() (*asserts.Model, error) {
 
 // Serial returns the device serial assertion.
 func (m *DeviceManager) Serial() (*asserts.Serial, error) {
-	return Serial(m.state)
+	return findSerial(m.state)
 }
 
 // SignDeviceSessionRequest produces a signed device-session-request with for given serial assertion and nonce.

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -245,7 +245,7 @@ func (m *DeviceManager) ensureOperational() error {
 	}
 
 	var storeID, gadget string
-	model, err := Model(m.state)
+	model, err := m.Model()
 	if err != nil && err != state.ErrNoState {
 		return err
 	}
@@ -538,7 +538,7 @@ func (m *DeviceManager) SetDevice(device *auth.DeviceState) error {
 
 // Model returns the device model assertion.
 func (m *DeviceManager) Model() (*asserts.Model, error) {
-	return Model(m.state)
+	return findModel(m.state)
 }
 
 // Serial returns the device serial assertion.

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -98,7 +98,7 @@ func (m *DeviceManager) confirmRegistered() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	device, err := Device(m.state)
+	device, err := m.Device()
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (m *DeviceManager) ensureOperational() error {
 
 	perfTimings := timings.New(map[string]string{"ensure": "become-operational"})
 
-	device, err := Device(m.state)
+	device, err := m.Device()
 	if err != nil {
 		return err
 	}
@@ -501,7 +501,7 @@ func (m *DeviceManager) Ensure() error {
 }
 
 func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
-	device, err := Device(m.state)
+	device, err := m.Device()
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ var _ storecontext.Backend = (*DeviceManager)(nil)
 
 // Device returns current device state.
 func (m *DeviceManager) Device() (*auth.DeviceState, error) {
-	return Device(m.state)
+	return getDeviceState(m.state)
 }
 
 // SetDevice sets the device details in the state.

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -44,8 +44,8 @@ var (
 	snapstateUpdate  = snapstate.Update
 )
 
-// Device returns the device details from the state.
-func Device(st *state.State) (*auth.DeviceState, error) {
+// getDeviceState returns the device details from the state.
+func getDeviceState(st *state.State) (*auth.DeviceState, error) {
 	var authStateData auth.AuthState
 
 	err := st.Get("auth", &authStateData)
@@ -81,7 +81,7 @@ func SetDevice(st *state.State, device *auth.DeviceState) error {
 
 // Model returns the device model assertion.
 func Model(st *state.State) (*asserts.Model, error) {
-	device, err := Device(st)
+	device, err := getDeviceState(st)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func Model(st *state.State) (*asserts.Model, error) {
 
 // Serial returns the device serial assertion.
 func Serial(st *state.State) (*asserts.Serial, error) {
-	device, err := Device(st)
+	device, err := getDeviceState(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -215,11 +215,7 @@ func delayedCrossMgrInit() {
 	snapstate.DeviceCtx = DeviceCtx
 }
 
-// ProxyStore returns the store assertion for the proxy store if one is set.
-func ProxyStore(st *state.State) (*asserts.Store, error) {
-	return proxyStore(st, config.NewTransaction(st))
-}
-
+// proxyStore returns the store assertion for the proxy store if one is set.
 func proxyStore(st *state.State, tr *config.Transaction) (*asserts.Store, error) {
 	var proxyStore string
 	err := tr.GetMaybe("core", "proxy.store", &proxyStore)

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -43,24 +44,6 @@ var (
 	snapstateInstall = snapstate.Install
 	snapstateUpdate  = snapstate.Update
 )
-
-// getDeviceState returns the device details from the state.
-func getDeviceState(st *state.State) (*auth.DeviceState, error) {
-	var authStateData auth.AuthState
-
-	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
-		return &auth.DeviceState{}, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	if authStateData.Device == nil {
-		return &auth.DeviceState{}, nil
-	}
-
-	return authStateData.Device, nil
-}
 
 // SetDevice updates the device details in the state.
 func SetDevice(st *state.State, device *auth.DeviceState) error {
@@ -81,7 +64,7 @@ func SetDevice(st *state.State, device *auth.DeviceState) error {
 
 // findModel returns the device model assertion.
 func findModel(st *state.State) (*asserts.Model, error) {
-	device, err := getDeviceState(st)
+	device, err := internal.Device(st)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +90,7 @@ func findModel(st *state.State) (*asserts.Model, error) {
 
 // findSerial returns the device serial assertion.
 func findSerial(st *state.State) (*asserts.Serial, error) {
-	device, err := getDeviceState(st)
+	device, err := internal.Device(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -30,7 +30,6 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/netutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -44,23 +43,6 @@ var (
 	snapstateInstall = snapstate.Install
 	snapstateUpdate  = snapstate.Update
 )
-
-// SetDevice updates the device details in the state.
-func SetDevice(st *state.State, device *auth.DeviceState) error {
-	var authStateData auth.AuthState
-
-	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
-		authStateData = auth.AuthState{}
-	} else if err != nil {
-		return err
-	}
-
-	authStateData.Device = device
-	st.Set("auth", authStateData)
-
-	return nil
-}
 
 // findModel returns the device model assertion.
 func findModel(st *state.State) (*asserts.Model, error) {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -79,8 +79,8 @@ func SetDevice(st *state.State, device *auth.DeviceState) error {
 	return nil
 }
 
-// Model returns the device model assertion.
-func Model(st *state.State) (*asserts.Model, error) {
+// findModel returns the device model assertion.
+func findModel(st *state.State) (*asserts.Model, error) {
 	device, err := getDeviceState(st)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 
 	// Check model exists, for sanity. We always have a model, either
 	// seeded or a generic one that ships with snapd.
-	_, err := Model(st)
+	_, err := findModel(st)
 	if err == state.ErrNoState {
 		return false, nil
 	}
@@ -190,7 +190,8 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 		return nil
 	}
 
-	model, err := Model(st)
+	// XXX use deviceCtx
+	model, err := findModel(st)
 	if err == state.ErrNoState {
 		return fmt.Errorf("cannot install %s without model assertion", kind)
 	}
@@ -390,7 +391,7 @@ func Remodel(st *state.State, new *asserts.Model) ([]*state.TaskSet, error) {
 		return nil, fmt.Errorf("cannot remodel until fully seeded")
 	}
 
-	current, err := Model(st)
+	current, err := findModel(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -155,7 +155,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 		return nil
 	}
 
-	// XXX use deviceCtx
+	// XXX: remodeling: use deviceCtx
 	model, err := findModel(st)
 	if err == state.ErrNoState {
 		return fmt.Errorf("cannot install %s without model assertion", kind)

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -105,8 +105,8 @@ func Model(st *state.State) (*asserts.Model, error) {
 	return a.(*asserts.Model), nil
 }
 
-// Serial returns the device serial assertion.
-func Serial(st *state.State) (*asserts.Serial, error) {
+// findSerial returns the device serial assertion.
+func findSerial(st *state.State) (*asserts.Serial, error) {
 	device, err := getDeviceState(st)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return false, err
 	}
 
-	_, err = Serial(st)
+	_, err = findSerial(st)
 	if err == state.ErrNoState {
 		return false, nil
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1496,10 +1496,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 	scb := s.mgr.StoreContextBackend()
 
 	// nothing in the state
-	_, err := devicestate.ProxyStore(s.state)
-	c.Check(err, Equals, state.ErrNoState)
-
-	_, err = scb.ProxyStore()
+	_, err := scb.ProxyStore()
 	c.Check(err, Equals, state.ErrNoState)
 
 	// have a store referenced
@@ -1527,10 +1524,6 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 	c.Assert(err, IsNil)
 
 	sto, err := scb.ProxyStore()
-	c.Assert(err, IsNil)
-	c.Assert(sto.Store(), Equals, "foo")
-
-	sto, err = devicestate.ProxyStore(s.state)
 	c.Assert(err, IsNil)
 	c.Assert(sto.Store(), Equals, "foo")
 	c.Assert(sto.URL().String(), Equals, mockServer.URL)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1326,10 +1326,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	// nothing in the state
-	_, err := devicestate.Model(s.state)
-	c.Check(err, Equals, state.ErrNoState)
-
-	_, err = s.mgr.Model()
+	_, err := s.mgr.Model()
 	c.Check(err, Equals, state.ErrNoState)
 	_, err = s.mgr.Serial()
 	c.Check(err, Equals, state.ErrNoState)
@@ -1359,10 +1356,6 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Assert(err, IsNil)
 
 	mod, err := s.mgr.Model()
-	c.Assert(err, IsNil)
-	c.Assert(mod.BrandID(), Equals, "canonical")
-
-	mod, err = devicestate.Model(s.state)
 	c.Assert(err, IsNil)
 	c.Assert(mod.BrandID(), Equals, "canonical")
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -256,7 +256,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappy(c *C) {
 		"gadget":       "pc",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -352,7 +352,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 		"gadget":       "pc",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -433,7 +433,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassicNoGadget(c *C) {
 		"store":   "alt-store",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "classic-alt-store",
 	})
@@ -574,7 +574,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationAltBrandHappy(c *C) {
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -632,7 +632,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C) {
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 		KeyID: privKey.PublicKey().ID(),
@@ -708,7 +708,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C) {
 
 	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 		KeyID: privKey.PublicKey().ID(),
@@ -775,7 +775,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 		KeyID: privKey.PublicKey().ID(),
@@ -822,7 +822,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialMaxTentatives(c *C) {
 
 	devicestatetest.MockGadget(c, s.state, "gadget", snap.R(2), nil)
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 		KeyID: privKey.PublicKey().ID(),
@@ -876,7 +876,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationPollHappy(c *C) {
 		"gadget":       "pc",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -969,7 +969,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(c *C) 
 		"gadget":       "gadget",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc2",
 	})
@@ -1111,7 +1111,7 @@ func (s *deviceMgrSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c *C, n
 		"gadget":       "gadget",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc2",
 	})
@@ -1175,7 +1175,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 		"gadget":       "pc",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -1272,7 +1272,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) {
 		"gadget":       "pc",
 	})
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -1292,23 +1292,6 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) {
 	c.Check(becomeOperational.Err(), ErrorMatches, `(?s).*obtained serial assertion does not match provided device identity information.*`)
 }
 
-func (s *deviceMgrSuite) TestSetDevice(c *C) {
-	// XXX move this test
-	s.state.Lock()
-	device, err := devicestatetest.Device(s.state)
-	s.state.Unlock()
-	c.Check(err, IsNil)
-	c.Check(device, DeepEquals, &auth.DeviceState{})
-
-	s.state.Lock()
-	err = devicestate.SetDevice(s.state, &auth.DeviceState{Brand: "some-brand"})
-	c.Check(err, IsNil)
-	device, err = devicestatetest.Device(s.state)
-	s.state.Unlock()
-	c.Check(err, IsNil)
-	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
-}
-
 func (s *deviceMgrSuite) TestModelAndSerial(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1319,7 +1302,7 @@ func (s *deviceMgrSuite) TestModelAndSerial(c *C) {
 	c.Check(err, Equals, state.ErrNoState)
 
 	// just brand and model
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -1350,7 +1333,7 @@ func (s *deviceMgrSuite) TestModelAndSerial(c *C) {
 	c.Check(err, Equals, state.ErrNoState)
 
 	// have a serial as well
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "8989",
@@ -1400,7 +1383,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Check(err, Equals, state.ErrNoState)
 
 	// just brand and model
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -1431,7 +1414,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Check(err, Equals, state.ErrNoState)
 
 	// have a serial as well
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "8989",
@@ -1484,7 +1467,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C)
 	// have a key
 	devicestate.KeypairManager(s.mgr).Put(devKey)
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "8989",
@@ -1707,7 +1690,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkError(c *C) {
 	// seeded
 	s.state.Set("seeded", true)
 	// has serial
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "8989",
@@ -1778,7 +1761,7 @@ func (s *deviceMgrSuite) TestCheckGadget(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, model)
 	c.Assert(err, IsNil)
-	err = devicestate.SetDevice(s.state, &auth.DeviceState{
+	err = devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -1847,7 +1830,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassic(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, model)
 	c.Assert(err, IsNil)
-	err = devicestate.SetDevice(s.state, &auth.DeviceState{
+	err = devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -1910,7 +1893,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassicGadgetNotSpecified(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, model)
 	c.Assert(err, IsNil)
-	err = devicestate.SetDevice(s.state, &auth.DeviceState{
+	err = devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -1950,7 +1933,7 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, model)
 	c.Assert(err, IsNil)
-	err = devicestate.SetDevice(s.state, &auth.DeviceState{
+	err = devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -2059,7 +2042,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnCore(c *C) {
 
 	// seeded, model, no serial -> no auto-refresh
 	s.state.Set("seeded", true)
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -2071,7 +2054,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnCore(c *C) {
 	c.Check(canAutoRefresh(), Equals, false)
 
 	// seeded, model, serial -> auto-refresh
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "8989",
@@ -2099,7 +2082,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshNoSerialFallback(c *C) {
 	devicestate.IncEnsureOperationalAttempts(s.state)
 	devicestate.IncEnsureOperationalAttempts(s.state)
 	s.state.Set("seeded", true)
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -2139,7 +2122,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnClassic(c *C) {
 	c.Check(canAutoRefresh(), Equals, false)
 
 	// seeded, model, no serial -> no auto-refresh
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})
@@ -2149,7 +2132,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnClassic(c *C) {
 	c.Check(canAutoRefresh(), Equals, false)
 
 	// seeded, model, serial -> auto-refresh
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "8989",
@@ -2313,7 +2296,7 @@ func (s *deviceMgrSuite) TestReloadRegistered(c *C) {
 	c.Check(ok, Equals, true)
 
 	st.Lock()
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "serial",
@@ -2342,7 +2325,7 @@ func (s *deviceMgrSuite) TestMarkSeededInConfig(c *C) {
 	defer st.Unlock()
 
 	// avoid device registration
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Serial: "123",
 	})
 
@@ -2508,7 +2491,7 @@ func (s *deviceMgrSuite) TestRemodelUnhappy(c *C) {
 		"gadget":       cur["gadget"],
 		"base":         cur["base"],
 	})
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: cur["brand"],
 		Model: cur["model"],
 	})
@@ -2572,7 +2555,7 @@ func (s *deviceMgrSuite) TestRemodelRequiredSnaps(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc-model",
 	})
@@ -2677,7 +2660,7 @@ func (s *deviceMgrSuite) TestRemodelSwitchKernelTrack(c *C) {
 		"gadget":       "pc",
 		"base":         "core18",
 	})
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc-model",
 	})
@@ -2747,7 +2730,7 @@ func (s *deviceMgrSuite) TestRemodelLessRequiredSnaps(c *C) {
 		"base":           "core18",
 		"required-snaps": []interface{}{"some-required-snap"},
 	})
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc-model",
 	})
@@ -2786,7 +2769,7 @@ func (s *deviceMgrSuite) TestDeviceCtxNoTask(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, model)
 	c.Assert(err, IsNil)
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
 	})

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -285,7 +285,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc")
@@ -381,7 +381,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc")
@@ -452,7 +452,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassicNoGadget(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "classic-alt-store")
@@ -517,7 +517,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassicFallback(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "generic")
 	c.Check(device.Model, Equals, "generic-classic")
@@ -593,7 +593,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationAltBrandHappy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "my-brand")
 	c.Check(device.Model, Equals, "my-model")
@@ -652,7 +652,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C) {
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Check(err, IsNil)
 	_, err = s.db.Find(asserts.SerialType, map[string]string{
 		"brand-id": "canonical",
@@ -676,7 +676,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C) {
 
 	// Repeated handler run but set original serial.
 	c.Check(chg.Status(), Equals, state.DoneStatus)
-	device, err = devicestate.Device(s.state)
+	device, err = s.mgr.Device()
 	c.Check(err, IsNil)
 	c.Check(device.Serial, Equals, "9999")
 
@@ -728,7 +728,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C) {
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Check(err, IsNil)
 	_, err = s.db.Find(asserts.SerialType, map[string]string{
 		"brand-id": "canonical",
@@ -744,7 +744,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C) {
 
 	// Repeated handler run but set original serial.
 	c.Check(chg.Status(), Equals, state.DoneStatus)
-	device, err = devicestate.Device(s.state)
+	device, err = s.mgr.Device()
 	c.Check(err, IsNil)
 	c.Check(device.Serial, Equals, "9999")
 }
@@ -904,7 +904,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationPollHappy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc")
@@ -1000,7 +1000,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(c *C) 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc2")
@@ -1130,7 +1130,7 @@ func (s *deviceMgrSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c *C, n
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc2")
@@ -1197,7 +1197,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), ErrorMatches, `(?s).*cannot deliver device serial request: bad serial-request.*`)
 
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.KeyID, Not(Equals), "")
 	keyID := device.KeyID
@@ -1221,7 +1221,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 
 	c.Check(devicestate.EnsureOperationalAttempts(s.state), Equals, 2)
 
-	device, err = devicestate.Device(s.state)
+	device, err = s.mgr.Device()
 	c.Assert(err, IsNil)
 	c.Check(device.KeyID, Equals, keyID)
 	c.Check(device.Serial, Equals, "10000")
@@ -1294,7 +1294,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) {
 
 func (s *deviceMgrSuite) TestSetDevice(c *C) {
 	s.state.Lock()
-	device, err := devicestate.Device(s.state)
+	device, err := s.mgr.Device()
 	s.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(device, DeepEquals, &auth.DeviceState{})
@@ -1302,7 +1302,7 @@ func (s *deviceMgrSuite) TestSetDevice(c *C) {
 	s.state.Lock()
 	err = devicestate.SetDevice(s.state, &auth.DeviceState{Brand: "some-brand"})
 	c.Check(err, IsNil)
-	device, err = devicestate.Device(s.state)
+	device, err = s.mgr.Device()
 	s.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1328,8 +1328,6 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	// nothing in the state
 	_, err := devicestate.Model(s.state)
 	c.Check(err, Equals, state.ErrNoState)
-	_, err = devicestate.Serial(s.state)
-	c.Check(err, Equals, state.ErrNoState)
 
 	_, err = s.mgr.Model()
 	c.Check(err, Equals, state.ErrNoState)
@@ -1388,10 +1386,6 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	_, err = s.mgr.Model()
 	c.Assert(err, IsNil)
 	ser, err := s.mgr.Serial()
-	c.Assert(err, IsNil)
-	c.Check(ser.Serial(), Equals, "8989")
-
-	ser, err = devicestate.Serial(s.state)
 	c.Assert(err, IsNil)
 	c.Check(ser.Serial(), Equals, "8989")
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -285,7 +285,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc")
@@ -381,7 +381,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc")
@@ -452,7 +452,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassicNoGadget(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "classic-alt-store")
@@ -517,7 +517,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassicFallback(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "generic")
 	c.Check(device.Model, Equals, "generic-classic")
@@ -593,7 +593,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationAltBrandHappy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "my-brand")
 	c.Check(device.Model, Equals, "my-model")
@@ -652,7 +652,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C) {
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Check(err, IsNil)
 	_, err = s.db.Find(asserts.SerialType, map[string]string{
 		"brand-id": "canonical",
@@ -676,7 +676,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C) {
 
 	// Repeated handler run but set original serial.
 	c.Check(chg.Status(), Equals, state.DoneStatus)
-	device, err = s.mgr.Device()
+	device, err = devicestatetest.Device(s.state)
 	c.Check(err, IsNil)
 	c.Check(device.Serial, Equals, "9999")
 
@@ -728,7 +728,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C) {
 	s.state.Lock()
 
 	c.Check(chg.Status(), Equals, state.DoingStatus)
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Check(err, IsNil)
 	_, err = s.db.Find(asserts.SerialType, map[string]string{
 		"brand-id": "canonical",
@@ -744,7 +744,7 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C) {
 
 	// Repeated handler run but set original serial.
 	c.Check(chg.Status(), Equals, state.DoneStatus)
-	device, err = s.mgr.Device()
+	device, err = devicestatetest.Device(s.state)
 	c.Check(err, IsNil)
 	c.Check(device.Serial, Equals, "9999")
 }
@@ -904,7 +904,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationPollHappy(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc")
@@ -1000,7 +1000,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(c *C) 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc2")
@@ -1130,7 +1130,7 @@ func (s *deviceMgrSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c *C, n
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "canonical")
 	c.Check(device.Model, Equals, "pc2")
@@ -1197,7 +1197,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), ErrorMatches, `(?s).*cannot deliver device serial request: bad serial-request.*`)
 
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.KeyID, Not(Equals), "")
 	keyID := device.KeyID
@@ -1221,7 +1221,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 
 	c.Check(devicestate.EnsureOperationalAttempts(s.state), Equals, 2)
 
-	device, err = s.mgr.Device()
+	device, err = devicestatetest.Device(s.state)
 	c.Assert(err, IsNil)
 	c.Check(device.KeyID, Equals, keyID)
 	c.Check(device.Serial, Equals, "10000")
@@ -1293,8 +1293,9 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) {
 }
 
 func (s *deviceMgrSuite) TestSetDevice(c *C) {
+	// XXX move this test
 	s.state.Lock()
-	device, err := s.mgr.Device()
+	device, err := devicestatetest.Device(s.state)
 	s.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(device, DeepEquals, &auth.DeviceState{})
@@ -1302,27 +1303,13 @@ func (s *deviceMgrSuite) TestSetDevice(c *C) {
 	s.state.Lock()
 	err = devicestate.SetDevice(s.state, &auth.DeviceState{Brand: "some-brand"})
 	c.Check(err, IsNil)
-	device, err = s.mgr.Device()
+	device, err = devicestatetest.Device(s.state)
 	s.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
 }
 
-func (s *deviceMgrSuite) TestStoreContextBackendSetDevice(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	device, err := s.mgr.Device()
-	c.Check(err, IsNil)
-	c.Check(device, DeepEquals, &auth.DeviceState{})
-
-	err = s.mgr.SetDevice(&auth.DeviceState{Brand: "some-brand"})
-	c.Check(err, IsNil)
-	device, err = s.mgr.Device()
-	c.Check(err, IsNil)
-	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
-}
-
-func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
+func (s *deviceMgrSuite) TestModelAndSerial(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	// nothing in the state
@@ -1383,12 +1370,95 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Check(ser.Serial(), Equals, "8989")
 }
 
+func (s *deviceMgrSuite) TestStoreContextBackendSetDevice(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	scb := s.mgr.StoreContextBackend()
+
+	device, err := scb.Device()
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{})
+
+	err = scb.SetDevice(&auth.DeviceState{Brand: "some-brand"})
+	c.Check(err, IsNil)
+	device, err = scb.Device()
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
+}
+
+func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	scb := s.mgr.StoreContextBackend()
+
+	// nothing in the state
+	_, err := scb.Model()
+	c.Check(err, Equals, state.ErrNoState)
+	_, err = scb.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	// just brand and model
+	devicestate.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
+	_, err = scb.Model()
+	c.Check(err, Equals, state.ErrNoState)
+	_, err = scb.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	// have a model assertion
+	model, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, model)
+	c.Assert(err, IsNil)
+
+	mod, err := scb.Model()
+	c.Assert(err, IsNil)
+	c.Assert(mod.BrandID(), Equals, "canonical")
+
+	_, err = scb.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	// have a serial as well
+	devicestate.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc",
+		Serial: "8989",
+	})
+	_, err = scb.Model()
+	c.Assert(err, IsNil)
+	_, err = scb.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	// have a serial assertion
+	s.makeSerialAssertionInState(c, "canonical", "pc", "8989")
+
+	_, err = scb.Model()
+	c.Assert(err, IsNil)
+	ser, err := scb.Serial()
+	c.Assert(err, IsNil)
+	c.Check(ser.Serial(), Equals, "8989")
+}
+
 func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	scb := s.mgr.StoreContextBackend()
+
 	// nothing there
-	_, err := s.mgr.SignDeviceSessionRequest(nil, "NONCE-1")
+	_, err := scb.SignDeviceSessionRequest(nil, "NONCE-1")
 	c.Check(err, ErrorMatches, "internal error: cannot sign a session request without a serial")
 
 	// setup state as done by device initialisation
@@ -1408,7 +1478,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C)
 	c.Assert(err, IsNil)
 	serial := seriala.(*asserts.Serial)
 
-	_, err = s.mgr.SignDeviceSessionRequest(serial, "NONCE-1")
+	_, err = scb.SignDeviceSessionRequest(serial, "NONCE-1")
 	c.Check(err, ErrorMatches, "internal error: inconsistent state with serial but no device key")
 
 	// have a key
@@ -1421,7 +1491,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C)
 		KeyID:  devKey.PublicKey().ID(),
 	})
 
-	sessReq, err := s.mgr.SignDeviceSessionRequest(serial, "NONCE-1")
+	sessReq, err := scb.SignDeviceSessionRequest(serial, "NONCE-1")
 	c.Assert(err, IsNil)
 
 	// correctly signed with device key
@@ -1440,11 +1510,13 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	scb := s.mgr.StoreContextBackend()
+
 	// nothing in the state
 	_, err := devicestate.ProxyStore(s.state)
 	c.Check(err, Equals, state.ErrNoState)
 
-	_, err = s.mgr.ProxyStore()
+	_, err = scb.ProxyStore()
 	c.Check(err, Equals, state.ErrNoState)
 
 	// have a store referenced
@@ -1453,7 +1525,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 	tr.Commit()
 	c.Assert(err, IsNil)
 
-	_, err = s.mgr.ProxyStore()
+	_, err = scb.ProxyStore()
 	c.Check(err, Equals, state.ErrNoState)
 
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
@@ -1471,7 +1543,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 	err = assertstate.Add(s.state, stoAs)
 	c.Assert(err, IsNil)
 
-	sto, err := s.mgr.ProxyStore()
+	sto, err := scb.ProxyStore()
 	c.Assert(err, IsNil)
 	c.Assert(sto.Store(), Equals, "foo")
 

--- a/overlord/devicestate/devicestatetest/state.go
+++ b/overlord/devicestate/devicestatetest/state.go
@@ -28,3 +28,7 @@ import (
 func Device(st *state.State) (*auth.DeviceState, error) {
 	return internal.Device(st)
 }
+
+func SetDevice(st *state.State, device *auth.DeviceState) error {
+	return internal.SetDevice(st, device)
+}

--- a/overlord/devicestate/devicestatetest/state.go
+++ b/overlord/devicestate/devicestatetest/state.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestatetest
+
+import (
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate/internal"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func Device(st *state.State) (*auth.DeviceState, error) {
+	return internal.Device(st)
+}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -280,7 +280,8 @@ func readAsserts(fn string, batch *assertstate.Batch) ([]*asserts.Ref, error) {
 }
 
 func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
-	device, err := Device(st)
+	// TODO: use some kind of context fo Device/SetDevice?
+	device, err := getDeviceState(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -281,7 +282,7 @@ func readAsserts(fn string, batch *assertstate.Batch) ([]*asserts.Ref, error) {
 
 func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
 	// TODO: use some kind of context fo Device/SetDevice?
-	device, err := getDeviceState(st)
+	device, err := internal.Device(st)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -168,7 +168,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	_, ok := as.(*asserts.Model)
 	c.Check(ok, Equals, true)
 
-	ds, err := devicestate.Device(st)
+	ds, err := s.overlord.DeviceManager().Device()
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "generic")
 	c.Check(ds.Model, Equals, "generic-classic")
@@ -200,7 +200,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	c.Assert(err, IsNil)
 	checkTrivialSeeding(c, tsAll)
 
-	ds, err := devicestate.Device(st)
+	ds, err := ovld.DeviceManager().Device()
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "my-brand")
 	c.Check(ds.Model, Equals, "my-model-classic")
@@ -272,7 +272,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudIns
 	c.Assert(err, IsNil)
 	checkTrivialSeeding(c, tsAll)
 
-	ds, err := devicestate.Device(st)
+	ds, err := s.overlord.DeviceManager().Device()
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "my-brand")
 	c.Check(ds.Model, Equals, "my-model-classic")
@@ -1193,7 +1193,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedHappy(c *C) {
 	_, ok := as.(*asserts.Model)
 	c.Check(ok, Equals, true)
 
-	ds, err := devicestate.Device(st)
+	ds, err := ovld.DeviceManager().Device()
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "my-brand")
 	c.Check(ds.Model, Equals, "my-model")

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -168,7 +169,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	_, ok := as.(*asserts.Model)
 	c.Check(ok, Equals, true)
 
-	ds, err := s.overlord.DeviceManager().Device()
+	ds, err := devicestatetest.Device(st)
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "generic")
 	c.Check(ds.Model, Equals, "generic-classic")
@@ -200,7 +201,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	c.Assert(err, IsNil)
 	checkTrivialSeeding(c, tsAll)
 
-	ds, err := ovld.DeviceManager().Device()
+	ds, err := devicestatetest.Device(st)
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "my-brand")
 	c.Check(ds.Model, Equals, "my-model-classic")
@@ -272,7 +273,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudIns
 	c.Assert(err, IsNil)
 	checkTrivialSeeding(c, tsAll)
 
-	ds, err := s.overlord.DeviceManager().Device()
+	ds, err := devicestatetest.Device(st)
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "my-brand")
 	c.Check(ds.Model, Equals, "my-model-classic")
@@ -1193,7 +1194,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedHappy(c *C) {
 	_, ok := as.(*asserts.Model)
 	c.Check(ok, Equals, true)
 
-	ds, err := ovld.DeviceManager().Device()
+	ds, err := devicestatetest.Device(st)
 	c.Assert(err, IsNil)
 	c.Check(ds.Brand, Equals, "my-brand")
 	c.Check(ds.Model, Equals, "my-model")

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -221,7 +221,7 @@ func (m *DeviceManager) doGenerateDeviceKey(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings := timings.NewForTask(t)
 	defer perfTimings.Save(st)
 
-	device, err := Device(st)
+	device, err := m.Device()
 	if err != nil {
 		return err
 	}
@@ -600,7 +600,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings := timings.NewForTask(t)
 	defer perfTimings.Save(st)
 
-	device, err := Device(st)
+	device, err := m.Device()
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -221,7 +221,7 @@ func (m *DeviceManager) doGenerateDeviceKey(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings := timings.NewForTask(t)
 	defer perfTimings.Save(st)
 
-	device, err := m.Device()
+	device, err := m.device()
 	if err != nil {
 		return err
 	}
@@ -600,7 +600,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings := timings.NewForTask(t)
 	defer perfTimings.Save(st)
 
-	device, err := m.Device()
+	device, err := m.device()
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -415,7 +415,7 @@ func submitSerialRequest(t *state.Task, serialRequest string, client *http.Clien
 	return serial, nil
 }
 
-func getSerial(t *state.Task, privKey asserts.PrivateKey, device *auth.DeviceState, tm timings.Measurer) (*asserts.Serial, error) {
+func (m *DeviceManager) getSerial(t *state.Task, privKey asserts.PrivateKey, device *auth.DeviceState, tm timings.Measurer) (*asserts.Serial, error) {
 	var serialSup serialSetup
 	err := t.Get("serial-setup", &serialSup)
 	if err != nil && err != state.ErrNoState {
@@ -439,7 +439,7 @@ func getSerial(t *state.Task, privKey asserts.PrivateKey, device *auth.DeviceSta
 		Proxy:      proxyConf.Conf,
 	})
 
-	cfg, err := getSerialRequestConfig(t, client)
+	cfg, err := m.getSerialRequestConfig(t, client)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func (cfg *serialRequestConfig) applyHeaders(req *http.Request) {
 	}
 }
 
-func getSerialRequestConfig(t *state.Task, client *http.Client) (*serialRequestConfig, error) {
+func (m *DeviceManager) getSerialRequestConfig(t *state.Task, client *http.Client) (*serialRequestConfig, error) {
 	var svcURL, proxyURL *url.URL
 
 	st := t.State()
@@ -516,7 +516,7 @@ func getSerialRequestConfig(t *state.Task, client *http.Client) (*serialRequestC
 	}
 
 	// gadget is optional on classic
-	model, err := Model(st)
+	model, err := m.Model()
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -634,7 +634,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 
 	var serial *asserts.Serial
 	timings.Run(perfTimings, "get-serial", "get device serial", func(tm timings.Measurer) {
-		serial, err = getSerial(t, privKey, device, tm)
+		serial, err = m.getSerial(t, privKey, device, tm)
 	})
 	if err == errPoll {
 		t.Logf("Will poll for device serial assertion in 60 seconds")

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -248,7 +248,7 @@ func (m *DeviceManager) doGenerateDeviceKey(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	device.KeyID = privKey.PublicKey().ID()
-	err = SetDevice(st, device)
+	err = m.setDevice(device)
 	if err != nil {
 		return err
 	}
@@ -578,7 +578,7 @@ func (m *DeviceManager) getSerialRequestConfig(t *state.Task, client *http.Clien
 
 func (m *DeviceManager) finishRegistration(t *state.Task, device *auth.DeviceState, serial *asserts.Serial) error {
 	device.Serial = serial.Serial()
-	err := SetDevice(t.State(), device)
+	err := m.setDevice(device)
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 )
 
 // TODO: should we move this into a new handlers suite?
 func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 	s.state.Lock()
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc-model",
 	})
@@ -81,7 +81,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
 
 	s.state.Lock()
 
-	devicestate.SetDevice(s.state, &auth.DeviceState{
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc-model",
 	})

--- a/overlord/devicestate/internal/state.go
+++ b/overlord/devicestate/internal/state.go
@@ -44,3 +44,20 @@ func Device(st *state.State) (*auth.DeviceState, error) {
 
 	return authStateData.Device, nil
 }
+
+// SetDevice updates the device details in the state.
+func SetDevice(st *state.State, device *auth.DeviceState) error {
+	var authStateData auth.AuthState
+
+	err := st.Get("auth", &authStateData)
+	if err == state.ErrNoState {
+		authStateData = auth.AuthState{}
+	} else if err != nil {
+		return err
+	}
+
+	authStateData.Device = device
+	st.Set("auth", authStateData)
+
+	return nil
+}

--- a/overlord/devicestate/internal/state.go
+++ b/overlord/devicestate/internal/state.go
@@ -1,0 +1,46 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package internal (of devicestate) provides functions to access and
+// set the device state for use only by devicestate, for convenience they
+// are also exposed via devicestatetest for use in tests.
+package internal
+
+import (
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// Device returns the device details from the state.
+func Device(st *state.State) (*auth.DeviceState, error) {
+	var authStateData auth.AuthState
+
+	err := st.Get("auth", &authStateData)
+	if err == state.ErrNoState {
+		return &auth.DeviceState{}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	if authStateData.Device == nil {
+		return &auth.DeviceState{}, nil
+	}
+
+	return authStateData.Device, nil
+}

--- a/overlord/devicestate/internal/state_test.go
+++ b/overlord/devicestate/internal/state_test.go
@@ -17,17 +17,42 @@
  *
  */
 
-package devicestate
+package internal_test
 
 import (
-	"github.com/snapcore/snapd/asserts"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-func setDeviceFromModelAssertion(st *state.State, device *auth.DeviceState, model *asserts.Model) error {
-	device.Brand = model.BrandID()
-	device.Model = model.Model()
-	return internal.SetDevice(st, device)
+func TestInternal(t *testing.T) { TestingT(t) }
+
+type internalSuite struct {
+	state *state.State
+}
+
+var _ = Suite(&internalSuite{})
+
+func (s *internalSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+}
+
+func (s *internalSuite) TestSetDevice(c *C) {
+	s.state.Lock()
+	device, err := internal.Device(s.state)
+	s.state.Unlock()
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{})
+
+	s.state.Lock()
+	err = internal.SetDevice(s.state, &auth.DeviceState{Brand: "some-brand"})
+	c.Check(err, IsNil)
+	device, err = internal.Device(s.state)
+	s.state.Unlock()
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -402,6 +402,11 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	deviceCtx, err := snapstate.DeviceCtx(st, task, nil)
+	if err != nil {
+		return err
+	}
+
 	conns, err := getConns(st)
 	if err != nil {
 		return err
@@ -451,13 +456,13 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 	// policy "connection" rules, other auto-connections obey the
 	// "auto-connection" rules
 	if autoConnect && !byGadget {
-		autochecker, err := newAutoConnectChecker(st)
+		autochecker, err := newAutoConnectChecker(st, deviceCtx)
 		if err != nil {
 			return err
 		}
 		policyChecker = autochecker.check
 	} else {
-		policyCheck, err := newConnectChecker(st)
+		policyCheck, err := newConnectChecker(st, deviceCtx)
 		if err != nil {
 			return err
 		}
@@ -896,12 +901,17 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	conns, err := getConns(st)
+	snapsup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
 		return err
 	}
 
-	snapsup, err := snapstate.TaskSnapSetup(task)
+	deviceCtx, err := snapstate.DeviceCtx(st, task, nil)
+	if err != nil {
+		return err
+	}
+
+	conns, err := getConns(st)
 	if err != nil {
 		return err
 	}
@@ -917,7 +927,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 	snapName := snapsup.InstanceName()
 
 	autots := state.NewTaskSet()
-	autochecker, err := newAutoConnectChecker(st)
+	autochecker, err := newAutoConnectChecker(st, deviceCtx)
 	if err != nil {
 		return err
 	}
@@ -1293,6 +1303,11 @@ func (m *InterfaceManager) doHotplugConnect(task *state.Task, _ *tomb.Tomb) erro
 	st.Lock()
 	defer st.Unlock()
 
+	deviceCtx, err := snapstate.DeviceCtx(st, task, nil)
+	if err != nil {
+		return err
+	}
+
 	conns, err := getConns(st)
 	if err != nil {
 		return err
@@ -1343,7 +1358,7 @@ func (m *InterfaceManager) doHotplugConnect(task *state.Task, _ *tomb.Tomb) erro
 	}
 
 	// find new auto-connections
-	autochecker, err := newAutoConnectChecker(st)
+	autochecker, err := newAutoConnectChecker(st, deviceCtx)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
-	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -463,20 +462,22 @@ type connState struct {
 }
 
 type autoConnectChecker struct {
-	st       *state.State
-	cache    map[string]*asserts.SnapDeclaration
-	baseDecl *asserts.BaseDeclaration
+	st        *state.State
+	deviceCtx snapstate.DeviceContext
+	cache     map[string]*asserts.SnapDeclaration
+	baseDecl  *asserts.BaseDeclaration
 }
 
-func newAutoConnectChecker(s *state.State) (*autoConnectChecker, error) {
+func newAutoConnectChecker(s *state.State, deviceCtx snapstate.DeviceContext) (*autoConnectChecker, error) {
 	baseDecl, err := assertstate.BaseDeclaration(s)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: cannot find base declaration: %v", err)
 	}
 	return &autoConnectChecker{
-		st:       s,
-		cache:    make(map[string]*asserts.SnapDeclaration),
-		baseDecl: baseDecl,
+		st:        s,
+		deviceCtx: deviceCtx,
+		cache:     make(map[string]*asserts.SnapDeclaration),
+		baseDecl:  baseDecl,
 	}, nil
 }
 
@@ -494,10 +495,7 @@ func (c *autoConnectChecker) snapDeclaration(snapID string) (*asserts.SnapDeclar
 }
 
 func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error) {
-	modelAs, err := devicestate.Model(c.st)
-	if err != nil {
-		return false, err
-	}
+	modelAs := c.deviceCtx.Model()
 
 	var storeAs *asserts.Store
 	if modelAs.Store() != "" {
@@ -543,26 +541,25 @@ func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfa
 }
 
 type connectChecker struct {
-	st       *state.State
-	baseDecl *asserts.BaseDeclaration
+	st        *state.State
+	deviceCtx snapstate.DeviceContext
+	baseDecl  *asserts.BaseDeclaration
 }
 
-func newConnectChecker(s *state.State) (*connectChecker, error) {
+func newConnectChecker(s *state.State, deviceCtx snapstate.DeviceContext) (*connectChecker, error) {
 	baseDecl, err := assertstate.BaseDeclaration(s)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: cannot find base declaration: %v", err)
 	}
 	return &connectChecker{
-		st:       s,
-		baseDecl: baseDecl,
+		st:        s,
+		deviceCtx: deviceCtx,
+		baseDecl:  baseDecl,
 	}, nil
 }
 
 func (c *connectChecker) check(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error) {
-	modelAs, err := devicestate.Model(c.st)
-	if err != nil {
-		return false, fmt.Errorf("cannot get model assertion: %v", err)
-	}
+	modelAs := c.deviceCtx.Model()
 
 	var storeAs *asserts.Store
 	if modelAs.Store() != "" {

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -141,7 +141,7 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 
 	s.mockSnapCmd = testutil.MockCommand(c, "snap", "")
 
-	s.SetupAsserts(c, s.state)
+	s.SetupAsserts(c, s.state, &s.BaseTest)
 
 	restoreTimeout := ifacestate.MockUDevInitRetryTimeout(0 * time.Second)
 	s.BaseTest.AddCleanup(restoreTimeout)
@@ -267,6 +267,8 @@ func testByHotplugTaskFlag(c *C, t *state.Task) {
 }
 
 func (s *hotplugSuite) TestHotplugAddBasic(c *C) {
+	s.MockModel(c, nil)
+
 	di, err := hotplug.NewHotplugDeviceInfo(map[string]string{"DEVPATH": "a/path", "ACTION": "add", "SUBSYSTEM": "foo"})
 	c.Assert(err, IsNil)
 	s.udevMon.AddDevice(di)
@@ -310,6 +312,8 @@ func (s *hotplugSuite) TestHotplugAddBasic(c *C) {
 }
 
 func (s *hotplugSuite) TestHotplugConnectWithGadgetSlot(c *C) {
+	s.MockModel(c, nil)
+
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -358,6 +362,8 @@ slots:
 }
 
 func (s *hotplugSuite) TestHotplugAddWithDefaultKey(c *C) {
+	s.MockModel(c, nil)
+
 	di, err := hotplug.NewHotplugDeviceInfo(map[string]string{
 		"DEVPATH":         "a/path",
 		"ACTION":          "add",
@@ -547,6 +553,8 @@ func (s *hotplugSuite) TestHotplugRemove(c *C) {
 }
 
 func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
+	s.MockModel(c, nil)
+
 	st := s.state
 	st.Lock()
 

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/overlord/assertstate"
-	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -406,7 +405,7 @@ func disconnectTasks(st *state.State, conn *interfaces.Connection, flags disconn
 }
 
 // CheckInterfaces checks whether plugs and slots of snap are allowed for installation.
-func CheckInterfaces(st *state.State, snapInfo *snap.Info) error {
+func CheckInterfaces(st *state.State, snapInfo *snap.Info, deviceCtx snapstate.DeviceContext) error {
 	// XXX: addImplicitSlots is really a brittle interface
 	if err := addImplicitSlots(st, snapInfo); err != nil {
 		return err
@@ -417,10 +416,7 @@ func CheckInterfaces(st *state.State, snapInfo *snap.Info) error {
 		return nil
 	}
 
-	modelAs, err := devicestate.Model(st)
-	if err != nil {
-		return err
-	}
+	modelAs := deviceCtx.Model()
 
 	var storeAs *asserts.Store
 	if modelAs.Store() != "" {
@@ -459,7 +455,7 @@ func delayedCrossMgrInit() {
 		// hook interface checks into snapstate installation logic
 
 		snapstate.AddCheckSnapCallback(func(st *state.State, snapInfo, _ *snap.Info, _ snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
-			return CheckInterfaces(st, snapInfo)
+			return CheckInterfaces(st, snapInfo, deviceCtx)
 		})
 
 		// hook into conflict checks mechanisms

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3594,7 +3594,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := ms.o.DeviceManager().Device()
+	device, err := devicestatetest.Device(st)
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "my-brand")
 	c.Check(device.Model, Equals, "my-model")

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -195,7 +195,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	// registered
 	err = assertstate.Add(st, sysdb.GenericClassicModel())
 	c.Assert(err, IsNil)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "generic",
 		Model:  "generic-classic",
 		Serial: "serialserial",
@@ -1510,7 +1510,7 @@ type: os
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, brandAccKey)
 	c.Assert(err, IsNil)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -1594,7 +1594,7 @@ type: kernel`
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, brandAccKey)
 	c.Assert(err, IsNil)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -2443,7 +2443,7 @@ func (s *storeCtxSetupSuite) TestStoreID(c *C) {
 	c.Check(storeID, Equals, "fallback")
 
 	// setup model in system statey
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  s.serial.BrandID(),
 		Model:  s.serial.Model(),
 		Serial: s.serial.Serial(),
@@ -2477,7 +2477,7 @@ func (s *storeCtxSetupSuite) TestDeviceSessionRequestParams(c *C) {
 	c.Assert(err, IsNil)
 	err = kpMgr.Put(deviceKey)
 	c.Assert(err, IsNil)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  s.serial.BrandID(),
 		Model:  s.serial.Model(),
 		Serial: s.serial.Serial(),
@@ -3291,7 +3291,7 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	model := makeModelAssertion(c, brandSigning, nil)
 
 	// setup model assertion
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 	})
@@ -3384,7 +3384,7 @@ type: base`
 		"brand-id":     "can0nical",
 	})
 	// setup model assertion
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "can0nical",
 		Model: "my-model",
 	})
@@ -3445,7 +3445,7 @@ version: 2.0`
 		"brand-id":     "can0nical",
 	})
 	// setup model assertion
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "can0nical",
 		Model: "my-model",
 	})
@@ -3535,7 +3535,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, brandAccKey)
 	c.Assert(err, IsNil)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
 		KeyID: deviceKey.PublicKey().ID(),

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3594,7 +3594,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
-	device, err := devicestate.Device(st)
+	device, err := ms.o.DeviceManager().Device()
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "my-brand")
 	c.Check(device.Model, Equals, "my-model")

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -156,7 +156,7 @@ func New() (*Overlord, error) {
 	defer s.Unlock()
 	// setting up the store
 	proxyConf := proxyconf.New(s)
-	storeCtx := storecontext.New(s, o.deviceMgr)
+	storeCtx := storecontext.New(s, o.deviceMgr.StoreContextBackend())
 	cfg := store.DefaultConfig()
 	cfg.Proxy = proxyConf.Conf
 	sto := storeNew(cfg, storeCtx)

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
@@ -232,7 +232,7 @@ func markSeeded(o *overlord.Overlord) {
 	st := o.State()
 	st.Lock()
 	st.Set("seeded", true)
-	devicestate.SetDevice(st, &auth.DeviceState{
+	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "canonical",
 		Model:  "pc",
 		Serial: "serialserial",

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2155,6 +2155,8 @@ func infoForType(st *state.State, snapType snap.Type) (*snap.Info, error) {
 	return res[0], nil
 }
 
+// XXX: remodeling: decide what to do with Gadget/KernelInfo and their derived functions
+
 // GadgetInfo finds the current gadget snap's info.
 func GadgetInfo(st *state.State) (*snap.Info, error) {
 	return infoForType(st, snap.TypeGadget)


### PR DESCRIPTION
Because under remodeling  we have two models, the current one, and the new model to be,  lots of operations to be correct need to get the device state, model assertions in a contextual manner, via the new snapstate.DeviceCtx for example. The previous accessors solely starting from state are dangerous, do without most of them and reduce the surface of DeviceManager as well.  

Device and SetDevice are still available for tests through devicestatetest (This is achieved introducing a devicestate/internal package).

DeviceManager is not directly a storecontext.Backend anymore, but can provide one via its StroreContextBackend method.

This leaves a few XXXs that will need to be addressed soon.

A follow will also use a registrationContext indirection instead of directly the DeviceManager in much of the registration handling code, to allow its reuse in a remodeling change.

