### PR TITLE
cmd/snap-confine: unshare per-user mount ns once

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -647,9 +647,6 @@ void sc_ensure_shared_snap_mount(void)
 
 static void sc_make_slave_mount_ns(void)
 {
-	if (unshare(CLONE_NEWNS) < 0) {
-		die("can not unshare mount namespace");
-	}
 	// In our new mount namespace, recursively change all mounts
 	// to slave mode, so we see changes from the parent namespace
 	// but don't propagate our own changes.


### PR DESCRIPTION
The function mount-support.c, sc_make_slave_mount_ns unshared the
per-user mount namespace again, even though it is explicitly done in
snap-confine.c, inside enter_non_classic_execution_environment. Both
unshare calls are close to each other for clarity but a third one stay
unnoticed in mount-support.c

The second mount namespace was unshared before any modifications took
place so this bug was unobservable apart from the increments in mount
namespace allocation numbers.

Fixes: https://bugs.launchpad.net/snapd/+bug/1828352
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
