### PR TITLE
daemon: pass the model to the create known user helpers (instead of full Overlord)

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -54,7 +54,6 @@ import (
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -2134,17 +2133,12 @@ func getUserDetailsFromStore(theStore snapstate.StoreService, email string) (str
 	return v.Username, opts, nil
 }
 
-func createAllKnownSystemUsers(o *overlord.Overlord, createData *postUserCreateData) Response {
+func createAllKnownSystemUsers(st *state.State, modelAs *asserts.Model, createData *postUserCreateData) Response {
 	var createdUsers []userResponseData
 
-	st := o.State()
 	st.Lock()
 	db := assertstate.DB(st)
-	modelAs, err := o.DeviceManager().Model()
 	st.Unlock()
-	if err != nil {
-		return InternalError("cannot get model assertion")
-	}
 
 	headers := map[string]string{
 		"brand-id": modelAs.BrandID(),
@@ -2160,7 +2154,7 @@ func createAllKnownSystemUsers(o *overlord.Overlord, createData *postUserCreateD
 		email := as.(*asserts.SystemUser).Email()
 		// we need to use getUserDetailsFromAssertion as this verifies
 		// the assertion against the current brand/model/time
-		username, opts, err := getUserDetailsFromAssertion(o, email)
+		username, opts, err := getUserDetailsFromAssertion(st, modelAs, email)
 		if err != nil {
 			logger.Noticef("ignoring system-user assertion for %q: %s", email, err)
 			continue
@@ -2189,17 +2183,12 @@ func createAllKnownSystemUsers(o *overlord.Overlord, createData *postUserCreateD
 	return SyncResponse(createdUsers, nil)
 }
 
-func getUserDetailsFromAssertion(o *overlord.Overlord, email string) (string, *osutil.AddUserOptions, error) {
+func getUserDetailsFromAssertion(st *state.State, modelAs *asserts.Model, email string) (string, *osutil.AddUserOptions, error) {
 	errorPrefix := fmt.Sprintf("cannot add system-user %q: ", email)
 
-	st := o.State()
 	st.Lock()
 	db := assertstate.DB(st)
-	modelAs, err := o.DeviceManager().Model()
 	st.Unlock()
-	if err != nil {
-		return "", nil, fmt.Errorf(errorPrefix+"cannot get model assertion: %s", err)
-	}
 
 	brandID := modelAs.BrandID()
 	series := modelAs.Series()
@@ -2321,10 +2310,22 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		}
 	}
 
+	var model *asserts.Model
+	createKnown := createData.Known
+	if createKnown {
+		var err error
+		st.Lock()
+		model, err = c.d.overlord.DeviceManager().Model()
+		st.Unlock()
+		if err != nil {
+			return InternalError("cannot create user: cannot get model assertion: %v", err)
+		}
+	}
+
 	// special case: the user requested the creation of all known
 	// system-users
-	if createData.Email == "" && createData.Known {
-		return createAllKnownSystemUsers(c.d.overlord, &createData)
+	if createData.Email == "" && createKnown {
+		return createAllKnownSystemUsers(st, model, &createData)
 	}
 	if createData.Email == "" {
 		return BadRequest("cannot create user: 'email' field is empty")
@@ -2332,8 +2333,8 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 
 	var username string
 	var opts *osutil.AddUserOptions
-	if createData.Known {
-		username, opts, err = getUserDetailsFromAssertion(c.d.overlord, createData.Email)
+	if createKnown {
+		username, opts, err = getUserDetailsFromAssertion(st, model, createData.Email)
 	} else {
 		username, opts, err = getUserDetailsFromStore(getStore(c), createData.Email)
 	}


### PR DESCRIPTION
This is a follow up to a previous review.  This is a bit more complicated than expected because it tries not to change the behavior for the store case, where we don't seem to need the model yet at least explicitly.
