### PR TITLE
cmd/okay: Remove err message when warning file not exist

### DIFF
--- a/cmd/snap/cmd_warnings.go
+++ b/cmd/snap/cmd_warnings.go
@@ -138,7 +138,7 @@ func (cmd *cmdOkay) Execute(args []string) error {
 
 	last, err := lastWarningTimestamp()
 	if err != nil {
-		return fmt.Errorf("no client-side warning timestamp found: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	return cmd.client.Okay(last)
@@ -194,13 +194,11 @@ func lastWarningTimestamp() (time.Time, error) {
 		return time.Time{}, fmt.Errorf("cannot determine real user: %v", err)
 	}
 
-	fileName := warnFilename(user.HomeDir)
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		return time.Time{}, nil
-	}
-
-	f, err := os.Open(fileName)
+	f, err := os.Open(warnFilename(user.HomeDir))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return time.Time{}, fmt.Errorf("you must have looked at the warnings before acknowledging them. Try 'snap warnings'.")
+		}
 		return time.Time{}, fmt.Errorf("cannot open timestamp file: %v", err)
 
 	}

--- a/cmd/snap/cmd_warnings.go
+++ b/cmd/snap/cmd_warnings.go
@@ -193,7 +193,13 @@ func lastWarningTimestamp() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("cannot determine real user: %v", err)
 	}
-	f, err := os.Open(warnFilename(user.HomeDir))
+
+	fileName := warnFilename(user.HomeDir)
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		return time.Time{}, nil
+	}
+
+	f, err := os.Open(fileName)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("cannot open timestamp file: %v", err)
 

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -149,7 +149,9 @@ func isNetworkDown(err error) bool {
 	case *net.DNSError:
 		// on 16.04 we will not have SyscallError here, but DNSError, with
 		// no further details other than error message
-		return strings.Contains(lowerErr.Err, "connect: network is unreachable")
+		return strings.Contains(lowerErr.Err, "connect: network is unreachable") ||
+			strings.Contains(lowerErr.Err, "no such host") ||
+			strings.Contains(lowerErr.Err, "server misbehaving")
 	case *os.SyscallError:
 		if errnoErr, ok := lowerErr.Err.(syscall.Errno); ok {
 			// the errno codes from kernel/libc when the network is down

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -149,9 +149,7 @@ func isNetworkDown(err error) bool {
 	case *net.DNSError:
 		// on 16.04 we will not have SyscallError here, but DNSError, with
 		// no further details other than error message
-		return strings.Contains(lowerErr.Err, "connect: network is unreachable") ||
-			strings.Contains(lowerErr.Err, "no such host") ||
-			strings.Contains(lowerErr.Err, "server misbehaving")
+		return strings.Contains(lowerErr.Err, "connect: network is unreachable")
 	case *os.SyscallError:
 		if errnoErr, ok := lowerErr.Err.(syscall.Errno); ok {
 			// the errno codes from kernel/libc when the network is down


### PR DESCRIPTION
cmd/okay: Remove err message when warning file not exist

if previously there is no warning message and hence there is no warning file;

`snap okay` returns 

> error: no client-side warning timestamp found: cannot open timestamp file: open /home/user/.snap/warnings.json: no such file or directory

Checking if file exists and if not, returning nothing can be more appropriate.