### PR TITLE
spread: enable Fedora 30 (2.39)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -82,6 +82,9 @@ backends:
                 manual: true
             - fedora-29-64:
                 workers: 6
+                manual: true
+            - fedora-30-64:
+                workers: 6
             - opensuse-42.3-64:
                 workers: 4
                 # golang stack cannot compile anything, needs investigation


### PR DESCRIPTION
Cherry-picked spread.yaml patch from #6860 