### PR TITLE
overlord/assertstate: add Batch.Precheck to check for the full validity of the batch before Commit

### DIFF
--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -145,8 +145,8 @@ func (b *Batch) linearize(db *asserts.Database) error {
 		return a, nil
 	}
 
-	// linearize using fetcher
-	f := newFetcher(db, retrieve)
+	// linearize using accumFetcher
+	f := newAccumFetcher(db, retrieve)
 	for _, ref := range b.refs {
 		if err := f.Fetch(ref); err != nil {
 			return err

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -164,8 +164,8 @@ func (b *Batch) Commit(st *state.State) error {
 	return b.commitTo(db)
 }
 
-// Preflight pre-checks whether adding the batch of assertions to the system assertion database should fully succeed.
-func (b *Batch) Preflight(st *state.State) error {
+// Precheck pre-checks whether adding the batch of assertions to the system assertion database should fully succeed.
+func (b *Batch) Precheck(st *state.State) error {
 	db := cachedDB(st)
 	db = db.WithStackedBackstore(asserts.NewMemoryBackstore())
 

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -362,7 +362,7 @@ func (s *assertMgrSuite) TestBatchCommitPartial(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *assertMgrSuite) TestBatchPreflightPartial(c *C) {
+func (s *assertMgrSuite) TestBatchPrecheckPartial(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -395,7 +395,7 @@ func (s *assertMgrSuite) TestBatchPreflightPartial(c *C) {
 	err = batch.Add(snapRev)
 	c.Assert(err, IsNil)
 
-	err = batch.Preflight(s.state)
+	err = batch.Precheck(s.state)
 	c.Check(err, ErrorMatches, `(?ms).*validity.*`)
 
 	// nothing was added
@@ -406,7 +406,7 @@ func (s *assertMgrSuite) TestBatchPreflightPartial(c *C) {
 	c.Assert(asserts.IsNotFound(err), Equals, true)
 }
 
-func (s *assertMgrSuite) TestBatchPreflightHappy(c *C) {
+func (s *assertMgrSuite) TestBatchPrecheckHappy(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -439,7 +439,7 @@ func (s *assertMgrSuite) TestBatchPreflightHappy(c *C) {
 	err = batch.Add(snapRev)
 	c.Assert(err, IsNil)
 
-	err = batch.Preflight(s.state)
+	err = batch.Precheck(s.state)
 	c.Assert(err, IsNil)
 
 	// nothing was added yet

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -38,14 +38,14 @@ func userFromUserID(st *state.State, userID int) (*auth.UserState, error) {
 	return auth.User(st, userID)
 }
 
-type fetcher struct {
+type accumFetcher struct {
 	asserts.Fetcher
 	fetched []asserts.Assertion
 }
 
-// newFetches creates a fetcher used to retrieve assertions and later commit them to the system database in one go.
-func newFetcher(db *asserts.Database, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *fetcher {
-	f := &fetcher{}
+// newAccumFetcher creates an accumFetcher used to retrieve assertions and later commit them to the system database in one go.
+func newAccumFetcher(db *asserts.Database, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *accumFetcher {
+	f := &accumFetcher{}
 
 	save := func(a asserts.Assertion) error {
 		f.fetched = append(f.fetched, a)
@@ -109,7 +109,7 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	}
 
 	db := cachedDB(s)
-	f := newFetcher(db, retrieve)
+	f := newAccumFetcher(db, retrieve)
 
 	s.Unlock()
 	err = fetching(f)

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -70,11 +70,11 @@ func (e *commitError) Error() string {
 	return fmt.Sprintf("cannot add some assertions to the system database:%s", strings.Join(l, "\n - "))
 }
 
-// commit does a best effort of adding all the fetched assertions to the system database.
-func (f *fetcher) commit() error {
+// commitTo does a best effort of adding all the fetched assertions to the system database.
+func commitTo(db *asserts.Database, assertions []asserts.Assertion) error {
 	var errs []error
-	for _, a := range f.fetched {
-		err := f.db.Add(a)
+	for _, a := range assertions {
+		err := db.Add(a)
 		if asserts.IsUnaccceptedUpdate(err) {
 			if _, ok := err.(*asserts.UnsupportedFormatError); ok {
 				// we kept the old one, but log the issue
@@ -122,5 +122,5 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	// TODO: trigger w. caller a global sanity check if a is revoked
 	// (but try to save as much possible still),
 	// or err is a check error
-	return f.commit()
+	return commitTo(db, f.fetched)
 }

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -45,9 +45,7 @@ type fetcher struct {
 }
 
 // newFetches creates a fetcher used to retrieve assertions and later commit them to the system database in one go.
-func newFetcher(s *state.State, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *fetcher {
-	db := cachedDB(s)
-
+func newFetcher(db *asserts.Database, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *fetcher {
 	f := &fetcher{db: db}
 
 	save := func(a asserts.Assertion) error {
@@ -111,7 +109,8 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 		return sto.Assertion(ref.Type, ref.PrimaryKey, user)
 	}
 
-	f := newFetcher(s, retrieve)
+	db := cachedDB(s)
+	f := newFetcher(db, retrieve)
 
 	s.Unlock()
 	err = fetching(f)

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -39,14 +39,13 @@ func userFromUserID(st *state.State, userID int) (*auth.UserState, error) {
 }
 
 type fetcher struct {
-	db *asserts.Database
 	asserts.Fetcher
 	fetched []asserts.Assertion
 }
 
 // newFetches creates a fetcher used to retrieve assertions and later commit them to the system database in one go.
 func newFetcher(db *asserts.Database, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *fetcher {
-	f := &fetcher{db: db}
+	f := &fetcher{}
 
 	save := func(a asserts.Assertion) error {
 		f.fetched = append(f.fetched, a)


### PR DESCRIPTION
The checking is based on the newly introduced asserts.Database.WithStackedBackstore which creates a database using a stacked write backstore, typically ephemeral.  Such a database is useful to accumulate and cross check assertions without adding them to the original database.
