### PR TITLE
tests: fix error doing snap pack running failover test

### DIFF
--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -69,6 +69,8 @@ execute: |
     . "$TESTSLIB"/boot.sh
     #shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB"/journalctl.sh
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
 
     if [ "$TARGET_SNAP" = kernel ]; then
         TARGET_SNAP_NAME=$kernel_name
@@ -87,7 +89,7 @@ execute: |
         eval "${INJECT_FAILURE}"
 
         # repack new target snap
-        snap pack "$BUILD_DIR/unpack" && mv ${TARGET_SNAP_NAME}_*.snap failing.snap
+        mksnap_fast "$BUILD_DIR/unpack" failing.snap
 
         # use journalctl wrapper to grep only the logs collected while the test is running
         if get_journalctl_log | MATCH "Waiting for system reboot"; then


### PR DESCRIPTION
It was happening that doing snap pack for core snap, sporadically the
systemd was going out of memory and hanging when running the failover
test (specially running failover test)

When using the mksquashfs command instead of snap pack the test is not
hanging anymore and the test speed is improved.

The fix was validated on gce machines and rpi as well with excelente
results.
