### PR TITLE
snapshotstate: disable automatic snapshots on core for now

### DIFF
--- a/overlord/snapshotstate/export_test.go
+++ b/overlord/snapshotstate/export_test.go
@@ -45,6 +45,8 @@ var (
 	SaveExpiration             = saveExpiration
 	ExpiredSnapshotSets        = expiredSnapshotSets
 	RemoveSnapshotState        = removeSnapshotState
+
+	DefaultAutomaticSnapshotExpiration = defaultAutomaticSnapshotExpiration
 )
 
 func (summaries snapshotSnapSummaries) AsMaps() []map[string]string {

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -96,6 +97,11 @@ func AutomaticSnapshotExpiration(st *state.State) (time.Duration, error) {
 			return dur, nil
 		}
 		logger.Noticef("snapshots.automatic.retention cannot be parsed: %v", err)
+	}
+	// TODO: automatic snapshots are currently disable by default
+	// on Ubuntu Core devices
+	if !release.OnClassic {
+		return 0, nil
 	}
 	return defaultAutomaticSnapshotExpiration, nil
 }

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -1451,4 +1452,28 @@ func (snapshotSuite) TestAutomaticSnapshot(c *check.C) {
 		"current": "unset",
 		"auto":    true,
 	})
+}
+
+func (snapshotSuite) TestAutomaticSnapshotDefaultClassic(c *check.C) {
+	release.MockOnClassic(true)
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	du, err := snapshotstate.AutomaticSnapshotExpiration(st)
+	c.Assert(err, check.IsNil)
+	c.Assert(du, check.Equals, snapshotstate.DefaultAutomaticSnapshotExpiration)
+}
+
+func (snapshotSuite) TestAutomaticSnapshotDefaultUbuntuCore(c *check.C) {
+	release.MockOnClassic(false)
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	du, err := snapshotstate.AutomaticSnapshotExpiration(st)
+	c.Assert(err, check.IsNil)
+	c.Assert(du, check.Equals, time.Duration(0))
 }


### PR DESCRIPTION
This disables automatic snapshot on Ubuntu Core devices to avoid
any diskspace issues with this new feature.

Once this is publicized a bit more we will re-enable this on
Core devices.
