### PR TITLE
overlord: do not fail if "current" is missing

### DIFF
--- a/overlord/patch/export_test.go
+++ b/overlord/patch/export_test.go
@@ -71,3 +71,7 @@ func Patch6SnapSetup(task *state.Task) (patch6SnapSetup, error) {
 	err := task.Get("snap-setup", &snapsup)
 	return snapsup, err
 }
+
+var (
+	MaybeResetSublevelForLevel60 = maybeResetSublevelForLevel60
+)

--- a/overlord/patch/patch.go
+++ b/overlord/patch/patch.go
@@ -149,7 +149,7 @@ func maybeResetSublevelForLevel60(s *state.State, sublevel *int) error {
 	var sublevelResetTime time.Time
 	lastRefresh, err := getCoreRefreshTime()
 	if err != nil {
-		return fmt.Errorf("cannot determine core refresh time: %s", err)
+		logger.Noticef("WARNING: cannot determine core refresh time: %s", err)
 	}
 
 	err = s.Get("patch-sublevel-reset", &sublevelResetTime)

--- a/overlord/patch/patch.go
+++ b/overlord/patch/patch.go
@@ -149,6 +149,16 @@ func maybeResetSublevelForLevel60(s *state.State, sublevel *int) error {
 	var sublevelResetTime time.Time
 	lastRefresh, err := getCoreRefreshTime()
 	if err != nil {
+		// Edge case (an error) where the current symlink for core
+		// is missing. In such case we don't error out as this
+		// aborts snapd startup, but instead carry on to give
+		// snapd chance to recover (e.g. refresh core). Note,
+		// because lastRefresh time cannot be determined here,
+		// we reset sublevel back to 0 and also set
+		// patch-sublevel-reset timestamp, which means we will
+		// run sublevel patches twice (now, in current
+		// iteration of patches and then after next core
+		// refresh).
 		logger.Noticef("WARNING: cannot determine core refresh time: %s", err)
 	}
 

--- a/overlord/patch/patch.go
+++ b/overlord/patch/patch.go
@@ -149,16 +149,20 @@ func maybeResetSublevelForLevel60(s *state.State, sublevel *int) error {
 	var sublevelResetTime time.Time
 	lastRefresh, err := getCoreRefreshTime()
 	if err != nil {
-		// Edge case (an error) where the current symlink for core
-		// is missing. In such case we don't error out as this
-		// aborts snapd startup, but instead carry on to give
-		// snapd chance to recover (e.g. refresh core). Note,
-		// because lastRefresh time cannot be determined here,
-		// we reset sublevel back to 0 and also set
-		// patch-sublevel-reset timestamp, which means we will
-		// run sublevel patches twice (now, in current
-		// iteration of patches and then after next core
-		// refresh).
+		// Edge case (an error) where the current symlink for
+		// core is missing (which should never happen but may
+		// because power goes off at a very bad time during a
+		// core refresh).
+		//
+		// In such case we don't error out as
+		// this aborts snapd startup, but instead carry on to
+		// give snapd chance to recover (e.g. refresh
+		// core). Note, because lastRefresh time cannot be
+		// determined here, we reset sublevel back to 0 and
+		// also set patch-sublevel-reset timestamp, which
+		// means we will run sublevel patches twice (now, in
+		// current iteration of patches and then after next
+		// core refresh).
 		logger.Noticef("WARNING: cannot determine core refresh time: %s", err)
 	}
 

--- a/overlord/patch/patch_test.go
+++ b/overlord/patch/patch_test.go
@@ -484,4 +484,15 @@ func (s *patchSuite) TestRegressionCoreCurrentSymlinkMissing(c *C) {
 	err := patch.MaybeResetSublevelForLevel60(st, &subLevel)
 	c.Assert(err, IsNil)
 	c.Assert(log.String(), Matches, `(?m).*WARNING: cannot determine core refresh time: lstat /.*/snap/core/current: no such file or directory`)
+	c.Assert(subLevel, Equals, 0)
+
+	st.Lock()
+	defer st.Unlock()
+	var stateSublevel int
+	var stateSublevelReset time.Time
+	c.Assert(st.Get("patch-sublevel", &stateSublevel), IsNil)
+	c.Assert(st.Get("patch-sublevel-reset", &stateSublevelReset), IsNil)
+	c.Check(stateSublevel, Equals, 0)
+	// sublevelReset time is not updated
+	c.Check(stateSublevelReset.IsZero(), Equals, true)
 }

--- a/overlord/patch/patch_test.go
+++ b/overlord/patch/patch_test.go
@@ -470,6 +470,8 @@ func (s *patchSuite) TestRegressionCoreCurrentSymlinkMissing(c *C) {
 	patch.Init(st)
 
 	st.Lock()
+	// init patch-sublevel-reset to ensure its really reset
+	st.Set("patch-sublevel-reset", time.Now())
 	siCore1 := &snap.SideInfo{RealName: "core", Revision: snap.R(1)}
 	siCore2 := &snap.SideInfo{RealName: "core", Revision: snap.R(2)}
 	snapstate.Set(st, "core", &snapstate.SnapState{
@@ -493,6 +495,6 @@ func (s *patchSuite) TestRegressionCoreCurrentSymlinkMissing(c *C) {
 	c.Assert(st.Get("patch-sublevel", &stateSublevel), IsNil)
 	c.Assert(st.Get("patch-sublevel-reset", &stateSublevelReset), IsNil)
 	c.Check(stateSublevel, Equals, 0)
-	// sublevelReset time is not updated
+	// sublevelReset time is reset
 	c.Check(stateSublevelReset.IsZero(), Equals, true)
 }


### PR DESCRIPTION
We had a bug report where /snap/core/current is missing. This
prevents snapd from starting. This is unfortunate as this prevents
snapd from refreshing itself out of this misery.

This trivial PR fixes this to make sure snapd starts.
