### PR TITLE
gadget: keep track of the index where structure content was defined

### DIFF
--- a/gadget/position.go
+++ b/gadget/position.go
@@ -86,6 +86,8 @@ type PositionedContent struct {
 	PositionedOffsetWrite *Size
 	// Size is the maximum size occupied by this image
 	Size Size
+	// Index of the content in structure declaration inside gadget YAML
+	Index int
 }
 
 // PositionVolume attempts to lay out the volume using constraints and returns a
@@ -246,6 +248,7 @@ func positionStructureContent(gadgetRootDir string, ps *PositionedStructure, kno
 			Size:                  actualSize,
 			StartOffset:           ps.StartOffset + start,
 			PositionedOffsetWrite: offsetWrite,
+			Index:                 idx,
 		}
 		previousEnd = start + actualSize
 		if previousEnd > ps.Size {

--- a/gadget/position.go
+++ b/gadget/position.go
@@ -244,11 +244,12 @@ func positionStructureContent(gadgetRootDir string, ps *PositionedStructure, kno
 		}
 
 		content[idx] = PositionedContent{
-			VolumeContent:         &ps.Content[idx],
-			Size:                  actualSize,
-			StartOffset:           ps.StartOffset + start,
+			VolumeContent: &ps.Content[idx],
+			Size:          actualSize,
+			StartOffset:   ps.StartOffset + start,
+			Index:         idx,
+			// break for gofmt < 1.11
 			PositionedOffsetWrite: offsetWrite,
-			Index:                 idx,
 		}
 		previousEnd = start + actualSize
 		if previousEnd > ps.Size {

--- a/gadget/position_test.go
+++ b/gadget/position_test.go
@@ -474,11 +474,13 @@ volumes:
 						VolumeContent: &vol.Structure[0].Content[1],
 						StartOffset:   1 * gadget.SizeMiB,
 						Size:          gadget.SizeMiB,
+						Index:         1,
 					},
 					{
 						VolumeContent: &vol.Structure[0].Content[0],
 						StartOffset:   2 * gadget.SizeMiB,
 						Size:          gadget.SizeMiB,
+						Index:         0,
 					},
 				},
 			},
@@ -523,11 +525,13 @@ volumes:
 						VolumeContent: &vol.Structure[0].Content[0],
 						StartOffset:   1 * gadget.SizeMiB,
 						Size:          gadget.SizeMiB,
+						Index:         0,
 					},
 					{
 						VolumeContent: &vol.Structure[0].Content[1],
 						StartOffset:   2 * gadget.SizeMiB,
 						Size:          gadget.SizeMiB,
+						Index:         1,
 					},
 				},
 			},
@@ -1034,10 +1038,12 @@ volumes:
 				VolumeContent: &vol.Structure[0].Content[0],
 				Size:          200 * gadget.SizeKiB,
 				StartOffset:   1 * gadget.SizeMiB,
+				Index:         0,
 			}, {
 				VolumeContent: &vol.Structure[0].Content[1],
 				Size:          150 * gadget.SizeKiB,
 				StartOffset:   1*gadget.SizeMiB + 300*gadget.SizeKiB,
+				Index:         1,
 			},
 		},
 	})
@@ -1053,10 +1059,12 @@ volumes:
 				VolumeContent: &vol.Structure[0].Content[0],
 				Size:          200 * gadget.SizeKiB,
 				StartOffset:   0,
+				Index:         0,
 			}, {
 				VolumeContent: &vol.Structure[0].Content[1],
 				Size:          150 * gadget.SizeKiB,
 				StartOffset:   300 * gadget.SizeKiB,
+				Index:         1,
 			},
 		},
 	})
@@ -1072,10 +1080,12 @@ volumes:
 				VolumeContent: &vol.Structure[0].Content[0],
 				Size:          200 * gadget.SizeKiB,
 				StartOffset:   2 * gadget.SizeMiB,
+				Index:         0,
 			}, {
 				VolumeContent: &vol.Structure[0].Content[1],
 				Size:          150 * gadget.SizeKiB,
 				StartOffset:   2*gadget.SizeMiB + 300*gadget.SizeKiB,
+				Index:         1,
 			},
 		},
 	})


### PR DESCRIPTION
Keep track of the original index of the declaration of content within the
structure. Makes it easier to refer back to the content.
