### PR TITLE
daemon: replace shutdownServer with net/http's native shutdown support

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -321,7 +321,7 @@ func (d *Daemon) Init() error {
 
 	// The SnapdSocket is required-- without it, die.
 	if listener, err := netutil.GetListener(dirs.SnapdSocket, listenerMap); err == nil {
-		d.snapdListener = &ucrednetListener{listener}
+		d.snapdListener = &ucrednetListener{Listener: listener}
 	} else {
 		return fmt.Errorf("when trying to listen on %s: %v", dirs.SnapdSocket, err)
 	}
@@ -329,7 +329,7 @@ func (d *Daemon) Init() error {
 	if listener, err := netutil.GetListener(dirs.SnapSocket, listenerMap); err == nil {
 		// This listener may also be nil if that socket wasn't among
 		// the listeners, so check it before using it.
-		d.snapListener = &ucrednetListener{listener}
+		d.snapListener = &ucrednetListener{Listener: listener}
 	} else {
 		logger.Debugf("cannot get listener for %q: %v", dirs.SnapSocket, err)
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -530,14 +530,16 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	})
 	st.Unlock()
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, check.IsNil)
+	l2, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, check.IsNil)
 
 	snapdAccept := make(chan struct{})
-	d.snapdListener = &witnessAcceptListener{Listener: l, accept: snapdAccept}
+	d.snapdListener = &witnessAcceptListener{Listener: l1, accept: snapdAccept}
 
 	snapAccept := make(chan struct{})
-	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
+	d.snapListener = &witnessAcceptListener{Listener: l2, accept: snapAccept}
 
 	d.Start()
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -980,16 +980,16 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *check.C) {
 	c.Check(d.restartSocket, check.Equals, false)
 }
 
-func (s *daemonSuite) TestShutdownServerCanShutdown(c *check.C) {
-	shush := newShutdownServer(nil, nil)
-	c.Check(shush.CanStandby(), check.Equals, true)
+func (s *daemonSuite) TestConnTrackerCanShutdown(c *check.C) {
+	ct := &connTracker{conns: make(map[net.Conn]struct{})}
+	c.Check(ct.CanStandby(), check.Equals, true)
 
 	con := &net.IPConn{}
-	shush.conns[con] = http.StateActive
-	c.Check(shush.CanStandby(), check.Equals, false)
+	ct.trackConn(con, http.StateActive)
+	c.Check(ct.CanStandby(), check.Equals, false)
 
-	shush.conns[con] = http.StateIdle
-	c.Check(shush.CanStandby(), check.Equals, true)
+	ct.trackConn(con, http.StateIdle)
+	c.Check(ct.CanStandby(), check.Equals, true)
 }
 
 func doTestReq(c *check.C, cmd *Command, mth string) *httptest.ResponseRecorder {

--- a/daemon/ucrednet_test.go
+++ b/daemon/ucrednet_test.go
@@ -58,15 +58,15 @@ func (s *ucrednetSuite) TestAcceptConnRemoteAddrString(c *check.C) {
 
 	l, err := net.Listen("unix", sock)
 	c.Assert(err, check.IsNil)
-	defer l.Close()
+	wl := &ucrednetListener{Listener: l}
+
+	defer wl.Close()
 
 	go func() {
 		cli, err := net.Dial("unix", sock)
 		c.Assert(err, check.IsNil)
 		cli.Close()
 	}()
-
-	wl := &ucrednetListener{l}
 
 	conn, err := wl.Accept()
 	c.Assert(err, check.IsNil)
@@ -83,7 +83,9 @@ func (s *ucrednetSuite) TestAcceptConnRemoteAddrString(c *check.C) {
 func (s *ucrednetSuite) TestNonUnix(c *check.C) {
 	l, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, check.IsNil)
-	defer l.Close()
+
+	wl := &ucrednetListener{Listener: l}
+	defer wl.Close()
 
 	addr := l.Addr().String()
 
@@ -92,8 +94,6 @@ func (s *ucrednetSuite) TestNonUnix(c *check.C) {
 		c.Assert(err, check.IsNil)
 		cli.Close()
 	}()
-
-	wl := &ucrednetListener{l}
 
 	conn, err := wl.Accept()
 	c.Assert(err, check.IsNil)
@@ -116,7 +116,7 @@ func (s *ucrednetSuite) TestAcceptErrors(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(l.Close(), check.IsNil)
 
-	wl := &ucrednetListener{l}
+	wl := &ucrednetListener{Listener: l}
 
 	_, err = wl.Accept()
 	c.Assert(err, check.NotNil)
@@ -129,7 +129,9 @@ func (s *ucrednetSuite) TestUcredErrors(c *check.C) {
 
 	l, err := net.Listen("unix", sock)
 	c.Assert(err, check.IsNil)
-	defer l.Close()
+
+	wl := &ucrednetListener{Listener: l}
+	defer wl.Close()
 
 	go func() {
 		cli, err := net.Dial("unix", sock)
@@ -137,10 +139,21 @@ func (s *ucrednetSuite) TestUcredErrors(c *check.C) {
 		cli.Close()
 	}()
 
-	wl := &ucrednetListener{l}
-
 	_, err = wl.Accept()
 	c.Assert(err, check.Equals, s.err)
+}
+
+func (s *ucrednetSuite) TestIdempPotentClose(c *check.C) {
+	s.ucred = &sys.Ucred{Pid: 100, Uid: 42}
+	d := c.MkDir()
+	sock := filepath.Join(d, "sock")
+
+	l, err := net.Listen("unix", sock)
+	c.Assert(err, check.IsNil)
+	wl := &ucrednetListener{Listener: l}
+
+	c.Assert(wl.Close(), check.IsNil)
+	c.Assert(wl.Close(), check.IsNil)
 }
 
 func (s *ucrednetSuite) TestGetNoUid(c *check.C) {

--- a/daemon/ucrednet_test.go
+++ b/daemon/ucrednet_test.go
@@ -143,7 +143,7 @@ func (s *ucrednetSuite) TestUcredErrors(c *check.C) {
 	c.Assert(err, check.Equals, s.err)
 }
 
-func (s *ucrednetSuite) TestIdempPotentClose(c *check.C) {
+func (s *ucrednetSuite) TestIdempotentClose(c *check.C) {
 	s.ucred = &sys.Ucred{Pid: 100, Uid: 42}
 	d := c.MkDir()
 	sock := filepath.Join(d, "sock")


### PR DESCRIPTION
While working on the session agent code, @chipaca suggested I not reuse the `shutdownServer` code in the daemon package and instead use the native shutdown support added to http.Server in Go 1.8.

That turned out to be fairly easy to do there, so I had a go removing `shutdownServer` all together.  I think I've maintained the same semantics as before, but here are some notes to help review:

1. There is a new `ConnTracker` type that can be plugged into an `http.Server`'s `ConnState` callback, and implements the Opinionator `CanStandBy` interface.  As it isn't responsible for the actual shutdown process, it only needs to track active connections.

2. The `snapServe` and `snapdServe` instances have been replaced with a single `http.Server` instance that listens on both sockets.  The two old servers shared the same handler, with `Command.canAccess` distinguishing connections on the two sockets with:

       isSnap := (socket == dirs.SnapSocket)

3. I am passing a context derived from `context.Background` to `http.Server.Shutdown`.  Using a context derived from the tomb won't result in a graceful shutdown, since it has already been cancelled at this point.