### PR TITLE
tests/unit/spread-shellcheck: temporary workaround for SC2251

### DIFF
--- a/tests/unit/spread-shellcheck/task.yaml
+++ b/tests/unit/spread-shellcheck/task.yaml
@@ -7,7 +7,8 @@ prepare: |
     # need to install shellcheck in devmode, the tests are run by 'root', the
     # source code is under /home/gopath, all file accesses to the source code
     # will end up getting DENIED even though shellcheck uses home interface
-    snap install --edge --devmode shellcheck
+    # FIXME: switch to stable to workaround for SC2251
+    snap install --stable --devmode shellcheck
 
 execute: |
     testdir=$PWD


### PR DESCRIPTION
Temporary workaround for https://github.com/koalaman/shellcheck/wiki/SC2251 complaining about the tests.
