### PR TITLE
interfaces/bluetooth-control: add mtk BT device node

### DIFF
--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -50,6 +50,9 @@ const bluetoothControlConnectedPlugAppArmor = `
 
   # Requires CONFIG_BT_VHCI to be loaded
   /dev/vhci                       rw,
+
+  # Device nodes for MTK combo driver
+  /dev/stpbt                      rw,
 `
 
 const bluetoothControlConnectedPlugSecComp = `


### PR DESCRIPTION
Extending allowed vevice nodes for bluetooth control as
some mtk drivers (mt7668) expose /dev/stpbt, /dev/stpbtfwlog device node
instead of usual /dev/vhci
