### PR TITLE
tests: avoid removing snaps which are cached to speed up the prepare on boards

### DIFF
--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -110,7 +110,7 @@ restore_snapd_state() {
 restore_snapd_lib() {
     # Clean all the state but the snaps and seed dirs. Then make a selective clean for 
     # snaps and seed dirs leaving the .snap files which then are going to be synchronized.
-    find /var/lib/snapd/* -maxdepth 0 ! \( -name 'snaps' -o -name 'seed' \) -exec rm -rf {} \;
+    find /var/lib/snapd/* -maxdepth 0 ! \( -name 'snaps' -o -name 'seed' -o -name 'cache'\) -exec rm -rf {} \;
 
     # Copy the whole state but the snaps, seed and cache dirs
     find "$SNAPD_STATE_PATH"/snapd-lib/* -maxdepth 0 ! \( -name 'snaps' -o -name 'seed' -o -name 'cache' \) -exec cp -rf {} /var/lib/snapd \;

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -110,7 +110,7 @@ restore_snapd_state() {
 restore_snapd_lib() {
     # Clean all the state but the snaps and seed dirs. Then make a selective clean for 
     # snaps and seed dirs leaving the .snap files which then are going to be synchronized.
-    find /var/lib/snapd/* -maxdepth 0 ! \( -name 'snaps' -o -name 'seed' -o -name 'cache'\) -exec rm -rf {} \;
+    find /var/lib/snapd/* -maxdepth 0 ! \( -name 'snaps' -o -name 'seed' -o -name 'cache' \) -exec rm -rf {} \;
 
     # Copy the whole state but the snaps, seed and cache dirs
     find "$SNAPD_STATE_PATH"/snapd-lib/* -maxdepth 0 ! \( -name 'snaps' -o -name 'seed' -o -name 'cache' \) -exec cp -rf {} /var/lib/snapd \;


### PR DESCRIPTION
The idea is to avoid deleting snaps cached so then they don't need to be copied (which is expensive on boards like pi3). 

This change is speeding up 10/20% (average) the preparation phase on boards on .

