### PR TITLE
tests: run spread tests on opensuse leap 15.1

### DIFF
--- a/packaging/opensuse-15.1
+++ b/packaging/opensuse-15.1
@@ -1,0 +1,1 @@
+opensuse

--- a/packaging/opensuse-42.1
+++ b/packaging/opensuse-42.1
@@ -1,1 +1,0 @@
-opensuse

--- a/packaging/opensuse-42.2
+++ b/packaging/opensuse-42.2
@@ -1,1 +1,0 @@
-opensuse

--- a/packaging/opensuse-42.3
+++ b/packaging/opensuse-42.3
@@ -1,1 +1,0 @@
-opensuse

--- a/spread.yaml
+++ b/spread.yaml
@@ -89,11 +89,10 @@ backends:
                 manual: true
             - fedora-30-64:
                 workers: 6
-            - opensuse-42.3-64:
-                workers: 4
-                # golang stack cannot compile anything, needs investigation
-                manual: true
             - opensuse-15.0-64:
+                workers: 6
+                manual: true
+            - opensuse-15.1-64:
                 workers: 6
             - opensuse-tumbleweed-64:
                 workers: 6

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -58,12 +58,6 @@ disable_refreshes() {
 
 setup_systemd_snapd_overrides() {
     START_LIMIT_INTERVAL="StartLimitInterval=0"
-    if [[ "$SPREAD_SYSTEM" =~ opensuse-42.[23]-* ]]; then
-        # StartLimitInterval is not supported by the systemd version
-        # openSUSE 42.2/3 ship.
-        START_LIMIT_INTERVAL=""
-    fi
-
     mkdir -p /etc/systemd/system/snapd.service.d
     cat <<EOF > /etc/systemd/system/snapd.service.d/local.conf
 [Unit]

--- a/tests/regression/lp-1805485/task.yaml
+++ b/tests/regression/lp-1805485/task.yaml
@@ -1,15 +1,13 @@
 summary: apparmor backend is not used on openSUSE Leap 42.3
+
 details: |
     AppArmor on openSUSE Leap 43.2 is too old to parse the snap-confine
     apparmor profile.  Because of "relaxed" error handling snapd was enabling
     apparmor backend even though it resulted in constant problems with setting
     up security for the core snap. With this bug fixed the old version of
     apparmor_parser makes snapd disable the relevant security backend. 
+
 systems: [ubuntu-*, opensuse-*, arch-linux-*]
+
 execute: |
-    if [[ "$SPREAD_SYSTEM" == opensuse-42.3* ]]; then
-        # openSUSE 43.2 has AppArmor parser in version too old to parse snap-confine profile
-        snap debug sandbox-features | MATCH -v "^apparmor:"
-    else
-        snap debug sandbox-features | MATCH "^apparmor:"
-    fi
+    snap debug sandbox-features | MATCH "^apparmor:"


### PR DESCRIPTION
This change includes:
. Run tests on new opensuse leap 15.1 image
. Move to manual opensuse leap 15.0
. Remove opensuse 42.3
