### PR TITLE
data/selinux: allow snap-confine to do search on snappy_var_t directories

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -464,7 +464,7 @@ allow snappy_confine_t snappy_snap_t:lnk_file read;
 allow snappy_confine_t snappy_var_lib_t:dir mounton;
 allow snappy_confine_t snappy_var_run_t:dir mounton;
 allow snappy_confine_t snappy_var_run_t:file mounton;
-allow snappy_confine_t snappy_var_t:dir { getattr mounton };
+allow snappy_confine_t snappy_var_t:dir { getattr mounton search };
 allow snappy_confine_t tmp_t:dir { add_name create mounton remove_name rmdir setattr write read };
 allow snappy_confine_t usr_t:dir mounton;
 allow snappy_confine_t var_log_t:dir mounton;


### PR DESCRIPTION
Address a new denial triggered on F30.
```
type=AVC msg=audit(05/20/19 21:19:40.020:1084) : avc:  denied  { search } for
         pid=14651 comm=snap-confine name=x1 dev="sda1" ino=538212
         scontext=system_u:system_r:snappy_confine_t:s0
         tcontext=system_u:object_r:snappy_var_t:s0
         tclass=dir permissive=1
```
