### PR TITLE
tests: fix how the base snap are deleted when there are multiple to deleted on reset

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -141,7 +141,7 @@ reset_all_snap() {
         for base in $remove_bases; do
             snap remove "$base"
             if [ -d "$SNAP_MOUNT_DIR/$base" ]; then
-                echo "Error removing base snap $base"
+                echo "Error: removing base $base has unexpected leftover dir $SNAP_MOUNT_DIR/$base"
                 ls -al "$SNAP_MOUNT_DIR"
                 ls -al "$SNAP_MOUNT_DIR/$base"
                 exit 1

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -138,7 +138,15 @@ reset_all_snap() {
     done
     # remove all base/os snaps at the end
     if [ -n "$remove_bases" ]; then
-        snap remove "$remove_bases"
+        for base in $remove_bases; do
+            snap remove "$base"
+            if [ -d "$SNAP_MOUNT_DIR/$base" ]; then
+                echo "Error removing base snap $base"
+                ls -al "$SNAP_MOUNT_DIR"
+                ls -al "$SNAP_MOUNT_DIR/$base"
+                exit 1
+            fi
+        done
     fi
 
     # ensure we have the same state as initially


### PR DESCRIPTION
This is the error to fix with the change introduced:

+ '[' -n 'test-snapd-base test-snapd-base-bare' ']'
+ snap remove 'test-snapd-base test-snapd-base-bare'
snap "test-snapd-base test-snapd-base-bare" is not installed
+ for base in '$remove_bases'
+ '[' -d /snap/test-snapd-base ']'
+ echo 'Error removing base snap test-snapd-base'
Error removing base snap test-snapd-base

