### PR TITLE
many: tweaks and fixes for Manjaro

### DIFF
--- a/osutil/overlay_linux.go
+++ b/osutil/overlay_linux.go
@@ -69,7 +69,8 @@ func IsRootWritableOverlay() (string, error) {
 					continue
 				}
 
-				if dir == "/media/root-rw/overlay" {
+				switch dir {
+				case "/media/root-rw/overlay":
 					// On the Ubuntu server ephemeral image, '/' is setup via
 					// overlayroot (on at least 18.10), which uses a combination
 					// of overlayfs and chroot. This differs from the livecd setup
@@ -77,10 +78,13 @@ func IsRootWritableOverlay() (string, error) {
 					// upperdir for this configuration, and return the required
 					// path. See LP: #1797218 for details.
 					return "/overlay", nil
+				case "/run/miso/overlay_root/upper":
+					// On the Manjaro ephemeral image, '/' is setup via
+					// overlayroot. This is similar to the workaround above.
+					return "/upper", nil
 				}
 
-				// Make sure trailing slashes are predicatably
-				// missing
+				// Make sure trailing slashes are predictably missing
 				return dir, nil
 			}
 		}

--- a/osutil/overlay_linux_test.go
+++ b/osutil/overlay_linux_test.go
@@ -87,6 +87,10 @@ func (s *overlaySuite) TestIsRootWritableOverlay(c *C) {
 		// The special cased version for 18.10 server release
 		mountinfo: "28 0 0:24 / / rw,realtime shared:1 - overlay overlayroot rw,lowerdir=/media/root-ro,upperdir=/media/root-rw/overlay,workdir=/media/root-rw/overlay-workdir/_",
 		overlay:   "/overlay",
+	}, {
+		// The special cased version for Manjaro live CD,
+		mountinfo: "37 1 0:24 / / rw,realtime shared:1 - overlay overlay rw,lowerdir=/run/miso/sfs/livefs:/run/miso/sfs/mhwdfs:/run/miso/sfs/desktopfs:/run/miso/sfs/rootfs,upperdir=/run/miso/overlay_root/upper,workdir=/run/miso/overlay_root/work,index=off",
+		overlay:   "/upper",
 	}}
 	for _, tc := range cases {
 		restore := osutil.MockMountInfo(tc.mountinfo)


### PR DESCRIPTION
This branch contains two patches that:
 - switch Manjaro to /snap
 - work around the apparmor limitation with overlayfs usage in the Manjaro live installer.