### PR TITLE
tests: add "not" command

### DIFF
--- a/tests/lib/bin/not
+++ b/tests/lib/bin/not
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This script executes whatever is given as argument and inverts the return
+# value. It is meant as a workaround for shellcheck discovery
+# https://github.com/koalaman/shellcheck/wiki/SC2251 where shell scripts using
+# "set -e" are not failing with a trivial code like "! true"
+! "$@"


### PR DESCRIPTION
The "not" command can be used as a replacement of shell's built-in
negation syntax "!" without triggering undesired behavior in relation to
set -e, where set -e; ! true; does not exit the script.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
