### PR TITLE
snap: refactor and explain layout blacklisting

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -763,8 +763,8 @@ var layoutRejectionList = []string{
 	// snap applications to be integrated with the rest of the system and
 	// therefore snaps should not be allowed to replace it.
 	"/run",
-	// The /tmp directory contains private, per-snap, view of /tmp and there's
-	// no valid reason to allow snaps to replace it.
+	// The /tmp directory contains a private, per-snap, view of /tmp and
+	// there's no valid reason to allow snaps to replace it.
 	"/tmp",
 	// The /var/lib/snapd directory contains essential state of snapd and is
 	// sometimes consulted from inside the mount namespace.

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -754,8 +754,8 @@ var layoutRejectionList = []string{
 	// The firmware is sometimes loaded on demand by the kernel, in response to
 	// a process performing generic I/O to a specific device. In that case the
 	// mount namespace of the process is searched, by the kernel, for the
-	// firmware. Therefore firmware must not be replicable to prevent malicious
-	// firmware from attacking the host.
+	// firmware. Therefore firmware must not be replaceable to prevent
+	// malicious firmware from attacking the host.
 	"/lib/firmware",
 	// Similarly the kernel will load modules and the modules should not be
 	// something that snaps can tamper with.

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -767,6 +767,9 @@ var layoutRejectionList = []string{
 	// The /sys directory exposes many kernel internals, similar to /proc and
 	// there is no known reason to allow snaps to replace it.
 	"/sys",
+	// The /tmp directory contains private, per-snap, view of /tmp and there's
+	// no valid reason to allow snaps to replace it.
+	"/tmp",
 	// The /var/lib/snapd directory contains essential state of snapd and is
 	// sometimes consulted from inside the mount namespace.
 	"/var/lib/snapd",

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -766,7 +766,7 @@ var layoutRejectionList = []string{
 	// The /tmp directory contains a private, per-snap, view of /tmp and
 	// there's no valid reason to allow snaps to replace it.
 	"/tmp",
-	// The /var/lib/snapd directory contains essential state of snapd and is
+	// The /var/lib/snapd directory contains essential snapd state and is
 	// sometimes consulted from inside the mount namespace.
 	"/var/lib/snapd",
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -760,6 +760,9 @@ var layoutRejectionList = []string{
 	// Similarly the kernel will load modules and the modules should not be
 	// something that snaps can tamper with.
 	"/lib/modules",
+	// The lost+found directory is used by fsck tools to link lost blocks back
+	// into the filesystem tree. Using layouts for this element is just
+	// confusing and there is no valid reason to allow it.
 	"/lost+found",
 	// The media directory is bi-directionally mounted and any mount operations
 	// there are reflected in the host's view of /media, which may be either

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -413,6 +413,16 @@ func ValidateLayoutAll(info *Info) error {
 		}
 	}
 
+	// Validate that layout are not attempting to define elements that normally
+	// come from other snaps. This is separate from the ValidateLayout below to
+	// simplify argument passing.
+	thisSnapMntDir := filepath.Join("/snap/", info.SnapName())
+	for _, path := range paths {
+		if strings.HasPrefix(path, "/snap/") && !strings.HasPrefix(path, thisSnapMntDir) {
+			return fmt.Errorf("layout %q defines a layout in space belonging to another snap", path)
+		}
+	}
+
 	// Validate each layout item and collect resulting constraints.
 	constraints := make([]LayoutConstraint, 0, len(info.Layout))
 	for _, path := range paths {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -737,6 +737,10 @@ var layoutRejectionList = []string{
 	// The /dev directory contains essential device nodes and there's no valid
 	// reason to allow snaps to replace it.
 	"/dev",
+	// The /home directory contains user data, including $SNAP_USER_DATA,
+	// $SNAP_USER_COMMON and should be disallowed for the same reasons as
+	// /var/snap.
+	"/home",
 	// The firmware is sometimes loaded on demand by the kernel, in response to
 	// a process performing generic I/O to a specific device. In that case the
 	// mount namespace of the process is searched, by the kernel, for the

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -754,9 +754,9 @@ var layoutRejectionList = []string{
 	// The /sys directory exposes many kernel internals, similar to /proc and
 	// there is no known reason to allow snaps to replace it.
 	"/sys",
-	// The media directory is bi-directionally mounted and any mount operations
-	// there are reflected in the host's view of /media, which may be either
-	// itself or /run/media.
+	// The media directory is mounted with bi-directional mount event sharing.
+	// Any mount operations there are reflected in the host's view of /media,
+	// which may be either itself or /run/media.
 	"/media",
 	// The /run directory contains various ephemeral information files or
 	// sockets used by various programs. Providing view of the true /run allows

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -742,15 +742,36 @@ func (layout *Layout) constraint() LayoutConstraint {
 // $SNAP_DATA, or $SNAP_COMMON content, even from the point of view of a single
 // snap.
 var layoutRejectionList = []string{
-	// There's no known reason to allow snaps to replace things there.
-	"/boot",
+	// Special locations that need to retain their properties:
+
 	// The /dev directory contains essential device nodes and there's no valid
 	// reason to allow snaps to replace it.
 	"/dev",
-	// The /home directory contains user data, including $SNAP_USER_DATA,
-	// $SNAP_USER_COMMON and should be disallowed for the same reasons as
-	// /var/snap.
-	"/home",
+	// The /proc directory contains essential process meta-data and
+	// miscellaneous kernel configuration parameters and there is no valid
+	// reason to allow snaps to replace it.
+	"/proc",
+	// The /sys directory exposes many kernel internals, similar to /proc and
+	// there is no known reason to allow snaps to replace it.
+	"/sys",
+	// The media directory is bi-directionally mounted and any mount operations
+	// there are reflected in the host's view of /media, which may be either
+	// itself or /run/media.
+	"/media",
+	// The /run directory contains various ephemeral information files or
+	// sockets used by various programs. Providing view of the true /run allows
+	// snap applications to be integrated with the rest of the system and
+	// therefore snaps should not be allowed to replace it.
+	"/run",
+	// The /tmp directory contains private, per-snap, view of /tmp and there's
+	// no valid reason to allow snaps to replace it.
+	"/tmp",
+	// The /var/lib/snapd directory contains essential state of snapd and is
+	// sometimes consulted from inside the mount namespace.
+	"/var/lib/snapd",
+
+	// Locations that may be used to attack the host:
+
 	// The firmware is sometimes loaded on demand by the kernel, in response to
 	// a process performing generic I/O to a specific device. In that case the
 	// mount namespace of the process is searched, by the kernel, for the
@@ -760,36 +781,26 @@ var layoutRejectionList = []string{
 	// Similarly the kernel will load modules and the modules should not be
 	// something that snaps can tamper with.
 	"/lib/modules",
-	// The lost+found directory is used by fsck tools to link lost blocks back
-	// into the filesystem tree. Using layouts for this element is just
-	// confusing and there is no valid reason to allow it.
-	"/lost+found",
-	// The media directory is bi-directionally mounted and any mount operations
-	// there are reflected in the host's view of /media, which may be either
-	// itself or /run/media.
-	"/media",
-	// The /proc directory contains essential process meta-data and
-	// miscellaneous kernel configuration parameters and there is no valid
-	// reason to allow snaps to replace it.
-	"/proc",
-	// The /run directory contains various ephemeral information files or
-	// sockets used by various programs. Providing view of the true /run allows
-	// snap applications to be integrated with the rest of the system and
-	// therefore snaps should not be allowed to replace it.
-	"/run",
-	// The /sys directory exposes many kernel internals, similar to /proc and
-	// there is no known reason to allow snaps to replace it.
-	"/sys",
-	// The /tmp directory contains private, per-snap, view of /tmp and there's
-	// no valid reason to allow snaps to replace it.
-	"/tmp",
-	// The /var/lib/snapd directory contains essential state of snapd and is
-	// sometimes consulted from inside the mount namespace.
-	"/var/lib/snapd",
+
+	// Locations that store essential data:
+
 	// The /var/snap directory contains system-wide state of particular snaps
 	// and should not be replaced as it would break content interface
 	// connections that use $SNAP_DATA or $SNAP_COMMON.
 	"/var/snap",
+	// The /home directory contains user data, including $SNAP_USER_DATA,
+	// $SNAP_USER_COMMON and should be disallowed for the same reasons as
+	// /var/snap.
+	"/home",
+
+	// Locations that should be pristine to avoid confusion.
+
+	// There's no known reason to allow snaps to replace things there.
+	"/boot",
+	// The lost+found directory is used by fsck tools to link lost blocks back
+	// into the filesystem tree. Using layouts for this element is just
+	// confusing and there is no valid reason to allow it.
+	"/lost+found",
 }
 
 // ValidateLayout ensures that the given layout contains only valid subset of constructs.

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -734,10 +734,11 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/lib/firmware" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lib/modules", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/lib/modules" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/tmp", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/tmp" in an off-limits area`)
 
 	// Several valid layouts.
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 01755}, nil), IsNil)
-	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/tmp", Type: "tmpfs"}, nil), IsNil)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/usr", Bind: "$SNAP/usr"}, nil), IsNil)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var", Bind: "$SNAP_DATA/var"}, nil), IsNil)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var", Bind: "$SNAP_COMMON/var"}, nil), IsNil)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -712,6 +712,8 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/dev" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/dev/foo", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/dev/foo" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/home", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/home" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/proc", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/proc" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/sys", Type: "tmpfs"}, nil),

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -983,6 +983,21 @@ layout:
 	c.Assert(info.Layout, HasLen, 2)
 	err = ValidateLayoutAll(info)
 	c.Assert(err, IsNil)
+
+	// Layout replacing files in another snap's mount p oit
+	const yaml12 = `
+name: this-snap
+layout:
+  /snap/that-snap/current/stuff:
+    symlink: $SNAP/stuff
+`
+
+	strk = NewScopedTracker()
+	info, err = InfoFromSnapYamlWithSideInfo([]byte(yaml12), &SideInfo{Revision: R(42)}, strk)
+	c.Assert(err, IsNil)
+	c.Assert(info.Layout, HasLen, 1)
+	err = ValidateLayoutAll(info)
+	c.Assert(err, ErrorMatches, `layout "/snap/that-snap/current/stuff" defines a layout in space belonging to another snap`)
 }
 
 func (s *YamlSuite) TestValidateAppStartupOrder(c *C) {


### PR DESCRIPTION
Some locations cannot be used for snap layouts. This patch extends the list of locations and expand a little on why they are disallowed.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

