### PR TITLE
packaging/debian-sid: merge debian upload changes back into master

### DIFF
--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -2,7 +2,7 @@ snapd (2.40-1) unstable; urgency=medium
 
   * New upstream release.
 
- -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 12 Jul 2019 10:40:08 +0200
+ -- Michael Vogt <mvo@debian.org>  Tue, 23 Jul 2019 15:38:36 +0200
 
 snapd (2.39.3-1) unstable; urgency=medium
 
@@ -24,23 +24,39 @@ snapd (2.39.2-1) unstable; urgency=medium
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Wed, 05 Jun 2019 08:46:14 +0200
 
+snapd (2.39-1) unstable; urgency=medium
+
+   * New upstream release
+   * d/patches0008-snap-squashsh-skip-TestBuildDate-on-Debian.patch: drop,
+     fixed upstream
+
+ -- Zygmunt Krynicki <me@zygoon.pl>  Thu, 28 Feb 2019 18:21:26 +0100
+
 snapd (2.39.1-1) unstable; urgency=medium
 
   * New upstream release
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Wed, 29 May 2019 12:08:43 +0200
 
-snapd (2.39-1) unstable; urgency=medium
-
-  * New upstream release
-
- -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 03 May 2019 11:55:23 +0200
-
 snapd (2.38-1) unstable; urgency=medium
 
   * New upstream release
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Thu, 21 Mar 2019 11:02:04 +0100
+
+snapd (2.37.4-1) unstable; urgency=medium
+
+  * New upstream release
+  * d/patches0008-snap-squashsh-skip-TestBuildDate-on-Debian.patch: drop,
+    fixed upstream
+
+ -- Zygmunt Krynicki <me@zygoon.pl>  Thu, 28 Feb 2019 18:21:26 +0100
+
+snapd (2.37.3-1) unstable; urgency=medium
+
+  * New upstream release
+
+ -- Zygmunt Krynicki <me@zygoon.pl>  Tue, 19 Feb 2019 13:46:24 +0100
 
 snapd (2.37.2-1) unstable; urgency=medium
 

--- a/packaging/debian-sid/gbp.conf
+++ b/packaging/debian-sid/gbp.conf
@@ -1,3 +1,4 @@
 [DEFAULT]
 debian-branch = debian
 export-dir = ../build-area
+upstream-tag = %(version)s


### PR DESCRIPTION
We released 2.40 into debian today and this PR merges the changes back into our tree.