### PR TITLE
tests: don't preserve size= when rewriting mount tables

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -922,7 +922,7 @@ class RenumberMountOptionsTests(unittest.TestCase):
         self.assertEqual(renumber_mount_option("fd=45", self.seen), "fd=1")
         self.assertEqual(renumber_mount_option("fd=21", self.seen), "fd=0")
 
-    def test_size_not_allocated(self):
+    def test_renumber_size_variable(self):
         # type: () -> None
         """
         size is special-cased and is not allocated because it is prone to fluctuations

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -925,7 +925,7 @@ class RenumberMountOptionsTests(unittest.TestCase):
     def test_renumber_size_variable(self):
         # type: () -> None
         """
-        size is special-cased and is not allocated because it is prone to fluctuations
+        size is special-cased and always rewritten to the same value because it is prone to fluctuations
         """
         self.assertEqual(renumber_mount_option("size=100", self.seen), "size=VARIABLE")
         self.assertEqual(renumber_mount_option("size=200", self.seen), "size=VARIABLE")

--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -467,7 +467,9 @@ def renumber_mount_option(opt, seen):
         mount_opt_key, mount_opt_value = opt.split("=", 1)
         # size, nr_inode: used by tmpfs
         # fd, pipe_ino: used by binfmtmisc
-        if mount_opt_key in {"size", "nr_inodes", "fd", "pipe_ino"}:
+        if mount_opt_key == "size":
+            return "size=VARIABLE"
+        if mount_opt_key in {"nr_inodes", "fd", "pipe_ino"}:
             return "{}={}".format(
                 mount_opt_key, alloc_n(mount_opt_key, mount_opt_value)
             )
@@ -911,14 +913,22 @@ class RenumberMountOptionsTests(unittest.TestCase):
         """
         numbers are allocated from subsets matching the key, this reduces delta.
         """
-        self.assertEqual(renumber_mount_option("size=100", self.seen), "size=0")
-        self.assertEqual(renumber_mount_option("size=100", self.seen), "size=0")
-        self.assertEqual(renumber_mount_option("size=200", self.seen), "size=1")
-        self.assertEqual(renumber_mount_option("size=100", self.seen), "size=0")
+        self.assertEqual(renumber_mount_option("pipe_ino=100", self.seen), "pipe_ino=0")
+        self.assertEqual(renumber_mount_option("pipe_ino=100", self.seen), "pipe_ino=0")
+        self.assertEqual(renumber_mount_option("pipe_ino=200", self.seen), "pipe_ino=1")
+        self.assertEqual(renumber_mount_option("pipe_ino=100", self.seen), "pipe_ino=0")
         self.assertEqual(renumber_mount_option("fd=21", self.seen), "fd=0")
         self.assertEqual(renumber_mount_option("fd=21", self.seen), "fd=0")
         self.assertEqual(renumber_mount_option("fd=45", self.seen), "fd=1")
         self.assertEqual(renumber_mount_option("fd=21", self.seen), "fd=0")
+
+    def test_size_not_allocated(self):
+        # type: () -> None
+        """
+        size is special-cased and is not allocated because it is prone to fluctuations
+        """
+        self.assertEqual(renumber_mount_option("size=100", self.seen), "size=VARIABLE")
+        self.assertEqual(renumber_mount_option("size=200", self.seen), "size=VARIABLE")
 
     def test_renumber_devtmpfs_opts(self):
         # type: () -> None
@@ -927,18 +937,20 @@ class RenumberMountOptionsTests(unittest.TestCase):
 
             23 98 0:6 / /dev rw,nosuid shared:21 - devtmpfs devtmpfs rw,size=4057388k,nr_inodes=1014347,mode=755
 
-        Here the size and nr_inodes options are not deterministic and need to be rewritten.
+        Here the size and nr_inodes options are not deterministic and need to
+        be rewritten.  The size quantity is very susceptible to free memory
+        fluctuations and is treated specially.
         """
         # Options size= and nr_inodes= are renumbered.
-        self.assertEqual(renumber_mount_option("size=4057388k", self.seen), "size=0")
+        self.assertEqual(
+            renumber_mount_option("size=4057388k", self.seen), "size=VARIABLE"
+        )
         self.assertEqual(
             renumber_mount_option("nr_inodes=1014347", self.seen), "nr_inodes=0"
         )
         # Option mode= is not renumbered.
         self.assertEqual(renumber_mount_option("mode=755", self.seen), "mode=755")
-        self.assertEqual(
-            self.seen, {("size", "4057388k"): 0, ("nr_inodes", "1014347"): 0}
-        )
+        self.assertEqual(self.seen, {("nr_inodes", "1014347"): 0})
 
     def test_renumber_binfmt_misc_opts(self):
         # type: () -> None
@@ -979,7 +991,7 @@ class RewriteTests(unittest.TestCase):
                 MountInfoEntry.parse(line)
                 for line in (
                     "1 0 0:0 mnt:[0] /run/snapd/ns/test-snapd-mountinfo.mnt rw - nsfs nsfs rw",
-                    "3 2 0:1 / /dev rw,nosuid shared:1 - devtmpfs devtmpfs rw,size=0,nr_inodes=0,mode=755",
+                    "3 2 0:1 / /dev rw,nosuid shared:1 - devtmpfs devtmpfs rw,size=VARIABLE,nr_inodes=0,mode=755",
                     "5 4 0:2 / /proc/sys/fs/binfmt_misc rw,relatime shared:2 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0",
                 )
             ],


### PR DESCRIPTION
When systemd mounts tmpfs it will compute and provide the maximum size
of the filesystem as a fraction of the available memory. This quantity
changes from execution to execution I've seen renumbering "failures" as
the computed quantity for /run/user/0 oscillated between 378180k and
378184k, resulting in either reuse of earlier renumbering of /run or an
allocation of a new value. To avoid this issue replace size= with
constant size=VARIABLE.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>