### PR TITLE
packaging/debian-sid: fix changelog, add revision

### DIFF
--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,4 +1,4 @@
-snapd (2.39.1) unstable; urgency=medium
+snapd (2.39.1-1) unstable; urgency=medium
 
   * New upstream release
 


### PR DESCRIPTION
The latest entry for 2.39.1 in the changelog is missing a revision number.

Package build fails with:
```
 dpkg-source -b .
dpkg-source: error: can't build with source format '3.0 (quilt)': non-native package version does not contain a revision
dpkg-source: info: using options from snapd/debian/source/options: --include-removal
dpkg-buildpackage: error: dpkg-source -b . subprocess returned exit status 255
```

@cjwatson thanks for spotting this!