### PR TITLE
interfaces/dbus: fix unit tests when default snap mount dir is not /snap

### DIFF
--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -329,7 +329,7 @@ func (s *backendSuite) TestSetupWritesUsedFilesForSnapd(c *C) {
 }
 
 func (s *backendSuite) TestSetupWritesUsedFilesBothSnapdAndCoreInstalled(c *C) {
-	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/snap/snapd/current"), 0755)
+	err := os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current"), 0755)
 	c.Assert(err, IsNil)
 
 	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(2)})


### PR DESCRIPTION
Unit tests assumed that default snap mount directory is /snap, but did not mock
the distro. Stick to whatever is correct for the host, and use proper paths
instead.

