### PR TITLE
cmd/libsnap: rename SC_LIBSNAP_ERROR to SC_LIBSNAP_DOMAIN

### DIFF
--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -63,7 +63,7 @@ typedef struct sc_error {
 /**
  * Error domain for errors in the libsnap-confine-private library.
  **/
-#define SC_LIBSNAP_ERROR "libsnap-confine-private"
+#define SC_LIBSNAP_DOMAIN "libsnap-confine-private"
 
 /** sc_libsnap_error represents distinct error codes used by libsnap-confine-private library. */
 typedef enum sc_libsnap_error {

--- a/cmd/libsnap-confine-private/infofile-test.c
+++ b/cmd/libsnap-confine-private/infofile-test.c
@@ -39,7 +39,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(NULL, "key", &value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
     g_assert_cmpstr(sc_error_msg(err), ==, "stream cannot be NULL");
     sc_error_free(err);
@@ -48,7 +48,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, NULL, &value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
     g_assert_cmpstr(sc_error_msg(err), ==, "key cannot be NULL");
     sc_error_free(err);
@@ -57,7 +57,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", NULL, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
     g_assert_cmpstr(sc_error_msg(err), ==, "value cannot be NULL");
     sc_error_free(err);
@@ -100,7 +100,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", &tricky_value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, 0);
     g_assert_cmpstr(sc_error_msg(err), ==, "line 1 is not a key=value assignment");
     g_assert_null(tricky_value);
@@ -114,7 +114,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", &tricky_value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, 0);
     g_assert_cmpstr(sc_error_msg(err), ==, "line 1 contains NUL byte");
     g_assert_null(tricky_value);
@@ -128,7 +128,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", &tricky_value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, 0);
     g_assert_cmpstr(sc_error_msg(err), ==, "line 1 does not end with a newline");
     g_assert_null(tricky_value);
@@ -154,7 +154,7 @@ static void test_infofile_get_key(void) {
     rc = sc_infofile_get_key(stream, "key", &tricky_value, &err);
     g_assert_cmpint(rc, ==, -1);
     g_assert_nonnull(err);
-    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_ERROR);
+    g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
     g_assert_cmpint(sc_error_code(err), ==, 0);
     g_assert_cmpstr(sc_error_msg(err), ==, "line 1 contains empty key");
     g_assert_null(tricky_value);

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -33,15 +33,15 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
     char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
 
     if (stream == NULL) {
-        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "stream cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, "stream cannot be NULL");
         goto out;
     }
     if (key == NULL) {
-        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "key cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, "key cannot be NULL");
         goto out;
     }
     if (value == NULL) {
-        err = sc_error_init(SC_LIBSNAP_ERROR, SC_API_MISUSE, "value cannot be NULL");
+        err = sc_error_init(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, "value cannot be NULL");
         goto out;
     }
 
@@ -65,13 +65,13 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
         /* Guard against malformed input that may contain NUL bytes that
          * would confuse the code below. */
         if (memchr(line_buf, '\0', nread) != NULL) {
-            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d contains NUL byte", lineno);
+            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d contains NUL byte", lineno);
             goto out;
         }
         /* Guard against non-strictly formatted input that doesn't contain
          * trailing newline. */
         if (line_buf[nread - 1] != '\n') {
-            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d does not end with a newline", lineno);
+            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d does not end with a newline", lineno);
             goto out;
         }
         /* Replace the trailing newline character with the NUL byte. */
@@ -79,12 +79,12 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
         /* Guard against malformed input that does not contain '=' byte */
         char *eq_ptr = memchr(line_buf, '=', nread);
         if (eq_ptr == NULL) {
-            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d is not a key=value assignment", lineno);
+            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d is not a key=value assignment", lineno);
             goto out;
         }
         /* Guard against malformed input with empty key. */
         if (eq_ptr == line_buf) {
-            err = sc_error_init(SC_LIBSNAP_ERROR, 0, "line %d contains empty key", lineno);
+            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d contains empty key", lineno);
             goto out;
         }
         /* Replace the first '=' with string terminator byte. */


### PR DESCRIPTION
This is in sync with SC_ERRNO_DOMAIN.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
