### PR TITLE
image: turn a missing default content provider into an error

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -569,7 +569,8 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options, local *l
 		// warn about missing default providers
 		for _, dp := range neededDefaultProviders(info) {
 			if !local.hasName(snaps, dp) {
-				fmt.Fprintf(Stderr, "WARNING: the default content provider %q requested by snap %q is not getting installed.", dp, info.InstanceName())
+				// TODO: have a way to ignore this issue on a snap by snap basis?
+				return fmt.Errorf("cannot use snap %q without its default content provider %q being added explicitly", info.InstanceName(), dp)
 			}
 		}
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1929,9 +1929,7 @@ func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 	local, err := image.LocalSnaps(s.tsto, opts)
 	c.Assert(err, IsNil)
 	err = image.SetupSeed(s.tsto, model, opts, local)
-	c.Assert(err, IsNil)
-
-	c.Check(s.stderr.String(), Equals, `WARNING: the default content provider "gtk-common-themes" requested by snap "snap-req-content-provider" is not getting installed.`)
+	c.Check(err, ErrorMatches, `cannot use snap "snap-req-content-provider" without its default content provider "gtk-common-themes" being added explicitly`)
 }
 
 func (s *imageSuite) TestMissingLocalSnaps(c *C) {


### PR DESCRIPTION
So far a missing default content provider for a snap used in the seed of an image would produce only a warning. We had cases where this behavior has produced broken images. In theory default providers are optional or could be satisfied by a different snap and then using gadget connections, but in practice those are uncommon cases. Turn this into an error for now to avoid broken images first.
