### PR TITLE
snap-userd-autostart: don't list as a startup application on the GUI

### DIFF
--- a/data/desktop/snap-userd-autostart.desktop.in
+++ b/data/desktop/snap-userd-autostart.desktop.in
@@ -3,3 +3,4 @@ Name=Snap user application autostart helper
 Comment=Helper program for launching snap applications that are configured to start automatically.
 Exec=@bindir@/snap userd --autostart
 Type=Application
+NoDisplay=true


### PR DESCRIPTION
Use NoDisplay=true so gnome-session-properties does list it as a startup program
We don't list the technical items/services in the GUI because it confuses users
and can lead to have them being turned off which creates problems.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
