### PR TITLE
many: install snap-confine-debug while testing

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -299,7 +299,7 @@ endif  # SELINUX
 
 # an extra build that has additional debugging enabled at compile time
 
-noinst_PROGRAMS += snap-confine/snap-confine-debug
+libexec_PROGRAMS += snap-confine/snap-confine-debug
 snap_confine_snap_confine_debug_SOURCES = $(snap_confine_snap_confine_SOURCES)
 snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS)
 snap_confine_snap_confine_debug_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -111,6 +111,14 @@ Depends: snapd (= ${binary:Version}), ${misc:Depends}
 Description: Transitional package for snapd
  This is a transitional dummy package. It can safely be removed.
 
+Package: snap-confine-debug
+Architecture: any
+Depends: snapd (= ${binary:Version}), ${misc:Depends}
+Description: snap-confine built with additional debugging.
+ This package is only useful for the internal snapd test
+ suite. It provides a binary that nothing otherwise uses
+ explicitly.
+
 Package: ubuntu-core-launcher
 Architecture: any
 Depends: snapd (= ${binary:Version}), ${misc:Depends}

--- a/packaging/ubuntu-16.04/snap-confine-debug.install
+++ b/packaging/ubuntu-16.04/snap-confine-debug.install
@@ -1,0 +1,1 @@
+usr/lib/snapd/snap-confine-debug

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -462,7 +462,7 @@ distro_install_build_snapd(){
         case "$SPREAD_SYSTEM" in
             ubuntu-*|debian-*)
                 # shellcheck disable=SC2125
-                packages="${GOHOME}"/snapd_*.deb
+                packages="$GOHOME/snapd_*.deb $GOHOME/snap-confine-debug_*.deb"
                 ;;
             fedora-*|amazon-*|centos-*)
                 # shellcheck disable=SC2125


### PR DESCRIPTION
For the longest time, snap-confine had a sibling, snap-confine-debug,
built with additional debugging messages. Those were almost never visble
outside of a particular contributor's computer. This patch creates a new
binary package, snap-confine-debug, which exists solely to ship the binary
so that it can be injected into the repackaged core or snapd snaps and
installed as a replacement for snap-confine during testing.

The patch is partial since it needs to be compensated in other packaging
systems, so that the new file is not installed anywhere.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
