### PR TITLE
cmd/snap-confine: remove newly unneeded getresuid() local assignments

### DIFF
--- a/cmd/snap-confine/seccomp-support-ext.c
+++ b/cmd/snap-confine/seccomp-support-ext.c
@@ -62,12 +62,7 @@ size_t sc_read_seccomp_filter(const char *filename, char *buf, size_t buf_size) 
 }
 
 void sc_apply_seccomp_filter(struct sock_fprog *prog) {
-    uid_t real_uid, effective_uid, saved_uid;
     int err;
-
-    if (getresuid(&real_uid, &effective_uid, &saved_uid) < 0) {
-        die("cannot call getresuid");
-    }
 
     // Load filter into the kernel (by this point we have dropped to the
     // calling user but still retain CAP_SYS_ADMIN).


### PR DESCRIPTION
PR 7032 performed some code shuffling which left local assignments from
getresuid() where the resulting variables were not used anywhere.

Prompted by zyga's question of why we called getresuid() when we did in
PR 7032.