### PR TITLE
recovery: use luks master key

### DIFF
--- a/recovery/device.go
+++ b/recovery/device.go
@@ -102,6 +102,12 @@ func (d *DiskDevice) CreateLUKSPartition(size uint64, label string, keyBuffer []
 	// FIXME: determine partition name in a civilized way
 	partdev := d.partDev(4)
 
+	// This shouldn't be necessary, but don't remove it.
+	time.Sleep(1 * time.Second)
+	if output, err := exec.Command("modprobe", "dm-crypt").CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, fmt.Errorf("cannot open LUKS device on %s: %s", partdev, err))
+	}
+
 	// Don't remove this delay, it prevents a kernel crash
 	// see https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1835279
 	time.Sleep(1 * time.Second)

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -149,7 +149,7 @@ func Install(version string) error {
 	cryptdev := "ubuntu-data"
 
 	logger.Noticef("Create LUKS key")
-	keySize := 4 * sizeKB
+	keySize := 32
 	keyBuffer := make([]byte, keySize)
 	n, err := rand.Read(keyBuffer)
 	if n != keySize || err != nil {
@@ -158,7 +158,7 @@ func Install(version string) error {
 
 	logger.Noticef("Install recovery %s", version)
 	if err := createWritable(keyBuffer, cryptdev); err != nil {
-		logger.Noticef("cannot create writable: %s", err)
+		logger.Noticef("cannot create data partition: %s", err)
 		return err
 	}
 
@@ -227,13 +227,13 @@ func createWritable(keyBuffer []byte, cryptdev string) error {
 	logger.Noticef("Creating new ubuntu-data partition")
 	disk := &DiskDevice{}
 	if err := disk.FindFromPartLabel("ubuntu-boot"); err != nil {
-		return fmt.Errorf("cannot determine boot device: %s", err)
+		return err
 	}
 
 	// FIXME: get values from gadget, system
 	err := disk.CreateLUKSPartition(1000*sizeMB, "ubuntu-data", keyBuffer, cryptdev)
 	if err != nil {
-		return fmt.Errorf("cannot create new ubuntu-data: %s", err)
+		return err
 	}
 
 	return nil

--- a/recovery/util.go
+++ b/recovery/util.go
@@ -92,3 +92,9 @@ func copyTree(src, dst string) error {
 	}
 	return nil
 }
+
+func wipe(name string) error {
+	// FIXME: overwrite file before unlinking
+	// better solution: have a custom cryptsetup util that reads master key from stdin
+	return os.Remove(name)
+}


### PR DESCRIPTION
Change LUKS device operations to use the master key directly. Cryptsetup
requires the master key to be read from the filesystem so we create a
temporary file with the unsealed master key on a RAM-backed device,
however we should consider writing a custom utility to read the key from
stdin instead.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>