### PR TITLE
overlord/configstate/configcore: allow setting start_x=1 to enable CSI camera on RPi

### DIFF
--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -54,6 +54,7 @@ var piConfigKeys = map[string]bool{
 	"sdtv_aspect":              true,
 	"config_hdmi_boost":        true,
 	"hdmi_force_hotplug":       true,
+	"start_x":                  true,
 }
 
 func init() {


### PR DESCRIPTION
allow setting start_x=1 which enables the CSI interface for the RPi camera in the firmware

To enable a locally attached Pi camera start_x=1 needs to be set in config.txt, this makes the bootloader turn on the CSI interface in the firmware. Add an option for ```snap set  system start_x=1```