### PR TITLE
cmd/snap-update-ns: use "none" for propagation changes

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -311,8 +311,8 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 				// now change mount propagation (shared/rshared, private/rprivate,
 				// slave/rslave, unbindable/runbindable).
 				flagsForMount := uintptr(maskedFlagsPropagation | maskedFlagsRecursive)
-				err = sysMount("", c.Entry.Dir, "", flagsForMount, "")
-				logger.Debugf("mount %q %q %q %d %q (error: %v)", "", c.Entry.Dir, "", flagsForMount, "", err)
+				err = sysMount("none", c.Entry.Dir, "", flagsForMount, "")
+				logger.Debugf("mount %q %q %q %d %q (error: %v)", "none", c.Entry.Dir, "", flagsForMount, "", err)
 			}
 			if err == nil {
 				as.AddChange(c)

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -488,7 +488,7 @@ func (s *changeSuite) TestPerformFilesystemMountAndShareChanges(c *C) {
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		{C: `lstat "/target"`, R: testutil.FileInfoDir},
 		{C: `mount "device" "/target" "type" 0 ""`},
-		{C: `mount "" "/target" "" MS_SHARED ""`},
+		{C: `mount "none" "/target" "" MS_SHARED ""`},
 	})
 }
 
@@ -928,7 +928,7 @@ func (s *changeSuite) TestPerformRecursiveDirectorySharedBindMount(c *C) {
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND|MS_REC ""`},
 		{C: `close 5`},
 		{C: `close 4`},
-		{C: `mount "" "/target" "" MS_REC|MS_SHARED ""`},
+		{C: `mount "none" "/target" "" MS_REC|MS_SHARED ""`},
 	})
 }
 


### PR DESCRIPTION
This is a purely cosmetic change. When mount(1), the command line tool,
makes propagation changes it supplies "none" for the, entirely unused,
mount source argument. Make snap-update-ns provide the same argument.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

