### PR TITLE
overlord: implement store switch remodeling 

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -526,10 +526,9 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 		// TODO: add test once we support this kind of remodel
 		msg = fmt.Sprintf(i18n.G("Remodel device to %v/%v (%v)"), new.BrandID(), new.Model(), new.Revision())
 	}
+
 	chg := st.NewChange("remodel", msg)
-	if err := remodCtx.Init(chg); err != nil {
-		return nil, err
-	}
+	remodCtx.Init(chg)
 	for _, ts := range tss {
 		chg.AddAll(ts)
 	}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -41,8 +41,8 @@ import (
 )
 
 var (
-	snapstateInstall = snapstate.Install
-	snapstateUpdate  = snapstate.Update
+	snapstateInstallWithDeviceContext = snapstate.InstallWithDeviceContext
+	snapstateUpdateWithDeviceContext  = snapstate.UpdateWithDeviceContext
 )
 
 // findModel returns the device model assertion.
@@ -332,13 +332,13 @@ func extractDownloadInstallEdgesFromTs(ts *state.TaskSet) (firstDl, lastDl, firs
 	return firstDl, tasks[edgeTaskIndex], tasks[edgeTaskIndex+1], lastInst, nil
 }
 
-func remodelTasks(st *state.State, current, new *asserts.Model) ([]*state.TaskSet, error) {
+func remodelTasks(st *state.State, current, new *asserts.Model, deviceCtx snapstate.DeviceContext) ([]*state.TaskSet, error) {
 	userID := 0
 
 	// adjust kernel track
 	var tss []*state.TaskSet
 	if current.KernelTrack() != new.KernelTrack() {
-		ts, err := snapstateUpdate(st, new.Kernel(), &snapstate.RevisionOptions{Channel: new.KernelTrack()}, userID, snapstate.Flags{NoReRefresh: true})
+		ts, err := snapstateUpdateWithDeviceContext(st, new.Kernel(), &snapstate.RevisionOptions{Channel: new.KernelTrack()}, userID, snapstate.Flags{NoReRefresh: true}, deviceCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -350,7 +350,7 @@ func remodelTasks(st *state.State, current, new *asserts.Model) ([]*state.TaskSe
 		_, err := snapstate.CurrentInfo(st, snapName)
 		// If the snap is not installed we need to install it now.
 		if _, ok := err.(*snap.NotInstalledError); ok {
-			ts, err := snapstateInstall(st, snapName, "", snap.R(0), userID, snapstate.Flags{Required: true})
+			ts, err := snapstateInstallWithDeviceContext(st, snapName, "", "", snap.R(0), userID, snapstate.Flags{Required: true}, deviceCtx)
 			if err != nil {
 				return nil, err
 			}
@@ -456,21 +456,20 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	if current.Series() != new.Series() {
 		return nil, fmt.Errorf("cannot remodel to different series yet")
 	}
+
 	// TODO: we need dedicated assertion language to permit for
 	// model transitions before we allow that cross vault
 	// transitions.
 	//
 	// Right now we only allow "remodel" to a different revision of
 	// the same model.
-	if current.BrandID() != new.BrandID() {
-		return nil, fmt.Errorf("cannot remodel to different brands yet")
+
+	remodelKind := ClassifyRemodel(current, new)
+
+	if remodelKind == ReregRemodel {
+		return nil, fmt.Errorf("cannot remodel to different brand/model yet")
 	}
-	if current.Model() != new.Model() {
-		return nil, fmt.Errorf("cannot remodel to different models yet")
-	}
-	if current.Store() != new.Store() {
-		return nil, fmt.Errorf("cannot remodel to different stores yet")
-	}
+
 	// TODO: should we restrict remodel from one arch to another?
 	// There are valid use-cases here though, i.e. amd64 machine that
 	// remodels itself to/from i386 (if the HW can do both 32/64 bit)
@@ -492,10 +491,33 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 		return nil, fmt.Errorf("cannot remodel to different gadgets yet")
 	}
 
-	tss, err := remodelTasks(st, current, new)
+	remodCtx, err := remodelCtx(st, current, new)
 	if err != nil {
 		return nil, err
 	}
+
+	if remodelKind == StoreSwitchRemodel {
+		sto := remodCtx.Store()
+		if sto == nil {
+			return nil, fmt.Errorf("internal error: a store switch remodeling should have built a store")
+		}
+		// ensure a new session accounting for the new brand store
+		st.Unlock()
+		_, err := sto.EnsureDeviceSession()
+		st.Lock()
+		if err != nil {
+			return nil, fmt.Errorf("cannot get a store session based on the new model assertion: %v", err)
+		}
+	}
+
+	tss, err := remodelTasks(st, current, new, remodCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: we released the lock a couple of times here:
+	// make sure the current model is essentially the same
+	// make sure no remodeling is in progress
 
 	var msg string
 	if current.BrandID() == new.BrandID() && current.Model() == new.Model() {
@@ -505,7 +527,9 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 		msg = fmt.Sprintf(i18n.G("Remodel device to %v/%v (%v)"), new.BrandID(), new.Model(), new.Revision())
 	}
 	chg := st.NewChange("remodel", msg)
-	chg.Set("new-model", string(asserts.Encode(new)))
+	if err := remodCtx.Init(chg); err != nil {
+		return nil, err
+	}
 	for _, ts := range tss {
 		chg.AddAll(ts)
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2871,7 +2871,8 @@ func (s *deviceMgrSuite) TestRemodelStoreSwitch(c *C) {
 	c.Check(freshStore.ensureDeviceSession, Equals, 1)
 
 	tl := chg.Tasks()
-	// 2 snaps,
+	// 2 snaps * 3 tasks (from the mock install above) +
+	// 1 "set-model" task at the end
 	c.Assert(tl, HasLen, 2*3+1)
 
 	remodCtx, err := devicestate.RemodelCtxFromTask(tl[0])

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -90,19 +90,19 @@ func MockRepeatRequestSerial(label string) (restore func()) {
 	}
 }
 
-func MockSnapstateInstall(f func(st *state.State, name, channel string, revision snap.Revision, userID int, flags snapstate.Flags) (*state.TaskSet, error)) (restore func()) {
-	old := snapstateInstall
-	snapstateInstall = f
+func MockSnapstateInstallWithDeviceContext(f func(st *state.State, name, channel, cohort string, revision snap.Revision, userID int, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) (*state.TaskSet, error)) (restore func()) {
+	old := snapstateInstallWithDeviceContext
+	snapstateInstallWithDeviceContext = f
 	return func() {
-		snapstateInstall = old
+		snapstateInstallWithDeviceContext = old
 	}
 }
 
-func MockSnapstateUpdate(f func(st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error)) (restore func()) {
-	old := snapstateUpdate
-	snapstateUpdate = f
+func MockSnapstateUpdateWithDeviceContext(f func(st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) (*state.TaskSet, error)) (restore func()) {
+	old := snapstateUpdateWithDeviceContext
+	snapstateUpdateWithDeviceContext = f
 	return func() {
-		snapstateUpdate = old
+		snapstateUpdateWithDeviceContext = old
 	}
 }
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -74,23 +74,13 @@ func (m *DeviceManager) doSetModel(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := t.Change()
-	var modelass string
-	if err := chg.Get("new-model", &modelass); err != nil {
-		return err
-	}
-
-	ass, err := asserts.Decode([]byte(modelass))
+	remodCtx, err := remodelCtxFromTask(t)
 	if err != nil {
 		return err
 	}
+	new := remodCtx.Model()
 
-	new, ok := ass.(*asserts.Model)
-	if !ok {
-		return fmt.Errorf("internal error: new-model is not a model assertion but: %s", ass.Type().Name)
-	}
-
-	err = assertstate.Add(st, ass)
+	err = assertstate.Add(st, new)
 	if err != nil && !isSameAssertsRevision(err) {
 		return err
 	}
@@ -122,9 +112,7 @@ func (m *DeviceManager) doSetModel(t *state.Task, _ *tomb.Tomb) error {
 		//       bootable base snap.
 	}
 
-	// TODO: set device,model from the new model assertion
-	// return setDeviceFromModelAssertion(st, device, model)
-	return nil
+	return remodCtx.Finish()
 }
 
 func useStaging() bool {

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/storecontext"
 )
 
 // TODO: should we move this into a new handlers suite?
@@ -53,8 +55,8 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 	s.state.Lock()
 	t := s.state.NewTask("set-model", "set-model test")
 	chg := s.state.NewChange("dummy", "...")
-	chg.AddTask(t)
 	chg.Set("new-model", string(asserts.Encode(newModel)))
+	chg.AddTask(t)
 
 	s.state.Unlock()
 
@@ -89,6 +91,7 @@ func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
 
 	t := s.state.NewTask("set-model", "set-model test")
 	chg := s.state.NewChange("dummy", "...")
+	chg.Set("new-model", string(asserts.Encode(model)))
 	chg.AddTask(t)
 	chg.Set("new-model", string(asserts.Encode(model)))
 
@@ -100,4 +103,68 @@ func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	c.Assert(chg.Err(), IsNil)
+}
+
+func (s *deviceMgrSuite) TestSetModelHandlerStoreSwitch(c *C) {
+	s.state.Lock()
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"revision":     "1",
+	})
+	s.state.Unlock()
+
+	newModel := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"store":        "switched-store",
+		"revision":     "2",
+	})
+
+	s.newFakeStore = func(devBE storecontext.DeviceBackend) snapstate.StoreService {
+		mod, err := devBE.Model()
+		c.Check(err, IsNil)
+		if err == nil {
+			c.Check(mod, DeepEquals, newModel)
+		}
+		return &freshSessionStore{}
+	}
+
+	s.state.Lock()
+	t := s.state.NewTask("set-model", "set-model test")
+	chg := s.state.NewChange("dummy", "...")
+	chg.Set("new-model", string(asserts.Encode(newModel)))
+	chg.Set("device", auth.DeviceState{
+		Brand:           "canonical",
+		Model:           "pc-model",
+		SessionMacaroon: "switched-store-session",
+	})
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(chg.Err(), IsNil)
+
+	m, err := s.mgr.Model()
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, newModel)
+
+	device, err := devicestatetest.Device(s.state)
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{
+		Brand:           "canonical",
+		Model:           "pc-model",
+		SessionMacaroon: "switched-store-session",
+	})
 }

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -93,7 +93,6 @@ func (s *deviceMgrSuite) TestSetModelHandlerSameRevisionNoError(c *C) {
 	chg := s.state.NewChange("dummy", "...")
 	chg.Set("new-model", string(asserts.Encode(model)))
 	chg.AddTask(t)
-	chg.Set("new-model", string(asserts.Encode(model)))
 
 	s.state.Unlock()
 

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -111,7 +111,7 @@ func cleanupRemodelCtx(chg *state.Change) {
 // access and evolution during a remodel.
 // All remodelContexts are at least a DeviceContext.
 type remodelContext interface {
-	Init(chg *state.Change) error
+	Init(chg *state.Change)
 	Finish() error
 	snapstate.DeviceContext
 
@@ -240,11 +240,10 @@ func (rc *updateRemodelContext) associate(chg *state.Change) {
 	rc.cacheViaChange(chg, rc)
 }
 
-func (rc *updateRemodelContext) Init(chg *state.Change) error {
+func (rc *updateRemodelContext) Init(chg *state.Change) {
 	rc.init(chg)
 
 	rc.associate(chg)
-	return nil
 }
 
 func (rc *updateRemodelContext) Store() snapstate.StoreService {
@@ -288,13 +287,12 @@ func (rc *newStoreRemodelContext) initialDevice(device *auth.DeviceState) {
 	rc.deviceState = &device1
 }
 
-func (rc *newStoreRemodelContext) Init(chg *state.Change) error {
+func (rc *newStoreRemodelContext) Init(chg *state.Change) {
 	rc.init(chg)
 	chg.Set("device", rc.deviceState)
 	rc.deviceState = nil
 
 	rc.associate(chg)
-	return nil
 }
 
 func (rc *newStoreRemodelContext) Store() snapstate.StoreService {

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -115,6 +115,8 @@ type remodelContext interface {
 	Finish() error
 	snapstate.DeviceContext
 
+	Kind() RemodelKind
+
 	// initialDevice takes the current/initial device state
 	// when setting up the remodel context
 	initialDevice(device *auth.DeviceState)
@@ -230,6 +232,10 @@ type updateRemodelContext struct {
 	baseRemodelContext
 }
 
+func (rc *updateRemodelContext) Kind() RemodelKind {
+	return UpdateRemodel
+}
+
 func (rc *updateRemodelContext) associate(chg *state.Change) {
 	rc.cacheViaChange(chg, rc)
 }
@@ -264,6 +270,10 @@ type newStoreRemodelContext struct {
 
 	st        *state.State
 	deviceMgr *DeviceManager
+}
+
+func (rc *newStoreRemodelContext) Kind() RemodelKind {
+	return StoreSwitchRemodel
 }
 
 func (rc *newStoreRemodelContext) associate(chg *state.Change) {

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -171,6 +171,7 @@ func (s *remodelLogicSuite) TestUpdateRemodelContext(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
+	c.Check(remodCtx.Kind(), Equals, devicestate.UpdateRemodel)
 
 	chg := s.state.NewChange("remodel", "...")
 
@@ -209,6 +210,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextInit(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
+	c.Check(remodCtx.Kind(), Equals, devicestate.StoreSwitchRemodel)
 
 	chg := s.state.NewChange("remodel", "...")
 

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -175,8 +175,7 @@ func (s *remodelLogicSuite) TestUpdateRemodelContext(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	var encNewModel string
 	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
@@ -214,8 +213,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextInit(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	var encNewModel string
 	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
@@ -286,8 +284,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendNoChangeYet(c *C) {
 	// have a change
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	// check device state is preserved across association with a Change
 	device, err = devBE.Device()
@@ -317,8 +314,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackend(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	devBE := devicestate.RemodelDeviceBackend(remodCtx)
 
@@ -377,8 +373,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendIsolation(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	devBE := devicestate.RemodelDeviceBackend(remodCtx)
 
@@ -467,8 +462,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextFinish(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	devBE := devicestate.RemodelDeviceBackend(remodCtx)
 
@@ -519,8 +513,7 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextFinishVsGlobalUpdateDevice
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	devBE := devicestate.RemodelDeviceBackend(remodCtx)
 
@@ -606,8 +599,7 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendSerial(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	serial0, err = devBE.Serial()
 	c.Assert(err, IsNil)
@@ -676,8 +668,7 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
 
 	chg := s.state.NewChange("remodel", "...")
 
-	err = remodCtx.Init(chg)
-	c.Assert(err, IsNil)
+	remodCtx.Init(chg)
 
 	t := s.state.NewTask("remodel-task-1", "...")
 	chg.AddTask(t)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -130,29 +130,29 @@ func verifyLastTasksetIsRerefresh(c *C, tts []*state.TaskSet) {
 	c.Check(ts.Tasks()[0].Kind(), Equals, "check-rerefresh")
 }
 
-func (ms *mgrsSuite) SetUpTest(c *C) {
-	ms.tempdir = c.MkDir()
-	dirs.SetRootDir(ms.tempdir)
+func (s *mgrsSuite) SetUpTest(c *C) {
+	s.tempdir = c.MkDir()
+	dirs.SetRootDir(s.tempdir)
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
 
 	// needed by hooks
-	ms.mockSnapCmd = testutil.MockCommand(c, "snap", "")
+	s.mockSnapCmd = testutil.MockCommand(c, "snap", "")
 
 	oldSetupInstallHook := snapstate.SetupInstallHook
 	oldSetupRemoveHook := snapstate.SetupRemoveHook
 	snapstate.SetupRemoveHook = hookstate.SetupRemoveHook
 	snapstate.SetupInstallHook = hookstate.SetupInstallHook
 
-	ms.automaticSnapshots = nil
+	s.automaticSnapshots = nil
 	restoreBackendSave := snapshotstate.MockBackendSave(func(_ context.Context, id uint64, si *snap.Info, cfg map[string]interface{}, usernames []string, flags *snapshotbackend.Flags) (*client.Snapshot, error) {
-		ms.automaticSnapshots = append(ms.automaticSnapshots, automaticSnapshotCall{InstanceName: si.InstanceName(), SnapConfig: cfg, Usernames: usernames, Flags: flags})
+		s.automaticSnapshots = append(s.automaticSnapshots, automaticSnapshotCall{InstanceName: si.InstanceName(), SnapConfig: cfg, Usernames: usernames, Flags: flags})
 		return nil, nil
 	})
 
 	restoreConnectRetryTimeout := ifacestate.MockConnectRetryTimeout(connectRetryTimeout)
 
-	ms.restore = func() {
+	s.restore = func() {
 		snapstate.SetupRemoveHook = oldSetupRemoveHook
 		snapstate.SetupInstallHook = oldSetupInstallHook
 		restoreBackendSave()
@@ -164,37 +164,37 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	// create a fake systemd environment
 	os.MkdirAll(filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants"), 0755)
 
-	ms.restoreSystemctl = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+	s.restoreSystemctl = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
 	})
 
-	ms.storeSigning = assertstest.NewStoreStack("can0nical", nil)
-	ms.brands = assertstest.NewSigningAccounts(ms.storeSigning)
-	ms.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"validation": "verified",
 	})
-	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
+	s.restoreTrusted = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
-	ms.devAcct = assertstest.NewAccount(ms.storeSigning, "devdevdev", map[string]interface{}{
+	s.devAcct = assertstest.NewAccount(s.storeSigning, "devdevdev", map[string]interface{}{
 		"account-id": "devdevdev",
 	}, "")
-	err = ms.storeSigning.Add(ms.devAcct)
+	err = s.storeSigning.Add(s.devAcct)
 	c.Assert(err, IsNil)
 
-	ms.serveIDtoName = make(map[string]string)
-	ms.serveSnapPath = make(map[string]string)
-	ms.serveRevision = make(map[string]string)
-	ms.serveOldPaths = make(map[string][]string)
-	ms.serveOldRevs = make(map[string][]string)
-	ms.hijackServeSnap = nil
+	s.serveIDtoName = make(map[string]string)
+	s.serveSnapPath = make(map[string]string)
+	s.serveRevision = make(map[string]string)
+	s.serveOldPaths = make(map[string][]string)
+	s.serveOldRevs = make(map[string][]string)
+	s.hijackServeSnap = nil
 
-	ms.restoreBackends = ifacestate.MockSecurityBackends(nil)
+	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
 	o.InterfaceManager().DisableUDevMonitor()
-	ms.o = o
-	st := ms.o.State()
+	s.o = o
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 	st.Set("seeded", true)
@@ -215,15 +215,15 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-	err = assertstate.Add(st, ms.storeSigning.StoreAccountKey(""))
+	err = assertstate.Add(st, s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
-	a, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	a, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, a)
 	c.Assert(err, IsNil)
-	ms.serveRevision["core"] = "1"
-	ms.serveIDtoName[fakeSnapID("core")] = "core"
-	err = ms.storeSigning.Add(a)
+	s.serveRevision["core"] = "1"
+	s.serveIDtoName[fakeSnapID("core")] = "core"
+	err = s.storeSigning.Add(a)
 	c.Assert(err, IsNil)
 
 	// add "snap1" snap declaration
@@ -234,10 +234,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-	a2, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	a2, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(assertstate.Add(st, a2), IsNil)
-	c.Assert(ms.storeSigning.Add(a2), IsNil)
+	c.Assert(s.storeSigning.Add(a2), IsNil)
 
 	// add "snap2" snap declaration
 	headers = map[string]interface{}{
@@ -247,10 +247,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-	a3, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	a3, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(assertstate.Add(st, a3), IsNil)
-	c.Assert(ms.storeSigning.Add(a3), IsNil)
+	c.Assert(s.storeSigning.Add(a3), IsNil)
 
 	// add "some-snap" snap declaration
 	headers = map[string]interface{}{
@@ -260,10 +260,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-	a4, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	a4, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(assertstate.Add(st, a4), IsNil)
-	c.Assert(ms.storeSigning.Add(a4), IsNil)
+	c.Assert(s.storeSigning.Add(a4), IsNil)
 
 	// add "other-snap" snap declaration
 	headers = map[string]interface{}{
@@ -273,10 +273,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-	a5, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	a5, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(assertstate.Add(st, a5), IsNil)
-	c.Assert(ms.storeSigning.Add(a5), IsNil)
+	c.Assert(s.storeSigning.Add(a5), IsNil)
 
 	// add pc-kernel snap declaration
 	headers = map[string]interface{}{
@@ -286,10 +286,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
 	headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-	a6, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	a6, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(assertstate.Add(st, a6), IsNil)
-	c.Assert(ms.storeSigning.Add(a6), IsNil)
+	c.Assert(s.storeSigning.Add(a6), IsNil)
 
 	// add core itself
 	snapstate.Set(st, "core", &snapstate.SnapState{
@@ -310,14 +310,14 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	st.Set("refresh-privacy-key", "privacy-key")
 }
 
-func (ms *mgrsSuite) TearDownTest(c *C) {
+func (s *mgrsSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	ms.restoreTrusted()
-	ms.restore()
-	ms.restoreSystemctl()
-	ms.mockSnapCmd.Restore()
+	s.restoreTrusted()
+	s.restore()
+	s.restoreSystemctl()
+	s.mockSnapCmd.Restore()
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	ms.restoreBackends()
+	s.restoreBackends()
 }
 
 var settleTimeout = 15 * time.Second
@@ -335,7 +335,7 @@ func makeTestSnap(c *C, snapYamlContent string) string {
 	return snaptest.MakeTestSnapWithFiles(c, snapYamlContent, files)
 }
 
-func (ms *mgrsSuite) TestHappyLocalInstall(c *C) {
+func (s *mgrsSuite) TestHappyLocalInstall(c *C) {
 	snapYamlContent := `name: foo
 apps:
  bar:
@@ -343,7 +343,7 @@ apps:
 `
 	snapPath := makeTestSnap(c, snapYamlContent+"version: 1.0")
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -353,7 +353,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -382,8 +382,8 @@ apps:
 	c.Assert(mup, testutil.FileMatches, "(?ms).*^What=/var/lib/snapd/snaps/foo_x1.snap")
 }
 
-func (ms *mgrsSuite) TestHappyRemove(c *C) {
-	st := ms.o.State()
+func (s *mgrsSuite) TestHappyRemove(c *C) {
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -392,7 +392,7 @@ apps:
  bar:
   command: bin/bar
 `
-	snapInfo := ms.installLocalTestSnap(c, snapYamlContent+"version: 1.0")
+	snapInfo := s.installLocalTestSnap(c, snapYamlContent+"version: 1.0")
 
 	// set config
 	tr := config.NewTransaction(st)
@@ -405,7 +405,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -425,7 +425,7 @@ apps:
 	c.Assert(osutil.FileExists(mup), Equals, false)
 
 	// automatic snapshot was created
-	c.Assert(ms.automaticSnapshots, DeepEquals, []automaticSnapshotCall{{"foo", map[string]interface{}{"key": "value"}, nil, &snapshotbackend.Flags{Auto: true}}})
+	c.Assert(s.automaticSnapshots, DeepEquals, []automaticSnapshotCall{{"foo", map[string]interface{}{"key": "value"}, nil, &snapshotbackend.Flags{Auto: true}}})
 }
 
 func fakeSnapID(name string) string {
@@ -461,7 +461,7 @@ const (
 
 var fooSnapID = fakeSnapID("foo")
 
-func (ms *mgrsSuite) prereqSnapAssertions(c *C, extraHeaders ...map[string]interface{}) *asserts.SnapDeclaration {
+func (s *mgrsSuite) prereqSnapAssertions(c *C, extraHeaders ...map[string]interface{}) *asserts.SnapDeclaration {
 	if len(extraHeaders) == 0 {
 		extraHeaders = []map[string]interface{}{{}}
 	}
@@ -477,16 +477,16 @@ func (ms *mgrsSuite) prereqSnapAssertions(c *C, extraHeaders ...map[string]inter
 			headers[h] = v
 		}
 		headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
-		a, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+		a, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 		c.Assert(err, IsNil)
-		err = ms.storeSigning.Add(a)
+		err = s.storeSigning.Add(a)
 		c.Assert(err, IsNil)
 		snapDecl = a.(*asserts.SnapDeclaration)
 	}
 	return snapDecl
 }
 
-func (ms *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (path, digest string) {
+func (s *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (path, digest string) {
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 
@@ -503,33 +503,33 @@ func (ms *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (pat
 		"developer-id":  "devdevdev",
 		"timestamp":     time.Now().Format(time.RFC3339),
 	}
-	snapRev, err := ms.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = ms.storeSigning.Add(snapRev)
+	err = s.storeSigning.Add(snapRev)
 	c.Assert(err, IsNil)
 
 	return snapPath, snapDigest
 }
 
-func (ms *mgrsSuite) pathFor(name, revno string) string {
-	if revno == ms.serveRevision[name] {
-		return ms.serveSnapPath[name]
+func (s *mgrsSuite) pathFor(name, revno string) string {
+	if revno == s.serveRevision[name] {
+		return s.serveSnapPath[name]
 	}
-	for i, r := range ms.serveOldRevs[name] {
+	for i, r := range s.serveOldRevs[name] {
 		if r == revno {
-			return ms.serveOldPaths[name][i]
+			return s.serveOldPaths[name][i]
 		}
 	}
 	return "/not/found"
 }
 
-func (ms *mgrsSuite) newestThatCanRead(name string, epoch snap.Epoch) (info *snap.Info, rev string) {
-	if ms.serveSnapPath[name] == "" {
+func (s *mgrsSuite) newestThatCanRead(name string, epoch snap.Epoch) (info *snap.Info, rev string) {
+	if s.serveSnapPath[name] == "" {
 		return nil, ""
 	}
-	idx := len(ms.serveOldPaths[name])
-	rev = ms.serveRevision[name]
-	path := ms.serveSnapPath[name]
+	idx := len(s.serveOldPaths[name])
+	rev = s.serveRevision[name]
+	path := s.serveSnapPath[name]
 	for {
 		snapf, err := snap.Open(path)
 		if err != nil {
@@ -546,12 +546,12 @@ func (ms *mgrsSuite) newestThatCanRead(name string, epoch snap.Epoch) (info *sna
 		if idx < 0 {
 			return nil, ""
 		}
-		path = ms.serveOldPaths[name][idx]
-		rev = ms.serveOldRevs[name][idx]
+		path = s.serveOldPaths[name][idx]
+		rev = s.serveOldRevs[name][idx]
 	}
 }
 
-func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
+func (s *mgrsSuite) mockStore(c *C) *httptest.Server {
 	var baseURL *url.URL
 	fillHit := func(hitTemplate, revno string, info *snap.Info) string {
 		epochBuf, err := json.Marshal(info.Epoch)
@@ -598,7 +598,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 				Type:       asserts.Type(comps[1]),
 				PrimaryKey: comps[2:],
 			}
-			a, err := ref.Resolve(ms.storeSigning.Find)
+			a, err := ref.Resolve(s.storeSigning.Find)
 			if asserts.IsNotFound(err) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(404)
@@ -613,16 +613,16 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 			w.Write(asserts.Encode(a))
 			return
 		case "download":
-			if ms.failNextDownload == comps[1] {
-				ms.failNextDownload = ""
+			if s.failNextDownload == comps[1] {
+				s.failNextDownload = ""
 				w.WriteHeader(418)
 				return
 			}
-			if ms.hijackServeSnap != nil {
-				ms.hijackServeSnap(w)
+			if s.hijackServeSnap != nil {
+				s.hijackServeSnap(w)
 				return
 			}
-			snapR, err := os.Open(ms.pathFor(comps[1], comps[2]))
+			snapR, err := os.Open(s.pathFor(comps[1], comps[2]))
 			if err != nil {
 				panic(err)
 			}
@@ -658,14 +658,14 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 			}
 			var results []resultJSON
 			for _, a := range input.Actions {
-				name := ms.serveIDtoName[a.SnapID]
+				name := s.serveIDtoName[a.SnapID]
 				epoch := id2epoch[a.SnapID]
 				if a.Action == "install" {
 					name = a.Name
 					epoch = a.Epoch
 				}
 
-				info, revno := ms.newestThatCanRead(name, epoch)
+				info, revno := s.newestThatCanRead(name, epoch)
 				if info == nil {
 					// no match
 					continue
@@ -699,9 +699,9 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	}
 
 	mStore := store.New(&storeCfg, nil)
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
-	snapstate.ReplaceStore(ms.o.State(), mStore)
+	snapstate.ReplaceStore(s.o.State(), mStore)
 	st.Unlock()
 
 	return mockServer
@@ -709,7 +709,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 
 // serveSnap starts serving the snap at snapPath, moving the current
 // one onto the list of previous ones if already set.
-func (ms *mgrsSuite) serveSnap(snapPath, revno string) {
+func (s *mgrsSuite) serveSnap(snapPath, revno string) {
 	snapf, err := snap.Open(snapPath)
 	if err != nil {
 		panic(err)
@@ -719,26 +719,26 @@ func (ms *mgrsSuite) serveSnap(snapPath, revno string) {
 		panic(err)
 	}
 	name := info.SnapName()
-	ms.serveIDtoName[fakeSnapID(name)] = name
+	s.serveIDtoName[fakeSnapID(name)] = name
 
-	if oldPath := ms.serveSnapPath[name]; oldPath != "" {
-		oldRev := ms.serveRevision[name]
+	if oldPath := s.serveSnapPath[name]; oldPath != "" {
+		oldRev := s.serveRevision[name]
 		if oldRev == "" {
 			panic("old path set but not old revision")
 		}
-		ms.serveOldPaths[name] = append(ms.serveOldPaths[name], oldPath)
-		ms.serveOldRevs[name] = append(ms.serveOldRevs[name], oldRev)
+		s.serveOldPaths[name] = append(s.serveOldPaths[name], oldPath)
+		s.serveOldRevs[name] = append(s.serveOldRevs[name], oldRev)
 	}
-	ms.serveSnapPath[name] = snapPath
-	ms.serveRevision[name] = revno
+	s.serveSnapPath[name] = snapPath
+	s.serveRevision[name] = revno
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpgradeSvc(c *C) {
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpgradeSvc(c *C) {
 	// test install through store and update, plus some mechanics
 	// of update
 	// TODO: ok to split if it gets too messy to maintain
 
-	ms.prereqSnapAssertions(c)
+	s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 version: @VERSION@
@@ -752,13 +752,13 @@ apps:
 
 	ver := "1.0"
 	revno := "42"
-	snapPath, digest := ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
-	ms.serveSnap(snapPath, revno)
+	snapPath, digest := s.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
+	s.serveSnap(snapPath, revno)
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -768,7 +768,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -808,8 +808,8 @@ apps:
 
 	ver = "2.0"
 	revno = "50"
-	snapPath, digest = ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
-	ms.serveSnap(snapPath, revno)
+	snapPath, digest = s.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
+	s.serveSnap(snapPath, revno)
 
 	ts, err = snapstate.Update(st, "foo", nil, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
@@ -817,7 +817,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -847,19 +847,19 @@ apps:
 	c.Assert(svcFile, testutil.FileContains, "/var/snap/foo/"+revno)
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithEpochBump(c *C) {
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateWithEpochBump(c *C) {
 	// test install through store and update, where there's an epoch bump in the upgrade
 	// this does less checks on the details of install/update than TestHappyRemoteInstallAndUpgradeSvc
 
-	ms.prereqSnapAssertions(c)
+	s.prereqSnapAssertions(c)
 
-	snapPath, _ := ms.makeStoreTestSnap(c, "{name: foo, version: 0}", "1")
-	ms.serveSnap(snapPath, "1")
+	snapPath, _ := s.makeStoreTestSnap(c, "{name: foo, version: 0}", "1")
+	s.serveSnap(snapPath, "1")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -869,7 +869,7 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithEpochBump(c *C) {
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -886,8 +886,8 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithEpochBump(c *C) {
 	// now add some more snaps
 	for i, epoch := range []string{"1*", "2*", "3*"} {
 		revno := fmt.Sprint(i + 2)
-		snapPath, _ := ms.makeStoreTestSnap(c, "{name: foo, version: 0, epoch: "+epoch+"}", revno)
-		ms.serveSnap(snapPath, revno)
+		snapPath, _ := s.makeStoreTestSnap(c, "{name: foo, version: 0, epoch: "+epoch+"}", revno)
+		s.serveSnap(snapPath, revno)
 	}
 
 	// refresh
@@ -898,7 +898,7 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithEpochBump(c *C) {
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -913,7 +913,7 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithEpochBump(c *C) {
 	c.Check(info.Epoch.String(), Equals, "3*")
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithPostHocEpochBump(c *C) {
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateWithPostHocEpochBump(c *C) {
 	// test install through store and update, where there is an epoch
 	// bump in the upgrade that comes in after the initial update is
 	// computed.
@@ -921,26 +921,26 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithPostHocEpochBump(c *C) {
 	// this is mostly checking the same as TestHappyRemoteInstallAndUpdateWithEpochBump
 	// but serves as a sanity check for the Without case that follows
 	// (these two together serve as a test for the refresh filtering)
-	ms.testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c, true)
+	s.testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c, true)
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateWithoutEpochBump(c *C) {
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateWithoutEpochBump(c *C) {
 	// test install through store and update, where there _isn't_ an epoch bump in the upgrade
 	// note that there _are_ refreshes available after the refresh,
 	// but they're not an epoch bump so they're ignored
-	ms.testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c, false)
+	s.testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c, false)
 }
 
-func (ms *mgrsSuite) testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c *C, doBump bool) {
-	ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c *C, doBump bool) {
+	s.prereqSnapAssertions(c)
 
-	snapPath, _ := ms.makeStoreTestSnap(c, "{name: foo, version: 1}", "1")
-	ms.serveSnap(snapPath, "1")
+	snapPath, _ := s.makeStoreTestSnap(c, "{name: foo, version: 1}", "1")
+	s.serveSnap(snapPath, "1")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -950,7 +950,7 @@ func (ms *mgrsSuite) testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c *C, doB
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -965,8 +965,8 @@ func (ms *mgrsSuite) testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c *C, doB
 	c.Assert(info.Epoch.String(), Equals, "0")
 
 	// add a new revision
-	snapPath, _ = ms.makeStoreTestSnap(c, "{name: foo, version: 2}", "2")
-	ms.serveSnap(snapPath, "2")
+	snapPath, _ = s.makeStoreTestSnap(c, "{name: foo, version: 2}", "2")
+	s.serveSnap(snapPath, "2")
 
 	// refresh
 
@@ -977,14 +977,14 @@ func (ms *mgrsSuite) testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c *C, doB
 
 	// add another new revision, after the update was computed (maybe with an epoch bump)
 	if doBump {
-		snapPath, _ = ms.makeStoreTestSnap(c, "{name: foo, version: 3, epoch: 1*}", "3")
+		snapPath, _ = s.makeStoreTestSnap(c, "{name: foo, version: 3, epoch: 1*}", "3")
 	} else {
-		snapPath, _ = ms.makeStoreTestSnap(c, "{name: foo, version: 3}", "3")
+		snapPath, _ = s.makeStoreTestSnap(c, "{name: foo, version: 3}", "3")
 	}
-	ms.serveSnap(snapPath, "3")
+	s.serveSnap(snapPath, "3")
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1007,21 +1007,21 @@ func (ms *mgrsSuite) testHappyRemoteInstallAndUpdateWithMaybeEpochBump(c *C, doB
 	}
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
 	// test install through store and update many, where there's an epoch bump in the upgrade
 	// this does less checks on the details of install/update than TestHappyRemoteInstallAndUpgradeSvc
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		ms.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
-		snapPath, _ := ms.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
-		ms.serveSnap(snapPath, "1")
+		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
+		s.serveSnap(snapPath, "1")
 	}
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1035,7 +1035,7 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
 	}
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1055,8 +1055,8 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
 	for _, name := range snapNames {
 		for i, epoch := range []string{"1*", "2*", "3*"} {
 			revno := fmt.Sprint(i + 2)
-			snapPath, _ := ms.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0, epoch: %s}", name, epoch), revno)
-			ms.serveSnap(snapPath, revno)
+			snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0, epoch: %s}", name, epoch), revno)
+			s.serveSnap(snapPath, revno)
 		}
 	}
 
@@ -1072,7 +1072,7 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
 	}
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1089,20 +1089,20 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBump(c *C) {
 	}
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFailing(c *C) {
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFailing(c *C) {
 	// test install through store and update, where there's an epoch bump in the upgrade and one of them fails
 
 	snapNames := []string{"aaaa", "bbbb", "cccc"}
 	for _, name := range snapNames {
-		ms.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
-		snapPath, _ := ms.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
-		ms.serveSnap(snapPath, "1")
+		s.prereqSnapAssertions(c, map[string]interface{}{"snap-name": name})
+		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0}", name), "1")
+		s.serveSnap(snapPath, "1")
 	}
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1116,7 +1116,7 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFaili
 	}
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1136,8 +1136,8 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFaili
 	for _, name := range snapNames {
 		for i, epoch := range []string{"1*", "2*", "3*"} {
 			revno := fmt.Sprint(i + 2)
-			snapPath, _ := ms.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0, epoch: %s}", name, epoch), revno)
-			ms.serveSnap(snapPath, revno)
+			snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 0, epoch: %s}", name, epoch), revno)
+			s.serveSnap(snapPath, revno)
 		}
 	}
 
@@ -1154,8 +1154,8 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFaili
 	st.Unlock()
 	// the download for the refresh above will be performed below, during 'settle'.
 	// fail the refresh of cccc by failing its download
-	ms.failNextDownload = "cccc"
-	err = ms.o.Settle(settleTimeout)
+	s.failNextDownload = "cccc"
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1181,8 +1181,8 @@ func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateManyWithEpochBumpAndOneFaili
 	}
 }
 
-func (ms *mgrsSuite) TestHappyLocalInstallWithStoreMetadata(c *C) {
-	snapDecl := ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) TestHappyLocalInstallWithStoreMetadata(c *C) {
+	snapDecl := s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 apps:
@@ -1197,12 +1197,12 @@ apps:
 		Revision: snap.R(55),
 	}
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// have the snap-declaration in the system db
-	err := assertstate.Add(st, ms.devAcct)
+	err := assertstate.Add(st, s.devAcct)
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
@@ -1213,7 +1213,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1245,8 +1245,8 @@ apps:
 	c.Assert(mup, testutil.FileMatches, "(?ms).*^What=/var/lib/snapd/snaps/foo_55.snap")
 }
 
-func (ms *mgrsSuite) TestParallelInstanceLocalInstallSnapNameMismatch(c *C) {
-	snapDecl := ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) TestParallelInstanceLocalInstallSnapNameMismatch(c *C) {
+	snapDecl := s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 apps:
@@ -1261,12 +1261,12 @@ apps:
 		Revision: snap.R(55),
 	}
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// have the snap-declaration in the system db
-	err := assertstate.Add(st, ms.devAcct)
+	err := assertstate.Add(st, s.devAcct)
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
@@ -1275,8 +1275,8 @@ apps:
 	c.Assert(err, ErrorMatches, `cannot install snap "bar_instance", the name does not match the metadata "foo"`)
 }
 
-func (ms *mgrsSuite) TestParallelInstanceLocalInstallInvalidInstanceName(c *C) {
-	snapDecl := ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) TestParallelInstanceLocalInstallInvalidInstanceName(c *C) {
+	snapDecl := s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 apps:
@@ -1291,12 +1291,12 @@ apps:
 		Revision: snap.R(55),
 	}
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// have the snap-declaration in the system db
-	err := assertstate.Add(st, ms.devAcct)
+	err := assertstate.Add(st, s.devAcct)
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
@@ -1305,8 +1305,8 @@ apps:
 	c.Assert(err, ErrorMatches, `invalid instance name: invalid instance key: "invalid_instance_name"`)
 }
 
-func (ms *mgrsSuite) TestCheckInterfaces(c *C) {
-	snapDecl := ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) TestCheckInterfaces(c *C) {
+	snapDecl := s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 apps:
@@ -1323,12 +1323,12 @@ slots:
 		Revision: snap.R(55),
 	}
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// have the snap-declaration in the system db
-	err := assertstate.Add(st, ms.devAcct)
+	err := assertstate.Add(st, s.devAcct)
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
@@ -1343,7 +1343,7 @@ slots:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1351,12 +1351,12 @@ slots:
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 }
 
-func (ms *mgrsSuite) TestHappyRefreshControl(c *C) {
+func (s *mgrsSuite) TestHappyRefreshControl(c *C) {
 	// test install through store and update, plus some mechanics
 	// of update
 	// TODO: ok to split if it gets too messy to maintain
 
-	ms.prereqSnapAssertions(c)
+	s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 version: @VERSION@
@@ -1364,13 +1364,13 @@ version: @VERSION@
 
 	ver := "1.0"
 	revno := "42"
-	snapPath, _ := ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
-	ms.serveSnap(snapPath, revno)
+	snapPath, _ := s.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
+	s.serveSnap(snapPath, revno)
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1380,7 +1380,7 @@ version: @VERSION@
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1403,9 +1403,9 @@ version: @VERSION@
 		"refresh-control": []interface{}{fooSnapID},
 		"timestamp":       time.Now().Format(time.RFC3339),
 	}
-	snapDeclBar, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	snapDeclBar, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = ms.storeSigning.Add(snapDeclBar)
+	err = s.storeSigning.Add(snapDeclBar)
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, snapDeclBar)
 	c.Assert(err, IsNil)
@@ -1421,14 +1421,14 @@ version: @VERSION@
 
 	develSigning := assertstest.NewSigningDB("devdevdev", develPrivKey)
 
-	develAccKey := assertstest.NewAccountKey(ms.storeSigning, ms.devAcct, nil, develPrivKey.PublicKey(), "")
-	err = ms.storeSigning.Add(develAccKey)
+	develAccKey := assertstest.NewAccountKey(s.storeSigning, s.devAcct, nil, develPrivKey.PublicKey(), "")
+	err = s.storeSigning.Add(develAccKey)
 	c.Assert(err, IsNil)
 
 	ver = "2.0"
 	revno = "50"
-	snapPath, _ = ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
-	ms.serveSnap(snapPath, revno)
+	snapPath, _ = s.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
+	s.serveSnap(snapPath, revno)
 
 	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, []string{"foo"}, 0, nil)
 	c.Check(updated, IsNil)
@@ -1446,7 +1446,7 @@ version: @VERSION@
 	}
 	barValidation, err := develSigning.Sign(asserts.ValidationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = ms.storeSigning.Add(barValidation)
+	err = s.storeSigning.Add(barValidation)
 	c.Assert(err, IsNil)
 
 	// ... and try again
@@ -1459,7 +1459,7 @@ version: @VERSION@
 	chg.AddAll(tss[0])
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1490,7 +1490,7 @@ func findKind(chg *state.Change, kind string) *state.Task {
 	return nil
 }
 
-func (ms *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(c *C) {
+func (s *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(c *C) {
 	loader := boottest.NewMockBootloader("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
@@ -1498,7 +1498,7 @@ func (ms *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	model := ms.brands.Model("my-brand", "my-model", modelDefaults)
+	model := s.brands.Model("my-brand", "my-model", modelDefaults)
 
 	const packageOS = `
 name: core
@@ -1507,12 +1507,12 @@ type: os
 `
 	snapPath := makeTestSnap(c, packageOS)
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// setup model assertion
-	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "my-brand",
 		Model:  "my-model",
@@ -1527,7 +1527,7 @@ type: os
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1552,7 +1552,7 @@ type: os
 	loader.BootVars["snap_core"] = "core_x1.snap"
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1560,7 +1560,7 @@ type: os
 
 }
 
-func (ms *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
+func (s *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
 	loader := boottest.NewMockBootloader("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
@@ -1568,7 +1568,7 @@ func (ms *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	model := ms.brands.Model("my-brand", "my-model", modelDefaults)
+	model := s.brands.Model("my-brand", "my-model", modelDefaults)
 
 	const packageKernel = `
 name: pc-kernel
@@ -1582,12 +1582,12 @@ type: kernel`
 	}
 	snapPath := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// setup model assertion
-	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "my-brand",
 		Model:  "my-model",
@@ -1603,7 +1603,7 @@ type: kernel`
 
 	// run, this will trigger a wait for the restart
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1615,7 +1615,7 @@ type: kernel`
 	state.MockRestarting(st, state.RestartUnset)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1627,8 +1627,8 @@ type: kernel`
 	})
 }
 
-func (ms *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.Info {
-	st := ms.o.State()
+func (s *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.Info {
+	st := s.o.State()
 
 	snapPath := makeTestSnap(c, snapYamlContent)
 	snapf, err := snap.Open(snapPath)
@@ -1647,7 +1647,7 @@ func (ms *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.In
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1657,8 +1657,8 @@ func (ms *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.In
 	return info
 }
 
-func (ms *mgrsSuite) removeSnap(c *C, name string) {
-	st := ms.o.State()
+func (s *mgrsSuite) removeSnap(c *C, name string) {
+	st := s.o.State()
 
 	ts, err := snapstate.Remove(st, name, snap.R(0), nil)
 	c.Assert(err, IsNil)
@@ -1666,7 +1666,7 @@ func (ms *mgrsSuite) removeSnap(c *C, name string) {
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1674,8 +1674,8 @@ func (ms *mgrsSuite) removeSnap(c *C, name string) {
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("remove-snap change failed with: %v", chg.Err()))
 }
 
-func (ms *mgrsSuite) TestHappyRevert(c *C) {
-	st := ms.o.State()
+func (s *mgrsSuite) TestHappyRevert(c *C) {
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1695,8 +1695,8 @@ apps:
 `
 	x2binary := filepath.Join(dirs.SnapBinariesDir, "foo.x2")
 
-	ms.installLocalTestSnap(c, x1Yaml)
-	ms.installLocalTestSnap(c, x2Yaml)
+	s.installLocalTestSnap(c, x1Yaml)
+	s.installLocalTestSnap(c, x2Yaml)
 
 	// ensure we are on x2
 	_, err := os.Lstat(x2binary)
@@ -1711,7 +1711,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1731,8 +1731,8 @@ apps:
 	}
 }
 
-func (ms *mgrsSuite) TestHappyAlias(c *C) {
-	st := ms.o.State()
+func (s *mgrsSuite) TestHappyAlias(c *C) {
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1742,7 +1742,7 @@ apps:
     foo:
         command: bin/foo
 `
-	ms.installLocalTestSnap(c, fooYaml)
+	s.installLocalTestSnap(c, fooYaml)
 
 	ts, err := snapstate.Alias(st, "foo", "foo", "foo_")
 	c.Assert(err, IsNil)
@@ -1750,7 +1750,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1772,13 +1772,13 @@ apps:
 		"foo_": {Manual: "foo"},
 	})
 
-	ms.removeSnap(c, "foo")
+	s.removeSnap(c, "foo")
 
 	c.Check(osutil.IsSymlink(foo_Alias), Equals, false)
 }
 
-func (ms *mgrsSuite) TestHappyUnalias(c *C) {
-	st := ms.o.State()
+func (s *mgrsSuite) TestHappyUnalias(c *C) {
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1788,7 +1788,7 @@ apps:
     foo:
         command: bin/foo
 `
-	ms.installLocalTestSnap(c, fooYaml)
+	s.installLocalTestSnap(c, fooYaml)
 
 	ts, err := snapstate.Alias(st, "foo", "foo", "foo_")
 	c.Assert(err, IsNil)
@@ -1796,7 +1796,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1816,7 +1816,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1833,8 +1833,8 @@ apps:
 	c.Check(snapst.Aliases, HasLen, 0)
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAutoAliases(c *C) {
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+func (s *mgrsSuite) TestHappyRemoteInstallAutoAliases(c *C) {
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app1", "target": "app1"},
@@ -1853,13 +1853,13 @@ apps:
 
 	ver := "1.0"
 	revno := "42"
-	snapPath, _ := ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
-	ms.serveSnap(snapPath, revno)
+	snapPath, _ := s.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
+	s.serveSnap(snapPath, revno)
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1869,7 +1869,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1896,8 +1896,8 @@ apps:
 	c.Check(dest, Equals, "foo.app2")
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliases(c *C) {
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliases(c *C) {
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app1", "target": "app1"},
@@ -1913,13 +1913,13 @@ apps:
   command: bin/app2
 `
 
-	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
-	ms.serveSnap(fooPath, "10")
+	fooPath, _ := s.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
+	s.serveSnap(fooPath, "10")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -1929,7 +1929,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1953,7 +1953,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Check(dest, Equals, "foo.app1")
 
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app2", "target": "app2"},
@@ -1962,8 +1962,8 @@ apps:
 	})
 
 	// new foo version/revision
-	fooPath, _ = ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
-	ms.serveSnap(fooPath, "15")
+	fooPath, _ = s.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
+	s.serveSnap(fooPath, "15")
 
 	// refresh all
 	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, 0, nil)
@@ -1975,7 +1975,7 @@ apps:
 	chg.AddAll(tss[0])
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2002,8 +2002,8 @@ apps:
 	c.Check(dest, Equals, "foo.app2")
 }
 
-func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliasesUnaliased(c *C) {
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+func (s *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliasesUnaliased(c *C) {
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app1", "target": "app1"},
@@ -2019,13 +2019,13 @@ apps:
   command: bin/app2
 `
 
-	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
-	ms.serveSnap(fooPath, "10")
+	fooPath, _ := s.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
+	s.serveSnap(fooPath, "10")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2035,7 +2035,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2057,7 +2057,7 @@ apps:
 	app1Alias := filepath.Join(dirs.SnapBinariesDir, "app1")
 	c.Check(osutil.IsSymlink(app1Alias), Equals, false)
 
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app2", "target": "app2"},
@@ -2066,8 +2066,8 @@ apps:
 	})
 
 	// new foo version/revision
-	fooPath, _ = ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
-	ms.serveSnap(fooPath, "15")
+	fooPath, _ = s.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
+	s.serveSnap(fooPath, "15")
 
 	// refresh foo
 	ts, err = snapstate.Update(st, "foo", nil, 0, snapstate.Flags{})
@@ -2076,7 +2076,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2101,8 +2101,8 @@ apps:
 	c.Check(osutil.IsSymlink(app2Alias), Equals, false)
 }
 
-func (ms *mgrsSuite) TestHappyOrthogonalRefreshAutoAliases(c *C) {
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+func (s *mgrsSuite) TestHappyOrthogonalRefreshAutoAliases(c *C) {
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app1", "target": "app1"},
@@ -2129,16 +2129,16 @@ apps:
   command: bin/app3
 `
 
-	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
-	ms.serveSnap(fooPath, "10")
+	fooPath, _ := s.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
+	s.serveSnap(fooPath, "10")
 
-	barPath, _ := ms.makeStoreTestSnap(c, strings.Replace(barYaml, "@VERSION@", "2.0", -1), "20")
-	ms.serveSnap(barPath, "20")
+	barPath, _ := s.makeStoreTestSnap(c, strings.Replace(barYaml, "@VERSION@", "2.0", -1), "20")
+	s.serveSnap(barPath, "20")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2148,7 +2148,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2162,7 +2162,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2190,7 +2190,7 @@ apps:
 	// bar gets only the latter
 	// app1 is transferred from foo to bar
 	// UpdateMany after a snap-declaration refresh handles all of this
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 		"aliases": []interface{}{
 			map[string]interface{}{"name": "app2", "target": "app2"},
@@ -2206,8 +2206,8 @@ apps:
 	})
 
 	// new foo version/revision
-	fooPath, _ = ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
-	ms.serveSnap(fooPath, "15")
+	fooPath, _ = s.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
+	s.serveSnap(fooPath, "15")
 
 	// refresh all
 	err = assertstate.RefreshSnapDeclarations(st, 0)
@@ -2225,7 +2225,7 @@ apps:
 	chg.AddAll(tss[2])
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2267,25 +2267,25 @@ apps:
 	c.Check(dest, Equals, "bar.app3")
 }
 
-func (ms *mgrsSuite) TestHappyStopWhileDownloadingHeader(c *C) {
-	ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) TestHappyStopWhileDownloadingHeader(c *C) {
+	s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 version: 1.0
 `
-	snapPath, _ := ms.makeStoreTestSnap(c, snapYamlContent, "42")
-	ms.serveSnap(snapPath, "42")
+	snapPath, _ := s.makeStoreTestSnap(c, snapYamlContent, "42")
+	s.serveSnap(snapPath, "42")
 
 	stopped := make(chan struct{})
-	ms.hijackServeSnap = func(_ http.ResponseWriter) {
-		ms.o.Stop()
+	s.hijackServeSnap = func(_ http.ResponseWriter) {
+		s.o.Stop()
 		close(stopped)
 	}
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2295,7 +2295,7 @@ version: 1.0
 	chg.AddAll(ts)
 
 	st.Unlock()
-	ms.o.Loop()
+	s.o.Loop()
 
 	<-stopped
 
@@ -2303,30 +2303,30 @@ version: 1.0
 	c.Assert(chg.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 }
 
-func (ms *mgrsSuite) TestHappyStopWhileDownloadingBody(c *C) {
-	ms.prereqSnapAssertions(c)
+func (s *mgrsSuite) TestHappyStopWhileDownloadingBody(c *C) {
+	s.prereqSnapAssertions(c)
 
 	snapYamlContent := `name: foo
 version: 1.0
 `
-	snapPath, _ := ms.makeStoreTestSnap(c, snapYamlContent, "42")
-	ms.serveSnap(snapPath, "42")
+	snapPath, _ := s.makeStoreTestSnap(c, snapYamlContent, "42")
+	s.serveSnap(snapPath, "42")
 
 	stopped := make(chan struct{})
-	ms.hijackServeSnap = func(w http.ResponseWriter) {
+	s.hijackServeSnap = func(w http.ResponseWriter) {
 		w.WriteHeader(200)
 		// best effort to reach the body reading part in the client
 		w.Write(make([]byte, 10000))
 		time.Sleep(100 * time.Millisecond)
 		w.Write(make([]byte, 10000))
-		ms.o.Stop()
+		s.o.Stop()
 		close(stopped)
 	}
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2336,7 +2336,7 @@ version: 1.0
 	chg.AddAll(ts)
 
 	st.Unlock()
-	ms.o.Loop()
+	s.o.Loop()
 
 	<-stopped
 
@@ -2549,11 +2549,11 @@ apps:
   command: bin/bar
 `
 
-func (ms *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snapYaml2 string) {
+func (s *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snapYaml2 string) {
 	snapPath1 := makeTestSnap(c, snapYaml1+"version: 1.0")
 	snapPath2 := makeTestSnap(c, snapYaml2+"version: 1.0")
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2569,7 +2569,7 @@ func (ms *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snap
 	chg.AddAll(ts2)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2594,7 +2594,7 @@ func (ms *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snap
 	c.Assert(st.Get("conns", &conns), IsNil)
 	c.Assert(conns, HasLen, 1)
 
-	repo := ms.o.InterfaceManager().Repository()
+	repo := s.o.InterfaceManager().Repository()
 	cn, err := repo.Connected("snap1", "shared-data-plug")
 	c.Assert(err, IsNil)
 	c.Assert(cn, HasLen, 1)
@@ -2604,20 +2604,20 @@ func (ms *mgrsSuite) testTwoInstalls(c *C, snapName1, snapYaml1, snapName2, snap
 	}})
 }
 
-func (ms *mgrsSuite) TestTwoInstallsWithAutoconnectPlugSnapFirst(c *C) {
-	ms.testTwoInstalls(c, "snap1", snapYamlContent1, "snap2", snapYamlContent2)
+func (s *mgrsSuite) TestTwoInstallsWithAutoconnectPlugSnapFirst(c *C) {
+	s.testTwoInstalls(c, "snap1", snapYamlContent1, "snap2", snapYamlContent2)
 }
 
-func (ms *mgrsSuite) TestTwoInstallsWithAutoconnectSlotSnapFirst(c *C) {
-	ms.testTwoInstalls(c, "snap2", snapYamlContent2, "snap1", snapYamlContent1)
+func (s *mgrsSuite) TestTwoInstallsWithAutoconnectSlotSnapFirst(c *C) {
+	s.testTwoInstalls(c, "snap2", snapYamlContent2, "snap1", snapYamlContent1)
 }
 
-func (ms *mgrsSuite) TestRemoveAndInstallWithAutoconnectHappy(c *C) {
-	st := ms.o.State()
+func (s *mgrsSuite) TestRemoveAndInstallWithAutoconnectHappy(c *C) {
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
-	_ = ms.installLocalTestSnap(c, snapYamlContent1+"version: 1.0")
+	_ = s.installLocalTestSnap(c, snapYamlContent1+"version: 1.0")
 
 	ts, err := snapstate.Remove(st, "snap1", snap.R(0), nil)
 	c.Assert(err, IsNil)
@@ -2631,7 +2631,7 @@ func (ms *mgrsSuite) TestRemoveAndInstallWithAutoconnectHappy(c *C) {
 	c.Assert(err, IsNil)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2647,7 +2647,7 @@ apps:
         plugs: [media-hub]
 `
 
-func (ms *mgrsSuite) TestUpdateManyWithAutoconnect(c *C) {
+func (s *mgrsSuite) TestUpdateManyWithAutoconnect(c *C) {
 	const someSnapYaml = `name: some-snap
 version: 1.0
 apps:
@@ -2661,19 +2661,19 @@ apps:
 type: os
 version: @VERSION@`
 
-	snapPath, _ := ms.makeStoreTestSnap(c, someSnapYaml, "40")
-	ms.serveSnap(snapPath, "40")
+	snapPath, _ := s.makeStoreTestSnap(c, someSnapYaml, "40")
+	s.serveSnap(snapPath, "40")
 
-	snapPath, _ = ms.makeStoreTestSnap(c, otherSnapYaml, "50")
-	ms.serveSnap(snapPath, "50")
+	snapPath, _ = s.makeStoreTestSnap(c, otherSnapYaml, "50")
+	s.serveSnap(snapPath, "50")
 
-	corePath, _ := ms.makeStoreTestSnap(c, strings.Replace(coreSnapYaml, "@VERSION@", "30", -1), "30")
-	ms.serveSnap(corePath, "30")
+	corePath, _ := s.makeStoreTestSnap(c, strings.Replace(coreSnapYaml, "@VERSION@", "30", -1), "30")
+	s.serveSnap(corePath, "30")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2715,7 +2715,7 @@ version: @VERSION@`
 		SnapType: "app",
 	})
 
-	repo := ms.o.InterfaceManager().Repository()
+	repo := s.o.InterfaceManager().Repository()
 
 	// add snaps to the repo to have plugs/slots
 	c.Assert(repo.AddSnap(snapInfo), IsNil)
@@ -2742,7 +2742,7 @@ version: @VERSION@`
 	tts[2].Tasks()[0].SetStatus(state.HoldStatus)
 
 	st.Unlock()
-	err = ms.o.Settle(3 * time.Second)
+	err = s.o.Settle(3 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2751,7 +2751,7 @@ version: @VERSION@`
 	tts[2].Tasks()[0].SetStatus(state.DefaultStatus)
 	st.Unlock()
 
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 
 	c.Assert(err, IsNil)
@@ -2772,7 +2772,7 @@ version: @VERSION@`
 	c.Assert(connections, HasLen, 3)
 }
 
-func (ms *mgrsSuite) TestUpdateWithAutoconnectAndInactiveRevisions(c *C) {
+func (s *mgrsSuite) TestUpdateWithAutoconnectAndInactiveRevisions(c *C) {
 	const someSnapYaml = `name: some-snap
 version: 1.0
 apps:
@@ -2784,13 +2784,13 @@ apps:
 type: os
 version: 1`
 
-	snapPath, _ := ms.makeStoreTestSnap(c, someSnapYaml, "40")
-	ms.serveSnap(snapPath, "40")
+	snapPath, _ := s.makeStoreTestSnap(c, someSnapYaml, "40")
+	s.serveSnap(snapPath, "40")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2818,7 +2818,7 @@ version: 1`
 		SnapType: "app",
 	})
 
-	repo := ms.o.InterfaceManager().Repository()
+	repo := s.o.InterfaceManager().Repository()
 
 	// add snaps to the repo to have plugs/slots
 	c.Assert(repo.AddSnap(snapInfo), IsNil)
@@ -2839,7 +2839,7 @@ version: 1`
 	chg.AddAll(tts[0])
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 
 	c.Assert(err, IsNil)
@@ -2861,17 +2861,17 @@ apps:
         slots: [media-hub]
 `
 
-func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeSnapName string) {
-	snapPath, _ := ms.makeStoreTestSnap(c, someSnapYaml, "40")
-	ms.serveSnap(snapPath, "40")
+func (s *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeSnapName string) {
+	snapPath, _ := s.makeStoreTestSnap(c, someSnapYaml, "40")
+	s.serveSnap(snapPath, "40")
 
-	snapPath, _ = ms.makeStoreTestSnap(c, otherSnapYaml, "50")
-	ms.serveSnap(snapPath, "50")
+	snapPath, _ = s.makeStoreTestSnap(c, otherSnapYaml, "50")
+	s.serveSnap(snapPath, "50")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -2898,7 +2898,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 		SnapType: "app",
 	})
 
-	repo := ms.o.InterfaceManager().Repository()
+	repo := s.o.InterfaceManager().Repository()
 
 	// add snaps to the repo to have plugs/slots
 	c.Assert(repo.AddSnap(snapInfo), IsNil)
@@ -2934,7 +2934,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	var autoconnectLog string
 	for i := 0; i < 50 && !retryCheck; i++ {
 		st.Unlock()
-		ms.o.Settle(aggressiveSettleTimeout)
+		s.o.Settle(aggressiveSettleTimeout)
 		st.Lock()
 
 		for _, t := range st.Tasks() {
@@ -2952,7 +2952,7 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	// back to default state, that will unblock autoconnect
 	ts2.Tasks()[0].SetStatus(state.DefaultStatus)
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -2965,15 +2965,15 @@ func (ms *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, remove
 	c.Assert(conns, HasLen, 0)
 }
 
-func (ms *mgrsSuite) TestUpdateWithAutoconnectRetrySlotSide(c *C) {
-	ms.testUpdateWithAutoconnectRetry(c, "some-snap", "other-snap")
+func (s *mgrsSuite) TestUpdateWithAutoconnectRetrySlotSide(c *C) {
+	s.testUpdateWithAutoconnectRetry(c, "some-snap", "other-snap")
 }
 
-func (ms *mgrsSuite) TestUpdateWithAutoconnectRetryPlugSide(c *C) {
-	ms.testUpdateWithAutoconnectRetry(c, "other-snap", "some-snap")
+func (s *mgrsSuite) TestUpdateWithAutoconnectRetryPlugSide(c *C) {
+	s.testUpdateWithAutoconnectRetry(c, "other-snap", "some-snap")
 }
 
-func (ms *mgrsSuite) TestDisconnectIgnoredOnSymmetricRemove(c *C) {
+func (s *mgrsSuite) TestDisconnectIgnoredOnSymmetricRemove(c *C) {
 	const someSnapYaml = `name: some-snap
 version: 1.0
 apps:
@@ -2992,7 +2992,7 @@ apps:
 hooks:
    disconnect-plug-media-hub:
 `
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -3021,7 +3021,7 @@ hooks:
 		SnapType: "app",
 	})
 
-	repo := ms.o.InterfaceManager().Repository()
+	repo := s.o.InterfaceManager().Repository()
 
 	// add snaps to the repo to have plugs/slots
 	c.Assert(repo.AddSnap(snapInfo), IsNil)
@@ -3043,7 +3043,7 @@ hooks:
 	chg2.AddAll(ts2)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -3081,8 +3081,8 @@ hooks:
 	c.Assert(err, ErrorMatches, `snap "other-snap" has no plug or slot named "media-hub"`)
 }
 
-func (ms *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
-	st := ms.o.State()
+func (s *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -3109,7 +3109,7 @@ func (ms *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
 		SnapType: "app",
 	})
 
-	repo := ms.o.InterfaceManager().Repository()
+	repo := s.o.InterfaceManager().Repository()
 
 	// add snaps to the repo to have plugs/slots
 	c.Assert(repo.AddSnap(snapInfo), IsNil)
@@ -3125,7 +3125,7 @@ func (ms *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -3216,19 +3216,19 @@ func (a byReadyTime) Len() int           { return len(a) }
 func (a byReadyTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byReadyTime) Less(i, j int) bool { return a[i].ReadyTime().Before(a[j].ReadyTime()) }
 
-func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
+func (s *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	for _, name := range []string{"foo", "bar", "baz"} {
-		ms.prereqSnapAssertions(c, map[string]interface{}{
+		s.prereqSnapAssertions(c, map[string]interface{}{
 			"snap-name": name,
 		})
-		snapPath, _ := ms.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", name), "1")
-		ms.serveSnap(snapPath, "1")
+		snapPath, _ := s.makeStoreTestSnap(c, fmt.Sprintf("{name: %s, version: 1.0}", name), "1")
+		s.serveSnap(snapPath, "1")
 	}
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -3243,9 +3243,9 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	})
 
 	// create/set custom model assertion
-	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
 
-	model := ms.brands.Model("my-brand", "my-model", modelDefaults)
+	model := s.brands.Model("my-brand", "my-model", modelDefaults)
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
@@ -3257,7 +3257,7 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	c.Assert(err, IsNil)
 
 	// create a new model
-	newModel := ms.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
 		"required-snaps": []interface{}{"foo", "bar", "baz"},
 		"revision":       "1",
 	})
@@ -3266,7 +3266,7 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	c.Assert(err, IsNil)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -3312,26 +3312,26 @@ func (ms *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	c.Assert(tasks, HasLen, i+1)
 }
 
-func (ms *mgrsSuite) TestRemodelDifferentBase(c *C) {
+func (s *mgrsSuite) TestRemodelDifferentBase(c *C) {
 	// make "core18" snap available in the store
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "core18",
 	})
 	snapYamlContent := `name: core18
 version: 18.04
 type: base`
-	snapPath, _ := ms.makeStoreTestSnap(c, snapYamlContent, "18")
-	ms.serveSnap(snapPath, "18")
+	snapPath, _ := s.makeStoreTestSnap(c, snapYamlContent, "18")
+	s.serveSnap(snapPath, "18")
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
 	// create/set custom model assertion
-	model := ms.brands.Model("can0nical", "my-model", modelDefaults)
+	model := s.brands.Model("can0nical", "my-model", modelDefaults)
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "can0nical",
@@ -3342,7 +3342,7 @@ type: base`
 	c.Assert(err, IsNil)
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
 		"base":     "core18",
 		"revision": "1",
 	})
@@ -3352,7 +3352,7 @@ type: base`
 	c.Assert(chg, IsNil)
 }
 
-func (ms *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
+func (s *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
 	loader := boottest.NewMockBootloader("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
@@ -3360,10 +3360,10 @@ func (ms *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	mockServer := ms.mockStore(c)
+	mockServer := s.mockStore(c)
 	defer mockServer.Close()
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -3378,17 +3378,17 @@ func (ms *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
 	const kernelYaml = `name: pc-kernel
 type: kernel
 version: 2.0`
-	snapPath, _ := ms.makeStoreTestSnap(c, kernelYaml, "2")
-	ms.serveSnap(snapPath, "2")
+	snapPath, _ := s.makeStoreTestSnap(c, kernelYaml, "2")
+	s.serveSnap(snapPath, "2")
 
-	ms.prereqSnapAssertions(c, map[string]interface{}{
+	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 	})
-	snapPath, _ = ms.makeStoreTestSnap(c, `{name: "foo", version: 1.0}`, "1")
-	ms.serveSnap(snapPath, "1")
+	snapPath, _ = s.makeStoreTestSnap(c, `{name: "foo", version: 1.0}`, "1")
+	s.serveSnap(snapPath, "1")
 
 	// create/set custom model assertion
-	model := ms.brands.Model("can0nical", "my-model", modelDefaults)
+	model := s.brands.Model("can0nical", "my-model", modelDefaults)
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand:  "can0nical",
@@ -3399,7 +3399,7 @@ version: 2.0`
 	c.Assert(err, IsNil)
 
 	// create a new model
-	newModel := ms.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
+	newModel := s.brands.Model("can0nical", "my-model", modelDefaults, map[string]interface{}{
 		"kernel":         "pc-kernel=18",
 		"revision":       "1",
 		"required-snaps": []interface{}{"foo"},
@@ -3409,7 +3409,7 @@ version: 2.0`
 	c.Assert(err, IsNil)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -3423,7 +3423,7 @@ version: 2.0`
 
 	// continue
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -3447,8 +3447,8 @@ version: 2.0`
 	c.Assert(tasks, HasLen, i+1)
 }
 
-func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
-	model := ms.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+func (s *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
+	model := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
 		"gadget": "gadget",
 	})
 
@@ -3459,11 +3459,11 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	err = kpMgr.Put(deviceKey)
 	c.Assert(err, IsNil)
 
-	st := ms.o.State()
+	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
 
-	assertstatetest.AddMany(st, ms.brands.AccountsAndKeys("my-brand")...)
+	assertstatetest.AddMany(st, s.brands.AccountsAndKeys("my-brand")...)
 	devicestatetest.SetDevice(st, &auth.DeviceState{
 		Brand: "my-brand",
 		Model: "my-model",
@@ -3478,7 +3478,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 		c.Check(brandID, Equals, "my-brand")
 		c.Check(model, Equals, "my-model")
 		headers["authority-id"] = brandID
-		return ms.brands.Signing("my-brand").Sign(asserts.SerialType, headers, body, "")
+		return s.brands.Signing("my-brand").Sign(asserts.SerialType, headers, body, "")
 	}
 
 	bhv := &devicestatetest.DeviceServiceBehavior{
@@ -3507,7 +3507,7 @@ func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 
 	// run the whole device registration process
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -136,6 +136,8 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	s.tempdir = c.MkDir()
 	dirs.SetRootDir(s.tempdir)
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
 
@@ -161,6 +163,7 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 	s.AddCleanup(ifacestate.MockConnectRetryTimeout(connectRetryTimeout))
 
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
+	s.AddCleanup(func() { os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS") })
 
 	// create a fake systemd environment
 	os.MkdirAll(filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants"), 0755)
@@ -315,12 +318,6 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 	snapstate.CanAutoRefresh = nil
 
 	st.Set("refresh-privacy-key", "privacy-key")
-}
-
-func (s *mgrsSuite) TearDownTest(c *C) {
-	s.BaseTest.TearDownTest(c)
-	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	dirs.SetRootDir("")
 }
 
 var settleTimeout = 15 * time.Second

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -35,6 +35,8 @@ import (
 
 // A StoreService can find, list available updates and download snaps.
 type StoreService interface {
+	EnsureDeviceSession() (*auth.DeviceState, error)
+
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -666,15 +666,15 @@ func installGeneric(st *state.State, name, channel, cohort string, revision snap
 		return nil, errors.New("cannot specify revision and cohort")
 	}
 
-	return InstallUnderDeviceContext(st, name, channel, cohort, revision, userID, flags, nil)
+	return InstallWithDeviceContext(st, name, channel, cohort, revision, userID, flags, nil)
 }
 
-// InstallUnderDeviceContext returns a set of tasks for installing snap.
-// It will query for the snap under the given deviceCtx.
+// InstallWithDeviceContext returns a set of tasks for installing snap.
+// It will query for the snap with the given deviceCtx.
 // Note that the state must be locked by the caller.
 //
 // The returned TaskSet will contain a DownloadAndChecksDoneEdge.
-func InstallUnderDeviceContext(st *state.State, name, channel, cohort string, revision snap.Revision, userID int, flags Flags, deviceCtx DeviceContext) (*state.TaskSet, error) {
+func InstallWithDeviceContext(st *state.State, name, channel, cohort string, revision snap.Revision, userID int, flags Flags, deviceCtx DeviceContext) (*state.TaskSet, error) {
 	if channel == "" {
 		channel = "stable"
 	}
@@ -1263,15 +1263,15 @@ type RevisionOptions struct {
 //
 // The returned TaskSet will contain a DownloadAndChecksDoneEdge.
 func Update(st *state.State, name string, opts *RevisionOptions, userID int, flags Flags) (*state.TaskSet, error) {
-	return UpdateUnderDeviceContext(st, name, opts, userID, flags, nil)
+	return UpdateWithDeviceContext(st, name, opts, userID, flags, nil)
 }
 
-// UpdateUnderDeviceContext initiates a change updating a snap.
-// It will query for the snap under the given deviceCtx.
+// UpdateWithDeviceContext initiates a change updating a snap.
+// It will query for the snap with the given deviceCtx.
 // Note that the state must be locked by the caller.
 //
 // The returned TaskSet will contain a DownloadAndChecksDoneEdge.
-func UpdateUnderDeviceContext(st *state.State, name string, opts *RevisionOptions, userID int, flags Flags, deviceCtx DeviceContext) (*state.TaskSet, error) {
+func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions, userID int, flags Flags, deviceCtx DeviceContext) (*state.TaskSet, error) {
 	if opts == nil {
 		opts = &RevisionOptions{}
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -647,7 +647,7 @@ func TryPath(st *state.State, name, path string, flags Flags) (*state.TaskSet, e
 	return ts, err
 }
 
-// Install returns a set of tasks for installing snap.
+// Install returns a set of tasks for installing a snap.
 // Note that the state must be locked by the caller.
 //
 // The returned TaskSet will contain a DownloadAndChecksDoneEdge.
@@ -669,7 +669,7 @@ func installGeneric(st *state.State, name, channel, cohort string, revision snap
 	return InstallWithDeviceContext(st, name, channel, cohort, revision, userID, flags, nil)
 }
 
-// InstallWithDeviceContext returns a set of tasks for installing snap.
+// InstallWithDeviceContext returns a set of tasks for installing a snap.
 // It will query for the snap with the given deviceCtx.
 // Note that the state must be locked by the caller.
 //

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -627,7 +627,7 @@ func (s *snapmgrTestSuite) TestInstallCohortTasks(c *C) {
 
 }
 
-func (s *snapmgrTestSuite) TestInstallUnderDeviceContext(c *C) {
+func (s *snapmgrTestSuite) TestInstallWithDeviceContext(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -636,7 +636,7 @@ func (s *snapmgrTestSuite) TestInstallUnderDeviceContext(c *C) {
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{CtxStore: s.fakeStore}
 
-	ts, err := snapstate.InstallUnderDeviceContext(s.state, "some-snap", "some-channel", "", snap.R(0), 0, snapstate.Flags{}, deviceCtx)
+	ts, err := snapstate.InstallWithDeviceContext(s.state, "some-snap", "some-channel", "", snap.R(0), 0, snapstate.Flags{}, deviceCtx)
 	c.Assert(err, IsNil)
 
 	verifyInstallTasks(c, 0, 0, ts, s.state)
@@ -2170,7 +2170,7 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 	c.Check(snapsup.Channel, Equals, "some-channel")
 }
 
-func (s *snapmgrTestSuite) TestUpdateUnderDeviceContext(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2199,7 +2199,7 @@ func (s *snapmgrTestSuite) TestUpdateUnderDeviceContext(c *C) {
 	// hook it up
 	snapstate.ValidateRefreshes = happyValidateRefreshes
 
-	ts, err := snapstate.UpdateUnderDeviceContext(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{}, deviceCtx)
+	ts, err := snapstate.UpdateWithDeviceContext(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{}, deviceCtx)
 	c.Assert(err, IsNil)
 	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts, s.state)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
@@ -2207,7 +2207,7 @@ func (s *snapmgrTestSuite) TestUpdateUnderDeviceContext(c *C) {
 	c.Check(validateCalled, Equals, true)
 }
 
-func (s *snapmgrTestSuite) TestUpdateUnderDeviceContextToRevision(c *C) {
+func (s *snapmgrTestSuite) TestUpdateWithDeviceContextToRevision(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2230,7 +2230,7 @@ func (s *snapmgrTestSuite) TestUpdateUnderDeviceContextToRevision(c *C) {
 	})
 
 	opts := &snapstate.RevisionOptions{Channel: "some-channel", Revision: snap.R(11)}
-	ts, err := snapstate.UpdateUnderDeviceContext(s.state, "some-snap", opts, 0, snapstate.Flags{}, deviceCtx)
+	ts, err := snapstate.UpdateWithDeviceContext(s.state, "some-snap", opts, 0, snapstate.Flags{}, deviceCtx)
 	c.Assert(err, IsNil)
 	verifyUpdateTasks(c, unlinkBefore|cleanupAfter|doesReRefresh, 0, ts, s.state)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -41,6 +41,10 @@ type Store struct{}
 // ensure we conform
 var _ snapstate.StoreService = Store{}
 
+func (Store) EnsureDeviceSession() (*auth.DeviceState, error) {
+	panic("Store.EnsureDeviceSession not expected")
+}
+
 func (Store) SnapInfo(store.SnapSpec, *auth.UserState) (*snap.Info, error) {
 	panic("Store.SnapInfo not expected")
 }


### PR DESCRIPTION
This is done using the corresponding remodel context.

So it starts using the remodel contexts in Remodel and doSetModel.
