### PR TITLE
tests: fix snap service watchdog test

### DIFF
--- a/tests/main/snap-service-watchdog/task.yaml
+++ b/tests/main/snap-service-watchdog/task.yaml
@@ -12,6 +12,8 @@ debug: |
 execute: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
+    # shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB"/journalctl.sh
 
     echo "When the service snap  is installed"
     install_local test-snapd-service-watchdog
@@ -56,4 +58,5 @@ execute: |
     systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH 'SubState=(failed|stop-sigabrt)'
     # reported differently by different systemd versions
     systemctl show -p Result snap.test-snapd-service-watchdog.$service | MATCH 'Result=(watchdog|signal|core-dump)'
-    journalctl -u snap.test-snapd-service-watchdog.$service | MATCH "systemd.*: snap.test-snapd-service-watchdog.$service.service:? [Ww]atchdog timeout"
+
+    check_journalctl_log "systemd.*: snap.test-snapd-service-watchdog.$service.service:? [Ww]atchdog timeout" -u snap.test-snapd-service-watchdog.$service


### PR DESCRIPTION
The idea of the change is to use journalctl check_journalctl_log function to check the logs instead of
using journalctl command.

This is to fix the errror on master:

+ MATCH 'systemd.*:
snap.test-snapd-service-watchdog.direct-watchdog-bad.service:?
[Ww]atchdog timeout'
+ journalctl -u snap.test-snapd-service-watchdog.direct-watchdog-bad
grep error: pattern not found, got:

This is the entire test error log: https://paste.ubuntu.com/p/x2rqyXCYqF/