### PR TITLE
snapcraft: also include ld.so.conf from libc in the snapcraft.yml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -60,10 +60,13 @@ parts:
     plugin: nil
     stage-packages:
       - libc6
+      - libc-bin
     stage:
       - lib/*
       - usr/lib/*
       - lib64/*
+      - etc/ld.so.conf
+      - etc/ld.so.conf.d/*
     override-stage: |
       snapcraftctl stage
       # fix symlinks of ld.so to be relative

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -32,3 +32,8 @@ execute: |
     echo "Ensure we have mksquashfs (and the dependencies)"
     unsquashfs -ll snapd_*.snap | MATCH bin/mksquashfs
     unsquashfs -ll snapd_*.snap | MATCH liblzma.so.5
+
+    echo "Ensure we have ld.so.conf"
+    unsquashfs -ll snapd_*.snap | MATCH etc/ld.so.conf
+    echo "Ensure we have libc"
+    unsquashfs -ll snapd_*.snap | MATCH libc.so


### PR DESCRIPTION
The cmdutil.CommandFromSystemSnap is using this to find what
library paths need setting.

This should finally fix running running mksquashfs, xdelta3, fc-cache-* 
from the snapd snap. In parallel I am working on a better test for the
binaries from the snapd snap (in a followup PR).