### PR TITLE
tests: revert "tests: stop catalog-update/apt-hooks test for now"

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -9,10 +9,6 @@ debug: |
     strings /var/cache/snapd/commands.db | sed  -e 's#"}\(]\)\?#"}\1\n#g'
     
 execute: |
-    # FIXME: remove this once the store is in good shape again
-    echo "the store is unhappy right now"
-    exit 0
-
     echo "Ensure we have a snap catalog in our cache"
     for _ in {1..30}; do
         if [ -s /var/cache/snapd/commands.db ]; then


### PR DESCRIPTION
This reverts commit 5bc0399ca6b2c9953f90c3136df3ad3ef792b9a3.

The catalog-update should work again.