### PR TITLE
spread-shellcheck: add support for variants and environment

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -118,6 +118,10 @@ def checksection(data, env: Dict[str, str]):
         # quotes so that one value can refer to another value.
         if '"' in value:
             value = value.replace('"', '\"')
+        # converts
+        # FOO: "$(HOST: echo $foo)"     -> FOO="$(echo $foo)"
+        # FOO: "$(HOST: echo \"$foo\")" -> FOO="$(echo \"$foo\")"
+        # FOO: "foo"                    -> FOO="foo"
         script_data.append("{}=\"{}\"".format(key, value))
         script_data.append("export {}".format(key))
     script_data.append(data)

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -20,6 +20,7 @@ import subprocess
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
+from typing import Dict
 
 import yaml
 
@@ -101,15 +102,30 @@ class ShellcheckFailures(Exception):
         return iter(self.failures)
 
 
-def checksection(data):
+def checksection(data, env: Dict[str, str]):
     # spread shell snippets are executed under 'set -e' shell, make sure
     # shellcheck knows about that
-    data = 'set -e\n' + data
+    script_data = []
+    script_data.append('set -e')
+    for key, value in env.items():
+        value = str(value)
+        # Unpack the special "$(HOST: ...) syntax and tell shellcheck not to
+        # worry about the use of echo to print variable value.
+        if value.startswith("$(HOST:") and value.endswith(")"):
+            script_data.append("# shellcheck disable=SC2116")
+            value = "$({})".format(value[len("$(HOST:"):-1])
+        # XXX: poor man's shell key=value assignment with values in double
+        # quotes so that one value can refer to another value.
+        if '"' in value:
+            value = value.replace('"', '\"')
+        script_data.append("{}=\"{}\"".format(key, value))
+        script_data.append("export {}".format(key))
+    script_data.append(data)
     proc = subprocess.Popen("shellcheck -s {} -x -".format(SHELLCHECK_SHELL),
                             stdout=subprocess.PIPE,
                             stdin=subprocess.PIPE,
                             shell=True)
-    stdout, _ = proc.communicate(input=data.encode('utf-8'), timeout=10)
+    stdout, _ = proc.communicate(input='\n'.join(script_data).encode('utf-8'), timeout=10)
     if proc.returncode != 0:
         raise ShellcheckRunError(stdout)
 
@@ -120,14 +136,21 @@ def checkfile(path):
         data = yaml.load(inf)
 
     errors = ShellcheckError(path)
-
+    # TODO: handle stacking of environment from other places that influence it:
+    # spread.yaml -> global env + backend env + suite env -> task.yaml (task
+    # env + variant env).
+    env = {}
+    for key, value in data.get("environment", {}).items():
+        if "/" in key:
+            # TODO: re-check with each variant's value set.
+            key = key.split('/', 1)[0]
+        env[key] = value
     for section in SECTIONS:
         if section not in data:
             continue
-
         try:
             logging.debug("%s: checking section %s", path, section)
-            checksection(data[section])
+            checksection(data[section], env)
         except ShellcheckRunError as serr:
             errors.addfailure(section, serr.stderr.decode('utf-8'))
 
@@ -139,7 +162,7 @@ def checkfile(path):
                     continue
                 try:
                     logging.debug("%s (suite %s): checking section %s", path, suite, section)
-                    checksection(data['suites'][suite][section])
+                    checksection(data['suites'][suite][section], env)
                 except ShellcheckRunError as serr:
                     errors.addfailure('suites/' + suite + '/' + section,
                                       serr.stderr.decode('utf-8'))

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,7 +3,7 @@ project: snapd
 environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
-    REUSE_PROJECT: "$(HOST: echo $REUSE_PROJECT)"
+    REUSE_PROJECT: "$(HOST: echo \"$REUSE_PROJECT\")"
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
     # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
     # a different go in gccgo tests)
@@ -14,45 +14,45 @@ environment:
     # the core snap so that it contains our new code.  So we run new
     # snapd from the deb that re-execs into new snapd in core.  To
     # test purely from the deb, set "export SPREAD_SNAP_REEXEC=0"
-    SNAP_REEXEC: "$(HOST: echo ${SPREAD_SNAP_REEXEC:-})"
-    MODIFY_CORE_SNAP_FOR_REEXEC: "$(HOST: echo ${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1})"
-    SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
-    SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
-    SPREAD_STORE_EXPIRED_MACAROON: "$(HOST: echo $SPREAD_STORE_EXPIRED_MACAROON)"
-    SPREAD_STORE_EXPIRED_DISCHARGE: "$(HOST: echo $SPREAD_STORE_EXPIRED_DISCHARGE)"
-    SPREAD_DEBUG_EACH: "$(HOST: echo ${SPREAD_DEBUG_EACH:-1})"
+    SNAP_REEXEC: "$(HOST: echo \"${SPREAD_SNAP_REEXEC:-}\")"
+    MODIFY_CORE_SNAP_FOR_REEXEC: "$(HOST: echo \"${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1}\")"
+    SPREAD_STORE_USER: "$(HOST: echo \"$SPREAD_STORE_USER\")"
+    SPREAD_STORE_PASSWORD: "$(HOST: echo \"$SPREAD_STORE_PASSWORD\")"
+    SPREAD_STORE_EXPIRED_MACAROON: "$(HOST: echo \"$SPREAD_STORE_EXPIRED_MACAROON\")"
+    SPREAD_STORE_EXPIRED_DISCHARGE: "$(HOST: echo \"$SPREAD_STORE_EXPIRED_DISCHARGE\")"
+    SPREAD_DEBUG_EACH: "$(HOST: echo \"${SPREAD_DEBUG_EACH:-1}\")"
     LANG: "C.UTF-8"
     LANGUAGE: "en"
     # important to ensure adhoc and linode/qemu behave the same
     SUDO_USER: ""
     SUDO_UID: ""
-    TRUST_TEST_KEYS: "$(HOST: echo ${SPREAD_TRUST_TEST_KEYS:-true})"
+    TRUST_TEST_KEYS: "$(HOST: echo \"${SPREAD_TRUST_TEST_KEYS:-true}\")"
     MANAGED_DEVICE: "false"
-    CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-edge})"
-    KERNEL_CHANNEL: "$(HOST: echo ${SPREAD_KERNEL_CHANNEL:-edge})"
-    GADGET_CHANNEL: "$(HOST: echo ${SPREAD_GADGET_CHANNEL:-edge})"
-    SNAPD_CHANNEL: "$(HOST: echo ${SPREAD_SNAPD_CHANNEL:-edge})"
-    REMOTE_STORE: "$(HOST: echo ${SPREAD_REMOTE_STORE:-production})"
-    SNAPPY_USE_STAGING_STORE: "$(HOST: if [ $SPREAD_REMOTE_STORE = staging ]; then echo 1; else echo 0; fi)"
+    CORE_CHANNEL: "$(HOST: echo \"${SPREAD_CORE_CHANNEL:-edge}\")"
+    KERNEL_CHANNEL: "$(HOST: echo \"${SPREAD_KERNEL_CHANNEL:-edge}\")"
+    GADGET_CHANNEL: "$(HOST: echo \"${SPREAD_GADGET_CHANNEL:-edge}\")"
+    SNAPD_CHANNEL: "$(HOST: echo \"${SPREAD_SNAPD_CHANNEL:-edge}\")"
+    REMOTE_STORE: "$(HOST: echo \"${SPREAD_REMOTE_STORE:-production}\")"
+    SNAPPY_USE_STAGING_STORE: "$(HOST: if [ \"$SPREAD_REMOTE_STORE\" = staging ]; then echo 1; else echo 0; fi)"
     DELTA_REF: 2.37.4
     DELTA_PREFIX: snapd-$DELTA_REF/
-    SNAPD_PUBLISHED_VERSION: "$(HOST: echo $SPREAD_SNAPD_PUBLISHED_VERSION)"
-    HTTP_PROXY: "$(HOST: echo $SPREAD_HTTP_PROXY)"
-    HTTPS_PROXY: "$(HOST: echo $SPREAD_HTTPS_PROXY)"
+    SNAPD_PUBLISHED_VERSION: "$(HOST: echo \"$SPREAD_SNAPD_PUBLISHED_VERSION\")"
+    HTTP_PROXY: "$(HOST: echo \"$SPREAD_HTTP_PROXY\")"
+    HTTPS_PROXY: "$(HOST: echo \"$SPREAD_HTTPS_PROXY\")"
     NO_PROXY: "127.0.0.1"
-    NEW_CORE_CHANNEL: "$(HOST: echo $SPREAD_NEW_CORE_CHANNEL)"
-    SRU_VALIDATION: "$(HOST: echo ${SPREAD_SRU_VALIDATION:-0})"
+    NEW_CORE_CHANNEL: "$(HOST: echo \"$SPREAD_NEW_CORE_CHANNEL\")"
+    SRU_VALIDATION: "$(HOST: echo \"${SPREAD_SRU_VALIDATION:-0}\")"
     # use the ppa_validation_name to install snapd from that ppa
-    PPA_VALIDATION_NAME: "$(HOST: echo ${SPREAD_PPA_VALIDATION_NAME:-})"
+    PPA_VALIDATION_NAME: "$(HOST: echo \"${SPREAD_PPA_VALIDATION_NAME:-}\")"
     PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
     # always skip removing the rsync snap
-    SKIP_REMOVE_SNAPS: "$(HOST: echo ${SPREAD_SKIP_REMOVE_SNAPS:-}) test-snapd-rsync test-snapd-rsync-core18"
+    SKIP_REMOVE_SNAPS: "$(HOST: echo \"${SPREAD_SKIP_REMOVE_SNAPS:-}\") test-snapd-rsync test-snapd-rsync-core18"
     # Use the installed snapd and reset the systems without removing snapd
-    REUSE_SNAPD: "$(HOST: echo ${SPREAD_REUSE_SNAPD:-0})"
+    REUSE_SNAPD: "$(HOST: echo \"${SPREAD_REUSE_SNAPD:-0}\")"
 
 backends:
     google:
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
@@ -110,7 +110,7 @@ backends:
 
     google-sru:
         type: google
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
@@ -126,7 +126,7 @@ backends:
 
     google-nested:
         type: google
-        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
         location: computeengine/us-east1-b
         plan: n1-standard-2
         halt-timeout: 2h
@@ -365,7 +365,7 @@ backends:
     external:
         type: adhoc
         environment:
-            SPREAD_EXTERNAL_ADDRESS: "$(HOST: echo ${SPREAD_EXTERNAL_ADDRESS:-localhost:8022})"
+            SPREAD_EXTERNAL_ADDRESS: "$(HOST: echo \"${SPREAD_EXTERNAL_ADDRESS:-localhost:8022}\")"
             MANAGED_DEVICE: "true"
             TRUST_TEST_KEYS: "false"
         allocate: |
@@ -734,15 +734,15 @@ suites:
         backends: [-autopkgtest]
         environment:
             # env vars required for coverage reporting from a spread task
-            TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"
-            TRAVIS_BRANCH: "$(HOST: echo $TRAVIS_BRANCH)"
-            TRAVIS_COMMIT: "$(HOST: echo $TRAVIS_COMMIT)"
-            TRAVIS_JOB_NUMBER: "$(HOST: echo $TRAVIS_JOB_NUMBER)"
-            TRAVIS_PULL_REQUEST: "$(HOST: echo $TRAVIS_PULL_REQUEST)"
-            TRAVIS_JOB_ID: "$(HOST: echo $TRAVIS_JOB_ID)"
-            TRAVIS_REPO_SLUG: "$(HOST: echo $TRAVIS_REPO_SLUG)"
-            TRAVIS_TAG: "$(HOST: echo $TRAVIS_TAG)"
-            COVERMODE: "$(HOST: echo $COVERMODE)"
+            TRAVIS_BUILD_NUMBER: "$(HOST: echo \"$TRAVIS_BUILD_NUMBER\")"
+            TRAVIS_BRANCH: "$(HOST: echo \"$TRAVIS_BRANCH\")"
+            TRAVIS_COMMIT: "$(HOST: echo \"$TRAVIS_COMMIT\")"
+            TRAVIS_JOB_NUMBER: "$(HOST: echo \"$TRAVIS_JOB_NUMBER\")"
+            TRAVIS_PULL_REQUEST: "$(HOST: echo \"$TRAVIS_PULL_REQUEST\")"
+            TRAVIS_JOB_ID: "$(HOST: echo \"$TRAVIS_JOB_ID\")"
+            TRAVIS_REPO_SLUG: "$(HOST: echo \"$TRAVIS_REPO_SLUG\")"
+            TRAVIS_TAG: "$(HOST: echo \"$TRAVIS_TAG\")"
+            COVERMODE: "$(HOST: echo \"$COVERMODE\")"
         prepare: |
             #shellcheck source=tests/lib/prepare.sh
             . "$TESTSLIB"/prepare.sh

--- a/spread.yaml
+++ b/spread.yaml
@@ -14,45 +14,45 @@ environment:
     # the core snap so that it contains our new code.  So we run new
     # snapd from the deb that re-execs into new snapd in core.  To
     # test purely from the deb, set "export SPREAD_SNAP_REEXEC=0"
-    SNAP_REEXEC: "$(HOST: echo \"${SPREAD_SNAP_REEXEC:-}\")"
-    MODIFY_CORE_SNAP_FOR_REEXEC: "$(HOST: echo \"${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1}\")"
-    SPREAD_STORE_USER: "$(HOST: echo \"$SPREAD_STORE_USER\")"
-    SPREAD_STORE_PASSWORD: "$(HOST: echo \"$SPREAD_STORE_PASSWORD\")"
-    SPREAD_STORE_EXPIRED_MACAROON: "$(HOST: echo \"$SPREAD_STORE_EXPIRED_MACAROON\")"
-    SPREAD_STORE_EXPIRED_DISCHARGE: "$(HOST: echo \"$SPREAD_STORE_EXPIRED_DISCHARGE\")"
-    SPREAD_DEBUG_EACH: "$(HOST: echo \"${SPREAD_DEBUG_EACH:-1}\")"
+    SNAP_REEXEC: '$(HOST: echo "${SPREAD_SNAP_REEXEC:-}")'
+    MODIFY_CORE_SNAP_FOR_REEXEC: '$(HOST: echo "${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1}")'
+    SPREAD_STORE_USER: '$(HOST: echo "$SPREAD_STORE_USER")'
+    SPREAD_STORE_PASSWORD: '$(HOST: echo "$SPREAD_STORE_PASSWORD")'
+    SPREAD_STORE_EXPIRED_MACAROON: '$(HOST: echo "$SPREAD_STORE_EXPIRED_MACAROON")'
+    SPREAD_STORE_EXPIRED_DISCHARGE: '$(HOST: echo "$SPREAD_STORE_EXPIRED_DISCHARGE")'
+    SPREAD_DEBUG_EACH: '$(HOST: echo "${SPREAD_DEBUG_EACH:-1}")'
     LANG: "C.UTF-8"
     LANGUAGE: "en"
     # important to ensure adhoc and linode/qemu behave the same
     SUDO_USER: ""
     SUDO_UID: ""
-    TRUST_TEST_KEYS: "$(HOST: echo \"${SPREAD_TRUST_TEST_KEYS:-true}\")"
+    TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     MANAGED_DEVICE: "false"
-    CORE_CHANNEL: "$(HOST: echo \"${SPREAD_CORE_CHANNEL:-edge}\")"
-    KERNEL_CHANNEL: "$(HOST: echo \"${SPREAD_KERNEL_CHANNEL:-edge}\")"
-    GADGET_CHANNEL: "$(HOST: echo \"${SPREAD_GADGET_CHANNEL:-edge}\")"
-    SNAPD_CHANNEL: "$(HOST: echo \"${SPREAD_SNAPD_CHANNEL:-edge}\")"
-    REMOTE_STORE: "$(HOST: echo \"${SPREAD_REMOTE_STORE:-production}\")"
-    SNAPPY_USE_STAGING_STORE: "$(HOST: if [ \"$SPREAD_REMOTE_STORE\" = staging ]; then echo 1; else echo 0; fi)"
+    CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
+    KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'
+    GADGET_CHANNEL: '$(HOST: echo "${SPREAD_GADGET_CHANNEL:-edge}")'
+    SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
+    REMOTE_STORE: '$(HOST: echo "${SPREAD_REMOTE_STORE:-production}")'
+    SNAPPY_USE_STAGING_STORE: '$(HOST: if [ "$SPREAD_REMOTE_STORE" = staging ]; then echo 1; else echo 0; fi)'
     DELTA_REF: 2.37.4
     DELTA_PREFIX: snapd-$DELTA_REF/
-    SNAPD_PUBLISHED_VERSION: "$(HOST: echo \"$SPREAD_SNAPD_PUBLISHED_VERSION\")"
-    HTTP_PROXY: "$(HOST: echo \"$SPREAD_HTTP_PROXY\")"
-    HTTPS_PROXY: "$(HOST: echo \"$SPREAD_HTTPS_PROXY\")"
+    SNAPD_PUBLISHED_VERSION: '$(HOST: echo "$SPREAD_SNAPD_PUBLISHED_VERSION")'
+    HTTP_PROXY: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+    HTTPS_PROXY: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
     NO_PROXY: "127.0.0.1"
-    NEW_CORE_CHANNEL: "$(HOST: echo \"$SPREAD_NEW_CORE_CHANNEL\")"
-    SRU_VALIDATION: "$(HOST: echo \"${SPREAD_SRU_VALIDATION:-0}\")"
+    NEW_CORE_CHANNEL: '$(HOST: echo "$SPREAD_NEW_CORE_CHANNEL")'
+    SRU_VALIDATION: '$(HOST: echo "${SPREAD_SRU_VALIDATION:-0}")'
     # use the ppa_validation_name to install snapd from that ppa
-    PPA_VALIDATION_NAME: "$(HOST: echo \"${SPREAD_PPA_VALIDATION_NAME:-}\")"
+    PPA_VALIDATION_NAME: '$(HOST: echo "${SPREAD_PPA_VALIDATION_NAME:-}")'
     PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
     # always skip removing the rsync snap
-    SKIP_REMOVE_SNAPS: "$(HOST: echo \"${SPREAD_SKIP_REMOVE_SNAPS:-}\") test-snapd-rsync test-snapd-rsync-core18"
+    SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18'
     # Use the installed snapd and reset the systems without removing snapd
     REUSE_SNAPD: "$(HOST: echo \"${SPREAD_REUSE_SNAPD:-0}\")"
 
 backends:
     google:
-        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
@@ -110,7 +110,7 @@ backends:
 
     google-sru:
         type: google
-        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
@@ -126,7 +126,7 @@ backends:
 
     google-nested:
         type: google
-        key: "$(HOST: echo \"$SPREAD_GOOGLE_KEY\")"
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: computeengine/us-east1-b
         plan: n1-standard-2
         halt-timeout: 2h
@@ -365,7 +365,7 @@ backends:
     external:
         type: adhoc
         environment:
-            SPREAD_EXTERNAL_ADDRESS: "$(HOST: echo \"${SPREAD_EXTERNAL_ADDRESS:-localhost:8022}\")"
+            SPREAD_EXTERNAL_ADDRESS: '$(HOST: echo "${SPREAD_EXTERNAL_ADDRESS:-localhost:8022}")'
             MANAGED_DEVICE: "true"
             TRUST_TEST_KEYS: "false"
         allocate: |
@@ -734,15 +734,15 @@ suites:
         backends: [-autopkgtest]
         environment:
             # env vars required for coverage reporting from a spread task
-            TRAVIS_BUILD_NUMBER: "$(HOST: echo \"$TRAVIS_BUILD_NUMBER\")"
-            TRAVIS_BRANCH: "$(HOST: echo \"$TRAVIS_BRANCH\")"
-            TRAVIS_COMMIT: "$(HOST: echo \"$TRAVIS_COMMIT\")"
-            TRAVIS_JOB_NUMBER: "$(HOST: echo \"$TRAVIS_JOB_NUMBER\")"
-            TRAVIS_PULL_REQUEST: "$(HOST: echo \"$TRAVIS_PULL_REQUEST\")"
-            TRAVIS_JOB_ID: "$(HOST: echo \"$TRAVIS_JOB_ID\")"
-            TRAVIS_REPO_SLUG: "$(HOST: echo \"$TRAVIS_REPO_SLUG\")"
-            TRAVIS_TAG: "$(HOST: echo \"$TRAVIS_TAG\")"
-            COVERMODE: "$(HOST: echo \"$COVERMODE\")"
+            TRAVIS_BUILD_NUMBER: '$(HOST: echo "$TRAVIS_BUILD_NUMBER")'
+            TRAVIS_BRANCH: '$(HOST: echo "$TRAVIS_BRANCH")'
+            TRAVIS_COMMIT: '$(HOST: echo "$TRAVIS_COMMIT")'
+            TRAVIS_JOB_NUMBER: '$(HOST: echo "$TRAVIS_JOB_NUMBER")'
+            TRAVIS_PULL_REQUEST: '$(HOST: echo "$TRAVIS_PULL_REQUEST")'
+            TRAVIS_JOB_ID: '$(HOST: echo "$TRAVIS_JOB_ID")'
+            TRAVIS_REPO_SLUG: '$(HOST: echo "$TRAVIS_REPO_SLUG")'
+            TRAVIS_TAG: '$(HOST: echo "$TRAVIS_TAG")'
+            COVERMODE: '$(HOST: echo "$COVERMODE")'
         prepare: |
             #shellcheck source=tests/lib/prepare.sh
             . "$TESTSLIB"/prepare.sh
@@ -790,8 +790,8 @@ suites:
         systems: [ubuntu-16.04-64, ubuntu-18.04-64]
         environment:
             NESTED_TYPE: classic
-            CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-stable})"
-            CORE_REFRESH_CHANNEL: "$(HOST: echo ${SPREAD_CORE_REFRESH_CHANNEL:-edge})"
+            CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-stable}")'
+            CORE_REFRESH_CHANNEL: '$(HOST: echo "${SPREAD_CORE_REFRESH_CHANNEL:-edge}")'
         manual: true
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -809,8 +809,8 @@ suites:
         systems: [ubuntu-16.04-64, ubuntu-18.04-64]
         environment:
             NESTED_TYPE: core
-            CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-stable})"
-            CORE_REFRESH_CHANNEL: "$(HOST: echo ${SPREAD_CORE_REFRESH_CHANNEL:-edge})"
+            CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-stable}")'
+            CORE_REFRESH_CHANNEL: '$(HOST: echo "${SPREAD_CORE_REFRESH_CHANNEL:-edge}")'
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
Spread support test variants where the environment section can be used
to convey specific variant information. In terms of YAML it looks like
this:

    environment:
        key/A: variant-a
        key/B: variant-b
    execute: |
        echo "$key"

Here key/A and key/B define the value of the environment variable "key"
and depending on the execution variant, the values will be "variant-a"
and "variant-b" respectively.

Currently spread-shellcheck would complain that the variable "$key" is
unset. With this patch it will know the definition of some of the
variant values. This is suboptimal but allows spread-shellcheck to not
complain about something that is clearly not broken.

As a future extension the checker could re-check the script with each
variant, carrying the exact values each time, in the hope that constant
propagation in shellcheck can make use of that information.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
