### PR TITLE
many: mostly stop needing Kernel/CoreInfo, make GadgetInfo consider a DeviceContext

### DIFF
--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -26,11 +26,14 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -108,6 +111,21 @@ func (s *configureHandlerSuite) TestBeforeInitializesTransaction(c *C) {
 	c.Check(value, Equals, "bar")
 }
 
+func makeModel(override map[string]interface{}) *asserts.Model {
+	model := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "brand",
+		"series":       "16",
+		"brand-id":     "brand",
+		"model":        "baz-3000",
+		"architecture": "armhf",
+		"gadget":       "brand-gadget",
+		"kernel":       "kernel",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(model, override).(*asserts.Model)
+}
+
 func (s *configureHandlerSuite) TestBeforeInitializesTransactionUseDefaults(c *C) {
 	r := release.MockOnClassic(false)
 	defer r()
@@ -140,6 +158,11 @@ volumes:
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
+
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+		"gadget": "canonical-pc",
+	}))
+	defer r()
 
 	const mockTestSnapYaml = `
 name: test-snap
@@ -209,6 +232,11 @@ volumes:
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
+
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+		"gadget": "canonical-pc",
+	}))
+	defer r()
 
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -86,8 +86,13 @@ func (h *configureHandler) Before() error {
 	instanceName := h.context.InstanceName()
 	st := h.context.State()
 	if useDefaults {
-		var err error
-		patch, err = snapstate.ConfigDefaults(st, instanceName)
+		task, _ := h.context.Task()
+		deviceCtx, err := snapstate.DeviceCtx(st, task, nil)
+		if err != nil {
+			return err
+		}
+
+		patch, err = snapstate.ConfigDefaults(st, deviceCtx, instanceName)
 		if err != nil && err != state.ErrNoState {
 			return err
 		}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1226,12 +1226,17 @@ func (m *InterfaceManager) doGadgetConnect(task *state.Task, _ *tomb.Tomb) error
 	st.Lock()
 	defer st.Unlock()
 
+	deviceCtx, err := snapstate.DeviceCtx(st, task, nil)
+	if err != nil {
+		return err
+	}
+
 	conns, err := getConns(st)
 	if err != nil {
 		return err
 	}
 
-	gconns, err := snapstate.GadgetConnections(st)
+	gconns, err := snapstate.GadgetConnections(st, deviceCtx)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/hotplug.go
+++ b/overlord/ifacestate/hotplug.go
@@ -126,7 +126,13 @@ func (m *InterfaceManager) hotplugDeviceAdded(devinfo *hotplug.HotplugDeviceInfo
 		return
 	}
 
-	gadget, err := snapstate.GadgetInfo(st)
+	deviceCtx, err := snapstate.DeviceCtxFromState(st, nil)
+	if err != nil {
+		logger.Noticef("internal error: cannot get global device context: %v", err)
+		return
+	}
+
+	gadget, err := snapstate.GadgetInfo(st, deviceCtx)
 	if err != nil && err != state.ErrNoState {
 		logger.Noticef("internal error: cannot get gadget information: %v", err)
 	}

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -334,7 +334,9 @@ func (s *hotplugSuite) TestHotplugAddBasic(c *C) {
 }
 
 func (s *hotplugSuite) TestHotplugConnectWithGadgetSlot(c *C) {
-	s.MockModel(c, nil)
+	s.MockModel(c, map[string]interface{}{
+		"gadget": "the-gadget",
+	})
 
 	st := s.state
 	st.Lock()

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -522,7 +522,7 @@ func (s *hotplugSuite) TestHotplugRemove(c *C) {
 		SnapType: "app",
 	})
 
-	core, err := snapstate.CoreInfo(s.state)
+	core, err := snapstate.CurrentInfo(s.state, "core")
 	c.Assert(err, IsNil)
 	c.Assert(repo.AddSlot(&snap.SlotInfo{
 		Interface:  "test-a",
@@ -606,7 +606,7 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 		Current:  snap.R(1),
 		SnapType: "app"})
 
-	core, err := snapstate.CoreInfo(s.state)
+	core, err := snapstate.CurrentInfo(s.state, "core")
 	c.Assert(err, IsNil)
 	c.Assert(repo.AddSlot(&snap.SlotInfo{
 		Interface:  "test-a",
@@ -708,7 +708,7 @@ func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
 		Current:  snap.R(1),
 		SnapType: "app"})
 
-	core, err := snapstate.CoreInfo(s.state)
+	core, err := snapstate.CurrentInfo(s.state, "core")
 	c.Assert(err, IsNil)
 	c.Assert(repo.AddSlot(&snap.SlotInfo{
 		Interface:  "test-a",

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -5003,6 +5003,7 @@ volumes:
 	err := ioutil.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
+	s.MockModel(c, nil)
 }
 
 func (s *interfaceManagerSuite) TestGadgetConnect(c *C) {
@@ -5137,6 +5138,8 @@ func (s *interfaceManagerSuite) TestGadgetConnectSkipUnknown(c *C) {
 	s.mockSnap(c, consumerYaml)
 	s.MockSnapDecl(c, "producer", "publisher2", nil)
 	s.mockSnap(c, producerYaml)
+
+	s.MockModel(c, nil)
 
 	s.manager(c)
 

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -61,12 +61,12 @@ func UpdateBootRevisions(st *state.State) error {
 	}
 
 	// nothing to check if there's no kernel
-	_, err := KernelInfo(st)
-	if err == state.ErrNoState {
-		return nil
-	}
+	ok, err := HasSnapOfType(st, snap.TypeKernel)
 	if err != nil {
 		return fmt.Errorf(errorPrefix+"%s", err)
+	}
+	if !ok {
+		return nil
 	}
 
 	loader, err := bootloader.Find()

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -300,25 +301,35 @@ func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, d
 }
 
 func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
+	typ := snapInfo.GetType()
 	kind := ""
-	var currentInfo func(*state.State) (*snap.Info, error)
-	switch snapInfo.GetType() {
+	var whichName func(*asserts.Model) string
+	switch typ {
 	case snap.TypeGadget:
 		kind = "gadget"
-		currentInfo = GadgetInfo
+		whichName = (*asserts.Model).Gadget
 	case snap.TypeKernel:
 		kind = "kernel"
-		currentInfo = KernelInfo
+		whichName = (*asserts.Model).Kernel
 	default:
 		// not a relevant check
 		return nil
 	}
 
-	currentSnap, err := currentInfo(st)
+	ok, err := HasSnapOfType(st, typ)
+	if err != nil {
+		return fmt.Errorf("cannot detect original %s snap: %v", kind, err)
+	}
 	// in firstboot we have no gadget/kernel yet - that is ok
 	// first install rules are in devicestate!
-	if err == state.ErrNoState {
+	if !ok {
 		return nil
+	}
+
+	currentSnap, err := infoForDeviceSnap(st, deviceCtx, kind, whichName)
+	if err == state.ErrNoState {
+		// TODO: remodeling logic
+		return fmt.Errorf("internal error: cannot remodel kernel/gadget yet")
 	}
 	if err != nil {
 		return fmt.Errorf("cannot find original %s snap: %v", kind, err)

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -272,7 +272,7 @@ func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, flags Flags, d
 		// already one of these installed
 		return nil
 	}
-	core, err := CoreInfo(st)
+	core, err := coreInfo(st)
 	if err == state.ErrNoState {
 		return nil
 	}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -39,11 +39,13 @@ import (
 	"github.com/snapcore/snapd/testutil"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 )
 
 type checkSnapSuite struct {
 	testutil.BaseTest
-	st *state.State
+	st        *state.State
+	deviceCtx snapstate.DeviceContext
 }
 
 var _ = Suite(&checkSnapSuite{})
@@ -53,6 +55,10 @@ func (s *checkSnapSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.st = state.New(nil)
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: MakeModel(map[string]interface{}{
+		"kernel": "kernel",
+		"gadget": "gadget",
+	})}
 }
 
 func (s *checkSnapSuite) TearDownTest(c *C) {
@@ -272,7 +278,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, IsNil)
 }
@@ -314,7 +320,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, IsNil)
 }
@@ -355,7 +361,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, ErrorMatches, `cannot replace signed gadget snap with an unasserted one`)
 }
@@ -396,7 +402,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, ErrorMatches, "cannot replace gadget snap with a different one")
 }
@@ -438,7 +444,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "gadget", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, ErrorMatches, "cannot replace gadget snap with a different one")
 }
@@ -598,7 +604,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "kernel", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "kernel", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, IsNil)
 }
@@ -640,7 +646,7 @@ version: 2
 	defer restore()
 
 	st.Unlock()
-	err = snapstate.CheckSnap(st, "snap-path", "kernel", nil, nil, snapstate.Flags{}, nil)
+	err = snapstate.CheckSnap(st, "snap-path", "kernel", nil, nil, snapstate.Flags{}, s.deviceCtx)
 	st.Lock()
 	c.Check(err, ErrorMatches, "cannot replace kernel snap with a different one")
 }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -73,6 +73,7 @@ func MockPrerequisitesRetryTimeout(d time.Duration) (restore func()) {
 }
 
 var (
+	CoreInfoInternal       = coreInfo
 	CheckSnap              = checkSnap
 	CanRemove              = canRemove
 	CanDisable             = canDisable

--- a/overlord/snapstate/models_test.go
+++ b/overlord/snapstate/models_test.go
@@ -54,3 +54,16 @@ func MakeModel(override map[string]interface{}) *asserts.Model {
 	}
 	return assertstest.FakeAssertion(model, override).(*asserts.Model)
 }
+
+func ClassicModel() *asserts.Model {
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "brand",
+		"series":       "16",
+		"brand-id":     "brand",
+		"model":        "classicbaz-3000",
+		"classic":      "true",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(headers).(*asserts.Model)
+}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2333,14 +2333,6 @@ func infosForType(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 	return res, nil
 }
 
-func infoForType(st *state.State, snapType snap.Type) (*snap.Info, error) {
-	res, err := infosForType(st, snapType)
-	if err != nil {
-		return nil, err
-	}
-	return res[0], nil
-}
-
 func infoForDeviceSnap(st *state.State, deviceCtx DeviceContext, which string, whichName func(*asserts.Model) string) (*snap.Info, error) {
 	if deviceCtx == nil {
 		return nil, fmt.Errorf("internal error: unset deviceCtx")
@@ -2348,7 +2340,7 @@ func infoForDeviceSnap(st *state.State, deviceCtx DeviceContext, which string, w
 	model := deviceCtx.Model()
 	snapName := whichName(model)
 	if snapName == "" {
-		return nil, fmt.Errorf("internal error: cannot get %s snap that is unspecified in the model", which)
+		return nil, state.ErrNoState
 	}
 	var snapst SnapState
 	err := Get(st, snapName, &snapst)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2300,7 +2300,7 @@ func HasSnapOfType(st *state.State, snapType snap.Type) (bool, error) {
 	return false, nil
 }
 
-func infosForTypes(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
+func infosForType(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 	var stateMap map[string]*SnapState
 	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
 		return nil, err
@@ -2333,7 +2333,7 @@ func infosForTypes(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 }
 
 func infoForType(st *state.State, snapType snap.Type) (*snap.Info, error) {
-	res, err := infosForTypes(st, snapType)
+	res, err := infosForType(st, snapType)
 	if err != nil {
 		return nil, err
 	}
@@ -2352,16 +2352,12 @@ func KernelInfo(st *state.State) (*snap.Info, error) {
 	return infoForType(st, snap.TypeKernel)
 }
 
-// CoreInfo finds the current OS snap's info. If both
+// coreInfo finds the current OS snap's info. If both
 // "core" and "ubuntu-core" is installed then "core"
 // is preferred. Different core names are not supported
 // currently and will result in an error.
-//
-// Once enough time has passed and everyone transitioned
-// from ubuntu-core to core we can simplify this again
-// and make it the same as the above "KernelInfo".
-func CoreInfo(st *state.State) (*snap.Info, error) {
-	res, err := infosForTypes(st, snap.TypeOS)
+func coreInfo(st *state.State) (*snap.Info, error) {
+	res, err := infosForType(st, snap.TypeOS)
 	if err != nil {
 		return nil, err
 	}
@@ -2400,11 +2396,7 @@ func ConfigDefaults(st *state.State, snapName string) (map[string]interface{}, e
 		return nil, err
 	}
 
-	core, err := CoreInfo(st)
-	if err != nil {
-		return nil, err
-	}
-	isCoreDefaults := core.InstanceName() == snapName
+	isCoreDefaults := snapName == defaultCoreSnapName
 
 	si := snapst.CurrentSideInfo()
 	// core snaps can be addressed even without a snap-id via the special

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2358,11 +2358,9 @@ func infoForDeviceSnap(st *state.State, deviceCtx DeviceContext, which string, w
 	return snapst.CurrentInfo()
 }
 
-// XXX: remodeling: decide what to do with Gadget/KernelInfo and their derived functions
-
-// GadgetInfo finds the current gadget snap's info.
-func GadgetInfo(st *state.State) (*snap.Info, error) {
-	return infoForType(st, snap.TypeGadget)
+// GadgetInfo finds the gadget snap's info for the given device context.
+func GadgetInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) {
+	return infoForDeviceSnap(st, deviceCtx, "gadget", (*asserts.Model).Gadget)
 }
 
 // TODO: reintroduce a KernelInfo(state.State, DeviceContext) if needed
@@ -2398,11 +2396,12 @@ func coreInfo(st *state.State) (*snap.Info, error) {
 	return nil, fmt.Errorf("unexpected number of cores, got %d", len(res))
 }
 
-// ConfigDefaults returns the configuration defaults for the snap specified in
-// the gadget. If gadget is absent or the snap has no snap-id it returns
+// ConfigDefaults returns the configuration defaults for the snap as
+// specified in the gadget for the given device context.
+// If gadget is absent or the snap has no snap-id it returns
 // ErrNoState.
-func ConfigDefaults(st *state.State, snapName string) (map[string]interface{}, error) {
-	gadget, err := GadgetInfo(st)
+func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (map[string]interface{}, error) {
+	gadget, err := GadgetInfo(st, deviceCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -2447,9 +2446,10 @@ func ConfigDefaults(st *state.State, snapName string) (map[string]interface{}, e
 }
 
 // GadgetConnections returns the interface connection instructions
-// specified in the gadget. If gadget is absent it returns ErrNoState.
-func GadgetConnections(st *state.State) ([]gadget.Connection, error) {
-	gadget, err := GadgetInfo(st)
+// specified in the gadget for the given device context.
+// If gadget is absent it returns ErrNoState.
+func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Connection, error) {
+	gadget, err := GadgetInfo(st, deviceCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10430,11 +10430,6 @@ func (s *snapmgrQuerySuite) TestTypeInfo(c *C) {
 			getInfo:  snapstate.GadgetInfo,
 		},
 		{
-			snapName: "core",
-			snapType: snap.TypeOS,
-			getInfo:  snapstate.CoreInfo,
-		},
-		{
 			snapName: "kernel",
 			snapType: snap.TypeKernel,
 			getInfo:  snapstate.KernelInfo,
@@ -10513,7 +10508,7 @@ func (s *snapmgrQuerySuite) TestTypeInfoCore(c *C) {
 			})
 		}
 
-		info, err := snapstate.CoreInfo(st)
+		info, err := snapstate.CoreInfoInternal(st)
 		if t.errMatcher != "" {
 			c.Assert(err, ErrorMatches, t.errMatcher)
 		} else {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10429,11 +10429,6 @@ func (s *snapmgrQuerySuite) TestTypeInfo(c *C) {
 			snapType: snap.TypeGadget,
 			getInfo:  snapstate.GadgetInfo,
 		},
-		{
-			snapName: "kernel",
-			snapType: snap.TypeKernel,
-			getInfo:  snapstate.KernelInfo,
-		},
 	} {
 		_, err := x.getInfo(st)
 		c.Assert(err, Equals, state.ErrNoState)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10414,48 +10414,42 @@ func (s *snapmgrQuerySuite) TestActiveInfos(c *C) {
 	c.Check(infos[1].Description(), Equals, "Lots of text")
 }
 
-func (s *snapmgrQuerySuite) TestTypeInfo(c *C) {
+func (s *snapmgrQuerySuite) TestGadgetInfo(c *C) {
 	st := s.st
 	st.Lock()
 	defer st.Unlock()
 
-	for _, x := range []struct {
-		snapName string
-		snapType snap.Type
-		getInfo  func(*state.State) (*snap.Info, error)
-	}{
-		{
-			snapName: "gadget",
-			snapType: snap.TypeGadget,
-			getInfo:  snapstate.GadgetInfo,
-		},
-	} {
-		_, err := x.getInfo(st)
-		c.Assert(err, Equals, state.ErrNoState)
+	deviceCtx := deviceWithGadgetContext("gadget")
 
-		sideInfo := &snap.SideInfo{
-			RealName: x.snapName,
-			Revision: snap.R(2),
-		}
-		snaptest.MockSnap(c, fmt.Sprintf("name: %q\ntype: %q\nversion: %q\n", x.snapName, x.snapType, x.snapName), sideInfo)
-		snapstate.Set(st, x.snapName, &snapstate.SnapState{
-			SnapType: string(x.snapType),
-			Active:   true,
-			Sequence: []*snap.SideInfo{sideInfo},
-			Current:  sideInfo.Revision,
-		})
+	_, err := snapstate.GadgetInfo(st, deviceCtx)
+	c.Assert(err, Equals, state.ErrNoState)
 
-		info, err := x.getInfo(st)
-		c.Assert(err, IsNil)
-
-		c.Check(info.InstanceName(), Equals, x.snapName)
-		c.Check(info.Revision, Equals, snap.R(2))
-		c.Check(info.Version, Equals, x.snapName)
-		c.Check(info.GetType(), Equals, x.snapType)
+	sideInfo := &snap.SideInfo{
+		RealName: "gadget",
+		Revision: snap.R(2),
 	}
+	snaptest.MockSnap(c, `
+name: gadget
+type: gadget
+version: v1
+`, sideInfo)
+	snapstate.Set(st, "gadget", &snapstate.SnapState{
+		SnapType: "gadget",
+		Active:   true,
+		Sequence: []*snap.SideInfo{sideInfo},
+		Current:  sideInfo.Revision,
+	})
+
+	info, err := snapstate.GadgetInfo(st, deviceCtx)
+	c.Assert(err, IsNil)
+
+	c.Check(info.InstanceName(), Equals, "gadget")
+	c.Check(info.Revision, Equals, snap.R(2))
+	c.Check(info.Version, Equals, "v1")
+	c.Check(info.GetType(), Equals, snap.TypeGadget)
 }
 
-func (s *snapmgrQuerySuite) TestTypeInfoCore(c *C) {
+func (s *snapmgrQuerySuite) TestCoreInfoInternal(c *C) {
 	st := s.st
 	st.Lock()
 	defer st.Unlock()
@@ -11791,6 +11785,14 @@ version: 1.0
 	})
 }
 
+func deviceWithGadgetContext(gadgetName string) snapstate.DeviceContext {
+	return &snapstatetest.TrivialDeviceContext{
+		DeviceModel: MakeModel(map[string]interface{}{
+			"gadget": gadgetName,
+		}),
+	}
+}
+
 func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	r := release.MockOnClassic(false)
 	defer r()
@@ -11803,6 +11805,8 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 
 	s.prepareGadget(c)
 
+	deviceCtx := deviceWithGadgetContext("the-gadget")
+
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
@@ -11813,7 +11817,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	})
 	makeInstalledMockCoreSnap(c)
 
-	defls, err := snapstate.ConfigDefaults(s.state, "some-snap")
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "some-snap")
 	c.Assert(err, IsNil)
 	c.Assert(defls, DeepEquals, map[string]interface{}{"key": "value"})
 
@@ -11825,7 +11829,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 		Current:  snap.R(5),
 		SnapType: "app",
 	})
-	_, err = snapstate.ConfigDefaults(s.state, "local-snap")
+	_, err = snapstate.ConfigDefaults(s.state, deviceCtx, "local-snap")
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
@@ -11845,9 +11849,11 @@ defaults:
         foo: bar
 `)
 
+	deviceCtx := deviceWithGadgetContext("the-gadget")
+
 	makeInstalledMockCoreSnap(c)
 
-	defls, err := snapstate.ConfigDefaults(s.state, "core")
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
 	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
 }
@@ -11871,6 +11877,8 @@ defaults:
         other-key: other-key-default
 `)
 
+	deviceCtx := deviceWithGadgetContext("the-gadget")
+
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
@@ -11883,7 +11891,7 @@ defaults:
 	makeInstalledMockCoreSnap(c)
 
 	// 'system' key defaults take precedence over snap-id ones
-	defls, err := snapstate.ConfigDefaults(s.state, "core")
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
 	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
 }
@@ -14392,10 +14400,12 @@ func (s *snapmgrTestSuite) TestGadgetConnections(c *C) {
 	// using MockSnap, we want to read the bits on disk
 	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
+	deviceCtx := deviceWithGadgetContext("the-gadget")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_, err := snapstate.GadgetConnections(s.state)
+	_, err := snapstate.GadgetConnections(s.state, deviceCtx)
 	c.Assert(err, Equals, state.ErrNoState)
 
 	s.prepareGadget(c, `
@@ -14404,7 +14414,7 @@ connections:
     slot: snap2idididididididididididididi:slot
 `)
 
-	conns, err := snapstate.GadgetConnections(s.state)
+	conns, err := snapstate.GadgetConnections(s.state, deviceCtx)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []gadget.Connection{
 		{Plug: gadget.ConnectionPlug{SnapID: "snap1idididididididididididididi", Plug: "plug"}, Slot: gadget.ConnectionSlot{SnapID: "snap2idididididididididididididi", Slot: "slot"}}})


### PR DESCRIPTION
In a world with remodeling there might be more than one kernel, gadget etc on the device, one for the current model and one for model to-be. So the \<deviceSnap\>Info helpers are misleading.

These changes clean up things in the area, remove Kernelnfo, and make GadgetInfo and derived helpers take a DeviceContext.

In the same context these make CoreInfo internal only to snapstate. Because "core" vs "snapd" as system snap, new code shouldn't take "core" as preeminent.