### PR TITLE
daemon, interfaces, travis: workaround build ID with Go 1.9, use 1.9 for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ git:
 jobs:
   include:
     - stage: quick
-      name: go 1.10/xenial static and unit test suites
+      name: go 1.9/xenial static and unit test suites
       dist: xenial
-      go: "1.10.x"
+      go: "1.9.x"
       before_install:
         - sudo apt --quiet -o Dpkg::Progress-Fancy=false update
       install:

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1031,8 +1031,9 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	// reload dirs for release info to have effect
 	dirs.SetRootDir(dirs.GlobalRootDir)
 
-	buildID, err := osutil.MyBuildID()
-	c.Assert(err, check.IsNil)
+	buildID := "this-is-my-build-id"
+	restore = MockBuildID(buildID)
+	defer restore()
 
 	sysInfoCmd.GET(sysInfoCmd, nil, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
@@ -1101,8 +1102,9 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	buildID, err := osutil.MyBuildID()
-	c.Assert(err, check.IsNil)
+	buildID := "this-is-my-build-id"
+	restore = MockBuildID(buildID)
+	defer restore()
 
 	sysInfoCmd.GET(sysInfoCmd, nil, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -41,3 +41,11 @@ func MockMuxVars(vars func(*http.Request) map[string]string) (restore func()) {
 		muxVars = old
 	}
 }
+
+func MockBuildID(mock string) (restore func()) {
+	old := buildID
+	buildID = mock
+	return func() {
+		buildID = old
+	}
+}

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -51,3 +51,11 @@ func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
 		isHomeUsingNFS = old
 	}
 }
+
+func MockReadBuildID(mock func(p string) (string, error)) (restore func()) {
+	old := readBuildID
+	readBuildID = mock
+	return func() {
+		readBuildID = old
+	}
+}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -80,6 +80,8 @@ var (
 	mockedSystemKey *systemKey
 
 	seccompCompilerVersionInfo = seccompCompilerVersionInfoImpl
+
+	readBuildID = osutil.ReadBuildID
 )
 
 func seccompCompilerVersionInfoImpl(path string) (string, error) {
@@ -103,7 +105,7 @@ func generateSystemKey() (*systemKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	buildID, err := osutil.ReadBuildID(snapdPath)
+	buildID, err := readBuildID(snapdPath)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -60,9 +60,7 @@ func (s *systemKeySuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
-	id, err := osutil.MyBuildID()
-	c.Assert(err, IsNil)
-	s.buildID = id
+	s.buildID = "this-is-my-build-id"
 
 	s.seccompCompilerVersion = "123 2.3.3 abcdef123 -"
 	testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), fmt.Sprintf(`
@@ -81,6 +79,12 @@ func (s *systemKeySuite) TearDownTest(c *C) {
 
 func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	restore := interfaces.MockIsHomeUsingNFS(func() (bool, error) { return nfsHome, nil })
+	defer restore()
+
+	restore = interfaces.MockReadBuildID(func(p string) (string, error) {
+		c.Assert(p, Equals, filepath.Join(dirs.DistroLibExecDir, "snapd"))
+		return s.buildID, nil
+	})
 	defer restore()
 
 	err := interfaces.WriteSystemKey()
@@ -104,9 +108,6 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	seccompActionsStr, err := json.Marshal(release.SecCompActions())
 	c.Assert(err, IsNil)
 
-	buildID, err := osutil.ReadBuildID("/proc/self/exe")
-	c.Assert(err, IsNil)
-
 	compiler, err := seccomp_compiler.New(func(name string) (string, error) {
 		return filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), nil
 	})
@@ -117,7 +118,7 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"apparmor-parser-mtime":%s,"apparmor-parser-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s,"seccomp-compiler-version":"%s"}`, buildID, apparmorFeaturesStr, apparmorParserMtime, apparmorParserFeaturesStr, nfsHome, overlayRoot, seccompActionsStr, seccompCompilerVersion))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"apparmor-parser-mtime":%s,"apparmor-parser-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s,"seccomp-compiler-version":"%s"}`, s.buildID, apparmorFeaturesStr, apparmorParserMtime, apparmorParserFeaturesStr, nfsHome, overlayRoot, seccompActionsStr, seccompCompilerVersion))
 }
 
 func (s *systemKeySuite) TestInterfaceWriteSystemKeyNoNFS(c *C) {
@@ -126,6 +127,20 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKeyNoNFS(c *C) {
 
 func (s *systemKeySuite) TestInterfaceWriteSystemKeyWithNFS(c *C) {
 	s.testInterfaceWriteSystemKey(c, true)
+}
+
+func (s *systemKeySuite) TestInterfaceWriteSystemKeyErrorOnBuildID(c *C) {
+	restore := interfaces.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
+	defer restore()
+
+	restore = interfaces.MockReadBuildID(func(p string) (string, error) {
+		c.Assert(p, Equals, filepath.Join(dirs.DistroLibExecDir, "snapd"))
+		return "", fmt.Errorf("no build ID for you")
+	})
+	defer restore()
+
+	err := interfaces.WriteSystemKey()
+	c.Assert(err, ErrorMatches, "no build ID for you")
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {


### PR DESCRIPTION
Resurrecting #7060 

It is assumed that the test binary has a build ID, either added by Go
toolchain (happens by default with Go 1.10+) or by gcc (only when built with
CGO). Since osutil package no longer requires CGO, the latter case does take
place.

When running with Go 1.9, the tests assuming build ID presence fail because the
Go toolchain never added one. Instead of working around the toolchain, add
mocking where needed.





