### PR TITLE
tests: remove test-snapd-snapctl-core18 in restore

### DIFF
--- a/tests/main/core18-with-hooks/task.yaml
+++ b/tests/main/core18-with-hooks/task.yaml
@@ -10,3 +10,5 @@ execute: |
 
     journalctl -u test-snapd-snapctl-core18.service
 
+restore: |
+    snap remove test-snapd-snapctl-core18


### PR DESCRIPTION
The tests/main/core18-with-hooks test was installing
test-snapd-snapctl-core18 but nothing removes it. It also installs
core18 but in another patch that is not clean for merging yet, I remove
core18 if it is installed by a test. This patch sets the stage by
removing dependencies that hold core18 in place.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
