### PR TITLE
tests: continue executing on errors either updating the repo db or installing dependencies

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -277,7 +277,9 @@ prepare_project() {
 
     create_test_user
 
-    distro_update_package_db
+    if ! distro_update_package_db; then
+        echo "Error updating the package db, continue with the system preparation"
+    fi
 
     if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
         # perform system upgrade on Arch so that we run with most recent kernel
@@ -376,7 +378,9 @@ prepare_project() {
             ;;
     esac
 
-    install_pkg_dependencies
+    if ! install_pkg_dependencies; then
+        echo "Error installing test dependencies, continue with the system preparation"
+    fi
 
     # We take a special case for Debian/Ubuntu where we install additional build deps
     # base on the packaging. In Fedora/Suse this is handled via mock/osc


### PR DESCRIPTION
The idea of this change is to continue preparing the test suite in case
the there is a problem either updating  the repo db or installing
dependencies.

This change will help when there are issues with the repositories. 

As in gce the images have already installed the dependencies, the case when the repo db cannot be updated or a dependencie cannot be installed should not affect. When using a different backend in case there is a problem with the repo, the test will fail because the dependencies needed won't be installed. 