### PR TITLE
timings: always store ensure timings as long as they have an associated change

### DIFF
--- a/timings/helpers.go
+++ b/timings/helpers.go
@@ -34,6 +34,11 @@ func NewForTask(task *state.Task) *Timings {
 	return New(tags)
 }
 
+// LinkChange sets the "change-id" tag on the Timings object.
+func (t *Timings) LinkChange(change *state.Change) {
+	t.AddTag("change-id", change.ID())
+}
+
 // Run creates, starts and then stops a nested Span under parent Measurer. The nested
 // Span is passed to the measured function and can used to create further spans.
 func Run(meas Measurer, label, summary string, f func(nestedTiming Measurer)) {

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -168,6 +168,29 @@ func (s *timingsSuite) TestSaveNoTimings(c *C) {
 	c.Assert(s.st.Get("timings", &stateTimings), Equals, state.ErrNoState)
 }
 
+func (s *timingsSuite) TestSaveNoTimingsWithChangeID(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	chg := s.st.NewChange("change", "...")
+	task := s.st.NewTask("kind", "...")
+	task.SetStatus(state.DoingStatus)
+	chg.AddTask(task)
+
+	timing := timings.New(nil)
+	timing.LinkChange(chg)
+	timing.Save(s.st)
+
+	var stateTimings []interface{}
+	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
+	c.Assert(stateTimings, DeepEquals, []interface{}{
+		map[string]interface{}{
+			"tags":       map[string]interface{}{"change-id": chg.ID()},
+			"start-time": "0001-01-01T00:00:00Z",
+			"stop-time":  "0001-01-01T00:00:00Z",
+		}})
+}
+
 func (s *timingsSuite) TestDuration(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()


### PR DESCRIPTION
Always store root "Timings" object for ensure timings, even if it has no nested timings (either because they were not created, or because they were too fast), as long as it has "change-id" set, meaning a related change was created. Requiring "change-id" tag to be present means we will not store unnecessary ensure timings that had no change, e.g. because of erroring out.

This is needed to find related changes when using `snap debug timings --ensure=xyz` syntax (the "ensure" timing keeps related "change-id" in its tags, and it's the only way to correlate things) - it may currently fail to find an ensure if it was too fast, and in case of "become-operational" it won't find it at all because that ensure loop never creates nested timings.
