### PR TITLE
[RFC] snapd: ensure GOMAXPROCS is at least 2

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -52,6 +53,24 @@ func init() {
 
 func main() {
 	cmd.ExecInSnapdOrCoreSnap()
+
+	// The Go scheduler by default has a single operating system
+	// thread per processor core, and does it's own goroutine
+	// scheduling inside of that thread.  For I/O operations that
+	// the Go runtime knows about, it has mechanisms to reschedule
+	// goroutines so the system thread isn't blocked waiting for
+	// I/O.  If a goroutine performs a blocking system call which
+	// the go runtime doesn't have special optimizations for, the
+	// system thread can become blocked waiting for the syscall.
+	// This can dramatically reduce runtime performance, and the
+	// problem is much worse on single processor systems because
+	// there is normally only a single system thread.
+	//
+	// We workaround by increasing the armound of procs to a
+	// minimum of two.
+	if runtime.GOMAXPROCS(-1) == 1 {
+		runtime.GOMAXPROCS(2)
+	}
 
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -55,7 +55,7 @@ func main() {
 	cmd.ExecInSnapdOrCoreSnap()
 
 	// The Go scheduler by default has a single operating system
-	// thread per processor core, and does it's own goroutine
+	// thread per processor core, and does its own goroutine
 	// scheduling inside of that thread.  For I/O operations that
 	// the Go runtime knows about, it has mechanisms to reschedule
 	// goroutines so the system thread isn't blocked waiting for
@@ -66,7 +66,7 @@ func main() {
 	// problem is much worse on single processor systems because
 	// there is normally only a single system thread.
 	//
-	// We workaround by increasing the armound of procs to a
+	// We workaround by increasing the number of procs to a
 	// minimum of two.
 	if runtime.GOMAXPROCS(-1) == 1 {
 		runtime.GOMAXPROCS(2)


### PR DESCRIPTION
This is a request from our friends from Rigardo. We should
measure it with the nice new tooling we have before merging.
Maybe @stolowski can help with that? The key to measure
is the firstboot seeding on a single core device (e.g. by
forcing "maxcpus=1 " in the kernel commandline on a PI
or in qemu).

The Go scheduler by default has a single operating system
thread per processor core, and does it's own goroutine
scheduling inside of that thread.  For I/O operations that
the Go runtime knows about, it has mechanisms to reschedule
goroutines so the system thread isn't blocked waiting for
I/O.  If a goroutine performs a blocking system call which
the go runtime doesn't have special optimizations for, the
system thread can become blocked waiting for the syscall.
This can dramatically reduce runtime performance, and the
problem is much worse on single processor systems because
there is normally only a single system thread.

We workaround by increasing the armound of procs to a
minimum of two.

