### PR TITLE
packaging: fix permissons powerpc docs dir

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -109,7 +109,7 @@ else
 		rm -rf debian/snapd; \
 	fi; \
 	if [ "$@" = "binary" ] || [ "$@" = "binary-arch" ]; then \
-		mkdir -p debian/snapd/usr/share/doc/snapd/; \
+		install -m755 -d debian/snapd/usr/share/doc/snapd/; \
 		cp debian/README.powerpc debian/snapd/usr/share/doc/snapd/; \
 		dh_installdeb; \
 		dh_gencontrol; \


### PR DESCRIPTION
When building powerpc, use install -d instead of mkdir to install
the base directory for the README.powerpc.

This fixes a lintian warning about unusual permissions on the
powerpc build.
