### PR TITLE
overlord/config: normalize nulls to support config unsetting semantics

### DIFF
--- a/overlord/configstate/config/export_test.go
+++ b/overlord/configstate/config/export_test.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 )
 
+var PurgeNulls = purgeNulls
+
 func (t *Transaction) PristineConfig() map[string]map[string]*json.RawMessage {
 	return t.pristine
 }

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -47,6 +47,46 @@ func ParseKey(key string) (subkeys []string, err error) {
 	return subkeys, nil
 }
 
+func purgeNulls(config interface{}) interface{} {
+	switch config := config.(type) {
+	// map of json raw messages is the starting point for purgeNulls, this is the configuration we receive
+	case map[string]*json.RawMessage:
+		for k, v := range config {
+			cfg := purgeNulls(v)
+			if cfg != nil {
+				config[k] = cfg.(*json.RawMessage)
+			} else {
+				delete(config, k)
+			}
+		}
+		// After removing nulls from the map we can end up with an empty map
+		if len(config) == 0 {
+			return nil
+		}
+	case map[string]interface{}:
+		for k, v := range config {
+			if purgeNulls(v) == nil {
+				delete(config, k)
+			}
+		}
+		// After removing nulls from the map we can end up with an empty map
+		if len(config) == 0 {
+			return nil
+		}
+	case *json.RawMessage:
+		var configm interface{}
+		if err := jsonutil.DecodeWithNumber(bytes.NewReader(*config), &configm); err != nil {
+			panic(fmt.Errorf("internal error: cannot unmarshal configuration: %v", err))
+		}
+		cfg := purgeNulls(configm)
+		if cfg == nil {
+			return nil
+		}
+		return jsonRaw(cfg)
+	}
+	return config
+}
+
 func PatchConfig(snapName string, subkeys []string, pos int, config interface{}, value *json.RawMessage) (interface{}, error) {
 
 	switch config := config.(type) {
@@ -70,6 +110,7 @@ func PatchConfig(snapName string, subkeys []string, pos int, config interface{},
 		if err != nil {
 			return nil, err
 		}
+
 		return jsonRaw(configm), nil
 
 	case map[string]interface{}:

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -102,7 +102,6 @@ func PatchConfig(snapName string, subkeys []string, pos int, config interface{},
 		if err != nil {
 			return nil, err
 		}
-
 		return jsonRaw(configm), nil
 
 	case map[string]interface{}:

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -230,10 +230,11 @@ func (s *configHelpersSuite) TestPurgeNulls(c *C) {
 		"bar": map[string]interface{}{
 			"one": 1,
 		},
+		"baz": map[string]interface{}{},
 	})
 
 	cfg2 := map[string]interface{}{"foo": nil}
-	c.Check(config.PurgeNulls(cfg2), Equals, nil)
+	c.Check(config.PurgeNulls(cfg2), DeepEquals, map[string]interface{}{})
 	c.Check(cfg2, DeepEquals, map[string]interface{}{})
 
 	jsonData, err := json.Marshal(map[string]interface{}{
@@ -262,5 +263,6 @@ func (s *configHelpersSuite) TestPurgeNulls(c *C) {
 		"bar": map[string]interface{}{
 			"one": json.Number("2"),
 		},
+		"baz": map[string]interface{}{},
 	})
 }

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -20,11 +20,13 @@
 package config_test
 
 import (
+	"bytes"
 	"encoding/json"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -210,4 +212,55 @@ func (s *configHelpersSuite) TestPatchInvalidConfig(c *C) {
 	value := json.RawMessage([]byte("[]"))
 	_, err := config.PatchConfig("snap1", []string{"foo"}, 0, invalid, &value)
 	c.Assert(err, ErrorMatches, `internal error: unexpected configuration type \[\]string`)
+}
+
+func (s *configHelpersSuite) TestPurgeNulls(c *C) {
+	cfg1 := map[string]interface{}{
+		"foo": nil,
+		"bar": map[string]interface{}{
+			"one": 1,
+			"two": nil,
+		},
+		"baz": map[string]interface{}{
+			"three": nil,
+		},
+	}
+	config.PurgeNulls(cfg1)
+	c.Check(cfg1, DeepEquals, map[string]interface{}{
+		"bar": map[string]interface{}{
+			"one": 1,
+		},
+	})
+
+	cfg2 := map[string]interface{}{"foo": nil}
+	c.Check(config.PurgeNulls(cfg2), Equals, nil)
+	c.Check(cfg2, DeepEquals, map[string]interface{}{})
+
+	jsonData, err := json.Marshal(map[string]interface{}{
+		"foo": nil,
+		"bar": map[string]interface{}{
+			"one": 2,
+			"two": nil,
+		},
+		"baz": map[string]interface{}{
+			"three": nil,
+		},
+	})
+	c.Assert(err, IsNil)
+	raw := json.RawMessage(jsonData)
+	cfg4 := map[string]*json.RawMessage{
+		"root": &raw,
+	}
+	config.PurgeNulls(cfg4)
+
+	val, ok := cfg4["root"]
+	c.Assert(ok, Equals, true)
+
+	var out interface{}
+	jsonutil.DecodeWithNumber(bytes.NewReader(*val), &out)
+	c.Check(out, DeepEquals, map[string]interface{}{
+		"bar": map[string]interface{}{
+			"one": json.Number("2"),
+		},
+	})
 }

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -175,9 +175,9 @@ func (t *Transaction) Get(snapName, key string, result interface{}) error {
 
 	out := purgeNulls(config)
 	if out == nil {
-		// XXX: an edge case - uncommited changes gave null after normalizing; we could return "snap has no configration" error
+		// XXX: an edge case - uncommitted changes gave null after normalizing; we could return "snap has no configration" error
 		// instead, this however affects feature flags which expect NoOptionError. Note, special-casing NoOptionError is not
-		// strictly neccessary here as it would be the outcome of getFromConfig() below, however it makes the intent more clear.
+		// strictly necessary here as it would be the outcome of getFromConfig() below, however it makes the intent more clear.
 		return &NoOptionError{SnapName: snapName, Key: key}
 	}
 	return getFromConfig(snapName, subkeys, 0, config, result)

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -127,20 +127,20 @@ var setGetTests = [][]setGetOp{{
 	// Nulls via dotted path, resuling in empty map
 	`set doc={"one":{"three":3},"two":2}`,
 	`set doc.one.three=null`,
-	`get doc={"two":2}`,
+	`get doc={"one":{},"two":2}`,
 	`commit`,
-	`get doc={"two":2}`,
-	`getunder doc={"two":2}`, // nils are not committed to state
+	`get doc={"one":{},"two":2}`,
+	`getunder doc={"one":{},"two":2}`, // nils are not committed to state
 }, {
 	// Nulls via dotted path in a doc
 	`set doc={"one":1,"two":2}`,
 	`set doc.three={"four":4}`,
 	`get doc={"one":1,"two":2,"three":{"four":4}}`,
 	`set doc.three={"four":null}`,
-	`get doc={"one":1,"two":2}`,
+	`get doc={"one":1,"two":2,"three":{}}`,
 	`commit`,
-	`get doc={"one":1,"two":2}`,
-	`getunder doc={"one":1,"two":2}`, // nils are not committed to state
+	`get doc={"one":1,"two":2,"three":{}}`,
+	`getunder doc={"one":1,"two":2,"three":{}}`, // nils are not committed to state
 }, {
 	// Nulls nested in a document
 	`set doc={"one":{"three":3,"two":2}}`,
@@ -165,24 +165,24 @@ var setGetTests = [][]setGetOp{{
 	`set doc={"one":{"two":2}}`,
 	`commit`,
 	`set doc.one.three.four.five=null`,
-	`get doc={"one":{"two":2}}`,
+	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
 	`commit`,
-	`get doc={"one":{"two":2}}`,
-	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not committed to state
+	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
+	`getrootunder ={"doc":{"one":{"two":2,"three":{"four":{}}}}}`, // nils are not committed to state
 }, {
 	// Nulls, same transaction, intermediate non-existing maps get dropped
 	`set doc={"one":{"two":2}}`,
 	`set doc.one.three.four.five=null`,
-	`get doc={"one":{"two":2}}`,
+	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
 	`commit`,
-	`get doc={"one":{"two":2}}`,
-	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not committed to state
+	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
+	`getrootunder ={"doc":{"one":{"two":2,"three":{"four":{}}}}}`, // nils are not committed to state
 }, {
 	// Nulls, empty doc dropped
 	`set doc={"one":1}`,
 	`set doc.one=null`,
 	`commit`,
-	`get doc=-`,
+	`get doc={}`,
 }, {
 	// Nulls leading to no snap configuration
 	`set doc="foo"`,

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -122,7 +122,7 @@ var setGetTests = [][]setGetOp{{
 	`commit`,
 	`get doc={"two":2}`,
 	`getroot ={"doc":{"two":2}}`,
-	`getunder doc={"two":2}`, // nils are not commited to state
+	`getunder doc={"two":2}`, // nils are not committed to state
 }, {
 	// Nulls via dotted path, resuling in empty map
 	`set doc={"one":{"three":3},"two":2}`,
@@ -130,7 +130,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"two":2}`,
 	`commit`,
 	`get doc={"two":2}`,
-	`getunder doc={"two":2}`, // nils are not commited to state
+	`getunder doc={"two":2}`, // nils are not committed to state
 }, {
 	// Nulls via dotted path in a doc
 	`set doc={"one":1,"two":2}`,
@@ -140,7 +140,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":1,"two":2}`,
 	`commit`,
 	`get doc={"one":1,"two":2}`,
-	`getunder doc={"one":1,"two":2}`, // nils are not commited to state
+	`getunder doc={"one":1,"two":2}`, // nils are not committed to state
 }, {
 	// Nulls nested in a document
 	`set doc={"one":{"three":3,"two":2}}`,
@@ -150,7 +150,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":{"two":2}}`,
 	`commit`,
 	`get doc={"one":{"two":2}}`,
-	`getunder doc={"one":{"two":2}}`, // nils are not commited to state
+	`getunder doc={"one":{"two":2}}`, // nils are not committed to state
 }, {
 	// Nulls with mutating
 	`set doc={"one":{"two":2}}`,
@@ -159,7 +159,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc.one="foo"`,
 	`commit`,
 	`get doc={"one":"foo"}`,
-	`getunder doc={"one":"foo"}`, // nils are not commited to state
+	`getunder doc={"one":"foo"}`, // nils are not committed to state
 }, {
 	// Nulls, intermediate temporary maps get dropped
 	`set doc={"one":{"two":2}}`,
@@ -168,7 +168,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":{"two":2}}`,
 	`commit`,
 	`get doc={"one":{"two":2}}`,
-	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not commited to state
+	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not committed to state
 }, {
 	// Nulls, same transaction, intermediate non-existing maps get dropped
 	`set doc={"one":{"two":2}}`,
@@ -176,7 +176,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":{"two":2}}`,
 	`commit`,
 	`get doc={"one":{"two":2}}`,
-	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not commited to state
+	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not committed to state
 }, {
 	// Nulls, empty doc dropped
 	`set doc={"one":1}`,

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -90,8 +90,8 @@ func (op setGetOp) fails() bool {
 
 var setGetTests = [][]setGetOp{{
 	// Basics.
-	`set n=null`,
-	`get n=null`,
+	`get foo=-`,
+	`getroot => snap "core" has no configuration`,
 	`set one=1 two=2`,
 	`set big=1234567890`,
 	`setunder three=3 big=9876543210`,
@@ -99,7 +99,6 @@ var setGetTests = [][]setGetOp{{
 	`getunder one=- two=- three=3 big=9876543210`,
 	`changes core.big core.one core.two`,
 	`commit`,
-	`get n=null`,
 	`getunder one=1 two=2 three=3`,
 	`get one=1 two=2 three=3`,
 	`set two=22 four=4 big=1234567890`,
@@ -113,6 +112,84 @@ var setGetTests = [][]setGetOp{{
 	`set doc={"one":1,"two":2}`,
 	`get doc={"one":1,"two":2}`,
 	`changes core.doc.one core.doc.two`,
+}, {
+	// Nulls via dotted path
+	`set doc={"one":1,"two":2}`,
+	`commit`,
+	`set doc.one=null`,
+	`get doc={"two":2}`,
+	`getunder doc={"one":1,"two":2}`,
+	`commit`,
+	`get doc={"two":2}`,
+	`getroot ={"doc":{"two":2}}`,
+	`getunder doc={"two":2}`, // nils are not commited to state
+}, {
+	// Nulls via dotted path, resuling in empty map
+	`set doc={"one":{"three":3},"two":2}`,
+	`set doc.one.three=null`,
+	`get doc={"two":2}`,
+	`commit`,
+	`get doc={"two":2}`,
+	`getunder doc={"two":2}`, // nils are not commited to state
+}, {
+	// Nulls via dotted path in a doc
+	`set doc={"one":1,"two":2}`,
+	`set doc.three={"four":4}`,
+	`get doc={"one":1,"two":2,"three":{"four":4}}`,
+	`set doc.three={"four":null}`,
+	`get doc={"one":1,"two":2}`,
+	`commit`,
+	`get doc={"one":1,"two":2}`,
+	`getunder doc={"one":1,"two":2}`, // nils are not commited to state
+}, {
+	// Nulls nested in a document
+	`set doc={"one":{"three":3,"two":2}}`,
+	`changes core.doc.one.three core.doc.one.two`,
+	`set doc={"one":{"three":null,"two":2}}`,
+	`changes core.doc.one.three core.doc.one.two`,
+	`get doc={"one":{"two":2}}`,
+	`commit`,
+	`get doc={"one":{"two":2}}`,
+	`getunder doc={"one":{"two":2}}`, // nils are not commited to state
+}, {
+	// Nulls with mutating
+	`set doc={"one":{"two":2}}`,
+	`set doc.one.two=null`,
+	`set doc.one="foo"`,
+	`get doc.one="foo"`,
+	`commit`,
+	`get doc={"one":"foo"}`,
+	`getunder doc={"one":"foo"}`, // nils are not commited to state
+}, {
+	// Nulls, intermediate temporary maps get dropped
+	`set doc={"one":{"two":2}}`,
+	`commit`,
+	`set doc.one.three.four.five=null`,
+	`get doc={"one":{"two":2}}`,
+	`commit`,
+	`get doc={"one":{"two":2}}`,
+	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not commited to state
+}, {
+	// Nulls, same transaction, intermediate non-existing maps get dropped
+	`set doc={"one":{"two":2}}`,
+	`set doc.one.three.four.five=null`,
+	`get doc={"one":{"two":2}}`,
+	`commit`,
+	`get doc={"one":{"two":2}}`,
+	`getrootunder ={"doc":{"one":{"two":2}}}`, // nils are not commited to state
+}, {
+	// Nulls, empty doc dropped
+	`set doc={"one":1}`,
+	`set doc.one=null`,
+	`commit`,
+	`get doc=-`,
+}, {
+	// Nulls leading to no snap configuration
+	`set doc="foo"`,
+	`set doc=null`,
+	`commit`,
+	`get doc=-`,
+	`getroot => snap "core" has no configuration`,
 }, {
 	// Root doc
 	`set doc={"one":1,"two":2}`,
@@ -297,7 +374,12 @@ func (s *transactionSuite) TestSetGet(c *C) {
 				}
 			case "getroot":
 				var obtained interface{}
-				c.Assert(t.Get(snap, "", &obtained), IsNil)
+				err := t.Get(snap, "", &obtained)
+				if op.fails() {
+					c.Assert(err, ErrorMatches, op.error())
+					continue
+				}
+				c.Assert(err, IsNil)
 				c.Assert(obtained, DeepEquals, op.args()[""])
 			case "getrootunder":
 				var config map[string]*json.RawMessage

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -265,8 +265,7 @@ func (s *setSuite) TestNull(c *C) {
 	// Verify config value
 	var value interface{}
 	tr := config.NewTransaction(s.mockContext.State())
-	c.Assert(tr.Get("test-snap", "foo", &value), IsNil)
-	c.Assert(value, IsNil)
+	c.Assert(config.IsNoOption(tr.Get("test-snap", "foo", &value)), Equals, true)
 	c.Assert(tr.Get("test-snap", "bar", &value), IsNil)
 	c.Assert(value, DeepEquals, []interface{}{nil})
 }

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -376,8 +376,7 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpired(c *C) {
 	tr = config.NewTransaction(s.state)
 	var t1 time.Time
 	err = tr.Get("core", "refresh.hold", &t1)
-	c.Assert(err, IsNil)
-	c.Check(t1.IsZero(), Equals, true)
+	c.Assert(config.IsNoOption(err), Equals, true)
 }
 
 func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredReschedule(c *C) {
@@ -412,8 +411,7 @@ func (s *autoRefreshTestSuite) TestLastRefreshRefreshHoldExpiredReschedule(c *C)
 	tr = config.NewTransaction(s.state)
 	var t1 time.Time
 	err = tr.Get("core", "refresh.hold", &t1)
-	c.Assert(err, IsNil)
-	c.Check(t1.IsZero(), Equals, true)
+	c.Assert(config.IsNoOption(err), Equals, true)
 
 	// check next refresh
 	nextRefresh1 := af.NextRefresh()

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -75,10 +75,11 @@ test_get_nested() {
   fi
 }
 
-test_snapctl_get_foo_null() {
+test_snapctl_foo_null() {
 	  echo "Getting foo"
+	  # note, snapctl doesn't fail on non-existing keys, this check is for other unexpected errors
 	  if ! output="$(snapctl get foo)"; then
-		    echo "Expected snapctl get to be able to retrieve value just set"
+		    echo "Did not expect snapctl get to fail"
 		    exit 1
 	  fi
 
@@ -110,8 +111,8 @@ case $command in
 	"test-snapctl-get-foo")
 		test_snapctl_get_foo
 		;;
-	"test-snapctl-get-foo-null")
-    test_snapctl_get_foo_null
+	"test-snapctl-foo-null")
+    test_snapctl_foo_null
     ;;
 	"test-exit-one")
 		test_exit_one

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -32,13 +32,19 @@ execute: |
         exit 1
     fi
 
-    echo "Test that the set value can be null and can be retrieved"
-    if ! snap set snapctl-hooks command=test-snapctl-get-foo-null foo=null; then
+    echo "Sanity check before we unset the value with null"
+    if ! obtained=$(snap get snapctl-hooks foo); then
+        echo "Expected snap get to be able to retrieve set value"
+        exit 1
+    fi
+    [[ "$obtained" == "bar" ]]
+
+    echo "Test that the set value can be null and it removes the option"
+    if ! snap set snapctl-hooks command=test-snapctl-foo-null foo=null; then
         echo "Expected hook to be able to retrieve set value"
         exit 1
     fi
-    obtained=$(snap get snapctl-hooks foo)
-    [[ "$obtained" == "" ]]
+    snap get snapctl-hooks foo 2>&1 | MATCH 'snap "snapctl-hooks" has no "foo" configuration option'
 
     echo "Test that an invalid key results in an error"
     if obtained=$(snap set snapctl-hooks invalid_key=value 2>&1); then


### PR DESCRIPTION
Purge (normalize) null values internally in snap configuration to support `snap unset` (`snap set foo!`) semantics (not implemented yet - will be done in a followup). Setting values to null with `snap set mysnap foo=null` will now remove the value from configuration. Normalization is done before commit and also after applying temporary changes on get.