### PR TITLE
tests: make create-user test support managed devices

### DIFF
--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -23,7 +23,7 @@ execute: |
     fi
     [[ "$obtained" =~ $expected ]]
 
-    if [ "$MANAGED_DEVICE" = "true" ]; then
+    if [ "$(snap managed)" = "true" ]; then
         echo "snap create-user -- not success when run as non-root user with sudo on managed device"
         if su - test /bin/sh -c "sudo snap create-user --sudoer $USER_EMAIL" 2>create.error; then
             echo "Did not get expected error creating user in managed device"

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -23,6 +23,16 @@ execute: |
     fi
     [[ "$obtained" =~ $expected ]]
 
+    if [ "$MANAGED_DEVICE" = "true" ]; then
+        echo "snap create-user -- not success when run as non-root user with sudo on managed device"
+        if su - test /bin/sh -c "sudo snap create-user --sudoer $USER_EMAIL" 2>create.error; then
+            echo "Did not get expected error creating user in managed device"
+            exit 1
+        fi
+        MATCH "cannot create user: device already managed" < create.error
+        exit 0
+    fi
+
     echo "snap create-user -- ensure success when run as non-root user with sudo"
     expected="created user \"$USER_NAME\""
     obtained=$(su - test /bin/sh -c "sudo snap create-user --sudoer $USER_EMAIL 2>&1")


### PR DESCRIPTION
On managed devices the test is failing with error:

+ echo 'snap create-user -- ensure success when run as non-root user with sudo'
snap create-user -- ensure success when run as non-root user with sudo
+ expected='created user "mvo"'
++ su - test /bin/sh -c 'sudo snap create-user --sudoer mvo@ubuntu.com 2>&1'
+ obtained='error: while creating user: cannot create user: device already managed'