### PR TITLE
daemon, overlord/snapstate: support leave-cohort

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -734,6 +734,7 @@ type snapInstruction struct {
 	Channel          string        `json:"channel"`
 	Revision         snap.Revision `json:"revision"`
 	CohortKey        string        `json:"cohort-key"`
+	LeaveCohort      bool          `json:"leave-cohort"`
 	DevMode          bool          `json:"devmode"`
 	JailMode         bool          `json:"jailmode"`
 	Classic          bool          `json:"classic"`
@@ -753,9 +754,10 @@ type snapInstruction struct {
 
 func (inst *snapInstruction) revnoOpts() *snapstate.RevisionOptions {
 	return &snapstate.RevisionOptions{
-		Channel:   inst.Channel,
-		Revision:  inst.Revision,
-		CohortKey: inst.CohortKey,
+		Channel:     inst.Channel,
+		Revision:    inst.Revision,
+		CohortKey:   inst.CohortKey,
+		LeaveCohort: inst.LeaveCohort,
 	}
 }
 
@@ -871,11 +873,19 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 
 func verifySnapInstructions(inst *snapInstruction) error {
 	if inst.CohortKey != "" {
+		if inst.LeaveCohort {
+			return fmt.Errorf("cannot specify both cohort-key and leave-cohort")
+		}
 		if !inst.Revision.Unset() {
 			return fmt.Errorf("cannot specify both cohort-key and revision")
 		}
 		if inst.Action != "install" && inst.Action != "refresh" && inst.Action != "switch" {
 			return fmt.Errorf("cohort-key can only be specified for install, refresh, or switch")
+		}
+	}
+	if inst.LeaveCohort {
+		if inst.Action != "refresh" && inst.Action != "switch" {
+			return fmt.Errorf("leave-cohort can only be specified for refresh or switch")
 		}
 	}
 	switch inst.Action {
@@ -1078,6 +1088,10 @@ func snapSwitch(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 
 	var msg string
 	switch {
+	case inst.LeaveCohort && inst.Channel != "":
+		msg = fmt.Sprintf(i18n.G("Switch %q snap to channel %q and away from cohort"), inst.Snaps[0], inst.Channel)
+	case inst.LeaveCohort:
+		msg = fmt.Sprintf(i18n.G("Switch %q snap away from cohort"), inst.Snaps[0])
 	case inst.CohortKey == "" && inst.Channel != "":
 		msg = fmt.Sprintf(i18n.G("Switch %q snap to channel %q"), inst.Snaps[0], inst.Channel)
 	case inst.CohortKey != "" && inst.Channel == "":
@@ -1261,7 +1275,8 @@ func snapsOp(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode request body into snap instruction: %v", err)
 	}
 
-	if inst.Channel != "" || !inst.Revision.Unset() || inst.DevMode || inst.JailMode || inst.CohortKey != "" {
+	// TODO: inst.Amend, etc?
+	if inst.Channel != "" || !inst.Revision.Unset() || inst.DevMode || inst.JailMode || inst.CohortKey != "" || inst.LeaveCohort {
 		return BadRequest("unsupported option provided for multi-snap operation")
 	}
 	if err := verifySnapInstructions(&inst); err != nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2446,6 +2446,50 @@ func (s *apiSuite) TestPostSnapCohortRandoAction(c *check.C) {
 	}
 }
 
+func (s *apiSuite) TestPostSnapLeaveCohortRandoAction(c *check.C) {
+	s.daemonWithOverlordMock(c)
+	s.vars = map[string]string{"name": "some-snap"}
+	const expectedErr = "leave-cohort can only be specified for refresh or switch"
+
+	for _, action := range []string{"install", "remove", "revert", "enable", "disable", "xyzzy"} {
+		buf := strings.NewReader(fmt.Sprintf(`{"action": "%s", "leave-cohort": true}`, action))
+		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", buf)
+		c.Assert(err, check.IsNil)
+
+		rsp := postSnap(snapCmd, req, nil).(*resp)
+
+		c.Check(rsp.Type, check.Equals, ResponseTypeError)
+		c.Check(rsp.Status, check.Equals, 400, check.Commentf("%q", action))
+		c.Check(rsp.Result.(*errorResult).Message, check.Equals, expectedErr, check.Commentf("%q", action))
+	}
+}
+
+func (s *apiSuite) TestPostSnapCohortIncompat(c *check.C) {
+	s.daemonWithOverlordMock(c)
+	s.vars = map[string]string{"name": "some-snap"}
+
+	type T struct {
+		opts   string
+		errmsg string
+	}
+
+	for i, t := range []T{
+		// TODO: more?
+		{`"cohort-key": "what", "revision": "42"`, `cannot specify both cohort-key and revision`},
+		{`"cohort-key": "what", "leave-cohort": true`, `cannot specify both cohort-key and leave-cohort`},
+	} {
+		buf := strings.NewReader(fmt.Sprintf(`{"action": "refresh", %s}`, t.opts))
+		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", buf)
+		c.Assert(err, check.IsNil, check.Commentf("%d (%s)", i, t.opts))
+
+		rsp := postSnap(snapCmd, req, nil).(*resp)
+
+		c.Check(rsp.Type, check.Equals, ResponseTypeError, check.Commentf("%d (%s)", i, t.opts))
+		c.Check(rsp.Status, check.Equals, 400, check.Commentf("%d (%s)", i, t.opts))
+		c.Check(rsp.Result.(*errorResult).Message, check.Equals, t.errmsg, check.Commentf("%d (%s)", i, t.opts))
+	}
+}
+
 func (s *apiSuite) TestPostSnapVerifyMultiSnapInstruction(c *check.C) {
 	s.daemonWithOverlordMock(c)
 
@@ -2467,11 +2511,12 @@ func (s *apiSuite) TestPostSnapsNoWeirdses(c *check.C) {
 	// one could add more actions here ... 🤷
 	for _, action := range []string{"install", "refresh", "remove"} {
 		for weird, v := range map[string]string{
-			"channel":    `"beta"`,
-			"revision":   `"1"`,
-			"devmode":    "true",
-			"jailmode":   "true",
-			"cohort-key": `"what"`,
+			"channel":      `"beta"`,
+			"revision":     `"1"`,
+			"devmode":      "true",
+			"jailmode":     "true",
+			"cohort-key":   `"what"`,
+			"leave-cohort": "true",
 		} {
 			buf := strings.NewReader(fmt.Sprintf(`{"action": "%s","snaps":["foo","bar"], "%s": %s}`, action, weird, v))
 			req, err := http.NewRequest("POST", "/v2/snaps", buf)
@@ -3754,10 +3799,42 @@ func (s *apiSuite) TestRefreshCohort(c *check.C) {
 	c.Check(summary, check.Equals, `Refresh "some-snap" snap`)
 }
 
+func (s *apiSuite) TestRefreshLeaveCohort(c *check.C) {
+	var leave *bool
+
+	snapstateUpdate = func(s *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
+		leave = &opts.LeaveCohort
+
+		t := s.NewTask("fake-refresh-snap", "Doing a fake install")
+		return state.NewTaskSet(t), nil
+	}
+	assertstateRefreshSnapDeclarations = func(s *state.State, userID int) error {
+		return nil
+	}
+
+	d := s.daemon(c)
+	inst := &snapInstruction{
+		Action:      "refresh",
+		LeaveCohort: true,
+		Snaps:       []string{"some-snap"},
+	}
+
+	st := d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	summary, _, err := inst.dispatch()(inst, st)
+	c.Check(err, check.IsNil)
+
+	c.Check(*leave, check.Equals, true)
+	c.Check(summary, check.Equals, `Refresh "some-snap" snap`)
+}
+
 func (s *apiSuite) TestSwitchInstruction(c *check.C) {
 	var cohort, channel string
+	var leave *bool
 	snapstateSwitch = func(s *state.State, name string, opts *snapstate.RevisionOptions) (*state.TaskSet, error) {
 		cohort = opts.CohortKey
+		leave = &opts.LeaveCohort
 		channel = opts.Channel
 
 		t := s.NewTask("fake-switch", "Doing a fake switch")
@@ -3768,21 +3845,28 @@ func (s *apiSuite) TestSwitchInstruction(c *check.C) {
 	st := d.overlord.State()
 
 	type T struct {
-		channel, cohort, summary string
+		channel string
+		cohort  string
+		leave   bool
+		summary string
 	}
 	table := []T{
-		{"", "some-cohort", `Switch "some-snap" snap to cohort "some-coho…"`},
-		{"some-channel", "", `Switch "some-snap" snap to channel "some-channel"`},
-		{"some-channel", "some-cohort", `Switch "some-snap" snap to channel "some-channel" and cohort "some-coho…"`},
+		{"", "some-cohort", false, `Switch "some-snap" snap to cohort "some-coho…"`},
+		{"some-channel", "", false, `Switch "some-snap" snap to channel "some-channel"`},
+		{"some-channel", "some-cohort", false, `Switch "some-snap" snap to channel "some-channel" and cohort "some-coho…"`},
+		{"", "", true, `Switch "some-snap" snap away from cohort`},
+		{"some-channel", "", true, `Switch "some-snap" snap to channel "some-channel" and away from cohort`},
 	}
 
 	for _, t := range table {
 		cohort, channel = "", ""
+		leave = nil
 		inst := &snapInstruction{
-			Action:    "switch",
-			CohortKey: t.cohort,
-			Channel:   t.channel,
-			Snaps:     []string{"some-snap"},
+			Action:      "switch",
+			CohortKey:   t.cohort,
+			Channel:     t.channel,
+			Snaps:       []string{"some-snap"},
+			LeaveCohort: t.leave,
 		}
 
 		st.Lock()
@@ -3793,6 +3877,7 @@ func (s *apiSuite) TestSwitchInstruction(c *check.C) {
 		c.Check(cohort, check.Equals, t.cohort)
 		c.Check(channel, check.Equals, t.channel)
 		c.Check(summary, check.Equals, t.summary)
+		c.Check(*leave, check.Equals, t.leave)
 	}
 }
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1216,42 +1216,63 @@ func resolveChannel(st *state.State, snapName, newChannel string, deviceCtx Devi
 var errRevisionSwitch = errors.New("cannot switch revision")
 
 func switchSummary(snap, chanFrom, chanTo, cohFrom, cohTo string) string {
-	switchChannel := chanFrom != chanTo && chanTo != ""
-	switchCohort := cohFrom != cohTo && cohTo != ""
-	switch {
-	case switchChannel && !switchCohort && chanFrom == "":
-		return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q"),
-			snap, chanTo)
-	case switchChannel && !switchCohort:
-		return fmt.Sprintf(i18n.G("Switch snap %q from channel %q to %q"),
-			snap, chanFrom, chanTo)
-	case switchCohort && !switchChannel && cohFrom == "":
-		return fmt.Sprintf(i18n.G("Switch snap %q from no cohort to %q"),
-			snap, strutil.ElliptRight(cohTo, 10))
-	case switchCohort && !switchChannel:
-		return fmt.Sprintf(i18n.G("Switch snap %q from cohort %q to %q"),
-			snap, strutil.ElliptRight(cohFrom, 10), strutil.ElliptRight(cohTo, 10))
-	case switchCohort && switchChannel && chanFrom == "" && cohFrom == "":
-		return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q and from no cohort to %q"),
-			snap, chanTo, strutil.ElliptRight(cohTo, 10),
-		)
-	case switchCohort && switchChannel && cohFrom == "":
-		return fmt.Sprintf(i18n.G("Switch snap %q from channel %q to %q and from no cohort to %q"),
-			snap, chanFrom, chanTo, strutil.ElliptRight(cohTo, 10),
-		)
-	case switchCohort && switchChannel && chanFrom == "":
-		return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q and from cohort %q to %q"),
-			snap, chanTo, strutil.ElliptRight(cohFrom, 10), strutil.ElliptRight(cohTo, 10),
-		)
-	case switchCohort && switchChannel:
+	if cohFrom != cohTo {
+		if cohTo == "" {
+			// leave cohort
+			if chanFrom == chanTo {
+				return fmt.Sprintf(i18n.G("Switch snap %q away from cohort %q"),
+					snap, strutil.ElliptRight(cohFrom, 10))
+			}
+			if chanFrom == "" {
+				return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q and away from cohort %q"),
+					snap, chanTo, strutil.ElliptRight(cohFrom, 10),
+				)
+			}
+			return fmt.Sprintf(i18n.G("Switch snap %q from channel %q to %q and away from cohort %q"),
+				snap, chanFrom, chanTo, strutil.ElliptRight(cohFrom, 10),
+			)
+		}
+		if cohFrom == "" {
+			// moving into a cohort
+			if chanFrom == chanTo {
+				return fmt.Sprintf(i18n.G("Switch snap %q from no cohort to %q"),
+					snap, strutil.ElliptRight(cohTo, 10))
+			}
+			if chanFrom == "" {
+				return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q and from no cohort to %q"),
+					snap, chanTo, strutil.ElliptRight(cohTo, 10),
+				)
+			}
+			// chanTo == "" is not interesting
+			return fmt.Sprintf(i18n.G("Switch snap %q from channel %q to %q and from no cohort to %q"),
+				snap, chanFrom, chanTo, strutil.ElliptRight(cohTo, 10),
+			)
+		}
+		if chanFrom == chanTo {
+			return fmt.Sprintf(i18n.G("Switch snap %q from cohort %q to %q"),
+				snap, strutil.ElliptRight(cohFrom, 10), strutil.ElliptRight(cohTo, 10))
+		}
+		if chanFrom == "" {
+			return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q and from cohort %q to %q"),
+				snap, chanTo, strutil.ElliptRight(cohFrom, 10), strutil.ElliptRight(cohTo, 10),
+			)
+		}
 		return fmt.Sprintf(i18n.G("Switch snap %q from channel %q to %q and from cohort %q to %q"),
 			snap, chanFrom, chanTo,
 			strutil.ElliptRight(cohFrom, 10), strutil.ElliptRight(cohTo, 10),
 		)
-	default:
-		// this might actually be an error
-		return "No change switch (bug?)"
 	}
+
+	if chanFrom == "" {
+		return fmt.Sprintf(i18n.G("Switch snap %q from no channel to %q"),
+			snap, chanTo)
+	}
+	if chanFrom != chanTo {
+		return fmt.Sprintf(i18n.G("Switch snap %q from channel %q to %q"),
+			snap, chanFrom, chanTo)
+	}
+	// this might actually be an error
+	return "No change switch (bug?)"
 }
 
 // Switch switches a snap to a new channel and/or cohort
@@ -1299,6 +1320,9 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 	if opts.CohortKey != "" {
 		snapsup.CohortKey = opts.CohortKey
 	}
+	if opts.LeaveCohort {
+		snapsup.CohortKey = ""
+	}
 
 	summary := switchSummary(snapsup.InstanceName(), snapst.Channel, snapsup.Channel, snapst.CohortKey, snapsup.CohortKey)
 	switchSnap := st.NewTask("switch-snap", summary)
@@ -1309,9 +1333,10 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 
 // RevisionOptions control the selection of a snap revision.
 type RevisionOptions struct {
-	Channel   string
-	Revision  snap.Revision
-	CohortKey string
+	Channel     string
+	Revision    snap.Revision
+	CohortKey   string
+	LeaveCohort bool
 }
 
 // Update initiates a change updating a snap.
@@ -1364,6 +1389,9 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 	if opts.CohortKey == "" {
 		// default to being in the same cohort
 		opts.CohortKey = snapst.CohortKey
+	}
+	if opts.LeaveCohort {
+		opts.CohortKey = ""
 	}
 
 	// TODO: make flags be per revision to avoid this logic (that

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9044,47 +9044,115 @@ type switchScenario struct {
 	summary  string
 }
 
-var switchScenarios = []switchScenario{
-	// no cohort at all
-	{"stable", "some-channel", "", "", `Switch snap "some-snap" from channel "stable" to "some-channel"`},
-	// no cohort, from empty channel
-	{"", "some-channel", "", "", `Switch snap "some-snap" from no channel to "some-channel"`},
-	// cohort specified is the same as current
-	{"stable", "some-channel", "some-cohort", "some-cohort", `Switch snap "some-snap" from channel "stable" to "some-channel"`},
-	// no cohort change requested
-	{"stable", "some-channel", "some-cohort", "", `Switch snap "some-snap" from channel "stable" to "some-channel"`},
-	// no channel at all (local installed snap? XXX: might actually need an error for sanity)
-	{"", "", "some-cohort", "some-other-cohort", `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`},
-	// channel specified is the same as current
-	{"stable", "stable", "some-cohort", "some-other-cohort", `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`},
-	// no channel change requested
-	{"stable", "", "some-cohort", "some-other-cohort", `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`},
-	// no channel change requested, from empty cohort
-	{"stable", "", "", "some-cohort", `Switch snap "some-snap" from no cohort to "some-coho…"`},
-	// all change
-	{"stable", "edge", "some-cohort", "some-other-cohort",
-		`Switch snap "some-snap" from channel "stable" to "edge" and from cohort "some-coho…" to "some-othe…"`},
-	// all change, from empty channel
-	{"", "stable", "some-cohort", "some-other-cohort",
-		`Switch snap "some-snap" from no channel to "stable" and from cohort "some-coho…" to "some-othe…"`},
-	// all change, from empty cohort
-	{"stable", "edge", "", "some-cohort",
-		`Switch snap "some-snap" from channel "stable" to "edge" and from no cohort to "some-coho…"`},
-	// all change, from empty channel and cohort
-	{"", "stable", "", "some-cohort",
-		`Switch snap "some-snap" from no channel to "stable" and from no cohort to "some-coho…"`},
-	// no change (XXX: error?)
-	{"stable", "stable", "some-cohort", "some-cohort", `No change switch (bug?)`},
+var switchScenarios = map[string]switchScenario{
+	"no cohort at all": {
+		chanFrom: "stable",
+		chanTo:   "some-channel",
+		cohFrom:  "",
+		cohTo:    "",
+		summary:  `Switch snap "some-snap" from channel "stable" to "some-channel"`,
+	},
+	"no cohort, from empty channel": {
+		chanFrom: "",
+		chanTo:   "some-channel",
+		cohFrom:  "",
+		cohTo:    "",
+		summary:  `Switch snap "some-snap" from no channel to "some-channel"`,
+	},
+	"no cohort change requested": {
+		chanFrom: "stable",
+		chanTo:   "some-channel",
+		cohFrom:  "some-cohort",
+		cohTo:    "some-cohort",
+		summary:  `Switch snap "some-snap" from channel "stable" to "some-channel"`,
+	},
+	"leave cohort": {
+		chanFrom: "stable",
+		chanTo:   "stable",
+		cohFrom:  "some-cohort",
+		cohTo:    "",
+		summary:  `Switch snap "some-snap" away from cohort "some-coho…"`,
+	},
+	"leave cohort, change channel": {
+		chanFrom: "stable",
+		chanTo:   "edge",
+		cohFrom:  "some-cohort",
+		cohTo:    "",
+		summary:  `Switch snap "some-snap" from channel "stable" to "edge" and away from cohort "some-coho…"`,
+	},
+	"leave cohort, change from empty channel": {
+		chanFrom: "",
+		chanTo:   "stable",
+		cohFrom:  "some-cohort",
+		cohTo:    "",
+		summary:  `Switch snap "some-snap" from no channel to "stable" and away from cohort "some-coho…"`,
+	},
+	"no channel at all": {
+		chanFrom: "",
+		chanTo:   "",
+		cohFrom:  "some-cohort",
+		cohTo:    "some-other-cohort",
+		summary:  `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`,
+	},
+	"no channel change requested": {
+		chanFrom: "stable",
+		chanTo:   "stable",
+		cohFrom:  "some-cohort",
+		cohTo:    "some-other-cohort",
+		summary:  `Switch snap "some-snap" from cohort "some-coho…" to "some-othe…"`,
+	},
+	"no channel change requested, from empty cohort": {
+		chanFrom: "stable",
+		chanTo:   "stable",
+		cohFrom:  "",
+		cohTo:    "some-cohort",
+		summary:  `Switch snap "some-snap" from no cohort to "some-coho…"`,
+	},
+	"all change": {
+		chanFrom: "stable",
+		chanTo:   "edge",
+		cohFrom:  "some-cohort",
+		cohTo:    "some-other-cohort",
+		summary:  `Switch snap "some-snap" from channel "stable" to "edge" and from cohort "some-coho…" to "some-othe…"`,
+	},
+	"all change, from empty channel": {
+		chanFrom: "",
+		chanTo:   "stable",
+		cohFrom:  "some-cohort",
+		cohTo:    "some-other-cohort",
+		summary:  `Switch snap "some-snap" from no channel to "stable" and from cohort "some-coho…" to "some-othe…"`,
+	},
+	"all change, from empty cohort": {
+		chanFrom: "stable",
+		chanTo:   "edge",
+		cohFrom:  "",
+		cohTo:    "some-cohort",
+		summary:  `Switch snap "some-snap" from channel "stable" to "edge" and from no cohort to "some-coho…"`,
+	},
+	"all change, from empty channel and cohort": {
+		chanFrom: "",
+		chanTo:   "stable",
+		cohFrom:  "",
+		cohTo:    "some-cohort",
+		summary:  `Switch snap "some-snap" from no channel to "stable" and from no cohort to "some-coho…"`,
+	},
+	"no change (XXX: error?)": {
+		chanFrom: "stable",
+		chanTo:   "stable",
+		cohFrom:  "some-cohort",
+		cohTo:    "some-cohort",
+		summary:  `No change switch (bug?)`,
+	},
 }
 
 func (s *snapmgrTestSuite) TestSwitchScenarios(c *C) {
-	for i, t := range switchScenarios {
-		s.testSwitchScenario(c, i, t)
+	for k, t := range switchScenarios {
+		s.testSwitchScenario(c, k, t)
 	}
 }
 
-func (s *snapmgrTestSuite) testSwitchScenario(c *C, i int, t switchScenario) {
-	comment := Commentf("%d (%+v)", i, t)
+func (s *snapmgrTestSuite) testSwitchScenario(c *C, desc string, t switchScenario) {
+	comment := Commentf("%q (%+v)", desc, t)
 	si := snap.SideInfo{
 		RealName: "some-snap",
 		Revision: snap.R(7),
@@ -9106,8 +9174,9 @@ func (s *snapmgrTestSuite) testSwitchScenario(c *C, i int, t switchScenario) {
 	c.Check(summary, Equals, t.summary, comment)
 	chg := s.state.NewChange("switch-snap", summary)
 	ts, err := snapstate.Switch(s.state, "some-snap", &snapstate.RevisionOptions{
-		Channel:   t.chanTo,
-		CohortKey: t.cohTo,
+		Channel:     t.chanTo,
+		CohortKey:   t.cohTo,
+		LeaveCohort: t.cohFrom != "" && t.cohTo == "",
 	})
 	c.Assert(err, IsNil, comment)
 	chg.AddAll(ts)
@@ -9124,9 +9193,6 @@ func (s *snapmgrTestSuite) testSwitchScenario(c *C, i int, t switchScenario) {
 		expectedChanTo = t.chanFrom
 	}
 	expectedCohTo := t.cohTo
-	if t.cohTo == "" {
-		expectedCohTo = t.cohFrom
-	}
 
 	// ensure the desired channel/cohort has changed
 	var snapst snapstate.SnapState
@@ -9143,16 +9209,16 @@ func (s *snapmgrTestSuite) testSwitchScenario(c *C, i int, t switchScenario) {
 
 func (s *snapmgrTestSuite) TestUpdateScenarios(c *C) {
 	// TODO: also use channel-for-7 or equiv to check updates that are switches
-	for i, t := range switchScenarios {
-		s.testUpdateScenario(c, i, t)
+	for k, t := range switchScenarios {
+		s.testUpdateScenario(c, k, t)
 	}
 }
 
-func (s *snapmgrTestSuite) testUpdateScenario(c *C, i int, t switchScenario) {
+func (s *snapmgrTestSuite) testUpdateScenario(c *C, desc string, t switchScenario) {
 	// reset
 	s.fakeBackend.ops = nil
 
-	comment := Commentf("%d (%+v)", i, t)
+	comment := Commentf("%q (%+v)", desc, t)
 	si := snap.SideInfo{
 		RealName: "some-snap",
 		Revision: snap.R(7),
@@ -9173,8 +9239,9 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, i int, t switchScenario) {
 
 	chg := s.state.NewChange("update-snap", t.summary)
 	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{
-		Channel:   t.chanTo,
-		CohortKey: t.cohTo,
+		Channel:     t.chanTo,
+		CohortKey:   t.cohTo,
+		LeaveCohort: t.cohFrom != "" && t.cohTo == "",
 	}, 0, snapstate.Flags{})
 	c.Assert(err, IsNil, comment)
 	chg.AddAll(ts)
@@ -9208,9 +9275,6 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, i int, t switchScenario) {
 		expectedChanTo = t.chanFrom
 	}
 	expectedCohTo := t.cohTo
-	if t.cohTo == "" {
-		expectedCohTo = t.cohFrom
-	}
 
 	// ensure the desired channel/cohort has changed
 	var snapst snapstate.SnapState


### PR DESCRIPTION
With this change, you can remove (unstick?) a snap from a cohort using
the `leave-cohort` option.

An interesting thing about leave-cohort is that it's not a thing once
the request has been made: the snap setup just needs to record that it
needs to move to an empty cohort. It's a flag in daemon's
snapInstruction (and snapstate.RevisionOptions) just to not have to
fiddle with empty-string-means-no-change vs
empty-string-means-change-to-nothing.

As such, the PR might seem surprisingly simple.
