### PR TITLE
tests: improve how the system is restored when the upgrade-from-2.15 test fails

### DIFF
--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -3,14 +3,18 @@ summary: Ensure upgrades from snapd 2.15 work
 systems: [ubuntu-16.04-64]
 
 prepare: |
-    dpkg --purge snapd
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    distro_purge_package snapd
 
 restore: |
-    # Just remove when it was installed
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
     if [ -e old_install_done ]; then
-        dpkg --purge snapd ubuntu-core-launcher snap-confine
+        echo "Ensure core is gone and we have ubuntu-core instead"
+        distro_purge_package snapd
     fi
-    apt install -y "${GOHOME}"/snapd_*.deb
+    distro_install_build_snapd
 
 execute: |
     #shellcheck source=tests/lib/systemd.sh

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -6,7 +6,11 @@ prepare: |
     dpkg --purge snapd
 
 restore: |
-    dpkg --purge ubuntu-core-launcher snap-confine
+    # Just remove when it was installed
+    if [ -e old_install_done ]; then
+        dpkg --purge snapd ubuntu-core-launcher snap-confine
+    fi
+    apt install -y "${GOHOME}"/snapd_*.deb
 
 execute: |
     #shellcheck source=tests/lib/systemd.sh
@@ -18,6 +22,9 @@ execute: |
     wget https://launchpad.net/ubuntu/+source/snapd/2.15.2ubuntu1/+build/10939171/+files/snapd_2.15.2ubuntu1_amd64.deb
     echo "Install snapd 2.15.2"
     apt install -y ./ubuntu-core-launcher_1.0.38-0ubuntu0.16.04.8_amd64.deb ./snap-confine_1.0.38-0ubuntu0.16.04.8_amd64.deb ./snapd_2.15.2ubuntu1_amd64.deb
+
+    echo "Installation completed"
+    touch old_install_done
 
     echo "install a service snap and check its active"
     snap install go-example-webserver


### PR DESCRIPTION
This fix is to make sure when the upgrade-from-2.15 test fails the
systems restores snapd and its dependencies properly.

To reproduce the error it is needed to add an "exit 1" at the begining
of the execution part, and the after this test failure all the following
tests will fail as well.

This fix was tested making the test fail before the old snapd is
installed and after that as well.

See this log as an example of the issue: https://api.travis-ci.org/v3/job/563445228/log.txt
