### PR TITLE
overlord: DeviceCtx must find the remodel context for a remodel change

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2638,8 +2638,11 @@ func (s *deviceMgrSuite) TestRemodelRequiredSnaps(c *C) {
 	// 2 snaps,
 	c.Assert(tl, HasLen, 2*3+1)
 
-	remodCtx, err := devicestate.RemodelCtxFromTask(tl[0])
+	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
+	// deviceCtx is actually a remodelContext here
+	remodCtx, ok := deviceCtx.(devicestate.RemodelContext)
+	c.Assert(ok, Equals, true)
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
 	c.Check(remodCtx.Kind(), Equals, devicestate.UpdateRemodel)
 	c.Check(remodCtx.Model(), DeepEquals, new)
@@ -2923,8 +2926,11 @@ func (s *deviceMgrSuite) TestRemodelStoreSwitch(c *C) {
 	// 1 "set-model" task at the end
 	c.Assert(tl, HasLen, 2*3+1)
 
-	remodCtx, err := devicestate.RemodelCtxFromTask(tl[0])
+	deviceCtx, err := devicestate.DeviceCtx(s.state, tl[0], nil)
 	c.Assert(err, IsNil)
+	// deviceCtx is actually a remodelContext here
+	remodCtx, ok := deviceCtx.(devicestate.RemodelContext)
+	c.Assert(ok, Equals, true)
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
 	c.Check(remodCtx.Kind(), Equals, devicestate.StoreSwitchRemodel)
 	c.Check(remodCtx.Model(), DeepEquals, new)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -129,7 +129,10 @@ func SetBootOkRan(m *DeviceManager, b bool) {
 	m.bootOkRan = b
 }
 
-type RegistrationContext = registrationContext
+type (
+	RegistrationContext = registrationContext
+	RemodelContext      = remodelContext
+)
 
 func RegistrationCtx(m *DeviceManager, t *state.Task) (registrationContext, error) {
 	return m.registrationCtx(t)
@@ -152,10 +155,9 @@ var (
 
 	RemodelTasks = remodelTasks
 
-	RemodelCtx         = remodelCtx
-	RemodelCtxFromTask = remodelCtxFromTask
-	CleanupRemodelCtx  = cleanupRemodelCtx
-	CachedRemodelCtx   = cachedRemodelCtx
+	RemodelCtx        = remodelCtx
+	CleanupRemodelCtx = cleanupRemodelCtx
+	CachedRemodelCtx  = cachedRemodelCtx
 
 	GadgetUpdateBlocked    = gadgetUpdateBlocked
 	GadgetCurrentAndUpdate = gadgetCurrentAndUpdate

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -636,8 +636,8 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
 	t := s.state.NewTask("remodel-task-1", "...")
 	chg.AddTask(t)
 
-	// caching
-	remodCtx1, err := devicestate.RemodelCtxFromTask(t)
+	// caching, internally this use remodelCtxFromTask
+	remodCtx1, err := devicestate.DeviceCtx(s.state, t, nil)
 	c.Assert(err, IsNil)
 	c.Check(remodCtx1, Equals, remodCtx)
 
@@ -645,7 +645,7 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
 	// compute a new one
 	devicestate.CleanupRemodelCtx(chg)
 
-	remodCtx2, err := devicestate.RemodelCtxFromTask(t)
+	remodCtx2, err := devicestate.DeviceCtx(s.state, t, nil)
 	c.Assert(err, IsNil)
 	c.Check(remodCtx2 != remodCtx, Equals, true)
 	c.Check(remodCtx2.Model(), DeepEquals, newModel)
@@ -655,20 +655,22 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskNo(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	// internally these use remodelCtxFromTask
+
 	// task is nil
-	remodCtx1, err := devicestate.RemodelCtxFromTask(nil)
+	remodCtx1, err := devicestate.DeviceCtx(s.state, nil, nil)
 	c.Check(err, Equals, state.ErrNoState)
 	c.Check(remodCtx1, IsNil)
 
 	// no change
 	t := s.state.NewTask("random-task", "...")
-	_, err = devicestate.RemodelCtxFromTask(t)
+	_, err = devicestate.DeviceCtx(s.state, t, nil)
 	c.Check(err, Equals, state.ErrNoState)
 
 	// not a remodel change
 	chg := s.state.NewChange("not-remodel", "...")
 	chg.AddTask(t)
-	_, err = devicestate.RemodelCtxFromTask(t)
+	_, err = devicestate.DeviceCtx(s.state, t, nil)
 	c.Check(err, Equals, state.ErrNoState)
 }
 
@@ -747,7 +749,7 @@ func (s *remodelLogicSuite) TestReregRemodelContextInit(c *C) {
 	t := s.state.NewTask("remodel-task-1", "...")
 	chg.AddTask(t)
 
-	remodCtx1, err := devicestate.RemodelCtxFromTask(t)
+	remodCtx1, err := devicestate.DeviceCtx(s.state, t, nil)
 	c.Assert(err, IsNil)
 	c.Check(remodCtx1, Equals, remodCtx)
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -631,6 +631,10 @@ func (s *mgrsSuite) mockStore(c *C) *httptest.Server {
 			w.Write(asserts.Encode(a))
 			return
 		case "download":
+			if s.sessionMacaroon != "" {
+				// FIXME: download is still using the old headers!
+				c.Check(r.Header.Get("X-Device-Authorization"), Equals, fmt.Sprintf(`Macaroon root="%s"`, s.sessionMacaroon))
+			}
 			if s.failNextDownload == comps[1] {
 				s.failNextDownload = ""
 				w.WriteHeader(418)
@@ -648,7 +652,6 @@ func (s *mgrsSuite) mockStore(c *C) *httptest.Server {
 		case "v2:refresh":
 			if s.sessionMacaroon != "" {
 				c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, fmt.Sprintf(`Macaroon root="%s"`, s.sessionMacaroon))
-
 			}
 			dec := json.NewDecoder(r.Body)
 			var input struct {

--- a/store/store.go
+++ b/store/store.go
@@ -1449,6 +1449,8 @@ func downloadReqOpts(storeURL *url.URL, cdnHeader string, opts *DownloadOptions)
 		Method:       "GET",
 		URL:          storeURL,
 		ExtraHeaders: map[string]string{},
+		// FIXME: use the new headers? with
+		// APILevel: apiV2Endps,
 	}
 	if cdnHeader != "" {
 		reqOptions.ExtraHeaders["Snap-CDN"] = cdnHeader


### PR DESCRIPTION
We were missing the wiring in devicestate/snapstate.DeviceCtx to find the remodel context in a remodel change, so the download tasks would use the wrong store/session. This fixes that.

I added some FIXMEs about the fact that it seems with download we still send old "X-*" headers, I'm not sure that is still intended.