### PR TITLE
Retry: Handle DNSError when network message different

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -153,7 +153,9 @@ func isNetworkDown(err error) bool {
 	case *net.DNSError:
 		// on 16.04 we will not have SyscallError here, but DNSError, with
 		// no further details other than error message
-		return strings.Contains(lowerErr.Err, "connect: network is unreachable")
+		return strings.Contains(lowerErr.Err, "connect: network is unreachable") ||
+			strings.Contains(lowerErr.Err, "no such host") ||
+			strings.Contains(lowerErr.Err, "server misbehaving")
 	case *os.SyscallError:
 		if errnoErr, ok := lowerErr.Err.(syscall.Errno); ok {
 			// the errno codes from kernel/libc when the network is down


### PR DESCRIPTION
As mentioned below launchpad link; in some cases when network connection does not exist, snap install command returns unclear message. Thus, I added "server misbehaving" check to make it clear to the user when there is possible network connectivity problem and its unit test.

https://bugs.launchpad.net/snapd/+bug/1794006