### PR TITLE
overlord/devicestate: introduce remodel kinds and contexts

### DIFF
--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -565,6 +565,10 @@ func (sa *SigningAccounts) PublicKey(accountID string) asserts.PublicKey {
 }
 
 func (sa *SigningAccounts) Signing(accountID string) *SigningDB {
+	// convenience
+	if accountID == sa.store.RootSigning.AuthorityID {
+		return sa.store.RootSigning
+	}
 	if signer := sa.signing[accountID]; signer != nil {
 		return signer
 	}
@@ -585,12 +589,7 @@ func (sa *SigningAccounts) Model(accountID, model string, extras ...map[string]i
 		}
 	}
 
-	var signer SignerDB
-	if accountID == sa.store.RootSigning.AuthorityID {
-		signer = sa.store.RootSigning
-	} else {
-		signer = sa.Signing(accountID)
-	}
+	signer := sa.Signing(accountID)
 
 	modelAs, err := signer.Sign(asserts.ModelType, headers, nil, "")
 	if err != nil {

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -54,7 +54,7 @@ func (s *apiSuite) TestPostRemodel(c *check.C) {
 	d := s.daemonWithOverlordMock(c)
 	hookMgr, err := hookstate.Manager(d.overlord.State(), d.overlord.TaskRunner())
 	c.Assert(err, check.IsNil)
-	deviceMgr, err := devicestate.Manager(d.overlord.State(), hookMgr, d.overlord.TaskRunner())
+	deviceMgr, err := devicestate.Manager(d.overlord.State(), hookMgr, d.overlord.TaskRunner(), nil)
 	c.Assert(err, check.IsNil)
 	d.overlord.AddManager(deviceMgr)
 	st := d.overlord.State()

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -48,6 +48,9 @@ type DeviceManager struct {
 	state      *state.State
 	keypairMgr asserts.KeypairManager
 
+	// newStore can make new stores for remodeling
+	newStore func(storecontext.DeviceBackend) snapstate.StoreService
+
 	bootOkRan            bool
 	bootRevisionsUpdated bool
 
@@ -60,7 +63,7 @@ type DeviceManager struct {
 }
 
 // Manager returns a new device manager.
-func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.TaskRunner) (*DeviceManager, error) {
+func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.TaskRunner, newStore func(storecontext.DeviceBackend) snapstate.StoreService) (*DeviceManager, error) {
 	delayedCrossMgrInit()
 
 	keypairMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)
@@ -69,7 +72,16 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 
 	}
 
-	m := &DeviceManager{state: s, keypairMgr: keypairMgr, reg: make(chan struct{})}
+	m := &DeviceManager{
+		state:      s,
+		keypairMgr: keypairMgr,
+		newStore:   newStore,
+		reg:        make(chan struct{}),
+	}
+
+	s.Lock()
+	s.Cache(deviceMgrKey{}, m)
+	s.Unlock()
 
 	if err := m.confirmRegistered(); err != nil {
 		return nil, err
@@ -84,6 +96,16 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	runner.AddHandler("set-model", m.doSetModel, nil)
 
 	return m, nil
+}
+
+type deviceMgrKey struct{}
+
+func deviceMgr(st *state.State) *DeviceManager {
+	mgr := st.Cached(deviceMgrKey{})
+	if mgr == nil {
+		panic("internal error: device manager is not yet associated with state")
+	}
+	return mgr.(*DeviceManager)
 }
 
 func (m *DeviceManager) CanStandby() bool {
@@ -532,7 +554,7 @@ func (m *DeviceManager) Model() (*asserts.Model, error) {
 
 // Serial returns the device serial assertion.
 func (m *DeviceManager) Serial() (*asserts.Serial, error) {
-	return findSerial(m.state)
+	return findSerial(m.state, nil)
 }
 
 // implement storecontext.Backend

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/netutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -70,11 +71,14 @@ func findModel(st *state.State) (*asserts.Model, error) {
 	return a.(*asserts.Model), nil
 }
 
-// findSerial returns the device serial assertion.
-func findSerial(st *state.State) (*asserts.Serial, error) {
-	device, err := internal.Device(st)
-	if err != nil {
-		return nil, err
+// findSerial returns the device serial assertion. device is optional and used instead of the global state if provided.
+func findSerial(st *state.State, device *auth.DeviceState) (*asserts.Serial, error) {
+	if device == nil {
+		var err error
+		device, err = internal.Device(st)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if device.Serial == "" {
@@ -122,7 +126,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return false, err
 	}
 
-	_, err = findSerial(st)
+	_, err = findSerial(st, nil)
 	if err == state.ErrNoState {
 		return false, nil
 	}

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
@@ -131,6 +132,12 @@ func RegistrationCtx(m *DeviceManager, t *state.Task) (registrationContext, erro
 	return m.registrationCtx(t)
 }
 
+func RemodelDeviceBackend(remodCtx remodelContext) storecontext.DeviceBackend {
+	return remodCtx.(interface {
+		deviceBackend() storecontext.DeviceBackend
+	}).deviceBackend()
+}
+
 var (
 	ImportAssertionsFromSeed = importAssertionsFromSeed
 	CheckGadgetOrKernel      = checkGadgetOrKernel
@@ -141,4 +148,8 @@ var (
 	EnsureOperationalAttempts    = ensureOperationalAttempts
 
 	RemodelTasks = remodelTasks
+
+	RemodelCtx         = remodelCtx
+	RemodelCtxFromTask = remodelCtxFromTask
+	CleanupRemodelCtx  = cleanupRemodelCtx
 )

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -274,7 +274,7 @@ type registrationContext interface {
 // initialRegistrationContext is a thin wrapper around DeviceManager
 // implementing registrationContext for initial regitration
 type initialRegistrationContext struct {
-	*DeviceManager
+	deviceMgr *DeviceManager
 
 	gadget string
 }
@@ -284,7 +284,7 @@ func (rc *initialRegistrationContext) ForRemodeling() bool {
 }
 
 func (rc *initialRegistrationContext) Device() (*auth.DeviceState, error) {
-	return rc.DeviceManager.device()
+	return rc.deviceMgr.device()
 }
 
 func (rc *initialRegistrationContext) GadgetForSerialRequestConfig() string {
@@ -300,20 +300,20 @@ func (rc *initialRegistrationContext) SerialRequestAncillaryAssertions() []asser
 }
 
 func (rc *initialRegistrationContext) FinishRegistration(serial *asserts.Serial) error {
-	device, err := rc.DeviceManager.device()
+	device, err := rc.deviceMgr.device()
 	if err != nil {
 		return err
 	}
 
 	device.Serial = serial.Serial()
-	if err := rc.DeviceManager.setDevice(device); err != nil {
+	if err := rc.deviceMgr.setDevice(device); err != nil {
 		return err
 	}
-	rc.DeviceManager.markRegistered()
+	rc.deviceMgr.markRegistered()
 
 	// make sure we timely consider anything that was blocked on
 	// registration
-	rc.DeviceManager.state.EnsureBefore(0)
+	rc.deviceMgr.state.EnsureBefore(0)
 
 	return nil
 }
@@ -326,8 +326,8 @@ func (m *DeviceManager) registrationCtx(t *state.Task) (registrationContext, err
 	}
 
 	return &initialRegistrationContext{
-		DeviceManager: m,
-		gadget:        model.Gadget(),
+		deviceMgr: m,
+		gadget:    model.Gadget(),
 	}, nil
 }
 

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -142,6 +142,7 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 		}
 		storeSwitchCtx.store = devMgr.newStore(storeSwitchCtx.deviceBackend())
 		remodCtx = storeSwitchCtx
+	// TODO: support ReregRemodel
 	default:
 		return nil, fmt.Errorf("unsupported remodel: %s", kind)
 	}
@@ -223,6 +224,8 @@ func (rc baseRemodelContext) init(chg *state.Change) {
 	chg.Set("new-model", string(asserts.Encode(rc.newModel)))
 }
 
+// updateRemodelContext: model assertion revision-only update remodel
+// (no change to brand/model or store)
 type updateRemodelContext struct {
 	baseRemodelContext
 }
@@ -247,6 +250,8 @@ func (rc *updateRemodelContext) Finish() error {
 	return nil
 }
 
+// newStoreRemodelContext: remodel needing a new store session
+// (for change of store (or brand/model))
 type newStoreRemodelContext struct {
 	baseRemodelContext
 

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -1,0 +1,299 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storecontext"
+)
+
+/*
+
+This is the central logic to setup and mediate the access to the to-be
+device state and dedicated store during remodeling and drive the
+re-registration, leveraging the snapstate.DeviceContext/DeviceCtx and
+storecontext.DeviceBackend mechanisms and also registrationContext.
+
+Different context implementations will be used depending on the kind
+of remodel, and those will play the roles/implement as needed
+snapstate.DeviceContext, storecontext.DeviceBackend and
+registrationContext:
+
+* same brand/model, brand store => updateRemodel
+  this is just a contextual carrier for the new model
+
+* same brand/model different brand store => storeSwitchRemodel this
+  mediates access to device state kept on the remodel change, it also
+  creates a store that uses that and refers to the new brand store
+
+* different brand/model, maybe different brand store => reregRemodel
+  similar to storeSwitchRemodel case after a first phase that performs
+  re-registration where the context plays registrationContext's role
+  (NOT IMPLEMENTED YET)
+
+*/
+
+// RemodelKind designates a kind of remodeling.
+type RemodelKind int
+
+const (
+	// same brand/model, brand store
+	UpdateRemodel RemodelKind = iota
+	// same brand/model, different brand store
+	StoreSwitchRemodel
+	// different brand/model, maybe different brand store
+	ReregRemodel
+)
+
+func (k RemodelKind) String() string {
+	switch k {
+	case UpdateRemodel:
+		return "revision update remodel"
+	case StoreSwitchRemodel:
+		return "store switch remodel"
+	case ReregRemodel:
+		return "re-registration remodel"
+	}
+	panic(fmt.Sprintf("internal error: unknown remodel kind: %d", k))
+}
+
+// ClassifyRemodel returns what kind of remodeling is going from oldModel to newModel.
+func ClassifyRemodel(oldModel, newModel *asserts.Model) RemodelKind {
+	if oldModel.BrandID() != newModel.BrandID() {
+		return ReregRemodel
+	}
+	if oldModel.Model() != newModel.Model() {
+		return ReregRemodel
+	}
+	if oldModel.Store() != newModel.Store() {
+		return StoreSwitchRemodel
+	}
+	return UpdateRemodel
+}
+
+type remodelCtxKey struct {
+	chgID string
+}
+
+func cachedRemodelCtx(chg *state.Change) (remodelContext, bool) {
+	key := remodelCtxKey{chg.ID()}
+	remodCtx, ok := chg.State().Cached(key).(remodelContext)
+	return remodCtx, ok
+}
+
+func cleanupRemodelCtx(chg *state.Change) {
+	chg.State().Cache(remodelCtxKey{chg.ID()}, nil)
+}
+
+// A remodelContext mediates the correct and isolated device state
+// access and evolution during a remodel.
+// All remodelContexts are at least a DeviceContext.
+type remodelContext interface {
+	Init(chg *state.Change) error
+	Finish() error
+	snapstate.DeviceContext
+}
+
+// remodelCtx returns a remodeling context for the given transition via chg.
+// It constructs and caches a dedicated store as needed as well.
+func remodelCtx(oldModel, newModel *asserts.Model, chg *state.Change) (remodelContext, error) {
+	// cached?
+	if remodCtx, ok := cachedRemodelCtx(chg); ok {
+		return remodCtx, nil
+	}
+
+	var remodCtx remodelContext
+	switch kind := ClassifyRemodel(oldModel, newModel); kind {
+	case UpdateRemodel:
+		// simple context for the simple case
+		remodCtx = &updateRemodelContext{baseRemodelContext{newModel}}
+	case StoreSwitchRemodel:
+		devMgr := deviceMgr(chg.State())
+		storeSwitchCtx := &newStoreRemodelContext{
+			baseRemodelContext: baseRemodelContext{newModel},
+			remodelChange:      chg,
+			deviceMgr:          devMgr,
+		}
+		storeSwitchCtx.store = devMgr.newStore(storeSwitchCtx.deviceBackend())
+		remodCtx = storeSwitchCtx
+	default:
+		return nil, fmt.Errorf("unsupported remodel: %s", kind)
+	}
+
+	// cache it as well
+	chg.State().Cache(remodelCtxKey{chg.ID()}, remodCtx)
+	return remodCtx, nil
+}
+
+// remodelCtxFromTask returns a possibly cached remodeling context associated
+// with the task via its change, if task is nil or the task change
+// is not a remodeling it will return ErrNoState.
+func remodelCtxFromTask(t *state.Task) (remodelContext, error) {
+	if t == nil {
+		return nil, state.ErrNoState
+	}
+	chg := t.Change()
+	if chg == nil {
+		return nil, state.ErrNoState
+	}
+
+	var encNewModel string
+	if err := chg.Get("new-model", &encNewModel); err != nil {
+		return nil, err
+	}
+
+	// shortcut, cached?
+	if remodCtx, ok := cachedRemodelCtx(chg); ok {
+		return remodCtx, nil
+	}
+
+	oldModel, err := findModel(t.State())
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot find old model during remodel: %v", err)
+	}
+	newModelA, err := asserts.Decode([]byte(encNewModel))
+	if err != nil {
+		return nil, err
+	}
+	newModel, ok := newModelA.(*asserts.Model)
+	if !ok {
+		return nil, fmt.Errorf("internal error: cannot use a remodel new-model, wrong type")
+	}
+
+	return remodelCtx(oldModel, newModel, chg)
+}
+
+type baseRemodelContext struct {
+	newModel *asserts.Model
+}
+
+func (rc baseRemodelContext) ForRemodeling() bool {
+	return true
+}
+
+func (rc baseRemodelContext) Model() *asserts.Model {
+	return rc.newModel
+}
+
+func (rc baseRemodelContext) init(chg *state.Change) {
+	chg.Set("new-model", string(asserts.Encode(rc.newModel)))
+}
+
+type updateRemodelContext struct {
+	baseRemodelContext
+}
+
+func (rc *updateRemodelContext) Init(chg *state.Change) error {
+	rc.init(chg)
+	return nil
+}
+
+func (rc *updateRemodelContext) Store() snapstate.StoreService {
+	return nil
+}
+
+func (rc *updateRemodelContext) Finish() error {
+	// nothing more to do
+	return nil
+}
+
+type newStoreRemodelContext struct {
+	baseRemodelContext
+	remodelChange *state.Change
+
+	store snapstate.StoreService
+
+	deviceMgr *DeviceManager
+}
+
+func (rc *newStoreRemodelContext) Init(chg *state.Change) error {
+	device, err := rc.deviceMgr.device()
+	if err != nil {
+		return err
+	}
+
+	rc.init(chg)
+	// we will need a new one, it might embed the store as well
+	device.SessionMacaroon = ""
+	chg.Set("device", device)
+
+	return nil
+}
+
+func (rc *newStoreRemodelContext) deviceBackend() storecontext.DeviceBackend {
+	return &remodelDeviceBackend{rc}
+}
+
+func (rc *newStoreRemodelContext) Store() snapstate.StoreService {
+	return rc.store
+}
+
+func (rc *newStoreRemodelContext) device() (*auth.DeviceState, error) {
+	var device auth.DeviceState
+	err := rc.remodelChange.Get("device", &device)
+	return &device, err
+}
+
+func (rc *newStoreRemodelContext) setCtxDevice(device *auth.DeviceState) {
+	rc.remodelChange.Set("device", device)
+}
+
+func (rc *newStoreRemodelContext) Finish() error {
+	// expose the device state of the remodel with the new session
+	// to the rest of the system
+	remodelDevice, err := rc.device()
+	if err != nil {
+		return err
+	}
+	return rc.deviceMgr.setDevice(remodelDevice)
+}
+
+type remodelDeviceBackend struct {
+	*newStoreRemodelContext
+}
+
+func (b remodelDeviceBackend) Device() (*auth.DeviceState, error) {
+	return b.device()
+}
+
+func (b remodelDeviceBackend) SetDevice(device *auth.DeviceState) error {
+	b.setCtxDevice(device)
+	return nil
+}
+
+func (b remodelDeviceBackend) Model() (*asserts.Model, error) {
+	return b.newModel, nil
+}
+
+func (b remodelDeviceBackend) Serial() (*asserts.Serial, error) {
+	// this the shared logic, also correct for the rereg case
+	// we should lookup the serial with the remodeling device state
+	device, err := b.device()
+	if err != nil {
+		return nil, err
+	}
+
+	return findSerial(b.remodelChange.State(), device)
+}

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
@@ -51,6 +52,8 @@ type remodelLogicSuite struct {
 var _ = Suite(&remodelLogicSuite{})
 
 func (s *remodelLogicSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+
 	o := overlord.Mock()
 	s.state = o.State()
 
@@ -84,6 +87,10 @@ func (s *remodelLogicSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.mgr, err = devicestate.Manager(s.state, hookMgr, o.TaskRunner(), newStore)
 	c.Assert(err, IsNil)
+}
+
+func (s *remodelLogicSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
 }
 
 var modelDefaults = map[string]interface{}{

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -1,0 +1,639 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storecontext"
+	"github.com/snapcore/snapd/store/storetest"
+)
+
+type remodelLogicSuite struct {
+	state *state.State
+	mgr   *devicestate.DeviceManager
+
+	storeSigning *assertstest.StoreStack
+	brands       *assertstest.SigningAccounts
+
+	capturedDevBE storecontext.DeviceBackend
+	dummyStore    snapstate.StoreService
+}
+
+var _ = Suite(&remodelLogicSuite{})
+
+func (s *remodelLogicSuite) SetUpTest(c *C) {
+	o := overlord.Mock()
+	s.state = o.State()
+
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, nil)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	func() {
+		s.state.Lock()
+		defer s.state.Unlock()
+		assertstate.ReplaceDB(s.state, db)
+
+		assertstatetest.AddMany(s.state, s.storeSigning.StoreAccountKey(""))
+		assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
+	}()
+
+	s.dummyStore = new(storetest.Store)
+
+	newStore := func(devBE storecontext.DeviceBackend) snapstate.StoreService {
+		s.capturedDevBE = devBE
+		return s.dummyStore
+	}
+
+	hookMgr, err := hookstate.Manager(s.state, o.TaskRunner())
+	c.Assert(err, IsNil)
+	s.mgr, err = devicestate.Manager(s.state, hookMgr, o.TaskRunner(), newStore)
+	c.Assert(err, IsNil)
+}
+
+var modelDefaults = map[string]interface{}{
+	"architecture":   "amd64",
+	"kernel":         "my-brand-kernel",
+	"gadget":         "my-brand-gadget",
+	"store":          "my-brand-store",
+	"required-snaps": []interface{}{"required1"},
+}
+
+func fakeRemodelingModel(extra map[string]interface{}) *asserts.Model {
+	primary := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+	}
+	return assertstest.FakeAssertion(primary, modelDefaults, extra).(*asserts.Model)
+}
+
+func (s *remodelLogicSuite) TestClassifyRemodel(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+
+	cases := []struct {
+		newHeaders map[string]interface{}
+		kind       devicestate.RemodelKind
+	}{
+		{map[string]interface{}{}, devicestate.UpdateRemodel},
+		{map[string]interface{}{
+			"required-snaps": []interface{}{"required1", "required2"},
+			"revision":       "1",
+		}, devicestate.UpdateRemodel},
+		{map[string]interface{}{
+			"store":    "my-other-store",
+			"revision": "1",
+		}, devicestate.StoreSwitchRemodel},
+		{map[string]interface{}{
+			"model": "my-other-model",
+			"store": "my-other-store",
+		}, devicestate.ReregRemodel},
+		{map[string]interface{}{
+			"authority-id": "other-brand",
+			"brand-id":     "other-brand",
+			"model":        "other-model",
+		}, devicestate.ReregRemodel},
+		{map[string]interface{}{
+			"authority-id":   "other-brand",
+			"brand-id":       "other-brand",
+			"model":          "other-model",
+			"required-snaps": []interface{}{"other-required1"},
+		}, devicestate.ReregRemodel},
+		{map[string]interface{}{
+			"authority-id": "other-brand",
+			"brand-id":     "other-brand",
+			"model":        "other-model",
+			"store":        "my-other-store",
+		}, devicestate.ReregRemodel},
+	}
+
+	for _, t := range cases {
+		newModel := fakeRemodelingModel(t.newHeaders)
+		c.Check(devicestate.ClassifyRemodel(oldModel, newModel), Equals, t.kind)
+	}
+}
+
+func (s *remodelLogicSuite) TestUpdateRemodelContext(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"required-snaps": []interface{}{"required1", "required2"},
+		"revision":       "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	c.Check(remodCtx.ForRemodeling(), Equals, true)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	var encNewModel string
+	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
+
+	c.Check(encNewModel, Equals, string(asserts.Encode(newModel)))
+
+	c.Check(remodCtx.Model(), DeepEquals, newModel)
+	// an update remodel does not need a new/dedicated store
+	c.Check(remodCtx.Store(), IsNil)
+
+	// caching
+	remodCtx1, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx1, Equals, remodCtx)
+}
+
+func (s *remodelLogicSuite) TestNewStoreRemodelContextInit(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "prev-session",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	c.Check(remodCtx.ForRemodeling(), Equals, true)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	var encNewModel string
+	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
+
+	c.Check(encNewModel, Equals, string(asserts.Encode(newModel)))
+
+	var device *auth.DeviceState
+	c.Assert(chg.Get("device", &device), IsNil)
+	// session macaroon was reset
+	c.Check(device, DeepEquals, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	c.Check(remodCtx.Model(), DeepEquals, newModel)
+}
+
+func (s *remodelLogicSuite) TestRemodelDeviceBackend(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
+	device, err := devBE.Device()
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	mod, err := devBE.Model()
+	c.Assert(err, IsNil)
+	c.Check(mod, DeepEquals, newModel)
+
+	err = devBE.SetDevice(&auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "session",
+	})
+	c.Assert(err, IsNil)
+
+	expectedDevice := &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "session",
+	}
+
+	var device1 *auth.DeviceState
+	c.Assert(chg.Get("device", &device1), IsNil)
+	c.Check(device1, DeepEquals, expectedDevice)
+
+	device, err = devBE.Device()
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, expectedDevice)
+}
+
+func (s *remodelLogicSuite) TestRemodelDeviceBackendIsolation(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
+	err = devBE.SetDevice(&auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "session",
+	})
+	c.Assert(err, IsNil)
+
+	// the global device state is as before
+	expectedGlobalDevice := &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	}
+
+	device, err := s.mgr.StoreContextBackend().Device()
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, expectedGlobalDevice)
+}
+func (s *remodelLogicSuite) TestNewStoreRemodelContextStore(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "prev-session",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	c.Check(s.capturedDevBE, NotNil)
+
+	sto := remodCtx.Store()
+	c.Check(sto, Equals, s.dummyStore)
+
+	s.dummyStore = nil
+
+	sto1 := remodCtx.Store()
+	c.Check(sto1, Equals, sto)
+}
+
+func (s *remodelLogicSuite) TestNewStoreRemodelContextFinish(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
+	err = devBE.SetDevice(&auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "session",
+	})
+	c.Assert(err, IsNil)
+
+	err = remodCtx.Finish()
+	c.Assert(err, IsNil)
+
+	// the global device now matches the state reached in the remodel
+	expectedGlobalDevice := &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "session",
+	}
+
+	device, err := s.mgr.StoreContextBackend().Device()
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, expectedGlobalDevice)
+}
+
+func (s *remodelLogicSuite) TestNewStoreRemodelContextFinishVsGlobalUpdateDeviceAuth(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "old-session",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
+	err = devBE.SetDevice(&auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "remodel-session",
+	})
+	c.Assert(err, IsNil)
+
+	// global store device and auth context
+	scb := s.mgr.StoreContextBackend()
+	dac := storecontext.New(s.state, scb)
+	// this is the unlikely start of the global store trying to
+	// refresh the session
+	s.state.Unlock()
+	globalDevice, err := dac.Device()
+	s.state.Lock()
+	c.Assert(err, IsNil)
+	c.Check(globalDevice.SessionMacaroon, Equals, "old-session")
+
+	err = remodCtx.Finish()
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	device1, err := dac.UpdateDeviceAuth(globalDevice, "fresh-session")
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	// the global device now matches the state reached in the remodel
+	expectedGlobalDevice := &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "serialserialserial",
+		SessionMacaroon: "remodel-session",
+	}
+
+	s.state.Unlock()
+	device, err := dac.Device()
+	s.state.Lock()
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, expectedGlobalDevice)
+
+	// also this was already the case
+	c.Check(device1, DeepEquals, expectedGlobalDevice)
+}
+
+func (s *remodelLogicSuite) TestRemodelDeviceBackendSerial(c *C) {
+	oldModel := fakeRemodelingModel(nil)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	// the logic is shared and correct also for re-reg
+	// XXX (this is really the re-reg case)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state and serial
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "base-model",
+		Serial: "serialserialserial1",
+	})
+
+	makeSerialAssertionInState(c, s.brands, s.state, "canonical", "base-model", "serialserialserial1")
+
+	serial, err := s.mgr.Serial()
+	c.Assert(err, IsNil)
+	c.Check(serial.Serial(), Equals, "serialserialserial1")
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
+	err = devBE.SetDevice(&auth.DeviceState{
+		Brand: "canonical",
+		Model: "other-model",
+	})
+	c.Assert(err, IsNil)
+
+	// lookup the serial, nothing there
+	_, err = devBE.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	makeSerialAssertionInState(c, s.brands, s.state, "canonical", "other-model", "serialserialserial2")
+
+	// same
+	_, err = devBE.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	err = devBE.SetDevice(&auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "other-model",
+		Serial: "serialserialserial2",
+	})
+	c.Assert(err, IsNil)
+
+	serial, err = devBE.Serial()
+	c.Check(err, IsNil)
+	c.Check(serial.Model(), Equals, "other-model")
+	c.Check(serial.Serial(), Equals, "serialserialserial2")
+
+	// finish
+	// XXX test separately
+	err = remodCtx.Finish()
+	c.Assert(err, IsNil)
+
+	serial, err = s.mgr.Serial()
+	c.Assert(err, IsNil)
+	c.Check(serial.Model(), Equals, "other-model")
+}
+
+func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
+	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+		"store":    "my-other-store",
+		"revision": "1",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	assertstatetest.AddMany(s.state, oldModel)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx, err := devicestate.RemodelCtx(oldModel, newModel, chg)
+	c.Assert(err, IsNil)
+
+	c.Check(remodCtx.ForRemodeling(), Equals, true)
+
+	err = remodCtx.Init(chg)
+	c.Assert(err, IsNil)
+
+	t := s.state.NewTask("remodel-task-1", "...")
+	chg.AddTask(t)
+
+	// caching
+	remodCtx1, err := devicestate.RemodelCtxFromTask(t)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx1, Equals, remodCtx)
+
+	// if the context goes away (e.g. because of restart) we
+	// compute a new one
+	devicestate.CleanupRemodelCtx(chg)
+
+	remodCtx2, err := devicestate.RemodelCtxFromTask(t)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx2 != remodCtx, Equals, true)
+	c.Check(remodCtx2.Model(), DeepEquals, newModel)
+}
+
+func (s *remodelLogicSuite) TestRemodelContextForTaskNo(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// task is nil
+	remodCtx1, err := devicestate.RemodelCtxFromTask(nil)
+	c.Check(err, Equals, state.ErrNoState)
+	c.Check(remodCtx1, IsNil)
+
+	// no change
+	t := s.state.NewTask("random-task", "...")
+	_, err = devicestate.RemodelCtxFromTask(t)
+	c.Check(err, Equals, state.ErrNoState)
+
+	// not a remodel change
+	chg := s.state.NewChange("not-remodel", "...")
+	chg.AddTask(t)
+	_, err = devicestate.RemodelCtxFromTask(t)
+	c.Check(err, Equals, state.ErrNoState)
+}

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -57,6 +59,11 @@ func MockEnsureNext(o *Overlord, t time.Time) {
 // Engine exposes the state engine in an Overlord for tests.
 func (o *Overlord) Engine() *StateEngine {
 	return o.stateEng
+}
+
+// NewStore exposes newStore.
+func (o *Overlord) NewStore(devBE storecontext.DeviceBackend) snapstate.StoreService {
+	return o.newStore(devBE)
 }
 
 // MockStoreNew mocks store.New as called by overlord.New.

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -22,6 +22,8 @@ package overlord
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -84,6 +86,8 @@ type Overlord struct {
 	deviceMgr *devicestate.DeviceManager
 	cmdMgr    *cmdstate.CommandManager
 	shotMgr   *snapshotstate.SnapshotManager
+	// proxyConf mediates the http proxy config
+	proxyConf func(req *http.Request) (*url.URL, error)
 }
 
 var storeNew = store.New
@@ -138,7 +142,7 @@ func New() (*Overlord, error) {
 	}
 	o.addManager(ifaceMgr)
 
-	deviceMgr, err := devicestate.Manager(s, hookMgr, o.runner)
+	deviceMgr, err := devicestate.Manager(s, hookMgr, o.runner, o.newStore)
 	if err != nil {
 		return nil, err
 	}
@@ -155,12 +159,9 @@ func New() (*Overlord, error) {
 	s.Lock()
 	defer s.Unlock()
 	// setting up the store
-	proxyConf := proxyconf.New(s)
+	o.proxyConf = proxyconf.New(s).Conf
 	storeCtx := storecontext.New(s, o.deviceMgr.StoreContextBackend())
-	cfg := store.DefaultConfig()
-	cfg.Proxy = proxyConf.Conf
-	sto := storeNew(cfg, storeCtx)
-	sto.SetCacheDownloads(defaultCachedDownloads)
+	sto := o.newStoreWithContext(storeCtx)
 
 	snapstate.ReplaceStore(s, sto)
 
@@ -221,6 +222,22 @@ func loadState(backend state.Backend) (*state.State, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func (o *Overlord) newStoreWithContext(storeCtx store.DeviceAndAuthContext) snapstate.StoreService {
+	cfg := store.DefaultConfig()
+	cfg.Proxy = o.proxyConf
+	sto := storeNew(cfg, storeCtx)
+	sto.SetCacheDownloads(defaultCachedDownloads)
+	return sto
+}
+
+// newStore can make new stores for use during remodeling.
+// The device backend will tie them to the remodeling device state.
+func (o *Overlord) newStore(devBE storecontext.DeviceBackend) snapstate.StoreService {
+	scb := o.deviceMgr.StoreContextBackend()
+	stoCtx := storecontext.NewComposed(o.State(), devBE, scb, scb)
+	return o.newStoreWithContext(stoCtx)
 }
 
 func (o *Overlord) ensureTimerSetup() {

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -113,6 +113,19 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(sto.(*store.Store).CacheDownloads(), Equals, 5)
 }
 
+func (ovs *overlordSuite) TestNewStore(c *C) {
+	// this is a shallow test, the deep testing happens in the
+	// remodeling tests in managers_test.go
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	devBE := o.DeviceManager().StoreContextBackend()
+
+	sto := o.NewStore(devBE)
+	c.Check(sto, FitsTypeOf, &store.Store{})
+	c.Check(sto.(*store.Store).CacheDownloads(), Equals, 5)
+}
+
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel))
 	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)

--- a/overlord/storecontext/context.go
+++ b/overlord/storecontext/context.go
@@ -125,7 +125,14 @@ func (sc *storeContext) UpdateDeviceAuth(device *auth.DeviceState, newSessionMac
 		return nil, err
 	}
 
-	// just do it, last update wins
+	// because of remodeling now more than one place (the global store)
+	// can be trying to set sessions, don't update if the original session
+	// doesn't match
+	if cur.SessionMacaroon != device.SessionMacaroon {
+		// nothing to do
+		return cur, nil
+	}
+
 	cur.SessionMacaroon = newSessionMacaroon
 	if err := sc.deviceBackend.SetDevice(cur); err != nil {
 		return nil, fmt.Errorf("internal error: cannot update just read device state: %v", err)

--- a/overlord/storecontext/context_test.go
+++ b/overlord/storecontext/context_test.go
@@ -161,12 +161,16 @@ func (s *storeCtxSuite) TestUpdateDeviceAuth(c *C) {
 func (s *storeCtxSuite) TestUpdateDeviceAuthOtherUpdate(c *C) {
 	device := &auth.DeviceState{}
 	otherUpdateDevice := *device
-	otherUpdateDevice.SessionMacaroon = "othe-session-macaroon"
+	otherUpdateDevice.SessionMacaroon = "other-session-macaroon"
 	otherUpdateDevice.KeyID = "KEYID"
 
 	b := &testBackend{device: &otherUpdateDevice}
 	storeCtx := storecontext.New(s.state, b)
 
+	// the global store refreshing sessions is now serialized
+	// and is a no-op in this case, but we do need not to overwrite
+	// the result of a remodeling (though unlikely as we will mostly avoid
+	// other store operations during it)
 	sessionMacaroon := "the-device-macaroon"
 	curDevice, err := storeCtx.UpdateDeviceAuth(device, sessionMacaroon)
 	c.Assert(err, IsNil)
@@ -174,7 +178,7 @@ func (s *storeCtxSuite) TestUpdateDeviceAuthOtherUpdate(c *C) {
 	c.Check(b.device, DeepEquals, curDevice)
 	c.Check(curDevice, DeepEquals, &auth.DeviceState{
 		KeyID:           "KEYID",
-		SessionMacaroon: sessionMacaroon,
+		SessionMacaroon: "other-session-macaroon",
 	})
 }
 


### PR DESCRIPTION
different context implementations will be used depending on the kind
of remodel, and those will play the roles/implement as needed
snapstate.DeviceContext, storecontext.DeviceBackend and
registrationContext:

* same brand/model, brand store => updateRemodel
  this is just a contextual carrier for the new model

* same brand/model different brand store => storeSwitchRemodel this
  mediates access to device state kept on the remodel change, it also
  creates a store that uses that and refers to the new brand store

* different brand/model, maybe different brand store => reregRemodel
  similar to storeSwitchRemodel case after a first phase that performs
  re-registration where the context plays registrationContext's role
  (NOT IMPLEMENTED YET)
