### PR TITLE
hookstate/ctlcmd: support hidden commands in snapctl

### DIFF
--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -79,16 +79,19 @@ type commandInfo struct {
 	shortHelp string
 	longHelp  string
 	generator func() command
+	hidden    bool
 }
 
 var commands = make(map[string]*commandInfo)
 
-func addCommand(name, shortHelp, longHelp string, generator func() command) {
-	commands[name] = &commandInfo{
+func addCommand(name, shortHelp, longHelp string, generator func() command) *commandInfo {
+	cmd := &commandInfo{
 		shortHelp: shortHelp,
 		longHelp:  longHelp,
 		generator: generator,
 	}
+	commands[name] = cmd
+	return cmd
 }
 
 // ForbiddenCommandError conveys that a command cannot be invoked in some context
@@ -130,7 +133,8 @@ func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr 
 		} else {
 			data = &ForbiddenCommand{Uid: uid, Name: name}
 		}
-		_, err = parser.AddCommand(name, cmdInfo.shortHelp, cmdInfo.longHelp, data)
+		theCmd, err := parser.AddCommand(name, cmdInfo.shortHelp, cmdInfo.longHelp, data)
+		theCmd.Hidden = cmdInfo.hidden
 		if err != nil {
 			logger.Panicf("cannot add command %q: %s", name, err)
 		}

--- a/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 
 	. "gopkg.in/check.v1"
 )
@@ -90,4 +92,21 @@ func taskKinds(tasks []*state.Task) []string {
 		kinds[i] = k
 	}
 	return kinds
+}
+
+func (s *ctlcmdSuite) TestHiddenCommand(c *C) {
+	ctlcmd.AddHiddenMockCommand("mock-hidden")
+	ctlcmd.AddMockCommand("mock-shown")
+	defer ctlcmd.RemoveCommand("mock-hidden")
+	defer ctlcmd.RemoveCommand("mock-shown")
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"--help"}, 0)
+	// help message output is returned as *flags.Error with
+	// Type as flags.ErrHelp
+	c.Assert(err, FitsTypeOf, &flags.Error{})
+	c.Check(err.(*flags.Error).Type, Equals, flags.ErrHelp)
+	// mock-shown is in the help message
+	c.Check(err.Error(), testutil.Contains, "  mock-shown\n")
+	// mock-hidden is not in the help message
+	c.Check(err.Error(), Not(testutil.Contains), "  mock-hidden\n")
 }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"fmt"
+
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -36,8 +37,17 @@ func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *services
 }
 
 func AddMockCommand(name string) *MockCommand {
+	return addMockCmd(name, false)
+}
+
+func AddHiddenMockCommand(name string) *MockCommand {
+	return addMockCmd(name, true)
+}
+
+func addMockCmd(name string, hidden bool) *MockCommand {
 	mockCommand := NewMockCommand()
-	addCommand(name, "", "", func() command { return mockCommand })
+	cmd := addCommand(name, "", "", func() command { return mockCommand })
+	cmd.hidden = hidden
 	return mockCommand
 }
 


### PR DESCRIPTION
This will be used in https://github.com/snapcore/snapd/pull/7107 to make `snapctl netplan-apply` hidden from the help message that `snapctl --help` shows. 

This is also done analogously to how hidden "snap xyz" commands are implemented.