### PR TITLE
spread.yaml: use "snap connections" in debug

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -437,8 +437,8 @@ debug-each: |
         esac
         echo '# seccomp denials (kills) '
         dmesg --ctime | grep type=1326 || true
-        echo '# snap interfaces'
-        snap interfaces || true
+        echo '# snap connections'
+        snap connections || true
         echo '# tasks executed on system'
         cat "$RUNTIME_STATE_PATH/runs" || true
         echo '# free space'

--- a/spread.yaml
+++ b/spread.yaml
@@ -437,8 +437,8 @@ debug-each: |
         esac
         echo '# seccomp denials (kills) '
         dmesg --ctime | grep type=1326 || true
-        echo '# snap connections'
-        snap connections || true
+        echo '# snap connections --all'
+        snap connections --all || true
         echo '# tasks executed on system'
         cat "$RUNTIME_STATE_PATH/runs" || true
         echo '# free space'


### PR DESCRIPTION
The debug-each section calls "snap interfaces" which has rather quirky
output. We now have a much better way to display that via "snap
connections", let's use it.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
