### PR TITLE
daemon: tweak for "add api endpoint for download" PR

### DIFF
--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -65,13 +65,13 @@ func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Respons
 	switch action.Action {
 	case "download":
 		snapName := action.Snaps[0]
-		return streamOne(c, user, snapName)
+		return streamOneSnap(c, user, snapName)
 	default:
 		return BadRequest("unknown download operation %q", action.Action)
 	}
 }
 
-func streamOne(c *Command, user *auth.UserState, snapName string) Response {
+func streamOneSnap(c *Command, user *auth.UserState, snapName string) Response {
 	info, err := getStore(c).SnapInfo(store.SnapSpec{Name: snapName}, user)
 	if err != nil {
 		return SnapNotFound(snapName, err)

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -68,23 +68,24 @@ func (s *snapDownloadSuite) SetUpTest(c *check.C) {
 var content = "SNAP"
 
 func (s *snapDownloadSuite) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	if spec.Name == "bar" {
+	switch spec.Name {
+	case "bar":
 		return &snap.Info{
 			DownloadInfo: snap.DownloadInfo{
 				Size:            int64(len(content)),
 				AnonDownloadURL: "http://localhost/bar",
 			},
 		}, nil
-	}
-	if spec.Name == "download-error-trigger-snap" {
+	case "download-error-trigger-snap":
 		return &snap.Info{
 			DownloadInfo: snap.DownloadInfo{
 				Size:            100,
 				AnonDownloadURL: "http://localhost/foo",
 			},
 		}, nil
+	default:
+		return nil, store.ErrSnapNotFound
 	}
-	return nil, store.ErrSnapNotFound
 }
 
 func (s *snapDownloadSuite) DownloadStream(ctx context.Context, name string, downloadInfo *snap.DownloadInfo, user *auth.UserState) (io.ReadCloser, error) {

--- a/daemon/export_api_download_test.go
+++ b/daemon/export_api_download_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -113,11 +113,11 @@ func MockDownload(f func(ctx context.Context, name, sha3_384, downloadURL string
 	}
 }
 
-func MockStream(f func(ctx context.Context, storeURL *url.URL, cdnHeader string, s *Store, user *auth.UserState) (*http.Response, error)) (restore func()) {
-	origStream := stream
-	stream = f
+func MockDoDownloadReq(f func(ctx context.Context, storeURL *url.URL, cdnHeader string, s *Store, user *auth.UserState) (*http.Response, error)) (restore func()) {
+	orig := doDownloadReq
+	doDownloadReq = f
 	return func() {
-		stream = origStream
+		doDownloadReq = orig
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -1622,16 +1622,16 @@ func (s *Store) DownloadStream(ctx context.Context, name string, downloadInfo *s
 		return nil, err
 	}
 
-	resp, err := stream(ctx, storeURL, cdnHeader, s, user)
+	resp, err := doDownloadReq(ctx, storeURL, cdnHeader, s, user)
 	if err != nil {
 		return nil, err
 	}
 	return resp.Body, nil
 }
 
-var stream = doDowloadReq
+var doDownloadReq = doDowloadReqImpl
 
-func doDowloadReq(ctx context.Context, storeURL *url.URL, cdnHeader string, s *Store, user *auth.UserState) (*http.Response, error) {
+func doDowloadReqImpl(ctx context.Context, storeURL *url.URL, cdnHeader string, s *Store, user *auth.UserState) (*http.Response, error) {
 	reqOptions := downloadReqOpts(storeURL, cdnHeader, nil)
 	return s.doRequest(ctx, httputil.NewHTTPClient(&httputil.ClientOptions{Proxy: s.proxy}), reqOptions, user)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -451,7 +451,7 @@ func (s *storeTestSuite) expectedAuthorization(c *C, user *auth.UserState) strin
 
 func (s *storeTestSuite) TestDownloadStreamOK(c *C) {
 	expectedContent := []byte("I was downloaded")
-	restore := store.MockStream(func(ctx context.Context, url *url.URL, cdnHeader string, s *store.Store, user *auth.UserState) (*http.Response, error) {
+	restore := store.MockDoDownloadReq(func(ctx context.Context, url *url.URL, cdnHeader string, s *store.Store, user *auth.UserState) (*http.Response, error) {
 		c.Check(url.String(), Equals, "http://anon-url")
 		r := &http.Response{
 			Body: ioutil.NopCloser(bytes.NewReader(expectedContent)),


### PR DESCRIPTION
During the review for the download api PR I had some nitpicks that I felt shouldn't block this PR (especially since with it in the work on the client side of this PR are unblocked). However I still wanted to raise them for discussion. Happy to drop bits (or close the PR entirely) if its too nitpickish.

The individual commits contain the details what changed.