### PR TITLE
cmd/snap-update-ns: allow changing mount propagation

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -308,7 +308,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			}
 			logger.Debugf("mount %q %q %q %d %q (error: %v)", c.Entry.Name, c.Entry.Dir, c.Entry.Type, flagsForMount, strings.Join(unparsed, ","), err)
 			if err == nil && maskedFlagsPropagation != 0 {
-				// now change mount propagationi (shared/rshared, private/rprivate,
+				// now change mount propagation (shared/rshared, private/rprivate,
 				// slave/rslave, unbindable/runbindable).
 				flagsForMount := uintptr(maskedFlagsPropagation | maskedFlagsRecursive)
 				err = sysMount("", c.Entry.Dir, "", flagsForMount, "")

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -290,7 +290,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 		case "", "file":
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
 			// Split the mount flags from the event propagation changes.
-			// Those have to be applied happen separately.
+			// Those have to be applied separately.
 			const sharingFlags = syscall.MS_SHARED | syscall.MS_SLAVE | syscall.MS_PRIVATE | syscall.MS_UNBINDABLE
 			flagsJustRecursive := flags & syscall.MS_REC
 			flagsJustSharing := flags & sharingFlags

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -296,17 +296,17 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			maskedFlagsPropagation := flags & propagationMask
 			maskedFlagsNotPropagationNotRecursive := flags & ^(propagationMask | syscall.MS_REC)
 
+			var flagsForMount uintptr
 			if flags&syscall.MS_BIND == syscall.MS_BIND {
 				// bind / rbind mount
-				flagsForMount := uintptr(maskedFlagsNotPropagationNotRecursive | maskedFlagsRecursive)
+				flagsForMount = uintptr(maskedFlagsNotPropagationNotRecursive | maskedFlagsRecursive)
 				err = BindMount(c.Entry.Name, c.Entry.Dir, uint(flagsForMount))
-				logger.Debugf("mount %q %q %q %d %q (error: %v)", c.Entry.Name, c.Entry.Dir, c.Entry.Type, flagsForMount, strings.Join(unparsed, ","), err)
 			} else {
 				// normal mount, not bind / rbind, not propagation change
-				flagsForMount := uintptr(maskedFlagsNotPropagationNotRecursive)
+				flagsForMount = uintptr(maskedFlagsNotPropagationNotRecursive)
 				err = sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flagsForMount), strings.Join(unparsed, ","))
-				logger.Debugf("mount %q %q %q %d %q (error: %v)", c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flagsForMount), strings.Join(unparsed, ","), err)
 			}
+			logger.Debugf("mount %q %q %q %d %q (error: %v)", c.Entry.Name, c.Entry.Dir, c.Entry.Type, flagsForMount, strings.Join(unparsed, ","), err)
 			if err == nil && maskedFlagsPropagation != 0 {
 				// now change mount propagationi (shared/rshared, private/rprivate,
 				// slave/rslave, unbindable/runbindable).


### PR DESCRIPTION
When snap-update-ns mount something it used to special-case bind-mounts
vs filesystem mounts but otherwise use a single mount system call for
the actual operation.

To support configuring mount event propagation we need to perform up to
two mount system calls: one that establishes the mount point and another
that configures the propagation changes.

This patch changes the low-level mount change perform function to do
this. The mount flags are separated into sets: recursive flag, sharing
flags, other flags. Bind mounts are performed with recursive flag +
other flags. Non-bind mounts are performed with other flags only. Mount
event propagation changes are performed with sharing flags + recursive
flag, and only if sharing changes are necessary.

This matches the logic documented by the mount(1) utility which performs
the same operation as two distinct steps.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
