### PR TITLE
client, cmd/snap: expose the new cohort options for snap ops

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -30,9 +30,10 @@ import (
 )
 
 type SnapOptions struct {
-	Amend            bool   `json:"amend,omitempty"`
 	Channel          string `json:"channel,omitempty"`
 	Revision         string `json:"revision,omitempty"`
+	CohortKey        string `json:"cohort-key,omitempty"`
+	LeaveCohort      bool   `json:"leave-cohort,omitempty"`
 	DevMode          bool   `json:"devmode,omitempty"`
 	JailMode         bool   `json:"jailmode,omitempty"`
 	Classic          bool   `json:"classic,omitempty"`
@@ -40,6 +41,7 @@ type SnapOptions struct {
 	IgnoreValidation bool   `json:"ignore-validation,omitempty"`
 	Unaliased        bool   `json:"unaliased,omitempty"`
 	Purge            bool   `json:"purge,omitempty"`
+	Amend            bool   `json:"amend,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -400,3 +400,26 @@ func (cs *clientSuite) TestClientOpTryModeDangerous(c *check.C) {
 	_, err := cs.cli.Try(snapdir, &client.SnapOptions{Dangerous: true})
 	c.Assert(err, check.Equals, client.ErrDangerousNotApplicable)
 }
+
+func (cs *clientSuite) TestSnapOptionsSerialises(c *check.C) {
+	tests := map[string]client.SnapOptions{
+		"{}":                         {},
+		`{"channel":"edge"}`:         {Channel: "edge"},
+		`{"revision":"42"}`:          {Revision: "42"},
+		`{"cohort-key":"what"}`:      {CohortKey: "what"},
+		`{"leave-cohort":true}`:      {LeaveCohort: true},
+		`{"devmode":true}`:           {DevMode: true},
+		`{"jailmode":true}`:          {JailMode: true},
+		`{"classic":true}`:           {Classic: true},
+		`{"dangerous":true}`:         {Dangerous: true},
+		`{"ignore-validation":true}`: {IgnoreValidation: true},
+		`{"unaliased":true}`:         {Unaliased: true},
+		`{"purge":true}`:             {Purge: true},
+		`{"amend":true}`:             {Amend: true},
+	}
+	for expected, opts := range tests {
+		buf, err := json.Marshal(&opts)
+		c.Assert(err, check.IsNil, check.Commentf("%s", expected))
+		c.Check(string(buf), check.Equals, expected)
+	}
+}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -983,27 +983,29 @@ func (x cmdSwitch) Execute(args []string) error {
 	// some duplication between this and the two other switch-summarisers...
 	// in this one, we have three boolean things to check, meaning 2³=8 possibilities
 	// of which 3 are errors (which is why we look at this before running it)
+	switchCohort := x.Cohort != ""
+	switchChannel := x.Channel != ""
 	switch {
-	case x.Cohort != "" && x.LeaveCohort:
+	case switchCohort && x.LeaveCohort:
 		// this one counts as two (no channel filter)
-		return fmt.Errorf(i18n.G("cannot request both --cohort and --leave-cohort"))
-	case x.Cohort != "" && !x.LeaveCohort && channel == "":
+		return fmt.Errorf(i18n.G("cannot specify both --cohort and --leave-cohort"))
+	case switchCohort && !x.LeaveCohort && !switchChannel:
 		// TRANSLATORS: the first %q will be the (quoted) snap name, the second an ellipted cohort string
 		msg = fmt.Sprintf(i18n.G("%q switched to the %q cohort\n"), name, strutil.ElliptRight(x.Cohort, 10))
-	case x.Cohort != "" && !x.LeaveCohort && channel != "":
+	case switchCohort && !x.LeaveCohort && switchChannel:
 		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel, the third an ellipted cohort string
-		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel in the %q cohort\n"), name, channel, strutil.ElliptRight(x.Cohort, 10))
-	case x.Cohort == "" && !x.LeaveCohort && channel != "":
+		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel and the %q cohort\n"), name, channel, strutil.ElliptRight(x.Cohort, 10))
+	case !switchCohort && !x.LeaveCohort && switchChannel:
 		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel\n"), name, channel)
-	case x.Cohort == "" && x.LeaveCohort && channel != "":
+	case !switchCohort && x.LeaveCohort && switchChannel:
 		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 		msg = fmt.Sprintf(i18n.G("%q left the cohort, and switched to the %q channel"), name, channel)
-	case x.Cohort == "" && x.LeaveCohort && channel == "":
+	case !switchCohort && x.LeaveCohort && !switchChannel:
 		// TRANSLATORS: %q will be the (quoted) snap name
 		msg = fmt.Sprintf(i18n.G("%q left the cohort"), name)
-	case x.Cohort == "" && !x.LeaveCohort && channel == "":
-		return fmt.Errorf(i18n.G("nothing to switch (specify --cohort=... or --leave-cohort, and/or --channel=...)"))
+	case !switchCohort && !x.LeaveCohort && !switchChannel:
+		return fmt.Errorf(i18n.G("nothing to switch; specify --channel (and/or one of --cohort/--leave-cohort)"))
 	} // and that's the 8 \o/
 
 	opts := &client.SnapOptions{

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -413,6 +414,7 @@ type cmdInstall struct {
 
 	Name string `long:"name"`
 
+	Cohort     string `long:"cohort"`
 	Positional struct {
 		Snaps []remoteSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -458,6 +460,7 @@ func (x *cmdInstall) installOne(nameOrPath, desiredName string, opts *client.Sna
 		}
 	}
 
+	// TODO: mention details of the install (e.g. like switch does)
 	return showDone(x.client, []string{snapName}, "install", opts, x.getEscapes())
 }
 
@@ -532,6 +535,7 @@ func (x *cmdInstall) Execute([]string) error {
 		Revision:  x.Revision,
 		Dangerous: dangerous,
 		Unaliased: x.Unaliased,
+		CohortKey: x.Cohort,
 	}
 	x.setModes(opts)
 
@@ -568,6 +572,8 @@ type cmdRefresh struct {
 
 	Amend            bool   `long:"amend"`
 	Revision         string `long:"revision"`
+	Cohort           string `long:"cohort"`
+	LeaveCohort      bool   `long:"leave-cohort"`
 	List             bool   `long:"list"`
 	Time             bool   `long:"time"`
 	IgnoreValidation bool   `long:"ignore-validation"`
@@ -622,6 +628,8 @@ func (x *cmdRefresh) refreshOne(name string, opts *client.SnapOptions) error {
 		return err
 	}
 
+	// TODO: this doesn't really tell about all the things you
+	// could set while refreshing (something switch does)
 	return showDone(x.client, []string{name}, "refresh", opts, x.getEscapes())
 }
 
@@ -735,6 +743,8 @@ func (x *cmdRefresh) Execute([]string) error {
 			Channel:          x.Channel,
 			IgnoreValidation: x.IgnoreValidation,
 			Revision:         x.Revision,
+			CohortKey:        x.Cohort,
+			LeaveCohort:      x.LeaveCohort,
 		}
 		x.setModes(opts)
 		return x.refreshOne(names[0], opts)
@@ -953,6 +963,9 @@ type cmdSwitch struct {
 	waitMixin
 	channelMixin
 
+	Cohort      string `long:"cohort"`
+	LeaveCohort bool   `long:"leave-cohort"`
+
 	Positional struct {
 		Snap installedSnapName `positional-arg-name:"<snap>" required:"1"`
 	} `positional-args:"yes" required:"yes"`
@@ -962,14 +975,41 @@ func (x cmdSwitch) Execute(args []string) error {
 	if err := x.setChannelFromCommandline(); err != nil {
 		return err
 	}
-	if x.Channel == "" {
-		return fmt.Errorf("missing --channel=<channel-name> parameter")
-	}
 
 	name := string(x.Positional.Snap)
 	channel := string(x.Channel)
+
+	var msg string
+	// some duplication between this and the two other switch-summarisers...
+	// in this one, we have three boolean things to check, meaning 2³=8 possibilities
+	// of which 3 are errors (which is why we look at this before running it)
+	switch {
+	case x.Cohort != "" && x.LeaveCohort:
+		// this one counts as two (no channel filter)
+		return fmt.Errorf(i18n.G("cannot request both --cohort and --leave-cohort"))
+	case x.Cohort != "" && !x.LeaveCohort && channel == "":
+		// TRANSLATORS: the first %q will be the (quoted) snap name, the second an ellipted cohort string
+		msg = fmt.Sprintf(i18n.G("%q switched to the %q cohort\n"), name, strutil.ElliptRight(x.Cohort, 10))
+	case x.Cohort != "" && !x.LeaveCohort && channel != "":
+		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel, the third an ellipted cohort string
+		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel in the %q cohort\n"), name, channel, strutil.ElliptRight(x.Cohort, 10))
+	case x.Cohort == "" && !x.LeaveCohort && channel != "":
+		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
+		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel\n"), name, channel)
+	case x.Cohort == "" && x.LeaveCohort && channel != "":
+		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
+		msg = fmt.Sprintf(i18n.G("%q left the cohort, and switched to the %q channel"), name, channel)
+	case x.Cohort == "" && x.LeaveCohort && channel == "":
+		// TRANSLATORS: %q will be the (quoted) snap name
+		msg = fmt.Sprintf(i18n.G("%q left the cohort"), name)
+	case x.Cohort == "" && !x.LeaveCohort && channel == "":
+		return fmt.Errorf(i18n.G("nothing to switch (specify --cohort=... or --leave-cohort, and/or --channel=...)"))
+	} // and that's the 8 \o/
+
 	opts := &client.SnapOptions{
-		Channel: channel,
+		Channel:     channel,
+		CohortKey:   x.Cohort,
+		LeaveCohort: x.LeaveCohort,
 	}
 	changeID, err := x.client.Switch(name, opts)
 	if err != nil {
@@ -983,7 +1023,7 @@ func (x cmdSwitch) Execute(args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(Stdout, i18n.G("%q switched to the %q channel\n"), name, channel)
+	fmt.Fprintln(Stdout, msg)
 	return nil
 }
 
@@ -1007,6 +1047,8 @@ func init() {
 			"unaliased": i18n.G("Install the given snap without enabling its automatic aliases"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"name": i18n.G("Install the snap file under the given instance name"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"cohort": i18n.G("Install the snap in the given cohort"),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{
@@ -1020,6 +1062,10 @@ func init() {
 			"time": i18n.G("Show auto refresh information but do not perform a refresh"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"ignore-validation": i18n.G("Ignore validation by other snaps blocking the refresh"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"cohort": i18n.G("Refresh the snap into the given cohort"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"leave-cohort": i18n.G("Refresh the snap out of its cohort"),
 		}), nil)
 	addCommand("try", shortTryHelp, longTryHelp, func() flags.Commander { return &cmdTry{} }, waitDescs.also(modeDescs), nil)
 	addCommand("enable", shortEnableHelp, longEnableHelp, func() flags.Commander { return &cmdEnable{} }, waitDescs, nil)
@@ -1028,5 +1074,10 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"revision": i18n.G("Revert to the given revision"),
 	}), nil)
-	addCommand("switch", shortSwitchHelp, longSwitchHelp, func() flags.Commander { return &cmdSwitch{} }, waitDescs.also(channelDescs), nil)
+	addCommand("switch", shortSwitchHelp, longSwitchHelp, func() flags.Commander { return &cmdSwitch{} }, waitDescs.also(channelDescs).also(map[string]string{
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"cohort": i18n.G("Switch the snap into the given cohort"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"leave-cohort": i18n.G("Switch the snap out of its cohort"),
+	}), nil)
 }

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -191,14 +191,15 @@ func (s *SnapOpSuite) TestInstall(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
-			"action":  "install",
-			"channel": "candidate",
+			"action":     "install",
+			"channel":    "candidate",
+			"cohort-key": "what",
 		})
 		s.srv.channel = "candidate"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "candidate", "foo"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel", "candidate", "--cohort", "what", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(candidate\) 1.0 from Bar installed`)
@@ -1178,6 +1179,36 @@ func (s *SnapOpSuite) TestRefreshOneSwitchChannel(c *check.C) {
 	c.Check(s.Stdout(), check.Matches, `(?sm).*foo \(beta\) 1.0 from Bar refreshed`)
 }
 
+func (s *SnapOpSuite) TestRefreshOneSwitchCohort(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":     "refresh",
+			"cohort-key": "what",
+		})
+	}
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--cohort=what", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar refreshed`)
+}
+
+func (s *SnapOpSuite) TestRefreshOneLeaveCohort(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"leave-cohort": true,
+		})
+	}
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--leave-cohort", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from Bar refreshed`)
+}
+
 func (s *SnapOpSuite) TestRefreshOneWithPinnedTrack(c *check.C) {
 	s.RedirectClientToTestServer(s.srv.handle)
 	s.srv.checker = func(r *http.Request) {
@@ -1864,6 +1895,88 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestSwitchHappyCohort(c *check.C) {
+	s.srv.total = 3
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":     "switch",
+			"cohort-key": "what",
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--cohort=what", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" switched to the "what" cohort`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
+func (s *SnapOpSuite) TestSwitchHappyLeaveCohort(c *check.C) {
+	s.srv.total = 3
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":       "switch",
+			"leave-cohort": true,
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--leave-cohort", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" left the cohort`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
+func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
+	s.srv.total = 3
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":     "switch",
+			"cohort-key": "what",
+			"channel":    "edge",
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--cohort=what", "--edge", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" switched to the "edge" channel in the "what" cohort`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
+func (s *SnapOpSuite) TestSwitchHappyChannelAndLeaveCohort(c *check.C) {
+	s.srv.total = 3
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":       "switch",
+			"leave-cohort": true,
+			"channel":      "edge",
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--leave-cohort", "--edge", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" left the cohort, and switched to the "edge" channel`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
 func (s *SnapOpSuite) TestSwitchUnhappy(c *check.C) {
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch"})
 	c.Assert(err, check.ErrorMatches, "the required argument `<snap>` was not provided")
@@ -1871,7 +1984,12 @@ func (s *SnapOpSuite) TestSwitchUnhappy(c *check.C) {
 
 func (s *SnapOpSuite) TestSwitchAlsoUnhappy(c *check.C) {
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "foo"})
-	c.Assert(err, check.ErrorMatches, `missing --channel=<channel-name> parameter`)
+	c.Assert(err, check.ErrorMatches, `nothing to switch.*`)
+}
+
+func (s *SnapOpSuite) TestSwitchMoreUnhappy(c *check.C) {
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "foo", "--cohort=what", "--leave-cohort"})
+	c.Assert(err, check.ErrorMatches, `cannot request both --cohort and --leave-cohort`)
 }
 
 func (s *SnapOpSuite) TestSnapOpNetworkTimeoutError(c *check.C) {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1950,7 +1950,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--cohort=what", "--edge", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" switched to the "edge" channel in the "what" cohort`)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" switched to the "edge" channel and the "what" cohort`)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(s.srv.n, check.Equals, s.srv.total)
@@ -1989,7 +1989,7 @@ func (s *SnapOpSuite) TestSwitchAlsoUnhappy(c *check.C) {
 
 func (s *SnapOpSuite) TestSwitchMoreUnhappy(c *check.C) {
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "foo", "--cohort=what", "--leave-cohort"})
-	c.Assert(err, check.ErrorMatches, `cannot request both --cohort and --leave-cohort`)
+	c.Assert(err, check.ErrorMatches, `cannot specify both --cohort and --leave-cohort`)
 }
 
 func (s *SnapOpSuite) TestSnapOpNetworkTimeoutError(c *check.C) {

--- a/tests/main/cohorts/task.yaml
+++ b/tests/main/cohorts/task.yaml
@@ -1,0 +1,26 @@
+summary: Check that cohorts work
+
+prepare: |
+    snap install yq
+
+execute: |
+    echo "Test we can create chorts:"
+    snap create-cohort test-snapd-tools > coh.yml
+    COHORT=$( yq r coh.yml cohorts.test-snapd-tools.cohort-key )
+    test -n "$COHORT"
+
+    echo "Test we can install from there:"
+    snap install --cohort="$COHORT" test-snapd-tools
+
+    echo "Test it's now in the cohort:"
+    snap info test-snapd-tools | MATCH ^installed:.*in-cohort
+
+    echo "We can refresh a few times and not leave the cohort"
+    # test added at pedronis's request
+    snap refresh test-snapd-tools
+    snap refresh test-snapd-tools
+    snap refresh test-snapd-tools
+    snap info test-snapd-tools | MATCH ^installed:.*in-cohort
+
+    snap switch --leave-cohort test-snapd-tools
+    snap info test-snapd-tools | grep installed: | MATCH -v in-cohort

--- a/tests/main/cohorts/task.yaml
+++ b/tests/main/cohorts/task.yaml
@@ -2,6 +2,7 @@ summary: Check that cohorts work
 
 prepare: |
     snap install yq
+    snap connect yq:home
 
 execute: |
     echo "Test we can create chorts:"


### PR DESCRIPTION
This exposes the new cohort-key and leave-cohort flags for install,
refresh and switch.

Of the [Managing cohorts doc] the only bit left to do is the part
associated with `snap refresh --list`, which will probably take quite
a bit more work (because it involves a rework of how we do `snap
refresh --list`, and hopefully (!) moving to `snap refresh --dry-run`
or similar).

[Managing cohorts doc]: https://forum.snapcraft.io/t/managing-cohorts/8995
