### PR TITLE
test: enable and run mount-ns test as last

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -1,12 +1,9 @@
 summary: The shape of the mount namespace on classic systems for non-classic snaps
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-core-16-64, ubuntu-core-18-64]
-# The test itself works perfectly fine but in conjunction with our leaky test
-# suite it often fails because it detects cruft left over by other tests in a
-# way that was not detected before.
-manual: true
 # The test is sensitive to backend type, which designates the used image.
 # Backends are enabled one-by-one along with the matching data set.
 backends: [google]
+priority: -1000
 details: |
     This test measures the mount table of the host, of the mount namespace for
     a simple core16-based snap for the per-user mount namespace of a simple


### PR DESCRIPTION
Given that we have some confidence that tests don't leak mount resources
anymore, we can now run the mount namespace measurement test as the last
one in the group. This way if something does misbehave and "cruft"
accumulates in the host mount namespace the test will be able to capture
that. This approach can be contrasted with running the test first, where
it would surely pass but not have the effect of spotting tests that
clobber the environment.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
