### PR TITLE
cmd/snap: handle unsetting of config options with "!"

### DIFF
--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -64,7 +64,7 @@ func init() {
 			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<conf value>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			desc: i18n.G("Configuration value (key=value) or key!"),
+			desc: i18n.G("Set (key=value) or unset (key!) configuration value"),
 		},
 	})
 }

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -74,7 +74,7 @@ func (x *cmdSet) Execute(args []string) error {
 	for _, patchValue := range x.Positional.ConfValues {
 		parts := strings.SplitN(patchValue, "=", 2)
 		if len(parts) == 1 && strings.HasSuffix(patchValue, "!") {
-			patchValues[patchValue[:len(patchValue)-1]] = nil
+			patchValues[strings.TrimSuffix(patchValue, "!")] = nil
 			continue
 		}
 		if len(parts) != 2 {

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -41,6 +41,9 @@ snap's configuration hook returns successfully.
 Nested values may be modified via a dotted path:
 
     $ snap set author.name=frank
+
+Configuration option may be unset with exclamation mark:
+    $ snap set author!
 `)
 
 type cmdSet struct {
@@ -61,7 +64,7 @@ func init() {
 			// TRANSLATORS: This needs to begin with < and end with >
 			name: i18n.G("<conf value>"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			desc: i18n.G("Configuration value (key=value)"),
+			desc: i18n.G("Configuration value (key=value) or key!"),
 		},
 	})
 }
@@ -70,6 +73,10 @@ func (x *cmdSet) Execute(args []string) error {
 	patchValues := make(map[string]interface{})
 	for _, patchValue := range x.Positional.ConfValues {
 		parts := strings.SplitN(patchValue, "=", 2)
+		if len(parts) == 1 && strings.HasSuffix(patchValue, "!") {
+			patchValues[patchValue[:len(patchValue)-1]] = nil
+			continue
+		}
 		if len(parts) != 2 {
 			return fmt.Errorf(i18n.G("invalid configuration: %q (want key=value)"), patchValue)
 		}

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -98,6 +98,34 @@ func (s *SnapSuite) TestSnapSetIntegrationJson(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+func (s *SnapSuite) TestSnapSetIntegrationUnsetWithExclamationMark(c *check.C) {
+	// mock installed snap
+	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
+		Revision: snap.R(1),
+	})
+
+	// and mock the server
+	s.mockSetConfigServer(c, nil)
+
+	// Unset config value via exclamation mark
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key!"})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SnapSuite) TestSnapSetIntegrationStringWithExclamationMark(c *check.C) {
+	// mock installed snap
+	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
+		Revision: snap.R(42),
+	})
+
+	// and mock the server
+	s.mockSetConfigServer(c, "value!")
+
+	// Set a config value ending with exclamation mark
+	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=value!"})
+	c.Assert(err, check.IsNil)
+}
+
 func (s *SnapSuite) mockSetConfigServer(c *check.C, expectedValue interface{}) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -27,106 +27,89 @@ import (
 	"gopkg.in/check.v1"
 
 	snapset "github.com/snapcore/snapd/cmd/snap"
-	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 )
 
-var validApplyYaml = []byte(`name: snapname
-version: 1.0
-hooks:
- configure:
-`)
+type snapSetSuite struct {
+	SnapSuite
 
-func (s *SnapSuite) TestInvalidSetParameters(c *check.C) {
+	setConfApiCalls int
+}
+
+var _ = check.Suite(&snapSetSuite{})
+
+func (s *snapSetSuite) SetUpTest(c *check.C) {
+	s.SnapSuite.SetUpTest(c)
+	s.setConfApiCalls = 0
+}
+
+func (s *snapSetSuite) TestInvalidSetParameters(c *check.C) {
 	invalidParameters := []string{"set", "snap-name", "key", "value"}
 	_, err := snapset.Parser(snapset.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, ".*invalid configuration:.*(want key=value).*")
+	c.Check(s.setConfApiCalls, check.Equals, 0)
 }
 
-func (s *SnapSuite) TestSnapSetIntegrationString(c *check.C) {
-	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
-		Revision: snap.R(42),
-	})
-
+func (s *snapSetSuite) TestSnapSetIntegrationString(c *check.C) {
 	// and mock the server
 	s.mockSetConfigServer(c, "value")
 
 	// Set a config value for the active snap
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=value"})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *SnapSuite) TestSnapSetIntegrationNumber(c *check.C) {
-	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
-		Revision: snap.R(42),
-	})
-
+func (s *snapSetSuite) TestSnapSetIntegrationNumber(c *check.C) {
 	// and mock the server
 	s.mockSetConfigServer(c, json.Number("1.2"))
 
 	// Set a config value for the active snap
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=1.2"})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *SnapSuite) TestSnapSetIntegrationBigInt(c *check.C) {
-	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
-		Revision: snap.R(42),
-	})
-
+func (s *snapSetSuite) TestSnapSetIntegrationBigInt(c *check.C) {
 	// and mock the server
 	s.mockSetConfigServer(c, json.Number("1234567890"))
 
 	// Set a config value for the active snap
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=1234567890"})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *SnapSuite) TestSnapSetIntegrationJson(c *check.C) {
-	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
-		Revision: snap.R(42),
-	})
-
+func (s *snapSetSuite) TestSnapSetIntegrationJson(c *check.C) {
 	// and mock the server
 	s.mockSetConfigServer(c, map[string]interface{}{"subkey": "value"})
 
 	// Set a config value for the active snap
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", `key={"subkey":"value"}`})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *SnapSuite) TestSnapSetIntegrationUnsetWithExclamationMark(c *check.C) {
-	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
-		Revision: snap.R(1),
-	})
-
+func (s *snapSetSuite) TestSnapSetIntegrationUnsetWithExclamationMark(c *check.C) {
 	// and mock the server
 	s.mockSetConfigServer(c, nil)
 
 	// Unset config value via exclamation mark
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key!"})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *SnapSuite) TestSnapSetIntegrationStringWithExclamationMark(c *check.C) {
-	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
-		Revision: snap.R(42),
-	})
-
+func (s *snapSetSuite) TestSnapSetIntegrationStringWithExclamationMark(c *check.C) {
 	// and mock the server
 	s.mockSetConfigServer(c, "value!")
 
 	// Set a config value ending with exclamation mark
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "snapname", "key=value!"})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }
 
-func (s *SnapSuite) mockSetConfigServer(c *check.C, expectedValue interface{}) {
+func (s *snapSetSuite) mockSetConfigServer(c *check.C, expectedValue interface{}) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/snaps/snapname/conf":
@@ -135,6 +118,7 @@ func (s *SnapSuite) mockSetConfigServer(c *check.C, expectedValue interface{}) {
 				"key": expectedValue,
 			})
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
+			s.setConfApiCalls += 1
 		case "/v2/changes/zzz":
 			c.Check(r.Method, check.Equals, "GET")
 			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done"}}`)

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -46,6 +46,18 @@ execute: |
     fi
     snap get snapctl-hooks foo 2>&1 | MATCH 'snap "snapctl-hooks" has no "foo" configuration option'
 
+    echo "Set foo back"
+    snap set snapctl-hooks command=test-snapctl-get-foo foo=bar
+    if ! obtained=$(snap get snapctl-hooks foo); then
+        echo "Expected snap get to be able to retrieve set value"
+        exit 1
+    fi
+    [[ "$obtained" == "bar" ]]
+
+    echo "Test that the foo value can be unset"
+    snap set snapctl-hooks command=test-snapctl-foo-null foo!
+    snap get snapctl-hooks foo 2>&1 | MATCH 'snap "snapctl-hooks" has no "foo" configuration option'
+
     echo "Test that an invalid key results in an error"
     if obtained=$(snap set snapctl-hooks invalid_key=value 2>&1); then
         echo "Expected usage of an invalid key to result in an error"

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -52,7 +52,7 @@ execute: |
         echo "Expected snap get to be able to retrieve set value"
         exit 1
     fi
-    [[ "$obtained" == "bar" ]]
+    test "$obtained" = "bar"
 
     echo "Test that the foo value can be unset"
     snap set snapctl-hooks command=test-snapctl-foo-null foo!


### PR DESCRIPTION
Handle exclamation mark after option name for unsetting it with snap set, e.g. `snap set mysnap foo!`.

This is done on the protocol/API level by passing nulls as option values and relies on already landed changes to config transaction internals.

Similiar change to `snapctl` as well as `snap unset` command will be proposed in a separate PRs.