### PR TITLE
interfaces: add an interface that grants access to the PackageKit service

### DIFF
--- a/interfaces/builtin/packagekit_control.go
+++ b/interfaces/builtin/packagekit_control.go
@@ -45,10 +45,17 @@ dbus (receive, send)
         interface=org.freedesktop.PackageKit.Offline
         path=/org/freedesktop/PackageKit
         peer=(label=unconfined),
-dbus (receive, send)
+dbus (send)
         bus=system
         interface=org.freedesktop.DBus.Properties
         path=/org/freedesktop/PackageKit
+        member=Get{,All}
+        peer=(label=unconfined),
+dbus (receive)
+        bus=system
+        interface=org.freedesktop.DBus.Properties
+        path=/org/freedesktop/PackageKit
+        member=PropertiesChanged
         peer=(label=unconfined),
 dbus (send)
 	bus=system
@@ -65,9 +72,15 @@ dbus (receive, send)
         bus=system
         interface=org.freedesktop.PackageKit.Transaction
         peer=(label=unconfined),
-dbus (receive, send)
+dbus (send)
         bus=system
         interface=org.freedesktop.DBus.Properties
+        member=Get{,All}
+        peer=(label=unconfined),
+dbus (receive)
+        bus=system
+        interface=org.freedesktop.DBus.Properties
+        member=PropertiesChanged
         peer=(label=unconfined),
 dbus (send)
 	bus=system

--- a/interfaces/builtin/packagekit_control.go
+++ b/interfaces/builtin/packagekit_control.go
@@ -32,7 +32,7 @@ const packageKitControlBaseDeclarationSlots = `
 const packageKitControlConnectedPlugAppArmor = `
 # Description: Allow access to PackageKit service
 
-#include <abstractions/dbus-system-strict>
+#include <abstractions/dbus-strict>
 
 # Allow communication with the main PackageKit end point.
 dbus (receive, send)

--- a/interfaces/builtin/packagekit_control.go
+++ b/interfaces/builtin/packagekit_control.go
@@ -77,24 +77,24 @@ dbus (send)
 # packagekitd) changes this, then these rules will need to change too.
 dbus (receive, send)
         bus=system
-        path=/[0-9][0-9]*_[0-9a-f][0-9a-f]*
+        path=/[0-9]*_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]
         interface=org.freedesktop.PackageKit.Transaction
         peer=(label=unconfined),
 dbus (send)
         bus=system
-        path=/[0-9][0-9]*_[0-9a-f][0-9a-f]*
+        path=/[0-9]*_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]
         interface=org.freedesktop.DBus.Properties
         member=Get{,All}
         peer=(label=unconfined),
 dbus (receive)
         bus=system
-        path=/[0-9][0-9]*_[0-9a-f][0-9a-f]*
+        path=/[0-9]*_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]
         interface=org.freedesktop.DBus.Properties
         member=PropertiesChanged
         peer=(label=unconfined),
 dbus (send)
 	bus=system
-        path=/[0-9][0-9]*_[0-9a-f][0-9a-f]*
+        path=/[0-9]*_[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]
 	interface=org.freedesktop.DBus.Introspectable
 	member=Introspect
 	peer=(label=unconfined),

--- a/interfaces/builtin/packagekit_control.go
+++ b/interfaces/builtin/packagekit_control.go
@@ -1,0 +1,88 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const packageKitControlSummary = `allows control of the PackageKit service`
+
+const packageKitControlBaseDeclarationSlots = `
+  packagekit-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const packageKitControlConnectedPlugAppArmor = `
+# Description: Allow access to PackageKit service
+
+#include <abstractions/dbus-system-strict>
+
+# Allow communication with the main PackageKit end point.
+dbus (receive, send)
+        bus=system
+        interface=org.freedesktop.PackageKit
+        path=/org/freedesktop/PackageKit
+        peer=(label=unconfined),
+dbus (receive, send)
+        bus=system
+        interface=org.freedesktop.PackageKit.Offline
+        path=/org/freedesktop/PackageKit
+        peer=(label=unconfined),
+dbus (receive, send)
+        bus=system
+        interface=org.freedesktop.DBus.Properties
+        path=/org/freedesktop/PackageKit
+        peer=(label=unconfined),
+dbus (send)
+	bus=system
+	interface=org.freedesktop.DBus.Introspectable
+	path=/org/freedesktop/PackageKit
+	member=Introspect
+	peer=(label=unconfined),
+
+# Allow communication with PackageKit transactions.  Unfortunately
+# transactions are exported using random object paths like
+# "/2371_dcbabcba", so we can't reliably use the path in the match
+# rule.
+dbus (receive, send)
+        bus=system
+        interface=org.freedesktop.PackageKit.Transaction
+        peer=(label=unconfined),
+dbus (receive, send)
+        bus=system
+        interface=org.freedesktop.DBus.Properties
+        peer=(label=unconfined),
+dbus (send)
+	bus=system
+	interface=org.freedesktop.DBus.Introspectable
+	member=Introspect
+	peer=(label=unconfined),
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "packagekit-control",
+		summary:               packageKitControlSummary,
+		implicitOnClassic:     true,
+		reservedForOS:         true,
+		baseDeclarationSlots:  packageKitControlBaseDeclarationSlots,
+		connectedPlugAppArmor: packageKitControlConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/packagekit_control_test.go
+++ b/interfaces/builtin/packagekit_control_test.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type PackageKitControlInterfaceSuite struct {
+	iface    interfaces.Interface
+	slot     *interfaces.ConnectedSlot
+	slotInfo *snap.SlotInfo
+	plug     *interfaces.ConnectedPlug
+	plugInfo *snap.PlugInfo
+}
+
+var _ = Suite(&PackageKitControlInterfaceSuite{
+	iface: builtin.MustInterface("packagekit-control"),
+})
+
+func (s *PackageKitControlInterfaceSuite) SetUpTest(c *C) {
+	const coreYaml = `name: core
+version: 0
+type: os
+slots:
+ packagekit-control:
+  interface: packagekit-control
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, coreYaml, nil, "packagekit-control")
+
+	var consumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [packagekit-control]
+`
+	s.plug, s.plugInfo = MockConnectedPlug(c, consumerYaml, nil, "packagekit-control")
+}
+
+func (s *PackageKitControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "packagekit-control")
+}
+
+func (s *PackageKitControlInterfaceSuite) TestSanitize(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *PackageKitControlInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 1)
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface=org.freedesktop.PackageKit`)
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface=org.freedesktop.PackageKit.Offline`)
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `interface=org.freedesktop.PackageKit.Transaction`)
+}
+
+func (s *PackageKitControlInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, false)
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.Summary, Equals, "allows control of the PackageKit service")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "packagekit-control")
+}
+
+func (s *PackageKitControlInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/packagekit_control_test.go
+++ b/interfaces/builtin/packagekit_control_test.go
@@ -83,6 +83,7 @@ func (s *PackageKitControlInterfaceSuite) TestStaticInfo(c *C) {
 	c.Check(si.ImplicitOnCore, Equals, false)
 	c.Check(si.ImplicitOnClassic, Equals, true)
 	c.Check(si.Summary, Equals, "allows control of the PackageKit service")
+	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "packagekit-control")
 	c.Check(si.BaseDeclarationSlots, testutil.Contains, "packagekit-control")
 }
 

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -140,13 +140,14 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	// these have more complex or in flux policies and have their
 	// own separate tests
 	snowflakes := map[string]bool{
-		"content":           true,
-		"core-support":      true,
-		"home":              true,
-		"lxd-support":       true,
-		"multipass-support": true,
-		"snapd-control":     true,
-		"dummy":             true,
+		"content":            true,
+		"core-support":       true,
+		"home":               true,
+		"lxd-support":        true,
+		"multipass-support":  true,
+		"packagekit-control": true,
+		"snapd-control":      true,
+		"dummy":              true,
 	}
 
 	// these simply auto-connect, anything else doesn't
@@ -508,6 +509,24 @@ plugs:
 	c.Check(err, IsNil)
 }
 
+func (s *baseDeclSuite) TestAutoConnectionPackagekitControlOverride(c *C) {
+	cand := s.connectCand(c, "packagekit-control", "", "")
+	err := cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"packagekit-control\"")
+
+	plugsSlots := `
+plugs:
+  packagekit-control:
+    allow-auto-connection: true
+`
+
+	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
+	cand.PlugSnapDeclaration = snapDecl
+	err = cand.CheckAutoConnect()
+	c.Check(err, IsNil)
+}
+
 func (s *baseDeclSuite) TestAutoConnectionOverrideMultiple(c *C) {
 	plugsSlots := `
 plugs:
@@ -686,6 +705,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 		"kubernetes-support":    true,
 		"lxd-support":           true,
 		"multipass-support":     true,
+		"packagekit-control":    true,
 		"personal-files":        true,
 		"snapd-control":         true,
 		"system-files":          true,
@@ -815,6 +835,7 @@ func (s *baseDeclSuite) TestSanity(c *C) {
 		"kubernetes-support":    true,
 		"lxd-support":           true,
 		"multipass-support":     true,
+		"packagekit-control":    true,
 		"personal-files":        true,
 		"snapd-control":         true,
 		"system-files":          true,

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -601,6 +601,7 @@ pkg_dependencies_ubuntu_classic(){
                 gccgo-6
                 evolution-data-server
                 gnome-online-accounts
+                packagekit
                 "
                 pkg_linux_image_extra
             ;;
@@ -611,6 +612,7 @@ pkg_dependencies_ubuntu_classic(){
                 gnome-online-accounts
                 kpartx
                 libvirt-bin
+                packagekit
                 qemu
                 x11-utils
                 xvfb
@@ -624,11 +626,13 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 gccgo-8
                 evolution-data-server
+                packagekit
                 "
             ;;
         ubuntu-18.10-64|ubuntu-19.04-64)
             echo "
                 evolution-data-server
+                packagekit
                 "
             ;;
         ubuntu-*)
@@ -641,6 +645,7 @@ pkg_dependencies_ubuntu_classic(){
                 eatmydata
                 evolution-data-server
                 net-tools
+                packagekit
                 sbuild
                 "
             ;;
@@ -683,6 +688,7 @@ pkg_dependencies_fedora(){
         mock
         net-tools
         nfs-utils
+        PackageKit
         python3-yaml
         python3-dbus
         python3-gobject
@@ -711,6 +717,7 @@ pkg_dependencies_amazon(){
         nc
         net-tools
         nfs-utils
+        PackageKit
         system-lsb-core
         rpm-build
         xdg-user-dirs
@@ -733,6 +740,7 @@ pkg_dependencies_opensuse(){
         lsb-release
         man
         nfs-kernel-server
+        PackageKit
         python3-yaml
         netcat-openbsd
         osc
@@ -762,6 +770,7 @@ pkg_dependencies_arch(){
     net-tools
     nfs-utils
     openbsd-netcat
+    packagekit
     python
     python-docutils
     python-dbus

--- a/tests/lib/snaps/test-snapd-packagekit/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-packagekit/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: test-snapd-packagekit
+base: core18
+version: '1.1.9'
+license: GPL-2.0+
+summary: utilities to test packagekit-control interface of snapd
+description: |
+  This package contains the command line utilities associated with the
+  PackageKit daemon.
+
+grade: stable
+confinement: strict
+
+apps:
+  pkcon:
+    command: usr/bin/pkcon
+    plugs:
+      - packagekit-control
+  pkmon:
+    command: usr/bin/pkmon
+    plugs:
+      - packagekit-control
+
+parts:
+  packagekit-tools:
+    plugin: nil
+    stage-packages:
+      - packagekit-tools
+    stage:
+      - usr/bin/pkcon
+      - usr/bin/pkmon
+      - usr/lib/*/libpackagekit-glib2.so*

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -269,6 +269,9 @@ apps:
   optical-drive:
     command: bin/run
     plugs: [ optical-drive ]
+  packagekit-control:
+    command: bin/run
+    plugs: [ packagekit-control ]
   password-manager-service:
     command: bin/run
     plugs: [ password-manager-service ]

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -1,6 +1,10 @@
 summary: The packagekit-control interface grants access to PackageKit
 
-systems: [-ubuntu-core-*]
+systems:
+    # Ubuntu Core does not provide a packagekitd implementation
+    - -ubuntu-core-*
+    # Ubuntu 14.04 PackageKit seems to be too old
+    - -ubuntu-14.04-*
 
 execute: |
     echo "Installing test-snapd-packagekit"

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -23,4 +23,4 @@ execute: |
 
     echo "With the plug connected it is possible to communicate with packagekit"
     test-snapd-packagekit.pkcon backend-details | MATCH "Name:"
-    test-snapd-packagekit.pkcon required-by snapd
+    test-snapd-packagekit.pkcon resolve snapd | MATCH "Installed[[:space:]]+snapd"

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -12,7 +12,7 @@ execute: |
 
     echo "The packagekit-control plug is disconnected by default"
     snap connections test-snapd-packagekit | MATCH "packagekit-control +test-snapd-packagekit:packagekit-control +- +-"
-    if [ "$(snap debuf confinement)" = strict ]; then
+    if [ "$(snap debug confinement)" = strict ]; then
         echo "Access to PackageKit is blocked without"
         test-snapd-packagekit.pkcon backend-details | MATCH "Failed to contact PackageKit"
     fi

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -1,0 +1,22 @@
+summary: The packagekit-control interface grants access to PackageKit
+
+systems: [-ubuntu-core-*]
+
+execute: |
+    echo "Installing test-snapd-packagekit"
+    snap install --edge test-snapd-packagekit
+
+    echo "The packagekit-control plug is disconnected by default"
+    snap connections test-snapd-packagekit | MATCH "packagekit-control +test-snapd-packagekit:packagekit-control +- +-"
+    if [ "$(snap debuf confinement)" = strict ]; then
+        echo "Access to PackageKit is blocked without"
+        test-snapd-packagekit.pkcon backend-details | MATCH "Failed to contact PackageKit"
+    fi
+
+    echo "The plug can be connected"
+    snap connect test-snapd-packagekit:packagekit-control
+    snap connections test-snapd-packagekit | MATCH "packagekit-control +test-snapd-packagekit:packagekit-control +:packagekit-control +manual"
+
+    echo "With the plug connected it is possible to communicate with packagekit"
+    test-snapd-packagekit.pkcon backend-details | MATCH "Name:"
+    test-snapd-packagekit.pkcon required-by snapd


### PR DESCRIPTION
This interface is intended to work in tandem with PR #7042.  I've structured this as two PRs because use of AppStream metadata is useful beyond PackageKit based GUIs, and there are ongoing attempts to replace PackageKit.

As with the other interface, I see this as being default disconnected with a few select clients autoconnected via a store assertion.

The PackageKit API doesn't specify what object paths transactions will be exported with, and current releases use random paths at the base level such as `/2371_dcbabcba`.  So we're granting read only property access and introspection to paths like `/{number}_{hexstring}`, which could unintentionally grant access to other services.

This is an interface that enables installation/removal of arbitrary packages though, so it's not like there aren't other avenues for sandbox escape.

Still todo: write a spread test.