### PR TITLE
debian: rework how we run autopkgtests

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -49,12 +49,35 @@ systemctl restart snapd
 snap install --classic go
 
 # and now run spread against localhost
-# shellcheck disable=SC1091
-. /etc/os-release
 export GOPATH=/tmp/go
 /snap/bin/go get -u github.com/snapcore/spread/cmd/spread
-export SPREAD_REUSE_SNAPD=1
-/tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)":tests/smoke/
+
+# the tests need this:
+groupadd --gid 12345 test
+adduser --uid 12345 --gid 12345 --disabled-password --gecos '' test
+
+# we build our own minimal spread.yaml
+cat > spread.yaml <<'EOF'
+project: snapd
+path: /home/gopath/src/github.com/snapcore/snapd
+environment:
+    PROJECT_PATH: /home/gopath/src/github.com/snapcore/snapd
+    TESTSLIB: $PROJECT_PATH/tests/lib
+    SNAPPY_TESTING: 1
+    PATH: $PATH:$PROJECT_PATH/tests/lib/bin
+backends:
+    autopkgtest:
+        type: adhoc
+        allocate: ADDRESS localhost:22
+        systems:
+        - adt-local:
+            username: ubuntu
+            password: ubuntu
+suites:
+        tests/smoke/:
+            summary: Essenial system level tests for snapd
+EOF
+/tmp/go/bin/spread -v autopkgtest:adt-local:tests/smoke/
 
 # store journal info for inspectsion
 journalctl --sync


### PR DESCRIPTION
Our current autopkgtest setup reuses the spread.yaml that we use
for regular spread runs. The regular spread.yaml will modify the
host heavily which is not what we want for the autopkgtest
tests. Here the idea is to use the binaries that got build as
part of the distro build and run a smoke test against the
most pristine system possible.

After poking in {prepare-restore,prepare,reset}.sh I think we
need something radically simpler: a minimal spread.yaml that
is just there for autopkgtest. This PR goes this way.

The downside of this approach is of couse that thing may
get out of sync between the main spread.yaml and the autopkgtest
spread.yaml. To fix this we need a test that runs the autopkgtest
regularly against a clean environment (probably in the nested
suite).
