### PR TITLE
cmd/snap-update-ns: rename ctx to upCtx

### DIFF
--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -41,13 +41,13 @@ type CommonProfileUpdateContext struct {
 }
 
 // InstanceName returns the snap instance name being updated.
-func (ctx *CommonProfileUpdateContext) InstanceName() string {
-	return ctx.instanceName
+func (upCtx *CommonProfileUpdateContext) InstanceName() string {
+	return upCtx.instanceName
 }
 
 // Lock acquires locks / freezes needed to synchronize mount namespace changes.
-func (ctx *CommonProfileUpdateContext) Lock() (func(), error) {
-	instanceName := ctx.instanceName
+func (upCtx *CommonProfileUpdateContext) Lock() (func(), error) {
+	instanceName := upCtx.instanceName
 
 	// Lock the mount namespace so that any concurrently attempted invocations
 	// of snap-confine are synchronized and will see consistent state.
@@ -57,7 +57,7 @@ func (ctx *CommonProfileUpdateContext) Lock() (func(), error) {
 	}
 
 	logger.Debugf("locking mount namespace of snap %q", instanceName)
-	if ctx.fromSnapConfine {
+	if upCtx.fromSnapConfine {
 		// When --from-snap-confine is passed then we just ensure that the
 		// namespace is locked. This is used by snap-confine to use
 		// snap-update-ns to apply mount profiles.
@@ -93,32 +93,32 @@ func (ctx *CommonProfileUpdateContext) Lock() (func(), error) {
 	return unlock, nil
 }
 
-func (ctx *CommonProfileUpdateContext) Assumptions() *Assumptions {
+func (upCtx *CommonProfileUpdateContext) Assumptions() *Assumptions {
 	return nil
 }
 
 // LoadDesiredProfile loads the desired mount profile.
-func (ctx *CommonProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
-	profile, err := osutil.LoadMountProfile(ctx.desiredProfilePath)
+func (upCtx *CommonProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
+	profile, err := osutil.LoadMountProfile(upCtx.desiredProfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load desired mount profile of snap %q: %s", ctx.instanceName, err)
+		return nil, fmt.Errorf("cannot load desired mount profile of snap %q: %s", upCtx.instanceName, err)
 	}
 	return profile, nil
 }
 
 // LoadCurrentProfile loads the current mount profile.
-func (ctx *CommonProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
-	profile, err := osutil.LoadMountProfile(ctx.currentProfilePath)
+func (upCtx *CommonProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
+	profile, err := osutil.LoadMountProfile(upCtx.currentProfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load current mount profile of snap %q: %s", ctx.instanceName, err)
+		return nil, fmt.Errorf("cannot load current mount profile of snap %q: %s", upCtx.instanceName, err)
 	}
 	return profile, nil
 }
 
 // SaveCurrentProfile saves the current mount profile.
-func (ctx *CommonProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
-	if err := profile.Save(ctx.currentProfilePath); err != nil {
-		return fmt.Errorf("cannot save current mount profile of snap %q: %s", ctx.instanceName, err)
+func (upCtx *CommonProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
+	if err := profile.Save(upCtx.currentProfilePath); err != nil {
+		return fmt.Errorf("cannot save current mount profile of snap %q: %s", upCtx.instanceName, err)
 	}
 	return nil
 }

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -35,21 +35,21 @@ import (
 )
 
 type commonSuite struct {
-	dir string
-	ctx *update.CommonProfileUpdateContext
+	dir   string
+	upCtx *update.CommonProfileUpdateContext
 }
 
 var _ = Suite(&commonSuite{})
 
 func (s *commonSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
-	s.ctx = update.NewCommonProfileUpdateContext("foo", false,
+	s.upCtx = update.NewCommonProfileUpdateContext("foo", false,
 		filepath.Join(s.dir, "current.fstab"),
 		filepath.Join(s.dir, "desired.fstab"))
 }
 
 func (s *commonSuite) TestInstanceName(c *C) {
-	c.Check(s.ctx.InstanceName(), Equals, "foo")
+	c.Check(s.upCtx.InstanceName(), Equals, "foo")
 }
 
 func (s *commonSuite) TestLock(c *C) {
@@ -62,14 +62,14 @@ func (s *commonSuite) TestLock(c *C) {
 	defer dirs.SetRootDir("")
 
 	// We will use 2nd lock for our testing.
-	testLock, err := snaplock.OpenLock(s.ctx.InstanceName())
+	testLock, err := snaplock.OpenLock(s.upCtx.InstanceName())
 	c.Assert(err, IsNil)
 	defer testLock.Close()
 
 	// When fromSnapConfine is false we acquire our own lock.
-	s.ctx.SetFromSnapConfine(false)
-	c.Check(s.ctx.FromSnapConfine(), Equals, false)
-	unlock, err := s.ctx.Lock()
+	s.upCtx.SetFromSnapConfine(false)
+	c.Check(s.upCtx.FromSnapConfine(), Equals, false)
+	unlock, err := s.upCtx.Lock()
 	c.Assert(err, IsNil)
 	// The lock is acquired now. We should not be able to get another lock.
 	c.Check(testLock.TryLock(), Equals, osutil.ErrAlreadyLocked)
@@ -78,51 +78,51 @@ func (s *commonSuite) TestLock(c *C) {
 	c.Assert(testLock.TryLock(), IsNil)
 
 	// When fromSnapConfine is true we test existing lock but don't grab one.
-	s.ctx.SetFromSnapConfine(true)
-	c.Check(s.ctx.FromSnapConfine(), Equals, true)
+	s.upCtx.SetFromSnapConfine(true)
+	c.Check(s.upCtx.FromSnapConfine(), Equals, true)
 	err = testLock.Lock()
 	c.Assert(err, IsNil)
-	unlock, err = s.ctx.Lock()
+	unlock, err = s.upCtx.Lock()
 	c.Assert(err, IsNil)
 	unlock()
 
 	// When the test lock is unlocked the common update helper reports an error
 	// since it was expecting the lock to be held. Oh, and the lock is not leaked.
 	testLock.Unlock()
-	unlock, err = s.ctx.Lock()
+	unlock, err = s.upCtx.Lock()
 	c.Check(err, ErrorMatches, `mount namespace of snap "foo" is not locked but --from-snap-confine was used`)
 	c.Check(unlock, IsNil)
 	c.Assert(testLock.TryLock(), IsNil)
 
 	// When freezing fails the lock acquired internally is not leaked.
 	freezingError = errTesting
-	s.ctx.SetFromSnapConfine(false)
-	c.Check(s.ctx.FromSnapConfine(), Equals, false)
+	s.upCtx.SetFromSnapConfine(false)
+	c.Check(s.upCtx.FromSnapConfine(), Equals, false)
 	testLock.Unlock()
-	unlock, err = s.ctx.Lock()
+	unlock, err = s.upCtx.Lock()
 	c.Check(err, Equals, errTesting)
 	c.Check(unlock, IsNil)
 	c.Check(testLock.TryLock(), IsNil)
 }
 
 func (s *commonSuite) TestLoadDesiredProfile(c *C) {
-	ctx := s.ctx
+	upCtx := s.upCtx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"
 
 	// Ask the common profile update helper to read the desired profile.
-	profile, err := ctx.LoadCurrentProfile()
+	profile, err := upCtx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 
 	// A profile that is not present on disk just reads as a valid empty profile.
 	c.Check(profile.Entries, HasLen, 0)
 
 	// Write a desired user mount profile for snap "foo".
-	path := ctx.DesiredProfilePath()
+	path := upCtx.DesiredProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the common profile update helper to read the desired profile.
-	profile, err = ctx.LoadDesiredProfile()
+	profile, err = upCtx.LoadDesiredProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -132,23 +132,23 @@ func (s *commonSuite) TestLoadDesiredProfile(c *C) {
 }
 
 func (s *commonSuite) TestLoadCurrentProfile(c *C) {
-	ctx := s.ctx
+	upCtx := s.upCtx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"
 
 	// Ask the common profile update helper to read the current profile.
-	profile, err := ctx.LoadCurrentProfile()
+	profile, err := upCtx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 
 	// A profile that is not present on disk just reads as a valid empty profile.
 	c.Check(profile.Entries, HasLen, 0)
 
 	// Write a current user mount profile for snap "foo".
-	path := ctx.CurrentProfilePath()
+	path := upCtx.CurrentProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the common profile update helper to read the current profile.
-	profile, err = ctx.LoadCurrentProfile()
+	profile, err = upCtx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -158,7 +158,7 @@ func (s *commonSuite) TestLoadCurrentProfile(c *C) {
 }
 
 func (s *commonSuite) TestSaveCurrentProfile(c *C) {
-	ctx := s.ctx
+	upCtx := s.upCtx
 	text := "tmpfs /tmp tmpfs defaults 0 0\n"
 
 	// Prepare a mount profile to be saved.
@@ -166,10 +166,10 @@ func (s *commonSuite) TestSaveCurrentProfile(c *C) {
 	c.Assert(err, IsNil)
 
 	// Prepare the directory for saving the profile.
-	path := ctx.CurrentProfilePath()
+	path := upCtx.CurrentProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 
 	// Ask the common profile update to write the current profile.
-	c.Assert(ctx.SaveCurrentProfile(profile), IsNil)
+	c.Assert(upCtx.SaveCurrentProfile(profile), IsNil)
 	c.Check(path, testutil.FileEquals, text)
 }

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -78,11 +78,11 @@ func run() error {
 	if err := parseArgs(os.Args[1:]); err != nil {
 		return err
 	}
-	var ctx MountProfileUpdateContext
+	var upCtx MountProfileUpdateContext
 	if opts.UserMounts {
-		ctx = NewUserProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine, os.Getuid())
+		upCtx = NewUserProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine, os.Getuid())
 	} else {
-		ctx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
+		upCtx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
 	}
-	return executeMountProfileUpdate(ctx)
+	return executeMountProfileUpdate(upCtx)
 }

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -79,8 +79,8 @@ func (s *mainSuite) TestExecuteMountProfileUpdate(c *C) {
 	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	err = update.ExecuteMountProfileUpdate(ctx)
+	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
+	err = update.ExecuteMountProfileUpdate(upCtx)
 	c.Assert(err, IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
@@ -147,8 +147,8 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals,
 		`tmpfs /usr/share tmpfs x-snapd.synthetic,x-snapd.needed-by=/usr/share/mysnap 0 0
@@ -225,8 +225,8 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	})
 	defer restore()
 
-	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -268,8 +268,8 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), ErrorMatches, "testing")
+	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -311,8 +311,8 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 	defer restore()
 
 	// The error was not ignored, we bailed out.
-	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), ErrorMatches, "testing")
+	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), ErrorMatches, "testing")
 
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -355,8 +355,8 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 	defer restore()
 
 	// The error was ignored, and no mount was recorded in the profile
-	ctx := update.NewSystemProfileUpdateContext(snapName, false)
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
@@ -381,8 +381,8 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	err = ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
 	c.Assert(err, IsNil)
 
-	ctx := update.NewUserProfileUpdateContext(snapName, true, 1000)
-	err = update.ExecuteMountProfileUpdate(ctx)
+	upCtx := update.NewUserProfileUpdateContext(snapName, true, 1000)
+	err = update.ExecuteMountProfileUpdate(upCtx)
 	c.Assert(err, IsNil)
 
 	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, 1000)

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -46,7 +46,7 @@ func NewSystemProfileUpdateContext(instanceName string, fromSnapConfine bool) *S
 // System mount profiles can write to /tmp (this is required for constructing
 // writable mimics) to /var/snap (where $SNAP_DATA is for services), /snap/$SNAP_NAME,
 // and, in case of instances, /snap/$SNAP_INSTANCE_NAME.
-func (ctx *SystemProfileUpdateContext) Assumptions() *Assumptions {
+func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	// Allow creating directories related to this snap name.
 	//
 	// Note that we allow /var/snap instead of /var/snap/$SNAP_NAME because
@@ -67,7 +67,7 @@ func (ctx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	// /snap/$SNAP_INSTANCE_NAME and /snap/$SNAP_NAME are added to allow
 	// remapping for parallel installs only when the snap has an instance key
 	as := &Assumptions{}
-	instanceName := ctx.InstanceName()
+	instanceName := upCtx.InstanceName()
 	as.AddUnrestrictedPaths("/tmp", "/var/snap", "/snap/"+instanceName)
 	if snapName := snap.InstanceSnap(instanceName); snapName != instanceName {
 		as.AddUnrestrictedPaths("/snap/" + snapName)

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -41,8 +41,8 @@ func (s *systemSuite) TestLock(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	ctx := update.NewSystemProfileUpdateContext("foo", false)
-	unlock, err := ctx.Lock()
+	upCtx := update.NewSystemProfileUpdateContext("foo", false)
+	unlock, err := upCtx.Lock()
 	c.Assert(err, IsNil)
 	c.Check(unlock, NotNil)
 	unlock()
@@ -50,13 +50,13 @@ func (s *systemSuite) TestLock(c *C) {
 
 func (s *systemSuite) TestAssumptions(c *C) {
 	// Non-instances can access /tmp, /var/snap and /snap/$SNAP_NAME
-	ctx := update.NewSystemProfileUpdateContext("foo", false)
-	as := ctx.Assumptions()
+	upCtx := update.NewSystemProfileUpdateContext("foo", false)
+	as := upCtx.Assumptions()
 	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo"})
 
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
-	ctx = update.NewSystemProfileUpdateContext("foo_instance", false)
-	as = ctx.Assumptions()
+	upCtx = update.NewSystemProfileUpdateContext("foo_instance", false)
+	as = upCtx.Assumptions()
 	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/snap/foo"})
 }
 
@@ -65,16 +65,16 @@ func (s *systemSuite) TestLoadDesiredProfile(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	ctx := update.NewSystemProfileUpdateContext("foo", false)
+	upCtx := update.NewSystemProfileUpdateContext("foo", false)
 	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
 
 	// Write a desired system mount profile for snap "foo".
-	path := update.DesiredSystemProfilePath(ctx.InstanceName())
+	path := update.DesiredSystemProfilePath(upCtx.InstanceName())
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the system profile update helper to read the desired profile.
-	profile, err := ctx.LoadDesiredProfile()
+	profile, err := upCtx.LoadDesiredProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -87,16 +87,16 @@ func (s *systemSuite) TestLoadCurrentProfile(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	ctx := update.NewSystemProfileUpdateContext("foo", false)
+	upCtx := update.NewSystemProfileUpdateContext("foo", false)
 	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
 
 	// Write a current system mount profile for snap "foo".
-	path := update.CurrentSystemProfilePath(ctx.InstanceName())
+	path := update.CurrentSystemProfilePath(upCtx.InstanceName())
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the system profile update helper to read the current profile.
-	profile, err := ctx.LoadCurrentProfile()
+	profile, err := upCtx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -111,7 +111,7 @@ func (s *systemSuite) TestSaveCurrentProfile(c *C) {
 	defer dirs.SetRootDir("/")
 	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
 
-	ctx := update.NewSystemProfileUpdateContext("foo", false)
+	upCtx := update.NewSystemProfileUpdateContext("foo", false)
 	text := "/snap/foo/42/dir /snap/bar/13/dir none bind,rw 0 0\n"
 
 	// Prepare a mount profile to be saved.
@@ -119,8 +119,8 @@ func (s *systemSuite) TestSaveCurrentProfile(c *C) {
 	c.Assert(err, IsNil)
 
 	// Ask the system profile update to write the current profile.
-	c.Assert(ctx.SaveCurrentProfile(profile), IsNil)
-	c.Check(update.CurrentSystemProfilePath(ctx.InstanceName()), testutil.FileEquals, text)
+	c.Assert(upCtx.SaveCurrentProfile(profile), IsNil)
+	c.Check(update.CurrentSystemProfilePath(upCtx.InstanceName()), testutil.FileEquals, text)
 }
 
 func (s *systemSuite) TestDesiredSystemProfilePath(c *C) {

--- a/cmd/snap-update-ns/update.go
+++ b/cmd/snap-update-ns/update.go
@@ -41,27 +41,27 @@ type MountProfileUpdateContext interface {
 	SaveCurrentProfile(*osutil.MountProfile) error
 }
 
-func executeMountProfileUpdate(ctx MountProfileUpdateContext) error {
-	unlock, err := ctx.Lock()
+func executeMountProfileUpdate(upCtx MountProfileUpdateContext) error {
+	unlock, err := upCtx.Lock()
 	if err != nil {
 		return err
 	}
 	defer unlock()
 
-	desired, err := ctx.LoadDesiredProfile()
+	desired, err := upCtx.LoadDesiredProfile()
 	if err != nil {
 		return err
 	}
 	debugShowProfile(desired, "desired mount profile")
 
-	currentBefore, err := ctx.LoadCurrentProfile()
+	currentBefore, err := upCtx.LoadCurrentProfile()
 	if err != nil {
 		return err
 	}
 	debugShowProfile(currentBefore, "current mount profile (before applying changes)")
 
 	// Synthesize mount changes that were applied before for the purpose of the tmpfs detector.
-	as := ctx.Assumptions()
+	as := upCtx.Assumptions()
 	for _, entry := range currentBefore.Entries {
 		as.AddChange(&Change{Action: Mount, Entry: entry})
 	}
@@ -109,5 +109,5 @@ func executeMountProfileUpdate(ctx MountProfileUpdateContext) error {
 		}
 	}
 	debugShowProfile(&currentAfter, "current mount profile (after applying changes)")
-	return ctx.SaveCurrentProfile(&currentAfter)
+	return upCtx.SaveCurrentProfile(&currentAfter)
 }

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -46,8 +46,8 @@ func (s *updateSuite) SetUpTest(c *C) {
 }
 
 func (s *updateSuite) TestSmoke(c *C) {
-	ctx := &testProfileUpdateContext{}
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	upCtx := &testProfileUpdateContext{}
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 }
 
 func (s *updateSuite) TestUpdateFlow(c *C) {
@@ -58,7 +58,7 @@ func (s *updateSuite) TestUpdateFlow(c *C) {
 	// - the updated current profile is saved
 	var funcsCalled []string
 	var nChanges int
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		loadCurrentProfile: func() (*osutil.MountProfile, error) {
 			funcsCalled = append(funcsCalled, "loaded-current")
 			return &osutil.MountProfile{}, nil
@@ -81,11 +81,12 @@ func (s *updateSuite) TestUpdateFlow(c *C) {
 			return nil
 		},
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Assert(funcsCalled, DeepEquals, []string{"loaded-desired", "loaded-current",
 		"changes-computed", "change-1-performed", "change-2-performed", "saved-current"})
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 }
 
 func (s *updateSuite) TestResultingProfile(c *C) {
@@ -94,7 +95,7 @@ func (s *updateSuite) TestResultingProfile(c *C) {
 	// unchanged) as well as newly mounted entries. Unmounted entries simple
 	// cease to be.
 	var saved *osutil.MountProfile
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		neededChanges: func(old, new *osutil.MountProfile) []*update.Change {
 			return []*update.Change{
 				{Action: update.Keep, Entry: osutil.MountEntry{Dir: "/keep"}},
@@ -107,9 +108,9 @@ func (s *updateSuite) TestResultingProfile(c *C) {
 			return nil
 		},
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Check(saved, DeepEquals, &osutil.MountProfile{Entries: []osutil.MountEntry{
 		{Dir: "/keep"},
 		{Dir: "/mount"},
@@ -124,17 +125,17 @@ func (s *updateSuite) TestSynthesizedPastChanges(c *C) {
 	entry, err := osutil.ParseMountEntry(text)
 	c.Assert(err, IsNil)
 	as := &update.Assumptions{}
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		loadCurrentProfile: func() (*osutil.MountProfile, error) { return osutil.LoadMountProfileText(text) },
 		loadDesiredProfile: func() (*osutil.MountProfile, error) { return osutil.LoadMountProfileText(text) },
 		assumptions:        func() *update.Assumptions { return as },
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
 
 	// Perform the update, this will modify assumptions.
 	c.Check(as.PastChanges(), HasLen, 0)
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Check(as.PastChanges(), HasLen, 1)
 	c.Check(as.PastChanges(), DeepEquals, []*update.Change{{
 		Action: update.Mount,
@@ -147,7 +148,7 @@ func (s *updateSuite) TestSyntheticChanges(c *C) {
 	// to be performed, that were needed internally. Such changes are recorded
 	// and saved into the current profile.
 	var saved *osutil.MountProfile
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		loadDesiredProfile: func() (*osutil.MountProfile, error) {
 			return &osutil.MountProfile{Entries: []osutil.MountEntry{
 				{Dir: "/subdir/mount"},
@@ -173,9 +174,9 @@ func (s *updateSuite) TestSyntheticChanges(c *C) {
 			return nil, nil
 		},
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Check(saved, DeepEquals, &osutil.MountProfile{Entries: []osutil.MountEntry{
 		{Dir: "/subdir", Type: "tmpfs"},
 		{Dir: "/subdir/mount"},
@@ -187,7 +188,7 @@ func (s *updateSuite) TestCannotPerformContentInterfaceChange(c *C) {
 	// ignore the error carry on. Such changes are not stored in the updated
 	// current profile.
 	var saved *osutil.MountProfile
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		saveCurrentProfile: func(profile *osutil.MountProfile) error {
 			saved = profile
 			return nil
@@ -212,9 +213,9 @@ func (s *updateSuite) TestCannotPerformContentInterfaceChange(c *C) {
 			return nil, nil
 		},
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
-	c.Assert(update.ExecuteMountProfileUpdate(ctx), IsNil)
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Check(saved, DeepEquals, &osutil.MountProfile{Entries: []osutil.MountEntry{
 		{Dir: "/dir-1"},
 		{Dir: "/dir-3"},
@@ -227,7 +228,7 @@ func (s *updateSuite) TestCannotPerformContentInterfaceChange(c *C) {
 func (s *updateSuite) TestCannotPerformLayoutChange(c *C) {
 	// When performing a mount change for a layout, errors are immediately fatal.
 	var saved *osutil.MountProfile
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		saveCurrentProfile: func(profile *osutil.MountProfile) error {
 			saved = profile
 			return nil
@@ -247,9 +248,9 @@ func (s *updateSuite) TestCannotPerformLayoutChange(c *C) {
 			return nil, nil
 		},
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
-	err := update.ExecuteMountProfileUpdate(ctx)
+	err := update.ExecuteMountProfileUpdate(upCtx)
 	c.Check(err, Equals, errTesting)
 	c.Check(saved, IsNil)
 }
@@ -257,7 +258,7 @@ func (s *updateSuite) TestCannotPerformLayoutChange(c *C) {
 func (s *updateSuite) TestCannotPerformOvermountChange(c *C) {
 	// When performing a mount change for an "overname", errors are immediately fatal.
 	var saved *osutil.MountProfile
-	ctx := &testProfileUpdateContext{
+	upCtx := &testProfileUpdateContext{
 		saveCurrentProfile: func(profile *osutil.MountProfile) error {
 			saved = profile
 			return nil
@@ -277,9 +278,9 @@ func (s *updateSuite) TestCannotPerformOvermountChange(c *C) {
 			return nil, nil
 		},
 	}
-	restore := ctx.MockRelatedFunctions()
+	restore := upCtx.MockRelatedFunctions()
 	defer restore()
-	err := update.ExecuteMountProfileUpdate(ctx)
+	err := update.ExecuteMountProfileUpdate(upCtx)
 	c.Check(err, Equals, errTesting)
 	c.Check(saved, IsNil)
 }

--- a/cmd/snap-update-ns/user.go
+++ b/cmd/snap-update-ns/user.go
@@ -49,19 +49,19 @@ func NewUserProfileUpdateContext(instanceName string, fromSnapConfine bool, uid 
 }
 
 // UID returns the user ID of the mount namespace being updated.
-func (ctx *UserProfileUpdateContext) UID() int {
-	return ctx.uid
+func (upCtx *UserProfileUpdateContext) UID() int {
+	return upCtx.uid
 }
 
 // Lock acquires locks / freezes needed to synchronize mount namespace changes.
-func (ctx *UserProfileUpdateContext) Lock() (unlock func(), err error) {
+func (upCtx *UserProfileUpdateContext) Lock() (unlock func(), err error) {
 	// TODO: when persistent user mount namespaces are enabled, grab a lock
 	// protecting the snap and freeze snap processes here.
 	return func() {}, nil
 }
 
 // Assumptions returns information about file system mutability rules.
-func (ctx *UserProfileUpdateContext) Assumptions() *Assumptions {
+func (upCtx *UserProfileUpdateContext) Assumptions() *Assumptions {
 	// TODO: configure the secure helper and inform it about directories that
 	// can be created without trespassing.
 	as := &Assumptions{}
@@ -72,29 +72,29 @@ func (ctx *UserProfileUpdateContext) Assumptions() *Assumptions {
 }
 
 // LoadDesiredProfile loads the desired, per-user mount profile, expanding user-specific variables.
-func (ctx *UserProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
-	profile, err := ctx.CommonProfileUpdateContext.LoadDesiredProfile()
+func (upCtx *UserProfileUpdateContext) LoadDesiredProfile() (*osutil.MountProfile, error) {
+	profile, err := upCtx.CommonProfileUpdateContext.LoadDesiredProfile()
 	if err != nil {
 		return nil, err
 	}
 	// TODO: when SNAP_USER_DATA, SNAP_USER_COMMON or other variables relating
 	// to the user name and their home directory need to be expanded then
 	// handle them here.
-	expandXdgRuntimeDir(profile, ctx.uid)
+	expandXdgRuntimeDir(profile, upCtx.uid)
 	return profile, nil
 }
 
 // SaveCurrentProfile does nothing at all.
 //
 // Per-user mount profiles are not persisted yet.
-func (ctx *UserProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
+func (upCtx *UserProfileUpdateContext) SaveCurrentProfile(profile *osutil.MountProfile) error {
 	return nil
 }
 
 // LoadCurrentProfile returns the empty profile.
 //
 // Per-user mount profiles are not persisted yet.
-func (ctx *UserProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
+func (upCtx *UserProfileUpdateContext) LoadCurrentProfile() (*osutil.MountProfile, error) {
 	return &osutil.MountProfile{}, nil
 }
 

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -42,18 +42,18 @@ func (s *userSuite) TestLock(c *C) {
 	defer dirs.SetRootDir("/")
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
 
-	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+	upCtx := update.NewUserProfileUpdateContext("foo", false, 1234)
 
 	// Locking is a no-op.
-	unlock, err := ctx.Lock()
+	unlock, err := upCtx.Lock()
 	c.Assert(err, IsNil)
 	c.Check(unlock, NotNil)
 	unlock()
 }
 
 func (s *userSuite) TestAssumptions(c *C) {
-	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
-	as := ctx.Assumptions()
+	upCtx := update.NewUserProfileUpdateContext("foo", false, 1234)
+	as := upCtx.Assumptions()
 	c.Check(as.UnrestrictedPaths(), IsNil)
 }
 
@@ -63,7 +63,7 @@ func (s *userSuite) TestLoadDesiredProfile(c *C) {
 	defer dirs.SetRootDir("/")
 	dirs.XdgRuntimeDirBase = "/run/user"
 
-	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+	upCtx := update.NewUserProfileUpdateContext("foo", false, 1234)
 
 	input := "$XDG_RUNTIME_DIR/doc/by-app/snap.foo $XDG_RUNTIME_DIR/doc none bind,rw 0 0\n"
 	output := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
@@ -74,7 +74,7 @@ func (s *userSuite) TestLoadDesiredProfile(c *C) {
 	c.Assert(ioutil.WriteFile(path, []byte(input), 0644), IsNil)
 
 	// Ask the user profile update helper to read the desired profile.
-	profile, err := ctx.LoadDesiredProfile()
+	profile, err := upCtx.LoadDesiredProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -88,16 +88,16 @@ func (s *userSuite) TestLoadCurrentProfile(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("/")
 
-	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+	upCtx := update.NewUserProfileUpdateContext("foo", false, 1234)
 
 	// Write a current user mount profile for snap "foo".
 	text := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
-	path := update.CurrentUserProfilePath(ctx.InstanceName(), ctx.UID())
+	path := update.CurrentUserProfilePath(upCtx.InstanceName(), upCtx.UID())
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the user profile update helper to read the current profile.
-	profile, err := ctx.LoadCurrentProfile()
+	profile, err := upCtx.LoadCurrentProfile()
 	c.Assert(err, IsNil)
 	builder := &bytes.Buffer{}
 	profile.WriteTo(builder)
@@ -113,7 +113,7 @@ func (s *userSuite) TestSaveCurrentProfile(c *C) {
 	defer dirs.SetRootDir("/")
 	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
 
-	ctx := update.NewUserProfileUpdateContext("foo", false, 1234)
+	upCtx := update.NewUserProfileUpdateContext("foo", false, 1234)
 
 	// Prepare a mount profile to be saved.
 	text := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
@@ -126,7 +126,7 @@ func (s *userSuite) TestSaveCurrentProfile(c *C) {
 	c.Assert(ioutil.WriteFile(path, []byte("banana"), 0644), IsNil)
 
 	// Ask the user profile update helper to write the current profile.
-	err = ctx.SaveCurrentProfile(profile)
+	err = upCtx.SaveCurrentProfile(profile)
 	c.Assert(err, IsNil)
 
 	// Note that the profile was not modified.


### PR DESCRIPTION
While doing a code review for the original branch Pedronis and me have
agreed to use upCtx to differentiate the plain ctx from a golang context
type.

Since the intermediate patches used ctx to avoid churn and re-basing we
need one follow up patch to rename everything at once. This is it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>