### PR TITLE
many: introduce assertstest.SigningAccounts and AddMany test helpers

### DIFF
--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -479,3 +479,20 @@ func FakeAssertionWithBody(body []byte, headerLayers ...map[string]interface{}) 
 func FakeAssertion(headerLayers ...map[string]interface{}) asserts.Assertion {
 	return FakeAssertionWithBody(nil, headerLayers...)
 }
+
+type accuDB interface {
+	Add(asserts.Assertion) error
+}
+
+// AddMany conveniently adds the given assertions to the db.
+// It is idempotent but otherwise panics on error.
+func AddMany(db accuDB, assertions ...asserts.Assertion) {
+	for _, a := range assertions {
+		err := db.Add(a)
+		if _, ok := err.(*asserts.RevisionError); !ok {
+			if err != nil {
+				panic(fmt.Sprintf("cannot add test assertions: %v", err))
+			}
+		}
+	}
+}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -78,7 +78,7 @@ type imageSuite struct {
 	tsto            *image.ToolingStore
 
 	storeSigning *assertstest.StoreStack
-	brandSigning *assertstest.SigningDB
+	brands       *assertstest.SigningAccounts
 
 	model *asserts.Model
 }
@@ -107,31 +107,19 @@ func (s *imageSuite) SetUpTest(c *C) {
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 
-	s.brandSigning = assertstest.NewSigningDB("my-brand", brandPrivKey)
-
-	brandAcct := assertstest.NewAccount(s.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
-	}, "")
-	s.storeSigning.Add(brandAcct)
+	})
+	assertstest.AddMany(s.storeSigning, s.brands.AccountsAndKeys("my-brand")...)
 
-	brandAccKey := assertstest.NewAccountKey(s.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
-	s.storeSigning.Add(brandAccKey)
-
-	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	s.model = s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"required-snap1"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	s.model = model.(*asserts.Model)
+	})
 
 	otherAcct := assertstest.NewAccount(s.storeSigning, "other", map[string]interface{}{
 		"account-id": "other",
@@ -533,18 +521,12 @@ func (s *imageSuite) TestDownloadUnpackGadgetFromTrack(c *C) {
 	s.downloadedSnaps["pc"] = snaptest.MakeTestSnapWithFiles(c, packageGadget, nil)
 	s.storeSnapInfo["pc"] = infoFromSnapYaml(c, packageGadget, snap.R(1818))
 
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+
 		"architecture": "amd64",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	gadgetUnpackDir := filepath.Join(c.MkDir(), "gadget-unpack-dir")
 	opts := &image.Options{
@@ -678,8 +660,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 	c.Check(seed.Snaps[3].Contact, Equals, "foo@example.com")
 
 	storeAccountKey := s.storeSigning.StoreAccountKey("")
-	brandPubKey, err := s.brandSigning.PublicKey("")
-	c.Assert(err, IsNil)
+	brandPubKey := s.brands.PublicKey("my-brand")
 
 	// check the assertions are in place
 	for _, fn := range []string{"model", brandPubKey.ID() + ".account-key", "my-brand.account", storeAccountKey.PublicKeyID() + ".account-key"} {
@@ -786,8 +767,7 @@ func (s *imageSuite) TestSetupSeedLocalCoreBrandKernel(c *C) {
 	c.Check(l, HasLen, 4)
 
 	storeAccountKey := s.storeSigning.StoreAccountKey("")
-	brandPubKey, err := s.brandSigning.PublicKey("")
-	c.Assert(err, IsNil)
+	brandPubKey := s.brands.PublicKey("my-brand")
 
 	// check the assertions are in place
 	for _, fn := range []string{"model", brandPubKey.ID() + ".account-key", "my-brand.account", storeAccountKey.PublicKeyID() + ".account-key"} {
@@ -939,20 +919,13 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
 		"base":           "core18",
 		"required-snaps": []interface{}{"other-base"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
@@ -1183,8 +1156,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAsserts(c *C) {
 	c.Check(l, HasLen, 4)
 
 	storeAccountKey := s.storeSigning.StoreAccountKey("")
-	brandPubKey, err := s.brandSigning.PublicKey("")
-	c.Assert(err, IsNil)
+	brandPubKey := s.brands.PublicKey("my-brand")
 
 	// check the assertions are in place
 	for _, fn := range []string{"model", brandPubKey.ID() + ".account-key", "my-brand.account", storeAccountKey.PublicKeyID() + ".account-key"} {
@@ -1346,18 +1318,12 @@ func (s *imageSuite) TestPrepareClassicModelNoClassicMode(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
 
-	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"classic":      "true",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+		"classic": "true",
+	})
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err = ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -1370,19 +1336,13 @@ func (s *imageSuite) TestPrepareClassicModelArchOverrideFails(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
 
-	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"classic":      "true",
 		"architecture": "amd64",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
+	})
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err = ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -1397,19 +1357,13 @@ func (s *imageSuite) TestPrepareClassicModelSnapsButNoArchFails(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
 
-	model, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"classic":      "true",
-		"gadget":       "classic-gadget",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+		"classic": "true",
+		"gadget":  "classic-gadget",
+	})
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err = ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -1424,18 +1378,11 @@ func (s *imageSuite) TestSetupSeedWithKernelAndGadgetTrack(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
@@ -1484,18 +1431,11 @@ func (s *imageSuite) TestSetupSeedWithKernelTrackWithDefaultChannel(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel=18",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -1546,18 +1486,11 @@ func (s *imageSuite) TestSetupSeedWithKernelTrackOnLocalSnap(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel=18",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
@@ -1607,20 +1540,13 @@ func (s *imageSuite) TestSetupSeedWithBaseAndLocalLegacyCoreOrdering(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"required-snap1"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
@@ -1687,20 +1613,13 @@ func (s *imageSuite) TestSetupSeedWithBaseAndLegacyCoreOrdering(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc18",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"required-snap1", "core"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
@@ -1764,20 +1683,14 @@ func (s *imageSuite) TestSetupSeedGadgetBaseModelBaseMismatch(c *C) {
 	defer restore()
 	// replace model with a model that uses core18 and a gadget
 	// without a base
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"base":           "core18",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"required-snap1"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -1798,19 +1711,13 @@ func (s *imageSuite) TestSetupSeedGadgetBaseModelBaseMismatch(c *C) {
 func (s *imageSuite) TestSetupSeedSnapReqBase(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"snap-req-other-base"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -1832,19 +1739,13 @@ func (s *imageSuite) TestSetupSeedSnapReqBase(c *C) {
 func (s *imageSuite) TestSetupSeedSnapCoreSatisfiesCore16(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"snap-req-core16-base"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -1866,19 +1767,13 @@ func (s *imageSuite) TestSetupSeedSnapCoreSatisfiesCore16(c *C) {
 func (s *imageSuite) TestSetupSeedStoreAssertionMissing(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel",
 		"store":        "my-store",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -1910,19 +1805,13 @@ func (s *imageSuite) TestSetupSeedStoreAssertionFetched(c *C) {
 	err = s.storeSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc",
 		"kernel":       "pc-kernel",
 		"store":        "my-store",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	seeddir := filepath.Join(rootdir, "var/lib/snapd/seed")
@@ -1950,19 +1839,13 @@ func (s *imageSuite) TestSetupSeedStoreAssertionFetched(c *C) {
 func (s *imageSuite) TestSetupSeedSnapReqBaseFromLocal(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"snap-req-other-base"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -1987,19 +1870,13 @@ func (s *imageSuite) TestSetupSeedSnapReqBaseFromLocal(c *C) {
 func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 	restore := image.MockTrusted(s.storeSigning.Trusted)
 	defer restore()
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
 		"required-snaps": []interface{}{"snap-req-content-provider"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
+
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()
 	s.setupSnaps(c, gadgetUnpackDir, map[string]string{
@@ -2034,19 +1911,12 @@ func (s *imageSuite) TestSetupSeedClassic(c *C) {
 	defer restore()
 
 	// classic model with gadget etc
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":         "16",
-		"authority-id":   "my-brand",
-		"brand-id":       "my-brand",
-		"model":          "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"classic":        "true",
 		"architecture":   "amd64",
 		"gadget":         "classic-gadget",
 		"required-snaps": []interface{}{"required-snap1"},
-		"timestamp":      time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "classic-image-root")
 	s.setupSnaps(c, "", map[string]string{
@@ -2111,17 +1981,10 @@ func (s *imageSuite) TestSetupSeedClassicWithClassicSnap(c *C) {
 	defer restore()
 
 	// classic model
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"classic":      "true",
 		"architecture": "amd64",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "classic-image-root")
 	s.setupSnaps(c, "", nil)
@@ -2181,16 +2044,9 @@ func (s *imageSuite) TestSetupSeedClassicNoSnaps(c *C) {
 	defer restore()
 
 	// classic model with gadget etc
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"classic":      "true",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
+		"classic": "true",
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "classic-image-root")
 
@@ -2228,18 +2084,11 @@ func (s *imageSuite) TestSetupSeedClassicNoSnaps(c *C) {
 }
 
 func (s *imageSuite) TestSnapChannel(c *C) {
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc=18",
 		"kernel":       "pc-kernel=18",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	opts := &image.Options{
 		Channel: "stable",
@@ -2282,19 +2131,12 @@ func (s *imageSuite) TestSetupSeedLocalSnapd(c *C) {
 	defer restore()
 
 	// replace model with a model that uses core18
-	rawmodel, err := s.brandSigning.Sign(asserts.ModelType, map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
+	model := s.brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture": "amd64",
 		"gadget":       "pc18",
 		"kernel":       "pc-kernel",
 		"base":         "core18",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}, nil, "")
-	c.Assert(err, IsNil)
-	model := rawmodel.(*asserts.Model)
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "imageroot")
 	gadgetUnpackDir := c.MkDir()

--- a/overlord/assertstate/assertstatetest/add_many.go
+++ b/overlord/assertstate/assertstatetest/add_many.go
@@ -17,23 +17,26 @@
  *
  */
 
-package daemon
+package assertstatetest
 
 import (
-	"net/http"
+	"fmt"
 
-	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/state"
 )
 
-func GetAssertTypeNames(c *Command, r *http.Request, user *auth.UserState) *resp {
-	return getAssertTypeNames(c, r, user).(*resp)
+// AddMany adds the given assertions to the system assertion database,
+// associated with the state.
+// It is idempotent but otherwise panics on error.
+func AddMany(st *state.State, assertions ...asserts.Assertion) {
+	for _, a := range assertions {
+		err := assertstate.Add(st, a)
+		if _, ok := err.(*asserts.RevisionError); !ok {
+			if err != nil {
+				panic(fmt.Sprintf("cannot add test assertions: %v", err))
+			}
+		}
+	}
 }
-
-func DoAssert(c *Command, r *http.Request, user *auth.UserState) *resp {
-	return doAssert(c, r, user).(*resp)
-}
-
-var (
-	AssertsCmd         = assertsCmd
-	AssertsFindManyCmd = assertsFindManyCmd
-)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -341,7 +341,6 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 	c.Assert(tr.Set("core", "proxy.store", "foo"), IsNil)
 	tr.Commit()
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
-	c.Assert(assertstate.Add(s.state, operatorAcct), IsNil)
 
 	// have a store assertion.
 	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
@@ -351,7 +350,8 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyWithProxy(c *C) {
 		"timestamp":   time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	c.Assert(assertstate.Add(s.state, stoAs), IsNil)
+
+	assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 
 	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
 		"architecture": "amd64",
@@ -1090,7 +1090,6 @@ func (s *deviceMgrSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c *C, n
 	c.Assert(tr.Set("core", "proxy.store", "foo"), IsNil)
 	tr.Commit()
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
-	c.Assert(assertstate.Add(s.state, operatorAcct), IsNil)
 
 	// have a store assertion.
 	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
@@ -1100,7 +1099,8 @@ func (s *deviceMgrSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c *C, n
 		"timestamp":   time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	c.Assert(assertstate.Add(s.state, stoAs), IsNil)
+
+	assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 
 	s.makeModelAssertionInState(c, "canonical", "pc2", map[string]interface{}{
 		"architecture": "amd64",
@@ -1441,8 +1441,7 @@ func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C)
 		"timestamp":           time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = assertstate.Add(s.state, seriala)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(s.state, seriala)
 	serial := seriala.(*asserts.Serial)
 
 	_, err = scb.SignDeviceSessionRequest(serial, "NONCE-1")
@@ -1493,8 +1492,6 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 	c.Check(err, Equals, state.ErrNoState)
 
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
-	err = assertstate.Add(s.state, operatorAcct)
-	c.Assert(err, IsNil)
 
 	// have a store assertion.
 	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
@@ -1504,8 +1501,8 @@ func (s *deviceMgrSuite) TestStoreContextBackendProxyStore(c *C) {
 		"timestamp":   time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = assertstate.Add(s.state, stoAs)
-	c.Assert(err, IsNil)
+
+	assertstatetest.AddMany(s.state, operatorAcct, stoAs)
 
 	sto, err := scb.ProxyStore()
 	c.Assert(err, IsNil)
@@ -1684,12 +1681,10 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkError(c *C) {
 
 func (s *deviceMgrSuite) setupBrands(c *C) {
 	assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
-
 	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]interface{}{
 		"account-id": "other-brand",
 	}, "")
-	err := assertstate.Add(s.state, otherAcct)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(s.state, otherAcct)
 }
 
 func (s *deviceMgrSuite) setupSnapDecl(c *C, name, snapID, publisherID string) {
@@ -1908,8 +1903,7 @@ func (s *deviceMgrSuite) makeModelAssertionInState(c *C, brandID, model string, 
 	modelAs := s.brands.Model(brandID, model, extras)
 
 	s.setupBrands(c)
-	err := assertstate.Add(s.state, modelAs)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(s.state, modelAs)
 }
 
 func (s *deviceMgrSuite) makeSerialAssertionInState(c *C, brandID, model, serialN string) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2432,7 +2432,7 @@ func (s *deviceMgrSuite) TestRemodelTasksSmoke(c *C) {
 	defer restore()
 
 	// set a model assertion
-	current := s.makeModelAssertion(c, "canonical", "pc-model", map[string]interface{}{
+	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -2445,7 +2445,7 @@ func (s *deviceMgrSuite) TestRemodelTasksSmoke(c *C) {
 		Model: "pc-model",
 	})
 
-	new := s.makeModelAssertion(c, "canonical", "pc-model", map[string]interface{}{
+	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"kernel":         "pc-kernel",
 		"gadget":         "pc",

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -63,8 +63,7 @@ type FirstBootTestSuite struct {
 	storeSigning *assertstest.StoreStack
 	restore      func()
 
-	brandPrivKey asserts.PrivateKey
-	brandSigning *assertstest.SigningDB
+	brands *assertstest.SigningAccounts
 
 	overlord *overlord.Overlord
 
@@ -98,8 +97,10 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.restore = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
-	s.brandPrivKey, _ = assertstest.GenerateKey(752)
-	s.brandSigning = assertstest.NewSigningDB("my-brand", s.brandPrivKey)
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+		"verification": "verified",
+	})
 
 	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
@@ -770,16 +771,8 @@ snaps:
 
 func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string, extraHeaders map[string]interface{}, reqSnaps ...string) *asserts.Model {
 	headers := map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        modelStr,
 		"architecture": "amd64",
 		"store":        "canonical",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}
-	for k, v := range extraHeaders {
-		headers[k] = v
 	}
 	if strings.HasSuffix(modelStr, "-classic") {
 		headers["classic"] = "true"
@@ -794,22 +787,14 @@ func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string, extraHead
 		}
 		headers["required-snaps"] = reqs
 	}
-	model, err := s.brandSigning.Sign(asserts.ModelType, headers, nil, "")
-	c.Assert(err, IsNil)
-	return model.(*asserts.Model)
+	return s.brands.Model("my-brand", modelStr, headers, extraHeaders)
 }
 
 func (s *FirstBootTestSuite) makeModelAssertionChain(c *C, modName string, extraHeaders map[string]interface{}, reqSnaps ...string) []asserts.Assertion {
 	assertChain := []asserts.Assertion{}
 
-	brandAcct := assertstest.NewAccount(s.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
-		"verification": "verified",
-	}, "")
-	assertChain = append(assertChain, brandAcct)
-
-	brandAccKey := assertstest.NewAccountKey(s.storeSigning, brandAcct, nil, s.brandPrivKey.PublicKey(), "")
-	assertChain = append(assertChain, brandAccKey)
+	assertChain = append(assertChain, s.brands.Account("my-brand"))
+	assertChain = append(assertChain, s.brands.AccountKey("my-brand"))
 
 	model := s.makeModelAssertion(c, modName, extraHeaders, reqSnaps...)
 	assertChain = append(assertChain, model)

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -35,16 +35,15 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 		Brand: "canonical",
 		Model: "pc-model",
 	})
-	err := assertstate.Add(s.state, s.makeModelAssertion(c, "canonical", "pc-model", map[string]interface{}{
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
 		"revision":     "1",
-	}))
-	c.Assert(err, IsNil)
+	})
 	s.state.Unlock()
 
-	newModel := s.makeModelAssertion(c, "canonical", "pc-model", map[string]interface{}{
+	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",
@@ -72,7 +71,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 }
 
 func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
-	model := s.makeModelAssertion(c, "canonical", "pc-model", map[string]interface{}{
+	model := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		"kernel":       "pc-kernel",
 		"gadget":       "pc",

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -82,6 +83,7 @@ type mgrsSuite struct {
 	restoreSystemctl func()
 
 	storeSigning   *assertstest.StoreStack
+	brands         *assertstest.SigningAccounts
 	restoreTrusted func()
 	mockSnapCmd    *testutil.MockCmd
 
@@ -167,6 +169,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	})
 
 	ms.storeSigning = assertstest.NewStoreStack("can0nical", nil)
+	ms.brands = assertstest.NewSigningAccounts(ms.storeSigning)
+	ms.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+		"validation": "verified",
+	})
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
 
 	ms.devAcct = assertstest.NewAccount(ms.storeSigning, "devdevdev", map[string]interface{}{
@@ -312,6 +318,11 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	ms.mockSnapCmd.Restore()
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
 	ms.restoreBackends()
+}
+
+// XXX
+func (ms *mgrsSuite) assertAdd(a asserts.Assertion) error {
+	return assertstate.Add(ms.o.State(), a)
 }
 
 var settleTimeout = 15 * time.Second
@@ -1468,6 +1479,13 @@ version: @VERSION@
 
 // core & kernel
 
+var modelDefaults = map[string]interface{}{
+	"architecture": "amd64",
+	"store":        "my-brand-store-id",
+	"gadget":       "pc",
+	"kernel":       "pc-kernel",
+}
+
 func findKind(chg *state.Change, kind string) *state.Task {
 	for _, t := range chg.Tasks() {
 		if t.Kind() == kind {
@@ -1485,14 +1503,7 @@ func (ms *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	brandAcct := assertstest.NewAccount(ms.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
-		"verification": "verified",
-	}, "")
-	brandAccKey := assertstest.NewAccountKey(ms.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
-
-	brandSigning := assertstest.NewSigningDB("my-brand", brandPrivKey)
-	model := makeModelAssertion(c, brandSigning, nil)
+	model := ms.brands.Model("my-brand", "my-model", modelDefaults)
 
 	const packageOS = `
 name: core
@@ -1506,16 +1517,13 @@ type: os
 	defer st.Unlock()
 
 	// setup model assertion
-	err := assertstate.Add(st, brandAcct)
-	c.Assert(err, IsNil)
-	err = assertstate.Add(st, brandAccKey)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "my-brand",
 		Model:  "my-model",
 		Serial: "serialserialserial",
 	})
-	err = assertstate.Add(st, model)
+	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
 	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "core"}, snapPath, "", "", snapstate.Flags{})
@@ -1565,14 +1573,7 @@ func (ms *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	brandAcct := assertstest.NewAccount(ms.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
-		"verification": "verified",
-	}, "")
-	brandAccKey := assertstest.NewAccountKey(ms.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
-
-	brandSigning := assertstest.NewSigningDB("my-brand", brandPrivKey)
-	model := makeModelAssertion(c, brandSigning, nil)
+	model := ms.brands.Model("my-brand", "my-model", modelDefaults)
 
 	const packageKernel = `
 name: pc-kernel
@@ -1591,16 +1592,13 @@ type: kernel`
 	defer st.Unlock()
 
 	// setup model assertion
-	err := assertstate.Add(st, brandAcct)
-	c.Assert(err, IsNil)
-	err = assertstate.Add(st, brandAccKey)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "my-brand",
 		Model:  "my-model",
 		Serial: "serialserialserial",
 	})
-	err = assertstate.Add(st, model)
+	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
 	ts, _, err := snapstate.InstallPath(st, &snap.SideInfo{RealName: "pc-kernel"}, snapPath, "", "", snapstate.Flags{})
@@ -2358,8 +2356,9 @@ type storeCtxSetupSuite struct {
 	storeSigning   *assertstest.StoreStack
 	restoreTrusted func()
 
-	brandSigning *assertstest.SigningDB
-	deviceKey    asserts.PrivateKey
+	brands *assertstest.SigningAccounts
+
+	deviceKey asserts.PrivateKey
 
 	model  *asserts.Model
 	serial *asserts.Serial
@@ -2383,21 +2382,17 @@ func (s *storeCtxSetupSuite) SetUpTest(c *C) {
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.restoreTrusted = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
-	s.brandSigning = assertstest.NewSigningDB("my-brand", brandPrivKey)
-
-	brandAcct := assertstest.NewAccount(s.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
-	}, "")
-	s.storeSigning.Add(brandAcct)
+	})
+	assertstest.AddMany(s.storeSigning, s.brands.AccountsAndKeys("my-brand")...)
 
-	brandAccKey := assertstest.NewAccountKey(s.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
-	s.storeSigning.Add(brandAccKey)
-	s.model = makeModelAssertion(c, s.brandSigning, nil)
+	s.model = s.brands.Model("my-brand", "my-model", modelDefaults)
 
 	encDevKey, err := asserts.EncodePublicKey(deviceKey.PublicKey())
 	c.Assert(err, IsNil)
-	serial, err := s.brandSigning.Sign(asserts.SerialType, map[string]interface{}{
+	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
 		"authority-id":        "my-brand",
 		"brand-id":            "my-brand",
 		"model":               "my-model",
@@ -2420,7 +2415,8 @@ func (s *storeCtxSetupSuite) SetUpTest(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	prereqs := []asserts.Assertion{s.storeSigning.StoreAccountKey(""), brandAcct, brandAccKey}
+	// XXX
+	prereqs := []asserts.Assertion{s.storeSigning.StoreAccountKey(""), s.brands.Account("my-brand"), s.brands.AccountKey("my-brand")}
 	for _, a := range prereqs {
 		err = assertstate.Add(st, a)
 		c.Assert(err, IsNil)
@@ -3150,29 +3146,6 @@ func (ms *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
 	c.Assert(conns, HasLen, 0)
 }
 
-// makeMockModel creates a model assertion using the given brandSigning DB.
-// The fields can be customized with the modelExtra map.
-func makeModelAssertion(c *C, brandSigning *assertstest.SigningDB, modelExtra map[string]interface{}) *asserts.Model {
-	modelV := map[string]interface{}{
-		"series":       "16",
-		"authority-id": "my-brand",
-		"brand-id":     "my-brand",
-		"model":        "my-model",
-		"architecture": "amd64",
-		"store":        "my-brand-store-id",
-		"gadget":       "pc",
-		"kernel":       "pc-kernel",
-		"timestamp":    time.Now().Format(time.RFC3339),
-	}
-	for k, v := range modelExtra {
-		modelV[k] = v
-	}
-	model, err := brandSigning.Sign(asserts.ModelType, modelV, nil, "")
-	c.Assert(err, IsNil)
-
-	return model.(*asserts.Model)
-}
-
 // TODO: add a custom checker in testutils for this and similar
 func validateDownloadCheckTasks(c *C, tasks []*state.Task, name, revno, channel string) int {
 	var i int
@@ -3279,18 +3252,9 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	})
 
 	// create/set custom model assertion
-	brandAcct := assertstest.NewAccount(ms.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
-		"verification": "verified",
-	}, "")
-	err := assertstate.Add(st, brandAcct)
-	c.Assert(err, IsNil)
-	brandAccKey := assertstest.NewAccountKey(ms.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
-	err = assertstate.Add(st, brandAccKey)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
 
-	brandSigning := assertstest.NewSigningDB("my-brand", brandPrivKey)
-	model := makeModelAssertion(c, brandSigning, nil)
+	model := ms.brands.Model("my-brand", "my-model", modelDefaults)
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
@@ -3298,11 +3262,11 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 		Model:  "my-model",
 		Serial: "serialserialserial",
 	})
-	err = assertstate.Add(st, model)
+	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
 
 	// create a new model
-	newModel := makeModelAssertion(c, brandSigning, map[string]interface{}{
+	newModel := ms.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
 		"required-snaps": []interface{}{"foo", "bar", "baz"},
 		"revision":       "1",
 	})
@@ -3376,10 +3340,7 @@ type: base`
 	defer st.Unlock()
 
 	// create/set custom model assertion
-	model := makeModelAssertion(c, ms.storeSigning.SigningDB, map[string]interface{}{
-		"authority-id": "can0nical",
-		"brand-id":     "can0nical",
-	})
+	model := ms.brands.Model("can0nical", "my-model", modelDefaults)
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "can0nical",
@@ -3390,11 +3351,9 @@ type: base`
 	c.Assert(err, IsNil)
 
 	// create a new model
-	newModel := makeModelAssertion(c, ms.storeSigning.SigningDB, map[string]interface{}{
-		"authority-id": "can0nical",
-		"brand-id":     "can0nical",
-		"base":         "core18",
-		"revision":     "1",
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+		"base":     "core18",
+		"revision": "1",
 	})
 
 	chg, err := devicestate.Remodel(st, newModel)
@@ -3438,10 +3397,7 @@ version: 2.0`
 	ms.serveSnap(snapPath, "1")
 
 	// create/set custom model assertion
-	model := makeModelAssertion(c, ms.storeSigning.SigningDB, map[string]interface{}{
-		"authority-id": "can0nical",
-		"brand-id":     "can0nical",
-	})
+	model := ms.brands.Model("can0nical", "my-model", modelDefaults)
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "can0nical",
@@ -3452,9 +3408,7 @@ version: 2.0`
 	c.Assert(err, IsNil)
 
 	// create a new model
-	newModel := makeModelAssertion(c, ms.storeSigning.SigningDB, map[string]interface{}{
-		"authority-id":   "can0nical",
-		"brand-id":       "can0nical",
+	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
 		"kernel":         "pc-kernel=18",
 		"revision":       "1",
 		"required-snaps": []interface{}{"foo"},
@@ -3503,14 +3457,7 @@ version: 2.0`
 }
 
 func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
-	brandAcct := assertstest.NewAccount(ms.storeSigning, "my-brand", map[string]interface{}{
-		"account-id":   "my-brand",
-		"verification": "verified",
-	}, "")
-	brandAccKey := assertstest.NewAccountKey(ms.storeSigning, brandAcct, nil, brandPrivKey.PublicKey(), "")
-
-	brandSigning := assertstest.NewSigningDB("my-brand", brandPrivKey)
-	model := makeModelAssertion(c, brandSigning, map[string]interface{}{
+	model := ms.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
 		"gadget": "gadget",
 	})
 
@@ -3525,10 +3472,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err = assertstate.Add(st, brandAcct)
-	c.Assert(err, IsNil)
-	err = assertstate.Add(st, brandAccKey)
-	c.Assert(err, IsNil)
+	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
@@ -3543,7 +3487,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 		c.Check(brandID, Equals, "my-brand")
 		c.Check(model, Equals, "my-model")
 		headers["authority-id"] = brandID
-		return brandSigning.Sign(asserts.SerialType, headers, body, "")
+		return ms.brands.Signing("my-brand").Sign(asserts.SerialType, headers, body, "")
 	}
 
 	bhv := &devicestatetest.DeviceServiceBehavior{

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -320,11 +320,6 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	ms.restoreBackends()
 }
 
-// XXX
-func (ms *mgrsSuite) assertAdd(a asserts.Assertion) error {
-	return assertstate.Add(ms.o.State(), a)
-}
-
 var settleTimeout = 15 * time.Second
 
 func makeTestSnap(c *C, snapYamlContent string) string {
@@ -2415,12 +2410,8 @@ func (s *storeCtxSetupSuite) SetUpTest(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	// XXX
-	prereqs := []asserts.Assertion{s.storeSigning.StoreAccountKey(""), s.brands.Account("my-brand"), s.brands.AccountKey("my-brand")}
-	for _, a := range prereqs {
-		err = assertstate.Add(st, a)
-		c.Assert(err, IsNil)
-	}
+	assertstatetest.AddMany(st, s.storeSigning.StoreAccountKey(""))
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
 }
 
 func (s *storeCtxSetupSuite) TearDownTest(c *C) {


### PR DESCRIPTION
This introduces assertstest.SigningAccounts as a streamlined way to setup brands/signing accounts in tests, typically and often to sign models, for which it has a dedicated Model method.

Converts all model signing in tests to use this (or FakeAssertion).

This could be used also for developer signing in tests but is not done yet.

This also introduces assertstest.AddMany and assertstatetest.AddMany, things are converted to these opportunistically,  but they mainly support these idioms:

```
assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
assertstest.AddMany(s.storeSigning, s.brands.AccountsAndKeys("my-brand")...)
```