### PR TITLE
tests: run unit tests without networking

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -190,13 +190,14 @@ func RetryRequest(endpoint string, doRequest func() (*http.Response, error), rea
 
 		resp, err = doRequest()
 		if err != nil {
+			if isNetworkDown(err) || isDnsUnavailable(err) {
+				err = &PerstistentNetworkError{Err: err}
+				break
+			}
 			if ShouldRetryError(attempt, err) {
 				continue
 			}
 
-			if isNetworkDown(err) || isDnsUnavailable(err) {
-				err = &PerstistentNetworkError{Err: err}
-			}
 			break
 		}
 

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -178,7 +178,7 @@ func isDnsUnavailable(err error) bool {
 	// not exposed in net.DNSError and in go-1.10 it is not even
 	// a temporary error so there is no way to distiguish it other
 	// than a fugly string compare on a (potentially) localized string
-	return strings.Contains(dnsErr.Err, "Temporary failure in name resolution")
+	return strings.Contains(dnsErr.Err, "connection refused") || strings.Contains(dnsErr.Err, "Temporary failure in name resolution")
 }
 
 // RetryRequest calls doRequest and read the response body in a retry loop using the given retryStrategy.

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3448,6 +3448,10 @@ version: 2.0`
 }
 
 func (ms *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
+	// just to 404 locally eager account-key requests
+	mockStoreServer := ms.mockStore(c)
+	defer mockStoreServer.Close()
+
 	model := ms.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
 		"gadget": "gadget",
 	})

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -8,6 +8,7 @@ priority: 1000
 
 restore: |
     rm -rf /tmp/static-unit-tests
+    rm -f script
 
 execute: |
     mkdir -p /tmp/static-unit-tests/src/github.com/snapcore
@@ -19,18 +20,21 @@ execute: |
     rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && PATH=$PATH GOPATH=/tmp/static-unit-tests ./run-checks --static" test
-    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-        TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER \
-        TRAVIS_BRANCH=$TRAVIS_BRANCH \
-        TRAVIS_COMMIT=$TRAVIS_COMMIT \
-        TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER \
-        TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST \
-        TRAVIS_JOB_ID=$TRAVIS_JOB_ID \
-        TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
-        TRAVIS_TAG=$TRAVIS_TAG \
-        PATH=$PATH \
-        COVERMODE=$COVERMODE \
-        TRAVIS=true \
-        CI=true \
-        GOPATH=/tmp/static-unit-tests \
-        ./run-checks --unit" test
+    cat <<SCRIPT >script
+    cd /tmp/static-unit-tests/src/github.com/snapcore/snapd
+    export TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
+    export TRAVIS_BRANCH=$TRAVIS_BRANCH
+    export TRAVIS_COMMIT=$TRAVIS_COMMIT
+    export TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER
+    export TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
+    export TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+    export TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
+    export TRAVIS_TAG=$TRAVIS_TAG
+    export PATH=$PATH
+    export COVERMODE=$COVERMODE
+    export TRAVIS=true
+    export CI=true
+    GOPATH=/tmp/static-unit-tests ./run-checks --unit
+    SCRIPT
+    chmod +x script
+    unshare -n sh -c "ifconfig lo up && su -l -c $(pwd)/script test"


### PR DESCRIPTION
While preparing the 2.39.1 package update for openSUSE I noticed that
some unit tests fail in non-obvious ways. Some further debugging and
code changes uncovered that the tests are attempting to talk to
api.snapcraft.io

As a quick way to see what is broken, run all unit tests with the
network namespace unshared. This gives us a system without any network
interfaces, apart from lo, where any attempt to use TCP/IP or even
plain DNS will fail.

Currently there are two test failures:
```
FAIL: retry_test.go:406: retrySuite.TestRetryDoesNotFailForPermanentDNSErrors

retry_test.go:424:
    // we try exactly once, a non-existing server is a permanent error
    c.Assert(n, Equals, 1)
... obtained int = 5
... expected int = 1
```

```
FAIL: managers_test.go:3450: mgrsSuite.TestHappyDeviceRegistrationWithPrepareDeviceHook

managers_test.go:3512:
    c.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"Settle is not converging"} ("Settle is not converging")
```

The branch also contains fixes for said issues, it was confirmed to pass in "osc build"

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
