### PR TITLE
daemon: increase `shutdownTimeout` to 25s to deal with slow HW

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -427,7 +427,7 @@ func (d *Daemon) addRoutes() {
 }
 
 var (
-	shutdownTimeout = 5 * time.Second
+	shutdownTimeout = 25 * time.Second
 )
 
 // shutdownServer supplements a http.Server with graceful shutdown.
@@ -667,7 +667,15 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 
 	err := d.tomb.Wait()
 	if err != nil {
-		return err
+		// do not stop the shutdown even if the tomb errors
+		// because we already scheduled a slow shutdown and
+		// exiting here will just restart snapd (via systemd)
+		// which will lead to confusing results.
+		if restartSystem {
+			logger.Noticef("WARNING: cannot stop daemon: %v", err)
+		} else {
+			return err
+		}
 	}
 
 	if restartSystem {


### PR DESCRIPTION
We got a bugreport from a customer that they get core refresh
errors. We see the following error in the journal:
```
cannot gracefully finish, still active connections...
```

This indicates that the HW is just too slow to deal with this
in the 5s timeout. This means that snapd does not exit cleanly
and systemd will restart it. This will mean that snapd gets
to WaitRestart() again and assumes a system restart has happend
(but only snapd was restarted). This leads to an abort of the
install as it looks (for snapd) like there was a rollback during
the reboot because the core revision has not changed.

There are multiple issues here that needs addressing. The first
one is that the timeout needs to be bigger and that it should
not be an error but a warning. The error in this situation will
not stop the shutdown so the still-connected client do not
benefit and the side-effect of the unclean exit is undesired.

So this PR increases the timeout and turns the error into a
warning.
