### PR TITLE
debian: make maintainer scripts do nothing on powerpc

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -2,6 +2,10 @@
 
 set -e
 
+# "powerpc" is not supported unfortunately, do nothing here# 
+if [ "$DPKG_MAINTSCRIPT_ARCH" = powerpc ]; then
+    exit 0
+fi
 
 case "$1" in
     configure)

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -2,6 +2,11 @@
 
 set -e
 
+# "powerpc" is not supported unfortunately, do nothing here# 
+if [ "$DPKG_MAINTSCRIPT_ARCH" = powerpc ]; then
+    exit 0
+fi
+
 systemctl_stop() {
     unit="$1"
 

--- a/packaging/ubuntu-16.04/snapd.preinst
+++ b/packaging/ubuntu-16.04/snapd.preinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e 
+
+# "powerpc" is not supported unfortunately, do nothing here# 
+if [ "$DPKG_MAINTSCRIPT_ARCH" = powerpc ]; then
+    exit 0
+fi
+
+#DEBHELPER#

--- a/packaging/ubuntu-16.04/snapd.prerm
+++ b/packaging/ubuntu-16.04/snapd.prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+# "powerpc" is not supported unfortunately, do nothing here# 
+if [ "$DPKG_MAINTSCRIPT_ARCH" = powerpc ]; then
+    exit 0
+fi
+
+
+#DEBHELPER#


### PR DESCRIPTION
We have an empty package on powerpc now. However the maintainer
scripts are still run on powerpc and fail on this empty package.

To fully fix the install of the package we need to ensure the
maintainer scripts also do nothing on powerpc.
