### PR TITLE
cmd/snap-apparmor-service: quit if there are no profiles

### DIFF
--- a/cmd/snapd-apparmor/snapd-apparmor
+++ b/cmd/snapd-apparmor/snapd-apparmor
@@ -81,6 +81,9 @@ case "$1" in
 		fi
 		# </copied-code>
 
+		if [ "$(find /var/lib/snapd/apparmor/profiles/ -type f | wc -l)" -eq 0 ]; then
+			exit 0
+		fi
 		for profile in /var/lib/snapd/apparmor/profiles/*; do
 			# Filter out profiles with names ending with ~, those are temporary files created by snapd.
 			test "${profile%\~}" != "${profile}" && continue


### PR DESCRIPTION
We got a word-of-mouth bug report from Manjaro that
snapd-apparmor.service crashes when there are no apparmor profiles in
/var/lib/snapd/apparmor/profiles.

Looking at the shell script implementing the logic it is clear that in
absence of the actual profiles the script will execute with a single
file "name" of /var/lib/snapd/apparmor/profiles/* - a well known
"feature" of shell where glob expands to itself when it doesn't match
any actual files.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>