### PR TITLE
daemon, overlord/snapstate: give RevisionOptions a CohortKey

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1081,7 +1081,7 @@ func snapSwitch(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	var msg string
 	switch {
 	case inst.CohortKey == "" && inst.Channel != "":
-		msg = fmt.Sprintf(i18n.G("Switch %q snap to %s"), inst.Snaps[0], inst.Channel)
+		msg = fmt.Sprintf(i18n.G("Switch %q snap to channel %q"), inst.Snaps[0], inst.Channel)
 	case inst.CohortKey != "" && inst.Channel == "":
 		msg = fmt.Sprintf(i18n.G("Switch %q snap to cohort %q"), inst.Snaps[0], strutil.ElliptRight(inst.CohortKey, 10))
 	default:

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -100,6 +100,7 @@ var (
 	RefreshAliases        = refreshAliases
 	CheckAliasesConflicts = checkAliasesConflicts
 	DisableAliases        = disableAliases
+	SwitchSummary         = switchSummary
 )
 
 // readme files

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1314,23 +1314,23 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-type switchFlags struct {
+type doSwitchFlags struct {
 	switchCurrentChannel bool
 }
 
 // doSwitchSnapChannel switches the snap's tracking channel and/or cohort. It
 // also switches the current channel if appropriate. For use from 'Update'.
 func (m *SnapManager) doSwitchSnapChannel(t *state.Task, _ *tomb.Tomb) error {
-	return m.genericSwitchSnap(t, switchFlags{switchCurrentChannel: true})
+	return m.genericDoSwitchSnap(t, doSwitchFlags{switchCurrentChannel: true})
 }
 
 // doSwitchSnap switches the snap's tracking channel and/or cohort, *without*
 // switching the current snap channel. For use from 'Switch'.
 func (m *SnapManager) doSwitchSnap(t *state.Task, _ *tomb.Tomb) error {
-	return m.genericSwitchSnap(t, switchFlags{})
+	return m.genericDoSwitchSnap(t, doSwitchFlags{})
 }
 
-func (m *SnapManager) genericSwitchSnap(t *state.Task, flags switchFlags) error {
+func (m *SnapManager) genericDoSwitchSnap(t *state.Task, flags doSwitchFlags) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1325,7 +1325,7 @@ func (m *SnapManager) doSwitchSnapChannel(t *state.Task, _ *tomb.Tomb) error {
 }
 
 // doSwitchSnap switches the snap's tracking channel and/or cohort, *without*
-// swtiching the current snap channel. For use from 'Switch'.
+// switching the current snap channel. For use from 'Switch'.
 func (m *SnapManager) doSwitchSnap(t *state.Task, _ *tomb.Tomb) error {
 	return m.genericSwitchSnap(t, switchFlags{})
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1314,6 +1314,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
+// NOTE this also switches the cohort
 func (m *SnapManager) doSwitchSnapChannel(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
@@ -1326,6 +1327,7 @@ func (m *SnapManager) doSwitchSnapChannel(t *state.Task, _ *tomb.Tomb) error {
 
 	// switched the tracked channel
 	snapst.Channel = snapsup.Channel
+	snapst.CohortKey = snapsup.CohortKey
 	// optionally support switching the current snap channel too, e.g.
 	// if a snap is in both stable and candidate with the same revision
 	// we can update it here and it will be displayed correctly in the UI
@@ -1347,6 +1349,7 @@ func (m *SnapManager) doSwitchSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 	snapst.Channel = snapsup.Channel
+	snapst.CohortKey = snapsup.CohortKey
 
 	Set(st, snapsup.InstanceName(), snapst)
 	return nil

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -382,7 +382,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddCleanup("copy-snap-data", m.cleanupCopySnapData)
 	runner.AddHandler("link-snap", m.doLinkSnap, m.undoLinkSnap)
 	runner.AddHandler("start-snap-services", m.startSnapServices, m.stopSnapServices)
-	runner.AddHandler("switch-snap-channel", m.doSwitchSnapChannel, nil)
+	runner.AddHandler("switch-snap-channel", m.doSwitchSnapChannel, nil) // also switches the cohort
 	runner.AddHandler("toggle-snap-flags", m.doToggleSnapFlags, nil)
 	runner.AddHandler("check-rerefresh", m.doCheckReRefresh, nil)
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -382,7 +382,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	runner.AddCleanup("copy-snap-data", m.cleanupCopySnapData)
 	runner.AddHandler("link-snap", m.doLinkSnap, m.undoLinkSnap)
 	runner.AddHandler("start-snap-services", m.startSnapServices, m.stopSnapServices)
-	runner.AddHandler("switch-snap-channel", m.doSwitchSnapChannel, nil) // also switches the cohort
+	runner.AddHandler("switch-snap-channel", m.doSwitchSnapChannel, nil)
 	runner.AddHandler("toggle-snap-flags", m.doToggleSnapFlags, nil)
 	runner.AddHandler("check-rerefresh", m.doCheckReRefresh, nil)
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9021,6 +9021,8 @@ type switchScenario struct {
 var switchScenarios = []switchScenario{
 	// no cohort at all
 	{"stable", "some-channel", "", "", `Switch snap "some-snap" from channel "stable" to "some-channel"`},
+	// no cohort, from empty channel
+	{"", "some-channel", "", "", `Switch snap "some-snap" from no channel to "some-channel"`},
 	// cohort specified is the same as current
 	{"stable", "some-channel", "some-cohort", "some-cohort", `Switch snap "some-snap" from channel "stable" to "some-channel"`},
 	// no cohort change requested
@@ -9031,12 +9033,22 @@ var switchScenarios = []switchScenario{
 	{"stable", "stable", "some-cohort", "some-other-cohort", `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`},
 	// no channel change requested
 	{"stable", "", "some-cohort", "some-other-cohort", `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`},
+	// no channel change requested, from empty cohort
+	{"stable", "", "", "some-cohort", `Switch snap "some-snap" from no cohort to "some-coho…"`},
 	// all change
 	{"stable", "edge", "some-cohort", "some-other-cohort",
 		`Switch snap "some-snap" from channel "stable" to "edge" and from cohort "some-coho…" to "some-othe…"`},
+	// all change, from empty channel
+	{"", "stable", "some-cohort", "some-other-cohort",
+		`Switch snap "some-snap" from no channel to "stable" and from cohort "some-coho…" to "some-othe…"`},
+	// all change, from empty cohort
+	{"stable", "edge", "", "some-cohort",
+		`Switch snap "some-snap" from channel "stable" to "edge" and from no cohort to "some-coho…"`},
+	// all change, from empty channel and cohort
+	{"", "stable", "", "some-cohort",
+		`Switch snap "some-snap" from no channel to "stable" and from no cohort to "some-coho…"`},
 	// no change (XXX: error?)
-	{"stable", "stable", "some-cohort", "some-cohort",
-		`Switch snap "some-snap" from channel "stable" to "stable" and from cohort "some-coho…" to "some-coho…"`},
+	{"stable", "stable", "some-cohort", "some-cohort", `No change switch (bug?)`},
 }
 
 func (s *snapmgrTestSuite) TestSwitchScenarios(c *C) {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -151,8 +151,9 @@ func updateInfo(st *state.State, snapst *SnapState, opts *RevisionOptions, userI
 		InstanceName: curInfo.InstanceName(),
 		SnapID:       curInfo.SnapID,
 		// the desired channel
-		Channel: opts.Channel,
-		Flags:   storeFlags,
+		Channel:   opts.Channel,
+		CohortKey: opts.CohortKey,
+		Flags:     storeFlags,
 	}
 
 	if curInfo.SnapID == "" { // amend


### PR DESCRIPTION
This means refresh and switch both gain cohort abilities.
