### PR TITLE
tests/lib/nested: fix multi argument copy_remote

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -235,7 +235,7 @@ execute_remote(){
 }
 
 copy_remote(){
-    sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$*" user1@localhost:~
+    sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@" user1@localhost:~
 }
 
 add_tty_chardev(){


### PR DESCRIPTION
When using copy_remote with multiple arguments, the command treats passed names
as a single string. When run, `copy_remote foo bar` fails as it tries to copy `'foo bar'`, rather than
individual files.

