### PR TITLE
tests: manually stop the gvfsd-metadata process

### DIFF
--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -26,12 +26,10 @@ prepare: |
 restore: |
     kill "$(cat dbus-launch.pid)"
 
-    # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
-    # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
-    # producing an error when the xdg directory is removed.
-    if pid="$(pidof gvfsd-metadata)"; then
-        kill -9 "$pid" || true
-    fi
+    # We make sure the gvfsd-metadata process is stopped because it locks the 
+    # xdg/share/gvfs-metadata directory content producing an error when the 
+    # xdg directory is removed.
+    pkill gvfsd-metadata || true
     rm -rf "$XDG"
 
 execute: |

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -25,12 +25,10 @@ restore: |
         kill "$(cat dbus-launch.pid)"
     fi
 
-    # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
-    # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
-    # producing an error when the xdg directory is removed.
-    if pid="$(pidof gvfsd-metadata)"; then
-        kill -9 "$pid" || true
-    fi
+    # We make sure the gvfsd-metadata process is stopped because it locks the 
+    # xdg/share/gvfs-metadata directory content producing an error when the 
+    # xdg directory is removed.
+    pkill gvfsd-metadata || true
     rm -rf "$XDG"
 
 execute: |


### PR DESCRIPTION
Seems to be a race between the gvfsd-metadata which is being stopped and
the rm command. By using pkill we make sure the process is finished and
the dir can be removed.

This is the log:

++ ps -ef
...
root     21163     1  0 13:52 ?        00:00:00
/usr/lib/gvfs/gvfsd-metadata
...

++ pidof gvfsd-metadata
+ pid=
+ rm -rf
/home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-calendar-service/xdg
rm: cannot remove
'/home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-calendar-service/xdg/share/gvfs-metadata':
Directory not empty

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
