### PR TITLE
tests: extra debug for snapshot-basic test

### DIFF
--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -4,6 +4,11 @@ prepare: |
     snap install test-snapd-tools
     snap install --edge test-snapd-just-edge
 
+debug: |
+    snap list || true
+    snap info core || true
+    snap saved || true
+
 execute: |
     # use the snaps, so they create the dirs:
     test-snapd-tools.echo


### PR DESCRIPTION
Print some debug info that may be helpful in determing the failure of 2.39 test on real board.
