### PR TITLE
gadget: add volume level update checks

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -27,4 +27,5 @@ var (
 
 	ResolveVolume      = resolveVolume
 	CanUpdateStructure = canUpdateStructure
+	CanUpdateVolume    = canUpdateVolume
 )

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -82,7 +82,7 @@ type Volume struct {
 
 func (v *Volume) EffectiveSchema() string {
 	if v.Schema == "" {
-		return "gpt"
+		return GPT
 	}
 	return v.Schema
 }

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -80,6 +80,13 @@ type Volume struct {
 	Structure []VolumeStructure `yaml:"structure"`
 }
 
+func (v *Volume) EffectiveSchema() string {
+	if v.Schema == "" {
+		return "gpt"
+	}
+	return v.Schema
+}
+
 // VolumeStructure describes a single structure inside a volume. A structure can
 // represent a partition, Master Boot Record, or any other contiguous range
 // within the volume.

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -119,3 +119,16 @@ func canUpdateStructure(from *PositionedStructure, to *PositionedStructure) erro
 
 	return nil
 }
+
+func canUpdateVolume(from *PositionedVolume, to *PositionedVolume) error {
+	if from.ID != to.ID {
+		return fmt.Errorf("cannot change volume ID from %q to %q", from.ID, to.ID)
+	}
+	if from.EffectiveSchema() != to.EffectiveSchema() {
+		return fmt.Errorf("cannot change volume schema from %q to %q", from.EffectiveSchema(), to.EffectiveSchema())
+	}
+	if len(from.PositionedStructure) != len(to.PositionedStructure) {
+		return fmt.Errorf("cannot change the number of structures within volume from %v to %v", len(from.PositionedStructure), len(to.PositionedStructure))
+	}
+	return nil
+}


### PR DESCRIPTION
Add volume level update sanity checks. We effectively assume there is no room for changes in the volume across updates. The rule may be lifted in the future, but currently, the number of structures, schema and ID must remain unchanged.

cc @cmatsuoka