### PR TITLE
bootloader: remove "Dir()" from Bootloader interface

### DIFF
--- a/boot/boottest/mockbootloader.go
+++ b/boot/boottest/mockbootloader.go
@@ -63,10 +63,6 @@ func (b *MockBootloader) GetBootVars(keys ...string) (map[string]string, error) 
 	return out, b.GetErr
 }
 
-func (b *MockBootloader) Dir() string {
-	return b.bootdir
-}
-
 func (b *MockBootloader) Name() string {
 	return b.name
 }

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -49,6 +49,8 @@ vendor: Someone
 // baseKernelOSSuite is used to setup the common test environment
 type baseKernelOSSuite struct {
 	testutil.BaseTest
+
+	bootdir string
 }
 
 func (s *baseKernelOSSuite) SetUpTest(c *C) {
@@ -60,6 +62,8 @@ func (s *baseKernelOSSuite) SetUpTest(c *C) {
 	s.AddCleanup(restore)
 	restore = release.MockOnClassic(false)
 	s.AddCleanup(restore)
+
+	s.bootdir = filepath.Join(dirs.GlobalRootDir, "boot")
 }
 
 // kernelOSSuite tests the abstract bootloader behaviour including
@@ -256,7 +260,7 @@ func (s *ubootKernelOSSuite) forceUbootBootloader(c *C) bootloader.Bootloader {
 	bootloader.Force(loader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
-	fn := filepath.Join(dirs.GlobalRootDir, "/boot/uboot/uboot.env")
+	fn := filepath.Join(s.bootdir, "/uboot/uboot.env")
 	c.Assert(osutil.FileExists(fn), Equals, true)
 	return loader
 }
@@ -289,7 +293,7 @@ func (s *ubootKernelOSSuite) TestExtractKernelAssetsAndRemoveOnUboot(c *C) {
 	c.Assert(err, IsNil)
 
 	// this is where the kernel/initrd is unpacked
-	kernelAssetsDir := filepath.Join(dirs.GlobalRootDir, "/boot/uboot/ubuntu-kernel_42.snap")
+	kernelAssetsDir := filepath.Join(s.bootdir, "/uboot/ubuntu-kernel_42.snap")
 	for _, def := range files {
 		if def[0] == "meta/kernel.yaml" {
 			break
@@ -338,7 +342,7 @@ func (s *grubKernelOSSuite) forceGrubBootloader(c *C) bootloader.Bootloader {
 	bootloader.Force(loader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
-	fn := filepath.Join(dirs.GlobalRootDir, "/boot/grub/grub.cfg")
+	fn := filepath.Join(s.bootdir, "/grub/grub.cfg")
 	c.Assert(osutil.FileExists(fn), Equals, true)
 	return loader
 }
@@ -366,7 +370,7 @@ func (s *grubKernelOSSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) 
 	c.Assert(err, IsNil)
 
 	// kernel is *not* here
-	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(s.bootdir, "grub", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, false)
 
 	// it's idempotent
@@ -398,10 +402,10 @@ func (s *grubKernelOSSuite) TestExtractKernelForceWorks(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is extracted
-	kernimg := filepath.Join(dirs.GlobalRootDir, "/boot/grub/ubuntu-kernel_42.snap/kernel.img")
+	kernimg := filepath.Join(s.bootdir, "/grub/ubuntu-kernel_42.snap/kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, true)
 	// initrd
-	initrdimg := filepath.Join(dirs.GlobalRootDir, "/boot/grub/ubuntu-kernel_42.snap/initrd.img")
+	initrdimg := filepath.Join(s.bootdir, "/grub/ubuntu-kernel_42.snap/initrd.img")
 	c.Assert(osutil.FileExists(initrdimg), Equals, true)
 
 	// it's idempotent

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -289,8 +289,7 @@ func (s *ubootKernelOSSuite) TestExtractKernelAssetsAndRemoveOnUboot(c *C) {
 	c.Assert(err, IsNil)
 
 	// this is where the kernel/initrd is unpacked
-	bootdir := loader.Dir()
-	kernelAssetsDir := filepath.Join(bootdir, "ubuntu-kernel_42.snap")
+	kernelAssetsDir := filepath.Join(dirs.GlobalRootDir, "/boot/uboot/ubuntu-kernel_42.snap")
 	for _, def := range files {
 		if def[0] == "meta/kernel.yaml" {
 			break
@@ -345,7 +344,7 @@ func (s *grubKernelOSSuite) forceGrubBootloader(c *C) bootloader.Bootloader {
 }
 
 func (s *grubKernelOSSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
-	loader := s.forceGrubBootloader(c)
+	s.forceGrubBootloader(c)
 
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
@@ -367,7 +366,7 @@ func (s *grubKernelOSSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) 
 	c.Assert(err, IsNil)
 
 	// kernel is *not* here
-	kernimg := filepath.Join(loader.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, false)
 
 	// it's idempotent
@@ -376,7 +375,7 @@ func (s *grubKernelOSSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) 
 }
 
 func (s *grubKernelOSSuite) TestExtractKernelForceWorks(c *C) {
-	loader := s.forceGrubBootloader(c)
+	s.forceGrubBootloader(c)
 
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
@@ -399,10 +398,10 @@ func (s *grubKernelOSSuite) TestExtractKernelForceWorks(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is extracted
-	kernimg := filepath.Join(loader.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(dirs.GlobalRootDir, "/boot/grub/ubuntu-kernel_42.snap/kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, true)
 	// initrd
-	initrdimg := filepath.Join(loader.Dir(), "ubuntu-kernel_42.snap", "initrd.img")
+	initrdimg := filepath.Join(dirs.GlobalRootDir, "/boot/grub/ubuntu-kernel_42.snap/initrd.img")
 	c.Assert(osutil.FileExists(initrdimg), Equals, true)
 
 	// it's idempotent

--- a/bootloader/androidboot.go
+++ b/bootloader/androidboot.go
@@ -44,12 +44,12 @@ func (a *androidboot) Name() string {
 	return "androidboot"
 }
 
-func (a *androidboot) Dir() string {
+func (a *androidboot) dir() string {
 	return filepath.Join(dirs.GlobalRootDir, "/boot/androidboot")
 }
 
 func (a *androidboot) ConfigFile() string {
-	return filepath.Join(a.Dir(), "androidboot.env")
+	return filepath.Join(a.dir(), "androidboot.env")
 }
 
 func (a *androidboot) GetBootVars(names ...string) (map[string]string, error) {

--- a/bootloader/androidboot_test.go
+++ b/bootloader/androidboot_test.go
@@ -91,6 +91,6 @@ func (s *androidBootTestSuite) TestExtractKernelAssetsNoUnpacksKernel(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is *not* here
-	kernimg := filepath.Join(a.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "androidboot", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, false)
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -55,9 +55,6 @@ type Bootloader interface {
 	// Set the value of the specified bootloader variable
 	SetBootVars(values map[string]string) error
 
-	// Dir returns the bootloader directory
-	Dir() string
-
 	// Name returns the bootloader name
 	Name() string
 

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -35,7 +35,7 @@ func NewAndroidBoot() Bootloader {
 
 func MockAndroidBootFile(c *C, mode os.FileMode) {
 	f := &androidboot{}
-	err := os.MkdirAll(f.Dir(), 0755)
+	err := os.MkdirAll(f.dir(), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(f.ConfigFile(), nil, mode)
 	c.Assert(err, IsNil)
@@ -47,7 +47,7 @@ func NewUboot() Bootloader {
 
 func MockUbootFiles(c *C) {
 	u := &uboot{}
-	err := os.MkdirAll(u.Dir(), 0755)
+	err := os.MkdirAll(u.dir(), 0755)
 	c.Assert(err, IsNil)
 
 	// ensure that we have a valid uboot.env too
@@ -63,7 +63,7 @@ func NewGrub() Bootloader {
 
 func MockGrubFiles(c *C) {
 	g := &grub{}
-	err := os.MkdirAll(g.Dir(), 0755)
+	err := os.MkdirAll(g.dir(), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(g.ConfigFile(), nil, 0644)
 	c.Assert(err, IsNil)

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -45,16 +45,16 @@ func (g *grub) Name() string {
 	return "grub"
 }
 
-func (g *grub) Dir() string {
+func (g *grub) dir() string {
 	return filepath.Join(dirs.GlobalRootDir, "/boot/grub")
 }
 
 func (g *grub) ConfigFile() string {
-	return filepath.Join(g.Dir(), "grub.cfg")
+	return filepath.Join(g.dir(), "grub.cfg")
 }
 
 func (g *grub) envFile() string {
-	return filepath.Join(g.Dir(), "grubenv")
+	return filepath.Join(g.dir(), "grubenv")
 }
 
 func (g *grub) GetBootVars(names ...string) (map[string]string, error) {
@@ -86,11 +86,11 @@ func (g *grub) SetBootVars(values map[string]string) error {
 func (g *grub) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
 	// XXX: should we use "kernel.yaml" for this?
 	if _, err := snapf.ReadFile("meta/force-kernel-extraction"); err == nil {
-		return extractKernelAssetsToBootDir(g.Dir(), s, snapf)
+		return extractKernelAssetsToBootDir(g.dir(), s, snapf)
 	}
 	return nil
 }
 
 func (g *grub) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return removeKernelAssetsFromBootDir(g.Dir(), s)
+	return removeKernelAssetsFromBootDir(g.dir(), s)
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -36,6 +36,8 @@ import (
 
 type grubTestSuite struct {
 	baseBootenvTestSuite
+
+	bootdir string
 }
 
 var _ = Suite(&grubTestSuite{})
@@ -43,6 +45,8 @@ var _ = Suite(&grubTestSuite{})
 func (s *grubTestSuite) SetUpTest(c *C) {
 	s.baseBootenvTestSuite.SetUpTest(c)
 	bootloader.MockGrubFiles(c)
+
+	s.bootdir = filepath.Join(dirs.GlobalRootDir, "boot")
 }
 
 // grubEditenvCmd finds the right grub{,2}-editenv command
@@ -161,7 +165,7 @@ func (s *grubTestSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is *not* here
-	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(s.bootdir, "grub", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, false)
 }
 
@@ -192,10 +196,10 @@ func (s *grubTestSuite) TestExtractKernelForceWorks(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is extracted
-	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(s.bootdir, "grub", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, true)
 	// initrd
-	initrdimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "initrd.img")
+	initrdimg := filepath.Join(s.bootdir, "grub", "ubuntu-kernel_42.snap", "initrd.img")
 	c.Assert(osutil.FileExists(initrdimg), Equals, true)
 
 	// ensure that removal of assets also works

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -161,7 +161,7 @@ func (s *grubTestSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is *not* here
-	kernimg := filepath.Join(g.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, false)
 }
 
@@ -192,10 +192,10 @@ func (s *grubTestSuite) TestExtractKernelForceWorks(c *C) {
 	c.Assert(err, IsNil)
 
 	// kernel is extracted
-	kernimg := filepath.Join(g.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
+	kernimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "kernel.img")
 	c.Assert(osutil.FileExists(kernimg), Equals, true)
 	// initrd
-	initrdimg := filepath.Join(g.Dir(), "ubuntu-kernel_42.snap", "initrd.img")
+	initrdimg := filepath.Join(dirs.GlobalRootDir, "boot", "grub", "ubuntu-kernel_42.snap", "initrd.img")
 	c.Assert(osutil.FileExists(initrdimg), Equals, true)
 
 	// ensure that removal of assets also works

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -44,7 +44,7 @@ func (u *uboot) Name() string {
 	return "uboot"
 }
 
-func (u *uboot) Dir() string {
+func (u *uboot) dir() string {
 	return filepath.Join(dirs.GlobalRootDir, "/boot/uboot")
 }
 
@@ -53,7 +53,7 @@ func (u *uboot) ConfigFile() string {
 }
 
 func (u *uboot) envFile() string {
-	return filepath.Join(u.Dir(), "uboot.env")
+	return filepath.Join(u.dir(), "uboot.env")
 }
 
 func (u *uboot) SetBootVars(values map[string]string) error {
@@ -95,9 +95,9 @@ func (u *uboot) GetBootVars(names ...string) (map[string]string, error) {
 }
 
 func (u *uboot) ExtractKernelAssets(s *snap.Info, snapf snap.Container) error {
-	return extractKernelAssetsToBootDir(u.Dir(), s, snapf)
+	return extractKernelAssetsToBootDir(u.dir(), s, snapf)
 }
 
 func (u *uboot) RemoveKernelAssets(s snap.PlaceInfo) error {
-	return removeKernelAssetsFromBootDir(u.Dir(), s)
+	return removeKernelAssetsFromBootDir(u.dir(), s)
 }

--- a/bootloader/uboot_test.go
+++ b/bootloader/uboot_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/ubootenv"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -159,9 +160,7 @@ func (s *ubootTestSuite) TestExtractKernelAssetsAndRemove(c *C) {
 	c.Assert(err, IsNil)
 
 	// this is where the kernel/initrd is unpacked
-	bootdir := u.Dir()
-
-	kernelAssetsDir := filepath.Join(bootdir, "ubuntu-kernel_42.snap")
+	kernelAssetsDir := filepath.Join(dirs.GlobalRootDir, "boot", "uboot", "ubuntu-kernel_42.snap")
 
 	for _, def := range files {
 		if def[0] == "meta/kernel.yaml" {

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -279,8 +279,9 @@ type: kernel
 
 	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, false)
 
-	l, _ = filepath.Glob(filepath.Join(loader.Dir(), "*"))
-	c.Assert(l, HasLen, 0)
+	// assets got extracted and then removed again
+	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 1)
+	c.Assert(loader.RemoveKernelAssetsCalls, HasLen, 1)
 }
 
 func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {


### PR DESCRIPTION
The Bootloader.Dir() method is no longer needed and can be removed.
It used to be used to extract kernel assets but that is now part
of the Bootloader interface so expect for test code nothing is
using "Dir()" anymore. The extraction of boot assets is now done
via the Bootloader interface directly.

Note that Dir() also does not make sense for bootloaders that work
inside partitions (like littleKernel).
