### PR TITLE
cmd/snap-update-ns: merge apply functions

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -62,8 +62,7 @@ var (
 	ExpandXdgRuntimeDir  = expandXdgRuntimeDir
 
 	// update
-	ApplySystemFstab = applySystemFstab
-	ApplyUserFstab   = applyUserFstab
+	ApplyFstab = applyFstab
 )
 
 // SystemCalls encapsulates various system interactions performed by this module.

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -81,8 +81,8 @@ func run() error {
 	var ctx MountProfileUpdateContext
 	if opts.UserMounts {
 		ctx = NewUserProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine, os.Getuid())
-		return applyUserFstab(ctx)
+	} else {
+		ctx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
 	}
-	ctx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
-	return applySystemFstab(ctx)
+	return applyFstab(ctx)
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -54,7 +54,7 @@ func (s *mainSuite) SetUpTest(c *C) {
 	s.log = buf
 }
 
-func (s *mainSuite) TestApplySystemFstab(c *C) {
+func (s *mainSuite) TestApplyFstab(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
@@ -80,7 +80,7 @@ func (s *mainSuite) TestApplySystemFstab(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	err = update.ApplySystemFstab(ctx)
+	err = update.ApplyFstab(ctx)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -148,7 +148,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx), IsNil)
+	c.Assert(update.ApplyFstab(ctx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -226,7 +226,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx), IsNil)
+	c.Assert(update.ApplyFstab(ctx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -269,7 +269,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx), ErrorMatches, "testing")
+	c.Assert(update.ApplyFstab(ctx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -312,7 +312,7 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx), ErrorMatches, "testing")
+	c.Assert(update.ApplyFstab(ctx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -356,7 +356,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	// The error was ignored, and no mount was recorded in the profile
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplySystemFstab(ctx), IsNil)
+	c.Assert(update.ApplyFstab(ctx), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -382,7 +382,7 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewUserProfileUpdateContext(snapName, true, 1000)
-	err = update.ApplyUserFstab(ctx)
+	err = update.ApplyFstab(ctx)
 	c.Assert(err, IsNil)
 
 	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, 1000)


### PR DESCRIPTION
applySystemFstab and applyUserFstab were already identical and calling
into applyProfile. I've spliced applyProfile inside applySystemFstab,
removed applyUserFstab and renamed the resulting function to just
applyFstab.

Test changes were entirely mechanical renames.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
