### PR TITLE
tests: introduce mountinfo-tool --ref feature

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -538,6 +538,12 @@ Known attributes, applicable for both filtering and display.
         help="parse specified mountinfo file",
     )
     parser.add_argument(
+        "--ref",
+        metavar="MOUNTINFO",
+        type=FileType(),
+        help="refer to another table while rewriting, makes output comparable across namespaces",
+    )
+    parser.add_argument(
         "--one", default=False, action="store_true", help="expect exactly one match"
     )
     parser.add_argument(
@@ -564,6 +570,12 @@ Known attributes, applicable for both filtering and display.
     entries = [MountInfoEntry.parse(line) for line in opts.file]
     entries = [e for e in entries if matches(e, filters)]
     rs = RewriteState()
+    if opts.ref:
+        ref_entries = [MountInfoEntry.parse(line) for line in opts.ref]
+        if opts.renumber:
+            rewrite_renumber(ref_entries, rs)
+        if opts.rename:
+            rewrite_rename(ref_entries, rs)
     if opts.renumber:
         rewrite_renumber(entries, rs)
     if opts.rename:


### PR DESCRIPTION
The main idea is:

    $ cat /proc/self/mountinfo > host
    $ sudo unshare -m cat /proc/self/mountinfo > unshared
    $ python mountinfo-tool --ref host --rename --renumber -f host  /
    0 25 1:0 / / rw,relatime shared:25 - ext4 /dev/sda2 rw
    $ python mountinfo-tool --ref host --rename --renumber -f unshared /
    120 119 1:0 / / rw,relatime - ext4 /dev/sda2 rw

What this tells us:

 - using unshare retained the same block device (1:0, after rewriting)
 - unshare did not chroot since we see the / subset of 1:0 mounted at /
 - interestingly, unshare changed propagation settings:
   the host used shared:25 - which means it belongs to peer group 25
   the slave used - (nothing) - which means it is not sharing any events

This is because unshare -m defaults to --propagation=private. We can
change it to "slave" to see what would happen then. We can reuse the
"host" file since that is our invariant.

    $ sudo unshare -m --propagation=slave cat /proc/self/mountinfo > unshared-slave
    $ python mountinfo-tool --ref host --rename --renumber -f host  /
    0 25 1:0 / / rw,relatime shared:25 - ext4 /dev/sda2 rw
    $ python mountinfo-tool --ref host --rename --renumber -f unshared-slave /
    120 119 1:0 / / rw,relatime master:25 - ext4 /dev/sda2 rw

Due to the use of --ref the peer group is retained across both rewrite
operations. The actual number is  different (and not stable across reboots)
but the rewritten number *is* stable.

The stability applies to all rewrite rules.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
