### PR TITLE
cmd/libsnap: add sc_error_init_{simple,api_misuse}

### DIFF
--- a/cmd/libsnap-confine-private/error-test.c
+++ b/cmd/libsnap-confine-private/error-test.c
@@ -49,6 +49,34 @@ static void test_sc_error_init_from_errno(void)
 	g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
 }
 
+static void test_sc_error_init_simple(void)
+{
+	struct sc_error *err;
+	// Create an error
+	err = sc_error_init_simple("hello %s", "errors");
+	g_assert_nonnull(err);
+	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+
+	// Inspect the exposed attributes
+	g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
+	g_assert_cmpint(sc_error_code(err), ==, 0);
+	g_assert_cmpstr(sc_error_msg(err), ==, "hello errors");
+}
+
+static void test_sc_error_init_api_misuse(void)
+{
+	struct sc_error *err;
+	// Create an error
+	err = sc_error_init_api_misuse("foo cannot be %d", 42);
+	g_assert_nonnull(err);
+	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+
+	// Inspect the exposed attributes
+	g_assert_cmpstr(sc_error_domain(err), ==, SC_LIBSNAP_DOMAIN);
+	g_assert_cmpint(sc_error_code(err), ==, SC_API_MISUSE);
+	g_assert_cmpstr(sc_error_msg(err), ==, "foo cannot be 42");
+}
+
 static void test_sc_error_cleanup(void)
 {
 	// Check that sc_error_cleanup() is safe to use.
@@ -236,6 +264,10 @@ static void __attribute__((constructor)) init(void)
 	g_test_add_func("/error/sc_error_init", test_sc_error_init);
 	g_test_add_func("/error/sc_error_init_from_errno",
 			test_sc_error_init_from_errno);
+	g_test_add_func("/error/sc_error_init_simple",
+			test_sc_error_init_simple);
+	g_test_add_func("/error/sc_error_init_api_misue",
+			test_sc_error_init_api_misuse);
 	g_test_add_func("/error/sc_error_cleanup", test_sc_error_cleanup);
 	g_test_add_func("/error/sc_error_domain/NULL",
 			test_sc_error_domain__NULL);

--- a/cmd/libsnap-confine-private/error.c
+++ b/cmd/libsnap-confine-private/error.c
@@ -59,6 +59,26 @@ sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt, ...)
 	return err;
 }
 
+sc_error *sc_error_init_simple(const char *msgfmt, ...)
+{
+	va_list ap;
+	va_start(ap, msgfmt);
+	sc_error *err = sc_error_initv(SC_LIBSNAP_DOMAIN,
+				       SC_UNSPECIFIED_ERROR, msgfmt, ap);
+	va_end(ap);
+	return err;
+}
+
+sc_error *sc_error_init_api_misuse(const char *msgfmt, ...)
+{
+	va_list ap;
+	va_start(ap, msgfmt);
+	sc_error *err = sc_error_initv(SC_LIBSNAP_DOMAIN,
+				       SC_API_MISUSE, msgfmt, ap);
+	va_end(ap);
+	return err;
+}
+
 const char *sc_error_domain(sc_error * err)
 {
 	if (err == NULL) {

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -100,7 +100,7 @@ __attribute__((warn_unused_result,
 sc_error *sc_error_init_simple(const char *msgfmt, ...);
 
 /**
- * Initialize an api misuse error with formatted message.
+ * Initialize an API misuse error with formatted message.
  *
  * This is just syntactic sugar for sc_error_init(SC_LIBSNAP_DOMAIN,
  * SC_API_MISUSE, msgfmt, ...) which is repeated often.

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -90,6 +90,26 @@ __attribute__((warn_unused_result,
 sc_error *sc_error_init(const char *domain, int code, const char *msgfmt, ...);
 
 /**
+ * Initialize an unspecified error with formatted message.
+ *
+ * This is just syntactic sugar for sc_error_init(SC_LIBSNAP_ERROR,
+ * SC_UNSPECIFIED_ERROR, msgfmt, ...) which is repeated often.
+ **/
+__attribute__((warn_unused_result,
+	       format(printf, 1, 2) SC_APPEND_RETURNS_NONNULL))
+sc_error *sc_error_init_simple(const char *msgfmt, ...);
+
+/**
+ * Initialize an unspecified error with formatted message.
+ *
+ * This is just syntactic sugar for sc_error_init(SC_LIBSNAP_DOMAIN,
+ * SC_API_MISUSE, msgfmt, ...) which is repeated often.
+ **/
+__attribute__((warn_unused_result,
+	       format(printf, 1, 2) SC_APPEND_RETURNS_NONNULL))
+sc_error *sc_error_init_api_misuse(const char *msgfmt, ...);
+
+/**
  * Initialize an errno-based error.
  *
  * The error carries a copy of errno and a custom error message as designed by

--- a/cmd/libsnap-confine-private/error.h
+++ b/cmd/libsnap-confine-private/error.h
@@ -100,7 +100,7 @@ __attribute__((warn_unused_result,
 sc_error *sc_error_init_simple(const char *msgfmt, ...);
 
 /**
- * Initialize an unspecified error with formatted message.
+ * Initialize an api misuse error with formatted message.
  *
  * This is just syntactic sugar for sc_error_init(SC_LIBSNAP_DOMAIN,
  * SC_API_MISUSE, msgfmt, ...) which is repeated often.

--- a/cmd/libsnap-confine-private/infofile.c
+++ b/cmd/libsnap-confine-private/infofile.c
@@ -33,15 +33,15 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
     char *line_buf SC_CLEANUP(sc_cleanup_string) = NULL;
 
     if (stream == NULL) {
-        err = sc_error_init(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, "stream cannot be NULL");
+        err = sc_error_init_api_misuse("stream cannot be NULL");
         goto out;
     }
     if (key == NULL) {
-        err = sc_error_init(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, "key cannot be NULL");
+        err = sc_error_init_api_misuse("key cannot be NULL");
         goto out;
     }
     if (value == NULL) {
-        err = sc_error_init(SC_LIBSNAP_DOMAIN, SC_API_MISUSE, "value cannot be NULL");
+        err = sc_error_init_api_misuse("value cannot be NULL");
         goto out;
     }
 
@@ -65,7 +65,7 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
         /* Guard against malformed input that may contain NUL bytes that
          * would confuse the code below. */
         if (memchr(line_buf, '\0', nread) != NULL) {
-            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d contains NUL byte", lineno);
+            err = sc_error_init_simple("line %d contains NUL byte", lineno);
             goto out;
         }
         /* Guard against non-strictly formatted input that doesn't contain
@@ -79,12 +79,12 @@ int sc_infofile_get_key(FILE *stream, const char *key, char **value, sc_error **
         /* Guard against malformed input that does not contain '=' byte */
         char *eq_ptr = memchr(line_buf, '=', nread);
         if (eq_ptr == NULL) {
-            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d is not a key=value assignment", lineno);
+            err = sc_error_init_simple("line %d is not a key=value assignment", lineno);
             goto out;
         }
         /* Guard against malformed input with empty key. */
         if (eq_ptr == line_buf) {
-            err = sc_error_init(SC_LIBSNAP_DOMAIN, 0, "line %d contains empty key", lineno);
+            err = sc_error_init_simple("line %d contains empty key", lineno);
             goto out;
         }
         /* Replace the first '=' with string terminator byte. */


### PR DESCRIPTION
This is just syntactic sugar for the two common cases of error from the
internal library, without any specific error code and when arguments
provided to a function are incorrect.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
