### PR TITLE
overlord/devicestate: update gadget update handlers and mocks

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -3196,7 +3196,7 @@ func setupGadgetUpdate(c *C, st *state.State) (chg *state.Change, tsk *state.Tas
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreSimple(c *C) {
 	var updateCalled bool
 	var passedRollbackDir string
-	restore := devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		updateCalled = true
 		passedRollbackDir = path
 		st, err := os.Stat(path)
@@ -3230,7 +3230,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreSimple(c *C) {
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNoUpdateNeeded(c *C) {
 	var called bool
-	restore := devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		called = true
 		return gadget.ErrNoUpdate
 	})
@@ -3257,7 +3257,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreRollbackDirCreateFailed(c *C) {
 		c.Skip("this test cannot run as root (permissions are not honored)")
 	}
 
-	restore := devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3283,7 +3283,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreRollbackDirCreateFailed(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreUpdateFailed(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		return errors.New("gadget exploded")
 	})
 	defer restore()
@@ -3306,7 +3306,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreUpdateFailed(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNotDuringFirstboot(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3350,7 +3350,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNotDuringFirstboot(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreBadGadgetYaml(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3410,7 +3410,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnClassicErrorsOut(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	restore = devicestate.MockGadgetUpdate(func(current, update *gadget.Info, path string) error {
+	restore = devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3511,20 +3511,26 @@ volumes:
 
 	current, update, err = devicestate.GadgetCurrentAndUpdate(s.state, snapsup)
 	c.Assert(err, IsNil)
-	c.Assert(current, DeepEquals, &gadget.Info{
-		Volumes: map[string]gadget.Volume{
-			"pc": {
-				Bootloader: "grub",
+	c.Assert(current, DeepEquals, &gadget.UpdateData{
+		Info: &gadget.Info{
+			Volumes: map[string]gadget.Volume{
+				"pc": {
+					Bootloader: "grub",
+				},
 			},
 		},
+		RootDir: ci.MountDir(),
 	})
-	c.Assert(update, DeepEquals, &gadget.Info{
-		Volumes: map[string]gadget.Volume{
-			"pc": {
-				Bootloader: "grub",
-				ID:         "123",
+	c.Assert(update, DeepEquals, &gadget.UpdateData{
+		Info: &gadget.Info{
+			Volumes: map[string]gadget.Volume{
+				"pc": {
+					Bootloader: "grub",
+					ID:         "123",
+				},
 			},
 		},
+		RootDir: ui.MountDir(),
 	})
 }
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -3196,7 +3196,7 @@ func setupGadgetUpdate(c *C, st *state.State) (chg *state.Change, tsk *state.Tas
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreSimple(c *C) {
 	var updateCalled bool
 	var passedRollbackDir string
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		updateCalled = true
 		passedRollbackDir = path
 		st, err := os.Stat(path)
@@ -3230,7 +3230,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreSimple(c *C) {
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNoUpdateNeeded(c *C) {
 	var called bool
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		called = true
 		return gadget.ErrNoUpdate
 	})
@@ -3257,7 +3257,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreRollbackDirCreateFailed(c *C) {
 		c.Skip("this test cannot run as root (permissions are not honored)")
 	}
 
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3283,7 +3283,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreRollbackDirCreateFailed(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreUpdateFailed(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		return errors.New("gadget exploded")
 	})
 	defer restore()
@@ -3306,7 +3306,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreUpdateFailed(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNotDuringFirstboot(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3350,7 +3350,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNotDuringFirstboot(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreBadGadgetYaml(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3410,7 +3410,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnClassicErrorsOut(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	restore = devicestate.MockGadgetUpdate(func(current, update gadget.UpdateData, path string) error {
+	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3511,7 +3511,7 @@ volumes:
 
 	current, update, err = devicestate.GadgetCurrentAndUpdate(s.state, snapsup)
 	c.Assert(err, IsNil)
-	c.Assert(current, DeepEquals, &gadget.UpdateData{
+	c.Assert(current, DeepEquals, &gadget.GadgetData{
 		Info: &gadget.Info{
 			Volumes: map[string]gadget.Volume{
 				"pc": {
@@ -3521,7 +3521,7 @@ volumes:
 		},
 		RootDir: ci.MountDir(),
 	})
-	c.Assert(update, DeepEquals, &gadget.UpdateData{
+	c.Assert(update, DeepEquals, &gadget.GadgetData{
 		Info: &gadget.Info{
 			Volumes: map[string]gadget.Volume{
 				"pc": {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -161,7 +161,7 @@ var (
 	GadgetCurrentAndUpdate = gadgetCurrentAndUpdate
 )
 
-func MockGadgetUpdate(mock func(current, update gadget.UpdateData, path string) error) (restore func()) {
+func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string) error) (restore func()) {
 	old := gadgetUpdate
 	gadgetUpdate = mock
 	return func() {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -161,7 +161,7 @@ var (
 	GadgetCurrentAndUpdate = gadgetCurrentAndUpdate
 )
 
-func MockGadgetUpdate(mock func(current, update *gadget.Info, path string) error) (restore func()) {
+func MockGadgetUpdate(mock func(current, update gadget.UpdateData, path string) error) (restore func()) {
 	old := gadgetUpdate
 	gadgetUpdate = mock
 	return func() {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -872,7 +872,7 @@ func makeRollbackDir(name string) (string, error) {
 	return rollbackDir, nil
 }
 
-func currentGadgetInfo(snapst *snapstate.SnapState) (*gadget.UpdateData, error) {
+func currentGadgetInfo(snapst *snapstate.SnapState) (*gadget.GadgetData, error) {
 	currentInfo, err := snapst.CurrentInfo()
 	if err != nil && err != snapstate.ErrNoCurrent {
 		return nil, err
@@ -886,10 +886,10 @@ func currentGadgetInfo(snapst *snapstate.SnapState) (*gadget.UpdateData, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &gadget.UpdateData{Info: gi, RootDir: currentInfo.MountDir()}, nil
+	return &gadget.GadgetData{Info: gi, RootDir: currentInfo.MountDir()}, nil
 }
 
-func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.UpdateData, error) {
+func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.GadgetData, error) {
 	info, err := snap.ReadInfo(snapsup.InstanceName(), snapsup.SideInfo)
 	if err != nil {
 		return nil, err
@@ -899,10 +899,10 @@ func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.UpdateData, error)
 	if err != nil {
 		return nil, err
 	}
-	return &gadget.UpdateData{Info: update, RootDir: info.MountDir()}, nil
+	return &gadget.GadgetData{Info: update, RootDir: info.MountDir()}, nil
 }
 
-func gadgetCurrentAndUpdate(st *state.State, snapsup *snapstate.SnapSetup) (current *gadget.UpdateData, update *gadget.UpdateData, err error) {
+func gadgetCurrentAndUpdate(st *state.State, snapsup *snapstate.SnapSetup) (current *gadget.GadgetData, update *gadget.GadgetData, err error) {
 	snapst, err := snapState(st, snapsup.InstanceName())
 	if err != nil {
 		return nil, nil, err

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -979,6 +979,8 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 		logger.Noticef("failed to remove gadget update rollback directory %q: %v", snapRollbackDir, err)
 	}
 
+	// TODO: consider having the option to do this early via recovery in
+	// core20, have fallback code as well there
 	st.RequestRestart(state.RestartSystem)
 
 	return nil

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -929,7 +929,7 @@ var (
 	gadgetUpdate = nopGadgetOp
 )
 
-func nopGadgetOp(current, update gadget.UpdateData, rollbackRootDir string) error {
+func nopGadgetOp(current, update gadget.GadgetData, rollbackRootDir string) error {
 	return nil
 }
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -872,24 +872,24 @@ func makeRollbackDir(name string) (string, error) {
 	return rollbackDir, nil
 }
 
-func currentGadgetInfo(snapst *snapstate.SnapState) (*gadget.Info, error) {
-	var gi *gadget.Info
-
+func currentGadgetInfo(snapst *snapstate.SnapState) (*gadget.UpdateData, error) {
 	currentInfo, err := snapst.CurrentInfo()
 	if err != nil && err != snapstate.ErrNoCurrent {
 		return nil, err
 	}
-	if currentInfo != nil {
-		const onClassic = false
-		gi, err = snap.ReadGadgetInfo(currentInfo, onClassic)
-		if err != nil {
-			return nil, err
-		}
+	if currentInfo == nil {
+		// no current yet
+		return nil, nil
 	}
-	return gi, nil
+	const onClassic = false
+	gi, err := snap.ReadGadgetInfo(currentInfo, onClassic)
+	if err != nil {
+		return nil, err
+	}
+	return &gadget.UpdateData{Info: gi, RootDir: currentInfo.MountDir()}, nil
 }
 
-func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.Info, error) {
+func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.UpdateData, error) {
 	info, err := snap.ReadInfo(snapsup.InstanceName(), snapsup.SideInfo)
 	if err != nil {
 		return nil, err
@@ -899,38 +899,37 @@ func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	return update, nil
+	return &gadget.UpdateData{Info: update, RootDir: info.MountDir()}, nil
 }
 
-func gadgetCurrentAndUpdate(st *state.State, snapsup *snapstate.SnapSetup) (current *gadget.Info, update *gadget.Info, err error) {
+func gadgetCurrentAndUpdate(st *state.State, snapsup *snapstate.SnapSetup) (current *gadget.UpdateData, update *gadget.UpdateData, err error) {
 	snapst, err := snapState(st, snapsup.InstanceName())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	currentInfo, err := currentGadgetInfo(snapst)
+	currentData, err := currentGadgetInfo(snapst)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if currentInfo == nil {
+	if currentData == nil {
 		// don't bother reading update if there is no current
 		return nil, nil, nil
 	}
 
-	newInfo, err := pendingGadgetInfo(snapsup)
+	newData, err := pendingGadgetInfo(snapsup)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return currentInfo, newInfo, nil
+	return currentData, newData, nil
 }
 
 var (
 	gadgetUpdate = nopGadgetOp
 )
 
-func nopGadgetOp(current, update *gadget.Info, rollbackRootDir string) error {
+func nopGadgetOp(current, update gadget.UpdateData, rollbackRootDir string) error {
 	return nil
 }
 
@@ -948,11 +947,11 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 		return err
 	}
 
-	current, update, err := gadgetCurrentAndUpdate(t.State(), snapsup)
+	currentData, updateData, err := gadgetCurrentAndUpdate(t.State(), snapsup)
 	if err != nil {
 		return err
 	}
-	if current == nil {
+	if currentData == nil {
 		// no updates during first boot & seeding
 		return nil
 	}
@@ -963,7 +962,7 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 	}
 
 	st.Unlock()
-	err = gadgetUpdate(current, update, snapRollbackDir)
+	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir)
 	st.Lock()
 	if err != nil {
 		if err == gadget.ErrNoUpdate {


### PR DESCRIPTION
#7087 without the patch that switches to `gadget.Update()`
