### PR TITLE
cmd/snap: use padded checkers for snapshot output

### DIFF
--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var snapshotsTests = []getCmdArgs{{
@@ -82,8 +83,8 @@ func (s *SnapSuite) TestSnapSnaphotsTest(c *C) {
 			c.Check(err, ErrorMatches, test.error)
 		} else {
 			c.Check(err, IsNil)
-			c.Check(s.Stderr(), Equals, test.stderr)
-			c.Check(s.Stdout(), Matches, test.stdout)
+			c.Check(s.Stderr(), testutil.EqualsWrapped, test.stderr)
+			c.Check(s.Stdout(), testutil.MatchesWrapped, test.stdout)
 		}
 	}
 }


### PR DESCRIPTION
When running the unit tests under fake time sometimes the resulting
time as worked out by go is a little bit too far out.

So we take the approach of just using a padded / wrapped checker,
which tolerates changes to column widths in the output.