### PR TITLE
gadget: add wrapper for creating and populating filesystems

### DIFF
--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -37,8 +37,9 @@ func MkfsExt4(img, label, contentsRootDir string) error {
 		"mkfs.ext4",
 		// default usage type
 		"-T", "default",
-		// disable metadata checksum
-		// XXX: why?
+		// disable metadata checksum, which were unsupported in Ubuntu
+		// 16.04 and Ubuntu Core 16 systems and would lead to a boot
+		// failure if enabled
 		"-O", "-metadata_csum",
 		// allow uninitialized block groups
 		"-O", "uninit_bg",

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -33,7 +33,6 @@ import (
 // directory.
 func MkfsExt4(img, label, contentsRootDir string) error {
 	// taken from ubuntu-image
-	// TODO: support e2fsprogs 1.42 without -d in Ubuntu 16.04
 	mkfsArgs := []string{
 		"mkfs.ext4",
 		// default usage type
@@ -45,12 +44,14 @@ func MkfsExt4(img, label, contentsRootDir string) error {
 		"-O", "uninit_bg",
 		// mkfs.ext4 can populate the filesystem with contents of given
 		// root directory
+		// TODO: support e2fsprogs 1.42 without -d in Ubuntu 16.04
 		"-d", contentsRootDir,
 	}
 	if label != "" {
 		mkfsArgs = append(mkfsArgs, "-L", label)
 	}
 	mkfsArgs = append(mkfsArgs, img)
+	// run through fakeroot so that files are owned by root
 	cmd := exec.Command("fakeroot", mkfsArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -1,0 +1,121 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package gadget
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// MkfsExt4 creates an EXT4 filesystem in given image file, with an optional
+// filesystem label, and populates it with the contents of provided root
+// directory.
+func MkfsExt4(img, label, contentsRootDir string) error {
+	// taken from ubuntu-image
+	// TODO: support e2fsprogs 1.42 without -d in Ubuntu 16.04
+	mkfsArgs := []string{
+		"mkfs.ext4",
+		// default usage type
+		"-T", "default",
+		// disable metadata checksum
+		// XXX: why?
+		"-O", "-metadata_csum",
+		// allow uninitialized block groups
+		"-O", "uninit_bg",
+		// mkfs.ext4 can populate the filesystem with contents of given
+		// root directory
+		"-d", contentsRootDir,
+	}
+	if label != "" {
+		mkfsArgs = append(mkfsArgs, "-L", label)
+	}
+	mkfsArgs = append(mkfsArgs, img)
+	cmd := exec.Command("fakeroot", mkfsArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return osutil.OutputErr(out, err)
+	}
+	return nil
+}
+
+// MkfsVfat creates a VFAT filesystem in given image file, with an optional
+// filesystem label, and populates it with the contents of provided root
+// directory.
+func MkfsVfat(img, label, contentsRootDir string) error {
+	// taken from ubuntu-image
+	mkfsArgs := []string{
+		// 512B logical sector size
+		"-S", "512",
+		// 1 sector per cluster
+		"-s", "1",
+		// 32b FAT size
+		"-F", "32",
+	}
+	if label != "" {
+		mkfsArgs = append(mkfsArgs, "-n", label)
+	}
+	mkfsArgs = append(mkfsArgs, img)
+
+	cmd := exec.Command("mkfs.vfat", mkfsArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return osutil.OutputErr(out, err)
+	}
+
+	// mkfs.vfat does not know how to populate the filesystem with contents,
+	// we need to do the work ourselves
+
+	fis, err := ioutil.ReadDir(contentsRootDir)
+	if err != nil {
+		return fmt.Errorf("cannot list directory contents: %v", err)
+	}
+	if len(fis) == 0 {
+		// nothing to copy to the image
+		return nil
+	}
+
+	mcopyArgs := make([]string, 0, 4+len(fis))
+	mcopyArgs = append(mcopyArgs,
+		// recursive copy
+		"-s",
+		// image file
+		"-i", img)
+	for _, fi := range fis {
+		mcopyArgs = append(mcopyArgs, filepath.Join(contentsRootDir, fi.Name()))
+	}
+	mcopyArgs = append(mcopyArgs,
+		// place content at the / of the filesystem
+		"::")
+
+	cmd = exec.Command("mcopy", mcopyArgs...)
+	cmd.Env = os.Environ()
+	// skip mtools checks to avoid unnecessary warnings
+	cmd.Env = append(cmd.Env, "MTOOLS_SKIP_CHECK=1")
+
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cannot populate vfat filesystem with contents: %v", osutil.OutputErr(out, err))
+	}
+	return nil
+}

--- a/gadget/mkfs_test.go
+++ b/gadget/mkfs_test.go
@@ -35,6 +35,8 @@ type mkfsSuite struct {
 var _ = Suite(&mkfsSuite{})
 
 func (m *mkfsSuite) SetUpTest(c *C) {
+	m.BaseTest.SetUpTest(c)
+
 	// fakeroot, mkfs.ext4, mkfs.vfat and mcopy are commonly installed in
 	// the host system, set up some overrides so that we avoid calling the
 	// host tools

--- a/gadget/mkfs_test.go
+++ b/gadget/mkfs_test.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type mkfsSuite struct {
+	cleanup []func()
+}
+
+var _ = Suite(&mkfsSuite{})
+
+func (m *mkfsSuite) SetUpTest(c *C) {
+	// fakeroot, mkfs.ext4, mkfs.vfat and mcopy are commonly installed in
+	// the host system, set up some overrides so that we avoid calling the
+	// host tools
+	cmdFakeroot := testutil.MockCommand(c, "fakeroot", "echo 'override in test' ; exit 1")
+	m.cleanup = append(m.cleanup, func() { cmdFakeroot.Restore() })
+
+	cmdMkfsExt4 := testutil.MockCommand(c, "mkfs.ext4", "echo 'override in test' ; exit 1")
+	m.cleanup = append(m.cleanup, func() { cmdMkfsExt4.Restore() })
+
+	cmdMkfsVfat := testutil.MockCommand(c, "mkfs.vfat", "echo 'override in test'; exit 1")
+	m.cleanup = append(m.cleanup, func() { cmdMkfsVfat.Restore() })
+
+	cmdMcopy := testutil.MockCommand(c, "mcopy", "echo 'override in test'; exit 1")
+	m.cleanup = append(m.cleanup, func() { cmdMcopy.Restore() })
+}
+
+func (m *mkfsSuite) TearDownTest(c *C) {
+	for _, r := range m.cleanup {
+		r()
+	}
+}
+
+func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
+	cmd := testutil.MockCommand(c, "fakeroot", "")
+	defer cmd.Restore()
+
+	err := gadget.MkfsExt4("foo.img", "my-label", "contents")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-T", "default",
+			"-O", "-metadata_csum",
+			"-O", "uninit_bg",
+			"-d", "contents",
+			"-L", "my-label",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// empty label
+	err = gadget.MkfsExt4("foo.img", "", "contents")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-T", "default",
+			"-O", "-metadata_csum",
+			"-O", "uninit_bg",
+			"-d", "contents",
+			"foo.img",
+		},
+	})
+}
+
+func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
+	cmd := testutil.MockCommand(c, "fakeroot", "echo 'command failed'; exit 1")
+	defer cmd.Restore()
+
+	err := gadget.MkfsExt4("foo.img", "my-label", "contents")
+	c.Assert(err, ErrorMatches, "command failed")
+}
+
+func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
+	// no contents, should not fail
+	d := c.MkDir()
+
+	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer cmd.Restore()
+
+	err := gadget.MkfsVfat("foo.img", "my-label", d)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "512",
+			"-s", "1",
+			"-F", "32",
+			"-n", "my-label",
+			"foo.img",
+		},
+	})
+
+	cmd.ForgetCalls()
+
+	// empty label
+	err = gadget.MkfsVfat("foo.img", "", d)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"mkfs.vfat",
+			"-S", "512",
+			"-s", "1",
+			"-F", "32",
+			"foo.img",
+		},
+	})
+}
+
+func (m *mkfsSuite) TestMkfsVfatHappyContents(c *C) {
+	d := c.MkDir()
+	makeSizedFile(c, filepath.Join(d, "foo"), 128, []byte("foo foo foo"))
+	makeSizedFile(c, filepath.Join(d, "bar/bar-content"), 128, []byte("bar bar bar"))
+
+	cmdMkfs := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer cmdMkfs.Restore()
+
+	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
+	defer cmdMcopy.Restore()
+
+	err := gadget.MkfsVfat("foo.img", "my-label", d)
+	c.Assert(err, IsNil)
+	c.Assert(cmdMkfs.Calls(), HasLen, 1)
+
+	c.Assert(cmdMcopy.Calls(), DeepEquals, [][]string{
+		{"mcopy", "-s", "-i", "foo.img", filepath.Join(d, "bar"), filepath.Join(d, "foo"), "::"},
+	})
+}
+
+func (m *mkfsSuite) TestMkfsVfatErrorSimpleFail(c *C) {
+	d := c.MkDir()
+
+	cmd := testutil.MockCommand(c, "mkfs.vfat", "echo 'failed'; false")
+	defer cmd.Restore()
+
+	err := gadget.MkfsVfat("foo.img", "my-label", d)
+	c.Assert(err, ErrorMatches, "failed")
+}
+
+func (m *mkfsSuite) TestMkfsVfatErrorUnreadableDir(c *C) {
+	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer cmd.Restore()
+
+	err := gadget.MkfsVfat("foo.img", "my-label", "dir-does-not-exist")
+	c.Assert(err, ErrorMatches, "cannot list directory contents: .* no such file or directory")
+	c.Assert(cmd.Calls(), HasLen, 1)
+}
+
+func (m *mkfsSuite) TestMkfsVfatErrorInMcopy(c *C) {
+	d := c.MkDir()
+	makeSizedFile(c, filepath.Join(d, "foo"), 128, []byte("foo foo foo"))
+
+	cmdMkfs := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer cmdMkfs.Restore()
+
+	cmdMcopy := testutil.MockCommand(c, "mcopy", "echo 'hard fail'; exit 1")
+	defer cmdMcopy.Restore()
+
+	err := gadget.MkfsVfat("foo.img", "my-label", d)
+	c.Assert(err, ErrorMatches, "cannot populate vfat filesystem with contents: hard fail")
+	c.Assert(cmdMkfs.Calls(), HasLen, 1)
+	c.Assert(cmdMcopy.Calls(), HasLen, 1)
+}

--- a/gadget/mkfs_test.go
+++ b/gadget/mkfs_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type mkfsSuite struct {
-	cleanup []func()
+	testutil.BaseTest
 }
 
 var _ = Suite(&mkfsSuite{})
@@ -39,22 +39,16 @@ func (m *mkfsSuite) SetUpTest(c *C) {
 	// the host system, set up some overrides so that we avoid calling the
 	// host tools
 	cmdFakeroot := testutil.MockCommand(c, "fakeroot", "echo 'override in test' ; exit 1")
-	m.cleanup = append(m.cleanup, func() { cmdFakeroot.Restore() })
+	m.AddCleanup(cmdFakeroot.Restore)
 
 	cmdMkfsExt4 := testutil.MockCommand(c, "mkfs.ext4", "echo 'override in test' ; exit 1")
-	m.cleanup = append(m.cleanup, func() { cmdMkfsExt4.Restore() })
+	m.AddCleanup(cmdMkfsExt4.Restore)
 
 	cmdMkfsVfat := testutil.MockCommand(c, "mkfs.vfat", "echo 'override in test'; exit 1")
-	m.cleanup = append(m.cleanup, func() { cmdMkfsVfat.Restore() })
+	m.AddCleanup(cmdMkfsVfat.Restore)
 
 	cmdMcopy := testutil.MockCommand(c, "mcopy", "echo 'override in test'; exit 1")
-	m.cleanup = append(m.cleanup, func() { cmdMcopy.Restore() })
-}
-
-func (m *mkfsSuite) TearDownTest(c *C) {
-	for _, r := range m.cleanup {
-		r()
-	}
+	m.AddCleanup(cmdMcopy.Restore)
 }
 
 func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {

--- a/gadget/position_test.go
+++ b/gadget/position_test.go
@@ -306,6 +306,9 @@ volumes:
 }
 
 func makeSizedFile(c *C, path string, size gadget.Size, content []byte) {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, IsNil)
+
 	f, err := os.Create(path)
 	c.Assert(err, IsNil)
 	defer f.Close()


### PR DESCRIPTION
Add wrappers for creating and populating filesystems that can specified in
gadget YAML. Only ext4 and vfat can be used, thus the patch adds support for
`mkfs.ext4` and `mkfs.vfat`.
    
For VFAT we also use `mtools` to populate the filesystem with contents of given
directory.
