### PR TITLE
tests: don't leak /run/netns mount

### DIFF
--- a/tests/main/auto-refresh-retry/task.yaml
+++ b/tests/main/auto-refresh-retry/task.yaml
@@ -8,6 +8,7 @@ prepare: |
 restore: |
     rm -f /etc/systemd/system/snapd.service.d/override.conf
     ip netns delete testns || true
+    umount /run/netns || true
 
 debug: |
     systemctl cat snapd.service


### PR DESCRIPTION
One test relied on a specially crafted network namespace to operate. As
a part of the cleanup, remove the network namespace mount point so that
it doesn't leak to other tests.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

