### PR TITLE
tests: unmount leftover /run/netns

### DIFF
--- a/tests/main/interfaces-network-control-ip-netns/task.yaml
+++ b/tests/main/interfaces-network-control-ip-netns/task.yaml
@@ -41,3 +41,4 @@ restore: |
     # If this doesn't work maybe it is because the test didn't execute correctly
     snapd-hacker-toolbelt.busybox sh -c '/bin/ip netns delete canary' 2>/dev/null || true
     ip netns delete canary 2>/dev/null || true
+    umount /run/netns || true

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -44,6 +44,7 @@ restore: |
 
     ip netns delete test-ns || true
     ip link delete veth0 || true
+    umount /run/netns || true
 
 execute: |
     #shellcheck source=tests/lib/network.sh


### PR DESCRIPTION
Tests that use the network namespace with the help of the 'ip netns'
tool must clean up the left-over /run/netns mount point. This patch
fixes two more offenders.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
