### PR TITLE
tests: fix test desktop-portal-filechooser

### DIFF
--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -53,6 +53,12 @@ execute: |
 
     echo "The confined application can write files via the portal"
     [ ! -f /tmp/file-to-write.txt ]
+    # The python code does open(path, 'w'), which attempts to truncate the
+    # file if it exists. Then in fuse handlers inside document-portal, the
+    # code path for when the inode exists and the caller requested O_TRUNC,
+    # returns -ENOSYS, resulting in OSError:
+    # [Errno 38] Function not implemented on the Python side
+    # To avoid the issue described we are creating manually the file.
     touch /tmp/file-to-write.txt
     chown test:test /tmp/file-to-write.txt
     as_user test-snapd-portal-client save-file "from-sandbox"

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -53,6 +53,8 @@ execute: |
 
     echo "The confined application can write files via the portal"
     [ ! -f /tmp/file-to-write.txt ]
+    touch /tmp/file-to-write.txt
+    chown test:test /tmp/file-to-write.txt
     as_user test-snapd-portal-client save-file "from-sandbox"
     [ -f /tmp/file-to-write.txt ]
     MATCH "from-sandbox" < /tmp/file-to-write.txt


### PR DESCRIPTION
Tis solution was discussed on a different PR #6541. The change in this case is just to fix the issue shown below, because the #6541 also was addressing some aspects related to the preparation and restoration of the portals.

This fix is to avoid an issue by pre-creating the file used to write and
then the test checks is is possible to write on it.
This issue has been fixed on ubuntu-18.10 and ubuntu-19.04 but is still
present on ubuntu-18.04.

Error:
+ su -l -c 'XDG_RUNTIME_DIR="/run/user/12345"
DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/12345/bus"
test-snapd-portal-client save-file from-sandbox' test
Traceback (most recent call last):
  File "/snap/test-snapd-portal-client/2/bin/client.py", line 147, in
<module>
    sys.exit(main(sys.argv))
  File "/snap/test-snapd-portal-client/2/bin/client.py", line 143, in
main
    return client.run(argv[1:])
  File "/snap/test-snapd-portal-client/2/bin/client.py", line 40, in run
    return command(*args)
  File "/snap/test-snapd-portal-client/2/bin/client.py", line 73, in
cmd_save_file
    with open(unquote(parsed.path), "w") as fp:
OSError: [Errno 38] Function not implemented:
'/run/user/12345/doc/dfa8ed8d/file-to-write.txt'
