### PR TITLE
gadget: fix handling of positioning constrains for structures of MBR role

### DIFF
--- a/gadget/position.go
+++ b/gadget/position.go
@@ -94,7 +94,7 @@ func PositionVolume(gadgetRootDir string, volume *Volume, constraints Positionin
 	for idx, s := range volume.Structure {
 		var start Size
 		if s.Offset == nil {
-			if previousEnd < constraints.NonMBRStartOffset {
+			if s.EffectiveRole() != MBR && previousEnd < constraints.NonMBRStartOffset {
 				start = constraints.NonMBRStartOffset
 			} else {
 				start = previousEnd


### PR DESCRIPTION
Positioning constrains can influence how non MBR-role structure are moved from
start of the volume. However, the constraint is only applicable to non-MBR-role
structures, the actual MBR structures are to be left unchanged.

