### PR TITLE
packaging: fix typo in changelog

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -969,7 +969,7 @@ fi
  - tests/lib/nested: fix multi argument copy_remote
  - tests/lib/nested: have mkfs.ext4 use a rootdir instead of mounting
    an image
- - packaging: fix permissons powerpc docs dir
+ - packaging: fix permissions powerpc docs dir
  - overlord: mock store to avoid net requests
  - debian: rework how we run autopkgtests
  - interface: builtin: avahi-observe/control: allow slots

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -102,7 +102,7 @@ snapd (2.40~14.04) trusty; urgency=medium
     - tests/lib/nested: fix multi argument copy_remote
     - tests/lib/nested: have mkfs.ext4 use a rootdir instead of mounting
       an image
-    - packaging: fix permissons powerpc docs dir
+    - packaging: fix permissions powerpc docs dir
     - overlord: mock store to avoid net requests
     - debian: rework how we run autopkgtests
     - interface: builtin: avahi-observe/control: allow slots

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -102,7 +102,7 @@ snapd (2.40) xenial; urgency=medium
     - tests/lib/nested: fix multi argument copy_remote
     - tests/lib/nested: have mkfs.ext4 use a rootdir instead of mounting
       an image
-    - packaging: fix permissons powerpc docs dir
+    - packaging: fix permissions powerpc docs dir
     - overlord: mock store to avoid net requests
     - debian: rework how we run autopkgtests
     - interface: builtin: avahi-observe/control: allow slots


### PR DESCRIPTION
Trivial typo check to fix the failing spellchecker test.