### PR TITLE
.gitignore: add mypy and local binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ po/snappy.pot
 .*.swp
 .*.swp
 .dirstamp
+# Locally built binaries
 cmd/decode-mount-opts/decode-mount-opts
 cmd/libsnap-confine-private/unit-tests
 cmd/snap-confine/snap-confine
@@ -23,8 +24,12 @@ cmd/snap-confine/snap-confine-debug
 cmd/snap-confine/snap-confine.apparmor
 cmd/snap-confine/unit-tests
 cmd/snap-discard-ns/snap-discard-ns
+cmd/snap-gdb-shim/snap-gdb-shim
+cmd/snap-mgmt/snap-mgmt
 cmd/snap-update-ns/snap-update-ns
 cmd/snap-update-ns/unit-tests
+cmd/snapd-env-generator/snapd-env-generator
+cmd/snapd-generator/snapd-generator
 cmd/system-shutdown/system-shutdown
 cmd/system-shutdown/unit-tests
 
@@ -65,3 +70,7 @@ cmd/install-sh
 cmd/missing
 cmd/stamp-h1
 cmd/test-driver
+
+# Mypy
+.mypy
+.mypy_cache


### PR DESCRIPTION
Using mypy can result in a lot of cache files and those can make 'git
status' pretty noisy. In addition there are several binaries that are
routinely built that were never added to .gitignore.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
