### PR TITLE
osutil: add EnsureTreeState helper

### DIFF
--- a/osutil/synctree.go
+++ b/osutil/synctree.go
@@ -51,6 +51,27 @@ func removeEmptyDirs(baseDir, relPath string) error {
 	return nil
 }
 
+// EnsureTreeState ensures that a directory tree content matches expectations.
+//
+// EnsureTreeState walks subdirectories of the base directory, and
+// uses EnsureDirStateGlobs to synchronise content with the
+// corresponding entry in the content map.  Any non-existent
+// subdirectories in the content map will be created.
+//
+// After synchronising all subdirectories, any subdirectories where
+// files were removed that are now empty will itself be removed, plus
+// its parent directories up to but not including the base directory.
+//
+// No checks are performed to see whether subdirectories match the
+// passed globs, so it is the caller's responsibility to not create
+// directories that may match any globs passed in.
+//
+// For example, if the glob "snap.$SNAP_NAME.*" is used then the
+// caller should avoid trying to populate any directories matching
+// "snap.*".
+//
+// A list of changed and removed files is returned, as relative paths
+// to the base directory.
 func EnsureTreeState(baseDir string, globs []string, content map[string]map[string]*FileState) (changed, removed []string, err error) {
 	// Find all existing subdirectories under the base dir.  Don't
 	// perform any modifications here because, as it may confuse

--- a/osutil/synctree.go
+++ b/osutil/synctree.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func appendWithPrefix(paths []string, prefix string, filenames []string) []string {
+	for _, filename := range filenames {
+		paths = append(paths, filepath.Join(prefix, filename))
+	}
+	return paths
+}
+
+func EnsureTreeState(baseDir string, globs []string, content map[string]map[string]*FileState) (changed, removed []string, err error) {
+	// Find all existing subdirectories under the base dir.  Don't
+	// perform any modifications here because, as it may confuse
+	// Walk().
+	subdirs := make(map[string]bool)
+	err = filepath.Walk(baseDir, func(path string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !fileInfo.IsDir() {
+			return nil
+		}
+		relPath, err := filepath.Rel(baseDir, path)
+		if err != nil {
+			return err
+		}
+		subdirs[relPath] = true
+		return nil
+	})
+	if err != nil {
+		return changed, removed, err
+	}
+	// Ensure we process directories listed in content
+	for relPath := range content {
+		subdirs[relPath] = true
+	}
+
+	// TODO: ensure that no directories in the tree match a
+	// directory glob (one that would match any globs that would
+	// be passed in a particular context).
+	for relPath := range subdirs {
+		dirContent := content[relPath]
+		path := filepath.Join(baseDir, relPath)
+		if err = os.MkdirAll(path, 0755); err != nil {
+			break
+		}
+		var dirChanged, dirRemoved []string
+		dirChanged, dirRemoved, err = EnsureDirStateGlobs(path, globs, dirContent)
+		changed = appendWithPrefix(changed, relPath, dirChanged)
+		removed = appendWithPrefix(removed, relPath, dirRemoved)
+		if err != nil {
+			break
+		}
+	}
+	sort.Strings(changed)
+	sort.Strings(removed)
+	return changed, removed, err
+}

--- a/osutil/synctree.go
+++ b/osutil/synctree.go
@@ -157,8 +157,9 @@ func EnsureTreeState(baseDir string, globs []string, content map[string]map[stri
 		}
 	}
 	// As with EnsureDirState, if an error occurred we want to
-	// delete all matching files.  This means reprocessing
-	// subdirectories that were successfully synchronised.
+	// delete all matching files under the whole baseDir
+	// hierarchy.  This also means emptying subdirectories that
+	// were successfully synchronised.
 	if firstErr != nil {
 		// changed paths will be deleted by this next step
 		changed = nil

--- a/osutil/synctree_test.go
+++ b/osutil/synctree_test.go
@@ -1,0 +1,110 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type EnsureTreeStateSuite struct {
+	dir   string
+	globs []string
+}
+
+var _ = Suite(&EnsureTreeStateSuite{globs: []string{"*.snap"}})
+
+func (s *EnsureTreeStateSuite) SetUpTest(c *C) {
+	s.dir = c.MkDir()
+}
+
+func (s *EnsureTreeStateSuite) TestVerifiesExpectedFiles(c *C) {
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo", "bar"), 0755), IsNil)
+	name := filepath.Join(s.dir, "foo", "bar", "expected.snap")
+	c.Assert(ioutil.WriteFile(name, []byte("expected"), 0600), IsNil)
+	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]*osutil.FileState{
+		"foo/bar": {
+			"expected.snap": {Content: []byte("expected"), Mode: 0600},
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(changed, HasLen, 0)
+	c.Check(removed, HasLen, 0)
+
+	// The content and permissions are correct
+	c.Check(name, testutil.FileEquals, "expected")
+	stat, err := os.Stat(name)
+	c.Assert(err, IsNil)
+	c.Check(stat.Mode().Perm(), Equals, os.FileMode(0600))
+}
+
+func (s *EnsureTreeStateSuite) TestCreatesMissingFiles(c *C) {
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo"), 0755), IsNil)
+
+	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]*osutil.FileState{
+		"foo": {
+			"missing1.snap": {Content: []byte(`content-1`), Mode: 0600},
+		},
+		"bar": {
+			"missing2.snap": {Content: []byte(`content-2`), Mode: 0600},
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(changed, DeepEquals, []string{"bar/missing2.snap", "foo/missing1.snap"})
+	c.Check(removed, HasLen, 0)
+}
+
+func (s *EnsureTreeStateSuite) TestRemovesUnexpectedFiles(c *C) {
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "bar"), 0755), IsNil)
+	name1 := filepath.Join(s.dir, "foo", "evil1.snap")
+	name2 := filepath.Join(s.dir, "bar", "evil2.snap")
+	c.Assert(ioutil.WriteFile(name1, []byte(`evil-1`), 0600), IsNil)
+	c.Assert(ioutil.WriteFile(name2, []byte(`evil-2`), 0600), IsNil)
+
+	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]*osutil.FileState{
+		"foo": {},
+	})
+	c.Assert(err, IsNil)
+	c.Check(changed, HasLen, 0)
+	c.Check(removed, DeepEquals, []string{"bar/evil2.snap", "foo/evil1.snap"})
+	c.Check(name1, testutil.FileAbsent)
+	c.Check(name2, testutil.FileAbsent)
+}
+
+func (s *EnsureTreeStateSuite) TestIgnoresUnrelatedFiles(c *C) {
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo"), 0755), IsNil)
+	name := filepath.Join(s.dir, "foo", "unrelated")
+	err := ioutil.WriteFile(name, []byte(`text`), 0600)
+	c.Assert(err, IsNil)
+	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]*osutil.FileState{})
+	c.Assert(err, IsNil)
+	// Report says that nothing has changed
+	c.Check(changed, HasLen, 0)
+	c.Check(removed, HasLen, 0)
+	// The file is still there
+	c.Check(name, testutil.FilePresent)
+}

--- a/osutil/synctree_test.go
+++ b/osutil/synctree_test.go
@@ -95,6 +95,25 @@ func (s *EnsureTreeStateSuite) TestRemovesUnexpectedFiles(c *C) {
 	c.Check(name2, testutil.FileAbsent)
 }
 
+func (s *EnsureTreeStateSuite) TestRemovesEmptyDirectories(c *C) {
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(s.dir, "bar", "baz"), 0755), IsNil)
+	name1 := filepath.Join(s.dir, "foo", "file1.snap")
+	name2 := filepath.Join(s.dir, "foo", "unrelated")
+	name3 := filepath.Join(s.dir, "bar", "baz", "file2.snap")
+	c.Assert(ioutil.WriteFile(name1, []byte(`text`), 0600), IsNil)
+	c.Assert(ioutil.WriteFile(name2, []byte(`text`), 0600), IsNil)
+	c.Assert(ioutil.WriteFile(name3, []byte(`text`), 0600), IsNil)
+
+	_, _, err := osutil.EnsureTreeState(s.dir, s.globs, nil)
+	c.Assert(err, IsNil)
+
+	// The "foo" directory is still present, while the "bar" tree
+	// has been removed.
+	c.Check(filepath.Join(s.dir, "foo"), testutil.FilePresent)
+	c.Check(filepath.Join(s.dir, "bar"), testutil.FileAbsent)
+}
+
 func (s *EnsureTreeStateSuite) TestIgnoresUnrelatedFiles(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo"), 0755), IsNil)
 	name := filepath.Join(s.dir, "foo", "unrelated")


### PR DESCRIPTION
This work has been split out from PR #6767.  It adds an `EnsureTreeState` helper, that acts similar to `EnsureDirState` but operates on a tree of directories.