### PR TITLE
gadget: effective structure role fallback, extra tests

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -138,6 +138,10 @@ func (vs *VolumeStructure) EffectiveRole() string {
 	if vs.Role == "" && vs.Type == MBR {
 		return MBR
 	}
+	if vs.Label == SystemBoot {
+		// for gadgets that only specify a filesystem-label, eg. pc
+		return SystemBoot
+	}
 	return ""
 }
 

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1175,3 +1175,23 @@ func (s *gadgetTestSuite) TestEffectiveRole(c *C) {
 	vs = gadget.VolumeStructure{Role: "", Label: gadget.SystemData}
 	c.Check(vs.EffectiveRole(), Equals, "")
 }
+
+func (s *gadgetTestSuite) TestEffectiveFilesystemLabel(c *C) {
+	// no label, and no role set
+	vs := gadget.VolumeStructure{Role: ""}
+	c.Check(vs.EffectiveFilesystemLabel(), Equals, "")
+
+	// explicitly set label
+	vs = gadget.VolumeStructure{Label: "my-label"}
+	c.Check(vs.EffectiveFilesystemLabel(), Equals, "my-label")
+
+	// inferred based on role
+	vs = gadget.VolumeStructure{Role: gadget.SystemData, Label: "unused-label"}
+	c.Check(vs.EffectiveFilesystemLabel(), Equals, gadget.ImplicitSystemDataLabel)
+	vs = gadget.VolumeStructure{Role: gadget.SystemData}
+	c.Check(vs.EffectiveFilesystemLabel(), Equals, gadget.ImplicitSystemDataLabel)
+
+	// only system-data role is special
+	vs = gadget.VolumeStructure{Role: gadget.SystemBoot}
+	c.Check(vs.EffectiveFilesystemLabel(), Equals, "")
+}


### PR DESCRIPTION
Enhance effective role handling with a fallback path for gadget YAMLs that are underspecified. eg. `pc`, which does not set a role for `EFI System`, but the actual role is `system-boot`, see:
```
volumes:
  pc:
    bootloader: grub
    structure:
      - name: mbr
        type: mbr
        size: 440
        content:
          - image: pc-boot.img
      - name: BIOS Boot
        type: DA,21686148-6449-6E6F-744E-656564454649
        size: 1M
        offset: 1M
        offset-write: mbr+92
        content:
          - image: pc-core.img
      - name: EFI System
        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
        filesystem: vfat
        filesystem-label: system-boot
        size: 50M
        content:
          - source: grubx64.efi
            target: EFI/boot/grubx64.efi
          - source: shim.efi.signed
            target: EFI/boot/bootx64.efi
          - source: grub.cfg
            target: EFI/ubuntu/grub.cfg
```

While at it, add some explicit tests for effective filesystem label.
