### PR TITLE
cmd: rework `snap run --gdb` to work as user

### DIFF
--- a/cmd/snap-gdb-shim/snap-gdb-shim.c
+++ b/cmd/snap-gdb-shim/snap-gdb-shim.c
@@ -29,7 +29,10 @@ int main(int argc, char **argv)
 			printf("-%s-\n", argv[i]);
 		}
 	}
-	// signal gdb to stop here
+	// signal gdb to stop here, after that snap run will `gdb -p` and
+	// sent SIGCONT
+	raise(SIGSTOP);
+
 	printf("\n\n");
 	printf("Welcome to `snap run --gdb`.\n");
 	printf("You are right before your application is execed():\n");

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -56,7 +56,13 @@ execute: |
        echo "Test snap run --gdb works"
        echo "c" | snap run --gdb test-snapd-tools.echo hello > stdout
        MATCH 'Continuing.' < stdout
-       MATCH hello < stdout
+       MATCH 'hello' < stdout
+
+       echo "Test snap run --gdb works as user too"
+       echo "c" | su -c "snap run --gdb test-snapd-tools.env" test > stdout
+       MATCH 'SNAP_USER_COMMON=/home/test/snap/test-snapd-tools/common' < stdout
+       echo "c" | su -c "snap run --gdb test-snapd-tools.cmd /usr/bin/id" test > stdout
+       MATCH '^uid=12345\(test\) gid=12345\(test\).*' < stdout
     fi
 
     snap run --trace-exec test-snapd-tools.echo hello 2> stderr


### PR DESCRIPTION
Right now snap run --gdb will run everything as root.
This is a problem because most developers expect to debug
their programs as user. However we need to run as root
because the setuid snap-confine will not run with root
permissions when run under gdb.

The fix is to change snap-gdb-shim to `raise(SIGSTOP)` and
catch that in snap run. Then `snap run` can continue and
snap-gdb-shim calls raise(SIGTRAP) which will drop the user
into the gdb environment.

This is a better approach than what was tried in https://github.com/snapcore/snapd/pull/6641

