### PR TITLE
cmd/snap, image: add --target-dir and --basename to 'snap download'

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -38,7 +38,7 @@ type cmdDownload struct {
 	channelMixin
 	Revision  string `long:"revision"`
 	Basename  string `long:"basename"`
-	TargetDir string `long:"target-dir"`
+	TargetDir string `long:"target-directory"`
 
 	CohortKey  string `long:"cohort"`
 	Positional struct {
@@ -61,9 +61,9 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"cohort": i18n.G("Download from the given cohort"),
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"basename": i18n.G("Use this basename for the snap and assertion (defaults to <snap>_<revision>)"),
+		"basename": i18n.G("Use this basename for the snap and assertion files (defaults to <snap>_<revision>)"),
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"target-dir": i18n.G("Download to this directory (defaults to the current directory)"),
+		"target-directory": i18n.G("Download to this directory (defaults to the current directory)"),
 	}), []argDesc{{
 		name: "<snap>",
 		// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -36,7 +36,9 @@ import (
 
 type cmdDownload struct {
 	channelMixin
-	Revision string `long:"revision"`
+	Revision  string `long:"revision"`
+	Basename  string `long:"basename"`
+	TargetDir string `long:"target-dir"`
 
 	CohortKey  string `long:"cohort"`
 	Positional struct {
@@ -58,6 +60,10 @@ func init() {
 		"revision": i18n.G("Download the given revision of a snap, to which you must have developer access"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"cohort": i18n.G("Download from the given cohort"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"basename": i18n.G("Use this basename for the snap and assertion (defaults to <snap>_<revision>)"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"target-dir": i18n.G("Download to this directory (defaults to the current directory)"),
 	}), []argDesc{{
 		name: "<snap>",
 		// TRANSLATORS: This should not start with a lowercase letter.
@@ -92,6 +98,9 @@ func fetchSnapAssertions(tsto *image.ToolingStore, snapPath string, snapInfo *sn
 }
 
 func (x *cmdDownload) Execute(args []string) error {
+	if strings.ContainsRune(x.Basename, filepath.Separator) {
+		return fmt.Errorf(i18n.G("cannot specify a path in basename (use --target-dir for that)"))
+	}
 	if err := x.setChannelFromCommandline(); err != nil {
 		return err
 	}
@@ -126,7 +135,8 @@ func (x *cmdDownload) Execute(args []string) error {
 
 	fmt.Fprintf(Stdout, i18n.G("Fetching snap %q\n"), snapName)
 	dlOpts := image.DownloadOptions{
-		TargetDir: "", // cwd
+		TargetDir: x.TargetDir,
+		Basename:  x.Basename,
 		Channel:   x.Channel,
 		CohortKey: x.CohortKey,
 		Revision:  revision,

--- a/cmd/snap/cmd_download_test.go
+++ b/cmd/snap/cmd_download_test.go
@@ -28,6 +28,14 @@ import (
 // these only cover errors that happen before hitting the network,
 // because we're not (yet!) mocking the tooling store
 
+func (s *SnapSuite) TestDownloadBadBasename(c *check.C) {
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{
+		"download", "--basename=/foo", "a-snap",
+	})
+
+	c.Check(err, check.ErrorMatches, "cannot specify a path in basename .use --target-dir for that.")
+}
+
 func (s *SnapSuite) TestDownloadBadChannelCombo(c *check.C) {
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{
 		"download", "--beta", "--channel=foo", "a-snap",

--- a/image/export_test.go
+++ b/image/export_test.go
@@ -53,4 +53,7 @@ func (opts *DownloadOptions) Validate() error {
 	return opts.validate()
 }
 
-var ErrRevisionAndCohort = errRevisionAndCohort
+var (
+	ErrRevisionAndCohort = errRevisionAndCohort
+	ErrPathInBase        = errPathInBase
+)

--- a/image/helpers_test.go
+++ b/image/helpers_test.go
@@ -34,18 +34,20 @@ import (
 func (s *imageSuite) TestDownloadOptionsString(c *check.C) {
 	for opts, str := range map[image.DownloadOptions]string{
 		{}:                     "",
-		{TargetDir: "foo"}:     `to "foo"`,
+		{TargetDir: "/foo"}:    `in "/foo"`,
+		{Basename: "foo"}:      `to "foo.snap"`,
 		{Channel: "foo"}:       `from channel "foo"`,
 		{Revision: snap.R(42)}: `(42)`,
 		{
 			CohortKey: "AbCdEfGhIjKlMnOpQrStUvWxYz",
 		}: `from cohort "…rStUvWxYz"`,
 		{
-			TargetDir: "foo",
-			Channel:   "bar",
+			TargetDir: "/foo",
+			Basename:  "bar",
+			Channel:   "baz",
 			Revision:  snap.R(13),
 			CohortKey: "MSBIc3dwOW9PemozYjRtdzhnY0MwMFh0eFduS0g5UWlDUSAxNTU1NDExNDE1IDBjYzJhNTc1ZjNjOTQ3ZDEwMWE1NTNjZWFkNmFmZDE3ZWJhYTYyNjM4ZWQ3ZGMzNjI5YmU4YjQ3NzAwMjdlMDk=",
-		}: `(13) from channel "bar" from cohort "…wMjdlMDk=" to "foo"`, // note this one is not 'valid' so it's ok if the string is a bit wonky
+		}: `(13) from channel "baz" from cohort "…wMjdlMDk=" to "bar.snap" in "/foo"`, // note this one is not 'valid' so it's ok if the string is a bit wonky
 	} {
 		c.Check(opts.String(), check.Equals, str)
 	}
@@ -72,6 +74,9 @@ func (s *imageSuite) TestDownloadOptionsValid(c *check.C) {
 			Revision:  snap.R(1),
 			CohortKey: "bar",
 		}: image.ErrRevisionAndCohort,
+		{
+			Basename: "/foo",
+		}: image.ErrPathInBase,
 	} {
 		c.Check(opts.Validate(), check.Equals, err)
 	}

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -48,6 +48,6 @@ execute: |
     MATCH 'cannot download snap.*: Invalid cohort key' < out
 
     echo "Snap download can specify basename and target directory"
-    snap download --target-dir=foo --basename=bar test-snapd-tools
+    snap download --target-directory=foo --basename=bar test-snapd-tools
     ls -l foo/bar.snap
     verify_asserts foo/bar.assert

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -47,3 +47,7 @@ execute: |
     not snap download --cohort="what" test-snapd-tools 2>out
     MATCH 'cannot download snap.*: Invalid cohort key' < out
 
+    echo "Snap download can specify basename and target directory"
+    snap download --target-dir=foo --basename=bar test-snapd-tools
+    ls -l foo/bar.snap
+    verify_asserts foo/bar.assert


### PR DESCRIPTION
For scripting, it's often convenient to construct the filename (or at
least the basename) of the snap to be downloaded in the script itself,
rather than deducing it from snap info, or 'snap download' output, or
from inspecting the current directory after the fact.

This introduces a Basename option to the tooling store, and exposes
it and the pre-existing TargetDir to 'snap download':

    --basename=           Use this basename for the snap and assertion files
                          (defaults to <snap>_<revision>)
    --target-directory=   Download to this directory (defaults to the current
                          directory)

HTH, HAND.