### PR TITLE
tests: mountinfo-tool allow many --refs

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -587,8 +587,11 @@ Known attributes, applicable for both filtering and display.
     )
     parser.add_argument(
         "--ref",
+        dest="refs",
         metavar="MOUNTINFO",
         type=FileType(),
+        action="append",
+        default=[],
         help="refer to another table while rewriting, makes output comparable across namespaces",
     )
     parser.add_argument(
@@ -618,8 +621,9 @@ Known attributes, applicable for both filtering and display.
     entries = [MountInfoEntry.parse(line) for line in opts.file]
     entries = [e for e in entries if matches(e, filters)]
     rs = RewriteState()
-    if opts.ref:
-        ref_entries = [MountInfoEntry.parse(line) for line in opts.ref]
+
+    for ref in opts.refs:
+        ref_entries = [MountInfoEntry.parse(line) for line in ref]
         if opts.renumber:
             rewrite_renumber(ref_entries, rs)
         if opts.rename:


### PR DESCRIPTION
When using mountinfo-tool to compute a renumbering of a per-snap mount
namespace we can use --ref to allocate numbers in a way that is comparable
with the re-numbererd host mount namespace.

To allow doing the same with the per-snap, per-user mount namespace we
need to be able to use --ref multiple times: one for the host and another
one for the per-snap numbers. This patch makes just that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>