### PR TITLE
tests: force removal to prevent restore fails when directory doesn't exist on lp-1801955 test

### DIFF
--- a/tests/regression/lp-1801955/task.yaml
+++ b/tests/regression/lp-1801955/task.yaml
@@ -7,7 +7,7 @@ prepare: |
     chown -vR 9999:9999 /home/potato
 
 restore: |
-    rm -rv /home/potato
+    rm -rfv /home/potato
 
 execute: |
     snap save test-snapd-tools


### PR DESCRIPTION
This could make the whole test suite fail.
