### PR TITLE
tests: new test to check the output after refreshing/reverting core

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -438,7 +438,7 @@ EOF
                            "$EXTRA_FUNDAMENTAL" \
                            --extra-snaps "${extra_snap[0]}" \
                            --output "$IMAGE_HOME/$IMAGE"
-    rm -f ./pc-kernel_*.{snap,assert} ./pc_*.{snap,assert}
+    rm -f ./pc-kernel_*.{snap,assert} ./pc_*.{snap,assert} ./snapd_*.{snap,assert}
 
     # mount fresh image and add all our SPREAD_PROJECT data
     kpartx -avs "$IMAGE_HOME/$IMAGE"

--- a/tests/main/ubuntu-core-refresh/task.yaml
+++ b/tests/main/ubuntu-core-refresh/task.yaml
@@ -1,0 +1,61 @@
+summary: check that the ubuntu-core system is rebooted after the core snap is refreshed
+
+details: |
+    This test checks that when invoking a manual refresh/revert for core or core18 snaps,
+    it is triggered a reboot and the command would exit after the first phase of the installation
+    reporting "snapd is about to reboot the system"
+
+systems: [ubuntu-core-1*]
+
+execute: |
+    #shellcheck source=tests/lib/journalctl.sh
+    . "$TESTSLIB"/journalctl.sh
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+
+    TARGET_SNAP_NAME=core
+    if is_core18_system; then
+        TARGET_SNAP_NAME=core18
+    fi    
+
+    # After installing a new version of the core/core18 snap the system is rebooted
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        snap list | awk "/^${TARGET_SNAP_NAME} / {print(\$3)}" > initialRev    
+
+        # use journalctl wrapper to grep only the logs collected while the test is running
+        if get_journalctl_log | MATCH "Waiting for system reboot"; then
+            echo "Already waiting for system reboot, exiting..."
+            exit 1
+        fi
+
+        # install new target snap
+        snap download "$TARGET_SNAP_NAME"
+        snap install --dangerous "${TARGET_SNAP_NAME}"_*.snap &> refresh.log
+        MATCH "snapd is about to reboot the system" < refresh.log
+
+        # use journalctl wrapper to grep only the logs collected while the test is running
+        while ! check_journalctl_log "Waiting for system reboot"; do
+            sleep 1
+        done
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        # Check the current revision has changed
+        currRev=$(snap list | awk "/^${TARGET_SNAP_NAME} / {print(\$3)}") 
+        [ "$(cat initialRev)" !=  "$currRev" ]
+
+        # revert the target snap
+        snap revert "$TARGET_SNAP_NAME" &> revert.log
+        MATCH "snapd is about to reboot the system" < revert.log
+
+        # use journalctl wrapper to grep only the logs collected while the test is running
+        while ! check_journalctl_log "Waiting for system reboot" -b; do
+            sleep 1
+        done
+
+        REBOOT
+    elif [  "$SPREAD_REBOOT" = 2 ]; then
+        # Check the current revision is the same than the original
+        currRev=$(snap list | awk "/^${TARGET_SNAP_NAME} / {print(\$3)}") 
+        [ "$(cat initialRev)" ==  "$currRev" ]
+    fi


### PR DESCRIPTION
Ths change includes:
. New test to validate that after installing core or core18 snaps,
  it is triggered a reboot and the command would exit after the
  first phase of the installation reporting "snapd is about to
  reboot the system"
. snapd snap was remaining as part of the test after the prepare
  phase
