### PR TITLE
cmd/snap: test for a friendly error on 'okay' without 'warnings'

### DIFF
--- a/cmd/snap/cmd_warnings.go
+++ b/cmd/snap/cmd_warnings.go
@@ -138,7 +138,7 @@ func (cmd *cmdOkay) Execute(args []string) error {
 
 	last, err := lastWarningTimestamp()
 	if err != nil {
-		return fmt.Errorf("%v", err)
+		return err
 	}
 
 	return cmd.client.Okay(last)

--- a/cmd/snap/cmd_warnings_test.go
+++ b/cmd/snap/cmd_warnings_test.go
@@ -172,6 +172,13 @@ func (s *warningSuite) TestOkay(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, "")
 }
 
+func (s *warningSuite) TestOkayBeforeWarnings(c *check.C) {
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"okay"})
+	c.Assert(err, check.ErrorMatches, "you must have looked at the warnings before acknowledging them. Try 'snap warnings'.")
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
+}
+
 func (s *warningSuite) TestListWithWarnings(c *check.C) {
 	var called bool
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is a test to cover what @ardaguclu helpfully fixed for us: that
when you run `snap okay` before ever running `snap warnings` you would
get a nasty error instead of something that explained what was going
on.