### PR TITLE
tests: remove lxd / lxcfs if pre-installed

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -529,6 +529,11 @@ prepare: |
         fi
     fi
 
+    if [[ "$SPREAD_SYSTEM" == ubuntu-* ]] && [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
+        apt-get remove --purge -y lxd lxcfs || true
+        apt-get autoremove --purge -y
+    fi
+
     if [[ "$SPREAD_SYSTEM" == debian-* ]]; then
         apt-get update && apt-get install -y eatmydata
     fi
@@ -600,6 +605,7 @@ prepare: |
     "$TESTSLIB"/prepare-restore.sh --prepare-project
 prepare-each: |
     "$TESTSLIB"/prepare-restore.sh --prepare-project-each
+    grep -v /var/lib/lxcfs /proc/self/mountinfo
 restore: |
     "$TESTSLIB"/prepare-restore.sh --restore-project
 restore-each: |
@@ -617,7 +623,7 @@ restore-each: |
             find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
             ;;
     esac
-
+    grep -v /var/lib/lxcfs /proc/self/mountinfo
 suites:
     # The essential tests designed to run inside the autopkgtest
     # environment on each platform. On autopkgtest we cannot run all tests


### PR DESCRIPTION
The new mount namespace test has data sets for google cloud images and
qemu images. Apart from some cgroup differences the main difference is
presence and absence of pre-installed LXD, including the lxcfs
filesystem.

Because of how our tests prepare and restore (in a non-obvious way) and
because chasing this now is ineffective, to ensure the mount namespace
looks the same across test execution, remove lxd if it is installed in
the initial image.

Tests that require lxd install and remove it already.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
