### PR TITLE
Add endpoint for snap download in the daemon

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -83,6 +83,7 @@ var api = []*Command{
 	snapsCmd,
 	snapCmd,
 	snapFileCmd,
+	snapDownloadCmd,
 	snapConfCmd,
 	interfacesCmd,
 	assertsCmd,

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -59,7 +59,7 @@ func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Respons
 	}
 
 	if len(action.Snaps) == 0 {
-		return BadRequest("download operation requires at least one snap name")
+		return BadRequest("download operation requires exactlywgrant one snap name")
 	}
 
 	if len(action.Snaps) != 1 {

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -1,0 +1,208 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/store"
+)
+
+var snapDownloadCmd = &Command{
+	Path:     "/v2/download",
+	UserOK:   true,
+	PolkitOK: "io.snapcraft.snapd.manage",
+	POST:     postSnapDownload,
+}
+
+// snapDownloadAction is used to request a snap download
+type snapDownloadAction struct {
+	Action string   `json:"action"`
+	Snaps  []string `json:"snaps,omitempty"`
+}
+
+// See: https://forum.snapcraft.io/t/downloading-snaps-via-snapd/11449
+func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Response {
+
+	fmt.Println(">>> postSnapDownload()")
+
+	var action snapDownloadAction
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&action); err != nil {
+		return BadRequest("cannot decode request body into download operation: %v", err)
+	}
+	if decoder.More() {
+		return BadRequest("extra content found after download operation")
+	}
+
+	if len(action.Snaps) == 0 {
+		return BadRequest("download operation requires at least one snap name")
+	}
+
+	if action.Action == "" {
+		return BadRequest("download operation requires action")
+	}
+
+	// st := c.d.overlord.State()
+	// st.Lock()
+	// defer st.Unlock()
+
+	switch action.Action {
+	case "download":
+		fmt.Printf(">>> postSnapDownload(): download %v snap\n", action.Snaps)
+	default:
+		return BadRequest("unknown download operation %q", action.Action)
+	}
+
+	name := action.Snaps[0]
+	theStore := getStore(c)
+
+	info, err := theStore.SnapInfo(store.SnapSpec{Name: name}, user)
+	if err != nil {
+		return SnapNotFound(name, err)
+	}
+	fmt.Printf(">>> postSnapDownload(): found snap %#v", info.DownloadInfo)
+
+	downloadInfo := info.DownloadInfo
+	url := downloadInfo.AnonDownloadURL
+	if url == "" {
+		url = downloadInfo.DownloadURL
+	}
+	w := NewMemoryStream()
+	// defer w.Close()
+
+	pbar := progress.MakeProgressBar()
+	defer pbar.Finished()
+
+	// func DownloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *DownloadOptions) error {
+	store.DownloadImpl(context.TODO(), name, downloadInfo.Sha3_384, url, user, theStore.(*store.Store), w, 0, pbar, nil)
+
+	return FileStream(w.Bytes())
+}
+
+type MemoryStream struct {
+	buff []byte
+	loc  int
+}
+
+// DefaultCapacity is the size in bytes of a new MemoryStream's backing buffer
+const DefaultCapacity = 512
+
+// New creates a new MemoryStream instance
+func NewMemoryStream() *MemoryStream {
+	return NewCapacity(DefaultCapacity)
+}
+
+// NewCapacity starts the returned MemoryStream with the given capacity
+func NewCapacity(cap int) *MemoryStream {
+	return &MemoryStream{buff: make([]byte, 0, DefaultCapacity), loc: 0}
+}
+
+// Seek sets the offset for the next Read or Write to offset, interpreted
+// according to whence: 0 means relative to the origin of the file, 1 means
+// relative to the current offset, and 2 means relative to the end. Seek
+// returns the new offset and an error, if any.
+//
+// Seeking to a negative offset is an error. Seeking to any positive offset is
+// legal. If the location is beyond the end of the current length, the position
+// will be placed at length.
+func (m *MemoryStream) Seek(offset int64, whence int) (int64, error) {
+	newLoc := m.loc
+	switch whence {
+	case 0:
+		newLoc = int(offset)
+	case 1:
+		newLoc += int(offset)
+	case 2:
+		newLoc = len(m.buff) - int(offset)
+	}
+
+	if newLoc < 0 {
+		return int64(m.loc), errors.New("Unable to seek to a location <0")
+	}
+
+	if newLoc > len(m.buff) {
+		newLoc = len(m.buff)
+	}
+
+	m.loc = newLoc
+
+	return int64(m.loc), nil
+}
+
+// Read puts up to len(p) bytes into p. Will return the number of bytes read.
+func (m *MemoryStream) Read(p []byte) (n int, err error) {
+	n = copy(p, m.buff[m.loc:len(m.buff)])
+	m.loc += n
+
+	if m.loc == len(m.buff) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+// Write writes the given bytes into the memory stream. If needed, the underlying
+// buffer will be expanded to fit the new bytes.
+func (m *MemoryStream) Write(p []byte) (n int, err error) {
+	// Do we have space?
+	if available := cap(m.buff) - m.loc; available < len(p) {
+		// How much should we expand by?
+		addCap := cap(m.buff)
+		if addCap < len(p) {
+			addCap = len(p)
+		}
+
+		newBuff := make([]byte, len(m.buff), cap(m.buff)+addCap)
+
+		copy(newBuff, m.buff)
+
+		m.buff = newBuff
+	}
+
+	// Write
+	n = copy(m.buff[m.loc:cap(m.buff)], p)
+	m.loc += n
+	if len(m.buff) < m.loc {
+		m.buff = m.buff[:m.loc]
+	}
+
+	return n, nil
+}
+
+// Bytes returns a copy of ALL valid bytes in the stream, regardless of the current
+// position.
+func (m *MemoryStream) Bytes() []byte {
+	b := make([]byte, len(m.buff))
+	copy(b, m.buff)
+	return b
+}
+
+// Rewind returns the stream to the beginning
+func (m *MemoryStream) Rewind() (int64, error) {
+	return m.Seek(0, 0)
+}

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -39,8 +39,8 @@ var snapDownloadCmd = &Command{
 
 // snapDownloadAction is used to request a snap download
 type snapDownloadAction struct {
-	Action string `json:"action"`
-	Snaps []snapDownloadInfo `json:"snaps,omitempty"`
+	Action string             `json:"action"`
+	Snaps  []snapDownloadInfo `json:"snaps,omitempty"`
 }
 
 type snapDownloadInfo struct {
@@ -89,6 +89,7 @@ func streamOne(snap snapDownloadInfo, theStore *store.Store, user *auth.UserStat
 	downloadInfo := info.DownloadInfo
 	memStream := NewMemoryStream()
 	go func() {
+		defer memStream.PipeWriter.Close()
 		err := store.DownloadStream(context.TODO(), theStore, snap.Name, snap.Resume, &downloadInfo, user, memStream)
 		if err != nil {
 			memStream.PipeWriter.CloseWithError(err)

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -22,13 +22,11 @@ package daemon
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 
+	"github.com/traherom/memstream"
+
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -45,11 +43,7 @@ type snapDownloadAction struct {
 	Snaps  []string `json:"snaps,omitempty"`
 }
 
-// See: https://forum.snapcraft.io/t/downloading-snaps-via-snapd/11449
 func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Response {
-
-	fmt.Println(">>> postSnapDownload()")
-
 	var action snapDownloadAction
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&action); err != nil {
@@ -63,146 +57,42 @@ func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Respons
 		return BadRequest("download operation requires at least one snap name")
 	}
 
+	if len(action.Snaps) != 1 {
+		return BadRequest("download operation supports only one snap")
+	}
+
 	if action.Action == "" {
 		return BadRequest("download operation requires action")
 	}
 
-	// st := c.d.overlord.State()
-	// st.Lock()
-	// defer st.Unlock()
-
 	switch action.Action {
 	case "download":
-		fmt.Printf(">>> postSnapDownload(): download %v snap\n", action.Snaps)
+		theStore := getStore(c)
+		name := action.Snaps[0]
+		return streamOne(name, theStore.(*store.Store), user)
 	default:
 		return BadRequest("unknown download operation %q", action.Action)
 	}
+}
 
-	name := action.Snaps[0]
-	theStore := getStore(c)
+func streamOne(name string, theStore *store.Store, user *auth.UserState) Response {
 
 	info, err := theStore.SnapInfo(store.SnapSpec{Name: name}, user)
 	if err != nil {
 		return SnapNotFound(name, err)
 	}
-	fmt.Printf(">>> postSnapDownload(): found snap %#v", info.DownloadInfo)
 
 	downloadInfo := info.DownloadInfo
 	url := downloadInfo.AnonDownloadURL
 	if url == "" {
 		url = downloadInfo.DownloadURL
 	}
-	w := NewMemoryStream()
-	// defer w.Close()
+	memStream := memstream.New()
 
-	pbar := progress.MakeProgressBar()
-	defer pbar.Finished()
-
-	// func DownloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *DownloadOptions) error {
-	store.DownloadImpl(context.TODO(), name, downloadInfo.Sha3_384, url, user, theStore.(*store.Store), w, 0, pbar, nil)
-
-	return FileStream(w.Bytes())
-}
-
-type MemoryStream struct {
-	buff []byte
-	loc  int
-}
-
-// DefaultCapacity is the size in bytes of a new MemoryStream's backing buffer
-const DefaultCapacity = 512
-
-// New creates a new MemoryStream instance
-func NewMemoryStream() *MemoryStream {
-	return NewCapacity(DefaultCapacity)
-}
-
-// NewCapacity starts the returned MemoryStream with the given capacity
-func NewCapacity(cap int) *MemoryStream {
-	return &MemoryStream{buff: make([]byte, 0, DefaultCapacity), loc: 0}
-}
-
-// Seek sets the offset for the next Read or Write to offset, interpreted
-// according to whence: 0 means relative to the origin of the file, 1 means
-// relative to the current offset, and 2 means relative to the end. Seek
-// returns the new offset and an error, if any.
-//
-// Seeking to a negative offset is an error. Seeking to any positive offset is
-// legal. If the location is beyond the end of the current length, the position
-// will be placed at length.
-func (m *MemoryStream) Seek(offset int64, whence int) (int64, error) {
-	newLoc := m.loc
-	switch whence {
-	case 0:
-		newLoc = int(offset)
-	case 1:
-		newLoc += int(offset)
-	case 2:
-		newLoc = len(m.buff) - int(offset)
+	store.DownloadImpl(context.TODO(), name, downloadInfo.Sha3_384, url, user, theStore, memStream)
+	return FileStream{
+		FileName: name,
+		Info:     downloadInfo,
+		stream:   memStream.Bytes(),
 	}
-
-	if newLoc < 0 {
-		return int64(m.loc), errors.New("Unable to seek to a location <0")
-	}
-
-	if newLoc > len(m.buff) {
-		newLoc = len(m.buff)
-	}
-
-	m.loc = newLoc
-
-	return int64(m.loc), nil
-}
-
-// Read puts up to len(p) bytes into p. Will return the number of bytes read.
-func (m *MemoryStream) Read(p []byte) (n int, err error) {
-	n = copy(p, m.buff[m.loc:len(m.buff)])
-	m.loc += n
-
-	if m.loc == len(m.buff) {
-		return n, io.EOF
-	}
-
-	return n, nil
-}
-
-// Write writes the given bytes into the memory stream. If needed, the underlying
-// buffer will be expanded to fit the new bytes.
-func (m *MemoryStream) Write(p []byte) (n int, err error) {
-	// Do we have space?
-	if available := cap(m.buff) - m.loc; available < len(p) {
-		// How much should we expand by?
-		addCap := cap(m.buff)
-		if addCap < len(p) {
-			addCap = len(p)
-		}
-
-		newBuff := make([]byte, len(m.buff), cap(m.buff)+addCap)
-
-		copy(newBuff, m.buff)
-
-		m.buff = newBuff
-	}
-
-	// Write
-	n = copy(m.buff[m.loc:cap(m.buff)], p)
-	m.loc += n
-	if len(m.buff) < m.loc {
-		m.buff = m.buff[:m.loc]
-	}
-
-	return n, nil
-}
-
-// Bytes returns a copy of ALL valid bytes in the stream, regardless of the current
-// position.
-func (m *MemoryStream) Bytes() []byte {
-	b := make([]byte, len(m.buff))
-	copy(b, m.buff)
-	return b
-}
-
-// Rewind returns the stream to the beginning
-func (m *MemoryStream) Rewind() (int64, error) {
-	return m.Seek(0, 0)
 }

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -59,7 +59,7 @@ func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Respons
 	}
 
 	if len(action.Snaps) == 0 {
-		return BadRequest("download operation requires exactlywgrant one snap name")
+		return BadRequest("download operation requires one snap name")
 	}
 
 	if len(action.Snaps) != 1 {

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -51,7 +51,7 @@ func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 				Action: "download",
 			},
 			status: 400,
-			err:    "download operation requires at least one snap name",
+			err:    "download operation requires exactly one snap name",
 		},
 		{
 			data: snapDownloadAction{

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -38,7 +38,7 @@ type snapDownloadSuite struct {
 func (s *snapDownloadSuite) SetUpTest(c *check.C) {
 }
 
-func (s *snapDownloadSuite) TestDownloadSnap(c *check.C) {
+func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 	type scenario struct {
 		data   snapDownloadAction
 		status int
@@ -55,16 +55,30 @@ func (s *snapDownloadSuite) TestDownloadSnap(c *check.C) {
 		},
 		{
 			data: snapDownloadAction{
-				Action: "stream",
-				Snaps:  []string{"foo"},
+				Action: "foo",
+				Snaps: []snapDownloadInfo{
+					{
+						Name:   "foo",
+						Resume: 0,
+					},
+				},
 			},
 			status: 400,
 			err:    `unknown download operation "stream"`,
 		},
 		{
 			data: snapDownloadAction{
-				Action: "stream",
-				Snaps:  []string{"foo", "bar"},
+				Action: "foo",
+				Snaps: []snapDownloadInfo{
+					{
+						Name:   "foo",
+						Resume: 0,
+					},
+					{
+						Name:   "bar",
+						Resume: 0,
+					},
+				},
 			},
 			status: 400,
 			err:    `download operation supports only one snap`,
@@ -76,8 +90,9 @@ func (s *snapDownloadSuite) TestDownloadSnap(c *check.C) {
 		c.Assert(err, check.IsNil)
 		rsp := postSnapDownload(snapDownloadCmd, req, nil).(*resp)
 		c.Assert(rsp.Status, check.Equals, scen.status)
-		if scen.err != "" {
-			c.Check(rsp.Result.(*errorResult).Message, check.Matches, scen.err)
+		if scen.err == "" {
+			c.Errorf("error is empty")
 		}
+		c.Check(rsp.Result.(*errorResult).Message, check.Matches, scen.err)
 	}
 }

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -1,0 +1,29 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import "gopkg.in/check.v1"
+
+var _ = check.Suite(&snapDownloadSuite{})
+
+type snapDownloadSuite struct{}
+
+func (s *snapDownloadSuite) SetUpTest(c *check.C) {
+}

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -22,11 +22,9 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/snapcore/snapd/store"
-	fakestore "github.com/snapcore/snapd/tests/lib/fakestore/store"
 
 	"gopkg.in/check.v1"
 )
@@ -38,20 +36,16 @@ type snapDownloadSuite struct {
 }
 
 func (s *snapDownloadSuite) SetUpTest(c *check.C) {
-	// s.fakeStore = fakestore.NewStore("", "localhost", false).(*store.Store)
 }
 
 func (s *snapDownloadSuite) TestDownloadSnap(c *check.C) {
-
-	fstore := fakestore.NewStore("", "localhost", false)
-
 	type scenario struct {
 		data   snapDownloadAction
 		status int
 		err    string
 	}
 
-	for i, scen := range []scenario{
+	for _, scen := range []scenario{
 		{
 			data: snapDownloadAction{
 				Action: "download",
@@ -76,7 +70,6 @@ func (s *snapDownloadSuite) TestDownloadSnap(c *check.C) {
 			err:    `download operation supports only one snap`,
 		},
 	} {
-		fmt.Printf("runnung test case number %d\n", i)
 		data, err := json.Marshal(scen.data)
 		c.Check(err, check.IsNil)
 		req, err := http.NewRequest("POST", "/v2/download", bytes.NewBuffer(data))
@@ -87,5 +80,4 @@ func (s *snapDownloadSuite) TestDownloadSnap(c *check.C) {
 			c.Check(rsp.Result.(*errorResult).Message, check.Matches, scen.err)
 		}
 	}
-
 }

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -51,7 +51,7 @@ func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 				Action: "download",
 			},
 			status: 400,
-			err:    "download operation requires exactly one snap name",
+			err:    "download operation requires one snap name",
 		},
 		{
 			data: snapDownloadAction{

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -64,7 +64,7 @@ func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 				},
 			},
 			status: 400,
-			err:    `unknown download operation "stream"`,
+			err:    `unknown download operation "foo"`,
 		},
 		{
 			data: snapDownloadAction{

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -247,27 +247,24 @@ func makeErrorResponder(status int) errorResponder {
 	}
 }
 
-type FileStream []byte
+// A FileStream ServeHTTP method streams the snap
+type FileStream struct {
+	FileName string
+	Info     snap.DownloadInfo
+	stream   []byte
+}
 
 // ServeHTTP from the Response interface
 func (s FileStream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// grab the generated receipt.pdf file and stream it to browser
-	// streamPDFbytes, err := ioutil.ReadFile("./receipt.pdf")
-	// if err != nil {
-	// 	fmt.Println(err)
-	// 	os.Exit(1)
-	// }
+	b := bytes.NewBuffer(s.stream)
 
-	b := bytes.NewBuffer(s)
-
-	// stream straight to client(browser)
-	w.Header().Set("Content-type", "application/octet-stream")
+	w.Header().Set("Content-Type", "application/octet-stream")
+	size := fmt.Sprintf("%d", s.Info.Size)
+	w.Header().Set("Content-Length", size)
 
 	if _, err := b.WriteTo(w); err != nil {
 		fmt.Fprintf(w, "%s", err)
 	}
-
-	// w.Write([]byte("PDF Generated"))
 }
 
 // A FileResponse 's ServeHTTP method serves the file

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -244,6 +245,29 @@ func makeErrorResponder(status int) errorResponder {
 			Status: status,
 		}
 	}
+}
+
+type FileStream []byte
+
+// ServeHTTP from the Response interface
+func (s FileStream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// grab the generated receipt.pdf file and stream it to browser
+	// streamPDFbytes, err := ioutil.ReadFile("./receipt.pdf")
+	// if err != nil {
+	// 	fmt.Println(err)
+	// 	os.Exit(1)
+	// }
+
+	b := bytes.NewBuffer(s)
+
+	// stream straight to client(browser)
+	w.Header().Set("Content-type", "application/octet-stream")
+
+	if _, err := b.WriteTo(w); err != nil {
+		fmt.Fprintf(w, "%s", err)
+	}
+
+	// w.Write([]byte("PDF Generated"))
 }
 
 // A FileResponse 's ServeHTTP method serves the file

--- a/store/store.go
+++ b/store/store.go
@@ -1461,9 +1461,9 @@ var ratelimitReader = ratelimit.Reader
 
 var download = downloadImpl
 
-// DownloadImpl ...
-func DownloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *DownloadOptions) error {
-	return downloadImpl(ctx, name, sha3_384, downloadURL, user, s, w, resume, pbar, dlOpts)
+// DownloadImpl wraps download implemetation of the store
+func DownloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user *auth.UserState, s *Store, w io.ReadWriteSeeker) error {
+	return downloadImpl(ctx, name, sha3_384, downloadURL, user, s, w, 0, nil, nil)
 }
 
 // download writes an http.Request showing a progress.Meter

--- a/store/store.go
+++ b/store/store.go
@@ -1461,6 +1461,11 @@ var ratelimitReader = ratelimit.Reader
 
 var download = downloadImpl
 
+// DownloadImpl ...
+func DownloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *DownloadOptions) error {
+	return downloadImpl(ctx, name, sha3_384, downloadURL, user, s, w, resume, pbar, dlOpts)
+}
+
 // download writes an http.Request showing a progress.Meter
 func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *DownloadOptions) error {
 	if dlOpts == nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -99,6 +99,12 @@
 			"tree": true
 		},
 		{
+			"checksumSHA1": "451qzVZIhYyGsK1Z4YueT3XBSso=",
+			"path": "github.com/traherom/memstream",
+			"revision": "b2247a2040b373fc4c81572104a7396a3c803c7f",
+			"revisionTime": "2015-10-17T19:59:31Z"
+		},
+		{
 			"checksumSHA1": "TT1rac6kpQp2vz24m5yDGUNQ/QQ=",
 			"path": "golang.org/x/crypto/cast5",
 			"revision": "5ef0053f77724838734b6945dd364d3847e5de1d"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -99,12 +99,6 @@
 			"tree": true
 		},
 		{
-			"checksumSHA1": "451qzVZIhYyGsK1Z4YueT3XBSso=",
-			"path": "github.com/traherom/memstream",
-			"revision": "b2247a2040b373fc4c81572104a7396a3c803c7f",
-			"revisionTime": "2015-10-17T19:59:31Z"
-		},
-		{
 			"checksumSHA1": "TT1rac6kpQp2vz24m5yDGUNQ/QQ=",
 			"path": "golang.org/x/crypto/cast5",
 			"revision": "5ef0053f77724838734b6945dd364d3847e5de1d"


### PR DESCRIPTION
This is first draft for implementing daemon-side endpoint for downloading snaps, see:
https://forum.snapcraft.io/t/downloading-snaps-via-snapd/11449/4
This supports download only for one snap at the time.
I tried to reuse as much code as possible.

* I have added `github.com/traherom/memstream` as external dependency, it is in memory buffer implementing `ReadWriteSeeker`. Maybe it's better way without this package