### PR TITLE
snapctl: handle unsetting of config options with "!"

### DIFF
--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -53,6 +53,9 @@ Nested values may be modified via a dotted path:
 
     $ snapctl set author.name=frank
 
+Configuration option may be unset with exclamation mark:
+    $ snap set author!
+
 Plug and slot attributes may be set in the respective prepare and connect hooks by
 naming the respective plug or slot:
 
@@ -99,6 +102,11 @@ func (s *setCommand) setConfigSetting(context *hookstate.Context) error {
 
 	for _, patchValue := range s.Positional.ConfValues {
 		parts := strings.SplitN(patchValue, "=", 2)
+		if len(parts) == 1 && strings.HasSuffix(patchValue, "!") {
+			key := strings.TrimSuffix(patchValue, "!")
+			tr.Set(s.context().InstanceName(), key, nil)
+			continue
+		}
 		if len(parts) != 2 {
 			return fmt.Errorf(i18n.G("invalid parameter: %q (want key=value)"), patchValue)
 		}

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -90,6 +90,14 @@ test_snapctl_foo_null() {
 	  fi
 }
 
+test_snapctl_unset() {
+	  echo "Unsetting an option"
+	  if ! snapctl set root.key2! ; then
+	  echo "snapctl set unexpectedly failed when un-setting root.key2"
+			exit 1
+	  fi
+}
+
 test_exit_one() {
 	echo "Failing as requested."
 	exit 1
@@ -123,6 +131,9 @@ case $command in
   "test-get-nested")
     test_get_nested
     ;;
+  "test-unset")
+    test_snapctl_unset
+	;;
 	*)
 		echo "Invalid command: '$command'"
 		exit 1

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -93,8 +93,8 @@ test_snapctl_foo_null() {
 test_snapctl_unset() {
 	  echo "Unsetting an option"
 	  if ! snapctl set root.key2! ; then
-	  echo "snapctl set unexpectedly failed when un-setting root.key2"
-			exit 1
+	            echo "snapctl set unexpectedly failed when un-setting root.key2"
+		    exit 1
 	  fi
 }
 

--- a/tests/main/snap-get/task.yaml
+++ b/tests/main/snap-get/task.yaml
@@ -98,6 +98,16 @@ execute: |
     echo "Ensure config value has correct format"
     jq ".data[\"config\"][\"snapctl-hooks\"].intnumber" /var/lib/snapd/state.json | MATCH "1234567890"
 
+    echo "Test unsetting of root.key2 with exclamation mark via snapctl"
+    # sanity check
+    snap get snapctl-hooks root.key2 | MATCH "b"
+    # note, unsetting happens in the configure hook in response to "test-unset" value
+    snap set snapctl-hooks command=test-unset root.key1="c"
+    if ! output=$(snap get snapctl-hooks root.key1); then
+        echo "snap get unexpectedly failed"
+    fi
+    snap get snapctl-hooks root.key2 2>&1 | MATCH 'snap "snapctl-hooks" has no "root.key2" configuration option'
+
     echo "Test that config values are not available once snap is removed"
     snap remove snapctl-hooks
     if output=$(snap get snapctl-hooks foo); then


### PR DESCRIPTION
Handle exclamation mark after option name for unsetting it with snapctl set, e.g. `snapctl set foo!`.
The unsetting logic is internally handled via nulls in the transaction logic (this change already landed some time ago).

This is a followup for #7096 

