### PR TITLE
interfaces: add an interface granting access to AppStream metadata

### DIFF
--- a/interfaces/builtin/appstream_metadata.go
+++ b/interfaces/builtin/appstream_metadata.go
@@ -49,6 +49,7 @@ const appstreamMetadataConnectedPlugAppArmor = `
 
 # Allow access to AppStream upstream metadata files
 /usr/share/metainfo/** r,
+/usr/share/appdata/** r,
 
 # Allow access to AppStream collection metadata
 /usr/share/app-info/** r,
@@ -61,6 +62,7 @@ const appstreamMetadataConnectedPlugAppArmor = `
 
 var appstreamMetadataDirs = []string{
 	"/usr/share/metainfo",
+	"/usr/share/appdata",
 	"/usr/share/app-info",
 	"/var/cache/app-info",
 	"/var/lib/app-info",
@@ -92,13 +94,7 @@ func (iface *appstreamMetadataInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 }
 
 func (iface *appstreamMetadataInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	for _, dir := range []string{
-		"/usr/share/metainfo",
-		"/usr/share/app-info",
-		"/var/cache/app-info",
-		"/var/lib/app-info",
-		"/var/lib/apt/lists",
-	} {
+	for _, dir := range appstreamMetadataDirs {
 		dir = filepath.Join(dirs.GlobalRootDir, dir)
 		if !osutil.IsDirectory(dir) {
 			continue

--- a/interfaces/builtin/appstream_metadata.go
+++ b/interfaces/builtin/appstream_metadata.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/osutil"
+)
+
+const appstreamMetadataSummary = `allows access to AppStream metadata`
+
+const appstreamMetadataBaseDeclarationSlots = `
+  appstream-metadata:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+// Paths for upstream and collection metadata are defined in the
+// AppStream specification:
+//   https://www.freedesktop.org/software/appstream/docs/
+const appstreamMetadataConnectedPlugAppArmor = `
+# Description: Allow access to AppStream metadata from the host system
+
+# Allow access to AppStream upstream metadata files
+/usr/share/metainfo/** r,
+
+# Allow access to AppStream collection metadata
+/usr/share/app-info/** r,
+/var/cache/app-info/** r,
+/var/lib/app-info/** r,
+
+# Apt symlinks the DEP-11 metadata to files in /var/lib/apt/lists
+/var/lib/apt/lists/*.yml.gz r,
+`
+
+type appstreamMetadataInterface struct {
+	commonInterface
+}
+
+func (iface *appstreamMetadataInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	for _, dir := range []string{
+		"/usr/share/metainfo",
+		"/usr/share/app-info",
+		"/var/cache/app-info",
+		"/var/lib/app-info",
+		"/var/lib/apt/lists",
+	} {
+		dir = filepath.Join(dirs.GlobalRootDir, dir)
+		if !osutil.IsDirectory(dir) {
+			continue
+		}
+		spec.AddMountEntry(osutil.MountEntry{
+			Name:    "/var/lib/snapd/hostfs" + dir,
+			Dir:     dirs.StripRootDir(dir),
+			Options: []string{"bind", "ro"},
+		})
+	}
+
+	return nil
+}
+
+func init() {
+	registerIface(&appstreamMetadataInterface{commonInterface{
+		name:                  "appstream-metadata",
+		summary:               appstreamMetadataSummary,
+		implicitOnClassic:     true,
+		reservedForOS:         true,
+		baseDeclarationSlots:  appstreamMetadataBaseDeclarationSlots,
+		connectedPlugAppArmor: appstreamMetadataConnectedPlugAppArmor,
+	}})
+}

--- a/interfaces/builtin/appstream_metadata_test.go
+++ b/interfaces/builtin/appstream_metadata_test.go
@@ -83,6 +83,8 @@ func (s *AppstreamMetadataInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 1)
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/var/cache/app-info/** r,`)
+	c.Assert(spec.UpdateNS(), HasLen, 1)
+	c.Check(spec.UpdateNS()[0], testutil.Contains, `# Read-only access to /usr/share/metainfo`)
 }
 
 func (s *AppstreamMetadataInterfaceSuite) TestMountConnectedPlug(c *C) {

--- a/interfaces/builtin/appstream_metadata_test.go
+++ b/interfaces/builtin/appstream_metadata_test.go
@@ -1,0 +1,131 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type AppstreamMetadataInterfaceSuite struct {
+	iface    interfaces.Interface
+	slot     *interfaces.ConnectedSlot
+	slotInfo *snap.SlotInfo
+	plug     *interfaces.ConnectedPlug
+	plugInfo *snap.PlugInfo
+}
+
+var _ = Suite(&AppstreamMetadataInterfaceSuite{
+	iface: builtin.MustInterface("appstream-metadata"),
+})
+
+func (s *AppstreamMetadataInterfaceSuite) SetUpTest(c *C) {
+	const coreYaml = `name: core
+version: 0
+type: os
+slots:
+  appstream-metadata:
+    interface: appstream-metadata
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, coreYaml, nil, "appstream-metadata")
+
+	const consumerYaml = `name: consumer
+version: 0
+apps:
+  app:
+    plugs: [appstream-metadata]
+`
+	s.plug, s.plugInfo = MockConnectedPlug(c, consumerYaml, nil, "appstream-metadata")
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TestName(c *C) {
+	c.Check(s.iface.Name(), Equals, "appstream-metadata")
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TestSanitize(c *C) {
+	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+	c.Check(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 1)
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/var/cache/app-info/** r,`)
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TestMountConnectedPlug(c *C) {
+	tmpdir := c.MkDir()
+	dirs.SetRootDir(tmpdir)
+
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/metainfo"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/app-info"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/var/cache/app-info"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/var/lib/app-info"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/var/lib/apt/lists"), 0777), IsNil)
+
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	entries := spec.MountEntries()
+	c.Assert(entries, HasLen, 5)
+
+	const hostfs = "/var/lib/snapd/hostfs"
+	c.Check(entries[0].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/usr/share/metainfo"))
+	c.Check(entries[0].Dir, Equals, "/usr/share/metainfo")
+	c.Check(entries[0].Options, DeepEquals, []string{"bind", "ro"})
+	c.Check(entries[1].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/usr/share/app-info"))
+	c.Check(entries[1].Dir, Equals, "/usr/share/app-info")
+	c.Check(entries[1].Options, DeepEquals, []string{"bind", "ro"})
+	c.Check(entries[2].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/cache/app-info"))
+	c.Check(entries[2].Dir, Equals, "/var/cache/app-info")
+	c.Check(entries[2].Options, DeepEquals, []string{"bind", "ro"})
+	c.Check(entries[3].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/lib/app-info"))
+	c.Check(entries[3].Dir, Equals, "/var/lib/app-info")
+	c.Check(entries[3].Options, DeepEquals, []string{"bind", "ro"})
+	c.Check(entries[4].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/lib/apt/lists"))
+	c.Check(entries[4].Dir, Equals, "/var/lib/apt/lists")
+	c.Check(entries[4].Options, DeepEquals, []string{"bind", "ro"})
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, false)
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.Summary, Equals, "allows access to AppStream metadata")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "appstream-metadata")
+}
+
+func (s *AppstreamMetadataInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/appstream_metadata_test.go
+++ b/interfaces/builtin/appstream_metadata_test.go
@@ -92,6 +92,7 @@ func (s *AppstreamMetadataInterfaceSuite) TestMountConnectedPlug(c *C) {
 	dirs.SetRootDir(tmpdir)
 
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/metainfo"), 0777), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/appdata"), 0777), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/app-info"), 0777), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/var/cache/app-info"), 0777), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/var/lib/app-info"), 0777), IsNil)
@@ -100,24 +101,27 @@ func (s *AppstreamMetadataInterfaceSuite) TestMountConnectedPlug(c *C) {
 	spec := &mount.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	entries := spec.MountEntries()
-	c.Assert(entries, HasLen, 5)
+	c.Assert(entries, HasLen, 6)
 
 	const hostfs = "/var/lib/snapd/hostfs"
 	c.Check(entries[0].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/usr/share/metainfo"))
 	c.Check(entries[0].Dir, Equals, "/usr/share/metainfo")
 	c.Check(entries[0].Options, DeepEquals, []string{"bind", "ro"})
-	c.Check(entries[1].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/usr/share/app-info"))
-	c.Check(entries[1].Dir, Equals, "/usr/share/app-info")
+	c.Check(entries[1].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/usr/share/appdata"))
+	c.Check(entries[1].Dir, Equals, "/usr/share/appdata")
 	c.Check(entries[1].Options, DeepEquals, []string{"bind", "ro"})
-	c.Check(entries[2].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/cache/app-info"))
-	c.Check(entries[2].Dir, Equals, "/var/cache/app-info")
+	c.Check(entries[2].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/usr/share/app-info"))
+	c.Check(entries[2].Dir, Equals, "/usr/share/app-info")
 	c.Check(entries[2].Options, DeepEquals, []string{"bind", "ro"})
-	c.Check(entries[3].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/lib/app-info"))
-	c.Check(entries[3].Dir, Equals, "/var/lib/app-info")
+	c.Check(entries[3].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/cache/app-info"))
+	c.Check(entries[3].Dir, Equals, "/var/cache/app-info")
 	c.Check(entries[3].Options, DeepEquals, []string{"bind", "ro"})
-	c.Check(entries[4].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/lib/apt/lists"))
-	c.Check(entries[4].Dir, Equals, "/var/lib/apt/lists")
+	c.Check(entries[4].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/lib/app-info"))
+	c.Check(entries[4].Dir, Equals, "/var/lib/app-info")
 	c.Check(entries[4].Options, DeepEquals, []string{"bind", "ro"})
+	c.Check(entries[5].Name, Equals, filepath.Join(hostfs, dirs.GlobalRootDir, "/var/lib/apt/lists"))
+	c.Check(entries[5].Dir, Equals, "/var/lib/apt/lists")
+	c.Check(entries[5].Options, DeepEquals, []string{"bind", "ro"})
 }
 
 func (s *AppstreamMetadataInterfaceSuite) TestStaticInfo(c *C) {

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -14,6 +14,9 @@ apps:
   alsa:
     command: bin/run
     plugs: [ alsa ]
+  appstream-metadata:
+    command: bin/run
+    plugs: [ appstream-metadata ]
   autopilot-introspection:
     command: bin/run
     plugs: [ autopilot-introspection ]

--- a/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
@@ -13,6 +13,9 @@ plugs:
 apps:
     test-snapd-sh:
         command: bin/sh
+    with-appstream-metadata-plug:
+        command: bin/sh
+        plugs: [appstream-metadata]
     with-broadcom-asic-control-plug:
         command: bin/sh
         plugs: [broadcom-asic-control]

--- a/tests/main/interfaces-appstream-metadata/task.yaml
+++ b/tests/main/interfaces-appstream-metadata/task.yaml
@@ -1,0 +1,55 @@
+summary: The appstream-metadata interface grants access to package metadata
+
+details: |
+    A number of Linux distributions use the AppStream format to
+    provide metadata about both installed and available packages.
+
+    The appstream-metadata interface makes this information available
+    to a confined application by creating bind mounts from the host
+    system to equivalent points in the sandbox.  Together with an
+    interface granting access to the host system packaging system
+    (e.g. via PackageKit), it is possible to confine a graphical
+    package manager.
+
+systems: [-ubuntu-core-*]
+
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-sh
+
+restore: |
+    rm -f /usr/share/metainfo/test.metainfo.xml
+    rm -f /usr/share/app-info/xmls/test1.xml
+    rm -f /var/cache/app-info/xmls/test2.xml
+    rm -f /var/lib/app-info/yaml/test3.yml.gz
+    rm -f /var/lib/apt/lists/test3.yml.gz
+
+execute: |
+    mkdir -p /usr/share/metainfo
+    echo "Appstream metainfo" > /usr/share/metainfo/test.metainfo.xml
+    mkdir -p /usr/share/app-info/xmls
+    echo "Appstream app-info 1" > /usr/share/app-info/xmls/test1.xml
+    mkdir -p /var/cache/app-info/xmls
+    echo "Appstream app-info 2" > /var/cache/app-info/xmls/test2.xml
+    # Apt exposes Appstream metadata via absolute symlinks to
+    # /var/lib/apt/lists
+    mkdir -p /var/lib/apt/lists
+    echo "Appstream app-info 3" | gzip -c > /var/lib/apt/lists/test3.yml.gz
+    mkdir -p /var/lib/app-info/yaml
+    ln -s /var/lib/apt/lists/test3.yml.gz /var/lib/app-info/yaml
+
+    echo "The plug is disconnected by default"
+    snap connections test-snapd-sh | MATCH "appstream-metadata +test-snapd-sh:appstream-metadata +- +-"
+
+    echo "The plug can be connected"
+    snap connect test-snapd-sh:appstream-metadata
+    snap connections test-snapd-sh | MATCH "appstream-metadata +test-snapd-sh:appstream-metadata +:appstream-metadata +manual"
+
+    echo "Appstream metadata is now available from the sandbox"
+    test-snapd-sh.with-appstream-metadata-plug -c "cat /usr/share/metainfo/test.metainfo.xml" | MATCH "Appstream metainfo"
+
+    test-snapd-sh.with-appstream-metadata-plug -c "cat /usr/share/app-info/xmls/test1.xml" | MATCH "Appstream app-info 1"
+    test-snapd-sh.with-appstream-metadata-plug -c "cat /var/cache/app-info/xmls/test2.xml" | MATCH "Appstream app-info 2"
+
+    test-snapd-sh.with-appstream-metadata-plug -c "cat /var/lib/app-info/yaml/test3.yml.gz" | gunzip -c | MATCH "Appstream app-info 3"

--- a/tests/main/interfaces-appstream-metadata/task.yaml
+++ b/tests/main/interfaces-appstream-metadata/task.yaml
@@ -18,15 +18,7 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-sh
 
-restore: |
-    rm -f /usr/share/metainfo/test1.metainfo.xml
-    rm -f /usr/share/appdata/test2.metainfo.xml
-    rm -f /usr/share/app-info/xmls/test1.xml
-    rm -f /var/cache/app-info/xmls/test2.xml
-    rm -f /var/lib/app-info/yaml/test3.yml.gz
-    rm -f /var/lib/apt/lists/test3.yml.gz
-
-execute: |
+    # Set up some dummy Appstream metadata on the host system
     mkdir -p /usr/share/metainfo
     echo "Appstream metainfo 1" > /usr/share/metainfo/test1.metainfo.xml
     mkdir -p /usr/share/appdata
@@ -42,6 +34,15 @@ execute: |
     mkdir -p /var/lib/app-info/yaml
     ln -s /var/lib/apt/lists/test3.yml.gz /var/lib/app-info/yaml
 
+restore: |
+    rm -f /usr/share/metainfo/test1.metainfo.xml
+    rm -f /usr/share/appdata/test2.metainfo.xml
+    rm -f /usr/share/app-info/xmls/test1.xml
+    rm -f /var/cache/app-info/xmls/test2.xml
+    rm -f /var/lib/app-info/yaml/test3.yml.gz
+    rm -f /var/lib/apt/lists/test3.yml.gz
+
+execute: |
     echo "The plug is disconnected by default"
     snap connections test-snapd-sh | MATCH "appstream-metadata +test-snapd-sh:appstream-metadata +- +-"
 

--- a/tests/main/interfaces-appstream-metadata/task.yaml
+++ b/tests/main/interfaces-appstream-metadata/task.yaml
@@ -19,7 +19,8 @@ prepare: |
     install_local test-snapd-sh
 
 restore: |
-    rm -f /usr/share/metainfo/test.metainfo.xml
+    rm -f /usr/share/metainfo/test1.metainfo.xml
+    rm -f /usr/share/appdata/test2.metainfo.xml
     rm -f /usr/share/app-info/xmls/test1.xml
     rm -f /var/cache/app-info/xmls/test2.xml
     rm -f /var/lib/app-info/yaml/test3.yml.gz
@@ -27,7 +28,9 @@ restore: |
 
 execute: |
     mkdir -p /usr/share/metainfo
-    echo "Appstream metainfo" > /usr/share/metainfo/test.metainfo.xml
+    echo "Appstream metainfo 1" > /usr/share/metainfo/test1.metainfo.xml
+    mkdir -p /usr/share/appdata
+    echo "Appstream metainfo 2" > /usr/share/appdata/test2.metainfo.xml
     mkdir -p /usr/share/app-info/xmls
     echo "Appstream app-info 1" > /usr/share/app-info/xmls/test1.xml
     mkdir -p /var/cache/app-info/xmls
@@ -47,7 +50,8 @@ execute: |
     snap connections test-snapd-sh | MATCH "appstream-metadata +test-snapd-sh:appstream-metadata +:appstream-metadata +manual"
 
     echo "Appstream metadata is now available from the sandbox"
-    test-snapd-sh.with-appstream-metadata-plug -c "cat /usr/share/metainfo/test.metainfo.xml" | MATCH "Appstream metainfo"
+    test-snapd-sh.with-appstream-metadata-plug -c "cat /usr/share/metainfo/test1.metainfo.xml" | MATCH "Appstream metainfo 1"
+    test-snapd-sh.with-appstream-metadata-plug -c "cat /usr/share/appdata/test2.metainfo.xml" | MATCH "Appstream metainfo 2"
 
     test-snapd-sh.with-appstream-metadata-plug -c "cat /usr/share/app-info/xmls/test1.xml" | MATCH "Appstream app-info 1"
     test-snapd-sh.with-appstream-metadata-plug -c "cat /var/cache/app-info/xmls/test2.xml" | MATCH "Appstream app-info 2"


### PR DESCRIPTION
AppStream is a data format used to describe packages and other components that can be installed on a Linux system as documented here:

https://www.freedesktop.org/software/appstream/docs/

In particular, Debian/Ubuntu systems publish AppStream collection metadata (aka DEP-11) about packages held in the repository.  Package managers can use this to display translated descriptions and extended metadata about packages to users.

This interface grants snaps permission to read the host system's AppStream metadata, and mounts it into the sandbox in locations where `libappstream` or `libappstream-glib` will search for it.