### PR TITLE
interfaces/builtin: add exec "/bin/runc" to docker-support

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -157,6 +157,7 @@ ptrace (read, trace) peer=docker-default,
 # needed by runc for mitigation of CVE-2019-5736
 # For details see https://bugs.launchpad.net/apparmor/+bug/1820344
 / ix,
+/bin/runc rix,
 `
 
 const dockerSupportConnectedPlugSecComp = `


### PR DESCRIPTION
Newer runC applied further improvements to their CVE-2019-5736 mitigation in opencontainers/runc#1984 which change the nature of our apparmor denial from `/` to `/bin/runc` (which I have also commented on https://bugs.launchpad.net/apparmor/+bug/1820344 about).

See also #6610.

(originally from Tianon Gravi, but re-committed due to CLA issues with the PR checks)

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>

Re-opening of #7090 because of CLA issues with that PR