### PR TITLE
tests: remove installed test snap

### DIFF
--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -24,6 +24,7 @@ restore: |
     for f in /var/lib/extrausers/*; do
         sed -i '/^alice:/d' "$f"
     done
+    snap remove "$TSNAP"
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh


### PR DESCRIPTION
The tests/main/interfaces-account-control snap was installing a snap
that, in one of the variants, kept core18 "locked" and busy. This patch
fixes this by removing the installed snap in the restore section.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
