### PR TITLE
tests: first part making tests run on ubuntu-core-18

### DIFF
--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -1,12 +1,5 @@
 summary: Check that auto-refresh works
 
-# FIXME: core18 right now does not have a canonical model. This means
-# that it will not get a serial. We code in devicestate.go that will only
-# try to auto-refresh after the systems has tried at least 3 times to get
-# a serial. But this means this test will timeout because the first retry
-# for the serial happens after 5min, then 10min, then 20min.
-systems: [-ubuntu-core-18-*]
-
 environment:
     SNAP_NAME/regular: test-snapd-tools
     SNAP_NAME/parallel: test-snapd-tools_instance

--- a/tests/main/classic-confinement-not-supported/task.yaml
+++ b/tests/main/classic-confinement-not-supported/task.yaml
@@ -3,7 +3,7 @@ summary: Ensure that classic confinement works
 environment:
     CLASSIC_SNAP: test-snapd-classic-confinement
 
-systems: [ubuntu-core-16-*, fedora-*]
+systems: [ubuntu-core-1*, fedora-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -3,7 +3,7 @@ summary: Ensure create-user functionality
 # FIXME: enable on ubuntu-core-18-* as well once the shadow SRU
 #        https://launchpad.net/ubuntu/+source/shadow/1:4.5-1ubuntu2
 #        is available on -updates
-systems: [ubuntu-core-16-*]
+systems: [ubuntu-core-1*]
 
 environment:
     USER_EMAIL: mvo@ubuntu.com

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -39,7 +39,6 @@ execute: |
         REV=$SIDELOAD_REV
         PUBLISHER=-
 
-    #shellcheck disable=SC2166
     elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" ]; then
         echo "With customized images the snapd snap is sideloaded"
         NAME=snapd

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -33,11 +33,13 @@ execute: |
     TRACKING=-
     NOTES=core
 
+    #shellcheck disable=SC2166
     if [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the core snap is sideloaded"
         REV=$SIDELOAD_REV
         PUBLISHER=-
 
+    #shellcheck disable=SC2166
     elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" ]; then
         echo "With customized images the snapd snap is sideloaded"
         NAME=snapd

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -11,35 +11,67 @@ prepare: |
 restore:
     snap set system experimental.parallel-instances=null
 
-# TODO: update test for core18 but its already pretty confusing as is
-systems: [-ubuntu-core-18-*]
-
-# autopkgtest run only a subset of tests that deals with the integration
-# with the distro
-backends: [-autopkgtest]
-
 execute: |
     echo "List prints core snap version"
     # most core versions should be like "16-2", so [0-9]{2}-[0-9.]+
     # but edge will have a timestamp in there, "16.2+201701010932", so add an optional \+[0-9]+ to the end
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
-    #shellcheck disable=SC2166
-    if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
+
+    # Expressions for version and revision
+    NUMERIC_VERSION="[0-9]+(\.[0-9]+)*"
+    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)?"
+    SNAPD_GIT_VERSION="+[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-z]+)?"
+    FINAL_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+[0-9]+\\.[0-9a-f]+)?"
+    SIDELOAD_REV="x[0-9]+"
+    NUMBER_REV="[0-9]+"
+
+    # Default values
+    NAME=core
+    VERSION=$CORE_GIT_VERSION
+    REV=$NUMBER_REV
+    PUBLISHER="canonical\\*"
+    TRACKING=-
+    NOTES=core
+
+    if [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core.*$'
+        REV=$SIDELOAD_REV
+        PUBLISHER=-
+
+    elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" ]; then
+        echo "With customized images the snapd snap is sideloaded"
+        NAME=snapd
+        VERSION=$SNAPD_GIT_VERSION
+        REV=$SIDELOAD_REV
+        PUBLISHER=-
+        NOTES=snapd
+
     elif [ "$SRU_VALIDATION" = "1" ] || [ -n "$PPA_VALIDATION_NAME" ]; then
         echo "When either sru or ppa validation is done the core snap is installed from the store"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical\* +core.*$'
-    elif [ "$SPREAD_BACKEND" = "external" ] || [ "$SPREAD_BACKEND" = "autopkgtest" ]; then
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical\* +core.*$'
+        VERSION=$FINAL_VERSION
+        TRACKING=stable
+
+    elif [ "$SPREAD_BACKEND" = "external" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-*" ]; then
+        echo "On the external device the core snap tested could be in any track"
+        TRACKING="(edge|beta|candidate|stable)"
+
+    elif [ "$SPREAD_BACKEND" = "external" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-*" ]; then
+        echo "On the external device the snapd snap tested could be in any track"
+        NAME=snapd
+        VERSION=$SNAPD_GIT_VERSION
+        TRACKING="(edge|beta|candidate|stable)"
+        NOTES=snapd
+
     else
-        expected="^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)? +[0-9]+ +$CORE_CHANNEL +canonical\\* +core.*$"
+        TRACKING=$CORE_CHANNEL
     fi
+
+    expected="^$NAME +$VERSION +$REV +$TRACKING +$PUBLISHER +$NOTES.*$"
     snap list --unicode=never | MATCH "$expected"
 
     echo "List prints installed snaps and versions"
-    snap list | MATCH '^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
-    snap list | MATCH '^test-snapd-tools_foo +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
+    snap list | MATCH "^test-snapd-tools +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
+    snap list | MATCH "^test-snapd-tools_foo +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
 
     echo "Install test-snapd-tools again"
     #shellcheck source=tests/lib/snaps.sh
@@ -47,7 +79,7 @@ execute: |
     install_local test-snapd-tools
 
     echo "And run snap list --all"
-    output=$(snap list --all |grep 'test-snapd-tools ')
+    output=$(snap list --all | grep 'test-snapd-tools ')
     if [ "$(grep -c test-snapd-tools <<< "$output")" != "2" ]; then
         echo "Expected two test-snapd-tools in the output, got:"
         echo "$output"

--- a/tests/main/ubuntu-core-os-release/task.yaml
+++ b/tests/main/ubuntu-core-os-release/task.yaml
@@ -1,7 +1,14 @@
 summary: check that os-release is correct
 
-systems: [ubuntu-core-16-*]
+systems: [ubuntu-core-1*]
 
 execute: |
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+
+    if is_core18_system; then
+        MATCH "DISTRIB_RELEASE=18" < /etc/lsb-release
+    else
+        MATCH "DISTRIB_RELEASE=16" < /etc/lsb-release
+    fi
     MATCH "ID=ubuntu-core" < /etc/os-release
-    MATCH "DISTRIB_RELEASE=16" < /etc/lsb-release

--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -1,10 +1,6 @@
 summary: Ensure that service and apparmor profiles work after a reboot
 
-systems:
-    - ubuntu-core-16-64
-    - ubuntu-core-16-32
-    - ubuntu-core-16-arm-64
-    - ubuntu-core-16-arm-32
+systems: [ubuntu-core-1*]
 
 # Start early as it takes a long time.
 priority: 100

--- a/tests/main/ubuntu-core-services/task.yaml
+++ b/tests/main/ubuntu-core-services/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure all services on Core are active
 
-systems: [ubuntu-core-16-*]
+systems: [ubuntu-core-1*]
 
 execute: |
     echo "Ensure one-shot services are working"


### PR DESCRIPTION
This change includes:
. Test ubuntu-core-os-release also runs on core18
. Test ubuntu-core-reboot also runs on core18
. Test ubuntu-core-services also runs on core18
. Test listing was refactored and also runs on core18
