### PR TITLE
gadget: offset-write: fix validation, calculate absolute position

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -407,12 +407,6 @@ func validateCrossVolumeStructure(structures []PositionedStructure, knownStructu
 				return fmt.Errorf("structure %v refers to an unknown structure %q",
 					ps, ps.OffsetWrite.RelativeTo)
 			}
-			// make sure there is enough room left in the structure to write the pointer
-			if other.Size < SizeLBA48Pointer || ps.OffsetWrite.Offset > (other.Size-SizeLBA48Pointer) {
-				return fmt.Errorf("structure %v offset-write crosses structure %v size",
-					ps, other)
-			}
-
 		}
 
 		if ps.StartOffset < previousEnd {
@@ -432,11 +426,6 @@ func validateCrossVolumeStructure(structures []PositionedStructure, knownStructu
 			relativeToStructure := knownStructures[c.OffsetWrite.RelativeTo]
 			if relativeToStructure == nil {
 				return fmt.Errorf("structure %v, content %v refers to an unknown structure %q",
-					ps, fmtIndexAndName(cidx, c.Image), c.OffsetWrite.RelativeTo)
-			}
-			// make sure there is enough room left in the structure to write the pointer
-			if relativeToStructure.Size < SizeLBA48Pointer || c.OffsetWrite.Offset > (relativeToStructure.Size-SizeLBA48Pointer) {
-				return fmt.Errorf("structure %v, content %v offset-write crosses structure %q size",
 					ps, fmtIndexAndName(cidx, c.Image), c.OffsetWrite.RelativeTo)
 			}
 		}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -960,52 +960,6 @@ volumes:
           - image: pc-core.img
             offset-write: bad-name+123
 `
-	gadgetYamlBadOffsetWriteCrossingSize := gadgetYamlHeader + `
-      - name: other-name
-        type: bare
-        size: 1M
-        offset: 1M
-        offset-write: my-name-is+438
-        content:
-          - image: pc-core.img
-`
-	gadgetYamlBadContentOffsetWriteCrossingSize := gadgetYamlHeader + `
-      - name: other-name
-        type: bare
-        size: 1M
-        offset: 1M
-        content:
-          - image: pc-core.img
-            offset-write: my-name-is+438
-`
-
-	gadgetYamlHeaderSmall := `
-volumes:
-  pc:
-    bootloader: grub
-    structure:
-      - name: too-small
-        type: bare
-        size: 3
-`
-	gadgetYamlBadContentOffsetWriteTooSmall := gadgetYamlHeaderSmall + `
-      - name: other-name
-        type: bare
-        size: 1M
-        offset: 1M
-        content:
-          - image: pc-core.img
-            offset-write: too-small+0
-`
-	gadgetYamlBadOffsetWriteTooSmall := gadgetYamlHeaderSmall + `
-      - name: other-name
-        type: bare
-        size: 1M
-        offset: 1M
-        offset-write: too-small+0
-        content:
-          - image: pc-core.img
-`
 
 	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadStructureName), 0644)
 	c.Assert(err, IsNil)
@@ -1018,30 +972,6 @@ volumes:
 
 	_, err = gadget.ReadInfo(s.dir, false)
 	c.Check(err, ErrorMatches, `invalid volume "pc": structure #1 \("other-name"\), content #0 \("pc-core.img"\) refers to an unknown structure "bad-name"`)
-
-	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadOffsetWriteCrossingSize), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = gadget.ReadInfo(s.dir, false)
-	c.Check(err, ErrorMatches, `invalid volume "pc": structure #1 \("other-name"\) offset-write crosses structure #0 \("my-name-is"\) size`)
-
-	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadOffsetWriteTooSmall), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = gadget.ReadInfo(s.dir, false)
-	c.Check(err, ErrorMatches, `invalid volume "pc": structure #1 \("other-name"\) offset-write crosses structure #0 \("too-small"\) size`)
-
-	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadContentOffsetWriteCrossingSize), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = gadget.ReadInfo(s.dir, false)
-	c.Check(err, ErrorMatches, `invalid volume "pc": structure #1 \("other-name"\), content #0 \("pc-core.img"\) offset-write crosses structure "my-name-is" size`)
-
-	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadContentOffsetWriteTooSmall), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = gadget.ReadInfo(s.dir, false)
-	c.Check(err, ErrorMatches, `invalid volume "pc": structure #1 \("other-name"\), content #0 \("pc-core.img"\) offset-write crosses structure "too-small" size`)
 
 }
 

--- a/gadget/position.go
+++ b/gadget/position.go
@@ -243,9 +243,9 @@ func positionStructureContent(gadgetRootDir string, ps *PositionedStructure, kno
 
 		content[idx] = PositionedContent{
 			VolumeContent:         &ps.Content[idx],
+			Size:                  actualSize,
 			StartOffset:           ps.StartOffset + start,
 			PositionedOffsetWrite: offsetWrite,
-			Size:                  actualSize,
 		}
 		previousEnd = start + actualSize
 		if previousEnd > ps.Size {

--- a/gadget/position_test.go
+++ b/gadget/position_test.go
@@ -855,32 +855,34 @@ volumes:
 				Index:           0,
 			}, {
 				// foo
-				VolumeStructure:       &vol.Structure[1],
-				StartOffset:           1 * gadget.SizeMiB,
-				Index:                 1,
+				VolumeStructure: &vol.Structure[1],
+				StartOffset:     1 * gadget.SizeMiB,
+				Index:           1,
+				// break for gofmt < 1.11
 				PositionedOffsetWrite: asSizePtr(92),
 				PositionedContent: []gadget.PositionedContent{
 					{
 						VolumeContent: &vol.Structure[1].Content[0],
+						Size:          200 * gadget.SizeKiB,
 						StartOffset:   1 * gadget.SizeMiB,
 						// offset-write: bar+10
 						PositionedOffsetWrite: asSizePtr(2*gadget.SizeMiB + 10),
-						Size:                  200 * gadget.SizeKiB,
 					},
 				},
 			}, {
 				// bar
-				VolumeStructure:       &vol.Structure[2],
-				StartOffset:           2 * gadget.SizeMiB,
-				Index:                 2,
+				VolumeStructure: &vol.Structure[2],
+				StartOffset:     2 * gadget.SizeMiB,
+				Index:           2,
+				// break for gofmt < 1.11
 				PositionedOffsetWrite: asSizePtr(600),
 				PositionedContent: []gadget.PositionedContent{
 					{
 						VolumeContent: &vol.Structure[2].Content[0],
+						Size:          150 * gadget.SizeKiB,
 						StartOffset:   2 * gadget.SizeMiB,
 						// offset-write: bar+10
 						PositionedOffsetWrite: asSizePtr(450),
-						Size:                  150 * gadget.SizeKiB,
 					},
 				},
 			},


### PR DESCRIPTION
The series fixes handling of offset-write and adds support for calculating the absolute position.

I have misread the documentation. The property defines the position *within* the volume, even when referencing another structure by name. The validation code has been updated to handle this.

The positioning code calculates the absolute position of offset-write within the volume. Thus later processing can directly use the calculated position, rather than doing the calculations in place.

Since offset-write is the position within the volume it may end up being farther than the last structure. Thus the volume needs to be sized accordingly.

cc @cmatsuoka