### PR TITLE
many: introduce a gadget helper for locating device matching given structure

### DIFF
--- a/gadget/device.go
+++ b/gadget/device.go
@@ -87,8 +87,6 @@ func encodeLabel(in string) string {
 		switch {
 		case utf8.RuneLen(r) > 1:
 			buf.WriteRune(r)
-		case r == '\\':
-			fallthrough
 		case strings.IndexRune(allowed, r) == -1:
 			fmt.Fprintf(buf, `\x%x`, r)
 		default:

--- a/gadget/device.go
+++ b/gadget/device.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package gadget
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
+)
+
+var ErrDeviceNotFound = errors.New("device not found")
+
+// FindDeviceForStructure attempts to find an existing device matching given
+// volume structure, by inspecting it's name and, optionally, the filesystem
+// label. Assumes that the host's udev has set up device symlinks correctly.
+func FindDeviceForStructure(ps *PositionedStructure) (string, error) {
+	var candidates []string
+
+	if ps.Name != "" {
+		byPartlabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/", strutil.HexEscapePath(ps.Name))
+		candidates = append(candidates, byPartlabel)
+	}
+
+	if ps.Label != "" {
+		byFsLabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label/", strutil.HexEscapePath(ps.Label))
+		candidates = append(candidates, byFsLabel)
+	}
+
+	var found string
+	for _, candidate := range candidates {
+		if !osutil.FileExists(candidate) {
+			continue
+		}
+		target, err := os.Readlink(candidate)
+		if err != nil {
+			return "", fmt.Errorf("cannot read device link: %v", err)
+		}
+		if found != "" && target != found {
+			// partition label and filesystem label links point to
+			// different devices
+			return "", fmt.Errorf("conflicting device match, %q points to %q, while other match points to %q",
+				candidate, target, found)
+		}
+		found = target
+	}
+
+	if found == "" {
+		return "", ErrDeviceNotFound
+	}
+
+	return found, nil
+}

--- a/gadget/device.go
+++ b/gadget/device.go
@@ -32,7 +32,7 @@ import (
 var ErrDeviceNotFound = errors.New("device not found")
 
 // FindDeviceForStructure attempts to find an existing device matching given
-// volume structure, by inspecting it's name and, optionally, the filesystem
+// volume structure, by inspecting its name and, optionally, the filesystem
 // label. Assumes that the host's udev has set up device symlinks correctly.
 func FindDeviceForStructure(ps *PositionedStructure) (string, error) {
 	var candidates []string

--- a/gadget/device.go
+++ b/gadget/device.go
@@ -48,6 +48,7 @@ func FindDeviceForStructure(ps *PositionedStructure) (string, error) {
 	}
 
 	var found string
+	var match string
 	for _, candidate := range candidates {
 		if !osutil.FileExists(candidate) {
 			continue
@@ -57,12 +58,13 @@ func FindDeviceForStructure(ps *PositionedStructure) (string, error) {
 			return "", fmt.Errorf("cannot read device link: %v", err)
 		}
 		if found != "" && target != found {
-			// partition label and filesystem label links point to
+			// partition and filesystem label links point to
 			// different devices
-			return "", fmt.Errorf("conflicting device match, %q points to %q, while other match points to %q",
-				candidate, target, found)
+			return "", fmt.Errorf("conflicting device match, %q points to %q, previous match %q points to %q",
+				candidate, target, match, found)
 		}
 		found = target
+		match = candidate
 	}
 
 	if found == "" {

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -20,7 +20,6 @@
 package gadget_test
 
 import (
-	// "fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -47,6 +46,10 @@ func (d *deviceSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(filepath.Join(d.dir, "/dev/fakedevice"), []byte(""), 0644)
 	c.Assert(err, IsNil)
+}
+
+func (d *deviceSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
 }
 
 func (d *deviceSuite) TestDeviceFindByStructureName(c *C) {

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -1,0 +1,163 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget_test
+
+import (
+	// "fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
+)
+
+type deviceSuite struct {
+	dir string
+}
+
+var _ = Suite(&deviceSuite{})
+
+func (d *deviceSuite) SetUpTest(c *C) {
+	d.dir = c.MkDir()
+	dirs.SetRootDir(d.dir)
+
+	err := os.MkdirAll(filepath.Join(d.dir, "/dev/disk/by-label"), 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Join(d.dir, "/dev/disk/by-partlabel"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(d.dir, "/dev/fakedevice"), []byte(""), 0644)
+	c.Assert(err, IsNil)
+}
+
+func (d *deviceSuite) TestDeviceFindByStructureName(c *C) {
+	names := []struct {
+		escaped   string
+		structure string
+	}{
+		{"foo", "foo"},
+		{"123", "123"},
+		{"foo\\x20bar", "foo bar"},
+		{"foo\\x23bar", "foo#bar"},
+	}
+	for _, name := range names {
+		err := os.Symlink(filepath.Join(d.dir, "/dev/fakedevice"), filepath.Join(d.dir, "/dev/disk/by-partlabel", name.escaped))
+		c.Assert(err, IsNil)
+	}
+
+	for _, tc := range names {
+		c.Logf("trying: %q", tc)
+		found, err := gadget.FindDeviceForStructure(&gadget.PositionedStructure{
+			VolumeStructure: &gadget.VolumeStructure{Name: tc.structure},
+		})
+		c.Check(err, IsNil)
+		c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
+	}
+}
+
+func (d *deviceSuite) TestDeviceFindByFilesystemLabel(c *C) {
+	names := []struct {
+		escaped   string
+		structure string
+	}{
+		{"foo", "foo"},
+		{"123", "123"},
+		{"foo\\x20bar", "foo bar"},
+		{"foo\\x23bar", "foo#bar"},
+	}
+	for _, name := range names {
+		err := os.Symlink(filepath.Join(d.dir, "/dev/fakedevice"), filepath.Join(d.dir, "/dev/disk/by-label", name.escaped))
+		c.Assert(err, IsNil)
+	}
+
+	for _, tc := range names {
+		c.Logf("trying: %q", tc)
+		found, err := gadget.FindDeviceForStructure(&gadget.PositionedStructure{
+			VolumeStructure: &gadget.VolumeStructure{Label: tc.structure},
+		})
+		c.Check(err, IsNil)
+		c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
+	}
+}
+
+func (d *deviceSuite) TestDeviceFindChecksPartlabelAndFilesystemLabelHappy(c *C) {
+	fakedevice := filepath.Join(d.dir, "/dev/fakedevice")
+	err := os.Symlink(fakedevice, filepath.Join(d.dir, "/dev/disk/by-label/foo"))
+	c.Assert(err, IsNil)
+
+	err = os.Symlink(fakedevice, filepath.Join(d.dir, "/dev/disk/by-partlabel/bar"))
+	c.Assert(err, IsNil)
+
+	found, err := gadget.FindDeviceForStructure(&gadget.PositionedStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Name:  "bar",
+			Label: "foo",
+		},
+	})
+	c.Check(err, IsNil)
+	c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
+}
+
+func (d *deviceSuite) TestDeviceFindChecksPartlabelAndFilesystemLabelMismatch(c *C) {
+	fakedevice := filepath.Join(d.dir, "/dev/fakedevice")
+	err := os.Symlink(fakedevice, filepath.Join(d.dir, "/dev/disk/by-label/foo"))
+	c.Assert(err, IsNil)
+
+	// partlabel of the structure points to a different device
+	fakedeviceOther := filepath.Join(d.dir, "/dev/fakedevice-other")
+	err = ioutil.WriteFile(fakedeviceOther, []byte(""), 0644)
+	c.Assert(err, IsNil)
+	err = os.Symlink(fakedeviceOther, filepath.Join(d.dir, "/dev/disk/by-partlabel/bar"))
+	c.Assert(err, IsNil)
+
+	found, err := gadget.FindDeviceForStructure(&gadget.PositionedStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Name:  "bar",
+			Label: "foo",
+		},
+	})
+	c.Check(err, ErrorMatches, `conflicting device match, ".*/by-label/foo" points to ".*/fakedevice", while other match points to ".*/fakedevice-other"`)
+	c.Check(found, Equals, "")
+}
+
+func (d *deviceSuite) TestDeviceFindNotFound(c *C) {
+	found, err := gadget.FindDeviceForStructure(&gadget.PositionedStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Name:  "bar",
+			Label: "foo",
+		},
+	})
+	c.Check(err, ErrorMatches, `device not found`)
+	c.Check(found, Equals, "")
+}
+
+func (d *deviceSuite) TestDeviceFindNotFoundEmpty(c *C) {
+	// neither name nor filesystem label set
+	found, err := gadget.FindDeviceForStructure(&gadget.PositionedStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Name:  "",
+			Label: "",
+		},
+	})
+	c.Check(err, ErrorMatches, `device not found`)
+	c.Check(found, Equals, "")
+}

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -135,7 +135,7 @@ func (d *deviceSuite) TestDeviceFindChecksPartlabelAndFilesystemLabelMismatch(c 
 			Label: "foo",
 		},
 	})
-	c.Check(err, ErrorMatches, `conflicting device match, ".*/by-label/foo" points to ".*/fakedevice", while other match points to ".*/fakedevice-other"`)
+	c.Check(err, ErrorMatches, `conflicting device match, ".*/by-label/foo" points to ".*/fakedevice", previous match ".*/by-partlabel/bar" points to ".*/fakedevice-other"`)
 	c.Check(found, Equals, "")
 }
 

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -61,6 +61,8 @@ func (d *deviceSuite) TestDeviceFindByStructureName(c *C) {
 		{"123", "123"},
 		{"foo\\x20bar", "foo bar"},
 		{"foo#bar", "foo#bar"},
+		{"Новый_том", "Новый_том"},
+		{`pinkié\x20pie`, `pinkié pie`},
 	}
 	for _, name := range names {
 		err := os.Symlink(filepath.Join(d.dir, "/dev/fakedevice"), filepath.Join(d.dir, "/dev/disk/by-partlabel", name.escaped))
@@ -86,6 +88,8 @@ func (d *deviceSuite) TestDeviceFindByFilesystemLabel(c *C) {
 		{"123", "123"},
 		{`foo\x20bar`, "foo bar"},
 		{"foo#bar", "foo#bar"},
+		{"Новый_том", "Новый_том"},
+		{`pinkié\x20pie`, `pinkié pie`},
 	}
 	for _, name := range names {
 		err := os.Symlink(filepath.Join(d.dir, "/dev/fakedevice"), filepath.Join(d.dir, "/dev/disk/by-label", name.escaped))

--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -27,4 +27,6 @@ var (
 
 	ResolveVolume      = resolveVolume
 	CanUpdateStructure = canUpdateStructure
+
+	EncodeLabel = encodeLabel
 )


### PR DESCRIPTION
Add a helper for locating a device that matches given structure, by inspecting the partition and filesystem labels.

Reshuffle some systemd specific code to strutil package.

cc @cmatsuoka