### PR TITLE
snapstate: make progress reporting less granular

### DIFF
--- a/overlord/snapstate/progress.go
+++ b/overlord/snapstate/progress.go
@@ -32,6 +32,8 @@ type taskProgressAdapter struct {
 	label    string
 	total    float64
 	current  float64
+
+	lastReported float64
 }
 
 // NewTaskProgressAdapterUnlocked creates an adapter of the task into a progress.Meter to use while the state is unlocked
@@ -48,10 +50,21 @@ func NewTaskProgressAdapterLocked(t *state.Task) progress.Meter {
 func (t *taskProgressAdapter) Start(label string, total float64) {
 	t.label = label
 	t.total = total
+	t.Set(0.0)
 }
+
+// minimalProgress before we lock the state and set the task progress
+const minProgress = 0.2
 
 // Set sets the current progress
 func (t *taskProgressAdapter) Set(current float64) {
+	t.current = current
+	// check if we made at least "minProgress" before we lock the state
+	if current != 0.0 && (t.current/t.total)*100.0-(t.lastReported/t.total)*100.0 < minProgress {
+		return
+	}
+	t.lastReported = t.current
+	// set progress in task
 	if t.unlocked {
 		t.task.State().Lock()
 		defer t.task.State().Unlock()
@@ -75,13 +88,8 @@ func (t *taskProgressAdapter) Finished() {
 
 // Write sets the current write progress
 func (t *taskProgressAdapter) Write(p []byte) (n int, err error) {
-	if t.unlocked {
-		t.task.State().Lock()
-		defer t.task.State().Unlock()
-	}
-
 	t.current += float64(len(p))
-	t.task.SetProgress(t.label, int(t.current), int(t.total))
+	t.Set(t.current)
 	return len(p), nil
 }
 


### PR DESCRIPTION
The progress reporting for e.g. downloads is a bit excessive. Each
taskProgressAdapter.Write() will lock the state and update the
task progress. While this is great for the UI it puts strain onto
slow systems and make the download slower. This PR will change the
code to only update the progress if it changed more than 0.2%.

