### PR TITLE
cmd/snap-update-ns: rename applyFstab to executeMountProfileUpdate

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -62,7 +62,7 @@ var (
 	ExpandXdgRuntimeDir  = expandXdgRuntimeDir
 
 	// update
-	ApplyFstab = applyFstab
+	ExecuteMountProfileUpdate = executeMountProfileUpdate
 )
 
 // SystemCalls encapsulates various system interactions performed by this module.

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -84,5 +84,5 @@ func run() error {
 	} else {
 		ctx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
 	}
-	return applyFstab(ctx)
+	return executeMountProfileUpdate(ctx)
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -54,7 +54,7 @@ func (s *mainSuite) SetUpTest(c *C) {
 	s.log = buf
 }
 
-func (s *mainSuite) TestApplyFstab(c *C) {
+func (s *mainSuite) TestExecuteMountProfileUpdate(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
@@ -80,7 +80,7 @@ func (s *mainSuite) TestApplyFstab(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	err = update.ApplyFstab(ctx)
+	err = update.ExecuteMountProfileUpdate(ctx)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -148,7 +148,7 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplyFstab(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -226,7 +226,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	defer restore()
 
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplyFstab(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -269,7 +269,7 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplyFstab(ctx), ErrorMatches, "testing")
+	c.Assert(update.ExecuteMountProfileUpdate(ctx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -312,7 +312,7 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 
 	// The error was not ignored, we bailed out.
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplyFstab(ctx), ErrorMatches, "testing")
+	c.Assert(update.ExecuteMountProfileUpdate(ctx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -356,7 +356,7 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	// The error was ignored, and no mount was recorded in the profile
 	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ApplyFstab(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -382,7 +382,7 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := update.NewUserProfileUpdateContext(snapName, true, 1000)
-	err = update.ApplyFstab(ctx)
+	err = update.ExecuteMountProfileUpdate(ctx)
 	c.Assert(err, IsNil)
 
 	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, 1000)

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -41,7 +41,7 @@ type MountProfileUpdateContext interface {
 	SaveCurrentProfile(*osutil.MountProfile) error
 }
 
-func applyFstab(ctx MountProfileUpdateContext) error {
+func executeMountProfileUpdate(ctx MountProfileUpdateContext) error {
 	unlock, err := ctx.Lock()
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
