### PR TITLE
tests: remove test-snapd-curl

### DIFF
--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -23,6 +23,9 @@ prepare: |
     fi
 
 restore: |
+    if snap list test-snapd-curl; then
+        snap remove test-snapd-curl
+    fi
     systemctl stop "user@${TEST_UID}.service"
     rm -rf "${USER_RUNTIME_DIR:?}"/* "${USER_RUNTIME_DIR:?}"/.[!.]*
 

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -9,6 +9,11 @@ prepare: |
         snap alias test-snapd-curl.curl curl
     fi
 
+restore: |
+    if snap list test-snapd-curl; then
+        snap remove test-snapd-curl
+    fi
+
 execute: |
     echo "Verify that snapctl -h runs without a context"
     if ! snapctl -h; then


### PR DESCRIPTION
The tests/main/{snapctl,snap-session-agent-socket-activation} tests can,
on core systems, install curl as a snap but never removes it. This patch
fixes that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
