### PR TITLE
systemd: workaround systemctl show quirks on older systemd versions

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -631,8 +631,8 @@ UnitFileState=potatoes
 Id=snap.foo.svc5.service
 ActiveState=inactive
 UnitFileState=static
-
-Id=snap.foo.svc5.timer
+`),
+		[]byte(`Id=snap.foo.svc5.timer
 ActiveState=active
 UnitFileState=enabled
 `),
@@ -640,8 +640,8 @@ UnitFileState=enabled
 Id=snap.foo.svc6.service
 ActiveState=inactive
 UnitFileState=static
-
-Id=snap.foo.svc6.sock.socket
+`),
+		[]byte(`Id=snap.foo.svc6.sock.socket
 ActiveState=active
 UnitFileState=enabled
 `),
@@ -649,8 +649,8 @@ UnitFileState=enabled
 Id=snap.foo.svc7.service
 ActiveState=inactive
 UnitFileState=static
-
-Id=snap.foo.svc7.other-sock.socket
+`),
+		[]byte(`Id=snap.foo.svc7.other-sock.socket
 ActiveState=inactive
 UnitFileState=enabled
 `),

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -287,13 +287,11 @@ var unitProperties = map[string][]string{
 	".mount": extendedProperties,
 }
 
-// Status fetches the status of given units. Statuses are returned in the same
-// order as unit names passed in argument.
-func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
+func getUnitStatus(properties []string, unitNames []string) ([]*UnitStatus, error) {
 	cmd := make([]string, len(unitNames)+2)
 	cmd[0] = "show"
 	// ask for all properties, regardless of unit type
-	cmd[1] = "--property=" + strings.Join(extendedProperties, ",")
+	cmd[1] = "--property=" + strings.Join(properties, ",")
 	copy(cmd[2:], unitNames)
 	bs, err := systemctlCmd(cmd...)
 	if err != nil {
@@ -367,6 +365,53 @@ func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
 
 	if len(sts) != len(unitNames) {
 		return nil, fmt.Errorf("cannot get unit status: expected %d results, got %d", len(unitNames), len(sts))
+	}
+	return sts, nil
+}
+
+// Status fetches the status of given units. Statuses are returned in the same
+// order as unit names passed in argument.
+func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
+	unitToStatus := make(map[string]*UnitStatus, len(unitNames))
+
+	var limitedUnits []string
+	var extendedUnits []string
+
+	for _, name := range unitNames {
+		if strings.HasSuffix(name, ".timer") || strings.HasSuffix(name, ".socket") {
+			limitedUnits = append(limitedUnits, name)
+		} else {
+			extendedUnits = append(extendedUnits, name)
+		}
+	}
+
+	for _, set := range []struct {
+		units      []string
+		properties []string
+	}{
+		{units: extendedUnits, properties: extendedProperties},
+		{units: limitedUnits, properties: baseProperties},
+	} {
+		if len(set.units) == 0 {
+			continue
+		}
+		sts, err := getUnitStatus(set.properties, set.units)
+		if err != nil {
+			return nil, err
+		}
+		for _, status := range sts {
+			unitToStatus[status.UnitName] = status
+		}
+	}
+
+	// unpack to preserve the promised order
+	sts := make([]*UnitStatus, len(unitNames))
+	for idx, name := range unitNames {
+		var ok bool
+		sts[idx], ok = unitToStatus[name]
+		if !ok {
+			return nil, fmt.Errorf("cannot determine status of unit %q", name)
+		}
 	}
 
 	return sts, nil

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -197,7 +197,8 @@ Type=potato
 Id=baz.service
 ActiveState=inactive
 UnitFileState=disabled
-
+`[1:]),
+		[]byte(`
 Id=some.timer
 ActiveState=active
 UnitFileState=enabled
@@ -237,7 +238,10 @@ UnitFileState=disabled
 		},
 	})
 	c.Check(s.rep.msgs, IsNil)
-	c.Assert(s.argses, DeepEquals, [][]string{{"show", "--property=Id,ActiveState,UnitFileState,Type", "foo.service", "bar.service", "baz.service", "some.timer", "other.socket"}})
+	c.Assert(s.argses, DeepEquals, [][]string{
+		{"show", "--property=Id,ActiveState,UnitFileState,Type", "foo.service", "bar.service", "baz.service"},
+		{"show", "--property=Id,ActiveState,UnitFileState", "some.timer", "other.socket"},
+	})
 }
 
 func (s *SystemdTestSuite) TestStatusBadNumberOfValues(c *C) {

--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -1,0 +1,21 @@
+summary: verify the output of 'snap services' command
+
+restore: |
+    rm -f ./*.out
+
+execute: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-service
+    install_local socket-activation
+    install_local test-snapd-timer-service
+
+    snap services test-snapd-timer-service > timer-service.out
+    MATCH '^test-snapd-timer-service.random-timer\s+ disabled\s+ (in)?active\s+ timer-activated$' < timer-service.out
+    MATCH '^test-snapd-timer-service.regular-timer\s+ disabled\s+ (in)?active\s+ timer-activated$' < timer-service.out
+
+    snap services socket-activation > socket-activation.out
+    MATCH '^socket-activation.sleep-daemon\s+ enabled\s+ inactive\s+ socket-activated$' < socket-activation.out
+
+    snap services test-snapd-service > test-snapd-service.out
+    MATCH '^test-snapd-service.test-snapd-service\s+ enabled\s+ active\s+ -$' < test-snapd-service.out


### PR DESCRIPTION
Older version of systemctl show --property=.. would exit with non-0 status when
asked for properties that are not defined for given type of unit. For example,
--property=Type fails for units of socket or timer type. On CentOS 7.6, snap
services would then drop an error like so:
```
$ snap services
error: cannot get status of services of app "daemon": [show
       --property=Id,ActiveState,UnitFileState,Type snap.lxd.daemon.service
       snap.lxd.daemon.unix.socket] failed with exit status 1: Type=simple
       Id=snap.lxd.daemon.service ActiveState=inactive UnitFileState=static

       Id=snap.lxd.daemon.unix.socket ActiveState=active UnitFileState=enabled
```
Workaround that by splitting how we ask for properties of systemd units which is
compatible with old and new systemd.

Fixes: https://bugs.launchpad.net/bugs/1828847