### PR TITLE
tests: retry govendor sync

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -405,7 +405,13 @@ prepare_project() {
         rm -rf "${GOPATH%%:*}/src/github.com/kardianos/govendor"
         go get -u github.com/kardianos/govendor
     fi
-    quiet govendor sync
+    # Retry govendor sync to minimize the number of connection errors during the sync
+    for _ in $(seq 10); do
+        if quiet govendor sync; then
+            break
+        fi
+        sleep 1
+    done
     # govendor runs as root and will leave strange permissions
     chown test.test -R "$SPREAD_PATH"
 


### PR DESCRIPTION
This change retries `govendor sync` to minimize the number of connection errors on prepare.

This is the kind of errors:

    + rm -rf /home/gopath/src/github.com/kardianos/govendor
    + go get -u github.com/kardianos/govendor
    + quiet govendor sync
    quiet: govendor sync
    quiet: exit status 2. Output follows:
    /home/gopath/.cache/govendor/golang.org/x/net
    Cloning into '/home/gopath/.cache/govendor/golang.org/x/net'...
    fatal: unable to access 'https://go.googlesource.com/net/': Failed to
    connect to go.googlesource.com port 443: Connection timed out
    Error: Remotes failed for:
            Failed for "golang.org/x/net/context" (failed to clone repo):
    exit status 128

    quiet: end of output.
