### PR TITLE
packaging: fix changelog typo

### DIFF
--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,6 +1,6 @@
 snapd (2.39) xenial; urgency=medium
 
-  * Placeholer 2.39 changelog
+  * Placeholder 2.39 changelog
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Thu, 18 Apr 2019 18:27:01 +0200
 


### PR DESCRIPTION
This is failing on master

Checking spelling errors
packaging/ubuntu-16.04/changelog:3:4: "Placeholer" is a misspelling of "Placeholder"