### PR TITLE
tests: sort commands from DumpCommands in the dumpDbHook

### DIFF
--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -235,7 +235,7 @@ func dumpDbHook() error {
 	var b []Snap
 
 	var sortedCmds []string
-	for cmd, _ := range commands {
+	for cmd := range commands {
 		sortedCmds = append(sortedCmds, cmd)
 	}
 	sort.Strings(sortedCmds)

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/jessevdk/go-flags"
@@ -233,7 +234,14 @@ func dumpDbHook() error {
 	commands_processed := make([]string, 0)
 	var b []Snap
 
-	for key, value := range commands {
+	var sortedCmds []string
+	for cmd, _ := range commands {
+		sortedCmds = append(sortedCmds, cmd)
+	}
+	sort.Strings(sortedCmds)
+
+	for _, key := range sortedCmds {
+		value := commands[key]
 		err := json.Unmarshal([]byte(value), &b)
 		if err != nil {
 			return err


### PR DESCRIPTION
Sort commands from DumpCommands to have deterministic order. This fixes occasional unit test faillure for the test introduced yesterday.
