### PR TITLE
configstate/config: fix crash in purgeNulls

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -67,6 +67,9 @@ func purgeNulls(config interface{}) interface{} {
 			}
 		}
 	case *json.RawMessage:
+		if config == nil {
+			return nil
+		}
 		var configm interface{}
 		if err := jsonutil.DecodeWithNumber(bytes.NewReader(*config), &configm); err != nil {
 			panic(fmt.Errorf("internal error: cannot unmarshal configuration: %v", err))

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -280,3 +280,36 @@ func (s *configHelpersSuite) TestPurgeNulls(c *C) {
 		},
 	})
 }
+
+func (s *configHelpersSuite) TestPurgeNullsTopLevelNull(c *C) {
+	cfgJSON := `{
+  "experimental": {
+    "parallel-instances": true,
+    "snapd-snap": true
+  },
+  "proxy": null,
+  "seed": {
+    "loaded": true
+  }
+}`
+	var cfg map[string]*json.RawMessage
+	err := jsonutil.DecodeWithNumber(bytes.NewReader([]byte(cfgJSON)), &cfg)
+	c.Assert(err, IsNil)
+
+	config.PurgeNulls(cfg)
+
+	cfgJSON2, err := json.Marshal(cfg)
+	c.Assert(err, IsNil)
+
+	var out interface{}
+	jsonutil.DecodeWithNumber(bytes.NewReader(cfgJSON2), &out)
+	c.Check(out, DeepEquals, map[string]interface{}{
+		"experimental": map[string]interface{}{
+			"parallel-instances": true,
+			"snapd-snap":         true,
+		},
+		"seed": map[string]interface{}{
+			"loaded": true,
+		},
+	})
+}

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -265,4 +265,18 @@ func (s *configHelpersSuite) TestPurgeNulls(c *C) {
 		},
 		"baz": map[string]interface{}{},
 	})
+
+	sub := json.RawMessage(`{"foo":"bar"}`)
+	cfg5 := map[string]interface{}{
+		"core": map[string]*json.RawMessage{
+			"proxy": nil,
+			"sub":   &sub,
+		},
+	}
+	config.PurgeNulls(cfg5)
+	c.Check(cfg5, DeepEquals, map[string]interface{}{
+		"core": map[string]*json.RawMessage{
+			"sub": &sub,
+		},
+	})
 }


### PR DESCRIPTION
In my system I had a configuration like:
```
{
  "experimental": {
    "parallel-instances": true,
    "snapd-snap": true
  },
  "proxy": null,
  "seed": {
    "loaded": true
  }
}
```
which lead to a crash on startup of master.

This PR fixes this crash.