### PR TITLE
.travis.yml: bump Go version back down to 1.9 for quick tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ git:
 jobs:
   include:
     - stage: quick
-      name: go 1.10/xenial static and unit test suites
+      name: go 1.9/xenial static and unit test suites
       dist: xenial
-      go: "1.10.x"
+      go: "1.9.x"
       before_install:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
       install:

--- a/cmd/cmd_compat.go
+++ b/cmd/cmd_compat.go
@@ -1,0 +1,26 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !cgo,!go1.10
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+// this should only get built when building on go 1.9, where some
+// weird build id stuff needs to happen
+
+import "C"


### PR DESCRIPTION
Not _all_ distros are on 1.10 (looking at you, amz2)