### PR TITLE
tests: switch mount-ns test to manual

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -1,5 +1,9 @@
 summary: The shape of the mount namespace on classic systems for non-classic snaps
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-core-16-64, ubuntu-core-18-64]
+# The test itself works perfectly fine but in conjunction with our leaky test
+# suite it often fails because it detects cruft left over by other tests in a
+# way that was not detected before.
+manual: true
 # The test is sensitive to backend type, which designates the used image.
 # Backends are enabled one-by-one along with the matching data set.
 backends: [google]


### PR DESCRIPTION
The test captures too much broken tests. We should iterate, off-master,
to address the leaky tests, before re-enabling this one.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
