### PR TITLE
cmd/snap-confine: handle device cgroup before pivot

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -38,6 +38,8 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libudev.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libseccomp.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcap.so* mr,
+    # Needed to run /usr/bin/sh for snap-device-helper.
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libtinfo.so* mr,
 
     @LIBEXECDIR@/snap-confine mr,
 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -575,6 +575,12 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 	// Init and check rootfs_dir, apply any fallback behaviors.
 	sc_check_rootfs_dir(inv);
 
+	/** Populate and join the device control group. */
+	struct snappy_udev udev_s;
+	if (snappy_udev_init(inv->security_tag, &udev_s) == 0)
+		setup_devices_cgroup(inv->security_tag, &udev_s);
+	snappy_udev_cleanup(&udev_s);
+
 	/**
 	 * is_normal_mode controls if we should pivot into the base snap.
 	 *
@@ -708,8 +714,4 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 			die("cannot set environment variable '%s'", tmpd[i]);
 		}
 	}
-	struct snappy_udev udev_s;
-	if (snappy_udev_init(inv->security_tag, &udev_s) == 0)
-		setup_devices_cgroup(inv->security_tag, &udev_s);
-	snappy_udev_cleanup(&udev_s);
 }

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -73,6 +73,10 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 			execle("/usr/lib/snapd/snap-device-helper",
 			       "/usr/lib/snapd/snap-device-helper", "add",
 			       udev_s->tagname, path, buf, NULL, env);
+		else if (access("/usr/libexec/snapd/snap-device-helper", X_OK) == 0)
+			execle("/usr/libexec/snapd/snap-device-helper",
+			       "/usr/libexec/snapd/snap-device-helper", "add",
+			       udev_s->tagname, path, buf, NULL, env);
 		else
 			execle("/lib/udev/snappy-app-dev",
 			       "/lib/udev/snappy-app-dev", "add",

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -77,9 +77,6 @@
 %define gotest() go test -compiler gc -ldflags "${LDFLAGS:-}" %{?**};
 %endif
 
-# Avoid causing incompatibilities among base snaps
-%global __brp_mangle_shebangs_exclude ^/bin/(bash|sh)$
-
 # Compat path macros
 %{!?_environmentdir: %global _environmentdir %{_prefix}/lib/environment.d}
 %{!?_systemdgeneratordir: %global _systemdgeneratordir %{_prefix}/lib/systemd/system-generators}


### PR DESCRIPTION
Since the dawn of snapd, snap-confine would populate and join the device
cgroup nearly just before executing the target application. This is done
by interrogating udev for devices with appropriate tags and adding them
to the control group. They way they are added to the control group,
however, is pretty inefficient, as it involves executing a shell script
that writes to /sys/fs/cgroup/devices/devices.allow. The shells script
uses the interpreter #!/bin/sh forcing all base snaps to ship shell
along with the minimal set of support libraries.

Normally that was "okay" with the exception that we recently started
adding new base snaps that are otherwise empty, raising the pressure on
the need to host the spurious shell.

While a better solution would be to write to the device cgroup directly,
from snap-confine, ignoring the script, that work is somewhat larger.
As a simple alternative, just run the script before we setup and switch
to the mount namespace of the snap application.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
