### PR TITLE
daemon, client, cmd/snap: show cohort key in snap info --verbose

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -63,6 +63,7 @@ type Snap struct {
 	License          string        `json:"license,omitempty"`
 	CommonIDs        []string      `json:"common-ids,omitempty"`
 	MountedFrom      string        `json:"mounted-from,omitempty"`
+	CohortKey        string        `json:"cohort-key,omitempty"`
 
 	Prices      map[string]float64    `json:"prices,omitempty"`
 	Screenshots []snap.ScreenshotInfo `json:"screenshots,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -204,6 +204,7 @@ const (
 func (cs *clientSuite) TestClientSnap(c *check.C) {
 	// example data obtained via
 	// printf "GET /v2/find?name=test-snapd-tools HTTP/1.0\r\n\r\n" | nc -U -q 1 /run/snapd.socket|grep '{'|python3 -m json.tool
+	// XXX: update / sync with what daemon is actually putting out
 	cs.rsp = `{
 		"type": "sync",
 		"result": {
@@ -242,6 +243,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
                             {"type": "screenshot", "url":"http://example.com/shot1.png", "width":640, "height":480},
                             {"type": "screenshot", "url":"http://example.com/shot2.png"}
                         ],
+                        "cohort-key": "some-long-cohort-key",
                         "common-ids": ["org.funky.snap"]
 		}
 	}`
@@ -285,6 +287,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			{Type: "screenshot", URL: "http://example.com/shot2.png"},
 		},
 		CommonIDs: []string{"org.funky.snap"},
+		CohortKey: "some-long-cohort-key",
 	})
 }
 

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -503,6 +503,20 @@ func (iw *infoWriter) maybePrintNotes() {
 	return
 }
 
+func (iw *infoWriter) maybePrintCohortKey() {
+	if !iw.verbose {
+		return
+	}
+	if iw.localSnap == nil {
+		return
+	}
+	if iw.localSnap.CohortKey == "" {
+		return
+	}
+	// 15 is 1 + the length of "refresh-date: "
+	fmt.Fprintf(iw, "cohort:\t%s\n", strutil.ElliptRight(iw.localSnap.CohortKey, iw.termWidth-15))
+}
+
 func (iw *infoWriter) maybePrintSum() {
 	if !iw.verbose {
 		return
@@ -675,6 +689,7 @@ func (x *infoCmd) Execute([]string) error {
 		iw.maybePrintBase()
 		iw.maybePrintSum()
 		iw.maybePrintID()
+		iw.maybePrintCohortKey()
 		iw.maybePrintTrackingChannel()
 		iw.maybePrintInstallDate()
 		iw.maybePrintChinfo()

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -510,11 +510,15 @@ func (iw *infoWriter) maybePrintCohortKey() {
 	if iw.localSnap == nil {
 		return
 	}
-	if iw.localSnap.CohortKey == "" {
+	coh := iw.localSnap.CohortKey
+	if coh == "" {
 		return
 	}
-	// 15 is 1 + the length of "refresh-date: "
-	fmt.Fprintf(iw, "cohort:\t%s\n", strutil.ElliptRight(iw.localSnap.CohortKey, iw.termWidth-15))
+	if isStdoutTTY {
+		// 15 is 1 + the length of "refresh-date: "
+		coh = strutil.ElliptRight(iw.localSnap.CohortKey, iw.termWidth-15)
+	}
+	fmt.Fprintf(iw, "cohort:\t%s\n", coh)
 }
 
 func (iw *infoWriter) maybePrintSum() {

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -917,6 +917,31 @@ func (infoSuite) TestDescr(c *check.C) {
 	}
 }
 
+func (infoSuite) TestMaybePrintCohortKey(c *check.C) {
+	type T struct {
+		snap     *client.Snap
+		verbose  bool
+		expected string
+	}
+
+	var buf flushBuffer
+	iw := snap.NewInfoWriter(&buf)
+	for i, t := range []T{
+		{snap: nil, verbose: false, expected: ""},
+		{snap: nil, verbose: true, expected: ""},
+		{snap: &client.Snap{}, verbose: false, expected: ""},
+		{snap: &client.Snap{}, verbose: true, expected: ""},
+		{snap: &client.Snap{CohortKey: "some-cohort-key"}, verbose: false, expected: ""},
+		{snap: &client.Snap{CohortKey: "some-cohort-key"}, verbose: true, expected: "cohort:\tsome…\n"},
+	} {
+		buf.Reset()
+		snap.SetupSnap(iw, t.snap, nil, nil)
+		snap.SetVerbose(iw, t.verbose)
+		snap.MaybePrintCohortKey(iw)
+		c.Check(buf.String(), check.Equals, t.expected, check.Commentf("%d", i))
+	}
+}
+
 func (infoSuite) TestWrapCornerCase(c *check.C) {
 	// this particular corner case isn't currently reachable from
 	// printDescr nor printSummary, but best to have it covered

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -108,6 +108,7 @@ var (
 	MaybePrintBase              = (*infoWriter).maybePrintBase
 	MaybePrintPath              = (*infoWriter).maybePrintPath
 	MaybePrintSum               = (*infoWriter).maybePrintSum
+	MaybePrintCohortKey         = (*infoWriter).maybePrintCohortKey
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -61,6 +61,7 @@ type Notes struct {
 	Disabled         bool
 	Broken           bool
 	IgnoreValidation bool
+	InCohort         bool
 }
 
 func NotesFromChannelSnapInfo(ref *snap.ChannelSnapInfo) *Notes {
@@ -95,6 +96,7 @@ func NotesFromLocal(snp *client.Snap) *Notes {
 		Disabled:         snp.Status != client.StatusActive,
 		Broken:           snp.Broken != "",
 		IgnoreValidation: snp.IgnoreValidation,
+		InCohort:         snp.CohortKey != "",
 	}
 }
 
@@ -159,6 +161,10 @@ func (n *Notes) String() string {
 
 	if n.IgnoreValidation {
 		ns = append(ns, i18n.G("ignore-validation"))
+	}
+
+	if n.InCohort {
+		ns = append(ns, i18n.G("in-cohort"))
 	}
 
 	if len(ns) == 0 {

--- a/cmd/snap/notes_test.go
+++ b/cmd/snap/notes_test.go
@@ -88,6 +88,12 @@ func (notesSuite) TestNotesIgnoreValidation(c *check.C) {
 	}).String(), check.Equals, "ignore-validation")
 }
 
+func (notesSuite) TestNotesInCohort(c *check.C) {
+	c.Check((&snap.Notes{
+		InCohort: true,
+	}).String(), check.Equals, "in-cohort")
+}
+
 func (notesSuite) TestNotesNothing(c *check.C) {
 	c.Check((&snap.Notes{}).String(), check.Equals, "-")
 }
@@ -104,4 +110,7 @@ func (notesSuite) TestNotesFromLocal(c *check.C) {
 	c.Check(snap.NotesFromLocal(&client.Snap{DevMode: true}).DevMode, check.Equals, true)
 	c.Check(snap.NotesFromLocal(&client.Snap{Confinement: client.DevModeConfinement}).DevMode, check.Equals, false)
 	c.Check(snap.NotesFromLocal(&client.Snap{IgnoreValidation: true}).IgnoreValidation, check.Equals, true)
+	// check that a cohort key in a snap sets the InCohort note flag
+	c.Check(snap.NotesFromLocal(&client.Snap{CohortKey: ""}).InCohort, check.Equals, false)
+	c.Check(snap.NotesFromLocal(&client.Snap{CohortKey: "123"}).InCohort, check.Equals, true)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -671,6 +671,7 @@ UnitFileState=enabled
 	// modify state
 	snapst.Channel = "beta"
 	snapst.IgnoreValidation = true
+	snapst.CohortKey = "some-long-cohort-key"
 	st.Lock()
 	snapstate.Set(st, "foo", &snapst)
 	st.Unlock()
@@ -786,6 +787,7 @@ UnitFileState=enabled
 			License:     "GPL-3.0",
 			CommonIDs:   []string{"org.foo.cmd"},
 			Screenshots: []snap.ScreenshotInfo{},
+			CohortKey:   "some-long-cohort-key",
 		},
 		Meta: meta,
 	}

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -278,6 +278,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 
 	result.TrackingChannel = snapst.Channel
 	result.IgnoreValidation = snapst.IgnoreValidation
+	result.CohortKey = snapst.CohortKey
 	result.DevMode = snapst.DevMode
 	result.TryMode = snapst.TryMode
 	result.JailMode = snapst.JailMode


### PR DESCRIPTION
Without this change there was no way of knowing a snap was tied to a
cohort. This exposes that information in the --verbose output.

The cohort key is ellipted, as it's too long to not mess up the
terminal.
