### PR TITLE
[RFC] daemon: unexport file{Response,Stream}

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1518,7 +1518,7 @@ func iconGet(st *state.State, name string) Response {
 		return NotFound("local snap has no icon")
 	}
 
-	return FileResponse(icon)
+	return fileResponse(icon)
 }
 
 func appIconGet(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -83,7 +83,7 @@ func streamOne(c *Command, user *auth.UserState, snapName string) Response {
 		return InternalError(err.Error())
 	}
 
-	return FileStream{
+	return fileStream{
 		SnapName: snapName,
 		Info:     downloadInfo,
 		stream:   r,

--- a/daemon/api_snap_file.go
+++ b/daemon/api_snap_file.go
@@ -64,5 +64,5 @@ func getSnapFile(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot download file for try-mode snap %q", name)
 	}
 
-	return FileResponse(info.MountFile())
+	return fileResponse(info.MountFile())
 }

--- a/daemon/export_api_download_test.go
+++ b/daemon/export_api_download_test.go
@@ -23,3 +23,7 @@ var (
 	SnapDownloadCmd  = snapDownloadCmd
 	PostSnapDownload = postSnapDownload
 )
+
+type (
+	FileStream = fileStream
+)

--- a/daemon/export_api_snap_file_test.go
+++ b/daemon/export_api_snap_file_test.go
@@ -19,6 +19,11 @@
 
 package daemon
 
-var SnapFileCmd = snapFileCmd
+var (
+	SnapFileCmd = snapFileCmd
+	GetSnapFile = getSnapFile
+)
 
-var GetSnapFile = getSnapFile
+type (
+	FileResponse = fileResponse
+)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -247,14 +247,14 @@ func makeErrorResponder(status int) errorResponder {
 }
 
 // A FileStream ServeHTTP method streams the snap
-type FileStream struct {
+type fileStream struct {
 	SnapName string
 	Info     snap.DownloadInfo
 	stream   io.ReadCloser
 }
 
 // ServeHTTP from the Response interface
-func (s FileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+func (s fileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	hdr := w.Header()
 	hdr.Set("Content-Type", "application/octet-stream")
 	snapname := fmt.Sprintf("attachment; filename=%s", s.SnapName)
@@ -275,11 +275,11 @@ func (s FileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-// A FileResponse 's ServeHTTP method serves the file
-type FileResponse string
+// A fileResponse 's ServeHTTP method serves the file
+type fileResponse string
 
 // ServeHTTP from the Response interface
-func (f FileResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (f fileResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	filename := fmt.Sprintf("attachment; filename=%s", filepath.Base(string(f)))
 	w.Header().Add("Content-Disposition", filename)
 	http.ServeFile(w, r, string(f))

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -88,7 +88,7 @@ func (s *responseSuite) TestFileResponseSetsContentDisposition(c *check.C) {
 	c.Check(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
-	rsp := FileResponse(path)
+	rsp := fileResponse(path)
 	req, err := http.NewRequest("GET", "", nil)
 	c.Check(err, check.IsNil)
 


### PR DESCRIPTION
While reviewing some other code I noticed that we have the exported
File{Resonse,Stream} types in the daemon. It seems like we don't
really need this to be exported so this PR just unexports them.

Maybe a bit too OCD?
