### PR TITLE
tests: add snap-tool for easier access to internal tools

### DIFF
--- a/tests/lib/bin/snap-tool
+++ b/tests/lib/bin/snap-tool
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# shellcheck source=tests/lib/dirs.sh
+. "$TESTSLIB/dirs.sh"
+
+case "${1:-}" in
+	'')
+		echo "usage: snap-tool <tool> [ARGS]"
+		echo
+		echo "The snap-tool program simplifies running internal tools"
+		echo "like snap-discard-ns, which are not on PATH and whose"
+		echo "location varies from one distribution to another"
+		;;
+	*)
+		tool="$1"
+		shift
+		exec "$LIBEXECDIR/snapd/$tool" "$@"
+		;;
+esac


### PR DESCRIPTION
Running snap-discard-ns, either in tests or in debug shell sessions is
tedious, because it is not on PATH and because users have to remember
that the location to which it is installed varies from one distribution
to another. Using a helper script that can multiplex to any tool in
$libexecdir/snapd/ make that problem go away.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
