### PR TITLE
cmd/snap-confine: umount everything under snap's view of hostfs

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -231,10 +231,8 @@
     pivot_root,
     # cleanup
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
-    umount /var/lib/snapd/hostfs/sys/,
-    umount /var/lib/snapd/hostfs/dev/,
-    umount /var/lib/snapd/hostfs/proc/,
     mount options=(rw rslave) -> /var/lib/snapd/hostfs/,
+    umount /var/lib/snapd/hostfs/**,
 
     # set up user mount namespace
     mount options=(rslave) -> /,


### PR DESCRIPTION
We used to unmount the second view of /sys, /dev and /proc that were
visible in /var/lib/snapd/hostfs, because those would routinely upset
certain programs that, for whatever reason, look for sysfs rather than
assuming it is at /sys. This patch extends that idea to unmount everything
visible under /hostfs. This reduces the clutter inside the per-snap
mount namespace.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
