### PR TITLE
packaging: fix reproducible build error

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -258,7 +258,10 @@ override_dh_auto_install: snap.8
 	dh_auto_install -O--buildsystem=golang
 
 snap.8:
-	$(CURDIR)/_build/bin/snap help --man > $@
+	# fix reproducible builds as reported by:
+	#   https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/snapd.html
+	# once golang-go-flags is fixed we can remove the "sed" expression
+	$(CURDIR)/_build/bin/snap help --man | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
 
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -265,7 +265,10 @@ override_dh_auto_install: snap.8
 	dh_auto_install -O--buildsystem=golang
 
 snap.8:
-	$(CURDIR)/_build/bin/snap help --man > $@
+	# fix reproducible builds as reported by:
+	#   https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/snapd.html
+	# once golang-go-flags is fixed we can remove the "sed" expression
+	$(CURDIR)/_build/bin/snap help --man | sed '1 s/^.*/.TH snap 8 "$(shell date --reference=debian/changelog +"%d %B %Y")"/' > $@
 
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang


### PR DESCRIPTION
The snapd build fails to build with exactly the same hash. This
is caused by the man page embedding the date. We fix this by
setting the man-page date to the date of the debian/changelog.

Unfortunately this involves a bit of ugly sed hacking because
go-flags provides no way to change the date and faketime also
does not work on golang.
