### PR TITLE
overlord/devicestate: implement reregRemodelContext with the essential re-registration logic

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1466,6 +1466,10 @@ func (s *deviceMgrSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Check(ser.Serial(), Equals, "8989")
 }
 
+var (
+	devKey, _ = assertstest.GenerateKey(testKeyLength)
+)
+
 func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1477,7 +1481,6 @@ func (s *deviceMgrSuite) TestStoreContextBackendDeviceSessionRequestParams(c *C)
 	c.Check(err, ErrorMatches, "internal error: cannot sign a session request without a serial")
 
 	// setup state as done by device initialisation
-	devKey, _ := assertstest.GenerateKey(testKeyLength)
 	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
 	c.Check(err, IsNil)
 	seriala, err := s.storeSigning.Sign(asserts.SerialType, map[string]interface{}{
@@ -1995,8 +1998,7 @@ func (s *deviceMgrSuite) makeModelAssertionInState(c *C, brandID, model string, 
 	assertstatetest.AddMany(s.state, modelAs)
 }
 
-func makeSerialAssertionInState(c *C, brands *assertstest.SigningAccounts, st *state.State, brandID, model, serialN string) {
-	devKey, _ := assertstest.GenerateKey(752)
+func makeSerialAssertionInState(c *C, brands *assertstest.SigningAccounts, st *state.State, brandID, model, serialN string) *asserts.Serial {
 	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
 	c.Assert(err, IsNil)
 	serial, err := brands.Signing(brandID).Sign(asserts.SerialType, map[string]interface{}{
@@ -2010,6 +2012,7 @@ func makeSerialAssertionInState(c *C, brands *assertstest.SigningAccounts, st *s
 	c.Assert(err, IsNil)
 	err = assertstate.Add(st, serial)
 	c.Assert(err, IsNil)
+	return serial.(*asserts.Serial)
 }
 
 func (s *deviceMgrSuite) makeSerialAssertionInState(c *C, brandID, model, serialN string) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -128,6 +128,8 @@ func SetBootOkRan(m *DeviceManager, b bool) {
 	m.bootOkRan = b
 }
 
+type RegistrationContext = registrationContext
+
 func RegistrationCtx(m *DeviceManager, t *state.Task) (registrationContext, error) {
 	return m.registrationCtx(t)
 }

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -119,7 +119,7 @@ type remodelContext interface {
 
 	// initialDevice takes the current/initial device state
 	// when setting up the remodel context
-	initialDevice(device *auth.DeviceState)
+	initialDevice(device *auth.DeviceState) error
 	// associate associates the remodel context with the change
 	// and caches it
 	associate(chg *state.Change)
@@ -137,14 +137,13 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 		// simple context for the simple case
 		remodCtx = &updateRemodelContext{baseRemodelContext{newModel}}
 	case StoreSwitchRemodel:
-		storeSwitchCtx := &newStoreRemodelContext{
-			baseRemodelContext: baseRemodelContext{newModel},
-			st:                 st,
-			deviceMgr:          devMgr,
-		}
-		storeSwitchCtx.store = devMgr.newStore(storeSwitchCtx.deviceBackend())
+		storeSwitchCtx := &newStoreRemodelContext{}
+		storeSwitchCtx.setup(st, devMgr, newModel)
 		remodCtx = storeSwitchCtx
-	// TODO: support ReregRemodel
+	case ReregRemodel:
+		reregCtx := &reregRemodelContext{}
+		reregCtx.setup(st, devMgr, newModel)
+		remodCtx = reregCtx
 	default:
 		return nil, fmt.Errorf("unsupported remodel: %s", kind)
 	}
@@ -153,7 +152,9 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 	if err != nil {
 		return nil, err
 	}
-	remodCtx.initialDevice(device)
+	if err := remodCtx.initialDevice(device); err != nil {
+		return nil, err
+	}
 
 	return remodCtx, nil
 }
@@ -214,8 +215,9 @@ func (rc baseRemodelContext) Model() *asserts.Model {
 	return rc.newModel
 }
 
-func (rc baseRemodelContext) initialDevice(*auth.DeviceState) {
+func (rc baseRemodelContext) initialDevice(*auth.DeviceState) error {
 	// do nothing
+	return nil
 }
 
 func (rc baseRemodelContext) cacheViaChange(chg *state.Change, remodCtx remodelContext) {
@@ -271,6 +273,13 @@ type newStoreRemodelContext struct {
 	deviceMgr *DeviceManager
 }
 
+func (rc *newStoreRemodelContext) setup(st *state.State, devMgr *DeviceManager, newModel *asserts.Model) {
+	rc.baseRemodelContext = baseRemodelContext{newModel}
+	rc.st = st
+	rc.deviceMgr = devMgr
+	rc.store = devMgr.newStore(rc.deviceBackend())
+}
+
 func (rc *newStoreRemodelContext) Kind() RemodelKind {
 	return StoreSwitchRemodel
 }
@@ -280,17 +289,23 @@ func (rc *newStoreRemodelContext) associate(chg *state.Change) {
 	rc.cacheViaChange(chg, rc)
 }
 
-func (rc *newStoreRemodelContext) initialDevice(device *auth.DeviceState) {
+func (rc *newStoreRemodelContext) initialDevice(device *auth.DeviceState) error {
 	device1 := *device
 	// we will need a new one, it might embed the store as well
 	device1.SessionMacaroon = ""
 	rc.deviceState = &device1
+	return nil
+}
+
+func (rc *newStoreRemodelContext) init(chg *state.Change) {
+	rc.baseRemodelContext.init(chg)
+
+	chg.Set("device", rc.deviceState)
+	rc.deviceState = nil
 }
 
 func (rc *newStoreRemodelContext) Init(chg *state.Change) {
 	rc.init(chg)
-	chg.Set("device", rc.deviceState)
-	rc.deviceState = nil
 
 	rc.associate(chg)
 }
@@ -359,4 +374,81 @@ func (b remodelDeviceBackend) Serial() (*asserts.Serial, error) {
 		return nil, err
 	}
 	return findSerial(b.st, device)
+}
+
+// reregRemodelContext: remodel for a change of brand/model
+type reregRemodelContext struct {
+	newStoreRemodelContext
+
+	origModel  *asserts.Model
+	origSerial *asserts.Serial
+}
+
+func (rc *reregRemodelContext) Kind() RemodelKind {
+	return ReregRemodel
+}
+
+func (rc *reregRemodelContext) associate(chg *state.Change) {
+	rc.remodelChange = chg
+	rc.cacheViaChange(chg, rc)
+}
+
+func (rc *reregRemodelContext) initialDevice(device *auth.DeviceState) error {
+	origModel, err := findModel(rc.st)
+	if err != nil {
+		return err
+	}
+	origSerial, err := findSerial(rc.st, nil)
+	if err != nil {
+		return fmt.Errorf("cannot find current serial before proceeding with re-registration: %v", err)
+	}
+	rc.origModel = origModel
+	rc.origSerial = origSerial
+
+	// starting almost from scratch with only device-key
+	rc.deviceState = &auth.DeviceState{
+		Brand: rc.newModel.BrandID(),
+		Model: rc.newModel.Model(),
+		KeyID: device.KeyID,
+	}
+	return nil
+}
+
+func (rc *reregRemodelContext) Init(chg *state.Change) {
+	rc.init(chg)
+
+	rc.associate(chg)
+}
+
+// reregRemodelContext impl of registrationContext
+
+func (rc *reregRemodelContext) Device() (*auth.DeviceState, error) {
+	return rc.device()
+}
+
+func (rc *reregRemodelContext) GadgetForSerialRequestConfig() string {
+	return rc.origModel.Gadget()
+}
+
+func (rc *reregRemodelContext) SerialRequestExtraHeaders() map[string]interface{} {
+	return map[string]interface{}{
+		"original-brand-id": rc.origSerial.BrandID(),
+		"original-model":    rc.origSerial.Model(),
+		"original-serial":   rc.origSerial.Serial(),
+	}
+}
+
+func (rc *reregRemodelContext) SerialRequestAncillaryAssertions() []asserts.Assertion {
+	return []asserts.Assertion{rc.origModel, rc.origSerial}
+}
+
+func (rc *reregRemodelContext) FinishRegistration(serial *asserts.Serial) error {
+	device, err := rc.device()
+	if err != nil {
+		return err
+	}
+
+	device.Serial = serial.Serial()
+	rc.setCtxDevice(device)
+	return nil
 }

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -20,6 +20,8 @@
 package devicestate_test
 
 import (
+	"time"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -252,7 +254,8 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendNoChangeYet(c *C) {
 	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
 	c.Assert(err, IsNil)
 
-	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+	devBE := s.capturedDevBE
+	c.Check(devBE, NotNil)
 
 	device, err := devBE.Device()
 	c.Assert(err, IsNil)
@@ -312,11 +315,11 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackend(c *C) {
 	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
 	c.Assert(err, IsNil)
 
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
 	chg := s.state.NewChange("remodel", "...")
 
 	remodCtx.Init(chg)
-
-	devBE := devicestate.RemodelDeviceBackend(remodCtx)
 
 	device, err := devBE.Device()
 	c.Assert(err, IsNil)
@@ -562,27 +565,24 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextFinishVsGlobalUpdateDevice
 	c.Check(device1, DeepEquals, expectedGlobalDevice)
 }
 
-func (s *remodelLogicSuite) TestRemodelDeviceBackendSerial(c *C) {
+func (s *remodelLogicSuite) TestRemodelDeviceBackendKeptSerial(c *C) {
 	oldModel := fakeRemodelingModel(nil)
 	newModel := fakeRemodelingModel(map[string]interface{}{
 		"store":    "my-other-store",
 		"revision": "1",
 	})
 
-	// the logic is shared and correct also for re-reg
-	// XXX (this is really the re-reg case)
-
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	// we have a device state and serial
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand:  "canonical",
-		Model:  "base-model",
+		Brand:  "my-brand",
+		Model:  "my-model",
 		Serial: "serialserialserial1",
 	})
 
-	makeSerialAssertionInState(c, s.brands, s.state, "canonical", "base-model", "serialserialserial1")
+	makeSerialAssertionInState(c, s.brands, s.state, "my-brand", "my-model", "serialserialserial1")
 
 	serial, err := s.mgr.Serial()
 	c.Assert(err, IsNil)
@@ -604,43 +604,6 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendSerial(c *C) {
 	serial0, err = devBE.Serial()
 	c.Assert(err, IsNil)
 	c.Check(serial0.Serial(), Equals, "serialserialserial1")
-
-	err = devBE.SetDevice(&auth.DeviceState{
-		Brand: "canonical",
-		Model: "other-model",
-	})
-	c.Assert(err, IsNil)
-
-	// lookup the serial, nothing there
-	_, err = devBE.Serial()
-	c.Check(err, Equals, state.ErrNoState)
-
-	makeSerialAssertionInState(c, s.brands, s.state, "canonical", "other-model", "serialserialserial2")
-
-	// same
-	_, err = devBE.Serial()
-	c.Check(err, Equals, state.ErrNoState)
-
-	err = devBE.SetDevice(&auth.DeviceState{
-		Brand:  "canonical",
-		Model:  "other-model",
-		Serial: "serialserialserial2",
-	})
-	c.Assert(err, IsNil)
-
-	serial, err = devBE.Serial()
-	c.Check(err, IsNil)
-	c.Check(serial.Model(), Equals, "other-model")
-	c.Check(serial.Serial(), Equals, "serialserialserial2")
-
-	// finish
-	// XXX test separately
-	err = remodCtx.Finish()
-	c.Assert(err, IsNil)
-
-	serial, err = s.mgr.Serial()
-	c.Assert(err, IsNil)
-	c.Check(serial.Model(), Equals, "other-model")
 }
 
 func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
@@ -707,4 +670,213 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskNo(c *C) {
 	chg.AddTask(t)
 	_, err = devicestate.RemodelCtxFromTask(t)
 	c.Check(err, Equals, state.ErrNoState)
+}
+
+func (s *remodelLogicSuite) setupForRereg(c *C) (oldModel, newModel *asserts.Model) {
+	oldModel = s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel = s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{
+		"authority-id": "other-brand",
+		"brand-id":     "other-brand",
+		"model":        "other-model",
+		"store":        "other-store",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
+	c.Assert(err, IsNil)
+	serial, err := s.brands.Signing("my-brand").Sign(asserts.SerialType, map[string]interface{}{
+		"authority-id":        "my-brand",
+		"brand-id":            "my-brand",
+		"model":               "my-model",
+		"serial":              "orig-serial",
+		"device-key":          string(encDevKey),
+		"device-key-sha3-384": devKey.PublicKey().ID(),
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	assertstatetest.AddMany(s.state, oldModel, serial)
+
+	return oldModel, newModel
+}
+
+func (s *remodelLogicSuite) TestReregRemodelContextInit(c *C) {
+	oldModel, newModel := s.setupForRereg(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "orig-serial",
+		KeyID:           "device-key-id",
+		SessionMacaroon: "prev-session",
+	})
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+
+	c.Check(remodCtx.ForRemodeling(), Equals, true)
+	c.Check(remodCtx.Kind(), Equals, devicestate.ReregRemodel)
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx.Init(chg)
+
+	var encNewModel string
+	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
+
+	c.Check(encNewModel, Equals, string(asserts.Encode(newModel)))
+
+	var device *auth.DeviceState
+	c.Assert(chg.Get("device", &device), IsNil)
+	// fresh device state before registration but with device-key
+	c.Check(device, DeepEquals, &auth.DeviceState{
+		Brand: "other-brand",
+		Model: "other-model",
+		KeyID: "device-key-id",
+	})
+
+	c.Check(remodCtx.Model(), DeepEquals, newModel)
+
+	// caching
+	t := s.state.NewTask("remodel-task-1", "...")
+	chg.AddTask(t)
+
+	remodCtx1, err := devicestate.RemodelCtxFromTask(t)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx1, Equals, remodCtx)
+}
+
+func (s *remodelLogicSuite) TestReregRemodelContextAsRegistrationContext(c *C) {
+	oldModel, newModel := s.setupForRereg(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we have a device state
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:           "my-brand",
+		Model:           "my-model",
+		Serial:          "orig-serial",
+		KeyID:           "device-key-id",
+		SessionMacaroon: "prev-session",
+	})
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+
+	c.Check(remodCtx.Kind(), Equals, devicestate.ReregRemodel)
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx.Init(chg)
+
+	regCtx := remodCtx.(devicestate.RegistrationContext)
+
+	c.Check(regCtx.ForRemodeling(), Equals, true)
+	device1, err := regCtx.Device()
+	c.Assert(err, IsNil)
+	// fresh device state before registration but with device-key
+	c.Check(device1, DeepEquals, &auth.DeviceState{
+		Brand: "other-brand",
+		Model: "other-model",
+		KeyID: "device-key-id",
+	})
+	c.Check(regCtx.GadgetForSerialRequestConfig(), Equals, "my-brand-gadget")
+	c.Check(regCtx.SerialRequestExtraHeaders(), DeepEquals, map[string]interface{}{
+		"original-brand-id": "my-brand",
+		"original-model":    "my-model",
+		"original-serial":   "orig-serial",
+	})
+
+	serial, err := s.mgr.Serial()
+	c.Assert(err, IsNil)
+	c.Check(regCtx.SerialRequestAncillaryAssertions(), DeepEquals, []asserts.Assertion{oldModel, serial})
+}
+
+func (s *remodelLogicSuite) TestReregRemodelContextNewSerial(c *C) {
+	// re-registration case
+	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel := fakeRemodelingModel(map[string]interface{}{
+		"model": "other-model",
+	})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	assertstatetest.AddMany(s.state, oldModel)
+
+	// we have a device state and serial
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial1",
+	})
+
+	makeSerialAssertionInState(c, s.brands, s.state, "my-brand", "my-model", "serialserialserial1")
+
+	serial, err := s.mgr.Serial()
+	c.Assert(err, IsNil)
+	c.Check(serial.Serial(), Equals, "serialserialserial1")
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+
+	devBE := devicestate.RemodelDeviceBackend(remodCtx)
+
+	// no new serial yet
+	_, err = devBE.Serial()
+	c.Assert(err, Equals, state.ErrNoState)
+
+	chg := s.state.NewChange("remodel", "...")
+
+	remodCtx.Init(chg)
+
+	// sanity check
+	device1, err := devBE.Device()
+	c.Assert(err, IsNil)
+	c.Check(device1, DeepEquals, &auth.DeviceState{
+		Brand: "my-brand",
+		Model: "other-model",
+	})
+
+	// still no new serial
+	_, err = devBE.Serial()
+	c.Assert(err, Equals, state.ErrNoState)
+
+	newSerial := makeSerialAssertionInState(c, s.brands, s.state, "my-brand", "other-model", "serialserialserial2")
+
+	// same
+	_, err = devBE.Serial()
+	c.Check(err, Equals, state.ErrNoState)
+
+	// finish registration
+	regCtx := remodCtx.(devicestate.RegistrationContext)
+	err = regCtx.FinishRegistration(newSerial)
+	c.Assert(err, IsNil)
+
+	serial, err = devBE.Serial()
+	c.Check(err, IsNil)
+	c.Check(serial.Model(), Equals, "other-model")
+	c.Check(serial.Serial(), Equals, "serialserialserial2")
+
+	// not exposed yet
+	serial, err = s.mgr.Serial()
+	c.Assert(err, IsNil)
+	c.Check(serial.Model(), Equals, "my-model")
+	c.Check(serial.Serial(), Equals, "serialserialserial1")
+
+	// finish
+	err = remodCtx.Finish()
+	c.Assert(err, IsNil)
+
+	serial, err = s.mgr.Serial()
+	c.Assert(err, IsNil)
+	c.Check(serial.Model(), Equals, "other-model")
+	c.Check(serial.Serial(), Equals, "serialserialserial2")
 }


### PR DESCRIPTION
Now that all cases are covered this also re-organizes the remodelDeviceBackend.Serial testing.