### PR TITLE
client,cmd/snap: stop depending on status/status-code in the JSON responses in client

### DIFF
--- a/client/aliases_test.go
+++ b/client/aliases_test.go
@@ -34,6 +34,7 @@ func (cs *clientSuite) TestClientAliasCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientAlias(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,
@@ -62,6 +63,7 @@ func (cs *clientSuite) TestClientUnaliasCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientUnalias(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,
@@ -89,6 +91,7 @@ func (cs *clientSuite) TestClientDisableAllAliasesCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientDisableAllAliases(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,
@@ -115,6 +118,7 @@ func (cs *clientSuite) TestClientRemoveManualAliasCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientRemoveManualAlias(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,
@@ -141,6 +145,7 @@ func (cs *clientSuite) TestClientPreferCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientPrefer(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,

--- a/client/apps.go
+++ b/client/apps.go
@@ -130,7 +130,7 @@ func (client *Client) Logs(names []string, opts LogOptions) (<-chan Log, error) 
 		if err := decodeInto(rsp.Body, &r); err != nil {
 			return nil, err
 		}
-		return nil, r.err(client)
+		return nil, r.err(client, rsp.StatusCode)
 	}
 
 	ch := make(chan Log, 20)

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -213,6 +213,7 @@ func (cs *clientSuite) TestClientLogsNotFound(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientServiceStart(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
 	type scenario struct {
@@ -274,6 +275,7 @@ func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientServiceStop(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
 	type tT struct {
@@ -335,6 +337,7 @@ func (cs *clientSuite) TestClientServiceStop(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientServiceRestart(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
 	type tT struct {

--- a/client/client.go
+++ b/client/client.go
@@ -262,12 +262,11 @@ func (client *Client) Hijack(f func(*http.Request) (*http.Response, error)) {
 // do performs a request and decodes the resulting json into the given
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.
-func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) error {
+func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (statusCode int, err error) {
 	retry := time.NewTicker(doRetry)
 	defer retry.Stop()
 	timeout := time.After(doTimeout)
 	var rsp *http.Response
-	var err error
 	for {
 		rsp, err = client.raw(method, path, query, headers, body)
 		if err == nil || method != "GET" {
@@ -281,17 +280,17 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 		break
 	}
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer rsp.Body.Close()
 
 	if v != nil {
 		if err := decodeInto(rsp.Body, v); err != nil {
-			return err
+			return rsp.StatusCode, err
 		}
 	}
 
-	return nil
+	return rsp.StatusCode, nil
 }
 
 func decodeInto(reader io.Reader, v interface{}) error {
@@ -313,10 +312,11 @@ func decodeInto(reader io.Reader, v interface{}) error {
 // which produces json.Numbers instead of float64 types for numbers.
 func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (*ResultInfo, error) {
 	var rsp response
-	if err := client.do(method, path, query, headers, body, &rsp); err != nil {
+	statusCode, err := client.do(method, path, query, headers, body, &rsp)
+	if err != nil {
 		return nil, err
 	}
-	if err := rsp.err(client); err != nil {
+	if err := rsp.err(client, statusCode); err != nil {
 		return nil, err
 	}
 	if rsp.Type != "sync" {
@@ -342,17 +342,17 @@ func (client *Client) doAsync(method, path string, query url.Values, headers map
 
 func (client *Client) doAsyncFull(method, path string, query url.Values, headers map[string]string, body io.Reader) (result json.RawMessage, changeID string, err error) {
 	var rsp response
-
-	if err := client.do(method, path, query, headers, body, &rsp); err != nil {
+	statusCode, err := client.do(method, path, query, headers, body, &rsp)
+	if err != nil {
 		return nil, "", err
 	}
-	if err := rsp.err(client); err != nil {
+	if err := rsp.err(client, statusCode); err != nil {
 		return nil, "", err
 	}
 	if rsp.Type != "async" {
 		return nil, "", fmt.Errorf("expected async response for %q on %q, got %q", method, path, rsp.Type)
 	}
-	if rsp.StatusCode != 202 {
+	if statusCode != 202 {
 		return nil, "", fmt.Errorf("operation not accepted")
 	}
 	if rsp.Change == "" {
@@ -392,11 +392,9 @@ func (client *Client) ServerVersion() (*ServerVersion, error) {
 // A response produced by the REST API will usually fit in this
 // (exceptions are the icons/ endpoints obvs)
 type response struct {
-	Result     json.RawMessage `json:"result"`
-	Status     string          `json:"status"`
-	StatusCode int             `json:"status-code"`
-	Type       string          `json:"type"`
-	Change     string          `json:"change"`
+	Result json.RawMessage `json:"result"`
+	Type   string          `json:"type"`
+	Change string          `json:"change"`
 
 	WarningCount     int       `json:"warning-count"`
 	WarningTimestamp time.Time `json:"warning-timestamp"`
@@ -524,7 +522,7 @@ type SysInfo struct {
 	SandboxFeatures map[string][]string `json:"sandbox-features,omitempty"`
 }
 
-func (rsp *response) err(cli *Client) error {
+func (rsp *response) err(cli *Client, statusCode int) error {
 	if cli != nil {
 		maintErr := rsp.Maintenance
 		// avoid setting to (*client.Error)(nil)
@@ -540,9 +538,9 @@ func (rsp *response) err(cli *Client) error {
 	var resultErr Error
 	err := json.Unmarshal(rsp.Result, &resultErr)
 	if err != nil || resultErr.Message == "" {
-		return fmt.Errorf("server error: %q", rsp.Status)
+		return fmt.Errorf("server error: %q", http.StatusText(statusCode))
 	}
-	resultErr.StatusCode = rsp.StatusCode
+	resultErr.StatusCode = statusCode
 
 	return &resultErr
 }
@@ -558,7 +556,7 @@ func parseError(r *http.Response) error {
 		return fmt.Errorf("cannot unmarshal error: %v", err)
 	}
 
-	err := rsp.err(nil)
+	err := rsp.err(nil, r.StatusCode)
 	if err == nil {
 		return fmt.Errorf("server error: %q", r.Status)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -105,7 +105,7 @@ func (cs *clientSuite) TestNewPanics(c *C) {
 
 func (cs *clientSuite) TestClientDoReportsErrors(c *C) {
 	cs.err = errors.New("ouchie")
-	err := cs.cli.Do("GET", "/", nil, nil, nil)
+	_, err := cs.cli.Do("GET", "/", nil, nil, nil)
 	c.Check(err, ErrorMatches, "cannot communicate with server: ouchie")
 	if cs.doCalls < 2 {
 		c.Fatalf("do did not retry")
@@ -116,8 +116,25 @@ func (cs *clientSuite) TestClientWorks(c *C) {
 	var v []int
 	cs.rsp = `[1,2]`
 	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	err := cs.cli.Do("GET", "/this", nil, reqBody, &v)
+	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v)
 	c.Check(err, IsNil)
+	c.Check(statusCode, Equals, 200)
+	c.Check(v, DeepEquals, []int{1, 2})
+	c.Assert(cs.req, NotNil)
+	c.Assert(cs.req.URL, NotNil)
+	c.Check(cs.req.Method, Equals, "GET")
+	c.Check(cs.req.Body, Equals, reqBody)
+	c.Check(cs.req.URL.Path, Equals, "/this")
+}
+
+func (cs *clientSuite) TestClientUnderstandsStatusCode(c *C) {
+	var v []int
+	cs.status = 202
+	cs.rsp = `[1,2]`
+	reqBody := ioutil.NopCloser(strings.NewReader(""))
+	statusCode, err := cs.cli.Do("GET", "/this", nil, reqBody, &v)
+	c.Check(err, IsNil)
+	c.Check(statusCode, Equals, 202)
 	c.Check(v, DeepEquals, []int{1, 2})
 	c.Assert(cs.req, NotNil)
 	c.Assert(cs.req.URL, NotNil)
@@ -131,7 +148,7 @@ func (cs *clientSuite) TestClientDefaultsToNoAuthorization(c *C) {
 	defer os.Unsetenv(client.TestAuthFileEnvKey)
 
 	var v string
-	_ = cs.cli.Do("GET", "/this", nil, nil, &v)
+	_, _ = cs.cli.Do("GET", "/this", nil, nil, &v)
 	c.Assert(cs.req, NotNil)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, "")
@@ -149,7 +166,7 @@ func (cs *clientSuite) TestClientSetsAuthorization(c *C) {
 	c.Assert(err, IsNil)
 
 	var v string
-	_ = cs.cli.Do("GET", "/this", nil, nil, &v)
+	_, _ = cs.cli.Do("GET", "/this", nil, nil, &v)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, `Macaroon root="macaroon", discharge="discharge"`)
 }
@@ -168,7 +185,7 @@ func (cs *clientSuite) TestClientHonorsDisableAuth(c *C) {
 	var v string
 	cli := client.New(&client.Config{DisableAuth: true})
 	cli.SetDoer(cs)
-	_ = cli.Do("GET", "/this", nil, nil, &v)
+	_, _ = cli.Do("GET", "/this", nil, nil, &v)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, "")
 }
@@ -177,13 +194,13 @@ func (cs *clientSuite) TestClientHonorsInteractive(c *C) {
 	var v string
 	cli := client.New(&client.Config{Interactive: false})
 	cli.SetDoer(cs)
-	_ = cli.Do("GET", "/this", nil, nil, &v)
+	_, _ = cli.Do("GET", "/this", nil, nil, &v)
 	interactive := cs.req.Header.Get(client.AllowInteractionHeader)
 	c.Check(interactive, Equals, "")
 
 	cli = client.New(&client.Config{Interactive: true})
 	cli.SetDoer(cs)
-	_ = cli.Do("GET", "/this", nil, nil, &v)
+	_, _ = cli.Do("GET", "/this", nil, nil, &v)
 	interactive = cs.req.Header.Get(client.AllowInteractionHeader)
 	c.Check(interactive, Equals, "true")
 }
@@ -318,10 +335,10 @@ func (cs *clientSuite) TestSnapClientIntegration(c *C) {
 }
 
 func (cs *clientSuite) TestClientReportsOpError(c *C) {
-	cs.status = 502
+	cs.status = 500
 	cs.rsp = `{"type": "error"}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, ErrorMatches, `.*server error: "Bad Gateway"`)
+	c.Check(err, ErrorMatches, `.*server error: "Internal Server Error"`)
 }
 
 func (cs *clientSuite) TestClientReportsOpErrorStr(c *C) {
@@ -466,7 +483,7 @@ func (cs *clientSuite) TestUserAgent(c *C) {
 	cli.SetDoer(cs)
 
 	var v string
-	_ = cli.Do("GET", "/", nil, nil, &v)
+	_, _ = cli.Do("GET", "/", nil, nil, &v)
 	c.Assert(cs.req, NotNil)
 	c.Check(cs.req.Header.Get("User-Agent"), Equals, "some-agent/9.87")
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -318,12 +318,14 @@ func (cs *clientSuite) TestSnapClientIntegration(c *C) {
 }
 
 func (cs *clientSuite) TestClientReportsOpError(c *C) {
-	cs.rsp = `{"type": "error", "status": "potatoes"}`
+	cs.status = 502
+	cs.rsp = `{"type": "error"}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, ErrorMatches, `.*server error: "potatoes"`)
+	c.Check(err, ErrorMatches, `.*server error: "Bad Gateway"`)
 }
 
 func (cs *clientSuite) TestClientReportsOpErrorStr(c *C) {
+	cs.status = 400
 	cs.rsp = `{
 		"result": {},
 		"status": "Bad Request",
@@ -368,6 +370,7 @@ func (cs *clientSuite) TestClientMaintenance(c *C) {
 }
 
 func (cs *clientSuite) TestClientAsyncOpMaintenance(c *C) {
+	cs.status = 202
 	cs.rsp = `{"type":"async", "status-code": 202, "change": "42", "maintenance": {"kind": "system-restart", "message": "system is restarting"}}`
 	_, err := cs.cli.Install("foo", nil)
 	c.Assert(err, IsNil)

--- a/client/conf_test.go
+++ b/client/conf_test.go
@@ -46,6 +46,7 @@ func (cs *clientSuite) TestClientGetConfCallsEndpointMultipleKeys(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientSetConf(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
 		"status-code": 202,

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -32,7 +32,9 @@ func (client *Client) SetDoer(d doer) {
 
 // Do does do.
 func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
-	return client.do(method, path, query, nil, body, v)
+	// XXX return and test status code
+	_, err := client.do(method, path, query, nil, body, v)
+	return err
 }
 
 // expose parseError for testing

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -31,10 +31,8 @@ func (client *Client) SetDoer(d doer) {
 }
 
 // Do does do.
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
-	// XXX return and test status code
-	_, err := client.do(method, path, query, nil, body, v)
-	return err
+func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) (statusCode int, err error) {
+	return client.do(method, path, query, nil, body, v)
 }
 
 // expose parseError for testing

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -163,6 +163,7 @@ func (cs *clientSuite) TestClientConnectCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientConnect(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,
@@ -200,6 +201,7 @@ func (cs *clientSuite) TestClientDisconnectCallsEndpoint(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientDisconnect(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
                 "status-code": 202,

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -33,6 +33,7 @@ func (cs *clientSuite) TestClientRemodelEndpoint(c *C) {
 }
 
 func (cs *clientSuite) TestClientRemodel(c *C) {
+	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
 		"status-code": 202,

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -77,21 +77,23 @@ func (cs *clientSuite) TestClientMultiOpSnapServerError(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpSnapResponseError(c *check.C) {
-	cs.rsp = `{"type": "error", "status": "potatoes"}`
+	cs.status = 400
+	cs.rsp = `{"type": "error"}`
 	for _, s := range ops {
 		_, err := s.op(cs.cli, pkgName, nil)
-		c.Check(err, check.ErrorMatches, `.*server error: "potatoes"`, check.Commentf(s.action))
+		c.Check(err, check.ErrorMatches, `.*server error: "Bad Request"`, check.Commentf(s.action))
 	}
 }
 
 func (cs *clientSuite) TestClientMultiOpSnapResponseError(c *check.C) {
-	cs.rsp = `{"type": "error", "status": "potatoes"}`
+	cs.status = 500
+	cs.rsp = `{"type": "error"}`
 	for _, s := range multiOps {
 		_, err := s.op(cs.cli, nil, nil)
-		c.Check(err, check.ErrorMatches, `.*server error: "potatoes"`, check.Commentf(s.action))
+		c.Check(err, check.ErrorMatches, `.*server error: "Internal Server Error"`, check.Commentf(s.action))
 	}
 	_, _, err := cs.cli.SnapshotMany(nil, nil)
-	c.Check(err, check.ErrorMatches, `.*server error: "potatoes"`)
+	c.Check(err, check.ErrorMatches, `.*server error: "Internal Server Error"`)
 }
 
 func (cs *clientSuite) TestClientOpSnapBadType(c *check.C) {
@@ -114,6 +116,7 @@ func (cs *clientSuite) TestClientOpSnapNotAccepted(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpSnapNoChange(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"status-code": 202,
 		"type": "async"
@@ -125,6 +128,7 @@ func (cs *clientSuite) TestClientOpSnapNoChange(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpSnap(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "d728",
 		"status-code": 202,
@@ -151,6 +155,7 @@ func (cs *clientSuite) TestClientOpSnap(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientMultiOpSnap(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "d728",
 		"status-code": 202,
@@ -179,6 +184,7 @@ func (cs *clientSuite) TestClientMultiOpSnap(c *check.C) {
 
 func (cs *clientSuite) TestClientMultiSnapshot(c *check.C) {
 	// Note body is essentially the same as TestClientMultiOpSnap; keep in sync
+	cs.status = 202
 	cs.rsp = `{
                 "result": {"set-id": 42},
 		"change": "d728",
@@ -203,6 +209,7 @@ func (cs *clientSuite) TestClientMultiSnapshot(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "66b3",
 		"status-code": 202,
@@ -230,6 +237,7 @@ func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpInstallPathInstance(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "66b3",
 		"status-code": 202,
@@ -258,6 +266,7 @@ func (cs *clientSuite) TestClientOpInstallPathInstance(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "66b3",
 		"status-code": 202,
@@ -294,6 +303,7 @@ func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientOpInstallUnaliased(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "66b3",
 		"status-code": 202,
@@ -344,6 +354,7 @@ func formToMap(c *check.C, mr *multipart.Reader) map[string]string {
 }
 
 func (cs *clientSuite) TestClientOpTryMode(c *check.C) {
+	cs.status = 202
 	cs.rsp = `{
 		"change": "66b3",
 		"status-code": 202,

--- a/client/snapshot_test.go
+++ b/client/snapshot_test.go
@@ -94,6 +94,7 @@ func (cs *clientSuite) TestClientSnapshotSets(c *check.C) {
 }
 
 func (cs *clientSuite) testClientSnapshotActionFull(c *check.C, action string, users []string, f func() (string, error)) {
+	cs.status = 202
 	cs.rsp = `{
 		"status-code": 202,
 		"type": "async",

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -55,6 +55,7 @@ func (s *SnapSuite) TestAlias(c *C) {
 				"app":    "cmd1",
 				"alias":  "alias1",
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -80,6 +80,7 @@ func (s *SnapSuite) TestConnectExplicitEverything(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
@@ -113,6 +114,7 @@ func (s *SnapSuite) TestConnectExplicitPlugImplicitSlot(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
@@ -146,6 +148,7 @@ func (s *SnapSuite) TestConnectImplicitPlugExplicitSlot(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
@@ -179,6 +182,7 @@ func (s *SnapSuite) TestConnectImplicitPlugImplicitSlot(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -73,6 +73,7 @@ func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
@@ -108,6 +109,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
@@ -143,6 +145,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnapPlugOrSlot(c *C) {
 					},
 				},
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -52,6 +52,7 @@ func (s *SnapSuite) TestPrefer(c *C) {
 				"action": "prefer",
 				"snap":   "some-snap",
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -117,6 +117,7 @@ func (s *snapSetSuite) mockSetConfigServer(c *check.C, expectedValue interface{}
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 				"key": expectedValue,
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 			s.setConfApiCalls += 1
 		case "/v2/changes/zzz":

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 type snapSetSuite struct {
-	SnapSuite
+	BaseSnapSuite
 
 	setConfApiCalls int
 }
@@ -38,7 +38,7 @@ type snapSetSuite struct {
 var _ = check.Suite(&snapSetSuite{})
 
 func (s *snapSetSuite) SetUpTest(c *check.C) {
-	s.SnapSuite.SetUpTest(c)
+	s.BaseSnapSuite.SetUpTest(c)
 	s.setConfApiCalls = 0
 }
 

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -102,6 +102,7 @@ func (s *SnapSuite) mockSnapshotsServer(c *C) {
 				}
 				fmt.Fprintf(w, `{"type":"sync","status-code":200,"status":"OK","result":[{"id":1,"snapshots":[{"set":1,"time":%q,"snap":"htop","revision":"1168","snap-id":"Z","epoch":{"read":[0],"write":[0]},"summary":"","version":"2","sha3-384":{"archive.tgz":""},"size":1}]}]}`, snapshotTime)
 			} else {
+				w.WriteHeader(202)
 				fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "9"}`)
 			}
 		case "/v2/changes/9":

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -53,6 +53,7 @@ func (s *SnapSuite) TestUnalias(c *C) {
 				"snap":   "alias1",
 				"alias":  "alias1",
 			})
+			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")


### PR DESCRIPTION
This is mostly a conceptual cleanup, client can access the HTTP status code, no need to get it from the JSON.
