### PR TITLE
interfaces: OpenGL/Vulkan drivers provided by a base should be usable.

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -58,6 +58,10 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/lib/glvnd/** r,
 /var/lib/snapd/hostfs/usr/share/glvnd/egl_vendor.d/*nvidia*.json r,
 
+# Support loading Mesa DRI drivers from the base snap
+/usr/lib/{,@{multiarch}/}dri/ r,
+/usr/lib/{,@{multiarch}/}dri/*.so rm,
+
 # Main bi-arch GL libraries
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}{,nvidia*/}lib{GL,GLU,GLESv1_CM,GLESv2,EGL,GLX}.so{,.*} rm,
 

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -44,12 +44,16 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}vdpau/libvdpau_nvidia.so{,.*} rm,
 
-# Support reading the Vulkan ICD files
+# Support reading the Vulkan ICD and layer files
+/usr/share/vulkan/icd.d/{,*.json} r,
+/usr/share/vulkan/explicit_layer.d/{,*.json} r,
+/usr/share/vulkan/implicit_layer.d/{,*.json} r,
 /var/lib/snapd/lib/vulkan/ r,
 /var/lib/snapd/lib/vulkan/** r,
 /var/lib/snapd/hostfs/usr/share/vulkan/icd.d/*nvidia*.json r,
 
 # Support reading the GLVND EGL vendor files
+/usr/share/glvnd/egl_vendor.d/{,*.json} r,
 /var/lib/snapd/lib/glvnd/ r,
 /var/lib/snapd/lib/glvnd/** r,
 /var/lib/snapd/hostfs/usr/share/glvnd/egl_vendor.d/*nvidia*.json r,


### PR DESCRIPTION
If a base snap ships OpenGL or Vulkan drivers, the `opengl` interface should grant access to them.  While the actual shared libraries are already accessible by the base AppArmor profile (they are files matching `lib*.so` under the `/usr/lib` hierarchy), we also need to grant access to the configuration files the dispatch library.

The added paths are not provided by the `core` or `core18` snaps, so should not change the behaviour of existing snaps.