### PR TITLE
data: update XDG_DATA_DIRS via the systemd environment.d mechanism too

### DIFF
--- a/data/systemd-env/990-snapd.conf.in
+++ b/data/systemd-env/990-snapd.conf.in
@@ -1,1 +1,2 @@
 PATH=$PATH:@SNAP_MOUNT_DIR@/bin
+XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}:/var/lib/snapd/desktop


### PR DESCRIPTION
This PR is a result of a problem reported on the #ubuntu-desktop IRC channel.  Desktop files from snaps were not visible in the launcher/dash.  The relevant change he had made from defaults was to change his shell to zsh.

This is because zsh does not run files dropped in `/etc/profile.d` in its default configuration.  This general problem had previously been reported as [bug 1640514](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1640514), which resulted in PR #5390 using the `/usr/lib/environment.d` mechanism to ensure `PATH` was updated.

This PR uses the same mechanism to set XDG_DATA_DIRS, as suggested in further comments on that bug.  The existing `/etc/profile.d` mechanism already checks for duplicates, so this shouldn't affect the final environment for bash users.