### PR TITLE
vendor: update chrisccoulson/ubuntu-core-fde-utils to really fix build on arm64

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,10 +7,10 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "X9uJjtPte7hdg0/LSEtnDD4v6Iw=",
+			"checksumSHA1": "R0xAbpPqRl81oYf3mZvMDO/a5VE=",
 			"path": "github.com/chrisccoulson/ubuntu-core-fde-utils",
-			"revision": "49b2130cfa1a95f940eaf348b3a71b3f7af344ba",
-			"revisionTime": "2019-07-11T08:52:23Z"
+			"revision": "7022bfc2b686ae1379ddd3e06a6823551fea85a9",
+			"revisionTime": "2019-07-12T09:43:21Z"
 		},
 		{
 			"checksumSHA1": "zg16zjZTQ9R89+UOLmEZxHgxDtM=",


### PR DESCRIPTION
The repo from fix is now updated to provide stubs on arm64 for the fde utils.