### PR TITLE
many: use a fake assertion model in the device contexts for tests

### DIFF
--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -444,3 +444,38 @@ func MockBuiltinBaseDeclaration(headers []byte) (restore func()) {
 		}
 	}
 }
+
+// FakeAssertionWithBody builds a fake assertion with the given body
+// and layered headers. A fake assertion cannot be verified or added
+// to a database or properly encoded. It can still be useful for unit
+// tests but shouldn't be used in integration tests.
+func FakeAssertionWithBody(body []byte, headerLayers ...map[string]interface{}) asserts.Assertion {
+	headers := map[string]interface{}{
+		"sign-key-sha3-384": "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+	}
+	for _, h := range headerLayers {
+		for k, v := range h {
+			headers[k] = v
+		}
+	}
+
+	_, hasTimestamp := headers["timestamp"]
+	_, hasSince := headers["since"]
+	if !(hasTimestamp || hasSince) {
+		headers["timestamp"] = time.Now().Format(time.RFC3339)
+	}
+
+	a, err := asserts.Assemble(headers, body, nil, []byte("AXNpZw=="))
+	if err != nil {
+		panic(fmt.Sprintf("cannot build fake assertion: %v", err))
+	}
+	return a
+}
+
+// FakeAssertion builds a fake assertion with given layered headers
+// and an empty body. A fake assertion cannot be verified or added to
+// a database or properly encoded. It can still be useful for unit
+// tests but shouldn't be used in integration tests.
+func FakeAssertion(headerLayers ...map[string]interface{}) asserts.Assertion {
+	return FakeAssertionWithBody(nil, headerLayers...)
+}

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -170,6 +170,8 @@ func (s *downloadSnapSuite) TestDoDownloadSnapNormal(c *C) {
 func (s *downloadSnapSuite) TestDoDownloadSnapWithDeviceContext(c *C) {
 	s.state.Lock()
 
+	// unset the global store, it will need to come via the device context
+	// CtxStore
 	snapstate.ReplaceStore(s.state, nil)
 
 	r := snapstatetest.MockDeviceContext(&snapstatetest.TrivialDeviceContext{

--- a/overlord/snapstate/models_test.go
+++ b/overlord/snapstate/models_test.go
@@ -21,45 +21,36 @@ package snapstate_test
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 )
 
 func ModelWithBase(baseName string) *asserts.Model {
-	return MakeModel(map[string]string{"base": baseName})
+	return MakeModel(map[string]interface{}{"base": baseName})
 }
 
 func ModelWithKernelTrack(kernelTrack string) *asserts.Model {
-	return MakeModel(map[string]string{"kernel": "kernel=" + kernelTrack})
+	return MakeModel(map[string]interface{}{"kernel": "kernel=" + kernelTrack})
 }
 
 func ModelWithGadgetTrack(gadgetTrack string) *asserts.Model {
-	return MakeModel(map[string]string{"gadget": "brand-gadget=" + gadgetTrack})
+	return MakeModel(map[string]interface{}{"gadget": "brand-gadget=" + gadgetTrack})
 }
 
 func DefaultModel() *asserts.Model {
 	return MakeModel(nil)
 }
 
-func MakeModel(override map[string]string) *asserts.Model {
+func MakeModel(override map[string]interface{}) *asserts.Model {
 	model := map[string]interface{}{
-		"type":              "model",
-		"authority-id":      "brand",
-		"series":            "16",
-		"brand-id":          "brand",
-		"model":             "baz-3000",
-		"architecture":      "armhf",
-		"gadget":            "brand-gadget",
-		"kernel":            "kernel",
-		"timestamp":         "2018-01-01T08:00:00+00:00",
-		"sign-key-sha3-384": "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		"type":         "model",
+		"authority-id": "brand",
+		"series":       "16",
+		"brand-id":     "brand",
+		"model":        "baz-3000",
+		"architecture": "armhf",
+		"gadget":       "brand-gadget",
+		"kernel":       "kernel",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
 	}
-	for k, v := range override {
-		model[k] = v
-	}
-
-	a, err := asserts.Assemble(model, nil, nil, []byte("AXNpZw=="))
-	if err != nil {
-		panic(err)
-	}
-
-	return a.(*asserts.Model)
+	return assertstest.FakeAssertion(model, override).(*asserts.Model)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -616,7 +616,7 @@ func (s *snapmgrTestSuite) TestInstallUnderDeviceContext(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// it will need to come via the device context
+	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{CtxStore: s.fakeStore}
@@ -2144,7 +2144,7 @@ func (s *snapmgrTestSuite) TestUpdateUnderDeviceContext(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// it will need to come via the device context
+	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{
@@ -2181,7 +2181,7 @@ func (s *snapmgrTestSuite) TestUpdateUnderDeviceContextToRevision(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// it will need to come via the device context
+	// unset the global store, it will need to come via the device context
 	snapstate.ReplaceStore(s.state, nil)
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{


### PR DESCRIPTION
Adopt and generalize the approach used by snapstate tests that use fake assertions for the model in-use via the device context. Given that those assertions are verified before, not stored further, nor encoded there is no need to setup a brand signing test fixture.

This adds FakeAssertion* helpers to assertstest for the purpose.

It contains a drive-by about the slow down that was provoked by the shellcheck-ing the MockCommand scripts if shellcheck is available; results for that are now internally cached.  E.g. ifacestate tests on my system went back from 20s to ~2s.