### PR TITLE
data/selinux: permit init_t to remount snappy_snap_t

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -60,7 +60,12 @@ files_tmp_file(snappy_tmp_t)
 
 # actual snap
 type snappy_snap_t;
+# XXX: snappy_snap_t should be declared a filesystem, but due to how modules are
+# handled we cannot generate required contexts with genfscon outside of core
+# policy
+# fs_type(snappy_snap_t)
 files_type(snappy_snap_t)
+files_mountpoint(snappy_snap_t)
 
 # CLI tools: snap, snapctl
 type snappy_cli_t;
@@ -615,3 +620,8 @@ allow init_t snappy_var_t:dir manage_dir_perms;
 allow init_t snappy_var_t:sock_file manage_sock_file_perms;
 # the snap is started via `snap run ..`
 allow init_t snappy_cli_t:unix_stream_socket create_stream_socket_perms;
+# init_t will try to remount snap mount directory when starting services that
+# use Private* directives, while init_t is allowed to remount all fs, we cannot
+# declare fs_type(snappy_snap_t) outside of core policy, add explicit permission
+# instead
+allow init_t snappy_snap_t:filesystem remount;

--- a/tests/regression/rhbz-1708991/task.yaml
+++ b/tests/regression/rhbz-1708991/task.yaml
@@ -22,7 +22,8 @@ restore: |
     rm -f stamp enforcing.mode
 
 execute: |
-    # prepare does systemctl daemon-reexec to workaround:
+    # global prepare calls systemctl daemon-reexec to make systemd run with
+    # additional init_t permissions from snapd package, workaround for:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1660141
     # https://github.com/systemd/systemd/issues/9997
 

--- a/tests/regression/rhbz-1708991/task.yaml
+++ b/tests/regression/rhbz-1708991/task.yaml
@@ -1,0 +1,32 @@
+summary: Check that snapd SELinux policy does not break systemd services with private mount ns
+
+systems: [fedora-*, centos-*]
+
+prepare: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+
+    if [[ "$SPREAD_SYSTEM" == centos-7-* ]]; then
+        distro_install_package systemd-resolved
+    fi
+
+    getenforce > enforcing.mode
+
+    # Enable enforcing mode, our policy is already marked as permissive, so we
+    # will get audit entries but the program will not be stopped by SELinux
+    setenforce 1
+    ausearch --checkpoint stamp -m AVC || true
+
+restore: |
+    setenforce "$(cat enforcing.mode)"
+    rm -f stamp enforcing.mode
+
+execute: |
+    # prepare does systemctl daemon-reexec to workaround:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1660141
+    # https://github.com/systemd/systemd/issues/9997
+
+    # resolved and hostnamed have private mount ns
+    systemctl restart systemd-resolved
+    systemctl restart systemd-hostnamed
+    ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'


### PR DESCRIPTION
Systemd services that get a new mount namespace on startup fail due to SELinux
blocking system from remounting /var/lib/snapd/snap into the new mount ns.

Since we cannot declare fs_type() and generate contexts through genfscon outside
of core policy, add an explicit permission for init_t.

Corresponding denial:
```
type=AVC msg=audit(1559625610.991:67): avc:  denied  { remount } for  pid=578
         comm="(resolved)"
         scontext=system_u:system_r:init_t:s0
         tcontext=system_u:object_r:snappy_snap_t:s0
         tclass=filesystem permissive=0
```
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1708991

cc @Conan-Kudo 