### PR TITLE
testutil: support sharing-related mount flags

### DIFF
--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -126,6 +126,22 @@ func formatMountFlags(flags int) string {
 		flags ^= syscall.MS_RDONLY
 		fl = append(fl, "MS_RDONLY")
 	}
+	if flags&syscall.MS_SHARED == syscall.MS_SHARED {
+		flags ^= syscall.MS_SHARED
+		fl = append(fl, "MS_SHARED")
+	}
+	if flags&syscall.MS_SLAVE == syscall.MS_SLAVE {
+		flags ^= syscall.MS_SLAVE
+		fl = append(fl, "MS_SLAVE")
+	}
+	if flags&syscall.MS_PRIVATE == syscall.MS_PRIVATE {
+		flags ^= syscall.MS_PRIVATE
+		fl = append(fl, "MS_PRIVATE")
+	}
+	if flags&syscall.MS_UNBINDABLE == syscall.MS_UNBINDABLE {
+		flags ^= syscall.MS_UNBINDABLE
+		fl = append(fl, "MS_UNBINDABLE")
+	}
 	if flags != 0 {
 		panic(fmt.Errorf("unrecognized mount flags %d", flags))
 	}

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -361,6 +361,25 @@ func (s *lowLevelSuite) TestMountSuccess(c *check.C) {
 	})
 }
 
+func (s *lowLevelSuite) TestMountPropagation(c *check.C) {
+	c.Assert(s.sys.Mount("", "target", "", syscall.MS_SHARED, ""), check.IsNil)
+	c.Assert(s.sys.Mount("", "target", "", syscall.MS_SLAVE, ""), check.IsNil)
+	c.Assert(s.sys.Mount("", "target", "", syscall.MS_PRIVATE, ""), check.IsNil)
+	c.Assert(s.sys.Mount("", "target", "", syscall.MS_UNBINDABLE, ""), check.IsNil)
+	c.Assert(s.sys.Calls(), check.DeepEquals, []string{
+		`mount "" "target" "" MS_SHARED ""`,
+		`mount "" "target" "" MS_SLAVE ""`,
+		`mount "" "target" "" MS_PRIVATE ""`,
+		`mount "" "target" "" MS_UNBINDABLE ""`,
+	})
+	c.Assert(s.sys.RCalls(), check.DeepEquals, []testutil.CallResultError{
+		{C: `mount "" "target" "" MS_SHARED ""`},
+		{C: `mount "" "target" "" MS_SLAVE ""`},
+		{C: `mount "" "target" "" MS_PRIVATE ""`},
+		{C: `mount "" "target" "" MS_UNBINDABLE ""`},
+	})
+}
+
 func (s *lowLevelSuite) TestMountFailure(c *check.C) {
 	s.sys.InsertFault(`mount "source" "target" "fstype" 0 ""`, syscall.EPERM)
 	err := s.sys.Mount("source", "target", "fstype", 0, "")


### PR DESCRIPTION
This allows tests to use MS_SHARED, MS_SLAVE, MS_PRIVATE and MS_UNBINDABLE
along with system call testing machinery.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
