### PR TITLE
[sketch] UC20: cmd/snap-verify: sketch of snap-verify

### DIFF
--- a/cmd/snap-verify/assert_batch.go
+++ b/cmd/snap-verify/assert_batch.go
@@ -1,0 +1,210 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+// TODO: this is essentially a copy of assertstate.Batch, adjust and
+// move that properly for sharing to asserts !!!!
+// Try to merge Batch and accumFetcher as well.
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/snapcore/snapd/asserts"
+)
+
+// Batch allows to accumulate a set of assertions possibly out of prerequisite order and then add them in one go to an assertion database.
+type Batch struct {
+	bs         asserts.Backstore
+	refs       []*asserts.Ref
+	linearized []asserts.Assertion
+}
+
+// NewBatch creates a new Batch to accumulate assertions to add in one go to an assertion database.
+func NewBatch() *Batch {
+	return &Batch{
+		bs:         asserts.NewMemoryBackstore(),
+		refs:       nil,
+		linearized: nil,
+	}
+}
+
+func (b *Batch) committing() error {
+	if b.linearized != nil {
+		return fmt.Errorf("internal error: cannot add to Batch while committing")
+	}
+	return nil
+}
+
+// Add one assertion to the batch.
+func (b *Batch) Add(a asserts.Assertion) error {
+	if err := b.committing(); err != nil {
+		return err
+	}
+
+	if !a.SupportedFormat() {
+		return &asserts.UnsupportedFormatError{Ref: a.Ref(), Format: a.Format()}
+	}
+	if err := b.bs.Put(a.Type(), a); err != nil {
+		if revErr, ok := err.(*asserts.RevisionError); ok {
+			if revErr.Current >= a.Revision() {
+				// we already got something more recent
+				return nil
+			}
+		}
+		return err
+	}
+	b.refs = append(b.refs, a.Ref())
+	return nil
+}
+
+// AddStream adds a stream of assertions to the batch.
+// Returns references to to the assertions effectively added.
+func (b *Batch) AddStream(r io.Reader) ([]*asserts.Ref, error) {
+	if err := b.committing(); err != nil {
+		return nil, err
+	}
+
+	start := len(b.refs)
+	dec := asserts.NewDecoder(r)
+	for {
+		a, err := dec.Decode()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := b.Add(a); err != nil {
+			return nil, err
+		}
+	}
+	added := b.refs[start:]
+	if len(added) == 0 {
+		return nil, nil
+	}
+	refs := make([]*asserts.Ref, len(added))
+	copy(refs, added)
+	return refs, nil
+}
+
+func (b *Batch) commitTo(db *asserts.Database) error {
+	if err := b.linearize(db); err != nil {
+		return err
+	}
+
+	// TODO: trigger w. caller a global sanity check if something is revoked
+	// (but try to save as much possible still),
+	// or err is a check error
+	errs := commitTo(db, b.linearized)
+	if errs == nil {
+		return nil
+	}
+	// XXX proper commitError struct
+	return fmt.Errorf("cannot accept some assertions: %v", errs)
+}
+
+func (b *Batch) linearize(db *asserts.Database) error {
+	if b.linearized != nil {
+		return nil
+	}
+
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		a, err := b.bs.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
+		if asserts.IsNotFound(err) {
+			// fallback to pre-existing assertions
+			a, err = ref.Resolve(db.Find)
+		}
+		if err != nil {
+			return nil, findError("cannot find %s", ref, err)
+		}
+		return a, nil
+	}
+
+	// linearize using accumFetcher
+	f := newAccumFetcher(db, retrieve)
+	for _, ref := range b.refs {
+		if err := f.Fetch(ref); err != nil {
+			return err
+		}
+	}
+
+	b.linearized = f.fetched
+	return nil
+}
+
+// CommitTo adds the batch of assertions to the given assertion database.
+func (b *Batch) CommitTo(db *asserts.Database) error {
+	return b.commitTo(db)
+}
+
+/*// Precheck pre-checks whether adding the batch of assertions to the given assertion database should fully succeed.
+func (b *Batch) Precheck(db *asserts.Database) error {
+	db = db.WithStackedBackstore(asserts.NewMemoryBackstore())
+
+	return b.commitTo(db)
+}*/
+
+func findError(format string, ref *asserts.Ref, err error) error {
+	if asserts.IsNotFound(err) {
+		return fmt.Errorf(format, ref)
+	} else {
+		return fmt.Errorf(format+": %v", ref, err)
+	}
+}
+
+// helpers
+
+type accumFetcher struct {
+	asserts.Fetcher
+	fetched []asserts.Assertion
+}
+
+func newAccumFetcher(db *asserts.Database, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *accumFetcher {
+	f := &accumFetcher{}
+
+	save := func(a asserts.Assertion) error {
+		f.fetched = append(f.fetched, a)
+		return nil
+	}
+
+	f.Fetcher = asserts.NewFetcher(db, retrieve, save)
+
+	return f
+}
+
+func commitTo(db *asserts.Database, assertions []asserts.Assertion) (errs []error) {
+	for _, a := range assertions {
+		err := db.Add(a)
+		if asserts.IsUnaccceptedUpdate(err) {
+			if _, ok := err.(*asserts.UnsupportedFormatError); ok {
+				// we kept the old one, but log the issue
+				// logger.Noticef("Cannot update assertion: %v", err)
+			}
+			// be idempotent
+			// system db has already the same or newer
+			continue
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}

--- a/cmd/snap-verify/main.go
+++ b/cmd/snap-verify/main.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func run() error {
+	if len(os.Args) < 2 {
+		return fmt.Errorf("must specify recovery system directory")
+	}
+
+	rsys, err := newRecoverySystem(os.Args[1])
+	if err != nil {
+		return err
+	}
+
+	if err := rsys.loadAssertions(); err != nil {
+		return err
+	}
+
+	// TODO:
+	//  - verify base
+	//  - verify kernel
+	//  - do we need a way to cross check kernel snap vs extracted
+	//    kernel image?
+	// any other snaps? other snaps should be verified by snapd itself
+	// over install/seeding?
+
+	// verify gadget
+	if err := rsys.verifyGadget(); err != nil {
+		return err
+	}
+
+	fmt.Println("series:", rsys.model.Series())
+	fmt.Println("brand-id:", rsys.model.BrandID())
+	fmt.Println("model:", rsys.model.Model())
+	// TODO: other things to measure
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+
+	}
+}

--- a/cmd/snap-verify/system.go
+++ b/cmd/snap-verify/system.go
@@ -1,0 +1,239 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/sysdb"
+)
+
+type recoverySystem struct {
+	dir      string
+	snapsDir string
+
+	db *asserts.Database
+
+	model *asserts.Model
+
+	snapDeclsByID   map[string]*asserts.SnapDeclaration
+	snapDeclsByName map[string]*asserts.SnapDeclaration
+
+	snapRevsByID map[string]*asserts.SnapRevision
+}
+
+var trusted = sysdb.Trusted()
+
+func newRecoverySystem(dir string) (*recoverySystem, error) {
+	dir = filepath.Clean(dir)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   trusted,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &recoverySystem{
+		dir:      dir,
+		snapsDir: filepath.Join(filepath.Dir(filepath.Dir(dir)), "snaps"),
+		db:       db,
+	}, nil
+}
+
+// XXX with the new model assertion we will always have the snap-id
+func (s *recoverySystem) lookupVerifiedRevisionByName(snapName string) (snapPath string, snapRev *asserts.SnapRevision, snapDecl *asserts.SnapDeclaration, err error) {
+	snapDecl = s.snapDeclsByName[snapName]
+	if snapDecl == nil {
+		return "", nil, nil, fmt.Errorf("cannot find snap-declaration for snap name: %s", snapName)
+	}
+
+	return s.lookupVerifiedRevisionByID(snapDecl.SnapID())
+}
+
+func (s *recoverySystem) verifyGadget() error {
+	_, _, snapDecl, err := s.lookupVerifiedRevisionByName(s.model.Gadget())
+	if err != nil {
+		return err
+	}
+	if snapDecl.PublisherID() != s.model.BrandID() && snapDecl.PublisherID() != "canonical" {
+		return fmt.Errorf("gadget publisher must match the brand-id")
+	}
+
+	// TODO: hash is valid: open to verify type etc?
+	return nil
+}
+
+func (s *recoverySystem) lookupVerifiedRevisionByID(snapID string) (snapPath string, snapRev *asserts.SnapRevision, snapDecl *asserts.SnapDeclaration, err error) {
+	snapDecl = s.snapDeclsByID[snapID]
+	if snapDecl == nil {
+		return "", nil, nil, fmt.Errorf("cannot find snap-declaration for snap-id: %s", snapID)
+	}
+	snapRev = s.snapRevsByID[snapID]
+	if snapRev == nil {
+		return "", nil, nil, fmt.Errorf("cannot find snap-revision for snap-id: %s", snapID)
+	}
+
+	snapName := snapDecl.SnapName()
+	snapPath = filepath.Join(s.snapsDir, fmt.Sprintf("%s_%d.snap", snapName, snapRev.SnapRevision()))
+
+	fi, err := os.Stat(snapPath)
+	if err != nil {
+		// TODO: fallback search based on filesize, digest if not found?
+		return "", nil, nil, fmt.Errorf("cannot stat snap %q: %v", snapPath, err)
+	}
+
+	if fi.Size() != int64(snapRev.SnapSize()) {
+		return "", nil, nil, fmt.Errorf("cannot validate snap %q for snap %q (snap-id %q), wrong size", snapPath, snapName, snapID)
+	}
+
+	snapSHA3_384, _, err := asserts.SnapFileSHA3_384(snapPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	// TODO: temp cache for digests if we have size based fallbacks
+	if snapSHA3_384 != snapRev.SnapSHA3_384() {
+		return "", nil, nil, fmt.Errorf("cannot validate snap %q for snap %q (snap-id %q), hash mismatch with snap-revision", snapPath, snapName, snapID)
+
+	}
+
+	return snapPath, snapRev, snapDecl, nil
+}
+
+func (s *recoverySystem) loadAssertions() error {
+	// collect
+	var modelRef *asserts.Ref
+	var declRefs []*asserts.Ref
+	var revRefs []*asserts.Ref
+
+	batch := NewBatch()
+
+	modelPath := filepath.Join(s.dir, "model")
+	refs, err := readAsserts(batch, modelPath)
+	if err != nil {
+		return fmt.Errorf("cannot read model assertion: %v", err)
+	}
+	if len(refs) != 1 || refs[0].Type != asserts.ModelType {
+		return fmt.Errorf("cannot proceed, expected exactly one model assertion in: %s", modelPath)
+	}
+	modelRef = refs[0]
+
+	assertDir := filepath.Join(s.dir, "assertions")
+	dc, err := ioutil.ReadDir(assertDir)
+	if err != nil {
+		return fmt.Errorf("cannot read assertions dir: %s", err)
+	}
+	for _, fi := range dc {
+		fn := filepath.Join(assertDir, fi.Name())
+		refs, err := readAsserts(batch, fn)
+		if err != nil {
+			return fmt.Errorf("cannot read assertions: %s", err)
+		}
+		for _, ref := range refs {
+			switch ref.Type {
+			case asserts.ModelType:
+				// XXX for now, actually we don't want models outside of /model
+				if modelRef != nil && modelRef.Unique() != ref.Unique() {
+					return fmt.Errorf("cannot have more than one model assertion")
+				}
+			case asserts.SnapDeclarationType:
+				declRefs = append(declRefs, ref)
+			case asserts.SnapRevisionType:
+				revRefs = append(revRefs, ref)
+			}
+		}
+	}
+
+	db := s.db
+
+	// this also verifies the consistency of all of them
+	if err := batch.CommitTo(db); err != nil {
+		return err
+	}
+
+	find := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		a, err := ref.Resolve(db.Find)
+		if err != nil {
+			return nil, fmt.Errorf("internal error: cannot find just accepted assertion %v: %v", modelRef, err)
+		}
+		return a, nil
+	}
+
+	a, err := find(modelRef)
+	if err != nil {
+		return err
+	}
+	modelAssertion := a.(*asserts.Model)
+
+	snapDeclsByName := make(map[string]*asserts.SnapDeclaration)
+	snapDeclsByID := make(map[string]*asserts.SnapDeclaration)
+
+	for _, declRef := range declRefs {
+		a, err := find(declRef)
+		if err != nil {
+			return err
+		}
+		snapDecl := a.(*asserts.SnapDeclaration)
+		snapDeclsByName[snapDecl.SnapName()] = snapDecl
+		snapDeclsByID[snapDecl.SnapID()] = snapDecl
+	}
+
+	snapRevsByID := make(map[string]*asserts.SnapRevision)
+
+	for _, revRef := range revRefs {
+		a, err := find(revRef)
+		if err != nil {
+			return err
+		}
+		snapRevision := a.(*asserts.SnapRevision)
+		snapRevision1 := snapRevsByID[snapRevision.SnapID()]
+		if snapRevision1 != nil {
+			if snapRevision1.SnapRevision() != snapRevision.SnapRevision() {
+				return fmt.Errorf("cannot have multiple snap-revisions for the same snap-id: %s", snapRevision1.SnapID())
+			}
+		} else {
+			snapRevsByID[snapRevision.SnapID()] = snapRevision
+		}
+	}
+
+	// remember
+
+	s.model = modelAssertion
+	s.snapDeclsByID = snapDeclsByID
+	s.snapDeclsByName = snapDeclsByName
+	s.snapRevsByID = snapRevsByID
+
+	return nil
+}
+
+func readAsserts(batch *Batch, fn string) ([]*asserts.Ref, error) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return batch.AddStream(f)
+}


### PR DESCRIPTION
* it takes a path to a recovery system

* for now it verifies only the gadget and on success prints out
series/brand-id/model

* see XXX and TODOs, some open questions
  about doing an effort for "misnamed" snaps and
  what kind of verification to do for the kernel
  that exists as snap and extracted image
  both possibly in the recovery,
  or one in the boot and one in snap-data

* it illustrates the logic to go from:

snap-id(/snap-name) -> snap-declaration,snap-revision ->
snap file in snaps/

of which then we can verify the hash and go from there

*

assert_batch.go is just a tweaked copy of preexisting code that
needs to be moved out of assertstate when/before we get to do this for real