### PR TITLE
tests: add more unit tests for mountinfo-tool

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -585,6 +585,22 @@ Known attributes, applicable for both filtering and display.
         )
 
 
+class MountInfoEntryTests(unittest.TestCase):
+    def test_init(self):
+        # type: () -> None
+        e = MountInfoEntry()
+        self.assertEqual(e.mount_id, 0)
+        self.assertEqual(e.parent_id, 0)
+        self.assertEqual(e.dev, Device.pack(0, 0))
+        self.assertEqual(e.root_dir, "")
+        self.assertEqual(e.mount_point, "")
+        self.assertEqual(e.mount_opts, "")
+        self.assertEqual(e.opt_fields, [])
+        self.assertEqual(e.fs_type, "")
+        self.assertEqual(e.mount_source, "")
+        self.assertEqual(e.sb_opts, "")
+
+
 class RenumberSnapRevisionTests(unittest.TestCase):
     def setUp(self):
         # type: () -> None

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -653,6 +653,13 @@ class MountInfoEntryTests(unittest.TestCase):
             "1 2 3:4 /root-dir /mount-point mount-opts opt:1 fields:2 - fs-type mount-source sb-opts",
         )
 
+    def test_dev_maj_min(self):
+        # type: () -> None
+        e = MountInfoEntry()
+        e.dev = Device.pack(1, 2)
+        self.assertEqual(e.dev_min, 2)
+        self.assertEqual(e.dev_maj, 1)
+
 
 class RenumberSnapRevisionTests(unittest.TestCase):
     def setUp(self):

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -586,6 +586,20 @@ Known attributes, applicable for both filtering and display.
 
 
 class MountInfoEntryTests(unittest.TestCase):
+
+    non_zero_values = {
+        "mount_id": 1,
+        "parent_id": 1,
+        "dev": Device.pack(1, 2),
+        "root_dir": "/",
+        "mount_point": "/",
+        "mount_opts": "rw",
+        "opt_fields": ["foo:1"],
+        "fs_type": "foo",
+        "mount_source": "source",
+        "sb_opts": "opts",
+    }  # Dict[Text, Any]
+
     def test_init(self):
         # type: () -> None
         e = MountInfoEntry()
@@ -621,19 +635,7 @@ class MountInfoEntryTests(unittest.TestCase):
         e0 = MountInfoEntry()
         e1 = MountInfoEntry()
         self.assertEqual(e0, e1)
-        non_zero_values = {
-            "mount_id": 1,
-            "parent_id": 1,
-            "dev": Device.pack(1, 2),
-            "root_dir": "/",
-            "mount_point": "/",
-            "mount_opts": "rw",
-            "opt_fields": ["foo:1"],
-            "fs_type": "foo",
-            "mount_source": "source",
-            "sb_opts": "opts",
-        }  # Dict[Text, Any]
-        for field, value in non_zero_values.items():
+        for field, value in self.non_zero_values.items():
             self.assertEqual(e0, e1)
             old_value = getattr(e1, field)
             setattr(e1, field, value)

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -643,6 +643,16 @@ class MountInfoEntryTests(unittest.TestCase):
             setattr(e1, field, old_value)
             self.assertEqual(e0, e1)
 
+    def test_str(self):
+        # type: () -> None
+        e = MountInfoEntry()
+        for field, value in self.non_zero_values.items():
+            setattr(e, field, value)
+        self.assertEqual(
+            str(e),
+            "1 2 3:4 /root-dir /mount-point mount-opts opt:1 fields:2 - fs-type mount-source sb-opts",
+        )
+
 
 class RenumberSnapRevisionTests(unittest.TestCase):
     def setUp(self):

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -589,15 +589,15 @@ class MountInfoEntryTests(unittest.TestCase):
 
     non_zero_values = {
         "mount_id": 1,
-        "parent_id": 1,
-        "dev": Device.pack(1, 2),
-        "root_dir": "/",
-        "mount_point": "/",
-        "mount_opts": "rw",
-        "opt_fields": ["foo:1"],
-        "fs_type": "foo",
-        "mount_source": "source",
-        "sb_opts": "opts",
+        "parent_id": 2,
+        "dev": Device.pack(3, 4),
+        "root_dir": "/root-dir",
+        "mount_point": "/mount-point",
+        "mount_opts": "mount-opts",
+        "opt_fields": ["opt:1", "fields:2"],
+        "fs_type": "fs-type",
+        "mount_source": "mount-source",
+        "sb_opts": "sb-opts",
     }  # Dict[Text, Any]
 
     def test_init(self):

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -151,6 +151,13 @@ class MountInfoEntry(object):
             return result.encode()
         return result
 
+    def __repr__(self):
+        # type: () -> str
+        result = "MountInfoEntry.parse({!r})".format(str(self))
+        if PY2:
+            return result.encode()
+        return result
+
     @property
     def dev_maj(self):
         # type: () -> int
@@ -651,6 +658,16 @@ class MountInfoEntryTests(unittest.TestCase):
         self.assertEqual(
             str(e),
             "1 2 3:4 /root-dir /mount-point mount-opts opt:1 fields:2 - fs-type mount-source sb-opts",
+        )
+
+    def test_repr(self):
+        # type: () -> None
+        e = MountInfoEntry()
+        for field, value in self.non_zero_values.items():
+            setattr(e, field, value)
+        self.assertEqual(
+            repr(e),
+            "MountInfoEntry.parse('1 2 3:4 /root-dir /mount-point mount-opts opt:1 fields:2 - fs-type mount-source sb-opts')",
         )
 
     def test_dev_maj_min(self):

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -600,6 +600,22 @@ class MountInfoEntryTests(unittest.TestCase):
         self.assertEqual(e.mount_source, "")
         self.assertEqual(e.sb_opts, "")
 
+    def test_parse(self):
+        # type: () -> None
+        e = MountInfoEntry.parse(
+            "2079 2266 0:3 mnt:[4026532791] /run/snapd/ns/test-snapd-mountinfo.mnt rw - nsfs nsfs rw"
+        )
+        self.assertEqual(e.mount_id, 2079)
+        self.assertEqual(e.parent_id, 2266)
+        self.assertEqual(e.dev, Device.pack(0, 3))
+        self.assertEqual(e.root_dir, "mnt:[4026532791]")
+        self.assertEqual(e.mount_point, "/run/snapd/ns/test-snapd-mountinfo.mnt")
+        self.assertEqual(e.mount_opts, "rw")
+        self.assertEqual(e.opt_fields, [])
+        self.assertEqual(e.fs_type, "nsfs")
+        self.assertEqual(e.mount_source, "nsfs")
+        self.assertEqual(e.sb_opts, "rw")
+
 
 class RenumberSnapRevisionTests(unittest.TestCase):
     def setUp(self):

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -616,6 +616,31 @@ class MountInfoEntryTests(unittest.TestCase):
         self.assertEqual(e.mount_source, "nsfs")
         self.assertEqual(e.sb_opts, "rw")
 
+    def test_eq(self):
+        # type: () -> None
+        e0 = MountInfoEntry()
+        e1 = MountInfoEntry()
+        self.assertEqual(e0, e1)
+        non_zero_values = {
+            "mount_id": 1,
+            "parent_id": 1,
+            "dev": Device.pack(1, 2),
+            "root_dir": "/",
+            "mount_point": "/",
+            "mount_opts": "rw",
+            "opt_fields": ["foo:1"],
+            "fs_type": "foo",
+            "mount_source": "source",
+            "sb_opts": "opts",
+        }  # Dict[Text, Any]
+        for field, value in non_zero_values.items():
+            self.assertEqual(e0, e1)
+            old_value = getattr(e1, field)
+            setattr(e1, field, value)
+            self.assertNotEqual(e0, e1)
+            setattr(e1, field, old_value)
+            self.assertEqual(e0, e1)
+
 
 class RenumberSnapRevisionTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
A few quick tests for MountInfoEntry class. I also added the __repr__ method that is
useful in case any of the tests fail, since it prints objects in meaningful ways.