### PR TITLE
cmd/snap-confine: don't pass MS_SLAVE along with MS_BIND

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -408,8 +408,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// directory is always /snap. On the host it is a build-time configuration
 	// option stored in SNAP_MOUNT_DIR.
 	sc_must_snprintf(dst, sizeof dst, "%s/snap", scratch_dir);
-	sc_do_mount(SNAP_MOUNT_DIR, dst, NULL, MS_BIND | MS_REC | MS_SLAVE,
-		    NULL);
+	sc_do_mount(SNAP_MOUNT_DIR, dst, NULL, MS_BIND | MS_REC, NULL);
 	sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
 	// Create the hostfs directory if one is missing. This directory is a part
 	// of packaging now so perhaps this code can be removed later.


### PR DESCRIPTION
While making other changes I noticed that we have a code sequence
performing bind mount and switching it to slave propagation mode:

    sc_do_mount(SNAP_MOUNT_DIR, dst, NULL, MS_BIND | MS_REC | MS_SLAVE, NULL);
    sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);

The first call, that establishes the bind mount, does not  use the
MS_SLAVE flag in practice. The kernel cannot change propagation and
crate a bind mount at the same time. This is documented in mount(2).

As such, remove the MS_SLAVE flag from the first line.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

