### PR TITLE
recovery: rename temporary mountpoints to london names

### DIFF
--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -50,7 +50,7 @@ func Recover(version string) error {
 	// reset env variables if we come from a recover reboot
 	if GetKernelParameter("snap_mode") == "recover_reboot" {
 
-		mntSysRecover := "/mnt/sys-recover"
+		mntSysRecover := "/run/ubuntu-seed"
 		if err := mountFilesystem("ubuntu-seed", mntSysRecover); err != nil {
 			return err
 		}
@@ -74,7 +74,7 @@ func Recover(version string) error {
 		}
 	}
 
-	mntRecovery := "/mnt/recovery"
+	mntRecovery := "/run/recovery"
 
 	if err := mountFilesystem("ubuntu-data", mntRecovery); err != nil {
 		return err
@@ -104,11 +104,7 @@ func RecoverReboot(version string) error {
 	// different version, we need to reboot
 	logger.Noticef("Recover: must reboot to use %s", version)
 
-	mntSysRecover := "/mnt/sys-recover"
-	// -- already mounted
-	//if err := mountFilesystem("sys-recover", mntSysRecover); err != nil {
-	//	return err
-	//}
+	mntSysRecover := "/run/ubuntu-seed"
 
 	// update recovery mode
 	logger.Noticef("update bootloader env")
@@ -142,9 +138,9 @@ func RecoverReboot(version string) error {
 
 func Install(version string) error {
 
-	mntWritable := "/mnt/new-writable"
-	mntSysRecover := "/mnt/sys-recover"
-	mntSystemBoot := "/mnt/system-boot"
+	mntWritable := "/run/ubuntu-data"
+	mntSysRecover := "/run/ubuntu-seed"
+	mntSystemBoot := "/run/ubuntu-boot"
 
 	if err := mountFilesystem("ubuntu-boot", mntSystemBoot); err != nil {
 		return err
@@ -359,7 +355,7 @@ func updateRecovery(mntWritable, mntSysRecover, mntSystemBoot, version string) (
 }
 
 func extractKernel(kernelPath, mntSystemBoot string) error {
-	mntKernelSnap := "/mnt/kernel-snap"
+	mntKernelSnap := "/run/kernel-snap"
 	if err := os.MkdirAll(mntKernelSnap, 0755); err != nil {
 		return fmt.Errorf("cannot create kernel mountpoint: %s", err)
 	}

--- a/recovery/util.go
+++ b/recovery/util.go
@@ -33,13 +33,14 @@ func GetKernelParameter(name string) string {
 
 func globFile(dir, pattern string) string {
 	files, err := filepath.Glob(path.Join(dir, pattern))
-	fmt.Printf("glob %s %s found: %s (err %s)\n", dir, pattern, files, err)
 	if err != nil {
+		fmt.Printf("glob error: %s", err)
 		return ""
 	}
 	if len(files) == 0 {
 		return ""
 	}
+	fmt.Printf("glob %s %s found: %v\n", dir, pattern, files)
 	return files[0]
 }
 


### PR DESCRIPTION
It was decided in London to adopt new names for the boot, recovery
and writable partitions, so update the code to mount the filesystems
created on those devices to match the new names and avoid confusion.
Also create temporary mountpoints on /run and keep /mnt clear for
local usage.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>