### PR TITLE
tests: remove installed snap in the restore section

### DIFF
--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -49,4 +49,7 @@ execute: |
 
 restore: |
 
+  if snap list test-snapd-core-migration; then
+    snap remove test-snapd-core-migration
+  fi
   rm -f test-snapd-core-migration_{1,2}_all.snap


### PR DESCRIPTION
The tests/main/base-migration test was installing a snap that, in one of
the versions, used core18 as base. This kept core18 locked. The restore
section did not remove the snap, now it does.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
