### PR TITLE
systemd: add InstanceMode enumeration to control which systemd instance to control

### DIFF
--- a/cmd/snapinfo.go
+++ b/cmd/snapinfo.go
@@ -127,7 +127,7 @@ func (a BySnapApp) Less(i, j int) bool {
 func ClientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) ([]client.AppInfo, error) {
 	// TODO: pass in an actual notifier here instead of null
 	//       (Status doesn't _need_ it, but benefits from it)
-	sysd := systemd.New(dirs.GlobalRootDir, progress.Null)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, progress.Null)
 
 	out := make([]client.AppInfo, 0, len(apps))
 	for _, app := range apps {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2316,7 +2316,7 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 		serviceNames[i] = appInfo.ServiceName()
 	}
 
-	sysd := systemd.New(dirs.GlobalRootDir, progress.Null)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, progress.Null)
 	reader, err := sysd.LogReader(serviceNames, n, follow)
 	if err != nil {
 		return InternalError("cannot get logs: %v", err)

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -69,7 +69,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 	}
 	glob := interfaces.InterfaceServiceName(snapName, "*")
 
-	systemd := sysd.New(dirs.GlobalRootDir, &dummyReporter{})
+	systemd := sysd.New(dirs.GlobalRootDir, sysd.SystemMode, &dummyReporter{})
 	// We need to be carefully here and stop all removed service units before
 	// we remove their files as otherwise systemd is not able to disable/stop
 	// them anymore.
@@ -100,7 +100,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 
 // Remove disables, stops and removes systemd services of a given snap.
 func (b *Backend) Remove(snapName string) error {
-	systemd := sysd.New(dirs.GlobalRootDir, &dummyReporter{})
+	systemd := sysd.New(dirs.GlobalRootDir, sysd.SystemMode, &dummyReporter{})
 	// Remove all the files matching snap glob
 	glob := interfaces.InterfaceServiceName(snapName, "*")
 	_, removed, errEnsure := osutil.EnsureDirState(dirs.SnapServicesDir, glob, nil)

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -52,7 +52,7 @@ func (l *sysdLogger) Notify(status string) {
 // switchDisableSSHService handles the special case of disabling/enabling ssh
 // service on core devices.
 func switchDisableSSHService(serviceName, value string) error {
-	sysd := systemd.New(dirs.GlobalRootDir, &sysdLogger{})
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, &sysdLogger{})
 	sshCanary := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_not_to_be_run")
 
 	switch value {
@@ -84,7 +84,7 @@ func switchDisableService(serviceName, value string) error {
 		return switchDisableSSHService(serviceName, value)
 	}
 
-	sysd := systemd.New(dirs.GlobalRootDir, &sysdLogger{})
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, &sysdLogger{})
 
 	switch value {
 	case "true":

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -30,12 +30,12 @@ func addMountUnit(s *snap.Info, meter progress.Meter) error {
 	squashfsPath := dirs.StripRootDir(s.MountFile())
 	whereDir := dirs.StripRootDir(s.MountDir())
 
-	sysd := systemd.New(dirs.GlobalRootDir, meter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, meter)
 	_, err := sysd.AddMountUnitFile(s.InstanceName(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
 	return err
 }
 
 func removeMountUnit(mountDir string, meter progress.Meter) error {
-	sysd := systemd.New(dirs.GlobalRootDir, meter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, meter)
 	return sysd.RemoveMountUnitFile(mountDir)
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -807,6 +807,21 @@ func (s *SystemdTestSuite) TestGlobalUserMode(c *C) {
 
 	c.Assert(sysd.Enable("foo"), IsNil)
 	c.Check(s.argses[0], DeepEquals, []string{"--user", "--global", "--root", rootDir, "enable", "foo"})
-	c.Assert(sysd.Start("foo"), IsNil)
-	c.Check(s.argses[1], DeepEquals, []string{"--user", "--global", "start", "foo"})
+	c.Assert(sysd.Disable("foo"), IsNil)
+	c.Check(s.argses[1], DeepEquals, []string{"--user", "--global", "--root", rootDir, "disable", "foo"})
+	c.Assert(sysd.Mask("foo"), IsNil)
+	c.Check(s.argses[2], DeepEquals, []string{"--user", "--global", "--root", rootDir, "mask", "foo"})
+	c.Assert(sysd.Unmask("foo"), IsNil)
+	c.Check(s.argses[3], DeepEquals, []string{"--user", "--global", "--root", rootDir, "unmask", "foo"})
+
+	// Commands that don't make sense for GlobalUserMode panic
+	c.Check(sysd.DaemonReload, Panics, "cannot call daemon-reload with GlobalUserMode")
+	c.Check(func() { sysd.Start("foo") }, Panics, "cannot call start with GlobalUserMode")
+	c.Check(func() { sysd.StartNoBlock("foo") }, Panics, "cannot call start with GlobalUserMode")
+	c.Check(func() { sysd.Stop("foo", 0) }, Panics, "cannot call stop with GlobalUserMode")
+	c.Check(func() { sysd.Restart("foo", 0) }, Panics, "cannot call restart with GlobalUserMode")
+	c.Check(func() { sysd.Kill("foo", "HUP", "") }, Panics, "cannot call kill with GlobalUserMode")
+	c.Check(func() { sysd.Status("foo") }, Panics, "cannot call status with GlobalUserMode")
+	c.Check(func() { sysd.IsEnabled("foo") }, Panics, "cannot call is-enabled with GlobalUserMode")
+	c.Check(func() { sysd.IsActive("foo") }, Panics, "cannot call is-active with GlobalUserMode")
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -144,19 +144,19 @@ func (s *SystemdTestSuite) myJctl(svcs []string, n int, follow bool) (io.ReadClo
 }
 
 func (s *SystemdTestSuite) TestDaemonReload(c *C) {
-	err := New("", s.rep).DaemonReload()
+	err := New("", SystemMode, s.rep).DaemonReload()
 	c.Assert(err, IsNil)
 	c.Assert(s.argses, DeepEquals, [][]string{{"daemon-reload"}})
 }
 
 func (s *SystemdTestSuite) TestStart(c *C) {
-	err := New("", s.rep).Start("foo")
+	err := New("", SystemMode, s.rep).Start("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"start", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestStartMany(c *C) {
-	err := New("", s.rep).Start("foo", "bar", "baz")
+	err := New("", SystemMode, s.rep).Start("foo", "bar", "baz")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"start", "foo", "bar", "baz"}})
 }
@@ -171,7 +171,7 @@ func (s *SystemdTestSuite) TestStop(c *C) {
 		[]byte("ActiveState=inactive\n"),
 	}
 	s.errors = []error{nil, nil, nil, nil, &Timeout{}}
-	err := New("", s.rep).Stop("foo", 1*time.Second)
+	err := New("", SystemMode, s.rep).Stop("foo", 1*time.Second)
 	c.Assert(err, IsNil)
 	c.Assert(s.argses, HasLen, 4)
 	c.Check(s.argses[0], DeepEquals, []string{"stop", "foo"})
@@ -209,7 +209,7 @@ UnitFileState=disabled
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service", "bar.service", "baz.service", "some.timer", "other.socket")
+	out, err := New("", SystemMode, s.rep).Status("foo.service", "bar.service", "baz.service", "some.timer", "other.socket")
 	c.Assert(err, IsNil)
 	c.Check(out, DeepEquals, []*UnitStatus{
 		{
@@ -259,7 +259,7 @@ UnitFileState=enabled
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Check(err, ErrorMatches, "cannot get unit status: expected 1 results, got 2")
 	c.Check(out, IsNil)
 	c.Check(s.rep.msgs, IsNil)
@@ -276,7 +276,7 @@ Potatoes
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Assert(err, ErrorMatches, `.* bad line "Potatoes" .*`)
 	c.Check(out, IsNil)
 }
@@ -291,7 +291,7 @@ UnitFileState=enabled
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Assert(err, ErrorMatches, `.* queried status of "foo.service" but got status of "bar.service"`)
 	c.Check(out, IsNil)
 }
@@ -307,7 +307,7 @@ Potatoes=false
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Assert(err, ErrorMatches, `.* unexpected field "Potatoes" .*`)
 	c.Check(out, IsNil)
 }
@@ -320,7 +320,7 @@ ActiveState=active
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Assert(err, ErrorMatches, `.* missing UnitFileState, Type .*`)
 	c.Check(out, IsNil)
 }
@@ -333,7 +333,7 @@ ActiveState=active
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.timer")
+	out, err := New("", SystemMode, s.rep).Status("foo.timer")
 	c.Assert(err, ErrorMatches, `.* missing UnitFileState .*`)
 	c.Check(out, IsNil)
 }
@@ -349,7 +349,7 @@ UnitFileState=enabled
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Assert(err, ErrorMatches, `.* duplicate field "ActiveState" .*`)
 	c.Check(out, IsNil)
 }
@@ -364,7 +364,7 @@ UnitFileState=enabled
 `[1:]),
 	}
 	s.errors = []error{nil}
-	out, err := New("", s.rep).Status("foo.service")
+	out, err := New("", SystemMode, s.rep).Status("foo.service")
 	c.Assert(err, ErrorMatches, `.* empty field "Id" .*`)
 	c.Check(out, IsNil)
 }
@@ -372,14 +372,14 @@ UnitFileState=enabled
 func (s *SystemdTestSuite) TestStopTimeout(c *C) {
 	restore := MockStopDelays(time.Millisecond, 25*time.Second)
 	defer restore()
-	err := New("", s.rep).Stop("foo", 10*time.Millisecond)
+	err := New("", SystemMode, s.rep).Stop("foo", 10*time.Millisecond)
 	c.Assert(err, FitsTypeOf, &Timeout{})
 	c.Assert(len(s.rep.msgs) > 0, Equals, true)
 	c.Check(s.rep.msgs[0], Equals, "Waiting for foo to stop.")
 }
 
 func (s *SystemdTestSuite) TestDisable(c *C) {
-	err := New("xyzzy", s.rep).Disable("foo")
+	err := New("xyzzy", SystemMode, s.rep).Disable("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "disable", "foo"}})
 }
@@ -391,19 +391,19 @@ func (s *SystemdTestSuite) TestAvailable(c *C) {
 }
 
 func (s *SystemdTestSuite) TestEnable(c *C) {
-	err := New("xyzzy", s.rep).Enable("foo")
+	err := New("xyzzy", SystemMode, s.rep).Enable("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "enable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestMask(c *C) {
-	err := New("xyzzy", s.rep).Mask("foo")
+	err := New("xyzzy", SystemMode, s.rep).Mask("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "mask", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestUnmask(c *C) {
-	err := New("xyzzy", s.rep).Unmask("foo")
+	err := New("xyzzy", SystemMode, s.rep).Unmask("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "unmask", "foo"}})
 }
@@ -417,7 +417,7 @@ func (s *SystemdTestSuite) TestRestart(c *C) {
 		nil, // for the "start"
 	}
 	s.errors = []error{nil, nil, nil, nil, &Timeout{}}
-	err := New("", s.rep).Restart("foo", 100*time.Millisecond)
+	err := New("", SystemMode, s.rep).Restart("foo", 100*time.Millisecond)
 	c.Assert(err, IsNil)
 	c.Check(s.argses, HasLen, 3)
 	c.Check(s.argses[0], DeepEquals, []string{"stop", "foo"})
@@ -426,7 +426,7 @@ func (s *SystemdTestSuite) TestRestart(c *C) {
 }
 
 func (s *SystemdTestSuite) TestKill(c *C) {
-	c.Assert(New("", s.rep).Kill("foo", "HUP", ""), IsNil)
+	c.Assert(New("", SystemMode, s.rep).Kill("foo", "HUP", ""), IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"kill", "foo", "-s", "HUP", "--kill-who=all"}})
 }
 
@@ -438,7 +438,7 @@ func (s *SystemdTestSuite) TestIsTimeout(c *C) {
 func (s *SystemdTestSuite) TestLogErrJctl(c *C) {
 	s.jerrs = []error{&Timeout{}}
 
-	reader, err := New("", s.rep).LogReader([]string{"foo"}, 24, false)
+	reader, err := New("", SystemMode, s.rep).LogReader([]string{"foo"}, 24, false)
 	c.Check(err, NotNil)
 	c.Check(reader, IsNil)
 	c.Check(s.jns, DeepEquals, []string{"24"})
@@ -453,7 +453,7 @@ func (s *SystemdTestSuite) TestLogs(c *C) {
 `
 	s.jouts = [][]byte{[]byte(expected)}
 
-	reader, err := New("", s.rep).LogReader([]string{"foo"}, 24, false)
+	reader, err := New("", SystemMode, s.rep).LogReader([]string{"foo"}, 24, false)
 	c.Check(err, IsNil)
 	logs, err := ioutil.ReadAll(reader)
 	c.Assert(err, IsNil)
@@ -511,7 +511,7 @@ func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := New(rootDir, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(rootDir, SystemMode, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -543,7 +543,7 @@ func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := New("", nil).AddMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
+	mountUnitName, err := New("", SystemMode, nil).AddMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -581,7 +581,7 @@ func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New("", SystemMode, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -623,7 +623,7 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New("", SystemMode, nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -661,7 +661,7 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New("", SystemMode, nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -707,7 +707,7 @@ func (s *SystemdTestSuite) TestIsActiveIsInactive(c *C) {
 	sysErr.SetMsg([]byte("inactive\n"))
 	s.errors = []error{sysErr}
 
-	active, err := New("xyzzy", s.rep).IsActive("foo")
+	active, err := New("xyzzy", SystemMode, s.rep).IsActive("foo")
 	c.Assert(active, Equals, false)
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "is-active", "foo"}})
@@ -716,7 +716,7 @@ func (s *SystemdTestSuite) TestIsActiveIsInactive(c *C) {
 func (s *SystemdTestSuite) TestIsActiveIsActive(c *C) {
 	s.errors = []error{nil}
 
-	active, err := New("xyzzy", s.rep).IsActive("foo")
+	active, err := New("xyzzy", SystemMode, s.rep).IsActive("foo")
 	c.Assert(active, Equals, true)
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "is-active", "foo"}})
@@ -728,7 +728,7 @@ func (s *SystemdTestSuite) TestIsActiveErr(c *C) {
 	sysErr.SetMsg([]byte("random-failure\n"))
 	s.errors = []error{sysErr}
 
-	active, err := New("xyzzy", s.rep).IsActive("foo")
+	active, err := New("xyzzy", SystemMode, s.rep).IsActive("foo")
 	c.Assert(active, Equals, false)
 	c.Assert(err, ErrorMatches, ".* failed with exit status 1: random-failure\n")
 }
@@ -746,7 +746,7 @@ func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
 
 	mountDir := rootDir + "/snap/foo/42"
 	mountUnit := makeMockMountUnit(c, mountDir)
-	err := New(rootDir, nil).RemoveMountUnitFile(mountDir)
+	err := New(rootDir, SystemMode, nil).RemoveMountUnitFile(mountDir)
 
 	c.Assert(err, IsNil)
 	// the file is gone
@@ -760,7 +760,7 @@ func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
 
 func (s *SystemdTestSuite) TestDaemonReloadMutex(c *C) {
 	rootDir := dirs.GlobalRootDir
-	sysd := New(rootDir, nil)
+	sysd := New(rootDir, SystemMode, nil)
 
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
@@ -789,4 +789,24 @@ func (s *SystemdTestSuite) TestDaemonReloadMutex(c *C) {
 	c.Assert(err, IsNil)
 	close(stopCh)
 	<-stoppedCh
+}
+
+func (s *SystemdTestSuite) TestUserMode(c *C) {
+	rootDir := dirs.GlobalRootDir
+	sysd := New(rootDir, UserMode, nil)
+
+	c.Assert(sysd.Enable("foo"), IsNil)
+	c.Check(s.argses[0], DeepEquals, []string{"--user", "--root", rootDir, "enable", "foo"})
+	c.Assert(sysd.Start("foo"), IsNil)
+	c.Check(s.argses[1], DeepEquals, []string{"--user", "start", "foo"})
+}
+
+func (s *SystemdTestSuite) TestGlobalUserMode(c *C) {
+	rootDir := dirs.GlobalRootDir
+	sysd := New(rootDir, GlobalUserMode, nil)
+
+	c.Assert(sysd.Enable("foo"), IsNil)
+	c.Check(s.argses[0], DeepEquals, []string{"--user", "--global", "--root", rootDir, "enable", "foo"})
+	c.Assert(sysd.Start("foo"), IsNil)
+	c.Check(s.argses[1], DeepEquals, []string{"--user", "--global", "start", "foo"})
 }

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -89,7 +89,7 @@ func writeSnapdServicesOnCore(s *snap.Info, inter interacter) error {
 	if release.OnClassic {
 		return nil
 	}
-	sysd := systemd.New(dirs.GlobalRootDir, inter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)
 
 	if err := writeSnapdToolingMountUnit(sysd, s.MountDir()); err != nil {
 		return err

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -103,7 +103,7 @@ func stopService(sysd systemd.Systemd, app *snap.AppInfo, inter interacter) erro
 // are services. Service units will be started in the order provided by the
 // caller.
 func StartServices(apps []*snap.AppInfo, inter interacter, tm timings.Measurer) (err error) {
-	sysd := systemd.New(dirs.GlobalRootDir, inter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)
 
 	services := make([]string, 0, len(apps))
 	for _, app := range apps {
@@ -204,7 +204,7 @@ func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 		return writeSnapdServicesOnCore(s, inter)
 	}
 
-	sysd := systemd.New(dirs.GlobalRootDir, inter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)
 	var written []string
 	var enabled []string
 	defer func() {
@@ -294,7 +294,7 @@ func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 
 // StopServices stops service units for the applications from the snap which are services.
 func StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReason, inter interacter, tm timings.Measurer) error {
-	sysd := systemd.New(dirs.GlobalRootDir, inter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)
 
 	logger.Debugf("StopServices called for %q, reason: %v", apps, reason)
 	for _, app := range apps {
@@ -340,7 +340,7 @@ func StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReason, inter int
 
 // RemoveSnapServices disables and removes service units for the applications from the snap which are services.
 func RemoveSnapServices(s *snap.Info, inter interacter) error {
-	sysd := systemd.New(dirs.GlobalRootDir, inter)
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)
 	nservices := 0
 
 	for _, app := range s.Apps {


### PR DESCRIPTION
This has been split out from PR #6954.  On a desktop system, there will usually be multiple instances of systemd running: one system instance as pid 1, and one for each logged in user on the system.  All can be configured in roughly the same way through the `systemctl` command, so it seems reasonable to control them through the same Go API.

This PR adds an `InstanceMode` argument to `systemd.New`, taking one of the following arguments:

* `SystemMode`: this was previously the only mode offered by the API.
* `UserMode`: this controls the user mode systemd instance for the current user.
* `GlobalUserMode`: this edits configuration used by all user mode instances on the system.  As this doesn't control a single instance, some operations do not make sense and are caught with `panic()`.

`SystemMode` and `GlobalUserMode` are both useful within snapd, while `UserMode` will be useful within the user session agent (which runs in the context of the user, so is allowed to communicate with that user's systemd instance).