### PR TITLE
overlord,daemon,cmd/snapd:  move expensive startup to dedicated StartUp methods

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -128,7 +128,9 @@ func run(ch chan os.Signal) error {
 
 	d.Version = cmd.Version
 
-	d.Start()
+	if err := d.Start(); err != nil {
+		return err
+	}
 
 	watchdog, err := runWatchdog(d)
 	if err != nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -363,6 +363,8 @@ func (s *apiBaseSuite) daemon(c *check.C) *Daemon {
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
 
+	c.Assert(d.overlord.StartUp(), check.IsNil)
+
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -429,6 +431,7 @@ func (s *apiBaseSuite) daemonWithFakeSnapManager(c *check.C) *Daemon {
 	runner := d.overlord.TaskRunner()
 	d.overlord.AddManager(newFakeSnapManager(st, runner))
 	d.overlord.AddManager(runner)
+	c.Assert(d.overlord.StartUp(), check.IsNil)
 	return d
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -541,7 +541,7 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l2, accept: snapAccept}
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 
 	c.Check(s.notified, check.DeepEquals, []string{"READY=1"})
 
@@ -588,7 +588,7 @@ func (s *daemonSuite) TestRestartWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 	defer d.Stop(nil)
 
 	snapdDone := make(chan struct{})
@@ -666,7 +666,7 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: snapL, accept: snapAccept}
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 
 	snapdAccepting := make(chan struct{})
 	go func() {
@@ -735,7 +735,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *check.C) {
 	snapAccept := make(chan struct{})
 	d.snapListener = &witnessAcceptListener{Listener: l, accept: snapAccept}
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 	defer d.Stop(nil)
 
 	st := d.overlord.State()
@@ -883,7 +883,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
 	makeDaemonListeners(c, d)
 	s.markSeeded(d)
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 	st := d.overlord.State()
 
 	st.Lock()
@@ -916,7 +916,7 @@ func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	makeDaemonListeners(c, d)
 	s.markSeeded(d)
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 	st := d.overlord.State()
 
 	st.Lock()
@@ -963,7 +963,7 @@ func (s *daemonSuite) TestRestartExpectedRebootDidNotHappen(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(n, check.Equals, 1)
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 
 	c.Check(s.notified, check.DeepEquals, []string{"READY=1"})
 
@@ -1039,10 +1039,10 @@ func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *check.C) {
 	// go into socket activation mode
 	s.markSeeded(d)
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 	// pretend some ensure happened
 	for i := 0; i < 5; i++ {
-		d.overlord.StateEngine().Ensure()
+		c.Check(d.overlord.StateEngine().Ensure(), check.IsNil)
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -1069,10 +1069,10 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *check.C) {
 	s.markSeeded(d)
 	st := d.overlord.State()
 
-	d.Start()
+	c.Assert(d.Start(), check.IsNil)
 	// pretend some ensure happened
 	for i := 0; i < 5; i++ {
-		d.overlord.StateEngine().Ensure()
+		c.Check(d.overlord.StateEngine().Ensure(), check.IsNil)
 		time.Sleep(5 * time.Millisecond)
 	}
 

--- a/overlord/cmdstate/cmdstate_test.go
+++ b/overlord/cmdstate/cmdstate_test.go
@@ -75,6 +75,7 @@ func (s *cmdSuite) SetUpTest(c *check.C) {
 	s.manager = cmdstate.Manager(s.state, runner)
 	s.se.AddManager(s.manager)
 	s.se.AddManager(runner)
+	c.Assert(s.se.StartUp(), check.IsNil)
 	s.restore = cmdstate.MockDefaultExecTimeout(time.Second / 10)
 }
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -185,6 +185,8 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 	}
 	s.o.TaskRunner().AddHandler("error-trigger", erroringHandler, nil)
 
+	c.Assert(s.o.StartUp(), IsNil)
+
 	s.state.Lock()
 	snapstate.ReplaceStore(s.state, &fakeStore{
 		state: s.state,

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -625,6 +625,8 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {
 	ifacemgr, err := ifacestate.Manager(st, nil, o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	o.AddManager(ifacemgr)
+	c.Assert(o.StartUp(), IsNil)
+
 	st.Lock()
 	assertstate.ReplaceDB(st, db.(*asserts.Database))
 	st.Unlock()

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -108,6 +108,7 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	ovld.InterfaceManager().DisableUDevMonitor()
 	s.overlord = ovld
+	c.Assert(ovld.StartUp(), IsNil)
 
 	// don't actually try to talk to the store on snapstate.Ensure
 	// needs doing after the call to devicestate.Manager (which happens in overlord.New)

--- a/overlord/healthstate/healthstate_test.go
+++ b/overlord/healthstate/healthstate_test.go
@@ -70,6 +70,8 @@ func (s *healthSuite) SetUpTest(c *check.C) {
 
 	healthstate.Init(s.hookMgr)
 
+	c.Assert(s.o.StartUp(), check.IsNil)
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -75,6 +75,7 @@ func (s *baseHookManagerSuite) commonSetUpTest(c *C) {
 	s.se = s.o.StateEngine()
 	s.o.AddManager(s.manager)
 	s.o.AddManager(s.o.TaskRunner())
+	c.Assert(s.o.StartUp(), IsNil)
 
 	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -43,47 +43,6 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-func (m *InterfaceManager) initialize(tm timings.Measurer) error {
-	m.state.Lock()
-	defer m.state.Unlock()
-
-	snaps, err := snapsWithSecurityProfiles(m.state)
-	if err != nil {
-		return err
-	}
-	// Before deciding about adding implicit slots to any snap we need to scan
-	// the set of snaps we know about. If any of those is "snapd" then for the
-	// duration of this process always add implicit slots to snapd and not to
-	// any other type: os snap and use a mapper to use names core-snapd-system
-	// on state, in memory and in API responses, respectively.
-	m.selectInterfaceMapper(snaps)
-
-	if err := m.addInterfaces(m.extraInterfaces); err != nil {
-		return err
-	}
-	if err := m.addBackends(m.extraBackends); err != nil {
-		return err
-	}
-	if err := m.addSnaps(snaps); err != nil {
-		return err
-	}
-	if err := m.renameCorePlugConnection(); err != nil {
-		return err
-	}
-	if err := removeStaleConnections(m.state); err != nil {
-		return err
-	}
-	if _, err := m.reloadConnections(""); err != nil {
-		return err
-	}
-	if profilesNeedRegeneration() {
-		if err := m.regenerateAllSecurityProfiles(tm); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (m *InterfaceManager) selectInterfaceMapper(snaps []*snap.Info) {
 	for _, snapInfo := range snaps {
 		if snapInfo.GetType() == snap.TypeSnapd {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -43,7 +43,7 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend, tm timings.Measurer) error {
+func (m *InterfaceManager) initialize(tm timings.Measurer) error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
@@ -58,10 +58,10 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 	// on state, in memory and in API responses, respectively.
 	m.selectInterfaceMapper(snaps)
 
-	if err := m.addInterfaces(extraInterfaces); err != nil {
+	if err := m.addInterfaces(m.extraInterfaces); err != nil {
 		return err
 	}
-	if err := m.addBackends(extraBackends); err != nil {
+	if err := m.addBackends(m.extraBackends); err != nil {
 		return err
 	}
 	if err := m.addSnaps(snaps); err != nil {

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -406,8 +406,10 @@ apps:
 	log, restore := logger.MockLogger()
 	defer restore()
 
-	// Construct the interface manager.
-	_, err = ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	// Construct and start up the interface manager.
+	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	c.Assert(err, IsNil)
+	err = mgr.StartUp()
 	c.Assert(err, IsNil)
 
 	// Check that system key is not on disk.

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -181,6 +181,13 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 	s.mgr, err = ifacestate.Manager(s.state, hookMgr, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
+	s.o.AddManager(s.mgr)
+	s.o.AddManager(s.o.TaskRunner())
+
+	// startup
+	err = s.o.StartUp()
+	c.Assert(err, IsNil)
+
 	autoConnectNo := func(*snap.PlugInfo, *snap.SlotInfo) bool {
 		return false
 	}
@@ -252,9 +259,6 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 		c.Assert(s.mgr.Repository().AddInterface(iface), IsNil)
 		s.AddCleanup(builtin.MockInterface(iface))
 	}
-
-	s.o.AddManager(s.mgr)
-	s.o.AddManager(s.o.TaskRunner())
 
 	// single Ensure to have udev monitor created and wired up by interface manager
 	c.Assert(s.mgr.Ensure(), IsNil)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -132,7 +132,7 @@ func (m *InterfaceManager) StartUp() error {
 	s := m.state
 	perfTimings := timings.New(map[string]string{"startup": "ifacemgr"})
 
-	if err := m.initialize(m.extraInterfaces, m.extraBackends, perfTimings); err != nil {
+	if err := m.initialize(perfTimings); err != nil {
 		return err
 	}
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -248,6 +248,8 @@ func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 
 		s.o.AddManager(s.o.TaskRunner())
 
+		c.Assert(s.o.StartUp(), IsNil)
+
 		// ensure the re-generation of security profiles did not
 		// confuse the tests
 		s.secBackend.SetupCalls = nil
@@ -5348,6 +5350,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
+	c.Assert(s.o.StartUp(), IsNil)
 
 	// succesfull initialization should result in exactly 1 connect and run call
 	for i := 0; i < 5; i++ {
@@ -5387,6 +5390,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
+	c.Assert(s.o.StartUp(), IsNil)
 
 	c.Assert(s.se.Ensure(), ErrorMatches, ".*Connect failed.*")
 	c.Assert(u.ConnectCalls, Equals, 1)
@@ -5423,6 +5427,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
+	c.Assert(s.o.StartUp(), IsNil)
 
 	for i := 0; i < 5; i++ {
 		c.Assert(s.se.Ensure(), IsNil)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -202,6 +202,8 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	o, err := overlord.New(nil)
 	c.Assert(err, IsNil)
+	err = o.StartUp()
+	c.Assert(err, IsNil)
 	o.InterfaceManager().DisableUDevMonitor()
 	s.o = o
 	st := s.o.State()

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -352,20 +352,7 @@ func (o *Overlord) StartUp() error {
 		return nil
 	}
 	o.startedUp = true
-
-	if err := o.stateEng.StartUp(); err != nil {
-		return err
-	}
-
-	s := o.State()
-	s.Lock()
-	defer s.Unlock()
-
-	if err := o.snapMgr.SyncCookies(s); err != nil {
-		return fmt.Errorf("failed to generate cookies: %q", err)
-	}
-
-	return nil
+	return o.stateEng.StartUp()
 }
 
 // Loop runs a loop in a goroutine to ensure the current state regularly through StateEngine Ensure.

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -296,6 +296,15 @@ func (o *Overlord) newStore(devBE storecontext.DeviceBackend) snapstate.StoreSer
 	return o.newStoreWithContext(stoCtx)
 }
 
+// StartUp proceeds to run any expensive Overlord or managers initialization. After this is done once it is a noop.
+func (o *Overlord) StartUp() error {
+	if o.startedUp {
+		return nil
+	}
+	o.startedUp = true
+	return o.stateEng.StartUp()
+}
+
 func (o *Overlord) ensureTimerSetup() {
 	o.ensureLock.Lock()
 	defer o.ensureLock.Unlock()
@@ -344,15 +353,6 @@ func (o *Overlord) requestRestart(t state.RestartType) {
 	} else {
 		o.restartBehavior.HandleRestart(t)
 	}
-}
-
-// StartUp proceeds to run any expensive Overlord or managers initialization. After this is done once it is a noop.
-func (o *Overlord) StartUp() error {
-	if o.startedUp {
-		return nil
-	}
-	o.startedUp = true
-	return o.stateEng.StartUp()
 }
 
 // Loop runs a loop in a goroutine to ensure the current state regularly through StateEngine Ensure.

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -82,6 +82,8 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	bs.o.AddManager(bs.snapmgr)
 	bs.o.AddManager(bs.o.TaskRunner())
 
+	c.Assert(bs.o.StartUp(), IsNil)
+
 	snapstate.SetSnapManagerBackend(bs.snapmgr, bs.fakeBackend)
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -60,6 +60,7 @@ func (s *baseHandlerSuite) setup(c *C, b state.Backend) {
 	s.se = overlord.NewStateEngine(s.state)
 	s.se.AddManager(s.snapmgr)
 	s.se.AddManager(s.runner)
+	c.Assert(s.se.StartUp(), IsNil)
 
 	AddForeignTaskHandlers(s.runner, s.fakeBackend)
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -415,9 +415,19 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 	// control serialisation
 	runner.AddBlocked(m.blockedTask)
 
+	return m, nil
+}
+
+// StartUp implements StateStarterUp.Startup.
+func (m *SnapManager) StartUp() error {
 	writeSnapReadme()
 
-	return m, nil
+	m.state.Lock()
+	defer m.state.Unlock()
+	if err := m.SyncCookies(m.state); err != nil {
+		return fmt.Errorf("failed to generate cookies: %q", err)
+	}
+	return nil
 }
 
 func (m *SnapManager) CanStandby() bool {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -127,6 +127,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.o.AddManager(s.snapmgr)
 	s.o.AddManager(s.o.TaskRunner())
 	s.se = s.o.StateEngine()
+	c.Assert(s.o.StartUp(), IsNil)
 
 	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo))
 	s.BaseTest.AddCleanup(snapstate.MockOpenSnapFile(s.fakeBackend.OpenSnapFile))

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -36,6 +36,13 @@ type StateManager interface {
 	Ensure() error
 }
 
+// StateStarterUp is optionally implemented by StateManager that have expensive
+// initialization to perform before the main Overlord loop.
+type StateStarterUp interface {
+	// StartUp asks manager to perform any expensive initialization.
+	StartUp() error
+}
+
 // StateWaiter is optionally implemented by StateManagers that have running
 // activities that can be waited.
 type StateWaiter interface {
@@ -60,8 +67,9 @@ type StateStopper interface {
 // cope with Ensure calls in any order, coordinating among themselves
 // solely via the state.
 type StateEngine struct {
-	state   *state.State
-	stopped bool
+	state     *state.State
+	stopped   bool
+	startedUp bool
 	// managers in use
 	mgrLock  sync.Mutex
 	managers []StateManager
@@ -77,6 +85,37 @@ func NewStateEngine(s *state.State) *StateEngine {
 // State returns the current system state.
 func (se *StateEngine) State() *state.State {
 	return se.state
+}
+
+type startupError struct {
+	errs []error
+}
+
+func (e *startupError) Error() string {
+	return fmt.Sprintf("state startup errors: %v", e.errs)
+}
+
+// StartUp asks all managers to perform any expensive initialization. It is a noop after the first invocation.
+func (se *StateEngine) StartUp() error {
+	se.mgrLock.Lock()
+	defer se.mgrLock.Unlock()
+	if se.startedUp {
+		return nil
+	}
+	se.startedUp = true
+	var errs []error
+	for _, m := range se.managers {
+		if starterUp, ok := m.(StateStarterUp); ok {
+			err := starterUp.StartUp()
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if len(errs) != 0 {
+		return &startupError{errs}
+	}
+	return nil
 }
 
 type ensureError struct {
@@ -98,6 +137,9 @@ func (e *ensureError) Error() string {
 func (se *StateEngine) Ensure() error {
 	se.mgrLock.Lock()
 	defer se.mgrLock.Unlock()
+	if !se.startedUp {
+		return fmt.Errorf("state engine skipped startup")
+	}
 	if se.stopped {
 		return fmt.Errorf("state engine already stopped")
 	}


### PR DESCRIPTION
This moves out any expensive/variable startup from the construction code of state managers and overlord.New, to dedicated StartUp methods in Overlord, StateEngine and optionally in the managers themselves.

It's an antipattern somewhat to have expensive work in construction code.

This is in preparation to try to adjust systemd start timeout and avoid timeouts on systems with many snaps.