### PR TITLE
cmd/snap: allow option descriptions to start with the command

### DIFF
--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -64,7 +64,7 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"command": i18n.G("Advise on snaps that provide the given command"),
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"from-apt": i18n.G("Advise will talk to apt via an apt hook"),
+		"from-apt": i18n.G("Run as an apt hook"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"format": i18n.G("Use the given output format"),
 	}, []argDesc{

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -146,11 +146,7 @@ func lintDesc(cmdName, optName, desc, origDesc string) {
 		// decode the first rune instead of converting all of desc into []rune
 		r, _ := utf8.DecodeRuneInString(desc)
 		// note IsLower != !IsUpper for runes with no upper/lower.
-		// Also note that login.u.c. is the only exception we're allowing for
-		// now, but the list of exceptions could grow -- if it does, we might
-		// want to change it to check for urlish things instead of just
-		// login.u.c.
-		if unicode.IsLower(r) && !strings.HasPrefix(desc, "login.ubuntu.com") {
+		if unicode.IsLower(r) && !strings.HasPrefix(desc, "login.ubuntu.com") && !strings.HasPrefix(desc, cmdName) {
 			noticef("description of %s's %q is lowercase: %q", cmdName, optName, desc)
 		}
 	}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -370,6 +370,10 @@ func (s *SnapSuite) TestLintDesc(c *C) {
 	}
 	c.Check(fn, PanicMatches, `option on "command" has no name`)
 	log.Reset()
+
+	snap.LintDesc("snap-advise", "from-apt", "snap-advise will run as a hook", "")
+	c.Check(log.String(), HasLen, 0)
+	log.Reset()
 }
 
 func (s *SnapSuite) TestLintArg(c *C) {


### PR DESCRIPTION
Before this change, option descriptions that were slightly
self-referential and started with the command name would trigger the
linter warning:

    2018/12/12 19:51:16.123791 main.go:152: description of advise-snap's "from-apt" is lowercase: "advise-snap vil tale med apt via en apt-hook"

this change makes it so that an option description can start with the
command without raising a warning.

It also fixes that particular option to be more correct, and
discourages this particular translation.
