### PR TITLE
cmd/snap: add snap unset command

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -200,7 +200,7 @@ var helpCategories = []helpCategory{
 	}, {
 		Label:       i18n.G("Configuration"),
 		Description: i18n.G("system administration and configuration"),
-		Commands:    []string{"get", "set", "wait"},
+		Commands:    []string{"get", "set", "unset", "wait"},
 	}, {
 		Label:       i18n.G("Account"),
 		Description: i18n.G("authentication to snapd and the snap store"),

--- a/cmd/snap/cmd_unset.go
+++ b/cmd/snap/cmd_unset.go
@@ -27,17 +27,17 @@ import (
 
 var shortUnsetHelp = i18n.G("Remove configuration options")
 var longUnsetHelp = i18n.G(`
- The unset command removes the provided configuration options as requested.
- 
-	 $ snap unset snap-name name address
- 
- All configuration changes are persisted at once, and only after the
- snap's configuration hook returns successfully.
- 
- Nested values may be removed via a dotted path:
- 
-	 $ snap unset user.name
- `)
+The unset command removes the provided configuration options as requested.
+
+	$ snap unset snap-name name address
+
+All configuration changes are persisted at once, and only after the
+snap's configuration hook returns successfully.
+
+Nested values may be removed via a dotted path:
+
+	$ snap unset user.name
+`)
 
 type cmdUnset struct {
 	waitMixin

--- a/cmd/snap/cmd_unset.go
+++ b/cmd/snap/cmd_unset.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
+)
+
+var shortUnsetHelp = i18n.G("Remove configuration options")
+var longUnsetHelp = i18n.G(`
+ The unset command removes the provided configuration options as requested.
+ 
+	 $ snap unset snap-name name address
+ 
+ All configuration changes are persisted at once, and only after the
+ snap's configuration hook returns successfully.
+ 
+ Nested values may be removed via a dotted path:
+ 
+	 $ snap unset user.name
+ `)
+
+type cmdUnset struct {
+	waitMixin
+	Positional struct {
+		Snap     installedSnapName
+		ConfKeys []string `required:"1"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+func init() {
+	addCommand("unset", shortUnsetHelp, longUnsetHelp, func() flags.Commander { return &cmdUnset{} }, waitDescs, []argDesc{
+		{
+			name: "<snap>",
+			// TRANSLATORS: This should not start with a lowercase letter.
+			desc: i18n.G("The snap to configure (e.g. hello-world)"),
+		}, {
+			// TRANSLATORS: This needs to begin with < and end with >
+			name: i18n.G("<conf key>"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			desc: i18n.G("Configuration key to unset"),
+		},
+	})
+}
+
+func (x *cmdUnset) Execute(args []string) error {
+	patchValues := make(map[string]interface{})
+	for _, confKey := range x.Positional.ConfKeys {
+		patchValues[confKey] = nil
+	}
+
+	snapName := string(x.Positional.Snap)
+	id, err := x.client.SetConf(snapName, patchValues)
+	if err != nil {
+		return err
+	}
+
+	if _, err := x.wait(id); err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cmd/snap/cmd_unset_test.go
+++ b/cmd/snap/cmd_unset_test.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"gopkg.in/check.v1"
+
+	snapunset "github.com/snapcore/snapd/cmd/snap"
+)
+
+func (s *SnapSuite) TestInvalidUnsetParameters(c *check.C) {
+	invalidParameters := []string{"unset"}
+	_, err := snapunset.Parser(snapunset.Client()).ParseArgs(invalidParameters)
+	c.Check(err, check.ErrorMatches, "the required arguments `<snap>` and `<conf key> \\(at least 1 argument\\)` were not provided")
+
+	invalidParameters = []string{"unset", "snap-name"}
+	_, err = snapunset.Parser(snapunset.Client()).ParseArgs(invalidParameters)
+	c.Check(err, check.ErrorMatches, "the required argument `<conf key> \\(at least 1 argument\\)` was not provided")
+}
+
+func (s *SnapSuite) TestSnapUnset(c *check.C) {
+	s.mockSetConfigServer(c, nil)
+
+	_, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "snapname", "key"})
+	c.Assert(err, check.IsNil)
+}

--- a/cmd/snap/cmd_unset_test.go
+++ b/cmd/snap/cmd_unset_test.go
@@ -25,19 +25,23 @@ import (
 	snapunset "github.com/snapcore/snapd/cmd/snap"
 )
 
-func (s *SnapSuite) TestInvalidUnsetParameters(c *check.C) {
+func (s *snapSetSuite) TestInvalidUnsetParameters(c *check.C) {
 	invalidParameters := []string{"unset"}
 	_, err := snapunset.Parser(snapunset.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, "the required arguments `<snap>` and `<conf key> \\(at least 1 argument\\)` were not provided")
+	c.Check(s.setConfApiCalls, check.Equals, 0)
 
 	invalidParameters = []string{"unset", "snap-name"}
 	_, err = snapunset.Parser(snapunset.Client()).ParseArgs(invalidParameters)
 	c.Check(err, check.ErrorMatches, "the required argument `<conf key> \\(at least 1 argument\\)` was not provided")
+	c.Check(s.setConfApiCalls, check.Equals, 0)
 }
 
-func (s *SnapSuite) TestSnapUnset(c *check.C) {
+func (s *snapSetSuite) TestSnapUnset(c *check.C) {
+	// expected value is "nil" as the key is unset
 	s.mockSetConfigServer(c, nil)
 
 	_, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "snapname", "key"})
 	c.Assert(err, check.IsNil)
+	c.Check(s.setConfApiCalls, check.Equals, 1)
 }

--- a/tests/main/snap-unset/task.yaml
+++ b/tests/main/snap-unset/task.yaml
@@ -1,0 +1,29 @@
+summary: Check that `snap unset` works and removes config options.
+
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    echo "Build basic test snap"
+    install_local basic-hooks
+
+execute: |
+    echo "Setting up initial configuration"
+    snap set basic-hooks foo=abc bar=def baz=1234
+    # sanity check
+    snap get basic-hooks foo bar baz
+
+    echo "Unsetting unknown option currently doesn't give an error"
+    snap unset basic-hooks unknown.option
+
+    echo "Unsetting foo option"
+    snap unset basic-hooks foo
+    snap get basic-hooks foo 2>&1 | MATCH 'snap "basic-hooks" has no "foo" configuration option'
+
+    # sanity check, two options still available
+    snap get basic-hooks bar baz
+
+    echo "Unsetting multiple options"
+    snap unset basic-hooks bar baz
+    snap get basic-hooks bar 2>&1 | MATCH 'snap "basic-hooks" has no "bar" configuration option'
+    snap get basic-hooks baz 2>&1 | MATCH 'snap "basic-hooks" has no "baz" configuration option'


### PR DESCRIPTION
Add `snap unset` command to complement `snap set` and `snap get`. This is a followup to #7096  and #7098.
