### PR TITLE
interfaces/docker-support: add exec "/bin/runc"

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -156,6 +156,7 @@ ptrace (read, trace) peer=docker-default,
 
 # needed by runc for mitigation of CVE-2019-5736
 # For details see https://bugs.launchpad.net/apparmor/+bug/1820344
+/bin/runc rix,
 / ix,
 `
 


### PR DESCRIPTION
Newer runC applied further improvements to their CVE-2019-5736 mitigation in https://github.com/opencontainers/runc/pull/1984 which change the nature of our apparmor denial from `/` to `/bin/runc` (which I have also commented on https://bugs.launchpad.net/apparmor/+bug/1820344 about).

See also https://github.com/snapcore/snapd/pull/6610.

cc @anonymouse64