### PR TITLE
interfaces: spi: update regex rules to accept spi nodes like spidev12…

### DIFF
--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -55,7 +55,7 @@ func (iface *spiInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-var spiDevPattern = regexp.MustCompile("^/dev/spidev[0-9].[0-9]+$")
+var spiDevPattern = regexp.MustCompile(`^/dev/spidev[0-9]+\.[0-9]+$`)
 
 func (iface *spiInterface) path(slotRef *interfaces.SlotRef, attrs interfaces.Attrer) (string, error) {
 	var path string

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -96,6 +96,9 @@ slots:
   spi-2:
     interface: spi
     path: /dev/spidev0.1
+  spi-3:
+    interface: spi
+    path: /dev/spidev33566.0
   bad-spi-1:
     interface: spi
     path: /dev/spev0.0


### PR DESCRIPTION
…345.0

updating allowed spi device node names
There are platforms (Mediatek) where spi device node is not single digit
e.g. /dev/spidev34566.0
