### PR TITLE
spread.yaml,tests: change MATCH and REBOOT to cmds

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -570,9 +570,17 @@ prepare: |
         rmdir "$DELTA_PREFIX"
     fi
 
-    # Take the MATCH and REBOOT functions from spread and allow our shell scripts to use them.
+    # Take the MATCH and REBOOT functions from spread and allow our shell
+    # scripts to use them as shell commands. The replacements are real
+    # executables in tests/lib/bin (which is on PATH) but they source
+    # spread-funcs.sh written here, base on the definitions provided by SPREAD.
+    # This ensures that 1) spread functions define the code 2) both MATCH and
+    # REBOOT are executables and not functions, and can be called from any
+    # context.
     type MATCH | tail -n +2 > "$TESTSLIB"/spread-funcs.sh
+    unset MATCH
     type REBOOT | tail -n +2 >> "$TESTSLIB"/spread-funcs.sh
+    unset REBOOT
 
     if [ -e /etc/profile.d/go.sh ]; then
         # Up until recently openSUSE golang packaging injected environment

--- a/tests/lib/bin/MATCH
+++ b/tests/lib/bin/MATCH
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Source spread-funcs.sh which, at runtime, contains the real definition of
+# MATCH and execute it.
+
+# shellcheck source=tests/lib/spread-funcs.sh 
+. "$TESTSLIB/spread-funcs.sh"
+
+MATCH "$@"

--- a/tests/lib/bin/REBOOT
+++ b/tests/lib/bin/REBOOT
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Source spread-funcs.sh which, at runtime, contains the real definition of
+# REBOOT and execute it.
+
+# shellcheck source=tests/lib/spread-funcs.sh 
+. "$TESTSLIB/spread-funcs.sh"
+
+REBOOT "$@"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -22,9 +22,6 @@ set -e
 # shellcheck source=tests/lib/random.sh
 . "$TESTSLIB/random.sh"
 
-# shellcheck source=tests/lib/spread-funcs.sh
-. "$TESTSLIB/spread-funcs.sh"
-
 # shellcheck source=tests/lib/journalctl.sh
 . "$TESTSLIB/journalctl.sh"
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -10,8 +10,6 @@ set -eux
 . "$TESTSLIB/pkgdb.sh"
 # shellcheck source=tests/lib/boot.sh
 . "$TESTSLIB/boot.sh"
-# shellcheck source=tests/lib/spread-funcs.sh
-. "$TESTSLIB/spread-funcs.sh"
 # shellcheck source=tests/lib/state.sh
 . "$TESTSLIB/state.sh"
 # shellcheck source=tests/lib/systems.sh


### PR DESCRIPTION
MATCH and REBOOT are bash functions defined by spread itself. For the
longest time we've been capturing their definitions so that scripts that
are not sourced from spread.yaml or task.yaml (so don't have access to
their definition) can still execute them.

This patch evolves the idea to unset the original definitions and
convert them to proper executables that are on PATH. This allows them to
be used from any programming language (including Python) and to be used
with the recently-introduced "not" command.

Existing users of the spread-funcs.sh are converted to just execute the
commands from PATH.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
