### PR TITLE
cmd: display special "snapcraft summit" version

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -68,6 +68,7 @@ func printVersions(cli *client.Client) error {
 	if sv.KernelVersion != "" {
 		fmt.Fprintf(w, "kernel\t%s\n", sv.KernelVersion)
 	}
+	fmt.Fprintf(w, "special\tsnapcraft summit\n")
 	w.Flush()
 
 	return nil

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
+	c.Assert(s.Stdout(), Equals, "snap     4.56\nsnapd    7.89\nseries   56\nubuntu   12.34\nspecial  snapcraft summit\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -54,7 +54,7 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
+	c.Assert(s.Stdout(), Equals, "snap     4.56\nsnapd    7.89\nseries   56\nspecial  snapcraft summit\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -69,6 +69,6 @@ func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\narch    -\n")
+	c.Assert(s.Stdout(), Equals, "snap     4.56\nsnapd    7.89\nseries   56\narch     -\nspecial  snapcraft summit\n")
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -244,7 +244,7 @@ func (s *SnapSuite) TestVersionOnClassic(c *C) {
 	defer restore()
 
 	c.Assert(func() { snap.RunMain() }, PanicMatches, `internal error: exitStatus\{0\} .*`)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
+	c.Assert(s.Stdout(), Equals, "snap     4.56\nsnapd    7.89\nseries   56\nubuntu   12.34\nspecial  snapcraft summit\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -258,7 +258,7 @@ func (s *SnapSuite) TestVersionOnAllSnap(c *C) {
 	defer restore()
 
 	c.Assert(func() { snap.RunMain() }, PanicMatches, `internal error: exitStatus\{0\} .*`)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
+	c.Assert(s.Stdout(), Equals, "snap     4.56\nsnapd    7.89\nseries   56\nspecial  snapcraft summit\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 


### PR DESCRIPTION
This version tweak is here to help developers identified that they've
successfully switched to the Snapcraft Summit branch of snapd.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
