### PR TITLE
cmd/snap-confine: bring /lib/firmware from the host

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -585,6 +585,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/var/tmp"},	// to get access to the other temporary directory
 			{"/run"},	// to get /run with sockets and what not
 			{"/lib/modules",.is_optional = true},	// access to the modules of the running kernel
+			{"/lib/firmware",.is_optional = true},	// access to the firmware of the running kernel
 			{"/usr/src"},	// FIXME: move to SecurityMounts in system-trace interface
 			{"/var/log"},	// FIXME: move to SecurityMounts in log-observe interface
 #ifdef MERGED_USR

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -193,6 +193,9 @@
     mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/modules/ -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
 
+    mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/firmware/ -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/log/,
 

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -458,6 +458,7 @@ gen_require(`
   type modules_object_t;
   type ifconfig_var_run_t;
   type var_log_t;
+  type lib_t;
 ')
 allow snappy_confine_t admin_home_t:dir mounton;
 allow snappy_confine_t bin_t:dir mounton;
@@ -468,6 +469,7 @@ allow snappy_confine_t etc_t:file mounton;
 allow snappy_confine_t home_root_t:dir mounton;
 allow snappy_confine_t ifconfig_var_run_t:dir mounton;
 allow snappy_confine_t modules_object_t:dir mounton;
+allow snappy_confine_t lib_t:dir mounton;
 allow snappy_confine_t ptmx_t:chr_file { getattr mounton };
 allow snappy_confine_t snappy_snap_t:dir { mounton read };
 allow snappy_confine_t snappy_snap_t:file mounton;


### PR DESCRIPTION
The kernel will use the mount namespace of the invoking process to
auto-load firmware on demand. On core18 systems or on systems using core
and core18 base snap apps the /lib/firmware directory is empty present,
causing issues with CUDA and some wifi stacks. This patch fixes this

Fixes: https://bugs.launchpad.net/snapd/+bug/1821023
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
