### PR TITLE
gadget: record gadget root directory used during positioning

### DIFF
--- a/gadget/position.go
+++ b/gadget/position.go
@@ -45,6 +45,8 @@ type PositionedVolume struct {
 	SectorSize Size
 	// PositionedStructure are sorted in order of 'appearance' in the volume
 	PositionedStructure []PositionedStructure
+	// RootDir is the root directory for volume data
+	RootDir string
 }
 
 // PositionedStructure describes a VolumeStructure that has been positioned
@@ -185,6 +187,7 @@ func PositionVolume(gadgetRootDir string, volume *Volume, constraints Positionin
 		Size:                volumeSize,
 		SectorSize:          constraints.SectorSize,
 		PositionedStructure: structures,
+		RootDir:             gadgetRootDir,
 	}
 	return vol, nil
 }

--- a/gadget/position_test.go
+++ b/gadget/position_test.go
@@ -64,6 +64,7 @@ func (p *positioningTestSuite) TestVolumeSize(c *C) {
 		},
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{VolumeStructure: &gadget.VolumeStructure{Size: 2 * gadget.SizeMiB}, StartOffset: 1 * gadget.SizeMiB},
 		},
@@ -103,6 +104,7 @@ volumes:
 		Volume:     vol,
 		Size:       501 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -145,6 +147,7 @@ volumes:
 		Volume:     vol,
 		Size:       1101 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -201,6 +204,7 @@ volumes:
 		Volume:     vol,
 		Size:       1300 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[3],
@@ -256,6 +260,7 @@ volumes:
 		Volume:     vol,
 		Size:       1200 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[3],
@@ -465,6 +470,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -516,6 +522,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -564,6 +571,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -606,6 +614,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -645,6 +654,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -671,6 +681,7 @@ volumes:
 		Volume:     vol,
 		Size:       2*gadget.SizeMiB + 512*gadget.SizeKiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -698,6 +709,7 @@ volumes:
 		Volume:     vol,
 		Size:       2*gadget.SizeMiB + 446,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -722,6 +734,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 1024,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				VolumeStructure: &vol.Structure[0],
@@ -799,6 +812,7 @@ volumes:
 		Volume:     vol,
 		Size:       2 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				// MBR
@@ -851,6 +865,7 @@ volumes:
 		Volume:     vol,
 		Size:       3 * gadget.SizeMiB,
 		SectorSize: 512,
+		RootDir:    p.dir,
 		PositionedStructure: []gadget.PositionedStructure{
 			{
 				// mbr


### PR DESCRIPTION
The positioning of gadget volume depends on the contents of the root directory.
Keep track of the directory.
