### PR TITLE
cmd/snap-update-ns: make apply{User,System}Fstab identical

### DIFF
--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -48,9 +48,6 @@ func applySystemFstab(ctx MountProfileUpdateContext) error {
 	}
 	defer unlock()
 
-	// Read the desired and current mount profiles. Note that missing files
-	// count as empty profiles so that we can gracefully handle a mount
-	// interface connection/disconnection.
 	desired, err := ctx.LoadDesiredProfile()
 	if err != nil {
 		return err
@@ -62,6 +59,7 @@ func applySystemFstab(ctx MountProfileUpdateContext) error {
 		return err
 	}
 	debugShowProfile(currentBefore, "current mount profile (before applying changes)")
+
 	// Synthesize mount changes that were applied before for the purpose of the tmpfs detector.
 	as := ctx.Assumptions()
 	for _, entry := range currentBefore.Entries {
@@ -77,21 +75,36 @@ func applySystemFstab(ctx MountProfileUpdateContext) error {
 }
 
 func applyUserFstab(ctx MountProfileUpdateContext) error {
+	unlock, err := ctx.Lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	desired, err := ctx.LoadDesiredProfile()
 	if err != nil {
 		return err
 	}
 	debugShowProfile(desired, "desired mount profile")
 
-	current, err := ctx.LoadCurrentProfile()
+	currentBefore, err := ctx.LoadCurrentProfile()
 	if err != nil {
 		return err
 	}
-	debugShowProfile(current, "current mount profile")
+	debugShowProfile(currentBefore, "current mount profile (before applying changes)")
 
+	// Synthesize mount changes that were applied before for the purpose of the tmpfs detector.
 	as := ctx.Assumptions()
-	_, err = applyProfile(ctx, current, desired, as)
-	return err
+	for _, entry := range currentBefore.Entries {
+		as.AddChange(&Change{Action: Mount, Entry: entry})
+	}
+
+	currentAfter, err := applyProfile(ctx, currentBefore, desired, as)
+	if err != nil {
+		return err
+	}
+
+	return ctx.SaveCurrentProfile(currentAfter)
 }
 
 func applyProfile(ctx MountProfileUpdateContext, currentBefore, desired *osutil.MountProfile, as *Assumptions) (*osutil.MountProfile, error) {


### PR DESCRIPTION
This mechanical step is done to ensure that subsequent changes
did not break the system. Note that the per-user mount profile update
logic now performs locking (which is no-op), loads the current profile
(which is empty), synthesizes additional filesystem assumptions based
on that (empty) profile (so no new assumptions). Lastly the updated
current profile is saved (which is a no-op).

In short, this makes user and system profile application use identical
code without changing anything in practice.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
