### PR TITLE
 cmd/libsnap: use fixed buffer for scanning infofile

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -59,6 +59,9 @@ new_format = \
 	 libsnap-confine-private/cgroup-pids-support.h \
 	 libsnap-confine-private/cgroup-support.c \
 	 libsnap-confine-private/cgroup-support.h \
+	 libsnap-confine-private/infofile-test.c \
+	 libsnap-confine-private/infofile.c \
+	 libsnap-confine-private/infofile.h \
 	 snap-confine/seccomp-support-ext.c \
 	 snap-confine/seccomp-support-ext.h \
 	 snap-confine/selinux-support.c \
@@ -119,6 +122,7 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/fault-injection.h \
 	libsnap-confine-private/feature.c \
 	libsnap-confine-private/feature.h \
+	libsnap-confine-private/infofile.c \
 	libsnap-confine-private/locking.c \
 	libsnap-confine-private/locking.h \
 	libsnap-confine-private/mount-opt.c \
@@ -151,6 +155,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/error-test.c \
 	libsnap-confine-private/fault-injection-test.c \
 	libsnap-confine-private/feature-test.c \
+	libsnap-confine-private/infofile-test.c \
 	libsnap-confine-private/locking-test.c \
 	libsnap-confine-private/mount-opt-test.c \
 	libsnap-confine-private/mountinfo-test.c \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -61,10 +61,10 @@ new_format = \
 	 libsnap-confine-private/cgroup-support.h \
 	 snap-confine/seccomp-support-ext.c \
 	 snap-confine/seccomp-support-ext.h \
-	 snap-confine/snap-confine-invocation.c \
-	 snap-confine/snap-confine-invocation.h \
 	 snap-confine/selinux-support.c \
 	 snap-confine/selinux-support.h \
+	 snap-confine/snap-confine-invocation.c \
+	 snap-confine/snap-confine-invocation.h \
 	 snap-discard-ns/snap-discard-ns.c
 
 # NOTE: clang-format is using project-wide .clang-format file.

--- a/cmd/libsnap-confine-private/error-test.c
+++ b/cmd/libsnap-confine-private/error-test.c
@@ -161,8 +161,10 @@ static void test_sc_error_forward__nothing(void)
 	// Check that forwarding NULL does exactly that.
 	struct sc_error *recipient = (void *)0xDEADBEEF;
 	struct sc_error *err = NULL;
-	sc_error_forward(&recipient, err);
+	int rc;
+	rc = sc_error_forward(&recipient, err);
 	g_assert_null(recipient);
+	g_assert_cmpint(rc, ==, 0);
 }
 
 static void test_sc_error_forward__something_somewhere(void)
@@ -170,10 +172,12 @@ static void test_sc_error_forward__something_somewhere(void)
 	// Check that forwarding a real error works OK.
 	struct sc_error *recipient = NULL;
 	struct sc_error *err = sc_error_init("domain", 42, "just testing");
+	int rc;
 	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
 	g_assert_nonnull(err);
-	sc_error_forward(&recipient, err);
+	rc = sc_error_forward(&recipient, err);
 	g_assert_nonnull(recipient);
+	g_assert_cmpint(rc, ==, -1);
 }
 
 static void test_sc_error_forward__something_nowhere(void)

--- a/cmd/libsnap-confine-private/error.c
+++ b/cmd/libsnap-confine-private/error.c
@@ -112,13 +112,14 @@ void sc_die_on_error(sc_error * error)
 	}
 }
 
-void sc_error_forward(sc_error ** recipient, sc_error * error)
+int sc_error_forward(sc_error ** recipient, sc_error * error)
 {
 	if (recipient != NULL) {
 		*recipient = error;
 	} else {
 		sc_die_on_error(error);
 	}
+	return error != NULL ? -1 : 0;
 }
 
 bool sc_error_match(sc_error * error, const char *domain, int code)

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -67,11 +67,11 @@ typedef struct sc_error {
 
 /** sc_libsnap_error represents distinct error codes used by libsnap-confine-private library. */
 typedef enum sc_libsnap_error {
-    /** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
+	/** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
 	SC_UNSPECIFIED_ERROR = 0,
-    /** SC_API_MISUSE indicates that public API was called incorrectly. */
+	/** SC_API_MISUSE indicates that public API was called incorrectly. */
 	SC_API_MISUSE,
-    /** SC_BUG indicates that private API was called incorrectly. */
+	/** SC_BUG indicates that private API was called incorrectly. */
 	SC_BUG,
 } sc_libsnap_error;
 

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -61,6 +61,11 @@ typedef struct sc_error {
 #define SC_ERRNO_DOMAIN "errno"
 
 /**
+ * Error domain for errors in the libsnap-confine-private library.
+ **/
+#define SC_INTERNAL_DOMAIN "libsnap-confine-private"
+
+/**
  * Initialize a new error object.
  *
  * The domain is a cookie-like string that allows the caller to distinguish

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -65,6 +65,15 @@ typedef struct sc_error {
  **/
 #define SC_INTERNAL_DOMAIN "libsnap-confine-private"
 
+typedef enum sc_internal_error {
+    /** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
+	SC_UNSPECIFIED_ERROR = 0,
+    /** SC_API_MISUSE indicates that public API was called incorrectly. */
+	SC_API_MISUSE,
+    /** SC_BUG indicates that private API was called incorrectly. */
+	SC_BUG,
+} sc_internal_error;
+
 /**
  * Initialize a new error object.
  *

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -158,10 +158,14 @@ void sc_die_on_error(sc_error * error);
  * sc_die_on_error() is called as a safety measure.
  *
  * Change of ownership takes place and the error is now stored in the recipient.
+ *
+ * The return value -1 if error is non-NULL and 0 otherwise. The return value
+ * makes it convenient to `return sc_error_forward(err_out, err);` as the last
+ * line of a function.
  **/
 // NOTE: There's no nonnull(1) attribute as the recipient *can* be NULL. With
 // the attribute in place GCC optimizes some things out and tests fail.
-void sc_error_forward(sc_error ** recipient, sc_error * error);
+int sc_error_forward(sc_error ** recipient, sc_error * error);
 
 /**
  * Check if a given error matches the specified domain and code.

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -63,16 +63,16 @@ typedef struct sc_error {
 /**
  * Error domain for errors in the libsnap-confine-private library.
  **/
-#define SC_INTERNAL_DOMAIN "libsnap-confine-private"
+#define SC_LIBSNAP_ERROR "libsnap-confine-private"
 
-typedef enum sc_internal_error {
+typedef enum sc_libsnap_error {
     /** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
 	SC_UNSPECIFIED_ERROR = 0,
     /** SC_API_MISUSE indicates that public API was called incorrectly. */
 	SC_API_MISUSE,
     /** SC_BUG indicates that private API was called incorrectly. */
 	SC_BUG,
-} sc_internal_error;
+} sc_libsnap_error;
 
 /**
  * Initialize a new error object.

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -65,6 +65,7 @@ typedef struct sc_error {
  **/
 #define SC_LIBSNAP_ERROR "libsnap-confine-private"
 
+/** sc_libsnap_error represents distinct error codes used by libsnap-confine-private library. */
 typedef enum sc_libsnap_error {
     /** SC_UNSPECIFIED_ERROR indicates an error not worthy of a distinct code. */
 	SC_UNSPECIFIED_ERROR = 0,

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "infofile.h"
+#include "infofile.c"
+
+#include <glib.h>
+
+static void test_infofile_query(void) {
+    char text[] =
+        "key=value\n"
+        "other-key=other-value\n"
+        "dup-key=value-one\n"
+        "dup-key=value-two\n";
+    FILE *stream = fmemopen(text, strlen(text), "r");
+    g_assert_nonnull(stream);
+
+    /* Keys that are not found get NULL values. */
+    char *value = (void *)0xfefefefe;
+    sc_infofile_query(stream, "missing-key", &value, NULL);
+    g_assert_null(value);
+
+    /* Keys that are found get strdup-duplicated values. */
+    value = NULL;
+    sc_infofile_query(stream, "key", &value, NULL);
+    g_assert_nonnull(value);
+    g_assert_cmpstr(value, ==, "value");
+    free(value);
+
+    /* Multiple keys can be extracted on one go. */
+    char *other_value;
+    sc_infofile_query(stream, "key", &value, "other-key", &other_value, NULL);
+    g_assert_nonnull(value);
+    g_assert_nonnull(other_value);
+    g_assert_cmpstr(value, ==, "value");
+    g_assert_cmpstr(other_value, ==, "other-value");
+    free(value);
+    free(other_value);
+
+    /* Order in which keys are extracted does not matter. */
+    sc_infofile_query(stream, "other-key", &other_value, "key", &value, NULL);
+    g_assert_nonnull(value);
+    g_assert_nonnull(other_value);
+    g_assert_cmpstr(value, ==, "value");
+    g_assert_cmpstr(other_value, ==, "other-value");
+    free(value);
+    free(other_value);
+
+    /* When duplicate keys are present the first value is extracted. */
+    char *dup_value;
+    sc_infofile_query(stream, "dup-key", &dup_value, NULL);
+    g_assert_nonnull(dup_value);
+    g_assert_cmpstr(dup_value, ==, "value-one");
+    free(dup_value);
+
+    fclose(stream);
+}
+
+static void __attribute__((constructor)) init(void) { g_test_add_func("/infofile/query", test_infofile_query); }

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -130,6 +130,19 @@ static void test_infofile_get_key(void) {
     sc_error_free(err);
     fclose(stream);
     free(malformed_value);
+
+    char malformed4[] = "=";
+    stream = fmemopen(malformed4, sizeof malformed4 - 1, "r");
+    g_assert_nonnull(stream);
+    rc = sc_infofile_get_key(stream, "key", &malformed_value, &err);
+    g_assert_cmpint(rc, ==, -1);
+    g_assert_nonnull(err);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpint(sc_error_code(err), ==, 0);
+    g_assert_cmpstr(sc_error_msg(err), ==, "line 1 contains empty key");
+    g_assert_null(malformed_value);
+    sc_error_free(err);
+    fclose(stream);
 }
 
 static void __attribute__((constructor)) init(void) { g_test_add_func("/infofile/get_key", test_infofile_get_key); }

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -21,29 +21,38 @@
 #include <glib.h>
 
 static void test_infofile_query(void) {
+    int rc;
+    sc_error *err;
+
     char text[] =
         "key=value\n"
         "other-key=other-value\n"
         "dup-key=value-one\n"
         "dup-key=value-two\n";
-    FILE *stream = fmemopen(text, strlen(text), "r");
+    FILE *stream = fmemopen(text, sizeof text - 1, "r");
     g_assert_nonnull(stream);
 
     /* Keys that are not found get NULL values. */
     char *value = (void *)0xfefefefe;
-    sc_infofile_query(stream, NULL, "missing-key", &value, NULL);
+    rc = sc_infofile_query(stream, &err, "missing-key", &value, NULL);
+    g_assert_cmpint(rc, ==, 0);
+    g_assert_null(err);
     g_assert_null(value);
 
     /* Keys that are found get strdup-duplicated values. */
     value = NULL;
-    sc_infofile_query(stream, NULL, "key", &value, NULL);
+    rc = sc_infofile_query(stream, &err, "key", &value, NULL);
+    g_assert_cmpint(rc, ==, 0);
+    g_assert_null(err);
     g_assert_nonnull(value);
     g_assert_cmpstr(value, ==, "value");
     free(value);
 
     /* Multiple keys can be extracted on one go. */
     char *other_value;
-    sc_infofile_query(stream, NULL, "key", &value, "other-key", &other_value, NULL);
+    rc = sc_infofile_query(stream, &err, "key", &value, "other-key", &other_value, NULL);
+    g_assert_cmpint(rc, ==, 0);
+    g_assert_null(err);
     g_assert_nonnull(value);
     g_assert_nonnull(other_value);
     g_assert_cmpstr(value, ==, "value");
@@ -52,7 +61,9 @@ static void test_infofile_query(void) {
     free(other_value);
 
     /* Order in which keys are extracted does not matter. */
-    sc_infofile_query(stream, NULL, "other-key", &other_value, "key", &value, NULL);
+    rc = sc_infofile_query(stream, &err, "other-key", &other_value, "key", &value, NULL);
+    g_assert_cmpint(rc, ==, 0);
+    g_assert_null(err);
     g_assert_nonnull(value);
     g_assert_nonnull(other_value);
     g_assert_cmpstr(value, ==, "value");
@@ -62,12 +73,47 @@ static void test_infofile_query(void) {
 
     /* When duplicate keys are present the first value is extracted. */
     char *dup_value;
-    sc_infofile_query(stream, NULL, "dup-key", &dup_value, NULL);
+    rc = sc_infofile_query(stream, &err, "dup-key", &dup_value, NULL);
+    g_assert_cmpint(rc, ==, 0);
+    g_assert_null(err);
     g_assert_nonnull(dup_value);
     g_assert_cmpstr(dup_value, ==, "value-one");
     free(dup_value);
 
     fclose(stream);
+
+    char *malformed_value;
+
+    char malformed1[] = "key\n";
+    stream = fmemopen(malformed1, sizeof malformed1 - 1, "r");
+    g_assert_nonnull(stream);
+    rc = sc_infofile_query(stream, &err, "key", &malformed_value, NULL);
+    g_assert_cmpint(rc, ==, -1);
+    g_assert_nonnull(err);
+    g_assert_null(malformed_value);
+    sc_error_free(err);
+    fclose(stream);
+
+    char malformed2[] = "key=value\0garbage\n";
+    stream = fmemopen(malformed2, sizeof malformed2 - 1, "r");
+    g_assert_nonnull(stream);
+    rc = sc_infofile_query(stream, &err, "key", &malformed_value, NULL);
+    g_assert_cmpint(rc, ==, -1);
+    g_assert_nonnull(err);
+    g_assert_null(malformed_value);
+    sc_error_free(err);
+    fclose(stream);
+
+    char malformed3[] = "key=";
+    stream = fmemopen(malformed3, sizeof malformed3 - 1, "r");
+    g_assert_nonnull(stream);
+    rc = sc_infofile_query(stream, &err, "key", &malformed_value, NULL);
+    g_assert_cmpint(rc, ==, 0);
+    g_assert_null(err);
+    g_assert_cmpstr(malformed_value, ==, "");
+    sc_error_free(err);
+    fclose(stream);
+    free(malformed_value);
 }
 
 static void __attribute__((constructor)) init(void) { g_test_add_func("/infofile/query", test_infofile_query); }

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -39,7 +39,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(NULL, "key", &value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_INTERNAL_DOMAIN);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
     g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
     g_assert_cmpstr(sc_error_msg(err), ==, "stream cannot be NULL");
     sc_error_free(err);
@@ -48,7 +48,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, NULL, &value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_INTERNAL_DOMAIN);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
     g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
     g_assert_cmpstr(sc_error_msg(err), ==, "key cannot be NULL");
     sc_error_free(err);
@@ -57,7 +57,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", NULL, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_INTERNAL_DOMAIN);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
     g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
     g_assert_cmpstr(sc_error_msg(err), ==, "value cannot be NULL");
     sc_error_free(err);
@@ -100,7 +100,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", &malformed_value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_INTERNAL_DOMAIN);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
     g_assert_cmpint(sc_error_code(err), ==, 0);
     g_assert_cmpstr(sc_error_msg(err), ==, "line 1 is not a key=value assignment");
     g_assert_null(malformed_value);
@@ -113,7 +113,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", &malformed_value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_INTERNAL_DOMAIN);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
     g_assert_cmpint(sc_error_code(err), ==, 0);
     g_assert_cmpstr(sc_error_msg(err), ==, "line 1 contains NUL byte");
     g_assert_null(malformed_value);

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -31,19 +31,19 @@ static void test_infofile_query(void) {
 
     /* Keys that are not found get NULL values. */
     char *value = (void *)0xfefefefe;
-    sc_infofile_query(stream, "missing-key", &value, NULL);
+    sc_infofile_query(stream, NULL, "missing-key", &value, NULL);
     g_assert_null(value);
 
     /* Keys that are found get strdup-duplicated values. */
     value = NULL;
-    sc_infofile_query(stream, "key", &value, NULL);
+    sc_infofile_query(stream, NULL, "key", &value, NULL);
     g_assert_nonnull(value);
     g_assert_cmpstr(value, ==, "value");
     free(value);
 
     /* Multiple keys can be extracted on one go. */
     char *other_value;
-    sc_infofile_query(stream, "key", &value, "other-key", &other_value, NULL);
+    sc_infofile_query(stream, NULL, "key", &value, "other-key", &other_value, NULL);
     g_assert_nonnull(value);
     g_assert_nonnull(other_value);
     g_assert_cmpstr(value, ==, "value");
@@ -52,7 +52,7 @@ static void test_infofile_query(void) {
     free(other_value);
 
     /* Order in which keys are extracted does not matter. */
-    sc_infofile_query(stream, "other-key", &other_value, "key", &value, NULL);
+    sc_infofile_query(stream, NULL, "other-key", &other_value, "key", &value, NULL);
     g_assert_nonnull(value);
     g_assert_nonnull(other_value);
     g_assert_cmpstr(value, ==, "value");
@@ -62,7 +62,7 @@ static void test_infofile_query(void) {
 
     /* When duplicate keys are present the first value is extracted. */
     char *dup_value;
-    sc_infofile_query(stream, "dup-key", &dup_value, NULL);
+    sc_infofile_query(stream, NULL, "dup-key", &dup_value, NULL);
     g_assert_nonnull(dup_value);
     g_assert_cmpstr(dup_value, ==, "value-one");
     free(dup_value);

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -222,7 +222,7 @@ static void test_infofile_get_key_scanner(void) {
     g_assert_true(scanner_state.stop);
     g_assert_nonnull(caller_state.stored_value);
     g_assert_cmpstr(caller_state.stored_value, ==, "value");
-    g_assert_cmpuint((intptr_t)caller_state.stored_value, !=, (intptr_t)"value");
+    g_assert_cmpuint((intptr_t)caller_state.stored_value, !=, (intptr_t) "value");
     free(caller_state.stored_value);
 }
 

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -139,10 +139,11 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
 
     sc_infofile_get_key_state scanner_state = {.wanted_key = key};
     sc_infofile_scanner_fn scanner_fn = sc_infofile_get_key_scanner;
-    /* Call the scanner and ignore the error code. We will forward any
-     * error in a moment, but first we want to store the result of the
-     * search, successful or not, so that *value is always defined. */
-    (void)sc_infofile_scan(stream, scanner_fn, &scanner_state, &err);
+
+    *value = NULL;
+    if (sc_infofile_scan(stream, scanner_fn, &scanner_state, &err) < 0) {
+        goto out;
+    }
     *value = scanner_state.stored_value;
 
 out:

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -42,9 +42,10 @@ void sc_infofile_query(FILE *stream, ...) {
             break;
         }
         char **value = va_arg(ap, char **);
-        if (value != NULL) {
-            *value = NULL;
+        if (value == NULL) {
+            die("no storage provided for key %s", key);
         }
+        *value = NULL;
         size_t key_len = strlen(key);
         if (fsetpos(stream, &start_pos) < 0) {
             die("cannot set stream position");
@@ -73,9 +74,7 @@ void sc_infofile_query(FILE *stream, ...) {
              * equals sign then this is a matching entry. Copy it to the
              * provided pointer, if any, and stop searching. */
             if (strstr(line_buf, key) == line_buf && line_buf[key_len] == '=') {
-                if (value != NULL) {
-                    *value = sc_strdup(line_buf + key_len + 1);
-                }
+                *value = sc_strdup(line_buf + key_len + 1);
                 break;
             }
         }

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "infofile.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
+
+void sc_infofile_query(FILE *stream, ...) {
+    va_list ap;
+    va_start(ap, stream);
+
+    fpos_t start_pos;
+    if (fgetpos(stream, &start_pos) < 0) {
+        die("cannot determine stream position");
+    }
+
+    size_t line_size = 0;
+    char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
+    for (;;) { /* This loop advances through the keys we are looking for. */
+        const char *key = va_arg(ap, const char *);
+        if (key == NULL) {
+            break;
+        }
+        char **value = va_arg(ap, char **);
+        if (value != NULL) {
+            *value = NULL;
+        }
+        size_t key_len = strlen(key);
+        if (fsetpos(stream, &start_pos) < 0) {
+            die("cannot set stream position");
+        }
+        for (;;) { /* This loop advances through subsequent lines. */
+            errno = 0;
+            ssize_t nread = getline(&line_buf, &line_size, stream);
+            if (nread < 0 && errno != 0) {
+                die("cannot read another line");
+            }
+            if (nread <= 0) {
+                break; /* There is nothing more to read. */
+            }
+            /* Skip lines shorter than the key length. They cannot match our
+             * key. The extra byte ensures that we can look for the equals sign
+             * ('='). Note that at this time nread cannot be negative. */
+            if ((size_t)nread < key_len + 1) {
+                continue;
+            }
+            /* Replace the newline character, if any, with the NUL byte. */
+            if (nread > 0 && line_buf[nread - 1] == '\n') {
+                line_buf[nread - 1] = '\0';
+                nread--;
+            }
+            /* If the prefix of the line is the search key followed by the
+             * equals sign then this is a matching entry. Copy it to the
+             * provided pointer, if any, and stop searching. */
+            if (strstr(line_buf, key) == line_buf && line_buf[key_len] == '=') {
+                if (value != NULL) {
+                    *value = sc_strdup(line_buf + key_len + 1);
+                }
+                break;
+            }
+        }
+    }
+    va_end(ap);
+    if (fsetpos(stream, &start_pos) < 0) {
+        die("cannot set stream position");
+    }
+}

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -191,6 +191,11 @@ static int sc_infofile_scan(FILE *stream, sc_infofile_scanner_fn scanner_fn, voi
             err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d is not a key=value assignment", lineno);
             goto out;
         }
+        /* Guard against malformed input with empty key. */
+        if (eq_ptr == line_buf) {
+            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d contains empty key", lineno);
+            goto out;
+        }
         /* Replace the first '=' with string terminator byte. */
         *eq_ptr = '\0';
 

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -105,12 +105,12 @@ typedef struct sc_infofile_get_key_state {
 static int sc_infofile_get_key_scanner(sc_infofile_scanner_state *scanner_state, sc_error **err_out) {
     sc_error *err = NULL;
     if (scanner_state == NULL) {
-        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_BUG, "scanner_state cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "scanner_state cannot be NULL");
         goto out;
     }
     sc_infofile_get_key_state *caller_state = scanner_state->caller_state;
     if (caller_state == NULL) {
-        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_BUG, "caller_state cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "caller_state cannot be NULL");
         goto out;
     }
 
@@ -128,11 +128,11 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
 
     /* NOTE: stream is checked by sc_infofile_scan */
     if (key == NULL) {
-        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "key cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "key cannot be NULL");
         goto out;
     }
     if (value == NULL) {
-        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "value cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "value cannot be NULL");
         goto out;
     }
 
@@ -154,11 +154,11 @@ static int sc_infofile_scan(FILE *stream, sc_infofile_scanner_fn scanner_fn, voi
     char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
 
     if (stream == NULL) {
-        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "stream cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "stream cannot be NULL");
         goto out;
     }
     if (scanner_fn == NULL) {
-        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "scanner_fn cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "scanner_fn cannot be NULL");
         goto out;
     }
 
@@ -178,7 +178,7 @@ static int sc_infofile_scan(FILE *stream, sc_infofile_scanner_fn scanner_fn, voi
         /* Guard against malformed input that may contain NUL bytes that
          * would confuse the code below. */
         if (memchr(line_buf, '\0', nread) != NULL) {
-            err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "line %d contains NUL byte", lineno);
+            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d contains NUL byte", lineno);
             goto out;
         }
         /* Replace the newline character, if any, with the NUL byte. */
@@ -188,7 +188,7 @@ static int sc_infofile_scan(FILE *stream, sc_infofile_scanner_fn scanner_fn, voi
         /* Guard against malformed input that does not contain '=' byte */
         char *eq_ptr = memchr(line_buf, '=', nread);
         if (eq_ptr == NULL) {
-            err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "line %d is not a key=value assignment", lineno);
+            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d is not a key=value assignment", lineno);
             goto out;
         }
         /* Replace the first '=' with string terminator byte. */

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -109,9 +109,21 @@ static int sc_infofile_get_key_scanner(sc_infofile_scanner_state *scanner_state,
         err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "scanner_state cannot be NULL");
         goto out;
     }
+    if (scanner_state->key == NULL) {
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "scanner_state->key cannot be NULL");
+        goto out;
+    }
+    if (scanner_state->value == NULL) {
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "scanner_state->value cannot be NULL");
+        goto out;
+    }
     sc_infofile_get_key_state *caller_state = scanner_state->caller_state;
     if (caller_state == NULL) {
-        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "caller_state cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "scanner_state->caller_state cannot be NULL");
+        goto out;
+    }
+    if (caller_state->wanted_key == NULL) {
+        err = sc_error_init(SC_LIBSNAP_ERROR, SC_BUG, "caller_state->wanted_key cannot be NULL");
         goto out;
     }
 

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -19,6 +19,7 @@
 
 #include <errno.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "../libsnap-confine-private/cleanup-funcs.h"

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -59,6 +59,11 @@ void sc_infofile_query(FILE *stream, ...) {
             if (nread <= 0) {
                 break; /* There is nothing more to read. */
             }
+            /* Guard against malformed input that may contain NUL bytes that
+             * would confuse the code below. */
+            if (memchr(line_buf, '\0', nread) != NULL) {
+                die("read line contains embedded NUL byte");
+            }
             /* Skip lines shorter than the key length. They cannot match our
              * key. The extra byte ensures that we can look for the equals sign
              * ('='). Note that at this time nread cannot be negative. */

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -26,86 +26,190 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
-int sc_infofile_query(FILE *stream, sc_error **err_out, ...) {
-    va_list ap;
-    va_start(ap, err_out);
+/**
+ * sc_infofile_scanner_state represents the state of the scanner.
+ *
+ * The fields, lineno, key and value are read-only and are meant to be consumed
+ * by the scanner callback function. The fields caller_state and stop can be
+ * modified by the scanner callback function to alter the caller state and to
+ * stop further scanning, respectively.
+ **/
+typedef struct sc_infofile_scanner_state {
+    /* in variables */
+    int lineno;
+    const char *key;
+    const char *value;
+    /* out variables */
+    void *caller_state;
+    bool stop;
+} sc_infofile_scanner_state;
+
+/**
+ * sc_infofile_scanner_fn is a callback type that assists sc_infofile_scan.
+ *
+ * The state is the same value that was provided to sc_infofile_scan and can
+ * be used by the caller to pass a structure or anything else that makes sense
+ * to retrieve useful information later.
+ *
+ * Both the key and the value strings are pointing into a temporary buffer and
+ * are NUL terminated.  The callback function must either use them in-place
+ * (e.g. mark their presence) or perform a copy in case the values need to
+ * outlive the call to sc_infofile_scan.
+ *
+ * The function prototype includes err_out and int return code, which behave
+ * exactly the same as in sc_infofile_scan, that is, return value is zero on
+ * success, -1 on failure. In both cases err_out is set to either NULL or an
+ * error object. If an error object cannot be stored the program dies.  In
+ * practice sc_infofile_scan always provides an error receiver so that the
+ * error can be forwarded to the caller.
+ **/
+typedef int (*sc_infofile_scanner_fn)(sc_infofile_scanner_state *scanner_state, sc_error **err_out);
+
+/**
+ * sc_infofile_scan performs linear scan of a given stream, extracting
+ * key=value pairs and passing them along to the scanner function.
+ *
+ * The stream is scanned exactly once, using internally managed buffer. The
+ * buffer is reused as key/value storage for the purpose of the scanner
+ * function. The values provided to the scanner function must be copied if they
+ * need to outlive the lifetime of the call into the scanner.
+ *
+ * Each line must be of the format key=value where key and value are arbitrary
+ * strings, excluding the NUL byte which would be confusing in traditional C
+ * strings.
+ *
+ * On success the return value is zero and err_out, if not NULL, is deferences
+ * and set to NULL.  On failure the return value is -1 is and detailed error
+ * information is stored by dereferencing err_out.  If an error occurs and
+ * err_out is NULL then the program dies, printing the error message.
+ **/
+static int sc_infofile_scan(FILE *stream, sc_infofile_scanner_fn scanner_fn, void *caller_state, sc_error **err_out);
+
+/**
+ * sc_infofile_get_key_state represents caller state for sc_infofile_get_key.
+ *
+ * The state gets passed to sc_infofile_scan and is used to convey the key
+ * that is being looked for as well as the value that was found.
+ **/
+typedef struct sc_infofile_get_key_state {
+    const char *wanted_key;
+    char *stored_value;
+} sc_infofile_get_key_state;
+
+/**
+ * sc_infofile_get_key_scanner is the scanner callback for sc_infofile_get_key.
+ *
+ * The callback unpacks the scanner state and if a key is found, stores the value
+ * into the caller state and stops the scanning process.
+ **/
+static int sc_infofile_get_key_scanner(sc_infofile_scanner_state *scanner_state, sc_error **err_out) {
+    sc_error *err = NULL;
+    if (scanner_state == NULL) {
+        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_BUG, "scanner_state cannot be NULL");
+        goto out;
+    }
+    sc_infofile_get_key_state *caller_state = scanner_state->caller_state;
+    if (caller_state == NULL) {
+        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_BUG, "caller_state cannot be NULL");
+        goto out;
+    }
+
+    if (sc_streq(caller_state->wanted_key, scanner_state->key)) {
+        caller_state->stored_value = sc_strdup(scanner_state->value);
+        scanner_state->stop = true;
+    }
+
+out:
+    return sc_error_forward(err_out, err);
+}
+
+int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **err_out) {
+    sc_error *err = NULL;
+
+    /* NOTE: stream is checked by sc_infofile_scan */
+    if (key == NULL) {
+        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "key cannot be NULL");
+        goto out;
+    }
+    if (value == NULL) {
+        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "value cannot be NULL");
+        goto out;
+    }
+
+    sc_infofile_get_key_state scanner_state = {.wanted_key = key};
+    sc_infofile_scanner_fn scanner_fn = sc_infofile_get_key_scanner;
+    /* Call the scanner and ignore the error code. We will forward any
+     * error in a moment, but first we want to store the result of the
+     * search, successful or not, so that *value is always defined. */
+    (void)sc_infofile_scan(stream, scanner_fn, &scanner_state, &err);
+    *value = scanner_state.stored_value;
+
+out:
+    return sc_error_forward(err_out, err);
+}
+
+static int sc_infofile_scan(FILE *stream, sc_infofile_scanner_fn scanner_fn, void *caller_state, sc_error **err_out) {
     sc_error *err = NULL;
     size_t line_size = 0;
     char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
 
-    fpos_t start_pos;
-    if (fgetpos(stream, &start_pos) < 0) {
-        err = sc_error_init_from_errno(errno, "cannot determine stream position");
+    if (stream == NULL) {
+        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "stream cannot be NULL");
+        goto out;
+    }
+    if (scanner_fn == NULL) {
+        err = sc_error_init(SC_INTERNAL_DOMAIN, SC_API_MISUSE, "scanner_fn cannot be NULL");
         goto out;
     }
 
-    for (;;) { /* This loop advances through the keys we are looking for. */
-        const char *key = va_arg(ap, const char *);
-        if (key == NULL) {
+    /* This loop advances through subsequent lines. */
+    for (int lineno = 1;; ++lineno) {
+        errno = 0;
+        ssize_t nread = getline(&line_buf, &line_size, stream);
+        if (nread < 0 && errno != 0) {
+            err = sc_error_init_from_errno(errno, "cannot read beyond line %d", lineno);
+            goto out;
+        }
+        if (nread <= 0) {
+            break; /* There is nothing more to read. */
+        }
+        /* NOTE: beyond this line the buffer is never empty. */
+
+        /* Guard against malformed input that may contain NUL bytes that
+         * would confuse the code below. */
+        if (memchr(line_buf, '\0', nread) != NULL) {
+            err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "line %d contains NUL byte", lineno);
+            goto out;
+        }
+        /* Replace the newline character, if any, with the NUL byte. */
+        if (line_buf[nread - 1] == '\n') {
+            line_buf[nread - 1] = '\0';
+        }
+        /* Guard against malformed input that does not contain '=' byte */
+        char *eq_ptr = memchr(line_buf, '=', nread);
+        if (eq_ptr == NULL) {
+            err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "line %d is not a key=value assignment", lineno);
+            goto out;
+        }
+        /* Replace the first '=' with string terminator byte. */
+        *eq_ptr = '\0';
+
+        /* Call the scanner callback with the state for this location. */
+        sc_infofile_scanner_state scanner_state = {
+            .key = line_buf,
+            .value = eq_ptr + 1,
+            .lineno = lineno,
+            .caller_state = caller_state,
+        };
+        if (scanner_fn(&scanner_state, &err) < 0) {
+            goto out;
+        }
+        /* Stop scanning if the callback asked us to do so. */
+        if (scanner_state.stop) {
             break;
         }
-        char **value = va_arg(ap, char **);
-        if (value == NULL) {
-            err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "no storage provided for key %s", key);
-            goto out;
-        }
-        *value = NULL;
-        size_t key_len = strlen(key);
-        if (fsetpos(stream, &start_pos) < 0) {
-            err = sc_error_init_from_errno(errno, "cannot set stream position");
-            goto out;
-        }
-        for (int lineno = 1;; ++lineno) { /* This loop advances through subsequent lines. */
-            errno = 0;
-            ssize_t nread = getline(&line_buf, &line_size, stream);
-            if (nread < 0 && errno != 0) {
-                err = sc_error_init_from_errno(errno, "cannot read beyond line %d", lineno);
-                goto out;
-            }
-            if (nread <= 0) {
-                break; /* There is nothing more to read. */
-            }
-            /* NOTE: beyond this line the buffer is never empty. */
-
-            /* Guard against malformed input that may contain NUL bytes that
-             * would confuse the code below. */
-            if (memchr(line_buf, '\0', nread) != NULL) {
-                err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "line %d contains NUL byte", lineno);
-                goto out;
-            }
-            /* Guard against malformed input that does not contain '=' byte */
-            char *eq_ptr = memchr(line_buf, '=', nread);
-            if (eq_ptr == NULL) {
-                err = sc_error_init(SC_INTERNAL_DOMAIN, 0, "line %d is not a key=value assignment", lineno);
-                goto out;
-            }
-
-            /* Skip lines shorter than the key length. They cannot match our
-             * key. The extra byte ensures that we can look for the equals sign
-             * ('='). Note that at this time nread cannot be negative. */
-            if ((size_t)nread < key_len + 1) {
-                continue;
-            }
-            /* Replace the newline character, if any, with the NUL byte. */
-            if (line_buf[nread - 1] == '\n') {
-                line_buf[nread - 1] = '\0';
-                nread--;
-            }
-            /* If the prefix of the line is the search key followed by the
-             * equals sign then this is a matching entry. Copy it to the
-             * provided pointer, if any, and stop searching. */
-            if (strstr(line_buf, key) == line_buf && line_buf[key_len] == '=') {
-                *value = sc_strdup(line_buf + key_len + 1);
-                break;
-            }
-        }
     }
-    if (fsetpos(stream, &start_pos) < 0) {
-        err = sc_error_init_from_errno(errno, "cannot set stream position");
-        goto out;
-    }
+
 out:
-    va_end(ap);
-    sc_error_forward(err_out, err);
-    return err != NULL ? -1 : 0;
+    return sc_error_forward(err_out, err);
 }

--- a/cmd/libsnap-confine-private/infofile.h
+++ b/cmd/libsnap-confine-private/infofile.h
@@ -20,6 +20,8 @@
 
 #include <stdio.h>
 
+#include "../libsnap-confine-private/error.h"
+
 /**
  * sc_infofile_query extracts specific KEY=VALUE fields from a given file.
  *
@@ -37,7 +39,12 @@
  * If the key is missing the value is set to NULL. If the key is found the
  * value is set to a dynamically allocated copy of the value. The caller is
  * responsible for calling free on the returned values.
+ *
+ * The return value on success is zero. On failure -1 is returned and more
+ * information is conveyed through the err_out pointer, which contains the
+ * forwareded error. If the error cannot be forwarded the program dies,
+ * printing the error message.
  **/
-void sc_infofile_query(FILE *stream, ...) __attribute__((sentinel));
+int sc_infofile_query(FILE *stream, sc_error **err_out, ...) __attribute__((sentinel));
 
 #endif

--- a/cmd/libsnap-confine-private/infofile.h
+++ b/cmd/libsnap-confine-private/infofile.h
@@ -26,6 +26,10 @@
  * sc_infofile_get_key extracts a single value of a key=value pair from a given
  * stream.
  *
+ * Internally a constant-size buffer is used, limiting the size of each scanned
+ * line to at most one kilobyte. Larger lines cause the parser to report an error
+ * and return.
+ *
  * On success the return value is zero and err_out, if not NULL, is deferences
  * and set to NULL.  On failure the return value is -1 is and detailed error
  * information is stored by dereferencing err_out.  If an error occurs and

--- a/cmd/libsnap-confine-private/infofile.h
+++ b/cmd/libsnap-confine-private/infofile.h
@@ -18,33 +18,20 @@
 #ifndef SNAP_CONFINE_INFOFILE_H
 #define SNAP_CONFINE_INFOFILE_H
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "../libsnap-confine-private/error.h"
 
 /**
- * sc_infofile_query extracts specific KEY=VALUE fields from a given file.
+ * sc_infofile_get_key extracts a single value of a key=value pair from a given
+ * stream.
  *
- * The first argument is a stream which must support seeking. The function
- * scans the stream, starting from the current position, all the way until the
- * end of the stream, once for each key being extracted. At the end of the
- * operation the stream position is reset to the original location. This allows
- * repeated operation against a stream, as more information about the necessary
- * queries becomes known.
- *
- * The remaining function arguments form a NULL terminated list of pairs (key,
- * value_pointer) with types (const char *, char **). Each value pointer is
- * always set.
- *
- * If the key is missing the value is set to NULL. If the key is found the
- * value is set to a dynamically allocated copy of the value. The caller is
- * responsible for calling free on the returned values.
- *
- * The return value on success is zero. On failure -1 is returned and more
- * information is conveyed through the err_out pointer, which contains the
- * forwareded error. If the error cannot be forwarded the program dies,
- * printing the error message.
+ * On success the return value is zero and err_out, if not NULL, is deferences
+ * and set to NULL.  On failure the return value is -1 is and detailed error
+ * information is stored by dereferencing err_out.  If an error occurs and
+ * err_out is NULL then the program dies, printing the error message.
  **/
-int sc_infofile_query(FILE *stream, sc_error **err_out, ...) __attribute__((sentinel));
+int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **err_out);
 
 #endif

--- a/cmd/libsnap-confine-private/infofile.h
+++ b/cmd/libsnap-confine-private/infofile.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_INFOFILE_H
+#define SNAP_CONFINE_INFOFILE_H
+
+#include <stdio.h>
+
+/**
+ * sc_infofile_query extracts specific KEY=VALUE fields from a given file.
+ *
+ * The first argument is a stream which must support seeking. The function
+ * scans the stream, starting from the current position, all the way until the
+ * end of the stream, once for each key being extracted. At the end of the
+ * operation the stream position is reset to the original location. This allows
+ * repeated operation against a stream, as more information about the necessary
+ * queries becomes known.
+ *
+ * The remaining function arguments form a NULL terminated list of pairs (key,
+ * value_pointer) with types (const char *, char **). Each value pointer is
+ * always set.
+ *
+ * If the key is missing the value is set to NULL. If the key is found the
+ * value is set to a dynamically allocated copy of the value. The caller is
+ * responsible for calling free on the returned values.
+ **/
+void sc_infofile_query(FILE *stream, ...) __attribute__((sentinel));
+
+#endif

--- a/cmd/libsnap-confine-private/infofile.h
+++ b/cmd/libsnap-confine-private/infofile.h
@@ -18,7 +18,6 @@
 #ifndef SNAP_CONFINE_INFOFILE_H
 #define SNAP_CONFINE_INFOFILE_H
 
-#include <stdbool.h>
 #include <stdio.h>
 
 #include "../libsnap-confine-private/error.h"

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -289,8 +289,23 @@ static bool should_discard_current_ns(dev_t base_snap_dev)
 }
 
 enum sc_discard_vote {
+	/**
+	 * SC_DISCARD_NO denotes that the mount namespace doesn't have to be
+	 * discarded. This happens when the base snap block has not changed.
+	 **/
 	SC_DISCARD_NO = 1,
+	/**
+	 * SC_DISCARD_SHOULD indicates that the mount namespace should be discarded
+	 * but may be reused if it is still inhabited by processes. This only
+	 * happens when the base snap revision changes but the name of the base
+	 * snap is the same as before.
+	 **/
 	SC_DISCARD_SHOULD = 2,
+	/**
+	 * SC_DISCARD_MUST indicates that the mount namespace must be discarded
+	 * even if it still inhabited by processes. This only happens when the name
+	 * of the base snap changes.
+	 **/
 	SC_DISCARD_MUST = 3,
 };
 

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -847,7 +847,7 @@ void sc_store_ns_info(const sc_invocation * inv)
 		die("cannot open %s", info_path);
 	}
 	fprintf(stream, "base-snap-name=%s\n", inv->orig_base_snap_name);
-	if (fflush(stream) < 0) {
+	if (fflush(stream) == EOF) {
 		die("cannot flush %s", info_path);
 	}
 	debug("saved mount namespace meta-data to %s", info_path);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -425,11 +425,11 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 			value = SC_DISCARD_SHOULD;
 			value_str = "should";
 
-			// The namespace is stale, let's check if we must discard it because
-			// base snap has changed. We must do so even though the "view" of the
-			// snap mount namespace becomes fractured because otherwise snaps might
-			// run against the base snap declared by an older revision of the app
-			// snap, For more information see LP: #1819875
+			// The namespace is stale so also check if we must discard it due to the
+			// base snap changing. If the base snap changed, we must discard since even
+			// though currently running processes from this snap will continue to see
+			// the old base, we want new processes to use the new base. See LP:
+			// #1819875 for details.
 			if (is_base_transition(inv)) {
 				// The base snap has changed. We must discard ...
 				value = SC_DISCARD_MUST;

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -847,6 +847,9 @@ void sc_store_ns_info(const sc_invocation * inv)
 		die("cannot open %s", info_path);
 	}
 	fprintf(stream, "base-snap-name=%s\n", inv->orig_base_snap_name);
+	if (ferror(stream) != 0) {
+		die("I/O error when writing to %s", info_path);
+	}
 	if (fflush(stream) == EOF) {
 		die("cannot flush %s", info_path);
 	}

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -325,8 +325,8 @@ static bool is_base_transition(const sc_invocation * inv)
 
 	char *base_snap_name SC_CLEANUP(sc_cleanup_string) = NULL;
 	sc_error *err = NULL;
-	if (sc_infofile_query
-	    (stream, &err, "base-snap-name", &base_snap_name, NULL) < 0) {
+	if (sc_infofile_get_key
+	    (stream, "base-snap-name", &base_snap_name, &err) < 0) {
 		sc_die_on_error(err);
 	}
 

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -291,7 +291,7 @@ static bool should_discard_current_ns(dev_t base_snap_dev)
 enum sc_discard_vote {
 	/**
 	 * SC_DISCARD_NO denotes that the mount namespace doesn't have to be
-	 * discarded. This happens when the base snap block has not changed.
+	 * discarded. This happens when the base snap has not changed.
 	 **/
 	SC_DISCARD_NO = 1,
 	/**

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -295,7 +295,7 @@ enum sc_discard_vote {
 };
 
 /**
- * is_base_transition returns true a base transition is occurring.
+ * is_base_transition returns true if a base transition is occurring.
  *
  * The function inspects /run/snapd/ns/snap.$SNAP_INSTANCE_NAME.info as well
  * as the invocation parameters of snap-confine. If the base snap name, as

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -324,7 +324,11 @@ static bool is_base_transition(const sc_invocation * inv)
 	}
 
 	char *base_snap_name SC_CLEANUP(sc_cleanup_string) = NULL;
-	sc_infofile_query(stream, "base-snap-name", &base_snap_name, NULL);
+	sc_error *err = NULL;
+	if (sc_infofile_query
+	    (stream, &err, "base-snap-name", &base_snap_name, NULL) < 0) {
+		sc_die_on_error(err);
+	}
 
 	if (base_snap_name == NULL) {
 		// If the info file doesn't record the name of the base snap then,

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -312,7 +312,7 @@ static bool is_base_transition(const sc_invocation * inv)
 			 "/run/snapd/ns/snap.%s.info", inv->snap_instance);
 
 	FILE *stream SC_CLEANUP(sc_cleanup_file) = NULL;
-	stream = fopen(info_path, "rt");
+	stream = fopen(info_path, "r");
 	if (stream == NULL && errno == ENOENT) {
 		// If the info file is absent then we cannot decide if a transition had
 		// occurred. For people upgrading from snap-confine without the info

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -146,4 +146,6 @@ void sc_preserve_populated_per_user_mount_ns(struct sc_mount_ns *group);
  **/
 void sc_wait_for_helper(struct sc_mount_ns *group);
 
+void sc_store_ns_info(const sc_invocation * inv);
+
 #endif

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -359,6 +359,8 @@
     # Allow snap-confine to unmount stale mount namespaces.
     umount /run/snapd/ns/*.mnt,
     /run/snapd/ns/snap.*.fstab w,
+    # Allow snap-confine to read and write mount namespace information files.
+    /run/snapd/ns/snap.*.info rw,
     # Required to correctly unmount bound mount namespace.
     # See LP: #1735459 for details.
     umount /,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -552,6 +552,7 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 			die("cannot unshare the mount namespace");
 		}
 		sc_populate_mount_ns(aa, snap_update_ns_fd, inv);
+		sc_store_ns_info(inv);
 
 		/* Preserve the mount namespace. */
 		sc_preserve_populated_mount_ns(group);

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Canonical Ltd
+ * Copyright (C) 2015-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -103,16 +103,21 @@ int main(int argc, char** argv) {
      * - "snap.$SNAP_INSTANCE_NAME.fstab"
      * - "snap.$SNAP_INSTANCE_NAME.[0-9]+.user-fstab"
      *
+     * Mount namespace information files:
+     * - "snap.$SNAP_INSTANCE_NAME.info"
+     *
      * Use PATH_MAX as the size of each buffer since those can store any file
      * name. */
     char sys_fstab_pattern[PATH_MAX];
     char usr_fstab_pattern[PATH_MAX];
     char sys_mnt_pattern[PATH_MAX];
     char usr_mnt_pattern[PATH_MAX];
+    char sys_info_pattern[PATH_MAX];
     sc_must_snprintf(sys_fstab_pattern, sizeof sys_fstab_pattern, "snap\\.%s\\.fstab", snap_instance_name);
     sc_must_snprintf(usr_fstab_pattern, sizeof usr_fstab_pattern, "snap\\.%s\\.*\\.user-fstab", snap_instance_name);
     sc_must_snprintf(sys_mnt_pattern, sizeof sys_mnt_pattern, "%s\\.mnt", snap_instance_name);
     sc_must_snprintf(usr_mnt_pattern, sizeof usr_mnt_pattern, "%s\\.*\\.mnt", snap_instance_name);
+    sc_must_snprintf(sys_info_pattern, sizeof sys_info_pattern, "%s\\.*\\.info", snap_instance_name);
 
     DIR* ns_dir = fdopendir(ns_dir_fd);
     if (ns_dir == NULL) {
@@ -145,11 +150,12 @@ int main(int argc, char** argv) {
             const char* pattern;
             bool unmount;
         };
-        struct variant variants[4] = {
+        struct variant variants[] = {
             {.pattern = sys_mnt_pattern, .unmount = true},
             {.pattern = usr_mnt_pattern, .unmount = true},
             {.pattern = sys_fstab_pattern},
             {.pattern = usr_fstab_pattern},
+            {.pattern = sys_info_pattern},
         };
         for (size_t i = 0; i < sizeof variants / sizeof *variants; ++i) {
             struct variant* v = &variants[i];

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -125,7 +125,7 @@ purge() {
                 rm -f "$mnt"
             done
         fi
-        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' -o -name '*.info' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -491,6 +491,9 @@ term_mount_pty_fs(snappy_confine_t)
 # device group
 fs_manage_cgroup_dirs(snappy_confine_t)
 fs_manage_cgroup_files(snappy_confine_t)
+# snap-update-ns and snap-confine use tmpfs when setting up the namespace,
+# things may end up keeping tmpfs_t label
+fs_read_tmpfs_symlinks(snappy_confine_t)
 
 # restoring file contexts
 seutil_read_file_contexts(snappy_confine_t)

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -104,7 +104,7 @@ if [ "$1" = "purge" ]; then
                 rm -f "$mnt"
             done
         fi
-        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' -o -name '*.info' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -107,7 +107,7 @@ if [ "$1" = "purge" ]; then
                 rm -f "$mnt"
             done
         fi
-        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
+        find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' -o -name '*.info' \) -delete
         umount -l /run/snapd/ns/ || true
     fi
 

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -182,7 +182,7 @@ if [ -d /run/snapd/ns ]; then
         umount -l "$mnt" || true
         rm -f "$mnt"
     done
-    find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' \) -delete
+    find /run/snapd/ns/ \( -name '*.fstab' -o -name '*.user-fstab' -o -name '*.info' \) -delete
 fi
 
 if [ "$REMOTE_STORE" = staging ] && [ "$1" = "--store" ]; then

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -1,0 +1,35 @@
+summary: a snap migrates from base "core" to "core18"
+prepare: |
+  snap install core18
+  snap pack test-snapd-core-migration.base-core
+  snap pack test-snapd-core-migration.base-core18
+execute: |
+  # When we install a snap that is using (implicitly) base: core, then that
+  # snap runs on top of the core16 runtime environment. This can be seen by
+  # looking at the os-release file which will match that of ubuntu core 16.
+  snap install --dangerous test-snapd-core-migration_1_all.snap
+  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+  # When said snap is refreshed to use "base core18" then because there are no
+  # active processes using that snap, the base will change correctly to core18.
+  # This can be again observed by looking at the os-release file.
+  snap install --dangerous test-snapd-core-migration_2_all.snap
+  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+  # If we rewind and do the update again, this time allowing one of the apps
+  # from core16 world to keep running. We will see that the base is not
+  # updated. This is unexpected but is the behavior of snapd 2.38 and earlier.
+  snap remove test-snapd-core-migration
+  snap install --dangerous test-snapd-core-migration_1_all.snap
+  test-snapd-core-migration.sh -c "exec sleep 1h" &
+  pid=$!
+  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+  snap install --dangerous test-snapd-core-migration_2_all.snap
+  # Even before the background process terminates we are now using the new base
+  # snap, processes across base snaps see different mount namespaces.
+  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+  kill "$pid"
+  wait "$pid" || true  # wait returns the exit code and we kill the process
+  # Nothing changes after the background app terminates.
+  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+restore: |
+  snap remove test-snapd-core-migration
+  rm -f test-snapd-core-migration_{1,2}_all.snap

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -9,22 +9,31 @@ execute: |
   # looking at the os-release file which will match that of ubuntu core 16.
   snap install --dangerous test-snapd-core-migration_1_all.snap
   test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
-  # When said snap is refreshed to use "base core18" then because there are no
-  # active processes using that snap, the base will change correctly to core18.
+
+  # When said snap is refreshed to use "base: core18" then, because there are
+  # no active processes in that snap, the base will change correctly to core18.
   # This can be again observed by looking at the os-release file.
   snap install --dangerous test-snapd-core-migration_2_all.snap
   test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
+
   # If we rewind and do the update again, this time allowing one of the apps
-  # from core16 world to keep running. We will see that the base is not
-  # updated. This is unexpected but is the behavior of snapd 2.38 and earlier.
+  # from the core16 world to keep running. Normally this would hold the update
+  # of the base snap, as seen by the processes of the application snap. This
+  # ensures that all processes in a given snap see a consistent view of the
+  # filesystem.
   snap remove test-snapd-core-migration
   snap install --dangerous test-snapd-core-migration_1_all.snap
   test-snapd-core-migration.sh -c "exec sleep 1h" &
   pid=$!
   test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
   snap install --dangerous test-snapd-core-migration_2_all.snap
-  # Even before the background process terminates we are now using the new base
-  # snap, processes across base snaps see different mount namespaces.
+  # With core -> core18 migration this doesn't work however, as now
+  # applications that were expecting to use core18 libraries would be forced to
+  # run on top of core16.
+  #
+  # Therefore, to ensure compatibility, even before the background process
+  # terminates we are now using the new base snap, processes across base snaps
+  # see different mount namespaces.
   test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="18"'
   kill "$pid"
   wait "$pid" || true  # wait returns the exit code and we kill the process

--- a/tests/main/base-migration/test-snapd-core-migration.base-core/bin/sh
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/base-migration/test-snapd-core-migration.base-core/meta/snap.yaml
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-core-migration
+version: 1
+# TODO: uncomment when "base: core" works.
+# base: core
+apps:
+  sh:
+    command: bin/sh

--- a/tests/main/base-migration/test-snapd-core-migration.base-core18/bin/sh
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core18/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/base-migration/test-snapd-core-migration.base-core18/meta/snap.yaml
+++ b/tests/main/base-migration/test-snapd-core-migration.base-core18/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snapd-core-migration
+version: 2
+base: core18
+apps:
+  sh:
+    command: bin/sh

--- a/tests/main/snap-discard-ns/task.yaml
+++ b/tests/main/snap-discard-ns/task.yaml
@@ -42,6 +42,7 @@ execute: |
     $LIBEXECDIR/snapd/snap-discard-ns test-snapd-tools
     test ! -e /run/snapd/ns/test-snapd-tools.mnt
     test ! -e /run/snapd/ns/test-snapd-tools.1000.mnt
+    test ! -e /run/snapd/ns/test-snapd-tools.info
 
     echo "We can fake a current mount profile and see that it is removed too"
     test-snapd-tools.success


### PR DESCRIPTION
While working on unit tests I was worried that some attacker might
be able to point the parser at a large file and therefore exhaust the
memory pool, all while running as root. Since for our needs we can
certainly put a small cap on the memory pool used by the key=value
extractor I did just that.

In addition, the test coverage for infofile is now at 100%

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>