### PR TITLE
strutil/shlex: fix ineffassign

### DIFF
--- a/strutil/shlex/shlex.go
+++ b/strutil/shlex/shlex.go
@@ -372,7 +372,6 @@ func (t *Tokenizer) scanStream() (*Token, error) {
 				case spaceRuneClass:
 					{
 						if nextRune == '\n' {
-							state = startState
 							token := &Token{
 								tokenType: tokenType,
 								value:     string(value)}


### PR DESCRIPTION
The `state` variable is function local, assigning before return does not make
sense.

Fixes:
github.com/snapcore/snapd/strutil/shlex/shlex.go:375:8: ineffectual assignment to state

