### PR TITLE
cmd/snap-confine: do not mount over non files/directories

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -324,30 +324,29 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 					continue;
 				}
 				die("cannot stat %s from desired rootfs", src);
-			} else {
-				if (!S_ISREG(src_stat.st_mode)
-				    && !S_ISDIR(src_stat.st_mode)) {
-					debug
-					    ("entry %s from the desired rootfs is not a file or directory, skipping mount",
-					     src);
-					continue;
-				}
 			}
+			if (!S_ISREG(src_stat.st_mode)
+			    && !S_ISDIR(src_stat.st_mode)) {
+				debug
+				    ("entry %s from the desired rootfs is not a file or directory, skipping mount",
+				     src);
+				continue;
+			}
+
 			if (lstat(dst, &dst_stat) != 0) {
 				if (errno == ENOENT) {
 					continue;
 				}
 				die("cannot stat %s from host", src);
-			} else {
-				if (!S_ISREG(dst_stat.st_mode)
-				    && !S_ISDIR(dst_stat.st_mode)) {
-					debug
-					    ("entry %s from the host is not a file or directory, skipping mount",
-					     src);
-					continue;
-				}
-
 			}
+			if (!S_ISREG(dst_stat.st_mode)
+			    && !S_ISDIR(dst_stat.st_mode)) {
+				debug
+				    ("entry %s from the host is not a file or directory, skipping mount",
+				     src);
+				continue;
+			}
+
 			if ((dst_stat.st_mode & S_IFMT) !=
 			    (src_stat.st_mode & S_IFMT)) {
 				debug

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -310,35 +310,55 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		};
 		for (const char **dirs = dirs_from_core; *dirs != NULL; dirs++) {
 			const char *dir = *dirs;
-			if (access(dir, F_OK) == 0) {
-				struct stat dst_stat;
-				struct stat src_stat;
-				sc_must_snprintf(src, sizeof src, "%s%s",
-						 config->rootfs_dir, dir);
-				sc_must_snprintf(dst, sizeof dst, "%s%s",
-						 scratch_dir, dir);
-				if (lstat(src, &src_stat) == 0
-				    && lstat(dst, &dst_stat) == 0) {
-					if (!S_ISREG(dst_stat.st_mode)
-					    && !S_ISDIR(dst_stat.st_mode)) {
-						debug
-						    ("entry %s from the host is not a file or directory, skipping mount",
-						     dst);
-						continue;
-					}
-					if (!S_ISREG(src_stat.st_mode)
-					    && !S_ISDIR(src_stat.st_mode)) {
-						debug
-						    ("entry %s from the desired rootfs is not a file or directory, skipping mount",
-						     src);
-						continue;
-					}
-					sc_do_mount(src, dst, NULL, MS_BIND,
-						    NULL);
-					sc_do_mount("none", dst, NULL, MS_SLAVE,
-						    NULL);
+			if (access(dir, F_OK) != 0) {
+				continue;
+			}
+			struct stat dst_stat;
+			struct stat src_stat;
+			sc_must_snprintf(src, sizeof src, "%s%s",
+					 config->rootfs_dir, dir);
+			sc_must_snprintf(dst, sizeof dst, "%s%s",
+					 scratch_dir, dir);
+			if (lstat(src, &src_stat) != 0) {
+				if (errno == ENOENT) {
+					continue;
+				}
+				die("cannot stat %s from desired rootfs", src);
+			} else {
+				if (!S_ISREG(src_stat.st_mode)
+				    && !S_ISDIR(src_stat.st_mode)) {
+					debug
+					    ("entry %s from the desired rootfs is not a file or directory, skipping mount",
+					     src);
+					continue;
 				}
 			}
+			if (lstat(dst, &dst_stat) != 0) {
+				if (errno == ENOENT) {
+					continue;
+				}
+				die("cannot stat %s from host", src);
+			} else {
+				if (!S_ISREG(dst_stat.st_mode)
+				    && !S_ISDIR(dst_stat.st_mode)) {
+					debug
+					    ("entry %s from the host is not a file or directory, skipping mount",
+					     src);
+					continue;
+				}
+
+			}
+			if ((dst_stat.st_mode & S_IFMT) !=
+			    (src_stat.st_mode & S_IFMT)) {
+				debug
+				    ("entries %s and %s are of different types, skipping mount",
+				     dst, src);
+				continue;
+			}
+			// both source and destination exist and are either files or
+			// directories
+			sc_do_mount(src, dst, NULL, MS_BIND, NULL);
+			sc_do_mount("none", dst, NULL, MS_SLAVE, NULL);
 		}
 	}
 	// The "core" base snap is special as it contains snapd and friends.

--- a/tests/regression/rhbz-1584461/task.yaml
+++ b/tests/regression/rhbz-1584461/task.yaml
@@ -1,0 +1,46 @@
+summary: Verify directories from the base snap are not mounted over symlinks in /etc
+
+description: |
+  The host's /etc is made avaialable inside the snap's mount namespace. During
+  setup, snap-confine attempts to preserve some entries from the base snap to
+  present a uniform environment for the snaps. When the entries in host
+  namespace are symlinks, they are followed when mounting and the mount, with
+  source from the base snap, appears in the host's mount namespace.
+
+# we only know of this happening on Fedora, see https://bugzilla.redhat.com/show_bug.cgi?id=1584461
+systems: [fedora-*]
+
+restore: |
+    if [ "$(readlink /etc/ssl)" == "/etc/ssl-backup" ]; then
+        rm /etc/ssl
+        mv /etc/ssl-backup /etc/ssl
+    fi
+
+    rm -f ./in-snap ./on-host
+
+execute: |
+    # on Fedora, /etc/nsswitch.conf is a symlink to /etc/authselect/nsswitch.conf
+    # TODO: uncomment once we fix this in spread images
+    # test -s /etc/nsswitch.conf
+
+    # the following mount entries are visible on a broken system:
+    # /var/lib/snapd/snaps/core_6818.snap on /etc/authselect/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
+    # /var/lib/snapd/snaps/core_6818.snap on /var/lib/snapd/snap/core/6818/etc/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
+    # /var/lib/snapd/snaps/core_6818.snap on /var/lib/snapd/snap/core/6818/etc/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
+    # /var/lib/snapd/snaps/core_6818.snap on /etc/authselect/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
+    # /var/lib/snapd/snaps/core_6818.snap on /etc/ssl-backup type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
+
+    # since we cannot look at /etc/nsswitch.conf, make /etc/ssl a symlink
+    mv /etc/ssl /etc/ssl-backup
+    ln -s /etc/ssl-backup /etc/ssl
+
+    find /etc/ssl/ -ls | sort > on-host
+
+    snap install test-snapd-tools
+    test-snapd-tools.echo hello
+
+    ! mount |MATCH /etc/ssl-backup
+
+    test-snapd-tools.cmd find /etc/ssl/ -ls | sort > in-snap
+    # same thing is visible in and out
+    diff -upw on-host in-snap


### PR DESCRIPTION
When bringing entries in /etc back from the desired rootfs, make sure that those
are either regular files or directories, and do not attempt to mount over
anything that is not a file or directory.

Otherwise we can break the host mount namespace.

This happens on Fedora, where /etc/nsswitch.conf is a symlink to
/etc/authselect/nsswitch.conf. Mounting over it breaks the host and the
following entries appear:
```
/var/lib/snapd/snaps/core_6818.snap on /etc/authselect/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
/var/lib/snapd/snaps/core_6818.snap on /etc/authselect/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
/var/lib/snapd/snaps/core_6818.snap on /etc/authselect/nsswitch.conf type squashfs (ro,nodev,relatime,context=system_u:object_r:snappy_snap_t:s0)
```
At this point, the file in the host mount namespace will also have the SELinux
label from the snap's mount context.

This seems to go back to Fedora 28. See: https://bugzilla.redhat.com/show_bug.cgi?id=1584461

