### PR TITLE
tests: support mountinfo-tool on Python 2.7+

### DIFF
--- a/tests/lib/bin/any-python
+++ b/tests/lib/bin/any-python
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Use any-python as interpreter in portable Python scripts.
+# Instead of /usr/bin/env python use /usr/bin/env any-python
+# The preferred choices are: Python 3, Python 2, anything called "python"
+py3="$(command -v python3)"
+py2="$(command -v python2)"
+py_dunno="$(command -v python)"
+if [ -n "$py3" ]; then
+    exec "$py3" "$@"
+elif [ -n "$py2" ]; then
+	exec "$py2" "$@"
+elif [ -n "$py_dunno" ]; then
+	exec "$py_dunno" "$@"
+else
+	echo "cannot find any Python installation" >&2
+	exit 1
+fi

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -39,14 +39,14 @@ class Device(int):
 
     def __str__(self):
         # type: () -> str
-        result = '{}:{}'.format(self.major, self.minor)
+        result = "{}:{}".format(self.major, self.minor)
         if PY2:
             return result.encode()
         return result
 
     def __repr__(self):
         # type: () -> str
-        result = 'Device.pack({}, {})'.format(self.major, self.minor)
+        result = "Device.pack({}, {})".format(self.major, self.minor)
         if PY2:
             return result.encode()
         return result
@@ -100,14 +100,14 @@ class MountInfoEntry(object):
         self = cls()
         self.mount_id = int(next(it))
         self.parent_id = int(next(it))
-        dev_maj, dev_min = map(int, next(it).split(':'))
+        dev_maj, dev_min = map(int, next(it).split(":"))
         self.dev = Device((dev_maj << 16) | dev_min)
         self.root_dir = next(it)
         self.mount_point = next(it)
         self.mount_opts = next(it)
         self.opt_fields = []
         for opt_field in it:
-            if opt_field == '-':
+            if opt_field == "-":
                 break
             self.opt_fields.append(opt_field)
         self.fs_type = next(it)
@@ -123,10 +123,11 @@ class MountInfoEntry(object):
 
     def __str__(self):
         # type: () -> str
-        result = ("{0.mount_id} {0.parent_id} {0.dev} {0.root_dir}"
-                  " {0.mount_point} {0.mount_opts} {opt_fields} {0.fs_type}"
-                  " {0.mount_source} {0.sb_opts}").format(
-                    self, opt_fields=' '.join(self.opt_fields + ['-']))
+        result = (
+            "{0.mount_id} {0.parent_id} {0.dev} {0.root_dir}"
+            " {0.mount_point} {0.mount_opts} {opt_fields} {0.fs_type}"
+            " {0.mount_source} {0.sb_opts}"
+        ).format(self, opt_fields=" ".join(self.opt_fields + ["-"]))
         if PY2:
             return result.encode()
         return result
@@ -181,11 +182,11 @@ class AttrPrefixFilter(FilterExpr):
 def parse_filter(expr):
     # type: (Text) -> FilterExpr
     """parse_filter parses one of the known filter expressions."""
-    if '=' in expr:
+    if "=" in expr:
         # Accept both .attr=value and attr=value as exact attribute match.
         if expr.startswith("."):
             expr = expr.lstrip(".")
-        attr, value = expr.split('=', 1)
+        attr, value = expr.split("=", 1)
         try:
             typ = MountInfoEntry.known_attrs[attr]
         except KeyError:
@@ -204,21 +205,24 @@ def parse_attr(expr):
     # type: (Text) -> Text
     """parse_attr parses attribute references (for display)."""
     known = sorted(MountInfoEntry.known_attrs)
-    if expr.lstrip('.') in known:
-        return expr.lstrip('.')
-    raise ValueError("invalid attribute selector {!r}"
-                     " (known: {})".format(expr, known))
+    if expr.lstrip(".") in known:
+        return expr.lstrip(".")
+    raise ValueError(
+        "invalid attribute selector {!r}" " (known: {})".format(expr, known)
+    )
 
 
 def parse_exprs(exprs):
     # type: (List[Text]) -> Tuple[List[FilterExpr], List[Text]]
     """parse_exprs parses filter expressions and attribute references."""
     # Filters are either .attr=value, /path, /path...
-    filters = [parse_filter(expr) for expr in exprs
-               if "=" in expr or not expr.startswith('.')]
+    filters = [
+        parse_filter(expr) for expr in exprs if "=" in expr or not expr.startswith(".")
+    ]
     # Attributes are always .attr
-    attrs = [parse_attr(expr) for expr in exprs
-             if expr.startswith('.') and "=" not in expr]
+    attrs = [
+        parse_attr(expr) for expr in exprs if expr.startswith(".") and "=" not in expr
+    ]
     return filters, attrs
 
 
@@ -256,7 +260,7 @@ def renumber_snap_revision(entry, seen):
             seen[key] = n
             return n
 
-    parts = entry.mount_point.split('/')
+    parts = entry.mount_point.split("/")
     if len(parts) >= 4 and parts[:2] == ["", "snap"]:
         snap_name = parts[2]
         snap_rev = parts[3]
@@ -274,6 +278,7 @@ def renumber_snap_revision(entry, seen):
 def renumber_opt_fields(entry, seen):
     # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_opt_fields re-numbers peer group in optional fields."""
+
     def alloc_n(peer_group):
         # type: (int) -> int
         key = peer_group
@@ -286,13 +291,15 @@ def renumber_opt_fields(entry, seen):
 
     def fn(m):
         # type: (Match[Text]) -> Text
-        return '{}'.format(alloc_n(int(m.group(1))))
-    entry.opt_fields = [re.sub('(\\d+)', fn, opt) for opt in entry.opt_fields]
+        return "{}".format(alloc_n(int(m.group(1))))
+
+    entry.opt_fields = [re.sub("(\\d+)", fn, opt) for opt in entry.opt_fields]
 
 
 def renumber_loop_devices(entry, seen):
     # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_loop_devices re-numbers loop device numbers."""
+
     def alloc_n(loop_nr):
         # type: (int) -> int
         key = loop_nr
@@ -305,13 +312,15 @@ def renumber_loop_devices(entry, seen):
 
     def fn(m):
         # type: (Match[Text]) -> Text
-        return 'loop{}'.format(alloc_n(int(m.group(1))))
-    entry.mount_source = re.sub('loop(\\d+)', fn, entry.mount_source)
+        return "loop{}".format(alloc_n(int(m.group(1))))
+
+    entry.mount_source = re.sub("loop(\\d+)", fn, entry.mount_source)
 
 
 def renumber_mount_ids(entry, seen):
     # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_mount_ids re-numbers mount and parent mount IDs."""
+
     def alloc_n(mount_id):
         # type: (int) -> int
         key = mount_id
@@ -321,6 +330,7 @@ def renumber_mount_ids(entry, seen):
             n = len(seen)
             seen[key] = n
             return n
+
     # NOTE: renumber the parent ahead of the mount to get more
     # expected relationship between them.
     entry.parent_id = alloc_n(entry.parent_id)
@@ -330,6 +340,7 @@ def renumber_mount_ids(entry, seen):
 def renumber_devices(entry, seen):
     # type: (MountInfoEntry, Dict[Device, Device]) -> None
     """renumber_devices re-numbers major:minor device numbers."""
+
     def alloc_n(dev):
         # type: (Device) -> Device
         key = dev
@@ -349,11 +360,11 @@ def renumber_devices(entry, seen):
                 major = len({orig.major for orig in seen})
             # Allocate the next minor number based on the cardinality of the
             # set of minor numbers matching the major number.
-            minor = len({orig.minor for orig in seen
-                        if orig.major == dev.major})
+            minor = len({orig.minor for orig in seen if orig.major == dev.major})
             n = Device.pack(major, minor)
             seen[key] = n
             return n
+
     entry.dev = alloc_n(entry.dev)
 
 
@@ -379,12 +390,14 @@ def rewrite_rename(entries):
     # TODO: allocate devices like everything else above.
     for entry in entries:
         entry.mount_source = re.sub(
-            '/dev/[sv]d([a-z])', '/dev/sd\\1', entry.mount_source)
+            "/dev/[sv]d([a-z])", "/dev/sd\\1", entry.mount_source
+        )
 
 
 def main():
     # type: () -> None
-    parser = ArgumentParser(epilog="""
+    parser = ArgumentParser(
+        epilog="""
 Expressions are ANDed together and have one of the following forms:
 
     .ATTR=VALUE     mount entry attribute ATTR is equal to VALUE
@@ -405,25 +418,37 @@ Known attributes, applicable for both filtering and display.
     parent_id:      identifier of parent mount point
     dev:            major:minor numbers of the mounted device
     root_dir:       subtree of the mounted filesystem exposed at mount_point
-    """, formatter_class=RawTextHelpFormatter)
-    parser.add_argument('-v', '--version', action="version", version="1.0")
+    """,
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument("-v", "--version", action="version", version="1.0")
     parser.add_argument(
-        '-f', metavar="MOUNTINFO", dest="file", type=FileType(),
-        default='/proc/self/mountinfo', help="parse specified mountinfo file")
+        "-f",
+        metavar="MOUNTINFO",
+        dest="file",
+        type=FileType(),
+        default="/proc/self/mountinfo",
+        help="parse specified mountinfo file",
+    )
     parser.add_argument(
-        '--one', default=False, action='store_true',
-        help="expect exactly one match")
+        "--one", default=False, action="store_true", help="expect exactly one match"
+    )
     parser.add_argument(
-        'exprs', metavar="EXPRESSION", nargs='*',
-        help="filter or display expression (see below)")
+        "exprs",
+        metavar="EXPRESSION",
+        nargs="*",
+        help="filter or display expression (see below)",
+    )
     group = parser.add_argument_group("Rewriting rules")
     group.add_argument(
-        "--renumber", action="store_true",
+        "--renumber",
+        action="store_true",
         help="Reassign mount IDs, device numbers, snap revisions"
-             " and loopback devices")
+        " and loopback devices",
+    )
     group.add_argument(
-        "--rename", action="store_true",
-        help="Reassign block device names")
+        "--rename", action="store_true", help="Reassign block device names"
+    )
     opts = parser.parse_args()
     try:
         filters, attrs = parse_exprs(opts.exprs)
@@ -436,8 +461,9 @@ Known attributes, applicable for both filtering and display.
     if opts.rename:
         rewrite_rename(entries)
     if opts.one and len(entries) != 1:
-        raise SystemExit("--one requires exactly one match, found {}".format(
-            len(entries)))
+        raise SystemExit(
+            "--one requires exactly one match, found {}".format(len(entries))
+        )
     for e in entries:
         if attrs:
             values = []  # type: List[Any]
@@ -451,5 +477,5 @@ Known attributes, applicable for both filtering and display.
             print(e)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -1,8 +1,27 @@
-#!/usr/bin/env python3
-from abc import ABC, abstractmethod
+#!/usr/bin/env any-python
+from __future__ import print_function, absolute_import, unicode_literals
+
 from argparse import ArgumentParser, FileType, RawTextHelpFormatter
-from typing import Dict, List, Tuple, Any, Type, Callable, Match
+import sys
 import re
+
+# PY2 is true when we're running under Python 2.x It is used for appropriate
+# return value selection of __str__ and __repr_ methods, which must both
+# return str, not unicode (in Python 2) and str (in Python 3). In both cases
+# the return type annotation is exactly the same, but due to unicode_literals
+# being in effect, and the fact we often use a format string (which is an
+# unicode string in Python 2), we must encode the it to byte string when
+# running under Python 2.
+PY2 = sys.version_info[0] == 2
+
+# Define MYPY as False and use it as a conditional for typing import. Despite
+# this declaration mypy will really treat MYPY as True when type-checking.
+# This is required so that we can import typing on Python 2.x without the
+# typing module installed. For more details see:
+# https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+MYPY = False
+if MYPY:
+    from typing import Any, Dict, List, Text, Tuple, Match
 
 
 class Device(int):
@@ -14,49 +33,69 @@ class Device(int):
     """
 
     @classmethod
-    def pack(cls, major: int, minor: int) -> 'Device':
+    def pack(cls, major, minor):
+        # type: (int, int) -> Device
         return cls((major << 16) | (minor & (1 << 16) - 1))
 
-    def __str__(self) -> str:
-        return '{}:{}'.format(self.major, self.minor)
+    def __str__(self):
+        # type: () -> str
+        result = '{}:{}'.format(self.major, self.minor)
+        if PY2:
+            return result.encode()
+        return result
 
-    def __repr__(self) -> str:
-        return 'Device.pack({}, {})'.format(self.major, self.minor)
+    def __repr__(self):
+        # type: () -> str
+        result = 'Device.pack({}, {})'.format(self.major, self.minor)
+        if PY2:
+            return result.encode()
+        return result
 
     @property
-    def major(self) -> int:
+    def major(self):
+        # type: () -> int
         """major is the higher 16 bits of the device number."""
         return self >> 16
 
     @property
-    def minor(self) -> int:
+    def minor(self):
+        # type: () -> int
         """minor is the lower 16 bits of the device number."""
         return self & ((1 << 16) - 1)
 
 
-class OptFields(List[str]):
-    """OptFields describes additional fields associated with a mount entry."""
-
-    def __str__(self) -> str:
-        return " ".join(self)
-
-
-class MountInfoEntry:
+class MountInfoEntry(object):
     """Single entry in /proc/pid/mointinfo, see proc(5)"""
 
-    mount_id: int
-    parent_id: int
-    dev: Device
-    root_dir: str
-    mount_point: str
-    mount_opts: str
-    opt_fields: OptFields
-    fs_type: str
-    mount_source: str
-    sb_opts: str
+    known_attrs = {
+        "mount_id": int,
+        "parent_id": int,
+        "dev": Device,
+        "root_dir": str,
+        "mount_point": str,
+        "mount_opts": str,
+        "opt_fields": list,
+        "fs_type": str,
+        "mount_source": str,
+        "sb_opts": str,
+    }
+
+    def __init__(self):
+        # type: () -> None
+        self.mount_id = 0
+        self.parent_id = 0
+        self.dev = Device.pack(0, 0)
+        self.root_dir = ""
+        self.mount_point = ""
+        self.mount_opts = ""
+        self.opt_fields = []  # type: List[Text]
+        self.fs_type = ""
+        self.mount_source = ""
+        self.sb_opts = ""
 
     @classmethod
-    def parse(cls: 'Type[MountInfoEntry]', line: str) -> 'MountInfoEntry':
+    def parse(cls, line):
+        # type: (Text) -> MountInfoEntry
         it = iter(line.split())
         self = cls()
         self.mount_id = int(next(it))
@@ -66,7 +105,7 @@ class MountInfoEntry:
         self.root_dir = next(it)
         self.mount_point = next(it)
         self.mount_opts = next(it)
-        self.opt_fields = OptFields()
+        self.opt_fields = []
         for opt_field in it:
             if opt_field == '-':
                 break
@@ -82,37 +121,45 @@ class MountInfoEntry:
             raise ValueError("leftovers after parsing {!r}".format(line))
         return self
 
-    def __str__(self) -> str:
-        return ("{0.mount_id} {0.parent_id} {0.dev} {0.root_dir}"
-                " {0.mount_point} {0.mount_opts} {opt_fields} {0.fs_type}"
-                " {0.mount_source} {0.sb_opts}").format(
+    def __str__(self):
+        # type: () -> str
+        result = ("{0.mount_id} {0.parent_id} {0.dev} {0.root_dir}"
+                  " {0.mount_point} {0.mount_opts} {opt_fields} {0.fs_type}"
+                  " {0.mount_source} {0.sb_opts}").format(
                     self, opt_fields=' '.join(self.opt_fields + ['-']))
+        if PY2:
+            return result.encode()
+        return result
 
     @property
-    def dev_maj(self) -> int:
+    def dev_maj(self):
+        # type: () -> int
         return self.dev.major
 
     @property
-    def dev_min(self) -> int:
+    def dev_min(self):
+        # type: () -> int
         return self.dev.minor
 
 
-class FilterExpr(ABC):
+class FilterExpr(object):
     """FilterExpr is the interface for filtering mount entries."""
 
-    @abstractmethod
-    def __contains__(self, entry: MountInfoEntry) -> bool:
+    def __contains__(self, entry):
+        # type: (MountInfoEntry) -> bool
         """__contains__ returns true if a mount entry matches the filter."""
 
 
 class AttrFilter(FilterExpr):
     """AttrFilter performs equality test against a given attribute."""
 
-    def __init__(self, attr: str, value: Any):
+    def __init__(self, attr, value):
+        # type: (Text, Any) -> None
         self.attr = attr
         self.value = value
 
-    def __contains__(self, entry: MountInfoEntry) -> bool:
+    def __contains__(self, entry):
+        # type: (MountInfoEntry) -> bool
         value = getattr(entry, self.attr)
         return bool(value == self.value)
 
@@ -120,26 +167,31 @@ class AttrFilter(FilterExpr):
 class AttrPrefixFilter(FilterExpr):
     """AttrPrefixFilter performs prefix test against a given attribute."""
 
-    def __init__(self, attr: str, value: str):
+    def __init__(self, attr, value):
+        # type: (Text, Text) -> None
         self.attr = attr
         self.value = value
 
-    def __contains__(self, entry: MountInfoEntry) -> bool:
+    def __contains__(self, entry):
+        # type: (MountInfoEntry) -> bool
         value = str(getattr(entry, self.attr))
         return value.startswith(self.value)
 
 
-def parse_filter(expr: str) -> FilterExpr:
+def parse_filter(expr):
+    # type: (Text) -> FilterExpr
     """parse_filter parses one of the known filter expressions."""
     if '=' in expr:
         # Accept both .attr=value and attr=value as exact attribute match.
         if expr.startswith("."):
             expr = expr.lstrip(".")
         attr, value = expr.split('=', 1)
-        if attr in MountInfoEntry.__annotations__:
-            typ = MountInfoEntry.__annotations__[attr]
+        try:
+            typ = MountInfoEntry.known_attrs[attr]
+        except KeyError:
+            raise ValueError("invalid filter expression {!r}".format(expr))
+        else:
             return AttrFilter(attr, typ(value))
-        raise ValueError("invalid filter expression {!r}".format(expr))
     elif expr.endswith("..."):
         # Treat /path/... as prefix match on mount_point.
         return AttrPrefixFilter("mount_point", expr.rstrip("..."))
@@ -148,16 +200,18 @@ def parse_filter(expr: str) -> FilterExpr:
         return AttrFilter("mount_point", expr)
 
 
-def parse_attr(expr: str) -> str:
+def parse_attr(expr):
+    # type: (Text) -> Text
     """parse_attr parses attribute references (for display)."""
-    known = sorted(MountInfoEntry.__annotations__.keys())
+    known = sorted(MountInfoEntry.known_attrs)
     if expr.lstrip('.') in known:
         return expr.lstrip('.')
     raise ValueError("invalid attribute selector {!r}"
                      " (known: {})".format(expr, known))
 
 
-def parse_exprs(exprs: List[str]) -> Tuple[List[FilterExpr], List[str]]:
+def parse_exprs(exprs):
+    # type: (List[Text]) -> Tuple[List[FilterExpr], List[Text]]
     """parse_exprs parses filter expressions and attribute references."""
     # Filters are either .attr=value, /path, /path...
     filters = [parse_filter(expr) for expr in exprs
@@ -168,7 +222,8 @@ def parse_exprs(exprs: List[str]) -> Tuple[List[FilterExpr], List[str]]:
     return filters, attrs
 
 
-def matches(entry: MountInfoEntry, filters: List[FilterExpr]) -> bool:
+def matches(entry, filters):
+    # type: (MountInfoEntry, List[FilterExpr]) -> bool
     """
     matches checks if a mount entry matches a list of filter expressions.
     Filter expressions are ANDed together.
@@ -179,29 +234,20 @@ def matches(entry: MountInfoEntry, filters: List[FilterExpr]) -> bool:
     return True
 
 
-def renumber_snap_revision(
-        entry: MountInfoEntry, seen: Dict[Tuple[str, str], int]) -> None:
+def renumber_snap_revision(entry, seen):
+    # type: (MountInfoEntry, Dict[Tuple[Text, Text], int]) -> None
     """renumber_snap_revisions re-numbers snap revision numbers in paths."""
-    parts = entry.mount_point.split('/')
-    snap_name: str
-    snap_rev: str
-    fn: Callable[[int], List[str]]
-    if len(parts) >= 4 and parts[:2] == ["", "snap"]:
-        snap_name = parts[2]
-        snap_rev = parts[3]
 
-        def fn(n: int) -> List[str]:
-            return parts[:3] + ["{}".format(n)] + parts[4:]
-    elif len(parts) >= 7 and parts[:5] == ["", "var", "lib", "snapd", "snap"]:
-        snap_name = parts[5]
-        snap_rev = parts[6]
+    def compose_preferred(parts, n):
+        # type: (List[Text], int) -> List[Text]
+        return parts[:3] + ["{}".format(n)] + parts[4:]
 
-        def fn(n: int) -> List[str]:
-            return parts[:6] + ["{}".format(n)] + parts[7:]
-    else:
-        return
+    def compose_alternate(parts, n):
+        # type: (List[Text], int) -> List[Text]
+        return parts[:6] + ["{}".format(n)] + parts[7:]
 
-    def alloc_n(snap_name: str, snap_rev: str) -> int:
+    def alloc_n(snap_name, snap_rev):
+        # type: (Text, Text) -> int
         key = (snap_name, snap_rev)
         try:
             return seen[key]
@@ -209,12 +255,27 @@ def renumber_snap_revision(
             n = len([name for (name, rev) in seen if name == snap_name]) + 1
             seen[key] = n
             return n
-    entry.mount_point = "/".join(fn(alloc_n(snap_name, snap_rev)))
+
+    parts = entry.mount_point.split('/')
+    if len(parts) >= 4 and parts[:2] == ["", "snap"]:
+        snap_name = parts[2]
+        snap_rev = parts[3]
+        compose = compose_preferred
+    elif len(parts) >= 7 and parts[:5] == ["", "var", "lib", "snapd", "snap"]:
+        snap_name = parts[5]
+        snap_rev = parts[6]
+        compose = compose_alternate
+    else:
+        return
+    n = alloc_n(snap_name, snap_rev)
+    entry.mount_point = "/".join(compose(parts, n))
 
 
-def renumber_opt_fields(entry: MountInfoEntry, seen: Dict[int, int]) -> None:
+def renumber_opt_fields(entry, seen):
+    # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_opt_fields re-numbers peer group in optional fields."""
-    def alloc_n(peer_group: int) -> int:
+    def alloc_n(peer_group):
+        # type: (int) -> int
         key = peer_group
         try:
             return seen[key]
@@ -223,15 +284,17 @@ def renumber_opt_fields(entry: MountInfoEntry, seen: Dict[int, int]) -> None:
             seen[key] = n
             return n
 
-    def fn(m: Match[str]) -> str:
-        return '{}'.format(alloc_n(int(m[1])))
-    entry.opt_fields = OptFields([
-        re.sub('(\\d+)', fn, opt) for opt in entry.opt_fields])
+    def fn(m):
+        # type: (Match[Text]) -> Text
+        return '{}'.format(alloc_n(int(m.group(1))))
+    entry.opt_fields = [re.sub('(\\d+)', fn, opt) for opt in entry.opt_fields]
 
 
-def renumber_loop_devices(entry: MountInfoEntry, seen: Dict[int, int]) -> None:
+def renumber_loop_devices(entry, seen):
+    # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_loop_devices re-numbers loop device numbers."""
-    def alloc_n(loop_nr: int) -> int:
+    def alloc_n(loop_nr):
+        # type: (int) -> int
         key = loop_nr
         try:
             return seen[key]
@@ -240,14 +303,17 @@ def renumber_loop_devices(entry: MountInfoEntry, seen: Dict[int, int]) -> None:
             seen[key] = n
             return n
 
-    def fn(m: Match[str]) -> str:
-        return 'loop{}'.format(alloc_n(int(m[1])))
+    def fn(m):
+        # type: (Match[Text]) -> Text
+        return 'loop{}'.format(alloc_n(int(m.group(1))))
     entry.mount_source = re.sub('loop(\\d+)', fn, entry.mount_source)
 
 
-def renumber_mount_ids(entry: MountInfoEntry, seen: Dict[int, int]) -> None:
+def renumber_mount_ids(entry, seen):
+    # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_mount_ids re-numbers mount and parent mount IDs."""
-    def alloc_n(mount_id: int) -> int:
+    def alloc_n(mount_id):
+        # type: (int) -> int
         key = mount_id
         try:
             return seen[key]
@@ -261,10 +327,11 @@ def renumber_mount_ids(entry: MountInfoEntry, seen: Dict[int, int]) -> None:
     entry.mount_id = alloc_n(entry.mount_id)
 
 
-def renumber_devices(
-        entry: MountInfoEntry, seen: Dict[Device, Device]) -> None:
+def renumber_devices(entry, seen):
+    # type: (MountInfoEntry, Dict[Device, Device]) -> None
     """renumber_devices re-numbers major:minor device numbers."""
-    def alloc_n(dev: Device) -> Device:
+    def alloc_n(dev):
+        # type: (Device) -> Device
         key = dev
         try:
             return seen[key]
@@ -273,7 +340,7 @@ def renumber_devices(
             # seen the major number already? Check if this major is already
             # remapped, if so reuse that value. If not just allocate the next
             # one based on cardinality of the set of major numbers we've seen.
-            major: int
+            major = 0
             for orig, remapped in seen.items():
                 if orig.major == dev.major:
                     major = remapped.major
@@ -290,13 +357,14 @@ def renumber_devices(
     entry.dev = alloc_n(entry.dev)
 
 
-def rewrite_renumber(entries: List[MountInfoEntry]) -> None:
+def rewrite_renumber(entries):
+    # type: (List[MountInfoEntry]) -> None
     """rewrite_renumber applies all re-numbering helpers."""
-    seen_opt_fields: Dict[int, int] = {}
-    seen_loops: Dict[int, int] = {}
-    seen_snap_revs: Dict[Tuple[str, str], int] = {}
-    seen_mount_ids: Dict[int, int] = {}
-    seen_devices: Dict[Device, Device] = {}
+    seen_opt_fields = {}  # type: Dict[int, int]
+    seen_loops = {}  # type: Dict[int, int]
+    seen_snap_revs = {}  # type: Dict[Tuple[Text, Text], int]
+    seen_mount_ids = {}  # type: Dict[int, int]
+    seen_devices = {}  # type: Dict[Device, Device]
     for entry in entries:
         renumber_mount_ids(entry, seen_mount_ids)
         renumber_devices(entry, seen_devices)
@@ -305,7 +373,8 @@ def rewrite_renumber(entries: List[MountInfoEntry]) -> None:
         renumber_loop_devices(entry, seen_loops)
 
 
-def rewrite_rename(entries: List[MountInfoEntry]) -> None:
+def rewrite_rename(entries):
+    # type: (List[MountInfoEntry]) -> None
     """rewrite_renameapplies all re-naming helpers."""
     # TODO: allocate devices like everything else above.
     for entry in entries:
@@ -313,7 +382,8 @@ def rewrite_rename(entries: List[MountInfoEntry]) -> None:
             '/dev/[sv]d([a-z])', '/dev/sd\\1', entry.mount_source)
 
 
-def main() -> None:
+def main():
+    # type: () -> None
     parser = ArgumentParser(epilog="""
 Expressions are ANDed together and have one of the following forms:
 
@@ -370,7 +440,13 @@ Known attributes, applicable for both filtering and display.
             len(entries)))
     for e in entries:
         if attrs:
-            print(*(getattr(e, a) for a in attrs))
+            values = []  # type: List[Any]
+            for attr in attrs:
+                value = getattr(e, attr)
+                if isinstance(value, list):
+                    value = " ".join(value)
+                values.append(value)
+            print(*values)
         else:
             print(e)
 

--- a/tests/main/mountinfo-tool/task.yaml
+++ b/tests/main/mountinfo-tool/task.yaml
@@ -1,3 +1,5 @@
 summary: the mountinfo-tool can be used in tests
 execute: |
-    mountinfo-tool --version | MATCH 1.0
+    # 2>&1 is required for some versions of python that chose
+    # to print the version to stderr, crazy!
+    mountinfo-tool --version 2>&1 | MATCH 1.0

--- a/tests/main/mountinfo-tool/task.yaml
+++ b/tests/main/mountinfo-tool/task.yaml
@@ -1,4 +1,3 @@
 summary: the mountinfo-tool can be used in tests
-systems: [ubuntu-core-18-64, ubuntu-18.04-64]
 execute: |
     mountinfo-tool --version | MATCH 1.0


### PR DESCRIPTION
Since mountinfo-tool is pretty useful and it is used by a significant
regression test, we want to support all the operating systems we are
testing against. As such, drop the nice Python 3.6+ annotations and
replace them with comments that are compatible with all the versions of
Python.

In addition, since abc.ABC class (which avoids the syntax
incompatibility in defining meta-classes across the major versions of
Python) is not available in Python 2.7, drop the use of abstract base
classes and replace it with an empty dummy class.

Attribute filters used annotations to know about attributes that can be
filtered, this is now replaced with an explicit map of attributes that
can be queried.

Small structural changes were done to renumber_snap_revision, so that it
would type check and be flake8 clean at the same time. Instead of using
a lambda we use helper functions instead.

All of the __str__ and __repr__ functions return correct values on both
Python 2 and Python 3 *while* being type-correct according to strict
mypy type checker. This required, in the Python 2 case, encoding the
Unicode return values to byte string equivalents.

The OptFields type, which was just syntactic sugar on top of a list of
strings, was dropped, because it was causing problems with proper type
checking in absence of the typing module. Specifically the class
declaration:
```
    class OptFields(List[Text]):
	pass
```
Was causing problems when defined as plain OptFields(list). I chose to
give up given the limited value of the output. To compensate we
special-case the list-of-strings value in the printer.

Lastly, to allow running mountinfo-tool directly, without worrying which
python interpreter is actually used, a new helper script "any-python" is
provided and used as the interpreter of mountinfo-tool.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
