### PR TITLE
cmd/snap: don't run install on 'snap --help install'

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -48,8 +48,18 @@ func addHelp(parser *flags.Parser) error {
 		// on which help is being requested (like "snap foo
 		// --help", active is foo), or nil in the toplevel.
 		if parser.Command.Active == nil {
-			// toplevel --help will get handled via ErrCommandRequired
-			return nil
+			// this means *either* a bare 'snap --help',
+			// *or* 'snap --help command'
+			//
+			// If we return nil in the first case go-flags
+			// will throw up an ErrCommandRequired on its
+			// own, but in the second case it'll go on to
+			// run the command, which is very unexpected.
+			//
+			// So we force the ErrCommandRequired here.
+
+			// toplevel --help gets handled via ErrCommandRequired
+			return &flags.Error{Type: flags.ErrCommandRequired}
 		}
 		// not toplevel, so ask for regular help
 		return &flags.Error{Type: flags.ErrHelp}

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -41,6 +41,7 @@ func (s *SnapSuite) TestHelpPrintsHelp(c *check.C) {
 		{"snap", "help"},
 		{"snap", "--help"},
 		{"snap", "-h"},
+		{"snap", "--help", "install"},
 	} {
 		s.ResetStdStreams()
 
@@ -191,15 +192,6 @@ func (s *SnapSuite) TestBadSub(c *check.C) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()
 	os.Args = []string{"snap", "debug", "brotato"}
-
-	err := snap.RunMain()
-	c.Assert(err, check.ErrorMatches, `unknown command "brotato", see 'snap help debug'.`)
-}
-
-func (s *SnapSuite) TestWorseSub(c *check.C) {
-	origArgs := os.Args
-	defer func() { os.Args = origArgs }()
-	os.Args = []string{"snap", "-h", "debug", "brotato"}
 
 	err := snap.RunMain()
 	c.Assert(err, check.ErrorMatches, `unknown command "brotato", see 'snap help debug'.`)


### PR DESCRIPTION
The way we were handling toplevel `--help`, letting go-flags pick it
up and throw an `ErrCommandRequired`, meant that if there actually was
a command after `--help` then that command got run. E.g.,

    ~$ snap --help install
    error: cannot install zero snaps

With this change, instead, the toplevel help is printed,

    ~$ snap --help install
    The snap command [...]

Thanks to @OddBloke for alerting me via https://forum.snapcraft.io/t/11686