### PR TITLE
tests: add "not" command as replacement for "!" in tests

### DIFF
--- a/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-destination/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-destination/task.yaml
@@ -15,7 +15,7 @@ execute: |
     echo "We can now run busybox true and expect it to fail"
     orig_ratelimit=$(sysctl -n kernel.printk_ratelimit)
     sysctl -w kernel.printk_ratelimit=0
-    ! /snap/bin/snapd-hacker-toolbelt.busybox true
+    not /snap/bin/snapd-hacker-toolbelt.busybox true
     sysctl -w kernel.printk_ratelimit=$orig_ratelimit
     echo "Not only the command failed because snap-confine failed, we see why!"
     dmesg --ctime | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/bin/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" flags="rw, bind"'

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-source/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-source/task.yaml
@@ -15,7 +15,7 @@ execute: |
     echo "We can now run busybox true and expect it to fail"
     orig_ratelimit=$(sysctl -n kernel.printk_ratelimit)
     sysctl -w kernel.printk_ratelimit=0
-    ! /snap/bin/snapd-hacker-toolbelt.busybox true
+    not /snap/bin/snapd-hacker-toolbelt.busybox true
     sysctl -w kernel.printk_ratelimit=$orig_ratelimit
     echo "Not only the command failed because snap-confine failed, we see why!"
     dmesg --ctime | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/bin/" flags="rw, bind"'

--- a/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
+++ b/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
@@ -44,9 +44,9 @@ execute: |
     PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
     cat /run/udev/spread-test.out
     echo "Ensure user-specified PATH is not used"
-    ! grep 'PATH=/foo' /run/udev/spread-test.out
+    not grep 'PATH=/foo' /run/udev/spread-test.out
     echo "Ensure environment is clean"
-    ! grep 'TESTVAR=bar' /run/udev/spread-test.out
+    not grep 'TESTVAR=bar' /run/udev/spread-test.out
 restore: |
     exit 0
     echo "Remove hello-world"

--- a/spread.yaml
+++ b/spread.yaml
@@ -7,7 +7,7 @@ environment:
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
     # a different go in gccgo tests)
-    PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin
+    PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/lib/bin
     TESTSLIB: $PROJECT_PATH/tests/lib
     SNAPPY_TESTING: 1
     # we run the entire suite with re-exec on (the default) and modify

--- a/tests/lib/bin/.keep
+++ b/tests/lib/bin/.keep
@@ -1,0 +1,1 @@
+This file is just to make git happy

--- a/tests/lib/bin/not
+++ b/tests/lib/bin/not
@@ -1,0 +1,10 @@
+#!/bin/sh
+# This script executes whatever is given as argument and inverts the return
+# value. It is meant as a workaround for shellcheck discovery
+# https://github.com/koalaman/shellcheck/wiki/SC2251 where shell scripts using
+# "set -e" are not failing with a trivial code like "! true"
+if "$@"; then
+    exit 1
+else
+    exit 0
+fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -580,7 +580,7 @@ restore_project_each() {
     fi
 
     # Something is hosing the filesystem so look for signs of that
-    ! grep -F "//deleted /etc" /proc/self/mountinfo
+    not grep -F "//deleted /etc" /proc/self/mountinfo
 }
 
 restore_project() {

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -491,7 +491,7 @@ EOF
     # - make sure the group matches
     # - bind mount /root/test-etc/* to /etc/* via custom systemd job
     # We also create /var/lib/extrausers/* and append ubuntu,test there
-    ! test -e /mnt/system-data/root
+    test ! -e /mnt/system-data/root
     mkdir -m 700 /mnt/system-data/root
     test -d /mnt/system-data/root
     mkdir -p /mnt/system-data/root/test-etc

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -269,7 +269,10 @@ prepare_classic() {
         # shellcheck disable=SC2086
         cache_snaps ${PRE_CACHE_SNAPS}
 
-        not snap list | grep core || exit 1
+        if snap list | grep -q core; then
+            echo "unexpectedly core was already installed"
+            exit 1
+        fi
         # use parameterized core channel (defaults to edge) instead
         # of a fixed one and close to stable in order to detect defects
         # earlier

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -269,7 +269,7 @@ prepare_classic() {
         # shellcheck disable=SC2086
         cache_snaps ${PRE_CACHE_SNAPS}
 
-        ! snap list | grep core || exit 1
+        not snap list | grep core || exit 1
         # use parameterized core channel (defaults to edge) instead
         # of a fixed one and close to stable in order to detect defects
         # earlier

--- a/tests/main/ack/task.yaml
+++ b/tests/main/ack/task.yaml
@@ -13,7 +13,7 @@ execute: |
     ALICE_ID=BGLTY1rcRKQQMbt9B407lDH38lbCW3wg
 
     echo "Ack when missing prerequisite fails"
-    ! snap ack alice.account-key
+    not snap ack alice.account-key
 
     echo "Ack account and account-key for alice"
     snap ack alice.account

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -37,7 +37,7 @@ execute: |
 
     echo "Check listing again"
     snap aliases|MATCH "aliases.cmd1 +alias1 +manual"
-    ! snap aliases|MATCH "aliases.cmd2 +alias2"
+    not snap aliases|MATCH "aliases.cmd2 +alias2"
 
     echo "Disable all aliases"
     snap unalias aliases|MATCH ".*- aliases.cmd1 as alias1*"
@@ -45,7 +45,7 @@ execute: |
     echo "Alias is gone"
     test ! -e "$SNAP_MOUNT_DIR/bin/alias1"
     alias1 2>&1|MATCH "alias1: command not found"
-    ! snap aliases|MATCH "aliases.cmd1 +alias1"
+    not snap aliases|MATCH "aliases.cmd1 +alias1"
 
     echo "Recreate one"
     snap alias aliases.cmd1 alias1

--- a/tests/main/auto-aliases/task.yaml
+++ b/tests/main/auto-aliases/task.yaml
@@ -21,8 +21,8 @@ execute: |
     snap remove test-snapd-auto-aliases
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown1"
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown2"
-    ! snap aliases|MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1"
-    ! snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2"
+    not snap aliases|MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1"
+    not snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2"
 
     echo "Installing the snap with --unaliased doesn't create the aliases"
     snap install --unaliased test-snapd-auto-aliases

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -37,7 +37,7 @@ execute: |
 
     if is_core_system; then
         # no holding
-        ! echo "$output" | MATCH "^hold:"
+        not echo "$output" | MATCH "^hold:"
     else
         # holding
         echo "$output" | MATCH "^hold:"
@@ -77,4 +77,4 @@ execute: |
     jq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH "$(date +%Y)"
 
     echo "No refresh hold at this point"
-    ! snap refresh --time| MATCH "^hold:"
+    not snap refresh --time| MATCH "^hold:"

--- a/tests/main/core-snap-refresh/task.yaml
+++ b/tests/main/core-snap-refresh/task.yaml
@@ -30,7 +30,7 @@ execute: |
         fi
 
         # there are no errors in the changes list
-        ! snap changes | MATCH '^[0-9]+ +Error'
+        not snap changes | MATCH '^[0-9]+ +Error'
 
         REBOOT
     fi
@@ -47,4 +47,4 @@ execute: |
     fi
 
     # and there are no errors in the changes list
-    ! snap changes | MATCH '^[0-9]+ +Error'
+    not snap changes | MATCH '^[0-9]+ +Error'

--- a/tests/main/core16-provided-by-core/task.yaml
+++ b/tests/main/core16-provided-by-core/task.yaml
@@ -25,7 +25,7 @@ execute: |
     install_local test-snapd-sh-core16
 
     echo "and core16 was not pulled in"
-    ! snap list core16
+    not snap list core16
 
     echo "and the snap works fine"
     test-snapd-sh-core16.sh -c "echo hello" | MATCH hello

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -19,7 +19,7 @@ execute: |
 
     # The command can be used as script helper
     snap debug sandbox-features --required kmod:mediated-modprobe
-    ! snap debug sandbox-features --required magic:evil-bit
+    not snap debug sandbox-features --required magic:evil-bit
 
     # Multiple requirements may be listed
     snap debug sandbox-features --required kmod:mediated-modprobe --required mount:stale-base-invalidation

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -68,7 +68,7 @@ execute: |
 
     echo "No attempt is made to activate the document portal due to the previous failure"
     test-snapd-desktop.check-dirs "$user_data"
-    ! MATCH "GetMountPoint called" < doc-portal.log
+    not MATCH "GetMountPoint called" < doc-portal.log
 
     echo "Remove the .portals-unavailable file to force a recheck"
     rm "$XDG_RUNTIME_DIR/.portals-unavailable"

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -20,10 +20,10 @@ execute: |
     . "$TESTSLIB"/systems.sh
 
     echo "When a snap is private it doesn't show up in the find without login and without specifying private search"
-    ! snap find test-snapd-private | MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
+    not snap find test-snapd-private | MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
 
     echo "When a snap is private it doesn't show up in the find --private results without login"
-    ! snap find test-snapd-private --private | MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
+    not snap find test-snapd-private --private | MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
 
     echo "Given account store credentials are available"
     # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems

--- a/tests/main/i18n/task.yaml
+++ b/tests/main/i18n/task.yaml
@@ -25,4 +25,4 @@ execute: |
             SNAPPY_TESTING=0 LANG="$b" snap 2>&1 >/dev/null | sed -e "s/[^ ]* [^ ]* /${b^^}: /" >> bad
         fi
     done
-    ! cat bad
+    not cat bad

--- a/tests/main/install-refresh-private/task.yaml
+++ b/tests/main/install-refresh-private/task.yaml
@@ -15,7 +15,7 @@ restore: |
 
 execute: |
     echo "Cannot install a private snap without login"
-    ! snap install test-snapd-private
+    not snap install test-snapd-private
 
     echo "Given account store credentials are available"
     # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems

--- a/tests/main/install-remove-multi/task.yaml
+++ b/tests/main/install-remove-multi/task.yaml
@@ -18,4 +18,4 @@ execute: |
     test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop
     echo "Removing a snap with a desktop file removes the desktop file again"
     snap remove  basic-desktop
-    ! test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop
+    not test -e /var/lib/snapd/desktop/applications/basic-desktop_io.snapcraft.echoecho.desktop

--- a/tests/main/install-sideload-epochs/task.yaml
+++ b/tests/main/install-sideload-epochs/task.yaml
@@ -13,15 +13,15 @@ prepare: |
 execute: |
     rx="cannot refresh \"[^ \"]*\" to local snap with epoch [^ ]*, because it can't read the current epoch"
     snap try "$TESTSLIB"/snaps/test-snapd-epoch-1
-    ! snap try "$TESTSLIB"/snaps/test-snapd-epoch-2 2> try.err
+    not snap try "$TESTSLIB"/snaps/test-snapd-epoch-2 2> try.err
     tr -s "\n " "  "  < try.err      | MATCH "$rx"
 
-    ! snap install --dangerous test-snapd-epoch_2_all.snap 2>install.err
+    not snap install --dangerous test-snapd-epoch_2_all.snap 2>install.err
     tr -s "\n " "  "  < install.err  | MATCH "$rx"
 
     snap remove test-snapd-epoch
     snap install --dangerous test-snapd-epoch_2_all.snap
-    ! snap install --dangerous test-snapd-epoch_1_all.snap 2>install1.err
+    not snap install --dangerous test-snapd-epoch_1_all.snap 2>install1.err
     tr -s "\n " "  "  < install1.err  | MATCH "$rx"
 
     snap remove test-snapd-epoch

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -42,7 +42,7 @@ execute: |
     echo "The interface is initially disconnected"
     snap interfaces -i calendar-service | MATCH -- '- +test-snapd-eds:calendar-service'
     if [ "$(snap debug confinement)" = strict ]; then
-      ! test-snapd-eds.calendar list test-calendar
+      not test-snapd-eds.calendar list test-calendar
     fi
 
     echo "When the plug is connected, we can add events to calendars"

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -51,7 +51,7 @@ execute: |
     echo "The interface is initially disconnected"
     snap interfaces -i contacts-service | MATCH -- '- +test-snapd-eds:contacts-service'
     if [ "$(snap debug confinement)" = strict ]; then
-      ! test-snapd-eds.contacts list test-address-book
+      not test-snapd-eds.contacts list test-address-book
     fi
 
     echo "When the plug is connected, we can add contacts to address books"

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -69,7 +69,7 @@ execute: |
     firewall-control-consumer.delete
 
     echo "Then the service listening on localhost is no longer accessible through the destination IP in the rule"
-    ! nc -w 2 "$DESTINATION_IP" "$PORT" < "$REQUEST_FILE"
+    not nc -w 2 "$DESTINATION_IP" "$PORT" < "$REQUEST_FILE"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0

--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -33,7 +33,7 @@ execute: |
     ps ax | grep -Pq "^ *$pid"
     process-control-consumer.signal "SIGTERM" $pid
     #shellcheck disable=SC2009
-    ! ps ax | grep -Pq "^ *$pid"
+    not ps ax | grep -Pq "^ *$pid"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
@@ -54,4 +54,4 @@ execute: |
     ps ax | grep -Pq "^ *$pid"
     kill -9 $pid
     #shellcheck disable=SC2009
-    ! ps ax | grep -Pq "^ *$pid"
+    not ps ax | grep -Pq "^ *$pid"

--- a/tests/main/interfaces-snapd-control/task.yaml
+++ b/tests/main/interfaces-snapd-control/task.yaml
@@ -23,7 +23,7 @@ execute: |
     snap interfaces -i snapd-control | MATCH ":snapd-control .*test-snapd-control-consumer"
 
     echo "Then the snap command is able to control snapd"
-    ! test-snapd-control-consumer.list | grep -q test-snapd-tools
+    not test-snapd-control-consumer.list | grep -q test-snapd-tools
     test-snapd-control-consumer.install test-snapd-tools
     while ! test-snapd-control-consumer.list | grep -q test-snapd-tools; do sleep 1; done
 

--- a/tests/main/interfaces-system-dbus/task.yaml
+++ b/tests/main/interfaces-system-dbus/task.yaml
@@ -42,9 +42,9 @@ execute: |
     snap disconnect test-snapd-dbus-provider:dbus-system-test-plug
 
     echo "And the consumer is not able to access the provided method"
-    ! test-snapd-dbus-consumer.dbus-system-consumer 2> call.error
+    not test-snapd-dbus-consumer.dbus-system-consumer 2> call.error
     MATCH "Permission denied" < call.error
 
     echo "And the consumer is not able to access the provided method (same snap)"
-    ! test-snapd-dbus-provider.system-consumer 2> call.error
+    not test-snapd-dbus-provider.system-consumer 2> call.error
     MATCH "Permission denied" < call.error

--- a/tests/main/interfaces-udev/task.yaml
+++ b/tests/main/interfaces-udev/task.yaml
@@ -27,4 +27,4 @@ execute: |
     snap remove modem-manager-consumer
 
     echo "Then the udev rules files are removed"
-    ! test -f /etc/udev/rules.d/70-snap.modem-manager-consumer.rules
+    not test -f /etc/udev/rules.d/70-snap.modem-manager-consumer.rules

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -23,7 +23,7 @@ execute: |
     su -c "snap run test-snapd-tools.echo foo" test | MATCH foo
 
     echo "Run as the non-home user (home dir outside of /home) - this will fail"
-    ! su -c "snap run test-snapd-tools.echo foo" "$TUSER" 2>stderr.log
+    not su -c "snap run test-snapd-tools.echo foo" "$TUSER" 2>stderr.log
 
     echo "Ensure we get a useful error message"
     MATCH "Sorry, home directories outside of /home" < stderr.log

--- a/tests/main/parallel-install-aliases/task.yaml
+++ b/tests/main/parallel-install-aliases/task.yaml
@@ -27,16 +27,16 @@ execute: |
     alias2|MATCH "ok command 2"
 
     echo "Attempting to create the same aliases for aliases_foo should conflict"
-    ! snap alias aliases_foo.cmd1 alias1
+    not snap alias aliases_foo.cmd1 alias1
     snap change --last=alias | MATCH 'cannot enable alias "alias1" for "aliases_foo", already enabled for "aliases"'
-    ! snap alias aliases_foo.cmd2 alias2
+    not snap alias aliases_foo.cmd2 alias2
     snap change --last=alias | MATCH 'cannot enable alias "alias2" for "aliases_foo", already enabled for "aliases"'
 
     echo "Check listing"
     snap aliases > aliases.out
     MATCH "aliases.cmd1 +alias1 +manual" < aliases.out
     MATCH "aliases.cmd2 +alias2 +manual" < aliases.out
-    ! MATCH aliases_foo                  < aliases.out
+    not MATCH aliases_foo                  < aliases.out
 
     echo "Disable one alias for aliases snap"
     snap unalias alias2|MATCH ".*- aliases.cmd2 as alias2.*"

--- a/tests/main/parallel-install-auto-aliases/task.yaml
+++ b/tests/main/parallel-install-auto-aliases/task.yaml
@@ -24,7 +24,7 @@ execute: |
     # install the snap directly from the file, but still let snapd fetch the
     # assertions from the store, leave a canary to catch when the store starts
     # supporting parallel installations
-    ! snap install test-snapd-auto-aliases_foo
+    not snap install test-snapd-auto-aliases_foo
 
     fname=$(find /var/lib/snapd/snaps -name 'test-snapd-auto-aliases*.snap')
     test "$(echo "$fname" | wc -l)" = "1"
@@ -58,8 +58,8 @@ execute: |
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown2"
     snap aliases > aliases.out
     # test-snapd-auto-aliases_foo instance aliases are no more
-    ! MATCH "test-snapd-auto-aliases_foo.wellknown1 +test_snapd_wellknown1"       < aliases.out
-    ! MATCH "test-snapd-auto-aliases_foo.wellknown2 +test_snapd_wellknown2"       < aliases.out
+    not MATCH "test-snapd-auto-aliases_foo.wellknown1 +test_snapd_wellknown1"       < aliases.out
+    not MATCH "test-snapd-auto-aliases_foo.wellknown2 +test_snapd_wellknown2"       < aliases.out
     # test-snapd-auto-aliases aliases are still disabled
     MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1 +disabled" < aliases.out
     MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +disabled" < aliases.out
@@ -80,7 +80,7 @@ execute: |
 
     echo "Installing test-snapd-auto-aliases will conflict"
     # TODO parallel-install: need to install using file
-    ! snap install "$name"
+    not snap install "$name"
     snap change --last=install | MATCH 'cannot enable aliases .* for "test-snapd-auto-aliases", already enabled for "test-snapd-auto-aliases_foo"'
 
     # make sure that symlinks are in place

--- a/tests/main/parallel-install-basic/task.yaml
+++ b/tests/main/parallel-install-basic/task.yaml
@@ -70,13 +70,13 @@ execute: |
     su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
     MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/x1/data
     # the file not present in non-instance snap data
-    ! test -f /home/test/snap/test-snapd-tools/x1/data
+    not test -f /home/test/snap/test-snapd-tools/x1/data
 
     # instance snap can write to common user data
     su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_COMMON/data'" test
     MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/common/data
     # the file not present in non-instance snap data
-    ! test -f /home/test/snap/test-snapd-tools/common/data
+    not test -f /home/test/snap/test-snapd-tools/common/data
 
     su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_USER_COMMON/canary'" test | MATCH canary-instance-common
     su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_USER_DATA/canary'" test | MATCH canary-instance-snap

--- a/tests/main/parallel-install-common-dirs-undo/task.yaml
+++ b/tests/main/parallel-install-common-dirs-undo/task.yaml
@@ -14,24 +14,24 @@ execute: |
     test -n "$path"
 
     echo "Given a snap that fails to install"
-    ! snap install --dangerous "$path"
+    not snap install --dangerous "$path"
     snap change --last=install | MATCH 'Error.*Start snap "test-snapd-service" \(unset\) services'
 
     echo "Shared snap directories are cleaned up in undo"
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-service"
-    ! test -d "/var/snap/test-snapd-service"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-service"
+    not test -d "/var/snap/test-snapd-service"
 
     echo "Given a snap with instance key foo that fails to install"
-    ! snap install --dangerous --name test-snapd-service_foo "$path"
+    not snap install --dangerous --name test-snapd-service_foo "$path"
     snap change --last=install | MATCH 'Error.*Start snap "test-snapd-service_foo" \(unset\) services'
 
     echo "Instance foo directories are cleaned up"
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-service_foo"
-    ! test -d "/var/snap/test-snapd-service_foo"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-service_foo"
+    not test -d "/var/snap/test-snapd-service_foo"
 
     echo "Shared snap directories are cleaned up as well"
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-service"
-    ! test -d "/var/snap/test-snapd-service"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-service"
+    not test -d "/var/snap/test-snapd-service"
 
 restore:
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -48,8 +48,8 @@ execute: |
     # remove foo instance snap
     snap remove test-snapd-tools_foo
     # foo instance directories should be gone now
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-tools_foo"
-    ! test -d "/var/snap/test-snapd-tools_foo"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools_foo"
+    not test -d "/var/snap/test-snapd-tools_foo"
     # common directories are still around, required by test-snapd-tools and
     # test-snapd-tools_bar
     test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
@@ -63,12 +63,12 @@ execute: |
 
     # remove bar instance
     snap remove test-snapd-tools_bar
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-tools_bar"
-    ! test -d "/var/snap/test-snapd-tools_bar"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools_bar"
+    not test -d "/var/snap/test-snapd-tools_bar"
 
     # common directors should be gone now too
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    ! test -d "/var/snap/test-snapd-tools"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
+    not test -d "/var/snap/test-snapd-tools"
 
     # make sure that the sole snap without instance key is handled correctly too
     install_local test-snapd-tools
@@ -77,8 +77,8 @@ execute: |
     test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
     test -d "/var/snap/test-snapd-tools"
     snap remove test-snapd-tools
-    ! test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    ! test -d "/var/snap/test-snapd-tools"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
+    not test -d "/var/snap/test-snapd-tools"
 
 restore:
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-local/task.yaml
+++ b/tests/main/parallel-install-local/task.yaml
@@ -13,7 +13,7 @@ execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
-    ! install_local_as test-snapd-tools test-snapd-tools_foo 2> run.err
+    not install_local_as test-snapd-tools test-snapd-tools_foo 2> run.err
     MATCH 'experimental feature disabled' < run.err
 
     snap set system experimental.parallel-instances=true

--- a/tests/main/parallel-install-services/task.yaml
+++ b/tests/main/parallel-install-services/task.yaml
@@ -45,7 +45,7 @@ execute: |
 
     echo "Removing one instance does not remove services from other instances"
     snap remove test-snapd-service_foo
-    ! test -f /etc/systemd/system/snap.test-snapd-service_foo.test-snapd-service.service
+    not test -f /etc/systemd/system/snap.test-snapd-service_foo.test-snapd-service.service
     test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service
     test -f /etc/systemd/system/snap.test-snapd-service.test-snapd-service.service
 
@@ -54,10 +54,10 @@ execute: |
     check_services_active test-snapd-service_longname
 
     snap remove test-snapd-service
-    ! test -f /etc/systemd/system/snap.test-snapd-service.test-snapd-service.service
+    not test -f /etc/systemd/system/snap.test-snapd-service.test-snapd-service.service
     test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service
     echo "The services of remaining snap are active"
     check_services_active test-snapd-service_longname
 
     snap remove test-snapd-service_longname
-    ! test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service
+    not test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service

--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for parallel installation of snaps from the store
 
 execute: |
-    ! snap install test-snapd-tools_foo 2> run.err
+    not snap install test-snapd-tools_foo 2> run.err
     MATCH 'experimental feature disabled' < run.err
 
     snap set system experimental.parallel-instances=true

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -45,7 +45,7 @@ execute: |
     unwrap_msg() {
         tr '\n' ' ' | sed -e 's/ \+/ /g'
     }
-    ! snap install --dangerous test-snapd-refresh_2_all.snap >install.log 2>&1
+    not snap install --dangerous test-snapd-refresh_2_all.snap >install.log 2>&1
     unwrap_msg < install.log | MATCH 'error: cannot install snap file: snap "test-snapd-refresh" has running apps +\(sh\)'
     test-snapd-refresh.version | MATCH v1
 

--- a/tests/main/remodel/task.yaml
+++ b/tests/main/remodel/task.yaml
@@ -62,7 +62,7 @@ execute: |
     fi
 
     # sanity check
-    ! snap list test-snapd-tools
+    not snap list test-snapd-tools
     
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
@@ -80,7 +80,7 @@ execute: |
     snap changes | MATCH "Refresh model assertion from revision 0 to 2"
 
     echo "and we cannot remove the new required snap"
-    ! snap remove test-snapd-tools
+    not snap remove test-snapd-tools
 
     echo "And we can remodel again this time test-snapd-tools is no longer required"
     snap remodel "$TESTSLIB"/assertions/developer1-pc-revno3.model

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -27,7 +27,7 @@ execute: |
 
     echo "Then the device is not assigned to that snap"
     if udevadm info /dev/ttyS4 > info.txt; then
-        ! MATCH "E: TAGS=.*snap_test-snapd-tools_env" < info.txt
+        not MATCH "E: TAGS=.*snap_test-snapd-tools_env" < info.txt
     else
         echo "No hardware for node /dev/ttyS4"
         exit 0

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -82,7 +82,7 @@ execute: |
     install_local test-snapd-tools
 
     echo "Then the device is not assigned to that snap"
-    ! udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-tools_env"
+    not udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-tools_env"
 
     echo "And the device is not shown in the snap device list"
     # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -49,6 +49,6 @@ execute: |
     # there is a known problem with the reference policy that disallows systemd
     # from creating a BPF map for unconfined_service_t, see:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1694115
-    ! ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | \
+    not ausearch --checkpoint stamp --start checkpoint -m AVC 2>&1 | \
         grep -v -E 'avc:  denied  { map_create } for  pid=[0-9]+ comm="systemd"' | \
         MATCH 'type=AVC'

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -66,7 +66,7 @@ execute: |
 
     echo "Switch back temporarely to the main store"
     snap set core proxy.store=
-    ! snap refresh --list | grep -Pzq "$expected"
+    not snap refresh --list | grep -Pzq "$expected"
 
     echo "Configure back to use fakestore"
     snap set core proxy.store=fake

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -38,8 +38,8 @@ execute: |
     echo "Non nvidia files are still there"
     test -f /run/udev/tags/snap_test-snapd-tools_echo/c226:0
     echo "But nvidia files are gone"
-    ! test -f /run/udev/tags/snap_test-snapd-tools_echo/+module:nvidia
-    ! test -f /run/udev/tags/snap_test-snapd-tools_echo/+module:nvidia_modeset
+    not test -f /run/udev/tags/snap_test-snapd-tools_echo/+module:nvidia
+    not test -f /run/udev/tags/snap_test-snapd-tools_echo/+module:nvidia_modeset
 
     echo "Ensure apparmor profile for snap-confine is parsable"
     for f in /etc/apparmor.d/usr.lib.snapd.snap-confine*; do

--- a/tests/main/snap-connections/task.yaml
+++ b/tests/main/snap-connections/task.yaml
@@ -69,5 +69,5 @@ execute: |
     # make sure that an interface that is not connected shows up too
     MATCH 'opengl +- +:opengl +-' < system.out
 
-    ! snap connections not-found > error.out 2>&1
+    not snap connections not-found > error.out 2>&1
     MATCH 'error: snap "not-found" not found' < error.out

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -44,6 +44,6 @@ execute: |
 
     echo "Can't ask for invalid cohort"
     # this is not a valid cohort key
-    ! snap download --cohort="what" test-snapd-tools 2>out
+    not snap download --cohort="what" test-snapd-tools 2>out
     MATCH 'cannot download snap.*: Invalid cohort key' < out
 

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -11,10 +11,10 @@ prepare: |
 
 execute: |
     echo "With no arguments, errors out"
-    ! snap info
+    not snap info
 
     echo "With one non-snap argument, errors out"
-    ! snap info /etc/passwd
+    not snap info /etc/passwd
 
     snap info --unicode=always        \
       basic_1.0_all.snap              \
@@ -48,7 +48,7 @@ execute: |
     snap info no-such-snap test-snapd-tools > out.stdout 2> out.stderr
     MATCH 'warning: no snap found for "no-such-snap"' < out.stdout
     # no error output generated
-    ! test -s out.stderr
+    not test -s out.stderr
 
     echo "Ensure we show versions as strings (LP: 1669291)"
     snap info test-snapd-number-version | MATCH "edge:[ ]+2.10"

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -71,16 +71,16 @@ execute: |
     done
 
     echo "State file is gone"
-    ! test -f /var/lib/snapd/state.json
+    not test -f /var/lib/snapd/state.json
     echo "And so is the system key"
-    ! test -f /var/lib/snapd/system-key
+    not test -f /var/lib/snapd/system-key
 
     echo "Preserved namespaces directory is not mounted"
-    ! MATCH "/run/snapd/ns" < /proc/mounts
+    not MATCH "/run/snapd/ns" < /proc/mounts
 
     systemctl daemon-reload
     echo "Snap *.service files are removed"
-    ! systemctl list-unit-files --type service | MATCH '^snap.test-snapd-service.*\.service'
+    not systemctl list-unit-files --type service | MATCH '^snap.test-snapd-service.*\.service'
 
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"

--- a/tests/main/snap-multi-service-failing/task.yaml
+++ b/tests/main/snap-multi-service-failing/task.yaml
@@ -5,7 +5,7 @@ execute: |
   #shellcheck source=tests/lib/snaps.sh
   . "$TESTSLIB"/snaps.sh
   echo "when a snap install fails"
-  ! install_local test-snapd-multi-service
+  not install_local test-snapd-multi-service
 
   echo "we don't leave a service running"
-  ! systemctl is-active snap.test-snapd-multi-service.ok.service
+  not systemctl is-active snap.test-snapd-multi-service.ok.service

--- a/tests/main/snap-service-start-timeout/task.yaml
+++ b/tests/main/snap-service-start-timeout/task.yaml
@@ -13,7 +13,7 @@ execute: |
     dir="$TESTSLIB/snaps/test-snapd-service-start-timeout"
 
     # with the 30s sleep, start-timeout stops the snap from working
-    ! snap try "$dir"
+    not snap try "$dir"
 
     # drop the 'sleep 30'
     sed -i -e '/@@@/d' "$dir/forking.sh"

--- a/tests/main/snap-service-timer/task.yaml
+++ b/tests/main/snap-service-timer/task.yaml
@@ -25,7 +25,7 @@ execute: |
             systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState="
         done
     else
-        ! systemctl list-timers | MATCH "test-snapd-timer-service"
+        not systemctl list-timers | MATCH "test-snapd-timer-service"
     fi
 
     echo "When reenabled, the timers are present again"
@@ -45,7 +45,7 @@ execute: |
             systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState="
         done
     else
-        ! systemctl list-timers | MATCH "test-snapd-timer-service"
+        not systemctl list-timers | MATCH "test-snapd-timer-service"
     fi
 
     echo "No timer files are left behind"

--- a/tests/main/snap-service-watchdog/task.yaml
+++ b/tests/main/snap-service-watchdog/task.yaml
@@ -25,7 +25,7 @@ execute: |
 
     echo "We can see all services running"
     for service in direct-watchdog-ok direct-watchdog-bad; do
-        ! systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH "SubState=dead"
+        not systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH "SubState=dead"
     done
 
     echo "Services that are correctly poking the watchdog remain running"

--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -23,7 +23,7 @@ execute: |
         # Only 18.10+ is fully working with the systemd generator, so for 18.04
         # we account for /snap/bin not being in the PATH, until LP: #1771858 is
         # fixed.
-        ! MATCH 'PATH=.*/snap/bin' < env.out
+        not MATCH 'PATH=.*/snap/bin' < env.out
         exit 0
     else
         # ensure PATH is updated (and check full PATH, see LP: #1814355)

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -9,7 +9,7 @@ priority: 100
 restore: |
     cd "$PROJECT_PATH"
     echo "Cleanup build artifacts"
-    ! command -v snapcraft >/dev/null || snapcraft clean
+    not command -v snapcraft >/dev/null || snapcraft clean
     echo "Cleanup the installed snapcraft"
     apt autoremove -y snapcraft
     echo "Cleanup the build snapd snap"

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -38,7 +38,7 @@ execute: |
     snap install test-snapd-tools-core18
     test-snapd-tools-core18.echo hello | MATCH hello
     echo "No core was installed"
-    ! snap list | grep ^"core "
+    not snap list | grep ^"core "
 
     echo "Ensure we re-exec to the snapd snap"
     SNAPD_DEBUG=1 test-snapd-tools-core18.echo 2>&1 | MATCH 'restarting into "/snap/snapd/current'

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -66,9 +66,9 @@ execute: |
     s=$TESTSLIB/snaps/$n
     echo "Given a buildable snap with classic confinement:"
     echo " - you can't try it without --classic:"
-    ! snap try "$s"
-    ! snap try --jailmode "$s"
-    ! snap try --devmode "$s"
+    not snap try "$s"
+    not snap try --jailmode "$s"
+    not snap try --devmode "$s"
 
     touch /tmp/lala
 

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -22,9 +22,9 @@ execute: |
 
     echo "Enable ipv6"
     snap set "$snap_nick" network.disable-ipv6=false
-    ! test -f /etc/sysctl.d/10-snapd-network.conf
+    not test -f /etc/sysctl.d/10-snapd-network.conf
     sysctl net.ipv6.conf.all.disable_ipv6 | MATCH "net.ipv6.conf.all.disable_ipv6 = 0"
 
     echo "Reset ipv6"
     snap set "$snap_nick" network.disable-ipv6=""
-    ! test -f /etc/sysctl.d/10-snapd-network.conf 
+    not test -f /etc/sysctl.d/10-snapd-network.conf 

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -19,7 +19,7 @@ execute: |
     . "$TESTSLIB/journalctl.sh"
 
     echo "Snap refuses to install"
-    ! snap try "$TESTSLIB/snaps/$SNAP" 2>error.log
+    not snap try "$TESTSLIB/snaps/$SNAP" 2>error.log
     echo "The error tells you to ask the dev"
     tr -s '\n ' ' ' < error.log | MATCH 'contact developer'
 

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -117,10 +117,10 @@ execute: |
 
     # Ensure other schemes are not passed through
     rm "$XDG_OPEN_OUTPUT"
-    ! xdg_open_url ftp://snapcraft.io
+    not xdg_open_url ftp://snapcraft.io
     test ! -e "$XDG_OPEN_OUTPUT"
-    ! xdg_open_url aabbcc
+    not xdg_open_url aabbcc
     test ! -e "$XDG_OPEN_OUTPUT"
     # help is blocked by snapd-xdg-open
-    ! xdg_open_url help:snapcraft
+    not xdg_open_url help:snapcraft
     test ! -e "$XDG_OPEN_OUTPUT"

--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -82,7 +82,7 @@ execute: |
 
     # Ensure other schemes are not passed through
     rm /tmp/xdg-open-output
-    ! test-snapd-desktop.cmd /usr/bin/xdg-open ftp://snapcraft.io
+    not test-snapd-desktop.cmd /usr/bin/xdg-open ftp://snapcraft.io
     test ! -e /tmp/xdg-open-output
-    ! test-snapd-desktop.cmd /usr/bin/xdg-open aabbcc
+    not test-snapd-desktop.cmd /usr/bin/xdg-open aabbcc
     test ! -e /tmp/xdg-open-output

--- a/tests/main/xdg-settings/task.yaml
+++ b/tests/main/xdg-settings/task.yaml
@@ -73,9 +73,9 @@ execute: |
 
     # Ensure settings whitelist for settings and values works
     rm /tmp/xdg-settings-output
-    ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-settings set random-settting something
+    not $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-settings set random-settting something
     test ! -e /tmp/xdg-settings-output
-    ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-settings set default-web-browser inälid
+    not $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-settings set default-web-browser inälid
     test ! -e /tmp/xdg-settings-output
 
 

--- a/tests/regression/lp-1797556/task.yaml
+++ b/tests/regression/lp-1797556/task.yaml
@@ -19,9 +19,9 @@ execute: |
     test ! -e /home/test/bin/evil-1
     test ! -e /home/test/bin/evil-2
     if [ "$(snap debug confinement)" = "strict" ]; then
-        ! su -l -c 'test-snapd-sh.with-home-plug -c "touch /home/test/bin/evil-1"' test 2>&1 | MATCH '.* Permission denied'
+        not su -l -c 'test-snapd-sh.with-home-plug -c "touch /home/test/bin/evil-1"' test 2>&1 | MATCH '.* Permission denied'
         dmesg | grep 'apparmor="DENIED" operation="mknod".* name="/home/test/bin/evil-1"'
-        ! su -l -c 'test-snapd-sh.with-home-plug -c "ln /home/test/snap/test-snapd-sh/common/evil-2 /home/test/bin/evil-2"' test 2>&1 | MATCH '.* Permission denied'
+        not su -l -c 'test-snapd-sh.with-home-plug -c "ln /home/test/snap/test-snapd-sh/common/evil-2 /home/test/bin/evil-2"' test 2>&1 | MATCH '.* Permission denied'
         dmesg | grep 'apparmor="DENIED" operation="link".* name="/home/test/bin/evil-2"'
     fi
     test ! -e /home/test/bin/evil-1

--- a/tests/regression/lp-1801955/task.yaml
+++ b/tests/regression/lp-1801955/task.yaml
@@ -2,7 +2,7 @@ summary: Check that snapshot works with unknown users in /home/*/snap
 
 prepare: |
     snap install test-snapd-tools
-    ! grep :9999: /etc/passwd
+    not grep :9999: /etc/passwd
     mkdir -pv /home/potato/snap/
     chown -vR 9999:9999 /home/potato
 

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -17,7 +17,7 @@ prepare: |
     if findmnt --noheadings /run/snapd/ns >/dev/null; then
         umount /run/snapd/ns
     fi
-    ! findmnt --noheadings /run/snapd/ns
+    not findmnt --noheadings /run/snapd/ns
 debug: |
     cat /proc/self/mountinfo
 execute: |

--- a/tests/regression/lp-1813365/task.yaml
+++ b/tests/regression/lp-1813365/task.yaml
@@ -11,4 +11,4 @@ restore: |
     rm -f /tmp/logger.log
 execute: |
     su -l -c "$(pwd)/helper" test
-    ! test -e /tmp/logger.log
+    not test -e /tmp/logger.log

--- a/tests/regression/lp-1819728/task.yaml
+++ b/tests/regression/lp-1819728/task.yaml
@@ -25,4 +25,4 @@ execute: |
         sleep 6
     done
     echo "No systemctl left"
-    ! pgrep systemctl
+    not pgrep systemctl

--- a/tests/regression/rhbz-1584461/task.yaml
+++ b/tests/regression/rhbz-1584461/task.yaml
@@ -39,7 +39,7 @@ execute: |
     snap install test-snapd-tools
     test-snapd-tools.echo hello
 
-    ! mount |MATCH /etc/ssl-backup
+    not mount |MATCH /etc/ssl-backup
 
     test-snapd-tools.cmd find /etc/ssl/ -ls | sort > in-snap
     # same thing is visible in and out

--- a/tests/smoke/sandbox/task.yaml
+++ b/tests/smoke/sandbox/task.yaml
@@ -26,18 +26,18 @@ execute: |
     echo "Ensure the apparmor sandbox for snaps works for root"
     for p in "/root/foo" "/home/foo" "/home/test/foo"; do
         # no writing
-        ! test-snapd-sh -c "touch $p" 2>stderr.log
+        not test-snapd-sh -c "touch $p" 2>stderr.log
         MATCH <stderr.log 'touch: .* Permission denied'
 
         # no reading
         touch "$p"
-        ! test-snapd-sh -c "cat $p" 2>stderr.log
+        not test-snapd-sh -c "cat $p" 2>stderr.log
         MATCH <stderr.log 'cat: .* Permission denied'
         rm -f "$p"
     done
 
     echo "Ensure the apparmor sandbox for snaps works for users"
-    ! su -l -c 'test-snapd-sh -c "touch /home/test/foo"' test 2>stderr.log
+    not su -l -c 'test-snapd-sh -c "touch /home/test/foo"' test 2>stderr.log
     MATCH <stderr.log '.* Permission denied'
 
     echo "But with the right plug the user can put files into home"


### PR DESCRIPTION
We've recently learned that shell's behaviour regarding "set -e" and "!
command" is rather unexpected. To preserve the ability to fail execution when a
command succeeds, when we were expecting it to fail, we can introduce a new
executable, "not" that acts like the "!" operator, but is exempt from shell's
logic as to when "set -e" is effective.

All spread tests are adjusted with the following shell command:

    find -name 'task.yaml' -exec sed -i -e 's/^\( \+\)!/\1not/g' {} \;

The remaining hits on the use of leading "!" in other scripts were adjusted
manually.
