### PR TITLE
tests: renumber snap revisions as seen via hostfs

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -269,6 +269,10 @@ if [ "$UNIT" = 1 ]; then
             curl -s https://codecov.io/bash | bash /dev/stdin -f .coverage/coverage.out
         fi
     fi
+
+    # python unit test for mountinfo-tool
+    command -v python2 && python2 ./tests/lib/bin/mountinfo-tool --self-test
+    command -v python3 && python3 ./tests/lib/bin/mountinfo-tool --self-test
 fi
 
 if [ -n "$SPREAD" ]; then

--- a/run-checks
+++ b/run-checks
@@ -271,8 +271,8 @@ if [ "$UNIT" = 1 ]; then
     fi
 
     # python unit test for mountinfo-tool
-    command -v python2 && python2 ./tests/lib/bin/mountinfo-tool --self-test
-    command -v python3 && python3 ./tests/lib/bin/mountinfo-tool --self-test
+    command -v python2 && python2 ./tests/lib/bin/mountinfo-tool --run-unit-tests
+    command -v python3 && python3 ./tests/lib/bin/mountinfo-tool --run-unit-tests
 fi
 
 if [ -n "$SPREAD" ]; then

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -22,7 +22,7 @@ PY2 = sys.version_info[0] == 2
 # https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
 MYPY = False
 if MYPY:
-    from typing import Any, Dict, List, Text, Tuple, Match, Optional
+    from typing import Any, Dict, List, Text, Tuple, Match, Optional, Union, Sequence
     from argparse import Namespace
 
 
@@ -522,10 +522,13 @@ class _UnitTestAction(Action):
         )
 
     def __call__(self, parser, ns, values, option_string=None):
-        # type: (ArgumentParser, Namespace, List[Text], Optional[Text]) -> None
+        # type: (ArgumentParser, Namespace, Union[str, Sequence[Any], None], Optional[Text]) -> None
         # We allow the caller to provide the test to invoke by giving
         # --run-unit-tests a set of arguments.
-        unittest.main(argv=[sys.argv[0]] + values)
+        argv = [sys.argv[0]]
+        if isinstance(values, list):
+            argv += values
+        unittest.main(argv=argv)
         parser.exit()
 
 

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -303,88 +303,6 @@ def renumber_snap_revision(entry, seen):
     entry.mount_point = "/".join(compose(parts, n))
 
 
-class RenumberSnapRevisionTests(unittest.TestCase):
-    def setUp(self):
-        # type: () -> None
-        self.entry = MountInfoEntry()
-        self.seen = {}  # type: Dict[Tuple[Text, Text], int]
-
-    def test_renumbering_allocation(self):
-        # type: () -> None
-        self.entry.mount_point = "/snap/core/7079"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/snap/core/1")
-
-        self.entry.mount_point = "/snap/core/7080"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/snap/core/2")
-
-        self.entry.mount_point = "/snap/snapd/x1"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/snap/snapd/1")
-
-        self.assertEqual(
-            self.seen, {("core", "7079"): 1, ("core", "7080"): 2, ("snapd", "x1"): 1}
-        )
-
-    def test_preferred(self):
-        # type: () -> None
-        self.entry.mount_point = "/snap/core/7079"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/snap/core/1")
-
-        self.entry.mount_point = "/snap/core/7079/subdir"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/snap/core/1/subdir")
-
-        self.assertEqual(self.seen, {("core", "7079"): 1})
-
-    def test_alternate(self):
-        # type: () -> None
-        self.entry.mount_point = "/var/lib/snapd/snap/core/7079"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/snap/core/1")
-
-        self.entry.mount_point = "/var/lib/snapd/snap/core/7079/subdir"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/snap/core/1/subdir")
-
-        self.assertEqual(self.seen, {("core", "7079"): 1})
-
-    def test_preferred_via_hostfs(self):
-        # type: () -> None
-        self.entry.mount_point = "/var/lib/snapd/hostfs/snap/core/7079"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/hostfs/snap/core/1")
-
-        self.entry.mount_point = "/var/lib/snapd/hostfs/snap/core/7079/subdir"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(
-            self.entry.mount_point, "/var/lib/snapd/hostfs/snap/core/1/subdir"
-        )
-
-        self.assertEqual(self.seen, {("core", "7079"): 1})
-
-    def test_alternate_via_hostfs(self):
-        # type: () -> None
-        self.entry.mount_point = "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/7079"
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(
-            self.entry.mount_point, "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/1"
-        )
-
-        self.entry.mount_point = (
-            "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/7079/subdir"
-        )
-        renumber_snap_revision(self.entry, self.seen)
-        self.assertEqual(
-            self.entry.mount_point,
-            "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/1/subdir",
-        )
-
-        self.assertEqual(self.seen, {("core", "7079"): 1})
-
-
 def renumber_opt_fields(entry, seen):
     # type: (MountInfoEntry, Dict[int, int]) -> None
     """renumber_opt_fields re-numbers peer group in optional fields."""
@@ -615,6 +533,88 @@ Known attributes, applicable for both filtering and display.
         raise SystemExit(
             "--one requires exactly one match, found {}".format(len(entries))
         )
+
+
+class RenumberSnapRevisionTests(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        self.entry = MountInfoEntry()
+        self.seen = {}  # type: Dict[Tuple[Text, Text], int]
+
+    def test_renumbering_allocation(self):
+        # type: () -> None
+        self.entry.mount_point = "/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/1")
+
+        self.entry.mount_point = "/snap/core/7080"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/2")
+
+        self.entry.mount_point = "/snap/snapd/x1"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/snapd/1")
+
+        self.assertEqual(
+            self.seen, {("core", "7079"): 1, ("core", "7080"): 2, ("snapd", "x1"): 1}
+        )
+
+    def test_preferred(self):
+        # type: () -> None
+        self.entry.mount_point = "/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/1")
+
+        self.entry.mount_point = "/snap/core/7079/subdir"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/1/subdir")
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
+
+    def test_alternate(self):
+        # type: () -> None
+        self.entry.mount_point = "/var/lib/snapd/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/snap/core/1")
+
+        self.entry.mount_point = "/var/lib/snapd/snap/core/7079/subdir"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/snap/core/1/subdir")
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
+
+    def test_preferred_via_hostfs(self):
+        # type: () -> None
+        self.entry.mount_point = "/var/lib/snapd/hostfs/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/hostfs/snap/core/1")
+
+        self.entry.mount_point = "/var/lib/snapd/hostfs/snap/core/7079/subdir"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(
+            self.entry.mount_point, "/var/lib/snapd/hostfs/snap/core/1/subdir"
+        )
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
+
+    def test_alternate_via_hostfs(self):
+        # type: () -> None
+        self.entry.mount_point = "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(
+            self.entry.mount_point, "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/1"
+        )
+
+        self.entry.mount_point = (
+            "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/7079/subdir"
+        )
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(
+            self.entry.mount_point,
+            "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/1/subdir",
+        )
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
 
 
 if __name__ == "__main__":

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -1,9 +1,10 @@
 #!/usr/bin/env any-python
 from __future__ import print_function, absolute_import, unicode_literals
 
-from argparse import ArgumentParser, FileType, RawTextHelpFormatter
-import sys
+from argparse import Action, ArgumentParser, FileType, RawTextHelpFormatter, SUPPRESS
 import re
+import sys
+import unittest
 
 # PY2 is true when we're running under Python 2.x It is used for appropriate
 # return value selection of __str__ and __repr_ methods, which must both
@@ -21,7 +22,8 @@ PY2 = sys.version_info[0] == 2
 # https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
 MYPY = False
 if MYPY:
-    from typing import Any, Dict, List, Text, Tuple, Match
+    from typing import Any, Dict, List, Text, Tuple, Match, Optional
+    from argparse import Namespace
 
 
 class Device(int):
@@ -250,6 +252,14 @@ def renumber_snap_revision(entry, seen):
         # type: (List[Text], int) -> List[Text]
         return parts[:6] + ["{}".format(n)] + parts[7:]
 
+    def compose_hostfs_preferred(parts, n):
+        # type: (List[Text], int) -> List[Text]
+        return parts[:7] + ["{}".format(n)] + parts[8:]
+
+    def compose_hostfs_alternate(parts, n):
+        # type: (List[Text], int) -> List[Text]
+        return parts[:10] + ["{}".format(n)] + parts[11:]
+
     def alloc_n(snap_name, snap_rev):
         # type: (Text, Text) -> int
         key = (snap_name, snap_rev)
@@ -269,10 +279,110 @@ def renumber_snap_revision(entry, seen):
         snap_name = parts[5]
         snap_rev = parts[6]
         compose = compose_alternate
+    elif len(parts) >= 8 and parts[:6] == ["", "var", "lib", "snapd", "hostfs", "snap"]:
+        snap_name = parts[6]
+        snap_rev = parts[7]
+        compose = compose_hostfs_preferred
+    elif len(parts) >= 11 and parts[:9] == [
+        "",
+        "var",
+        "lib",
+        "snapd",
+        "hostfs",
+        "var",
+        "lib",
+        "snapd",
+        "snap",
+    ]:
+        snap_name = parts[9]
+        snap_rev = parts[10]
+        compose = compose_hostfs_alternate
     else:
         return
     n = alloc_n(snap_name, snap_rev)
     entry.mount_point = "/".join(compose(parts, n))
+
+
+class RenumberSnapRevisionTests(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        self.entry = MountInfoEntry()
+        self.seen = {}  # type: Dict[Tuple[Text, Text], int]
+
+    def test_renumbering_allocation(self):
+        # type: () -> None
+        self.entry.mount_point = "/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/1")
+
+        self.entry.mount_point = "/snap/core/7080"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/2")
+
+        self.entry.mount_point = "/snap/snapd/x1"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/snapd/1")
+
+        self.assertEqual(
+            self.seen, {("core", "7079"): 1, ("core", "7080"): 2, ("snapd", "x1"): 1}
+        )
+
+    def test_preferred(self):
+        # type: () -> None
+        self.entry.mount_point = "/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/1")
+
+        self.entry.mount_point = "/snap/core/7079/subdir"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/snap/core/1/subdir")
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
+
+    def test_alternate(self):
+        # type: () -> None
+        self.entry.mount_point = "/var/lib/snapd/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/snap/core/1")
+
+        self.entry.mount_point = "/var/lib/snapd/snap/core/7079/subdir"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/snap/core/1/subdir")
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
+
+    def test_preferred_via_hostfs(self):
+        # type: () -> None
+        self.entry.mount_point = "/var/lib/snapd/hostfs/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(self.entry.mount_point, "/var/lib/snapd/hostfs/snap/core/1")
+
+        self.entry.mount_point = "/var/lib/snapd/hostfs/snap/core/7079/subdir"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(
+            self.entry.mount_point, "/var/lib/snapd/hostfs/snap/core/1/subdir"
+        )
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
+
+    def test_alternate_via_hostfs(self):
+        # type: () -> None
+        self.entry.mount_point = "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/7079"
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(
+            self.entry.mount_point, "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/1"
+        )
+
+        self.entry.mount_point = (
+            "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/7079/subdir"
+        )
+        renumber_snap_revision(self.entry, self.seen)
+        self.assertEqual(
+            self.entry.mount_point,
+            "/var/lib/snapd/hostfs/var/lib/snapd/snap/core/1/subdir",
+        )
+
+        self.assertEqual(self.seen, {("core", "7079"): 1})
 
 
 def renumber_opt_fields(entry, seen):
@@ -394,6 +504,31 @@ def rewrite_rename(entries):
         )
 
 
+class _SelfTestAction(Action):
+    def __init__(
+        self,
+        option_strings,
+        dest=SUPPRESS,
+        default=SUPPRESS,
+        help="run program's self-test suite and exit",
+    ):
+        # type: (Text, Text, Text, Text) -> None
+        super(_SelfTestAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs="...",
+            help=help,
+        )
+
+    def __call__(self, parser, ns, values, option_string=None):
+        # type: (ArgumentParser, Namespace, List[Text], Optional[Text]) -> None
+        # We allow the caller to provide the test to invoke by giving
+        # --self-test a set of arguments.
+        unittest.main(argv=[sys.argv[0]] + values)
+        parser.exit()
+
+
 def main():
     # type: () -> None
     parser = ArgumentParser(
@@ -421,7 +556,9 @@ Known attributes, applicable for both filtering and display.
     """,
         formatter_class=RawTextHelpFormatter,
     )
+    parser.register("action", "self-test", _SelfTestAction)
     parser.add_argument("-v", "--version", action="version", version="1.0")
+    parser.add_argument("--self-test", action="self-test")
     parser.add_argument(
         "-f",
         metavar="MOUNTINFO",
@@ -475,6 +612,7 @@ Known attributes, applicable for both filtering and display.
         raise SystemExit(
             "--one requires exactly one match, found {}".format(len(entries))
         )
+
 
 if __name__ == "__main__":
     main()

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -504,16 +504,16 @@ def rewrite_rename(entries):
         )
 
 
-class _SelfTestAction(Action):
+class _UnitTestAction(Action):
     def __init__(
         self,
         option_strings,
         dest=SUPPRESS,
         default=SUPPRESS,
-        help="run program's self-test suite and exit",
+        help="run program's unit test suite and exit",
     ):
         # type: (Text, Text, Text, Text) -> None
-        super(_SelfTestAction, self).__init__(
+        super(_UnitTestAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
@@ -524,7 +524,7 @@ class _SelfTestAction(Action):
     def __call__(self, parser, ns, values, option_string=None):
         # type: (ArgumentParser, Namespace, List[Text], Optional[Text]) -> None
         # We allow the caller to provide the test to invoke by giving
-        # --self-test a set of arguments.
+        # --run-unit-tests a set of arguments.
         unittest.main(argv=[sys.argv[0]] + values)
         parser.exit()
 
@@ -556,9 +556,9 @@ Known attributes, applicable for both filtering and display.
     """,
         formatter_class=RawTextHelpFormatter,
     )
-    parser.register("action", "self-test", _SelfTestAction)
+    parser.register("action", "unit-test", _UnitTestAction)
     parser.add_argument("-v", "--version", action="version", version="1.0")
-    parser.add_argument("--self-test", action="self-test")
+    parser.add_argument("--run-unit-tests", action="unit-test")
     parser.add_argument(
         "-f",
         metavar="MOUNTINFO",


### PR DESCRIPTION
The mountinfo-tool program has an useful option that understands certain
properties of filesystem and allows to remove some non-determinism
caused by snap revisions. This worked fine for /snap/foo/123 and
/var/lib/snapd/snap/foo/123 but heavier use uncovered absence of support
for both of those prefixed with /var/lib/snapd/hostfs.

This patch addresses this while adding minimalistic unit tests and a way
to run them via the mountinfo-tool --self-test switch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
