### PR TITLE
overlord/hookstate: don't run handler unless hooksup.Always

### DIFF
--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -775,6 +775,40 @@ func (s *hookManagerSuite) TestHookWithoutHookOptional(c *C) {
 	s.se.Ensure()
 	s.se.Wait()
 
+	c.Check(s.mockHandler.BeforeCalled, Equals, false)
+	c.Check(s.mockHandler.DoneCalled, Equals, false)
+	c.Check(s.mockHandler.ErrorCalled, Equals, false)
+
+	c.Check(s.command.Calls(), IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.DoneStatus)
+	c.Check(s.change.Status(), Equals, state.DoneStatus)
+
+	c.Logf("Task log:\n%s\n", s.task.Log())
+}
+
+func (s *hookManagerSuite) TestHookWithoutHookAlways(c *C) {
+	s.manager.Register(regexp.MustCompile("missing-hook"), func(context *hookstate.Context) hookstate.Handler {
+		return s.mockHandler
+	})
+
+	hooksup := &hookstate.HookSetup{
+		Snap:     "test-snap",
+		Hook:     "missing-hook",
+		Optional: true,
+		Always:   true,
+	}
+	s.state.Lock()
+	s.task.Set("hook-setup", hooksup)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
 	c.Check(s.mockHandler.BeforeCalled, Equals, true)
 	c.Check(s.mockHandler.DoneCalled, Equals, true)
 	c.Check(s.mockHandler.ErrorCalled, Equals, false)


### PR DESCRIPTION
Without this change, a non-hijacked hook in a snap that had no script
file would still result in the handler getting called. This change
avoids that: unless the (new) Always flag is set, the hook runner
bails early. This means we avoid a bunch of work (e.g. setting up the
context) for hooks that are going to no-op anyway, while avoiding (for
now) having to pass a flag to Done() to specify whether the script
actually ran. This last bit is important for health checks, and is the
driver for this change.
