### PR TITLE
cmd/snap: mangle descriptions that have indent > terminal width

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -209,6 +209,10 @@ func wrapLine(out io.Writer, text []rune, pad string, termWidth int) error {
 	}
 	indent := pad + string(text[:idx])
 	text = text[idx:]
+	if len(indent) > termWidth/2 {
+		// give up
+		indent = pad + "  "
+	}
 	return wrapGeneric(out, text, indent, indent, termWidth)
 }
 

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -210,7 +210,10 @@ func wrapLine(out io.Writer, text []rune, pad string, termWidth int) error {
 	indent := pad + string(text[:idx])
 	text = text[idx:]
 	if len(indent) > termWidth/2 {
-		// give up
+		// If indent is too big there's not enough space for the actual
+		// text, in the pathological case the indent can even be bigger
+		// than the terminal which leads to lp:1828425.
+		// Rather than let that happen, give up.
 		indent = pad + "  "
 	}
 	return wrapGeneric(out, text, indent, indent, termWidth)

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -603,3 +603,21 @@ func (infoSuite) TestWrapCornerCase(c *check.C) {
   All hail EN SPACE.
 `[1:])
 }
+
+func (infoSuite) TestBug1828425(c *check.C) {
+	const s = `This is a description
+                                  that has
+                                  lines
+                                  too deeply
+                                  indented.
+`
+	var buf bytes.Buffer
+	err := snap.PrintDescr(&buf, s, 30)
+	c.Assert(err, check.IsNil)
+	c.Check(buf.String(), check.Equals, `  This is a description
+    that has
+    lines
+    too deeply
+    indented.
+`)
+}


### PR DESCRIPTION
Without this, a snap's description could have lines that were indented
wider than the terminal, which would cause a panic in snap.

As there is no good way of dealing with these, we simply replace any
indent bigger than half the terminal width with a fixed two-space
indent.

This fixes https://bugs.launchpad.net/snapd/+bug/1828425
