### PR TITLE
spread.yaml: make HOST: usage shellcheck-clean

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -3,7 +3,7 @@ project: snapd
 environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
-    REUSE_PROJECT: "$(HOST: echo $REUSE_PROJECT)"
+    REUSE_PROJECT: "$(HOST: echo \"$REUSE_PROJECT\")"
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
     # a different go in gccgo tests)
@@ -14,45 +14,45 @@ environment:
     # the core snap so that it contains our new code.  So we run new
     # snapd from the deb that re-execs into new snapd in core.  To
     # test purely from the deb, set "export SPREAD_SNAP_REEXEC=0"
-    SNAP_REEXEC: "$(HOST: echo ${SPREAD_SNAP_REEXEC:-})"
-    MODIFY_CORE_SNAP_FOR_REEXEC: "$(HOST: echo ${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1})"
-    SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
-    SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
-    SPREAD_STORE_EXPIRED_MACAROON: "$(HOST: echo $SPREAD_STORE_EXPIRED_MACAROON)"
-    SPREAD_STORE_EXPIRED_DISCHARGE: "$(HOST: echo $SPREAD_STORE_EXPIRED_DISCHARGE)"
-    SPREAD_DEBUG_EACH: "$(HOST: echo ${SPREAD_DEBUG_EACH:-1})"
+    SNAP_REEXEC: "$(HOST: echo \"${SPREAD_SNAP_REEXEC:-}\")"
+    MODIFY_CORE_SNAP_FOR_REEXEC: "$(HOST: echo \"${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1}\")"
+    SPREAD_STORE_USER: "$(HOST: echo \"$SPREAD_STORE_USER\")"
+    SPREAD_STORE_PASSWORD: "$(HOST: echo \"$SPREAD_STORE_PASSWORD\")"
+    SPREAD_STORE_EXPIRED_MACAROON: "$(HOST: echo \"$SPREAD_STORE_EXPIRED_MACAROON\")"
+    SPREAD_STORE_EXPIRED_DISCHARGE: "$(HOST: echo \"$SPREAD_STORE_EXPIRED_DISCHARGE\")"
+    SPREAD_DEBUG_EACH: "$(HOST: echo \"${SPREAD_DEBUG_EACH:-1}\")"
     LANG: "C.UTF-8"
     LANGUAGE: "en"
     # important to ensure adhoc and linode/qemu behave the same
     SUDO_USER: ""
     SUDO_UID: ""
-    TRUST_TEST_KEYS: "$(HOST: echo ${SPREAD_TRUST_TEST_KEYS:-true})"
+    TRUST_TEST_KEYS: "$(HOST: echo \"${SPREAD_TRUST_TEST_KEYS:-true}\")"
     MANAGED_DEVICE: "false"
-    CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-edge})"
-    KERNEL_CHANNEL: "$(HOST: echo ${SPREAD_KERNEL_CHANNEL:-edge})"
-    GADGET_CHANNEL: "$(HOST: echo ${SPREAD_GADGET_CHANNEL:-edge})"
-    SNAPD_CHANNEL: "$(HOST: echo ${SPREAD_SNAPD_CHANNEL:-edge})"
-    REMOTE_STORE: "$(HOST: echo ${SPREAD_REMOTE_STORE:-production})"
-    SNAPPY_USE_STAGING_STORE: "$(HOST: if [ $SPREAD_REMOTE_STORE = staging ]; then echo 1; else echo 0; fi)"
+    CORE_CHANNEL: "$(HOST: echo \"${SPREAD_CORE_CHANNEL:-edge}\")"
+    KERNEL_CHANNEL: "$(HOST: echo \"${SPREAD_KERNEL_CHANNEL:-edge}\")"
+    GADGET_CHANNEL: "$(HOST: echo \"${SPREAD_GADGET_CHANNEL:-edge}\")"
+    SNAPD_CHANNEL: "$(HOST: echo \"${SPREAD_SNAPD_CHANNEL:-edge}\")"
+    REMOTE_STORE: "$(HOST: echo \"${SPREAD_REMOTE_STORE:-production}\")"
+    SNAPPY_USE_STAGING_STORE: "$(HOST: if [ \"$SPREAD_REMOTE_STORE\" = staging ]; then echo 1; else echo 0; fi)"
     DELTA_REF: 2.37.4
     DELTA_PREFIX: snapd-$DELTA_REF/
-    SNAPD_PUBLISHED_VERSION: "$(HOST: echo $SPREAD_SNAPD_PUBLISHED_VERSION)"
-    HTTP_PROXY: "$(HOST: echo $SPREAD_HTTP_PROXY)"
-    HTTPS_PROXY: "$(HOST: echo $SPREAD_HTTPS_PROXY)"
+    SNAPD_PUBLISHED_VERSION: "$(HOST: echo \"$SPREAD_SNAPD_PUBLISHED_VERSION\")"
+    HTTP_PROXY: "$(HOST: echo \"$SPREAD_HTTP_PROXY\")"
+    HTTPS_PROXY: "$(HOST: echo \"$SPREAD_HTTPS_PROXY\")"
     NO_PROXY: "127.0.0.1"
-    NEW_CORE_CHANNEL: "$(HOST: echo $SPREAD_NEW_CORE_CHANNEL)"
-    SRU_VALIDATION: "$(HOST: echo ${SPREAD_SRU_VALIDATION:-0})"
+    NEW_CORE_CHANNEL: "$(HOST: echo \"$SPREAD_NEW_CORE_CHANNEL\")"
+    SRU_VALIDATION: "$(HOST: echo \"${SPREAD_SRU_VALIDATION:-0}\")"
     # use the ppa_validation_name to install snapd from that ppa
-    PPA_VALIDATION_NAME: "$(HOST: echo ${SPREAD_PPA_VALIDATION_NAME:-})"
+    PPA_VALIDATION_NAME: "$(HOST: echo \"${SPREAD_PPA_VALIDATION_NAME:-}\")"
     PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
     # always skip removing the rsync snap
-    SKIP_REMOVE_SNAPS: "$(HOST: echo ${SPREAD_SKIP_REMOVE_SNAPS:-}) test-snapd-rsync test-snapd-rsync-core18"
+    SKIP_REMOVE_SNAPS: "$(HOST: echo \"${SPREAD_SKIP_REMOVE_SNAPS:-}\") test-snapd-rsync test-snapd-rsync-core18"
     # Use the installed snapd and reset the systems without removing snapd
-    REUSE_SNAPD: "$(HOST: echo ${SPREAD_REUSE_SNAPD:-0})"
+    REUSE_SNAPD: "$(HOST: echo \"${SPREAD_REUSE_SNAPD:-0}\")"
 
 backends:
     google:
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
@@ -110,7 +110,7 @@ backends:
 
     google-sru:
         type: google
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
@@ -126,7 +126,7 @@ backends:
 
     google-nested:
         type: google
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
         location: computeengine/us-east1-b
         plan: n1-standard-2
         halt-timeout: 2h
@@ -365,7 +365,7 @@ backends:
     external:
         type: adhoc
         environment:
-            SPREAD_EXTERNAL_ADDRESS: "$(HOST: echo ${SPREAD_EXTERNAL_ADDRESS:-localhost:8022})"
+            SPREAD_EXTERNAL_ADDRESS: "$(HOST: echo \"${SPREAD_EXTERNAL_ADDRESS:-localhost:8022}\")"
             MANAGED_DEVICE: "true"
             TRUST_TEST_KEYS: "false"
         allocate: |
@@ -734,15 +734,15 @@ suites:
         backends: [-autopkgtest]
         environment:
             # env vars required for coverage reporting from a spread task
-            TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"
-            TRAVIS_BRANCH: "$(HOST: echo $TRAVIS_BRANCH)"
-            TRAVIS_COMMIT: "$(HOST: echo $TRAVIS_COMMIT)"
-            TRAVIS_JOB_NUMBER: "$(HOST: echo $TRAVIS_JOB_NUMBER)"
-            TRAVIS_PULL_REQUEST: "$(HOST: echo $TRAVIS_PULL_REQUEST)"
-            TRAVIS_JOB_ID: "$(HOST: echo $TRAVIS_JOB_ID)"
-            TRAVIS_REPO_SLUG: "$(HOST: echo $TRAVIS_REPO_SLUG)"
-            TRAVIS_TAG: "$(HOST: echo $TRAVIS_TAG)"
-            COVERMODE: "$(HOST: echo $COVERMODE)"
+            TRAVIS_BUILD_NUMBER: "$(HOST: echo \"$TRAVIS_BUILD_NUMBER\")"
+            TRAVIS_BRANCH: "$(HOST: echo \"$TRAVIS_BRANCH\")"
+            TRAVIS_COMMIT: "$(HOST: echo \"$TRAVIS_COMMIT\")"
+            TRAVIS_JOB_NUMBER: "$(HOST: echo \"$TRAVIS_JOB_NUMBER\")"
+            TRAVIS_PULL_REQUEST: "$(HOST: echo \"$TRAVIS_PULL_REQUEST\")"
+            TRAVIS_JOB_ID: "$(HOST: echo \"$TRAVIS_JOB_ID\")"
+            TRAVIS_REPO_SLUG: "$(HOST: echo \"$TRAVIS_REPO_SLUG\")"
+            TRAVIS_TAG: "$(HOST: echo \"$TRAVIS_TAG\")"
+            COVERMODE: "$(HOST: echo \"$COVERMODE\")"
         prepare: |
             #shellcheck source=tests/lib/prepare.sh
             . "$TESTSLIB"/prepare.sh


### PR DESCRIPTION
spread-shellcheck is about to perform rudimentary checks of environment
variables. With this is has complained about spread.yaml's own
environment section, full of HOST: shell calls that lacked some serious
number of double quotes.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
