### PR TITLE
cmd/Makefile.am: support building with the go snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cmd/snap-confine/unit-tests
 cmd/snap-discard-ns/snap-discard-ns
 cmd/snap-gdb-shim/snap-gdb-shim
 cmd/snap-mgmt/snap-mgmt
+cmd/snap-seccomp/snap-seccomp
 cmd/snap-update-ns/snap-update-ns
 cmd/snap-update-ns/unit-tests
 cmd/snapd-env-generator/snapd-env-generator

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -93,9 +93,9 @@ hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-up
 
 # for the hack target also:
 snap-update-ns/snap-update-ns: snap-update-ns/*.go snap-update-ns/*.[ch]
-	cd snap-update-ns && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -i -v
+	cd snap-update-ns && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -v
 snap-seccomp/snap-seccomp: snap-seccomp/*.go
-	cd snap-seccomp && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -i -v
+	cd snap-seccomp && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -v
 
 ##
 ## libsnap-confine-private.a


### PR DESCRIPTION
* gitignore: ignore snap-seccomp/snap-seccomp
* cmd/Makefile.am: don't use -i option

This lets one run `make hack` with a go snap which is read-only. See for example this failure:
```
$ make hack
cd snap-seccomp && GOPATH=/home/$USER/go go build -i -v
github.com/snapcore/snapd/cmd/snap-seccomp/syscalls
runtime/cgo
github.com/snapcore/snapd/osutil/sys
github.com/snapcore/snapd/vendor/gopkg.in/yaml.v2
github.com/snapcore/snapd/vendor/gopkg.in/tomb.v2
github.com/snapcore/snapd/strutil
go build runtime/cgo: open /snap/go/3133/pkg/linux_amd64/runtime/cgo.a: read-only file system
make: *** [Makefile:4097: snap-seccomp/snap-seccomp] Error 1
$ go version
go version go1.10.8 linux/amd64
$ snap info go | grep installed
installed:        1.10.8                   (3133) 58MB classic
$ which go
/snap/bin/go
$
```