### PR TITLE
tests/lib/nested: tweak assert disk prepare step

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -39,10 +39,8 @@ prepare_ssh(){
 
 create_assertions_disk(){
     dd if=/dev/null of=assertions.disk bs=1M seek=1
-    tmpdir="$(mktemp -d)"
-    cp "$TESTSLIB/assertions/auto-import.assert" "$tmpdir"
-    mkfs.ext4 -F -d "$tmpdir" assertions.disk
-    rm -rf "$tmpdir"
+    mkfs.ext4 -F assertions.disk
+    debugfs -w -R "write $TESTSLIB/assertions/auto-import.assert auto-import.assert" assertions.disk
 }
 
 get_qemu_for_nested_vm(){


### PR DESCRIPTION
Xenials e2fsprogs does not have -d switch in mkfs.ex4. For this reason, try to
use debugfs to copy the asserts file into the image.

