### PR TITLE
spread-shellcheck: use safe loader

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -137,7 +137,7 @@ def checksection(data, env: Dict[str, str]):
 def checkfile(path):
     logging.debug("checking file %s", path)
     with open(path) as inf:
-        data = yaml.load(inf)
+        data = yaml.safe_load(inf)
 
     errors = ShellcheckError(path)
     # TODO: handle stacking of environment from other places that influence it:

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -137,7 +137,7 @@ def checksection(data, env: Dict[str, str]):
 def checkfile(path):
     logging.debug("checking file %s", path)
     with open(path) as inf:
-        data = yaml.safe_load(inf)
+        data = yaml.load(inf, Loader=yaml.CSafeLoader)
 
     errors = ShellcheckError(path)
     # TODO: handle stacking of environment from other places that influence it:


### PR DESCRIPTION
Fix the warning when loading PyYAML:
```
./spread-shellcheck:140: YAMLLoadWarning: calling yaml.load() without Loader=...
  is deprecated, as the default Loader is unsafe.
  Please read https://msg.pyyaml.org/load for full details.
```
