### PR TITLE
tests: restore cpuset clone_children clobbered by lxd

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -31,6 +31,9 @@ restore: |
     lxd.lxc stop my-ubuntu --force
     lxd.lxc delete my-ubuntu
 
+    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
+    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+
 debug: |
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -18,6 +18,9 @@ restore: |
     setenforce "$(cat enforcing.mode)"
     rm -f stamp enforcing.mode
 
+    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
+    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+
 execute: |
     snap install lxd
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -58,6 +58,9 @@ restore: |
 
     snap remove lxd
 
+    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
+    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+
 execute: |
     # Run python0 with a hello.py script and redirect the logs to /var/lib/test/hello.log
     # Run the script as a regular user for extra (lower) permissions.


### PR DESCRIPTION
The testbed-tool reported deviation on Ubuntu 18.04 was:

    -21 18 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,cpuset
    +21 18 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,cpuset,clone_children

Internally LXD + LXC enable the clone_children property on the cpuset
controller but nothing removes this change on LXD removal. This patch
fixes this.

Corresponding code in LXC:
https://github.com/lxc/lxc/blob/113ca429334073af2a969ded6f143065660c19d3/src/lxc/cgroups/cgfsng.c#L569

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
