### PR TITLE
tests: make more robust how we check the journal log is ready to start a test

### DIFF
--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -24,10 +24,14 @@ start_new_journalctl_log(){
 
 check_journalctl_ready(){
     marker="test-${RANDOM}${RANDOM}"
-    echo "Running test: $marker" | systemd-cat -t snapd-test
-    if check_journalctl_log "$marker"; then
-        return 0
-    fi
+    for _ in $(seq 10); do
+        echo "Running test: $marker" | systemd-cat -t snapd-test
+        if get_journalctl_log | grep "$marker"; then
+            return 0
+        fi
+        sleep 1
+    done
+
     echo "Test id not found in journalctl, exiting..."
     exit 1
 }


### PR DESCRIPTION
This is done because some tests (random) are failing to detect when we do:
>  echo "Running test: $marker" | systemd-cat -t snapd-test

This is mostly happening with the opensuse systemd (242) version.