### PR TITLE
tests: remove locally installed core in more tests

### DIFF
--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -6,6 +6,12 @@ systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 restore: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
+
+    # Remove the locale revision of core, if we installed one.
+    if [ "$(readlink "$SNAP_MOUNT_DIR/core/current")" = x1 ]; then
+        snap revert core
+        snap remove --revision=x1 core
+    fi
     # extra cleanup in case something in this test went wrong
     rm -f /etc/systemd/system/snapd.service.d/no-reexec.conf
     systemctl stop snapd.service snapd.socket

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -37,6 +37,13 @@ prepare: |
 restore: |
     rm -rf squashfs-root
     rm -f core-customized.snap
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB"/dirs.sh
+    # Remove the locale revision of core, if we installed one.
+    if [ "$(readlink "$SNAP_MOUNT_DIR/core/current")" = x1 ]; then
+        snap revert core
+        snap remove --revision=x1 core
+    fi
 
 execute: |
     # Start a "sleep" process in the background


### PR DESCRIPTION
Two more tests were installing a local revision of core.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
