### PR TITLE
tests: mountinfo-tool --one prints matches on failure

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -460,10 +460,6 @@ Known attributes, applicable for both filtering and display.
         rewrite_renumber(entries)
     if opts.rename:
         rewrite_rename(entries)
-    if opts.one and len(entries) != 1:
-        raise SystemExit(
-            "--one requires exactly one match, found {}".format(len(entries))
-        )
     for e in entries:
         if attrs:
             values = []  # type: List[Any]
@@ -475,7 +471,10 @@ Known attributes, applicable for both filtering and display.
             print(*values)
         else:
             print(e)
-
+    if opts.one and len(entries) != 1:
+        raise SystemExit(
+            "--one requires exactly one match, found {}".format(len(entries))
+        )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When mountinfo-tool is invoked with --one it expects to see exactly one
mount point matching the filter expression. When more are found an error
is printed but the user is left wondering what really happened. This
patch changes that, so that output is printed unconditionally and the
failure related to using --one is only reported later.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
