### PR TITLE
recovery: remove recover_reboot mode

### DIFF
--- a/cmd/snap/cmd_recover.go
+++ b/cmd/snap/cmd_recover.go
@@ -38,14 +38,12 @@ type cmdRecover struct {
 	} `positional-args:"yes"`
 
 	Install bool `long:"install"`
-	Reboot  bool `long:"reboot"`
 }
 
 func init() {
 	cmd := addCommand("recover", shortRecoverHelp, longRecoverHelp, func() flags.Commander { return &cmdRecover{} },
 		map[string]string{
 			"install": "Run recover in install mode",
-			"reboot":  "Reboot to recover with new recovery version",
 		}, []argDesc{{
 			name: i18n.G("<version>"),
 			desc: i18n.G("The recovery version to use"),
@@ -61,7 +59,6 @@ func (x *cmdRecover) Execute(args []string) error {
 	options := client.RecoverOptions{
 		Version: x.Positional.Version,
 		Install: x.Install,
-		Reboot:  x.Reboot,
 	}
 
 	return x.client.Recover(&options)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2434,7 +2434,6 @@ func getWarnings(c *Command, r *http.Request, _ *auth.UserState) Response {
 type postRecoverData struct {
 	Version string `json:"version"`
 	Install bool   `json:"install"`
-	Reboot  bool   `json:"reboot"`
 }
 
 func postRecover(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -2453,10 +2452,6 @@ func postRecover(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	if recoverData.Install {
 		modeTask := st.NewTask("snap-mode-install", "Run system in install mode")
-		modeTask.Set("recovery-version", recoverData.Version)
-		tasks = append(tasks, modeTask)
-	} else if recoverData.Reboot {
-		modeTask := st.NewTask("snap-mode-recover-reboot", "Run system in recover_reboot mode")
 		modeTask.Set("recovery-version", recoverData.Version)
 		tasks = append(tasks, modeTask)
 	} else {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -94,7 +94,6 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	runner.AddHandler("mark-seeded", m.doMarkSeeded, nil)
 	runner.AddHandler("snap-mode-install", m.doInstallMode, nil)
 	runner.AddHandler("snap-mode-recover", m.doRecoverMode, nil)
-	runner.AddHandler("snap-mode-recover-reboot", m.doRecoverRebootMode, nil)
 	// this *must* always run last and finalizes a remodel
 	runner.AddHandler("set-model", m.doSetModel, nil)
 	// There is no undo for successful gadget updates. The system is

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -833,24 +833,6 @@ func (m *DeviceManager) doRecoverMode(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func (m *DeviceManager) doRecoverRebootMode(t *state.Task, tomb *tomb.Tomb) error {
-	st := t.State()
-	st.Lock()
-	defer st.Unlock()
-
-	var version string
-	if err := t.Get("recovery-version", &version); err != nil {
-		return err
-	}
-
-	logger.Noticef("Running in recover + reboot mode")
-	if err := recovery.RecoverReboot(version); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func snapState(st *state.State, name string) (*snapstate.SnapState, error) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, name, &snapst)


### PR DESCRIPTION
The recover_reboot mode is no longer necessary, rebooting to a different
recovery version is handled inside the initramfs.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>