### PR TITLE
overlord/configstate: don't panic on invalid configuration

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -86,7 +86,7 @@ func PatchConfig(snapName string, subkeys []string, pos int, config interface{},
 			return config, nil
 		}
 	}
-	panic(fmt.Errorf("internal error: unexpected configuration type %T", config))
+	return nil, fmt.Errorf("internal error: unexpected configuration type %T", config)
 }
 
 // GetSnapConfig retrieves the raw configuration of a given snap.

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -201,3 +201,13 @@ func (s *configHelpersSuite) TestGetFeatureFlag(c *C) {
 	_, err = config.GetFeatureFlag(tr, features.Layouts)
 	c.Assert(err, ErrorMatches, `layouts can only be set to 'true' or 'false', got "banana"`)
 }
+
+func (s *configHelpersSuite) TestPatchInvalidConfig(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	invalid := []string{}
+	value := json.RawMessage([]byte("[]"))
+	_, err := config.PatchConfig("snap1", []string{"foo"}, 0, invalid, &value)
+	c.Assert(err, ErrorMatches, `internal error: unexpected configuration type \[\]string`)
+}


### PR DESCRIPTION
Don't panic on invalid snap configuration. This is generally a "theoretical" problem that can only be caused by a bug that results in such invalid snap configuration passed to PatchConfig. This happened to me while working on the snap unset branch due to my programming error and if something like this happens, it's catastrophic as it leaves snapd panicking in the configure hook task, so it never completes and restarting snapd doesn't help. It's better to error out and let the hook fail. Again, the problem is hypotetical, but it's much better to stay on the safe side and if we ever have an internal bug like this, have a chance for user to recover.