### PR TITLE
interfaces/apparmor: use available apparmor features

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -502,19 +502,12 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 
 func downgradeConfinement() bool {
 	kver := osutil.KernelVersion()
-	switch {
-	case release.DistroLike("opensuse-tumbleweed"):
-		if cmp, _ := strutil.VersionCompare(kver, "4.16"); cmp >= 0 {
-			// As a special exception, for openSUSE Tumbleweed which ships Linux
-			// 4.16, do not downgrade the confinement template.
-			return false
-		}
-	case release.DistroLike("arch", "archlinux"):
-		// The default kernel has AppArmor enabled since 4.18.8, the
-		// hardened one since 4.17.4
-		return false
-	}
-	return true
+	// When the kernel version is at least 4.16, do not downgrade the
+	// confinement template. This allows everyone to benefit from common
+	// features like "file" checks, even if some more advanced access patterns
+	// are not mediated (typically DBus IPC).
+	cmp, _ := strutil.VersionCompare(kver, "4.16")
+	return cmp < 0
 }
 
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState, spec *Specification) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -663,10 +663,11 @@ func mockPartalAppArmorOnDistro(c *C, kernelVersion string, releaseID string, re
 	}
 }
 
-// On openSUSE Tumbleweed partial apparmor support doesn't change apparmor template to classic.
-// Strict confinement template, along with snippets, are used.
-func (s *backendSuite) TestCombineSnippetsOpenSUSETumbleweed(c *C) {
-	restore := mockPartalAppArmorOnDistro(c, "4.16-10-1-default", "opensuse-tumbleweed")
+// On recent enough kernel, partial apparmor support doesn't change apparmor
+// template to classic.  Strict confinement template, along with snippets, are
+// used.
+func (s *backendSuite) TestCombineSnippetsNewKernel(c *C) {
+	restore := mockPartalAppArmorOnDistro(c, "4.16-10-1-default", "not-important")
 	defer restore()
 	s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 		spec.AddSnippet("snippet")
@@ -677,10 +678,10 @@ func (s *backendSuite) TestCombineSnippetsOpenSUSETumbleweed(c *C) {
 	c.Check(profile, testutil.FileEquals, commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n")
 }
 
-// On openSUSE Tumbleweed running older kernel partial apparmor support changes
-// apparmor template to classic.
-func (s *backendSuite) TestCombineSnippetsOpenSUSETumbleweedOldKernel(c *C) {
-	restore := mockPartalAppArmorOnDistro(c, "4.14", "opensuse-tumbleweed")
+// On older kernel partial apparmor support changes apparmor template to
+// classic.
+func (s *backendSuite) TestCombineSnippetsOldKernel(c *C) {
+	restore := mockPartalAppArmorOnDistro(c, "4.14", "not-important")
 	defer restore()
 	s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 		spec.AddSnippet("snippet")
@@ -689,31 +690,6 @@ func (s *backendSuite) TestCombineSnippetsOpenSUSETumbleweedOldKernel(c *C) {
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
 	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 	c.Check(profile, testutil.FileEquals, "\n#classic"+commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\n\n}\n")
-}
-
-func (s *backendSuite) TestCombineSnippetsArchOldIDSufficientHardened(c *C) {
-	restore := mockPartalAppArmorOnDistro(c, "4.18.2.a-1-hardened", "arch", "archlinux")
-	defer restore()
-	s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
-		spec.AddSnippet("snippet")
-		return nil
-	}
-	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
-	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
-	c.Check(profile, testutil.FileEquals, commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n")
-}
-
-func (s *backendSuite) TestCombineSnippetsArchSufficientHardened(c *C) {
-	restore := mockPartalAppArmorOnDistro(c, "4.18.2.a-1-hardened", "archlinux")
-	defer restore()
-	s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
-		spec.AddSnippet("snippet")
-		return nil
-	}
-
-	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
-	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
-	c.Check(profile, testutil.FileEquals, commonPrefix+"\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n")
 }
 
 const coreYaml = `name: core


### PR DESCRIPTION
Historically snapd would fallback to "forced devmode", which is like
applying a very open and permissive confinement to all the systems that
do not implement full confinement. This is due to inability, at the
time, of ancient apparmor userspace, to even parse and compile the
regular snapd security template.

Over time we started allowing use of true partial confinement, that is
without the degradation to classic template, on openSUSE Tumbleweed.
That distribution was selected due to its rolling nature and the fact
that up-to-date apparmor userspace and kernel was available. The
experiment was further extended to cover Arch, along with the hardened
kernel that supports apparmor. This experiment was very successful,
showing that there are practical benefits in more complete sandbox
without any observable downsides.

Recently we reached a point where using the forced devmode fallback has
started to hurt the ecosystem, as people routinely develop snap packages
on Debian, openSUSE Leap or even on Ubuntu using mainline kernel. In
that situation they may not fully comprehend the snap interface system
and fail to use interfaces that are required under strict confinement.

While the complete journey towards explaining the state of confinement
is yet to be designed, we think it is important to use as many apparmor
features as are available, even if not all of the features we want are
present.

This patch will effectively start to enforce path based file protections
on Debian and openSUSE as well as any distribution running with apparmor
enabled. In practice it will shrink the perception delta between the
upstream kernel and the Ubuntu kernel down to fine-grained DBus
mediation and perhaps some of the network rules.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>