### PR TITLE
cmd/snap-exec: fix snap completion for classic snaps with non /usr/lib/snapd libexecdir

### DIFF
--- a/cmd/snap-exec/export_test.go
+++ b/cmd/snap-exec/export_test.go
@@ -49,3 +49,12 @@ func SetOptsHook(s string) {
 func GetOptsHook() string {
 	return opts.Hook
 }
+
+// MockOsReadlink is for use in tests
+func MockOsReadlink(f func(string) (string, error)) func() {
+	realOsReadlink := osReadlink
+	osReadlink = f
+	return func() {
+		osReadlink = realOsReadlink
+	}
+}

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -201,8 +201,12 @@ func execApp(snapApp, revision, command string, args []string) error {
 		cmdArgs = nil
 	case "complete":
 		fullCmd[0] = defaultShell
+		completionHelper := dirs.CompletionHelperInCore
+		if info.NeedsClassic() {
+			completionHelper = filepath.Join(dirs.SnapMountDir, "core/current", dirs.CompletionHelperInCore)
+		}
 		cmdArgs = []string{
-			dirs.CompletionHelper,
+			completionHelper,
 			filepath.Join(app.Snap.MountDir(), app.Completer),
 		}
 	case "gdb":

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -62,11 +62,11 @@ apps:
   command: run-app cmd-arg1 $SNAP_DATA
   stop-command: stop-app
   post-stop-command: post-stop-app
+  completer: you/complete/me
   environment:
    BASE_PATH: /some/path
    LD_LIBRARY_PATH: ${BASE_PATH}/lib
    MY_PATH: $PATH
-  completer: you/complete/me
  app2:
   command: run-app2
   stop-command: stop-app2

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -100,8 +100,8 @@ var (
 	XdgRuntimeDirBase string
 	XdgRuntimeDirGlob string
 
-	CompletionHelper string
-	CompletersDir    string
+	CompletionHelperInCore string
+	CompletersDir          string
 
 	SystemFontsDir            string
 	SystemLocalFontsDir       string
@@ -295,7 +295,7 @@ func SetRootDir(rootdir string) {
 	XdgRuntimeDirBase = filepath.Join(rootdir, "/run/user")
 	XdgRuntimeDirGlob = filepath.Join(rootdir, XdgRuntimeDirBase, "*/")
 
-	CompletionHelper = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
+	CompletionHelperInCore = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
 	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
 
 	// These paths agree across all supported distros


### PR DESCRIPTION
Fix completion for classic snaps on systems where snapd libexecdir is not
/usr/lib/snapd. These are for instance Fedora and CentOS, where libexecdir is
set to /usr/libexec/snapd.

When run for completions, snap-exec would always attempt to run the completer
from the path which is correct given the snap gets a mount namespace (i.e. is
not classic).

This worked by accident on systems that use /usr/lib/snapd (eg. Ubuntu, Debian,
Arch), but failed on those using /usr/libexec/snapd.

For instance, on CentOS, one would see:
``` 
$ cmake -G Ni<tab>
/bin/bash: /usr/lib/snapd/etelpmoc.sh: No such file or directory
```

Fixes: https://bugs.launchpad.net/snapd/+bug/1833043
