### PR TITLE
tests/main/auto-refresh-retry: fix loop/break condition

### DIFF
--- a/tests/main/auto-refresh-retry/task.yaml
+++ b/tests/main/auto-refresh-retry/task.yaml
@@ -39,9 +39,10 @@ execute: |
     systemctl daemon-reload
     systemctl start snapd.{socket,service}
 
+    wanted="state ensure error: persistent network error"
     echo "wait for auto-refresh to happen and fail"
     for _ in $(seq 120); do
-        if get_journalctl_log | MATCH "state ensure error"; then
+        if check_journalctl_log "$wanted" --system -u snapd; then
             break
         fi
         echo "Ensure refresh"
@@ -49,7 +50,7 @@ execute: |
         sleep 5
     done
 
-    journalctl | MATCH "state ensure error: persistent network error"
+    get_journalctl_log --system -u snapd | MATCH "$wanted"
 
     # restart snapd with network access back
     systemctl stop snapd.{service,socket}


### PR DESCRIPTION
auto-refresh-retry checked for a condition in a limited loop, and on
exiting the loop checked the condition again. Unfortunately those two
conditions were different, so in some cases could break the test.

While I was there I limited it to only check snapd's journal instead
of the whole thing, and to only use MATCH on exit of the loop, so the
test output wasn't so needlessly big.
