### PR TITLE
bootloader: remove extra mock bootloader implementation

### DIFF
--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
@@ -35,43 +36,9 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 // partition specific testsuite
-type PartitionTestSuite struct {
-}
+type PartitionTestSuite struct{}
 
 var _ = Suite(&PartitionTestSuite{})
-
-type mockBootloader struct {
-	bootVars map[string]string
-}
-
-func newMockBootloader() *mockBootloader {
-	return &mockBootloader{
-		bootVars: make(map[string]string),
-	}
-}
-func (b *mockBootloader) Name() string {
-	return "mocky"
-}
-func (b *mockBootloader) Dir() string {
-	return "/boot/mocky"
-}
-func (b *mockBootloader) GetBootVars(names ...string) (map[string]string, error) {
-	out := map[string]string{}
-	for _, name := range names {
-		out[name] = b.bootVars[name]
-	}
-
-	return out, nil
-}
-func (b *mockBootloader) SetBootVars(values map[string]string) error {
-	for k, v := range values {
-		b.bootVars[k] = v
-	}
-	return nil
-}
-func (b *mockBootloader) ConfigFile() string {
-	return "/boot/mocky/mocky.env"
-}
 
 func (s *PartitionTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
@@ -82,7 +49,7 @@ func (s *PartitionTestSuite) SetUpTest(c *C) {
 }
 
 func (s *PartitionTestSuite) TestForceBootloader(c *C) {
-	b := newMockBootloader()
+	b := boottest.NewMockBootloader("mocky", c.MkDir())
 	Force(b)
 	defer Force(nil)
 
@@ -92,10 +59,10 @@ func (s *PartitionTestSuite) TestForceBootloader(c *C) {
 }
 
 func (s *PartitionTestSuite) TestMarkBootSuccessfulAllSnap(c *C) {
-	b := newMockBootloader()
-	b.bootVars["snap_mode"] = "trying"
-	b.bootVars["snap_try_core"] = "os1"
-	b.bootVars["snap_try_kernel"] = "k1"
+	b := boottest.NewMockBootloader("mocky", c.MkDir())
+	b.BootVars["snap_mode"] = "trying"
+	b.BootVars["snap_try_core"] = "os1"
+	b.BootVars["snap_try_kernel"] = "k1"
 	err := MarkBootSuccessful(b)
 	c.Assert(err, IsNil)
 
@@ -108,24 +75,24 @@ func (s *PartitionTestSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 		"snap_kernel": "k1",
 		"snap_core":   "os1",
 	}
-	c.Assert(b.bootVars, DeepEquals, expected)
+	c.Assert(b.BootVars, DeepEquals, expected)
 
 	// do it again, verify its still valid
 	err = MarkBootSuccessful(b)
 	c.Assert(err, IsNil)
-	c.Assert(b.bootVars, DeepEquals, expected)
+	c.Assert(b.BootVars, DeepEquals, expected)
 }
 
 func (s *PartitionTestSuite) TestMarkBootSuccessfulKKernelUpdate(c *C) {
-	b := newMockBootloader()
-	b.bootVars["snap_mode"] = "trying"
-	b.bootVars["snap_core"] = "os1"
-	b.bootVars["snap_kernel"] = "k1"
-	b.bootVars["snap_try_core"] = ""
-	b.bootVars["snap_try_kernel"] = "k2"
+	b := boottest.NewMockBootloader("mocky", c.MkDir())
+	b.BootVars["snap_mode"] = "trying"
+	b.BootVars["snap_core"] = "os1"
+	b.BootVars["snap_kernel"] = "k1"
+	b.BootVars["snap_try_core"] = ""
+	b.BootVars["snap_try_kernel"] = "k2"
 	err := MarkBootSuccessful(b)
 	c.Assert(err, IsNil)
-	c.Assert(b.bootVars, DeepEquals, map[string]string{
+	c.Assert(b.BootVars, DeepEquals, map[string]string{
 		// cleared
 		"snap_mode":       "",
 		"snap_try_kernel": "",


### PR DESCRIPTION
For historic (and organic) reasons the bootloader/bootloader_test.go
code contains an implementation of a mock bootloader. However this
is redundant now that we have boot/boottest/mockbootloader.go
that implements the same. So this PR updates the bootloader_test
code to use the common mock loader.
