### PR TITLE
tests: work around classic snap affecting the host

### DIFF
--- a/tests/main/ubuntu-core-classic/task.yaml
+++ b/tests/main/ubuntu-core-classic/task.yaml
@@ -14,6 +14,9 @@ prepare: |
 
 restore: |
     rm -f /etc/sudoers.d/create-test
+    # Undo the change done by the classic snap.
+    # FIXME: https://github.com/snapcore/classic-snap/issues/32
+    mount devpts -t devpts /dev/pts -o remount,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000
 
 execute: |
     echo "Ensure classic can be installed"

--- a/tests/main/ubuntu-core-classic/task.yaml
+++ b/tests/main/ubuntu-core-classic/task.yaml
@@ -16,7 +16,9 @@ restore: |
     rm -f /etc/sudoers.d/create-test
     # Undo the change done by the classic snap.
     # FIXME: https://github.com/snapcore/classic-snap/issues/32
-    mount devpts -t devpts /dev/pts -o remount,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000
+    if [ "$(mountinfo-tool /dev/pts .sb_opts)" = "rw,mode=666,ptmxmode=666" ]; then
+        mount devpts -t devpts /dev/pts -o remount,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000
+    fi
 
 execute: |
     echo "Ensure classic can be installed"


### PR DESCRIPTION
The classic snap somehow ends up changing /dev/pts on the host. My hunch
is because it can mount anything and it actually _remounts_ an existing
mount point rather than mounting something new, therefore the
propagation settings don't protect us from this.

The bug is filed as https://github.com/snapcore/classic-snap/issues/32

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
