### PR TITLE
tests: synchronize journal logs before check logs

### DIFF
--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -36,7 +36,6 @@ check_journalctl_log(){
     expression=$1
     shift
     for _ in $(seq 10); do
-        journalctl --flush --sync
         log=$(get_journalctl_log "$@")
         if echo "$log" | grep -q -E "$expression"; then
             return 0
@@ -52,6 +51,8 @@ get_journalctl_log(){
     if [ -f "$JOURNALCTL_CURSOR_FILE" ]; then
         cursor=$(tail -n1 "$JOURNALCTL_CURSOR_FILE")
     fi
+    journalctl --flush || true
+    journalctl --sync || true
     get_journalctl_log_from_cursor "$cursor" "$@"
 }
 

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -36,6 +36,7 @@ check_journalctl_log(){
     expression=$1
     shift
     for _ in $(seq 10); do
+        journalctl --flush --sync
         log=$(get_journalctl_log "$@")
         if echo "$log" | grep -q -E "$expression"; then
             return 0


### PR DESCRIPTION
This is to enforce the logs synchronization before checking a text
appears in the journal logs

On some tests, and specially on opensuse sometimes the logs are taking
more than 10 seconds to sync making the tests fail.

Error:
https://paste.ubuntu.com/p/Ky9SFkNM5w/

To check it works what I did is to reduce the loop from 10 to 3 iterations on teh check_journalctl_log function and run the tests with -repeat 100 times. By doing that the test without the fix fails on the first iterations and with the fix it works well the 100 iterations. 