### PR TITLE
overlord/snapstate, daemon: snapstate.Switch now takes a RevisionOption

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1071,7 +1071,7 @@ func snapSwitch(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	if !inst.Revision.Unset() {
 		return "", nil, errors.New("switch takes no revision")
 	}
-	ts, err := snapstate.Switch(st, inst.Snaps[0], inst.Channel)
+	ts, err := snapstate.Switch(st, inst.Snaps[0], &snapstate.RevisionOptions{Channel: inst.Channel})
 	if err != nil {
 		return "", nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1252,7 +1252,7 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 	return state.NewTaskSet(switchSnap), nil
 }
 
-// RevisionOptions control the selection of a snap revision
+// RevisionOptions control the selection of a snap revision.
 type RevisionOptions struct {
 	Channel  string
 	Revision snap.Revision


### PR DESCRIPTION
Also added a comment about what RevisionOption is *for*.

Note you can't switch to a revision, so that's detected and blocked
(and other than this it's a pure refactor).
