### PR TITLE
interfaces: special-case "snapd" in sanitizeSlotReservedForOS* helper…

### DIFF
--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -75,7 +75,7 @@ func plugAppLabelExpr(plug *interfaces.ConnectedPlug) string {
 
 // sanitizeSlotReservedForOS checks if slot is of type os.
 func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *snap.SlotInfo) error {
-	if slot.Snap.Type != snap.TypeOS {
+	if slot.Snap.Type != snap.TypeOS && slot.Snap.InstanceName() != "snapd" {
 		return fmt.Errorf("%s slots are reserved for the core snap", iface.Name())
 	}
 	return nil
@@ -83,7 +83,7 @@ func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *snap.SlotInfo) 
 
 // sanitizeSlotReservedForOSOrGadget checks if the slot is of type os or gadget.
 func sanitizeSlotReservedForOSOrGadget(iface interfaces.Interface, slot *snap.SlotInfo) error {
-	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeGadget {
+	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeGadget && slot.Snap.InstanceName() != "snapd" {
 		return fmt.Errorf("%s slots are reserved for the core and gadget snaps", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -35,6 +35,7 @@ type utilsSuite struct {
 	iface      interfaces.Interface
 	slotOS     *snap.SlotInfo
 	slotApp    *snap.SlotInfo
+	slotSnapd  *snap.SlotInfo
 	slotGadget *snap.SlotInfo
 }
 
@@ -42,12 +43,14 @@ var _ = Suite(&utilsSuite{
 	iface:      &ifacetest.TestInterface{InterfaceName: "iface"},
 	slotOS:     &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeOS}},
 	slotApp:    &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeApp}},
+	slotSnapd:  &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeApp, SuggestedName: "snapd"}},
 	slotGadget: &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeGadget}},
 })
 
 func (s *utilsSuite) TestSanitizeSlotReservedForOS(c *C) {
 	errmsg := "iface slots are reserved for the core snap"
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotOS), IsNil)
+	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotSnapd), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotApp), ErrorMatches, errmsg)
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotGadget), ErrorMatches, errmsg)
 }
@@ -55,6 +58,7 @@ func (s *utilsSuite) TestSanitizeSlotReservedForOS(c *C) {
 func (s *utilsSuite) TestSanitizeSlotReservedForOSOrGadget(c *C) {
 	errmsg := "iface slots are reserved for the core and gadget snaps"
 	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotOS), IsNil)
+	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotSnapd), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotApp), ErrorMatches, errmsg)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotGadget), IsNil)
 }


### PR DESCRIPTION
Special-case "snapd" in sanitizeSlotReservedForOSOrGadget and sanitizeSlotReservedForOS helpers used by most of interfaces in their sanitize* mathods, so that hotplug slots can be attached to snapd snap in core18+snapd system.

This is cherry-pick of https://github.com/snapcore/snapd/pull/6844 for 2.39