### PR TITLE
overlord,overlord/devicestate: do without GadgetInfo/KernelInfo in devicestate

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -274,6 +274,13 @@ func (m *DeviceManager) ensureOperational() error {
 	var hasPrepareDeviceHook bool
 	// if there's a gadget specified wait for it
 	if gadget != "" {
+		// if have a gadget wait until seeded to proceed
+		if !seeded {
+			// this will be run again, so eventually when the system is
+			// seeded the code below runs
+			return nil
+
+		}
 		var err error
 		gadgetInfo, err = snapstate.GadgetInfo(m.state)
 		if err == state.ErrNoState {
@@ -284,15 +291,6 @@ func (m *DeviceManager) ensureOperational() error {
 			return err
 		}
 		hasPrepareDeviceHook = (gadgetInfo.Hooks["prepare-device"] != nil)
-	}
-
-	// When the prepare-device hook is used we need a fully seeded system
-	// to ensure the prepare-device hook has access to the things it
-	// needs
-	if !seeded && hasPrepareDeviceHook {
-		// this will be run again, so eventually when the system is
-		// seeded the code below runs
-		return nil
 	}
 
 	// have some backoff between full retries

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -39,7 +39,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -270,7 +269,6 @@ func (m *DeviceManager) ensureOperational() error {
 		}
 	}
 
-	var gadgetInfo *snap.Info
 	var hasPrepareDeviceHook bool
 	// if there's a gadget specified wait for it
 	if gadget != "" {
@@ -281,12 +279,8 @@ func (m *DeviceManager) ensureOperational() error {
 			return nil
 
 		}
-		var err error
-		gadgetInfo, err = snapstate.GadgetInfo(m.state)
-		if err == state.ErrNoState {
-			// no gadget installed yet, cannot proceed
-			return nil
-		}
+
+		gadgetInfo, err := snapstate.CurrentInfo(m.state, gadget)
 		if err != nil {
 			return err
 		}
@@ -310,7 +304,7 @@ func (m *DeviceManager) ensureOperational() error {
 	if hasPrepareDeviceHook {
 		summary := i18n.G("Run prepare-device hook")
 		hooksup := &hookstate.HookSetup{
-			Snap: gadgetInfo.InstanceName(),
+			Snap: gadget,
 			Hook: "prepare-device",
 		}
 		prepareDevice = hookstate.HookTask(m.state, summary, hooksup, nil)

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -135,12 +135,12 @@ func canAutoRefresh(st *state.State) (bool, error) {
 
 func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
 	kind := ""
-	var currentInfo func(*state.State) (*snap.Info, error)
+	var snapType snap.Type
 	var getName func(*asserts.Model) string
 	switch snapInfo.Type {
 	case snap.TypeGadget:
 		kind = "gadget"
-		currentInfo = snapstate.GadgetInfo
+		snapType = snap.TypeGadget
 		getName = (*asserts.Model).Gadget
 	case snap.TypeKernel:
 		if release.OnClassic {
@@ -148,7 +148,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 		}
 
 		kind = "kernel"
-		currentInfo = snapstate.KernelInfo
+		snapType = snap.TypeKernel
 		getName = (*asserts.Model).Kernel
 	default:
 		// not a relevant check
@@ -177,11 +177,11 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 		logger.Noticef("installing unasserted %s %q", kind, snapInfo.InstanceName())
 	}
 
-	currentSnap, err := currentInfo(st)
-	if err != nil && err != state.ErrNoState {
-		return fmt.Errorf("cannot find original %s snap: %v", kind, err)
+	found, err := snapstate.HasSnapOfType(st, snapType)
+	if err != nil {
+		return fmt.Errorf("cannot detect original %s snap: %v", kind, err)
 	}
-	if currentSnap != nil {
+	if found {
 		// already installed, snapstate takes care
 		return nil
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1269,7 +1269,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) {
 	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
-		"gadget":       "pc",
+		"gadget":       "gadget",
 	})
 
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -264,7 +264,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappy(c *C) {
 	// avoid full seeding
 	s.seeding()
 
-	// not started without gadget
+	// not started if not seeded
 	s.state.Unlock()
 	s.se.Ensure()
 	s.state.Lock()
@@ -273,6 +273,8 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappy(c *C) {
 	c.Check(becomeOperational, IsNil)
 
 	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
+	// mark it as seeded
+	s.state.Set("seeded", true)
 
 	// runs the whole device registration process
 	s.state.Unlock()
@@ -357,25 +359,16 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 		Model: "pc",
 	})
 
-	// avoid full seeding
-	s.seeding()
-
-	// not started without gadget
-	s.state.Unlock()
-	s.se.Ensure()
-	s.state.Lock()
-
-	becomeOperational := s.findBecomeOperationalChange()
-	c.Check(becomeOperational, IsNil)
-
 	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
+	// mark as seeded
+	s.state.Set("seeded", true)
 
 	// runs the whole device registration process
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
 
-	becomeOperational = s.findBecomeOperationalChange()
+	becomeOperational := s.findBecomeOperationalChange()
 	c.Assert(becomeOperational, NotNil)
 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
@@ -882,9 +875,8 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationPollHappy(c *C) {
 	})
 
 	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
-
-	// avoid full seeding
-	s.seeding()
+	// mark as seeded
+	s.state.Set("seeded", true)
 
 	// runs the whole device registration process with polling
 	s.state.Unlock()
@@ -1181,9 +1173,8 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 	})
 
 	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
-
-	// avoid full seeding
-	s.seeding()
+	// mark as seeded
+	s.state.Set("seeded", true)
 
 	// try the whole device registration process
 	s.state.Unlock()
@@ -1277,8 +1268,8 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationMismatchedSerial(c *C) {
 		Model: "pc",
 	})
 
-	// avoid full seeding
-	s.seeding()
+	// mark as seeded
+	s.state.Set("seeded", true)
 
 	// try the whole device registration process
 	s.state.Unlock()

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -908,8 +908,9 @@ snaps:
 		ctx.Lock()
 		defer ctx.Unlock()
 		// we have a gadget at this point(s)
-		_, err := snapstate.GadgetInfo(st)
+		ok, err := snapstate.HasSnapOfType(st, snap.TypeGadget)
 		c.Check(err, IsNil)
+		c.Check(ok, Equals, true)
 		configured = append(configured, ctx.InstanceName())
 		return nil, nil
 	}

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -525,11 +525,11 @@ func (m *DeviceManager) getSerialRequestConfig(t *state.Task, client *http.Clien
 
 	if model != nil && model.Gadget() != "" {
 		// model specifies a gadget
-		gadgetInfo, err := snapstate.GadgetInfo(st)
-		if err != nil {
-			return nil, fmt.Errorf("cannot find gadget snap and its name: %v", err)
+		gadgetName := model.Gadget()
+		var gadgetSt snapstate.SnapState
+		if err := snapstate.Get(st, gadgetName, &gadgetSt); err != nil {
+			return nil, fmt.Errorf("cannot find gadget snap %q: %v", gadgetName, err)
 		}
-		gadgetName := gadgetInfo.InstanceName()
 
 		var svcURI string
 		err = tr.GetMaybe(gadgetName, "device-service.url", &svcURI)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1511,8 +1511,9 @@ type: os
 	err = assertstate.Add(st, brandAccKey)
 	c.Assert(err, IsNil)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "my-brand",
-		Model: "my-model",
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -1595,8 +1596,9 @@ type: kernel`
 	err = assertstate.Add(st, brandAccKey)
 	c.Assert(err, IsNil)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "my-brand",
-		Model: "my-model",
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -3292,8 +3294,9 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "my-brand",
-		Model: "my-model",
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err = assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -3385,8 +3388,9 @@ type: base`
 	})
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "can0nical",
-		Model: "my-model",
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -3446,8 +3450,9 @@ version: 2.0`
 	})
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "can0nical",
-		Model: "my-model",
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2117,6 +2117,25 @@ func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 	return infos, nil
 }
 
+func HasSnapOfType(st *state.State, snapType snap.Type) (bool, error) {
+	var stateMap map[string]*SnapState
+	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
+		return false, err
+	}
+
+	for _, snapst := range stateMap {
+		typ, err := snapst.Type()
+		if err != nil {
+			return false, err
+		}
+		if typ == snapType {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func infosForTypes(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 	var stateMap map[string]*SnapState
 	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {


### PR DESCRIPTION
This is mostly achieved by using the fact that we know the name of the gadget snap from the model and by introducing instead a snapstate.HasSnapOfType.

As a drive-by this also simplifies a bit the triggering logic for registration.
