### PR TITLE
interfaces: add missing adjtimex to time-control

### DIFF
--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -109,6 +109,7 @@ const timeControlConnectedPlugSecComp = `
 # gives full access to the RTC device nodes and relevant parts of sysfs.
 
 settimeofday
+adjtimex
 
 # util-linux built with libaudit tries to write to the audit subsystem. We
 # allow the socket call here to avoid seccomp kill, but omit the AppArmor

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -93,6 +93,7 @@ func (s *TimeControlInterfaceSuite) TestSecCompSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "settimeofday")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "adjtimex")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_AUDIT")
 }
 


### PR DESCRIPTION
This came up during snapping "chrony" - apparently we do not allow
adjtimex in time-control but its used by chrony and I see no reason
not to add it. Hence this PR :)

