### PR TITLE
tests/lib/nested: create WORK_DIR before accessing it

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -39,6 +39,7 @@ prepare_ssh(){
 }
 
 create_assertions_disk(){
+    mkdir -p "$WORK_DIR"
     dd if=/dev/null of="$WORK_DIR/assertions.disk" bs=1M seek=1
     mkfs.ext4 -F "$WORK_DIR/assertions.disk"
     debugfs -w -R "write $TESTSLIB/assertions/auto-import.assert auto-import.assert" "$WORK_DIR/assertions.disk"


### PR DESCRIPTION
$WORK_DIR is only created in create_nested_{classic,core}_vm. Attempting to
create an assertions disk before calling the create_*_vm helpers fails because
WORK_DIR has not been created yet.
