### PR TITLE
tests: remove local revision of core

### DIFF
--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -15,3 +15,6 @@ execute: |
     echo "Ensure the dbus service file got created"
     test -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service
     diff -u /usr/share/dbus-1/services/io.snapcraft.Launcher.service.orig /usr/share/dbus-1/services/io.snapcraft.Launcher.service
+restore: |
+    snap revert core
+    snap remove --revision=x1 core

--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -16,5 +16,10 @@ execute: |
     test -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service
     diff -u /usr/share/dbus-1/services/io.snapcraft.Launcher.service.orig /usr/share/dbus-1/services/io.snapcraft.Launcher.service
 restore: |
-    snap revert core
-    snap remove --revision=x1 core
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    # Remove the locale revision of core, if we installed one.
+    if [ "$(readlink "$SNAP_MOUNT_DIR/core/current")" = x1 ]; then
+        snap revert core
+        snap remove --revision=x1 core
+    fi


### PR DESCRIPTION
The snap-userd-reexec test re-installs the current revision of core to
measure some re-execution logic. It does not clean up after itself.
This patch fixes this by reverting core and removing the x1 revision.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
