### PR TITLE
snap: introduce GetType() function for snap.Info

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -52,8 +52,8 @@ func RemoveKernelAssets(s snap.PlaceInfo) error {
 // kernel snap, if required, to a versioned bootloader directory so
 // that the bootloader can use it.
 func ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
-	if s.Type != snap.TypeKernel {
-		return fmt.Errorf("cannot extract kernel assets from snap type %q", s.Type)
+	if s.GetType() != snap.TypeKernel {
+		return fmt.Errorf("cannot extract kernel assets from snap type %q", s.GetType())
 	}
 
 	loader, err := bootloader.Find()
@@ -106,8 +106,8 @@ func SetNextBoot(s *snap.Info) error {
 		return fmt.Errorf("cannot set next boot on classic systems")
 	}
 
-	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel && s.Type != snap.TypeBase {
-		return fmt.Errorf("cannot set next boot to snap %q with type %q", s.SnapName(), s.Type)
+	if s.GetType() != snap.TypeOS && s.GetType() != snap.TypeKernel && s.GetType() != snap.TypeBase {
+		return fmt.Errorf("cannot set next boot to snap %q with type %q", s.SnapName(), s.GetType())
 	}
 
 	bootloader, err := bootloader.Find()
@@ -116,7 +116,7 @@ func SetNextBoot(s *snap.Info) error {
 	}
 
 	var nextBoot, goodBoot string
-	switch s.Type {
+	switch s.GetType() {
 	case snap.TypeOS, snap.TypeBase:
 		nextBoot = "snap_try_core"
 		goodBoot = "snap_core"
@@ -156,7 +156,7 @@ func SetNextBoot(s *snap.Info) error {
 // ChangeRequiresReboot returns whether a reboot is required to switch
 // to the given OS, base or kernel snap.
 func ChangeRequiresReboot(s *snap.Info) bool {
-	if s.Type != snap.TypeKernel && s.Type != snap.TypeOS && s.Type != snap.TypeBase {
+	if s.GetType() != snap.TypeKernel && s.GetType() != snap.TypeOS && s.GetType() != snap.TypeBase {
 		return false
 	}
 
@@ -167,7 +167,7 @@ func ChangeRequiresReboot(s *snap.Info) bool {
 	}
 
 	var nextBoot, goodBoot string
-	switch s.Type {
+	switch s.GetType() {
 	case snap.TypeKernel:
 		nextBoot = "snap_try_kernel"
 		goodBoot = "snap_kernel"

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -182,7 +182,7 @@ func (s *kernelOSSuite) TestExtractKernelForceWorks(c *C) {
 
 func (s *kernelOSSuite) TestExtractKernelAssetsError(c *C) {
 	info := &snap.Info{}
-	info.Type = snap.TypeApp
+	info.SnapType = snap.TypeApp
 
 	err := boot.ExtractKernelAssets(info, nil)
 	c.Assert(err, ErrorMatches, `cannot extract kernel assets from snap type "app"`)
@@ -206,7 +206,7 @@ func (s *kernelOSSuite) TestSetNextBootForCore(c *C) {
 	defer restore()
 
 	info := &snap.Info{}
-	info.Type = snap.TypeOS
+	info.SnapType = snap.TypeOS
 	info.RealName = "core"
 	info.Revision = snap.R(100)
 
@@ -226,7 +226,7 @@ func (s *kernelOSSuite) TestSetNextBootWithBaseForCore(c *C) {
 	defer restore()
 
 	info := &snap.Info{}
-	info.Type = snap.TypeBase
+	info.SnapType = snap.TypeBase
 	info.RealName = "core18"
 	info.Revision = snap.R(1818)
 
@@ -246,7 +246,7 @@ func (s *kernelOSSuite) TestSetNextBootForKernel(c *C) {
 	defer restore()
 
 	info := &snap.Info{}
-	info.Type = snap.TypeKernel
+	info.SnapType = snap.TypeKernel
 	info.RealName = "krnl"
 	info.Revision = snap.R(42)
 
@@ -272,7 +272,7 @@ func (s *kernelOSSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	defer restore()
 
 	info := &snap.Info{}
-	info.Type = snap.TypeKernel
+	info.SnapType = snap.TypeKernel
 	info.RealName = "krnl"
 	info.Revision = snap.R(40)
 
@@ -291,7 +291,7 @@ func (s *kernelOSSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C) {
 	defer restore()
 
 	info := &snap.Info{}
-	info.Type = snap.TypeKernel
+	info.SnapType = snap.TypeKernel
 	info.RealName = "krnl"
 	info.Revision = snap.R(40)
 

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -102,7 +102,7 @@ func NotesFromLocal(snp *client.Snap) *Notes {
 
 func NotesFromInfo(info *snap.Info) *Notes {
 	return &Notes{
-		SnapType: info.Type,
+		SnapType: info.GetType(),
 		Private:  info.Private,
 		DevMode:  info.Confinement == client.DevModeConfinement,
 		Classic:  info.Confinement == client.ClassicConfinement,

--- a/cmd/snapinfo.go
+++ b/cmd/snapinfo.go
@@ -61,7 +61,7 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info) (*client.Snap, error) {
 		Name:        snapInfo.InstanceName(),
 		Revision:    snapInfo.Revision,
 		Summary:     snapInfo.Summary(),
-		Type:        string(snapInfo.Type),
+		Type:        string(snapInfo.GetType()),
 		Base:        snapInfo.Base,
 		Version:     snapInfo.Version,
 		Channel:     snapInfo.Channel,

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -51,7 +51,7 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 			},
 		},
 		Current:  snapInfo.Revision,
-		SnapType: string(snapInfo.Type),
+		SnapType: string(snapInfo.GetType()),
 	})
 
 	// Put the snap into the interface repository

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -873,7 +873,7 @@ func (s *apiSuite) TestMapLocalFields(c *check.C) {
 			Private:           true,
 		},
 		InstanceKey: "instance",
-		Type:        "app",
+		SnapType:    "app",
 		Base:        "the-base",
 		Version:     "v1.0",
 		License:     "MIT",
@@ -1857,8 +1857,8 @@ func (s *apiSuite) TestFindOneUserAgentContextCreated(c *check.C) {
 	s.daemon(c)
 
 	s.rsnaps = []*snap.Info{{
-		Type:    snap.TypeApp,
-		Version: "v2",
+		SnapType: snap.TypeApp,
+		Version:  "v2",
 		SideInfo: snap.SideInfo{
 			RealName: "banana",
 		},
@@ -2089,8 +2089,8 @@ func (s *apiSuite) TestFindPriced(c *check.C) {
 	s.suggestedCurrency = "GBP"
 
 	s.rsnaps = []*snap.Info{{
-		Type:    snap.TypeApp,
-		Version: "v2",
+		SnapType: snap.TypeApp,
+		Version:  "v2",
 		Prices: map[string]float64{
 			"GBP": 1.23,
 			"EUR": 2.34,
@@ -2130,8 +2130,8 @@ func (s *apiSuite) TestFindScreenshotted(c *check.C) {
 	s.daemon(c)
 
 	s.rsnaps = []*snap.Info{{
-		Type:    snap.TypeApp,
-		Version: "v2",
+		SnapType: snap.TypeApp,
+		Version:  "v2",
 		Media: []snap.MediaInfo{
 			{
 				Type:   "screenshot",

--- a/image/image.go
+++ b/image/image.go
@@ -560,7 +560,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options, local *l
 		// Sanity check, note that we could support this case
 		// if we have a use-case but it requires changes in the
 		// devicestate/firstboot.go ordering code.
-		if info.Type == snap.TypeGadget && info.Base != model.Base() {
+		if info.GetType() == snap.TypeGadget && info.Base != model.Base() {
 			return fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, model.Base())
 		}
 		if err := hasBase(info, local, snaps); err != nil {
@@ -575,7 +575,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options, local *l
 		}
 
 		seen[name] = true
-		typ := info.Type
+		typ := info.GetType()
 
 		needsClassic := info.NeedsClassic()
 		if needsClassic && !opts.Classic {
@@ -749,7 +749,7 @@ func setBootvars(downloadedSnapsInfoForBootConfig map[string]*snap.Info, model *
 			}
 			return fmt.Errorf("cannot get download info for snap %s, available infos: %v", fn, keys)
 		}
-		switch info.Type {
+		switch info.GetType() {
 		case snap.TypeOS, snap.TypeBase:
 			bootvar = "snap_core"
 		case snap.TypeKernel:

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -56,7 +56,7 @@ apps:
 
 func (s *AccountControlSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "account-control",
 		Interface: "account-control",
 		Apps: map[string]*snap.AppInfo{

--- a/interfaces/builtin/autopilot_test.go
+++ b/interfaces/builtin/autopilot_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&AutopilotInterfaceSuite{
 
 func (s *AutopilotInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "autopilot-introspection",
 		Interface: "autopilot-introspection",
 	}

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -54,7 +54,7 @@ var _ = Suite(&BluetoothControlInterfaceSuite{
 
 func (s *BluetoothControlInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "bluetooth-control",
 		Interface: "bluetooth-control",
 		Apps: map[string]*snap.AppInfo{

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&BrowserSupportInterfaceSuite{
 
 func (s *BrowserSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "browser-support",
 		Interface: "browser-support",
 	}

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&ClassicSupportInterfaceSuite{
 
 func (s *ClassicSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "classic-support",
 		Interface: "classic-support",
 	}

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -51,7 +51,7 @@ hooks:
      plugs: [core-support]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "core-support",
 		Interface: "core-support",
 	}

--- a/interfaces/builtin/cpu_control_test.go
+++ b/interfaces/builtin/cpu_control_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&CpuControlInterfaceSuite{
 
 func (s *CpuControlInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "cpu-control",
 		Interface: "cpu-control",
 	}

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -52,7 +52,7 @@ apps:
     plugs: [dcdbas-control]
 `, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "dcdbas-control",
 		Interface: "dcdbas-control",
 	}

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&GsettingsInterfaceSuite{
 
 func (s *GsettingsInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "gsettings",
 		Interface: "gsettings",
 	}

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&HardwareObserveInterfaceSuite{
 
 func (s *HardwareObserveInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "hardware-observe",
 		Interface: "hardware-observe",
 	}

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [home]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "home",
 		Interface: "home",
 	}

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -76,7 +76,7 @@ var _ = Suite(&KubernetesSupportInterfaceSuite{
 
 func (s *KubernetesSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "kubernetes-support",
 		Interface: "kubernetes-support",
 	}

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -54,7 +54,7 @@ apps:
 	s.plugInfo = snapInfo.Plugs["locale-control"]
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "locale-control",
 		Interface: "locale-control",
 	}

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [log-observe]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "log-observe",
 		Interface: "log-observe",
 	}

--- a/interfaces/builtin/login_session_control_test.go
+++ b/interfaces/builtin/login_session_control_test.go
@@ -54,7 +54,7 @@ apps:
 	s.plugInfo = consumingSnapInfo.Plugs["login-session-control"]
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "login-session-control",
 		Interface: "login-session-control",
 	}

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [mount-observe]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "mount-observe",
 		Interface: "mount-observe",
 	}

--- a/interfaces/builtin/multipass_support_test.go
+++ b/interfaces/builtin/multipass_support_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&MultipassSupportInterfaceSuite{
 
 func (s *MultipassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "multipass-support",
 		Interface: "multipass-support",
 	}

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&NetlinkAuditInterfaceSuite{
 
 func (s *NetlinkAuditInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "netlink-audit",
 		Interface: "netlink-audit",
 	}

--- a/interfaces/builtin/netlink_connector_test.go
+++ b/interfaces/builtin/netlink_connector_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&NetlinkConnectorInterfaceSuite{
 
 func (s *NetlinkConnectorInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "netlink-connector",
 		Interface: "netlink-connector",
 	}

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&NetworkBindInterfaceSuite{
 
 func (s *NetworkBindInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "network-bind",
 		Interface: "network-bind",
 	}

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&NetworkObserveInterfaceSuite{
 
 func (s *NetworkObserveInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "network-observe",
 		Interface: "network-observe",
 	}

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -52,7 +52,7 @@ apps:
     plugs: [network-setup-control]
 `, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "network-setup-control",
 		Interface: "network-setup-control",
 	}

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [network-setup-observe]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "network-setup-observe",
 		Interface: "network-setup-observe",
 	}

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&NetworkInterfaceSuite{
 
 func (s *NetworkInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "network",
 		Interface: "network",
 	}

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -52,7 +52,7 @@ apps:
   plugs: [openvswitch-support]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "openvswitch-support",
 		Interface: "openvswitch-support",
 	}

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [openvswitch]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "openvswitch",
 		Interface: "openvswitch",
 	}

--- a/interfaces/builtin/password_manager_service_test.go
+++ b/interfaces/builtin/password_manager_service_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [password-manager-service]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "password-manager-service",
 		Interface: "password-manager-service",
 	}

--- a/interfaces/builtin/personal_files_test.go
+++ b/interfaces/builtin/personal_files_test.go
@@ -57,7 +57,7 @@ apps:
   plugs: [personal-files]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "personal-files",
 		Interface: "personal-files",
 	}

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&ProcessControlInterfaceSuite{
 
 func (s *ProcessControlInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "process-control",
 		Interface: "process-control",
 	}

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -52,7 +52,7 @@ apps:
     plugs: [removable-media]
 `, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "removable-media",
 		Interface: "removable-media",
 	}

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [screen-inhibit-control]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "screen-inhibit-control",
 		Interface: "screen-inhibit-control",
 	}

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -54,7 +54,7 @@ apps:
 	s.plugInfo = consumingSnapInfo.Plugs["shutdown"]
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "shutdown",
 		Interface: "shutdown",
 	}

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -52,7 +52,7 @@ apps:
     plugs: [snapd-control]
 `, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "snapd-control",
 		Interface: "snapd-control",
 	}

--- a/interfaces/builtin/system_files_test.go
+++ b/interfaces/builtin/system_files_test.go
@@ -57,7 +57,7 @@ apps:
   plugs: [system-files]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "system-files",
 		Interface: "system-files",
 	}
@@ -163,7 +163,7 @@ apps:
   plugs: [system-files]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "system-files",
 		Interface: "system-files",
 	}

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&SystemObserveInterfaceSuite{
 
 func (s *SystemObserveInterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "system-observe",
 		Interface: "system-observe",
 	}

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [system-trace]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "system-trace",
 		Interface: "system-trace",
 	}

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [timeserver-control]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "timeserver-control",
 		Interface: "timeserver-control",
 	}

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -51,7 +51,7 @@ apps:
   plugs: [timezone-control]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "timezone-control",
 		Interface: "timezone-control",
 	}

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -54,7 +54,7 @@ apps:
 	s.plugInfo = snapInfo.Plugs["ubuntu-download-manager"]
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "ubuntu-download-manager",
 		Interface: "ubuntu-download-manager",
 	}

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -53,7 +53,7 @@ apps:
 
 func (s *Unity7InterfaceSuite) SetUpTest(c *C) {
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "unity7",
 		Interface: "unity7",
 	}

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -62,7 +62,7 @@ apps:
   plugs: [unity8-calendar]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "unity8-calendar",
 		Interface: "unity8-calendar",
 	}

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -63,7 +63,7 @@ apps:
   slots: [unity8-contacts]
 `
 	s.slotInfo = &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "unity8-contacts",
 		Interface: "unity8-contacts",
 	}

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -76,7 +76,7 @@ func plugAppLabelExpr(plug *interfaces.ConnectedPlug) string {
 
 // sanitizeSlotReservedForOS checks if slot is of type os.
 func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *snap.SlotInfo) error {
-	if slot.Snap.Type != snap.TypeOS && slot.Snap.InstanceName() != "snapd" {
+	if slot.Snap.GetType() != snap.TypeOS && slot.Snap.InstanceName() != "snapd" {
 		return fmt.Errorf("%s slots are reserved for the core snap", iface.Name())
 	}
 	return nil
@@ -84,7 +84,7 @@ func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *snap.SlotInfo) 
 
 // sanitizeSlotReservedForOSOrGadget checks if the slot is of type os or gadget.
 func sanitizeSlotReservedForOSOrGadget(iface interfaces.Interface, slot *snap.SlotInfo) error {
-	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeGadget && slot.Snap.InstanceName() != "snapd" {
+	if slot.Snap.GetType() != snap.TypeOS && slot.Snap.GetType() != snap.TypeGadget && slot.Snap.InstanceName() != "snapd" {
 		return fmt.Errorf("%s slots are reserved for the core and gadget snaps", iface.Name())
 	}
 	return nil
@@ -92,7 +92,7 @@ func sanitizeSlotReservedForOSOrGadget(iface interfaces.Interface, slot *snap.Sl
 
 // sanitizeSlotReservedForOSOrApp checks if the slot is of type os or app.
 func sanitizeSlotReservedForOSOrApp(iface interfaces.Interface, slot *snap.SlotInfo) error {
-	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeApp {
+	if slot.Snap.GetType() != snap.TypeOS && slot.Snap.GetType() != snap.TypeApp {
 		return fmt.Errorf("%s slots are reserved for the core and app snaps", iface.Name())
 	}
 	return nil
@@ -105,7 +105,7 @@ func sanitizeSlotReservedForOSOrApp(iface interfaces.Interface, slot *snap.SlotI
 // - slot owned by application snap typically requires rules update
 func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 	if release.OnClassic &&
-		(slot.Snap.Type == snap.TypeOS || slot.Snap.Type == snap.TypeSnapd) {
+		(slot.Snap.GetType() == snap.TypeOS || slot.Snap.GetType() == snap.TypeSnapd) {
 		return true
 	}
 	return false
@@ -115,7 +115,7 @@ func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 // as for isPermanentSlotSystemSlot() slot can be owned by app or system
 func implicitSystemConnectedSlot(slot *interfaces.ConnectedSlot) bool {
 	if release.OnClassic &&
-		(slot.Snap().Type == snap.TypeOS || slot.Snap().Type == snap.TypeSnapd) {
+		(slot.Snap().GetType() == snap.TypeOS || slot.Snap().GetType() == snap.TypeSnapd) {
 		return true
 	}
 	return false

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -44,13 +44,13 @@ type utilsSuite struct {
 
 var _ = Suite(&utilsSuite{
 	iface:        &ifacetest.TestInterface{InterfaceName: "iface"},
-	slotOS:       &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeOS}},
-	slotApp:      &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeApp}},
-	slotSnapd:    &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeSnapd, SuggestedName: "snapd"}},
-	slotGadget:   &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeGadget}},
-	conSlotOS:    interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeOS}}, nil, nil),
-	conSlotSnapd: interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeSnapd}}, nil, nil),
-	conSlotApp:   interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeApp}}, nil, nil),
+	slotOS:       &snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeOS}},
+	slotApp:      &snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeApp}},
+	slotSnapd:    &snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeSnapd, SuggestedName: "snapd"}},
+	slotGadget:   &snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeGadget}},
+	conSlotOS:    interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeOS}}, nil, nil),
+	conSlotSnapd: interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeSnapd}}, nil, nil),
+	conSlotApp:   interfaces.NewConnectedSlot(&snap.SlotInfo{Snap: &snap.Info{SnapType: snap.TypeApp}}, nil, nil),
 })
 
 func (s *utilsSuite) TestSanitizeSlotReservedForOS(c *C) {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -47,7 +47,7 @@ func checkSnapType(snap *snap.Info, types []string) error {
 		return nil
 	}
 	snapID := snap.SnapID
-	s := string(snap.Type)
+	s := string(snap.GetType())
 	if s == "os" || snapIDSnapd(snapID) {
 		// we use "core" in the assertions and we need also to
 		// allow for the "snapd" snap

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1468,7 +1468,7 @@ func (s *RepositorySuite) TestConnectedFindsConnections(c *C) {
 // Connected uses the core snap if snap name is empty
 func (s *RepositorySuite) TestConnectedFindsCoreSnap(c *C) {
 	slot := &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
 		Name:      "slot",
 		Interface: "interface",
 	}
@@ -2116,7 +2116,7 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) {
 	repo, _, slotSnap := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
-	slotSnap.Type = snap.TypeOS
+	slotSnap.SnapType = snap.TypeOS
 
 	candidateSlots := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -141,7 +141,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 	kind := ""
 	var snapType snap.Type
 	var getName func(*asserts.Model) string
-	switch snapInfo.Type {
+	switch snapInfo.GetType() {
 	case snap.TypeGadget:
 		kind = "gadget"
 		snapType = snap.TypeGadget

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -304,7 +304,7 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithCore(c *C) {
 		Active:      true,
 		Sequence:    []*snap.SideInfo{sideInfo},
 		Current:     sideInfo.Revision,
-		SnapType:    string(snapInfo.Type),
+		SnapType:    string(snapInfo.GetType()),
 		InstanceKey: snapInfo.InstanceKey,
 	})
 	s.st.Unlock()
@@ -334,7 +334,7 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithSnapd(c *C) {
 		Active:      true,
 		Sequence:    []*snap.SideInfo{sideInfo},
 		Current:     sideInfo.Revision,
-		SnapType:    string(snapInfo.Type),
+		SnapType:    string(snapInfo.GetType()),
 		InstanceKey: snapInfo.InstanceKey,
 	})
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1631,7 +1631,7 @@ func (s *interfaceManagerSuite) mockSnapInstance(c *C, instanceName, yamlText st
 		Active:      true,
 		Sequence:    []*snap.SideInfo{sideInfo},
 		Current:     sideInfo.Revision,
-		SnapType:    string(snapInfo.Type),
+		SnapType:    string(snapInfo.GetType()),
 		InstanceKey: snapInfo.InstanceKey,
 	})
 	return snapInfo

--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -44,7 +44,7 @@ func addImplicitSlots(st *state.State, snapInfo *snap.Info) error {
 	// Implicit slots can be added to the special "snapd" snap or to snaps with
 	// type "os". Currently there are no other snaps that gain implicit
 	// interfaces.
-	if snapInfo.Type != snap.TypeOS && snapInfo.InstanceName() != "snapd" {
+	if snapInfo.GetType() != snap.TypeOS && snapInfo.InstanceName() != "snapd" {
 		return nil
 	}
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -566,7 +566,7 @@ func (s *mgrsSuite) mockStore(c *C) *httptest.Server {
 		hit = strings.Replace(hit, "@ICON@", baseURL.String()+"/icon", -1)
 		hit = strings.Replace(hit, "@VERSION@", info.Version, -1)
 		hit = strings.Replace(hit, "@REVISION@", revno, -1)
-		hit = strings.Replace(hit, `@TYPE@`, string(info.Type), -1)
+		hit = strings.Replace(hit, `@TYPE@`, string(info.GetType()), -1)
 		hit = strings.Replace(hit, `@EPOCH@`, string(epochBuf), -1)
 		return hit
 	}

--- a/overlord/patch/patch1.go
+++ b/overlord/patch/patch1.go
@@ -56,7 +56,7 @@ var patch1ReadType = func(name string, rev snap.Revision) (snap.Type, error) {
 		return snap.TypeApp, err
 	}
 
-	return info.Type, nil
+	return info.GetType(), nil
 }
 
 type patch1Flags int

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -48,7 +48,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 			return
 		}
 		// XXX: this will also remove the snap from /var/lib/snapd/snaps
-		if e := b.RemoveSnapFiles(s, s.Type, meter); e != nil {
+		if e := b.RemoveSnapFiles(s, s.GetType(), meter); e != nil {
 			meter.Notify(fmt.Sprintf("while trying to clean up due to previous failure: %v", e))
 		}
 	}()
@@ -73,13 +73,13 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 		return snapType, err
 	}
 
-	if s.Type == snap.TypeKernel {
+	if s.GetType() == snap.TypeKernel {
 		if err := boot.ExtractKernelAssets(s, snapf); err != nil {
 			return snapType, fmt.Errorf("cannot install kernel: %s", err)
 		}
 	}
 
-	return s.Type, err
+	return s.GetType(), err
 }
 
 // RemoveSnapFiles removes the snap files from the disk after unmounting the snap.

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -225,7 +225,7 @@ func (f *fakeStore) snap(spec snapSpec, user *auth.UserState) (*snap.Info, error
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		Confinement: confinement,
-		Type:        typ,
+		SnapType:    typ,
 		Epoch:       epoch,
 	}
 	switch spec.Channel {
@@ -331,7 +331,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	}
 
 	info := &snap.Info{
-		Type: typ,
+		SnapType: typ,
 		SideInfo: snap.SideInfo{
 			RealName: name,
 			Channel:  cand.channel,
@@ -695,7 +695,7 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		SuggestedName: snapName,
 		SideInfo:      *si,
 		Architectures: []string{"all"},
-		Type:          snap.TypeApp,
+		SnapType:      snap.TypeApp,
 		Epoch:         snap.E("1*"),
 	}
 	if strings.Contains(snapName, "alias-snap") {
@@ -708,9 +708,9 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 	case "some-epoch-snap":
 		info.Epoch = snap.E("13")
 	case "gadget":
-		info.Type = snap.TypeGadget
+		info.SnapType = snap.TypeGadget
 	case "core":
-		info.Type = snap.TypeOS
+		info.SnapType = snap.TypeOS
 	case "services-snap":
 		var err error
 		// fix services after/before so that there is only one solution

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -264,7 +264,7 @@ func MockCheckSnapCallbacks(checks []CheckSnapCallback) (restore func()) {
 }
 
 func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
-	if snapInfo.Type != snap.TypeOS {
+	if snapInfo.GetType() != snap.TypeOS {
 		// not a relevant check
 		return nil
 	}
@@ -302,7 +302,7 @@ func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, d
 func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
 	kind := ""
 	var currentInfo func(*state.State) (*snap.Info, error)
-	switch snapInfo.Type {
+	switch snapInfo.GetType() {
 	case snap.TypeGadget:
 		kind = "gadget"
 		currentInfo = GadgetInfo
@@ -345,7 +345,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags Fl
 
 func checkBases(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
 	// check if this is relevant
-	if snapInfo.Type != snap.TypeApp && snapInfo.Type != snap.TypeGadget {
+	if snapInfo.GetType() != snap.TypeApp && snapInfo.GetType() != snap.TypeGadget {
 		return nil
 	}
 	if snapInfo.Base == "" {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1035,7 +1035,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	}
 
 	// record type
-	snapst.SetType(newInfo.Type)
+	snapst.SetType(newInfo.GetType())
 
 	// XXX: this block is slightly ugly, find a pattern when we have more examples
 	model, _ := ModelFromTask(t)
@@ -1105,7 +1105,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 
 	// Compatibility with old snapd: check if we have auto-connect task and
 	// if not, inject it after self (link-snap) for snaps that are not core
-	if newInfo.Type != snap.TypeOS {
+	if newInfo.GetType() != snap.TypeOS {
 		var hasAutoConnect, hasSetupProfiles bool
 		for _, other := range t.Change().Tasks() {
 			// Check if this is auto-connect task for same snap and we it's part of the change with setup-profiles task
@@ -1146,7 +1146,7 @@ func maybeRestart(t *state.Task, info *snap.Info) {
 	if release.OnClassic {
 		// ignore error here as we have no way to return to caller
 		snapdSnapInstalled, _ := isInstalled(st, "snapd")
-		if (info.Type == snap.TypeOS && !snapdSnapInstalled) ||
+		if (info.GetType() == snap.TypeOS && !snapdSnapInstalled) ||
 			info.InstanceName() == "snapd" {
 			t.Logf("Requested daemon restart.")
 			st.RequestRestart(state.RestartDaemon)
@@ -1310,7 +1310,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// snap. We need to undo that restart here. Instead of in
 	// doUnlinkCurrentSnap() like we usually do when going from
 	// core snap -> next core snap
-	if release.OnClassic && newInfo.Type == snap.TypeOS && oldCurrent.Unset() {
+	if release.OnClassic && newInfo.GetType() == snap.TypeOS && oldCurrent.Unset() {
 		t.Logf("Requested daemon restart (undo classic initial core install)")
 		st.RequestRestart(state.RestartDaemon)
 	}

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -957,7 +957,7 @@ func (s *linkSnapSuite) testDoUnlinkSnapRefreshAwareness(c *C) *state.Change {
 	// mock that "some-snap" has an app and that this app has pids running
 	writePids(c, filepath.Join(dirs.PidsCgroupDir, "snap.some-snap.some-app"), []int{1234})
 	snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
-		info := &snap.Info{SuggestedName: name, SideInfo: *si, Type: snap.TypeApp}
+		info := &snap.Info{SuggestedName: name, SideInfo: *si, SnapType: snap.TypeApp}
 		info.Apps = map[string]*snap.AppInfo{
 			"some-app": {Snap: info, Name: "some-app"},
 		}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -887,7 +887,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 		if name != "some-snap" {
 			return s.fakeBackend.ReadInfo(name, si)
 		}
-		info := &snap.Info{SuggestedName: name, SideInfo: *si, Type: snap.TypeApp}
+		info := &snap.Info{SuggestedName: name, SideInfo: *si, SnapType: snap.TypeApp}
 		info.Apps = map[string]*snap.AppInfo{
 			"app": {Snap: info, Name: "app"},
 		}
@@ -941,7 +941,7 @@ func (s snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 		if name != "some-snap" {
 			return s.fakeBackend.ReadInfo(name, si)
 		}
-		info := &snap.Info{SuggestedName: name, SideInfo: *si, Type: snap.TypeApp}
+		info := &snap.Info{SuggestedName: name, SideInfo: *si, SnapType: snap.TypeApp}
 		info.Apps = map[string]*snap.AppInfo{
 			"app": {Snap: info, Name: "app"},
 		}
@@ -1842,7 +1842,7 @@ func (s *snapmgrTestSuite) TestDoUpdateHadSlots(c *C) {
 
 		info := &snap.Info{
 			SideInfo: *si,
-			Type:     snap.TypeApp,
+			SnapType: snap.TypeApp,
 		}
 		info.Slots = map[string]*snap.SlotInfo{
 			"some-slot": {
@@ -10456,7 +10456,7 @@ func (s *snapmgrQuerySuite) TestTypeInfo(c *C) {
 		c.Check(info.InstanceName(), Equals, x.snapName)
 		c.Check(info.Revision, Equals, snap.R(2))
 		c.Check(info.Version, Equals, x.snapName)
-		c.Check(info.Type, Equals, x.snapType)
+		c.Check(info.GetType(), Equals, x.snapType)
 	}
 }
 
@@ -10514,7 +10514,7 @@ func (s *snapmgrQuerySuite) TestTypeInfoCore(c *C) {
 		} else {
 			c.Assert(info, NotNil)
 			c.Check(info.InstanceName(), Equals, t.expectedSnap, Commentf("(%d) test %q %v", testNr, t.expectedSnap, t.snapNames))
-			c.Check(info.Type, Equals, snap.TypeOS)
+			c.Check(info.GetType(), Equals, snap.TypeOS)
 		}
 	}
 }
@@ -10953,7 +10953,7 @@ func (s *canRemoveSuite) TearDownTest(c *C) {
 
 func (s *canRemoveSuite) TestAppAreAlwaysOKToRemove(c *C) {
 	info := &snap.Info{
-		Type: snap.TypeApp,
+		SnapType: snap.TypeApp,
 	}
 	info.RealName = "foo"
 
@@ -10963,7 +10963,7 @@ func (s *canRemoveSuite) TestAppAreAlwaysOKToRemove(c *C) {
 
 func (s *canRemoveSuite) TestLastGadgetsAreNotOK(c *C) {
 	info := &snap.Info{
-		Type: snap.TypeGadget,
+		SnapType: snap.TypeGadget,
 	}
 	info.RealName = "foo"
 
@@ -10972,11 +10972,11 @@ func (s *canRemoveSuite) TestLastGadgetsAreNotOK(c *C) {
 
 func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *C) {
 	os := &snap.Info{
-		Type: snap.TypeOS,
+		SnapType: snap.TypeOS,
 	}
 	os.RealName = "os"
 	kernel := &snap.Info{
-		Type: snap.TypeKernel,
+		SnapType: snap.TypeKernel,
 	}
 	// this kernel part of the model
 	kernel.RealName = "kernel"
@@ -10988,7 +10988,7 @@ func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *C) {
 
 func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *C) {
 	kernel := &snap.Info{
-		Type: snap.TypeKernel,
+		SnapType: snap.TypeKernel,
 		SideInfo: snap.SideInfo{
 			Revision: snap.R(3),
 		},
@@ -11005,7 +11005,7 @@ func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *C) {
 
 func (s *canRemoveSuite) TestOstInUseIsKept(c *C) {
 	base := &snap.Info{
-		Type: snap.TypeBase,
+		SnapType: snap.TypeBase,
 		SideInfo: snap.SideInfo{
 			Revision: snap.R(3),
 		},
@@ -11022,7 +11022,7 @@ func (s *canRemoveSuite) TestOstInUseIsKept(c *C) {
 
 func (s *canRemoveSuite) TestRemoveNonModelKernelIsOk(c *C) {
 	kernel := &snap.Info{
-		Type: snap.TypeKernel,
+		SnapType: snap.TypeKernel,
 	}
 	kernel.RealName = "other-non-model-kernel"
 
@@ -11031,7 +11031,7 @@ func (s *canRemoveSuite) TestRemoveNonModelKernelIsOk(c *C) {
 
 func (s *canRemoveSuite) TestRemoveNonModelKernelStillInUseNotOk(c *C) {
 	kernel := &snap.Info{
-		Type: snap.TypeKernel,
+		SnapType: snap.TypeKernel,
 		SideInfo: snap.SideInfo{
 			Revision: snap.R(2),
 		},
@@ -11051,7 +11051,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseIsOk(c *C) {
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: ModelWithBase("core18")}
 	os := &snap.Info{
-		Type: snap.TypeOS,
+		SnapType: snap.TypeOS,
 	}
 	os.RealName = "os"
 
@@ -11076,7 +11076,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUse(c *C) {
 
 	// now pretend we want to remove the core snap
 	os := &snap.Info{
-		Type: snap.TypeOS,
+		SnapType: snap.TypeOS,
 	}
 	os.RealName = "core"
 	c.Check(snapstate.CanRemove(s.st, os, &snapstate.SnapState{}, true, deviceCtx), Equals, false)
@@ -11084,7 +11084,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUse(c *C) {
 
 func (s *canRemoveSuite) TestOneRevisionIsOK(c *C) {
 	info := &snap.Info{
-		Type: snap.TypeGadget,
+		SnapType: snap.TypeGadget,
 	}
 	info.RealName = "foo"
 
@@ -11093,7 +11093,7 @@ func (s *canRemoveSuite) TestOneRevisionIsOK(c *C) {
 
 func (s *canRemoveSuite) TestRequiredIsNotOK(c *C) {
 	info := &snap.Info{
-		Type: snap.TypeApp,
+		SnapType: snap.TypeApp,
 	}
 	info.RealName = "foo"
 
@@ -11107,7 +11107,7 @@ func (s *canRemoveSuite) TestBaseUnused(c *C) {
 	defer s.st.Unlock()
 
 	info := &snap.Info{
-		Type: snap.TypeBase,
+		SnapType: snap.TypeBase,
 	}
 	info.RealName = "some-base"
 
@@ -11130,7 +11130,7 @@ func (s *canRemoveSuite) TestBaseInUse(c *C) {
 
 	// pretend now we want to remove "some-base"
 	info := &snap.Info{
-		Type: snap.TypeBase,
+		SnapType: snap.TypeBase,
 	}
 	info.RealName = "some-base"
 	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: true}, true, s.deviceCtx), Equals, false)
@@ -11155,7 +11155,7 @@ func (s *canRemoveSuite) TestBaseInUseOtherRevision(c *C) {
 
 	// pretend now we want to remove "some-base"
 	info := &snap.Info{
-		Type: snap.TypeBase,
+		SnapType: snap.TypeBase,
 	}
 	info.RealName = "some-base"
 	// revision 1 requires some-base
@@ -11163,7 +11163,7 @@ func (s *canRemoveSuite) TestBaseInUseOtherRevision(c *C) {
 
 	// now pretend we want to remove the core snap
 	os := &snap.Info{
-		Type: snap.TypeOS,
+		SnapType: snap.TypeOS,
 	}
 	os.RealName = "core"
 	// but revision 2 requires core
@@ -14386,7 +14386,7 @@ func (s *canDisableSuite) TestCanDisable(c *C) {
 		{snap.TypeKernel, false},
 		{snap.TypeOS, false},
 	} {
-		info := &snap.Info{Type: tt.typ}
+		info := &snap.Info{SnapType: tt.typ}
 		c.Check(snapstate.CanDisable(info), Equals, tt.canDisable)
 	}
 }

--- a/snap/broken.go
+++ b/snap/broken.go
@@ -78,7 +78,7 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 // was not validated before.  To avoid a flag day and any potential issues,
 // transparently rename the two clashing plugs by appending the "-plug" suffix.
 func (info *Info) renameClashingCorePlugs() {
-	if info.InstanceName() == "core" && info.Type == TypeOS {
+	if info.InstanceName() == "core" && info.GetType() == TypeOS {
 		for _, plugName := range []string{"network-bind", "core-support"} {
 			info.forceRenamePlug(plugName, plugName+"-plug")
 		}

--- a/snap/gadget.go
+++ b/snap/gadget.go
@@ -31,7 +31,7 @@ import (
 func ReadGadgetInfo(info *Info, classic bool) (*gadget.Info, error) {
 	const errorFormat = "cannot read gadget snap details: %s"
 
-	if info.Type != TypeGadget {
+	if info.GetType() != TypeGadget {
 		return nil, fmt.Errorf(errorFormat, "not a gadget snap")
 	}
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -203,7 +203,7 @@ type Info struct {
 	SuggestedName string
 	InstanceKey   string
 	Version       string
-	Type          Type
+	SnapType      Type
 	Architectures []string
 	Assumes       []string
 
@@ -355,6 +355,10 @@ func (s *Info) Description() string {
 		return s.EditedDescription
 	}
 	return s.OriginalDescription
+}
+
+func (s *Info) GetType() Type {
+	return s.SnapType
 }
 
 // MountDir returns the base directory of the snap where it gets mounted.
@@ -1156,7 +1160,7 @@ type ByType []*Info
 func (r ByType) Len() int      { return len(r) }
 func (r ByType) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
 func (r ByType) Less(i, j int) bool {
-	return r[i].Type.SortsBefore(r[j].Type)
+	return r[i].GetType().SortsBefore(r[j].GetType())
 }
 
 func SortServices(apps []*AppInfo) (sorted []*AppInfo, err error) {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -259,7 +259,7 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 	snap := &Info{
 		SuggestedName:       y.Name,
 		Version:             y.Version,
-		Type:                typ,
+		SnapType:            typ,
 		Architectures:       architectures,
 		Assumes:             y.Assumes,
 		OriginalTitle:       y.Title,

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -61,7 +61,7 @@ func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(info.InstanceName(), Equals, "foo")
 	c.Assert(info.Version, Equals, "1.0")
-	c.Assert(info.Type, Equals, snap.TypeApp)
+	c.Assert(info.GetType(), Equals, snap.TypeApp)
 	c.Assert(info.Epoch, DeepEquals, snap.E("0"))
 }
 
@@ -71,7 +71,7 @@ version: 1.0`))
 	c.Assert(err, IsNil)
 	c.Assert(info.InstanceName(), Equals, "snapd")
 	c.Assert(info.Version, Equals, "1.0")
-	c.Assert(info.Type, Equals, snap.TypeSnapd)
+	c.Assert(info.GetType(), Equals, snap.TypeSnapd)
 }
 
 func (s *InfoSnapYamlTestSuite) TestFail(c *C) {
@@ -1203,7 +1203,7 @@ slots:
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.2")
-	c.Check(info.Type, Equals, snap.TypeApp)
+	c.Check(info.GetType(), Equals, snap.TypeApp)
 	c.Check(info.Epoch, DeepEquals, snap.E("1*"))
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.Title(), Equals, "Foo")
@@ -1336,7 +1336,7 @@ version: 1.0
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
-	c.Assert(info.Type, Equals, snap.TypeApp)
+	c.Assert(info.GetType(), Equals, snap.TypeApp)
 }
 
 func (s *YamlSuite) TestSnapYamlEpochDefault(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -399,7 +399,7 @@ confinement: devmode`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.Type, Equals, snap.TypeApp)
+	c.Check(info.GetType(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
 	c.Check(info.Epoch.String(), Equals, "1*")
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
@@ -421,7 +421,7 @@ confinement: classic`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.Type, Equals, snap.TypeApp)
+	c.Check(info.GetType(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
 	c.Check(info.Confinement, Equals, snap.ClassicConfinement)
 	c.Check(info.NeedsDevMode(), Equals, false)
@@ -441,7 +441,7 @@ type: app`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.Type, Equals, snap.TypeApp)
+	c.Check(info.GetType(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
 	c.Check(info.Epoch.String(), Equals, "0") // Defaults to 0
 	c.Check(info.Confinement, Equals, snap.StrictConfinement)
@@ -464,7 +464,7 @@ type: app`
 	c.Assert(err, IsNil)
 	c.Check(info.InstanceName(), Equals, "baz")
 	c.Check(info.Version, Equals, "1.0")
-	c.Check(info.Type, Equals, snap.TypeApp)
+	c.Check(info.GetType(), Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(42))
 }
 
@@ -1529,39 +1529,39 @@ func (s *infoSuite) TestDirAndFileHelpers(c *C) {
 
 func (s *infoSuite) TestSortByType(c *C) {
 	infos := []*snap.Info{
-		{SuggestedName: "app1", Type: "app"},
-		{SuggestedName: "os1", Type: "os"},
-		{SuggestedName: "base1", Type: "base"},
-		{SuggestedName: "gadget1", Type: "gadget"},
-		{SuggestedName: "kernel1", Type: "kernel"},
-		{SuggestedName: "app2", Type: "app"},
-		{SuggestedName: "os2", Type: "os"},
-		{SuggestedName: "snapd", Type: "snapd"},
-		{SuggestedName: "base2", Type: "base"},
-		{SuggestedName: "gadget2", Type: "gadget"},
-		{SuggestedName: "kernel2", Type: "kernel"},
+		{SuggestedName: "app1", SnapType: "app"},
+		{SuggestedName: "os1", SnapType: "os"},
+		{SuggestedName: "base1", SnapType: "base"},
+		{SuggestedName: "gadget1", SnapType: "gadget"},
+		{SuggestedName: "kernel1", SnapType: "kernel"},
+		{SuggestedName: "app2", SnapType: "app"},
+		{SuggestedName: "os2", SnapType: "os"},
+		{SuggestedName: "snapd", SnapType: "snapd"},
+		{SuggestedName: "base2", SnapType: "base"},
+		{SuggestedName: "gadget2", SnapType: "gadget"},
+		{SuggestedName: "kernel2", SnapType: "kernel"},
 	}
 	sort.Stable(snap.ByType(infos))
 
 	c.Check(infos, DeepEquals, []*snap.Info{
-		{SuggestedName: "snapd", Type: "snapd"},
-		{SuggestedName: "os1", Type: "os"},
-		{SuggestedName: "os2", Type: "os"},
-		{SuggestedName: "kernel1", Type: "kernel"},
-		{SuggestedName: "kernel2", Type: "kernel"},
-		{SuggestedName: "base1", Type: "base"},
-		{SuggestedName: "base2", Type: "base"},
-		{SuggestedName: "gadget1", Type: "gadget"},
-		{SuggestedName: "gadget2", Type: "gadget"},
-		{SuggestedName: "app1", Type: "app"},
-		{SuggestedName: "app2", Type: "app"},
+		{SuggestedName: "snapd", SnapType: "snapd"},
+		{SuggestedName: "os1", SnapType: "os"},
+		{SuggestedName: "os2", SnapType: "os"},
+		{SuggestedName: "kernel1", SnapType: "kernel"},
+		{SuggestedName: "kernel2", SnapType: "kernel"},
+		{SuggestedName: "base1", SnapType: "base"},
+		{SuggestedName: "base2", SnapType: "base"},
+		{SuggestedName: "gadget1", SnapType: "gadget"},
+		{SuggestedName: "gadget2", SnapType: "gadget"},
+		{SuggestedName: "app1", SnapType: "app"},
+		{SuggestedName: "app2", SnapType: "app"},
 	})
 }
 
 func (s *infoSuite) TestSortByTypeAgain(c *C) {
-	core := &snap.Info{Type: snap.TypeOS}
-	base := &snap.Info{Type: snap.TypeBase}
-	app := &snap.Info{Type: snap.TypeApp}
+	core := &snap.Info{SnapType: snap.TypeOS}
+	base := &snap.Info{SnapType: snap.TypeBase}
+	app := &snap.Info{SnapType: snap.TypeApp}
 	snapd := &snap.Info{}
 	snapd.SideInfo = snap.SideInfo{RealName: "snapd"}
 

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -183,7 +183,7 @@ func Snap(sourceDir, targetDir, snapName string) (string, error) {
 
 	snapName = snapPath(info, targetDir, snapName)
 	d := squashfs.New(snapName)
-	if err = d.Build(sourceDir, string(info.Type), excludes); err != nil {
+	if err = d.Build(sourceDir, string(info.GetType()), excludes); err != nil {
 		return "", err
 	}
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -357,9 +357,9 @@ func Validate(info *Info) error {
 // ValidateBase validates the base field.
 func ValidateBase(info *Info) error {
 	// validate that bases do not have base fields
-	if info.Type == TypeOS || info.Type == TypeBase {
+	if info.GetType() == TypeOS || info.GetType() == TypeBase {
 		if info.Base != "" && info.Base != "none" {
-			return fmt.Errorf(`cannot have "base" field on %q snap %q`, info.Type, info.InstanceName())
+			return fmt.Errorf(`cannot have "base" field on %q snap %q`, info.GetType(), info.InstanceName())
 		}
 	}
 

--- a/store/details.go
+++ b/store/details.go
@@ -71,7 +71,7 @@ type snapDetails struct {
 func infoFromRemote(d *snapDetails) *snap.Info {
 	info := &snap.Info{}
 	info.Architectures = d.Architectures
-	info.Type = d.Type
+	info.SnapType = d.Type
 	info.Version = d.Version
 	info.RealName = d.Name
 	info.SnapID = d.SnapID

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -233,7 +233,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.Private = d.Private
 	info.Contact = d.Contact
 	info.Architectures = d.Architectures
-	info.Type = d.Type
+	info.SnapType = d.Type
 	info.Version = d.Version
 	info.Epoch = d.Epoch
 	info.Confinement = snap.ConfinementType(d.Confinement)

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -164,7 +164,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
 			Paid:              false,
 		},
 		Epoch:       snap.E("0"),
-		Type:        snap.TypeOS,
+		SnapType:    snap.TypeOS,
 		Version:     "16-2.30",
 		Confinement: snap.StrictConfinement,
 		Publisher: snap.StoreAccount{
@@ -215,7 +215,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			Read:  []uint32{0, 1},
 			Write: []uint32{1},
 		},
-		Type:        snap.TypeApp,
+		SnapType:    snap.TypeApp,
 		Version:     "9.50",
 		Confinement: snap.StrictConfinement,
 		License:     "Proprietary",

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -229,7 +229,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 		Digest:      snapDigest,
 		Size:        size,
 		Confinement: string(info.Confinement),
-		Type:        string(info.Type),
+		Type:        string(info.GetType()),
 	}, nil
 }
 


### PR DESCRIPTION
Introduce GetType() function for snap.Info and rename Info.Type to SnapType to catch all cases where Type is read (or compared). 

This is preparation for "snapd" type handling where GetType() will remap the type for snapd based on SnapID. In further PRs we may rename GetType() to Type().