### PR TITLE
cmd/snap, etc: add health to 'snap list' and 'snap info'

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -74,6 +74,16 @@ type Snap struct {
 
 	// The ordered list of tracks that contains channels
 	Tracks []string `json:"tracks,omitempty"`
+
+	Health *SnapHealth `json:"health,omitempty"`
+}
+
+type SnapHealth struct {
+	Revision  snap.Revision `json:"revision"`
+	Timestamp time.Time     `json:"timestamp"`
+	Status    string        `json:"status"`
+	Message   string        `json:"message,omitempty"`
+	Code      string        `json:"code,omitempty"`
 }
 
 func (s *Snap) MarshalJSON() ([]byte, error) {

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -115,6 +115,10 @@ func (cs *clientSuite) TestClientNoSnaps(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientSnaps(c *check.C) {
+	healthTimestamp, err := time.Parse(time.RFC3339Nano, "2019-05-13T16:27:01.475851677+01:00")
+	c.Assert(err, check.IsNil)
+
+	// TODO: update this JSON as it's ancient
 	cs.rsp = `{
 		"type": "sync",
 		"result": [{
@@ -123,6 +127,11 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 			"summary": "salutation snap",
 			"description": "hello-world",
 			"download-size": 22212,
+                        "health": {
+				"revision": "29",
+				"timestamp": "2019-05-13T16:27:01.475851677+01:00",
+				"status": "okay"
+                        },
 			"icon": "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
 			"installed-size": -1,
 			"license": "GPL-3.0",
@@ -147,12 +156,17 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 	applications, err := cs.cli.List(nil, nil)
 	c.Check(err, check.IsNil)
 	c.Check(applications, check.DeepEquals, []*client.Snap{{
-		ID:            "funky-snap-id",
-		Title:         "Title",
-		Summary:       "salutation snap",
-		Description:   "hello-world",
-		DownloadSize:  22212,
-		Icon:          "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+		ID:           "funky-snap-id",
+		Title:        "Title",
+		Summary:      "salutation snap",
+		Description:  "hello-world",
+		DownloadSize: 22212,
+		Icon:         "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+		Health: &client.SnapHealth{
+			Revision:  snap.R(29),
+			Timestamp: healthTimestamp,
+			Status:    "okay",
+		},
 		InstalledSize: -1,
 		License:       "GPL-3.0",
 		Name:          "hello-world",

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -97,7 +97,7 @@ func (iw *infoWriter) maybePrintHealth() {
 
 	fmt.Fprintln(iw, "health:")
 	fmt.Fprintf(iw, "  status:\t%s\n", health.Status)
-	wrapGeneric(iw, []rune(quotedIfNeeded(health.Message)), "  message:\t", "    ", iw.termWidth)
+	wrapGeneric(iw, quotedIfNeeded(health.Message), "  message:\t", "    ", iw.termWidth)
 	if health.Code != "" {
 		fmt.Fprintf(iw, "  code:\t%s\n", health.Code)
 	}
@@ -232,7 +232,7 @@ func wrapGeneric(out io.Writer, text []rune, indent, indent2 string, termWidth i
 	return err
 }
 
-func quotedIfNeeded(raw string) string {
+func quotedIfNeeded(raw string) []rune {
 	// simplest way of checking to see if it needs quoting is to try
 	raw = strings.TrimSpace(raw)
 	type T struct {
@@ -243,7 +243,7 @@ func quotedIfNeeded(raw string) string {
 	} else if err := yaml.UnmarshalStrict([]byte("s: "+raw), &T{}); err != nil {
 		raw = strconv.Quote(raw)
 	}
-	return raw
+	return []rune(raw)
 }
 
 // printDescr formats a given string (typically a snap description)
@@ -397,18 +397,7 @@ func (iw *infoWriter) printName() {
 }
 
 func (iw *infoWriter) printSummary() {
-	// simplest way of checking to see if it needs quoting is to try
-	raw := strings.TrimSpace(iw.theSnap.Summary)
-	type T struct {
-		S string
-	}
-	if len(raw) == 0 {
-		raw = `""`
-	} else if err := yaml.UnmarshalStrict([]byte("s: "+raw), &T{}); err != nil {
-		raw = strconv.Quote(raw)
-	}
-
-	wrapFlow(iw, []rune(raw), "summary:\t", iw.termWidth)
+	wrapFlow(iw, quotedIfNeeded(iw.theSnap.Summary), "summary:\t", iw.termWidth)
 }
 
 func (iw *infoWriter) maybePrintPublisher() {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -90,7 +91,7 @@ func (iw *infoWriter) maybePrintHealth() {
 	if health.Status == "okay" && !iw.verbose {
 		return
 	}
-	buf := new(strings.Builder)
+	buf := new(bytes.Buffer) // replace with a strings.Builder when >=1.10
 	fmt.Fprint(buf, health.Status)
 	if health.Message != "" {
 		fmt.Fprintf(buf, " (%s)", health.Message)

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -107,6 +107,7 @@ func (iw *infoWriter) maybePrintHealth() {
 	if !health.Revision.Unset() {
 		fmt.Fprintf(iw, "  revision:\t%s\n", health.Revision)
 	}
+	iw.Flush()
 }
 
 func clientSnapFromPath(path string) (*client.Snap, error) {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -758,6 +758,7 @@ func (x *infoCmd) Execute([]string) error {
 		iw.maybePrintPath()
 		iw.printName()
 		iw.printSummary()
+		iw.maybePrintHealth()
 		iw.maybePrintPublisher()
 		iw.maybePrintStandaloneVersion()
 		iw.maybePrintBuildDate()
@@ -768,7 +769,6 @@ func (x *infoCmd) Execute([]string) error {
 		iw.maybePrintCommands()
 		iw.maybePrintServices()
 		iw.maybePrintNotes()
-		iw.maybePrintHealth()
 		// stops the notes etc trying to be aligned with channels
 		iw.Flush()
 		iw.maybePrintType()

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -88,7 +88,6 @@ func (iw *infoWriter) maybePrintHealth() {
 		health = &client.SnapHealth{
 			Status:  "unknown",
 			Message: "health has not been set",
-			Code:    "snapd-no-health",
 		}
 	}
 	if health.Status == "okay" && !iw.verbose {
@@ -97,7 +96,9 @@ func (iw *infoWriter) maybePrintHealth() {
 
 	fmt.Fprintln(iw, "health:")
 	fmt.Fprintf(iw, "  status:\t%s\n", health.Status)
-	wrapGeneric(iw, quotedIfNeeded(health.Message), "  message:\t", "    ", iw.termWidth)
+	if health.Message != "" {
+		wrapGeneric(iw, quotedIfNeeded(health.Message), "  message:\t", "    ", iw.termWidth)
+	}
 	if health.Code != "" {
 		fmt.Fprintf(iw, "  code:\t%s\n", health.Code)
 	}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -475,6 +475,7 @@ snap-id: mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
+// only used for results on /v2/find
 const mockInfoJSON = `
 {
   "type": "sync",
@@ -594,6 +595,7 @@ snap-id: mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
+// only used for /v2/snaps/hello
 const mockInfoJSONOtherLicense = `
 {
   "type": "sync",
@@ -610,6 +612,7 @@ const mockInfoJSONOtherLicense = `
          "display-name": "Canonical",
          "validation": "verified"
       },
+      "health": {"revision": "1", "status": "blocked", "message": "please configure the grawflit", "timestamp": "2019-05-13T16:27:01.475851677+01:00"},
       "id": "mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6",
       "install-date": "2006-01-02T22:04:07.123456789Z",
       "installed-size": 1024,
@@ -680,8 +683,11 @@ func (s *infoSuite) TestInfoWithLocalDifferentLicense(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"info", "--abs-time", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, `name:      hello
-summary:   The GNU Hello snap
+	c.Check(s.Stdout(), check.Equals, `
+name:    hello
+summary: The GNU Hello snap
+health:  blocked (please configure the grawflit), last run
+  2019-05-13T16:27:01+01:00 for revision 1.
 publisher: Canonical*
 license:   BSD-3
 description: |
@@ -690,8 +696,8 @@ description: |
 snap-id:      mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:     beta
 refresh-date: 2006-01-02T22:04:07Z
-installed:    2.10 (1) 1kB disabled
-`)
+installed:    2.10 (1) 1kB disabled,blocked
+`[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
 

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -686,8 +686,11 @@ func (s *infoSuite) TestInfoWithLocalDifferentLicense(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `
 name:    hello
 summary: The GNU Hello snap
-health:  blocked (please configure the grawflit), last run
-  2019-05-13T16:27:01+01:00 for revision 1.
+health:
+  status:   blocked
+  message:  please configure the grawflit
+  checked:  2019-05-13T16:27:01+01:00
+  revision: 1
 publisher: Canonical*
 license:   BSD-3
 description: |

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -55,7 +55,17 @@ func (s *SnapSuite) TestList(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(r.URL.RawQuery, check.Equals, "")
-			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar", "validation": "unproven"}, "revision":17, "tracking-channel": "potatoes"}]}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": [
+{
+  "name": "foo",
+  "status": "active",
+  "version": "4.2",
+  "developer": "bar",
+  "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar", "validation": "unproven"},
+  "health": {"status": "blocked"},
+  "revision": 17,
+  "tracking-channel": "potatoes"
+}]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -65,9 +75,10 @@ func (s *SnapSuite) TestList(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Publisher +Notes
-foo +4.2 +17 +potatoes +bar +-
-`)
+	c.Check(s.Stdout(), check.Equals, `
+Name  Version  Rev  Tracking  Publisher  Notes
+foo   4.2      17   potatoes  bar        blocked
+`[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
 

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -109,6 +109,7 @@ var (
 	MaybePrintPath              = (*infoWriter).maybePrintPath
 	MaybePrintSum               = (*infoWriter).maybePrintSum
 	MaybePrintCohortKey         = (*infoWriter).maybePrintCohortKey
+	MaybePrintHealth            = (*infoWriter).maybePrintHealth
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -51,8 +51,6 @@ func formatPrice(val float64, currency string) string {
 // Notes encapsulate everything that might be interesting about a
 // snap, in order to present a brief summary of it.
 type Notes struct {
-	Price            string
-	Health           string
 	SnapType         snap.Type
 	Private          bool
 	DevMode          bool
@@ -63,6 +61,8 @@ type Notes struct {
 	Broken           bool
 	IgnoreValidation bool
 	InCohort         bool
+	Health           string
+	Price            string
 }
 
 func NotesFromChannelSnapInfo(ref *snap.ChannelSnapInfo) *Notes {

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -52,6 +52,7 @@ func formatPrice(val float64, currency string) string {
 // snap, in order to present a brief summary of it.
 type Notes struct {
 	Price            string
+	Health           string
 	SnapType         snap.Type
 	Private          bool
 	DevMode          bool
@@ -86,6 +87,10 @@ func NotesFromRemote(snp *client.Snap, resInfo *client.ResultInfo) *Notes {
 }
 
 func NotesFromLocal(snp *client.Snap) *Notes {
+	var health string
+	if snp.Health != nil {
+		health = snp.Health.Status
+	}
 	return &Notes{
 		SnapType:         snap.Type(snp.Type),
 		Private:          snp.Private,
@@ -97,16 +102,7 @@ func NotesFromLocal(snp *client.Snap) *Notes {
 		Broken:           snp.Broken != "",
 		IgnoreValidation: snp.IgnoreValidation,
 		InCohort:         snp.CohortKey != "",
-	}
-}
-
-func NotesFromInfo(info *snap.Info) *Notes {
-	return &Notes{
-		SnapType: info.GetType(),
-		Private:  info.Private,
-		DevMode:  info.Confinement == client.DevModeConfinement,
-		Classic:  info.Confinement == client.ClassicConfinement,
-		Broken:   info.Broken != "",
+		Health:           health,
 	}
 }
 
@@ -165,6 +161,9 @@ func (n *Notes) String() string {
 
 	if n.InCohort {
 		ns = append(ns, i18n.G("in-cohort"))
+	}
+	if n.Health != "" && n.Health != "okay" {
+		ns = append(ns, n.Health)
 	}
 
 	if len(ns) == 0 {

--- a/cmd/snap/notes_test.go
+++ b/cmd/snap/notes_test.go
@@ -113,4 +113,5 @@ func (notesSuite) TestNotesFromLocal(c *check.C) {
 	// check that a cohort key in a snap sets the InCohort note flag
 	c.Check(snap.NotesFromLocal(&client.Snap{CohortKey: ""}).InCohort, check.Equals, false)
 	c.Check(snap.NotesFromLocal(&client.Snap{CohortKey: "123"}).InCohort, check.Equals, true)
+	c.Check(snap.NotesFromLocal(&client.Snap{Health: &client.SnapHealth{Status: "blocked"}}).Health, check.Equals, "blocked")
 }

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -68,6 +69,20 @@ func publisherAccount(st *state.State, snapID string) (snap.StoreAccount, error)
 type aboutSnap struct {
 	info   *snap.Info
 	snapst *snapstate.SnapState
+	health *client.SnapHealth
+}
+
+func clientHealthFromHealthstate(h *healthstate.HealthState) *client.SnapHealth {
+	if h == nil {
+		return nil
+	}
+	return &client.SnapHealth{
+		Revision:  h.Revision,
+		Timestamp: h.Timestamp,
+		Status:    h.Status.String(),
+		Message:   h.Message,
+		Code:      h.Code,
+	}
 }
 
 // localSnapInfo returns the information about the current snap for the given name plus the SnapState with the active flag and other snap revisions.
@@ -94,9 +109,15 @@ func localSnapInfo(st *state.State, name string) (aboutSnap, error) {
 		return aboutSnap{}, err
 	}
 
+	health, err := healthstate.Get(st, name)
+	if err != nil {
+		return aboutSnap{}, err
+	}
+
 	return aboutSnap{
 		info:   info,
 		snapst: &snapst,
+		health: clientHealthFromHealthstate(health),
 	}, nil
 }
 
@@ -111,11 +132,17 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 	}
 	about := make([]aboutSnap, 0, len(snapStates))
 
+	healths, err := healthstate.All(st)
+	if err != nil {
+		return nil, err
+	}
+
 	var firstErr error
 	for name, snapst := range snapStates {
 		if len(wanted) > 0 && !wanted[name] {
 			continue
 		}
+		health := clientHealthFromHealthstate(healths[name])
 		var aboutThis []aboutSnap
 		var info *snap.Info
 		var err error
@@ -137,13 +164,13 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 				if err != nil && firstErr == nil {
 					firstErr = err
 				}
-				aboutThis = append(aboutThis, aboutSnap{info, snapst})
+				aboutThis = append(aboutThis, aboutSnap{info, snapst, health})
 			}
 		} else {
 			info, err = snapst.CurrentInfo()
 			if err == nil {
 				info.Publisher, err = publisherAccount(st, info.SnapID)
-				aboutThis = append(aboutThis, aboutSnap{info, snapst})
+				aboutThis = append(aboutThis, aboutSnap{info, snapst, health})
 			}
 		}
 
@@ -290,6 +317,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 		// prime dir)
 		result.MountedFrom, _ = os.Readlink(result.MountedFrom)
 	}
+	result.Health = about.health
 
 	return result
 }

--- a/overlord/healthstate/healthstate_test.go
+++ b/overlord/healthstate/healthstate_test.go
@@ -220,7 +220,7 @@ func (s *healthSuite) TestSetFromHookContext(c *check.C) {
 	ctx.Lock()
 	defer ctx.Unlock()
 
-	var hs map[string]healthstate.HealthState
+	var hs map[string]*healthstate.HealthState
 	c.Check(s.state.Get("health", &hs), check.Equals, state.ErrNoState)
 
 	ctx.Set("health", &healthstate.HealthState{Status: 42})
@@ -228,9 +228,9 @@ func (s *healthSuite) TestSetFromHookContext(c *check.C) {
 	err = healthstate.SetFromHookContext(ctx)
 	c.Assert(err, check.IsNil)
 
-	err = s.state.Get("health", &hs)
+	hs, err = healthstate.All(s.state)
 	c.Check(err, check.IsNil)
-	c.Check(hs, check.DeepEquals, map[string]healthstate.HealthState{
+	c.Check(hs, check.DeepEquals, map[string]*healthstate.HealthState{
 		"foo": {Status: 42},
 	})
 }


### PR DESCRIPTION
Without this change, neither 'info' nor 'list' would mention a snap's
health. This fixes both of those :-)