### PR TITLE
snap-confine: improve error when running on a not /home homedir

### DIFF
--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -53,6 +53,27 @@ static void test_sc_endswith(void)
 	g_assert_false(sc_endswith("ba", "bar"));
 }
 
+static void test_sc_startswith(void)
+{
+	// NULL doesn't start with anything, nothing starts with NULL
+	g_assert_false(sc_startswith("", NULL));
+	g_assert_false(sc_startswith(NULL, ""));
+	g_assert_false(sc_startswith(NULL, NULL));
+	// Empty string starts with an empty string
+	g_assert_true(sc_startswith("", ""));
+	// Starts-with (matches)
+	g_assert_true(sc_startswith("foobar", "foo"));
+	g_assert_true(sc_startswith("foobar", "fo"));
+	g_assert_true(sc_startswith("foobar", "f"));
+	g_assert_true(sc_startswith("foobar", ""));
+	g_assert_true(sc_startswith("bar", "bar"));
+	// Starts-with (non-matches)
+	g_assert_false(sc_startswith("foobar", "quux"));
+	g_assert_false(sc_startswith("", "bar"));
+	g_assert_false(sc_startswith("b", "bar"));
+	g_assert_false(sc_startswith("ba", "bar"));
+}
+
 static void test_sc_must_snprintf(void)
 {
 	char buf[5] = { 0 };
@@ -794,6 +815,7 @@ static void __attribute__((constructor)) init(void)
 {
 	g_test_add_func("/string-utils/sc_streq", test_sc_streq);
 	g_test_add_func("/string-utils/sc_endswith", test_sc_endswith);
+        g_test_add_func("/string-utils/sc_startswith", test_sc_startswith);
 	g_test_add_func("/string-utils/sc_must_snprintf",
 			test_sc_must_snprintf);
 	g_test_add_func("/string-utils/sc_must_snprintf/fail",

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -56,6 +56,22 @@ bool sc_endswith(const char *str, const char *suffix)
 	return strncmp(str - xlen + slen, suffix, xlen) == 0;
 }
 
+bool sc_startswith(const char *str, const char *prefix)
+{
+	if (!str || !prefix) {
+		return false;
+	}
+
+	size_t xlen = strlen(prefix);
+	size_t slen = strlen(str);
+
+	if (slen < xlen) {
+		return false;
+	}
+
+	return strncmp(str, prefix, xlen) == 0;
+}
+
 char *sc_strdup(const char *str)
 {
 	size_t len;

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -32,6 +32,11 @@ bool sc_streq(const char *a, const char *b);
 bool sc_endswith(const char *str, const char *suffix);
 
 /**
+ * Check if a string has a given prefix.
+ **/
+bool sc_startswith(const char *str, const char *prefix);
+
+/**
  * Allocate and return a copy of a string.
 **/
 char *sc_strdup(const char *str);

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
+#include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
 void setup_user_data(void)
@@ -37,6 +38,11 @@ void setup_user_data(void)
 
 	debug("creating user data directory: %s", user_data);
 	if (sc_nonfatal_mkpath(user_data, 0755) < 0) {
+		if (errno == EROFS && !sc_startswith(user_data, "/home")) {
+				// clear errno or it will be displayed in die()
+				errno = 0;
+				die("Sorry, cannot use home directories outside /home.\nSee https://forum.snapcraft.io/t/11209 for details.");
+		}
 		die("cannot create user data directory: %s", user_data);
 	};
 }

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -38,7 +38,7 @@ void setup_user_data(void)
 
 	debug("creating user data directory: %s", user_data);
 	if (sc_nonfatal_mkpath(user_data, 0755) < 0) {
-		if (errno == EROFS && !sc_startswith(user_data, "/home")) {
+		if (errno == EROFS && !sc_startswith(user_data, "/home/")) {
 				// clear errno or it will be displayed in die()
 				errno = 0;
 				die("Sorry, cannot use home directories outside /home.\nSee https://forum.snapcraft.io/t/11209 for details.");

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -41,7 +41,7 @@ void setup_user_data(void)
 		if (errno == EROFS && !sc_startswith(user_data, "/home/")) {
 				// clear errno or it will be displayed in die()
 				errno = 0;
-				die("Sorry, cannot use home directories outside /home.\nSee https://forum.snapcraft.io/t/11209 for details.");
+				die("Sorry, home directories outside of /home are not currently supported. \nSee https://forum.snapcraft.io/t/11209 for details.");
 		}
 		die("cannot create user data directory: %s", user_data);
 	};

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -26,6 +26,6 @@ execute: |
     ! su -c "snap run test-snapd-tools.echo foo" "$TUSER" 2>stderr.log
 
     echo "Ensure we get a useful error message"
-    MATCH "Sorry, cannot use home directories outside /home" < stderr.log
+    MATCH "Sorry, home directories outside of /home" < stderr.log
     # ensure no (useless) "Read-only file system..." error is shown to the user
     MATCH -v "Read-only file system" < stderr.log

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -5,7 +5,8 @@ systems: [ubuntu-1*, ubuntu-2*]
 
 environment:
     TUSER: jim
-    THOME: /var/home/jim
+    THOME/var: /var/home/jim
+    THOME/home2: /home2/jim
 
 prepare: |
     echo "create a non home user"

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -1,0 +1,30 @@
+summary: Ensure running on none /home dirs gives a useful error
+
+# limit to ubuntu for easier user creation
+systems: [ubuntu-1*, ubuntu-2*]
+
+environment:
+    TUSER: jim
+    THOME: /var/home/jim
+
+prepare: |
+    echo "create a non home user"
+    adduser --home "$THOME" "$TUSER"
+
+restore: |
+    deluser --remove-home "$TUSER"
+
+execute: |
+    echo "Install a snap"
+    snap install test-snapd-tools
+
+    echo "Run as the test user (normal home dir)"
+    su -c "snap run test-snapd-tools.echo foo" test | MATCH foo
+
+    echo "Run as the non-home user (home dir outside of /home) - this will fail"
+    ! su -c "snap run test-snapd-tools.echo foo" "$TUSER" 2>stderr.log
+
+    echo "Ensure we get a useful error message"
+    MATCH "Sorry, cannot use home directories outside /home" < stderr.log
+    # ensure no (useless) "Read-only file system..." error is shown to the user
+    MATCH -v "Read-only file system" < stderr.log


### PR DESCRIPTION
We currently don't support running on a non /home homedirs. The
error in this case is very cryptic:
```
cannot create user data directory: /data1/home/username/snap/hello/20: Read-only file system
```

This PR detects the error in snap-confine and provides a clearer
error message to the user with a link to the relevant forum topic.

Ideally we would have a step-by-step guide in the forum docs how
to fix things there.
