### PR TITLE
many: fix some races and missing locking, make sure UDevMonitor is stopped

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -547,6 +547,8 @@ func (d *Daemon) Start() {
 			d.restartSystem = true
 			d.tomb.Kill(nil)
 		case state.RestartSocket:
+			d.mu.Lock()
+			defer d.mu.Unlock()
 			d.restartSocket = true
 			d.tomb.Kill(nil)
 		default:

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -5344,12 +5344,13 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 
 	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
+	s.o.AddManager(mgr)
 
 	// succesfull initialization should result in exactly 1 connect and run call
 	for i := 0; i < 5; i++ {
-		c.Assert(mgr.Ensure(), IsNil)
+		c.Assert(s.se.Ensure(), IsNil)
 	}
-	mgr.Stop()
+	s.se.Stop()
 
 	c.Assert(u.ConnectCalls, Equals, 1)
 	c.Assert(u.RunCalls, Equals, 1)
@@ -5382,24 +5383,25 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 
 	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
+	s.o.AddManager(mgr)
 
-	c.Assert(mgr.Ensure(), ErrorMatches, "Connect failed")
+	c.Assert(s.se.Ensure(), ErrorMatches, ".*Connect failed.*")
 	c.Assert(u.ConnectCalls, Equals, 1)
 	c.Assert(u.RunCalls, Equals, 0)
 	c.Assert(u.StopCalls, Equals, 0)
 
 	u.ConnectError = nil
 	u.RunError = fmt.Errorf("Run failed")
-	c.Assert(mgr.Ensure(), ErrorMatches, "Run failed")
+	c.Assert(s.se.Ensure(), ErrorMatches, ".*Run failed.*")
 	c.Assert(u.ConnectCalls, Equals, 2)
 	c.Assert(u.RunCalls, Equals, 1)
 	c.Assert(u.StopCalls, Equals, 0)
 	c.Assert(u.DisconnectCalls, Equals, 1)
 
 	u.RunError = nil
-	c.Assert(mgr.Ensure(), IsNil)
+	c.Assert(s.se.Ensure(), IsNil)
 
-	mgr.Stop()
+	s.se.Stop()
 
 	c.Assert(u.StopCalls, Equals, 1)
 }
@@ -5417,9 +5419,10 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 
 	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
+	s.o.AddManager(mgr)
 
 	for i := 0; i < 5; i++ {
-		c.Assert(mgr.Ensure(), IsNil)
+		c.Assert(s.se.Ensure(), IsNil)
 		c.Assert(udevMonitorCreated, Equals, false)
 	}
 
@@ -5437,7 +5440,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 	st.Unlock()
 
 	// and udev monitor is now created
-	c.Assert(mgr.Ensure(), IsNil)
+	c.Assert(s.se.Ensure(), IsNil)
 	c.Assert(udevMonitorCreated, Equals, true)
 }
 

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -332,7 +332,6 @@ func (o *Overlord) Loop() {
 
 func (o *Overlord) ensureDidRun() {
 	atomic.StoreInt32(&o.ensureRun, 1)
-
 }
 
 func (o *Overlord) CanStandby() bool {

--- a/overlord/standby/standby_test.go
+++ b/overlord/standby/standby_test.go
@@ -120,7 +120,7 @@ func (f opine) CanStandby() bool {
 
 func (s *standbySuite) TestStartChecks(c *C) {
 	n := 0
-	ch1 := make(chan struct{})
+	ch1 := make(chan bool, 1)
 	ch2 := make(chan struct{})
 
 	defer standby.MockStandbyWait(time.Millisecond)()
@@ -130,21 +130,19 @@ func (s *standbySuite) TestStartChecks(c *C) {
 		<-ch2
 	})()
 
-	opinion := false
 	m := standby.New(s.state)
 	m.AddOpinion(opine(func() bool {
-		<-ch1
+		opinion := <-ch1
 		return opinion
 	}))
 
 	m.Start()
-	ch1 <- struct{}{}
+	ch1 <- false
 	c.Check(n, Equals, 0)
-	ch1 <- struct{}{}
+	ch1 <- false
 	c.Check(n, Equals, 0)
 
-	opinion = true
-	ch1 <- struct{}{}
+	ch1 <- true
 	ch2 <- struct{}{}
 	c.Check(n, Equals, 1)
 

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -36,14 +36,20 @@ type StateManager interface {
 	Ensure() error
 }
 
-// StateWaiterStopper is implemented by StateManagers that have
-// running activities that can be waited or terminated.
-type StateWaiterStopper interface {
-	// Wait asks manager to wait for all running activities to finish.
+// StateWaiter is optionally implemented by StateManagers that have running
+// activities that can be waited.
+type StateWaiter interface {
+	// Wait asks manager to wait for all running activities to
+	// finish.
 	Wait()
+}
 
-	// Stop asks the manager to terminate all activities running concurrently.
-	// It must not return before these activities are finished.
+// StateStopper is optionally implemented by StateManagers that have
+// running activities that can be terminated.
+type StateStopper interface {
+	// Stop asks the manager to terminate all activities running
+	// concurrently.  It must not return before these activities
+	// are finished.
 	Stop()
 }
 
@@ -124,7 +130,7 @@ func (se *StateEngine) Wait() {
 		return
 	}
 	for _, m := range se.managers {
-		if waiter, ok := m.(StateWaiterStopper); ok {
+		if waiter, ok := m.(StateWaiter); ok {
 			waiter.Wait()
 		}
 	}
@@ -138,7 +144,7 @@ func (se *StateEngine) Stop() {
 		return
 	}
 	for _, m := range se.managers {
-		if stopper, ok := m.(StateWaiterStopper); ok {
+		if stopper, ok := m.(StateStopper); ok {
 			stopper.Stop()
 		}
 	}


### PR DESCRIPTION
To avoid the kind of confusion where we ended up with
InterfaceManager.Stop not being called, make StateStopper/StateWaiter
fully orthogonal.