### PR TITLE
snapstate: auto-install snapd when needed (2.39)

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -132,6 +132,14 @@ func defaultBaseSnapsChannel() string {
 	return channel
 }
 
+func defaultSnapdSnapsChannel() string {
+	channel := os.Getenv("SNAPD_SNAPD_CHANNEL")
+	if channel == "" {
+		return "stable"
+	}
+	return channel
+}
+
 func defaultPrereqSnapsChannel() string {
 	channel := os.Getenv("SNAPD_PREREQS_CHANNEL")
 	if channel == "" {
@@ -214,10 +222,12 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 
 func (m *SnapManager) installOneBaseOrRequired(st *state.State, snapName, channel string, onInFlight error, userID int) (*state.TaskSet, error) {
 	// The core snap provides everything we need for core16.
-	if snapName == "core16" {
-		if hasCore, err := isInstalled(st, "core"); hasCore && err == nil {
-			return nil, nil
-		}
+	coreInstalled, err := isInstalled(st, "core")
+	if err != nil {
+		return nil, err
+	}
+	if snapName == "core16" && coreInstalled {
+		return nil, nil
 	}
 
 	// installed already?
@@ -275,6 +285,26 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		return err
 	}
 
+	// on systems without core or snapd need to install snapd to
+	// make interfaces work - LP: 1819318
+	var tsSnapd *state.TaskSet
+	snapdSnapInstalled, err := isInstalled(st, "snapd")
+	if err != nil {
+		return err
+	}
+	coreSnapInstalled, err := isInstalled(st, "core")
+	if err != nil {
+		return err
+	}
+	if base != "core" && !snapdSnapInstalled && !coreSnapInstalled {
+		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
+			tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", defaultSnapdSnapsChannel(), onInFlightErr, userID)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	chg := t.Change()
 	// add all required snaps, no ordering, this will be done in the
 	// auto-connect task handler
@@ -282,13 +312,21 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		ts.JoinLane(st.NewLane())
 		chg.AddAll(ts)
 	}
-	// add the base if needed, everything else must wait on this
+	// add the base if needed, prereqs else must wait on this
 	if tsBase != nil {
 		tsBase.JoinLane(st.NewLane())
 		for _, t := range chg.Tasks() {
 			t.WaitAll(tsBase)
 		}
 		chg.AddAll(tsBase)
+	}
+	// add snapd if needed, everything must wait on this
+	if tsSnapd != nil {
+		tsSnapd.JoinLane(st.NewLane())
+		for _, t := range chg.Tasks() {
+			t.WaitAll(tsSnapd)
+		}
+		chg.AddAll(tsSnapd)
 	}
 
 	// make sure that the new change is committed to the state
@@ -1013,19 +1051,15 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	return nil
 }
 
-func snapdSnapInstalled(st *state.State) bool {
-	var snapst SnapState
-	err := Get(st, "snapd", &snapst)
-	return err == nil
-}
-
 // maybeRestart will schedule a reboot or restart as needed for the
 // just linked snap with info if it's a core or snapd or kernel snap.
 func maybeRestart(t *state.Task, info *snap.Info) {
 	st := t.State()
 
 	if release.OnClassic {
-		if (info.Type == snap.TypeOS && !snapdSnapInstalled(st)) ||
+		// ignore error here as we have no way to return to caller
+		snapdSnapInstalled, _ := isInstalled(st, "snapd")
+		if (info.Type == snap.TypeOS && !snapdSnapInstalled) ||
 			info.InstanceName() == "snapd" {
 			t.Logf("Requested daemon restart.")
 			st.RequestRestart(state.RestartDaemon)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -297,9 +297,7 @@ func (m *SnapManager) installPrereqs(t *state.Task, base string, prereq []string
 		return err
 	}
 	if base != "core" && !snapdSnapInstalled && !coreSnapInstalled {
-		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
-			tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", defaultSnapdSnapsChannel(), onInFlightErr, userID)
-		})
+		tsSnapd, err = m.installOneBaseOrRequired(st, "snapd", defaultSnapdSnapsChannel(), onInFlightErr, userID)
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -472,6 +472,7 @@ func (s *prereqSuite) testDoPrereqNoCorePullsInSnaps(c *C, base string) {
 		},
 	})
 
+	c.Check(t.Change().Err(), IsNil)
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
@@ -95,6 +96,16 @@ func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {
 
 func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 	s.state.Lock()
+
+	snapstate.Set(s.state, "core", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "core", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "os",
+	})
+
 	t := s.state.NewTask("prerequisites", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
@@ -259,6 +270,16 @@ func (s *prereqSuite) TestDoPrereqChannelEnvvars(c *C) {
 	os.Setenv("SNAPD_PREREQS_CHANNEL", "candidate")
 	defer os.Unsetenv("SNAPD_PREREQS_CHANNEL")
 	s.state.Lock()
+
+	snapstate.Set(s.state, "core", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "core", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "os",
+	})
+
 	t := s.state.NewTask("prerequisites", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
@@ -402,7 +423,10 @@ func (s *prereqSuite) TestDoPrereqCore16wCoreNothingToDo(c *C) {
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 
-func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
+func (s *prereqSuite) testDoPrereqNoCorePullsInSnaps(c *C, base string) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	s.state.Lock()
 
 	t := s.state.NewTask("prerequisites", "test")
@@ -411,7 +435,7 @@ func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
 			RealName: "foo",
 			Revision: snap.R(33),
 		},
-		Base: "core16",
+		Base: base,
 	})
 	s.state.NewChange("dummy", "...").AddTask(t)
 	s.state.Unlock()
@@ -429,7 +453,19 @@ func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
 			op: "storesvc-snap-action:action",
 			action: store.SnapAction{
 				Action:       "install",
-				InstanceName: "core16",
+				InstanceName: base,
+				Channel:      "stable",
+			},
+			revno: snap.R(11),
+		},
+		{
+			op: "storesvc-snap-action",
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:       "install",
+				InstanceName: "snapd",
 				Channel:      "stable",
 			},
 			revno: snap.R(11),
@@ -437,4 +473,16 @@ func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
 	})
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
+}
+
+func (s *prereqSuite) TestDoPrereqCore16noCore(c *C) {
+	s.testDoPrereqNoCorePullsInSnaps(c, "core16")
+}
+
+func (s *prereqSuite) TestDoPrereqCore18NoCorePullsInSnapd(c *C) {
+	s.testDoPrereqNoCorePullsInSnaps(c, "core18")
+}
+
+func (s *prereqSuite) TestDoPrereqOtherBaseNoCorePullsInSnapd(c *C) {
+	s.testDoPrereqNoCorePullsInSnaps(c, "other-base")
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -80,24 +80,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	if err != nil && !config.IsNoOption(err) {
 		return nil, err
 	}
-	experimentalAllowSnapd, err := config.GetFeatureFlag(tr, features.SnapdSnap)
-	if err != nil && !config.IsNoOption(err) {
-		return nil, err
-	}
 
 	if snapsup.InstanceName() == "system" {
 		return nil, fmt.Errorf("cannot install reserved snap name 'system'")
-	}
-	if snapsup.InstanceName() == "snapd" {
-		model, err := Model(st)
-		if err != nil && err != state.ErrNoState {
-			return nil, err
-		}
-		if model == nil || model.Base() == "" {
-			if !experimentalAllowSnapd {
-				return nil, fmt.Errorf("cannot install snapd snap on a model without a base snap yet")
-			}
-		}
 	}
 	if snapst.IsInstalled() && !snapst.Active {
 		return nil, fmt.Errorf("cannot update disabled snap %q", snapsup.InstanceName())
@@ -537,7 +522,10 @@ func checkInstallPreconditions(st *state.State, info *snap.Info, flags Flags, sn
 			return err
 		}
 
-		model := Model()
+		model, err := Model(st)
+		if err != nil {
+			return err
+		}
 		if model != nil && model.Base() == "" {
 			if !experimentalAllowSnapd {
 				return fmt.Errorf("cannot install snapd snap on a model without a base snap yet")

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -13353,7 +13353,10 @@ func (s *snapmgrTestSuite) TestNoConfigureForBasesTask(c *C) {
 	c.Check(hasConfigureTask(ts), Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestNoSnapdSnapOnSystemsWithoutBase(c *C) {
+func (s *snapmgrTestSuite) TestNoSnapdSnapOnSystemsWithoutBaseOnUbuntuCore(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -1,0 +1,23 @@
+summary: Ensure the snapd gets auto installed when needed
+
+# not testing on ubuntu-core because we have core/snapd installed there
+systems: [-ubuntu-core-*]
+
+execute: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    distro_purge_package snapd
+    distro_install_build_snapd
+    snap wait system seed.loaded
+
+    echo "Ensure nothing is installed"
+    snap list | grep -c -v "^Name " | MATCH 0
+
+    echo "Install a snap that needs core18 only"
+    snap install test-snapd-tools-core18
+
+    echo "Ensure that the snapd snap got installed as well"
+    snap list | grep -c -v "^Name " | MATCH 3
+    snap list | MATCH ^snapd
+    snap list | MATCH ^core18
+    snap list | MATCH ^test-snapd-tools


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/6778 for 2.39 plus some fixes because the code has changed between we branched and master.

* snapstate: auto-install snapd when needed

When installing a snap that does not require "core" on a fresh
system, currently we do nothing special. This means however that
on such systems there is no "core" or "snapd" snap installed.

This means that no system interfaces are available. This PR
fixes this by auto-installing the snapd snap if its missing.

As a side effect, "snap install snapd" on classic is no longer
blocked (it still is on core).

* snapstate: add more tests for snapd auto-install with core18/other-bases

* snapstate: rework the check if the snapd snap can be installed on a Core system

* snapstate: use isInstalled instead of {snapd,core}SnapInstalled

* snapstate: update doInstall now that the "snapd" install check moved to checkInstallPreconditions
