### PR TITLE
gadget: support for writing symlinks

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -31,7 +31,7 @@ var (
 
 	EncodeLabel = encodeLabel
 
-	WriteFile      = writeFile
+	WriteFile      = writeFileOrSymlink
 	WriteDirectory = writeDirectory
 
 	RawContentBackupPath = rawContentBackupPath

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -181,6 +181,17 @@ func writeFile(src, dst string, preserveInDst []string) error {
 		return fmt.Errorf("cannot create prefix directory: %v", err)
 	}
 
+	if osutil.IsSymlink(src) {
+		to, err := os.Readlink(src)
+		if err != nil {
+			return fmt.Errorf("cannot read symlink: %v", err)
+		}
+		if err := os.Symlink(to, dst); err != nil {
+			return fmt.Errorf("cannot deploy a symlink: %v", err)
+		}
+		return nil
+	}
+
 	// overwrite & sync by default
 	copyFlags := osutil.CopyFlagOverwrite | osutil.CopyFlagSync
 

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -352,7 +352,7 @@ func (f *MountedFilesystemUpdater) sourceDirectoryEntries(source string) ([]os.F
 		return nil, err
 	}
 
-	// TODO: enable support for symlnks when needed
+	// TODO: enable support for symlinks when needed
 	if osutil.IsSymlink(srcPath) {
 		return nil, fmt.Errorf("source is a symbolic link")
 	}
@@ -410,7 +410,7 @@ func (f *MountedFilesystemUpdater) updateOrSkipFile(dstRoot, source, target stri
 	srcPath := f.entrySourcePath(source)
 	dstPath, backupPath := f.entryDestPaths(dstRoot, source, target, backupDir)
 
-	// TODO: enable support for symlnks when needed
+	// TODO: enable support for symlinks when needed
 	if osutil.IsSymlink(srcPath) {
 		return fmt.Errorf("cannot update file %s: symbolic links are not supported", source)
 	}
@@ -541,7 +541,7 @@ func (f *MountedFilesystemUpdater) checkpointPrefix(dstRoot, target string, back
 	for prefix := filepath.Dir(target); prefix != "." && prefix != "/"; prefix = filepath.Dir(prefix) {
 		prefixDst, prefixBackupBase := f.entryDestPaths(dstRoot, "", prefix, backupDir)
 
-		// TODO: enable support for symlnks when needed
+		// TODO: enable support for symlinks when needed
 		if osutil.IsSymlink(prefixDst) {
 			return fmt.Errorf("cannot create a checkpoint for directory %v: symbolic links are not supported", prefix)
 		}
@@ -573,7 +573,7 @@ func (f *MountedFilesystemUpdater) backupOrCheckpointFile(dstRoot, source, targe
 	sameStamp := backupPath + ".same"
 	preserveStamp := backupPath + ".preserve"
 
-	// TODO: enable support for symlnks when needed
+	// TODO: enable support for symlinks when needed
 	if osutil.IsSymlink(dstPath) {
 		return fmt.Errorf("cannot backup file %s: symbolic links are not supported", target)
 	}


### PR DESCRIPTION
Add support for writing symlinks in mounted filesystem writer. Since mounted filesystem writer is used for 'populating the staging directory while preparing a structure image in `snap-image`, this enables us to correctly preserve optimizations made by `snap prepare-image`.

At the same time, symlinks are awkward during update, thus updated will loudly complain about symlinks.
