### PR TITLE
tests: correctly escape mount unit path

### DIFF
--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -86,8 +86,8 @@ restore: |
     rm /var/lib/snapd/seed/snaps/pc_x1.snap
 
     TEST_REVNO=$(awk "/^snap-revision: / {print \$2}" test-snapd-with-configure_*.assert)
-    if systemctl status "snap-test-snapd-with-configure-${TEST_REVNO}.mount" ; then
-       systemctl stop "snap-test-snapd-with-configure-${TEST_REVNO}.mount"
+    if systemctl status "$(systemd-escape --path /snap/test-snapd-with-configure/"$TEST_REVNO".mount)"; then
+       systemctl stop "$(systemd-escape --path /snap/test-snapd-with-configure/"$TEST_REVNO".mount)"
        rm -f "/etc/systemd/system/snap-test-snapd-with-configure-${TEST_REVNO}.mount"
        rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure-${TEST_REVNO}.mount"
        rm -f /var/lib/snapd/snaps/test-snapd-with-configure_*.snap


### PR DESCRIPTION
Systemd unit names follow a particular naming scheme, where mount units
use dashes in place of forward slashes. A mount unit representing the
revision 123 of the core snap, might be snap-core-1234.mount. When
dashes appear in mount unit they must be escaped. One way of doing that
is with systemd-escape --path. The mount unit representing the revision
42 of test-snapd-oh is not snap-test-snapd-oh-42.mount but actually
snap-test\x2dsnapd\x2doh-42.mount, doh!

This patch fixes a test that used systemctl status with a bogus mount
unit name.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
