### PR TITLE
packaging/debian: don't md5sum absent files

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -45,7 +45,7 @@ case "$1" in
         # the old usr.lib.snap-confine file. This seems to be loaded instead
         # of the correct usr.lib.snap-confine.real profile. To fix this we
         # use the rather blunt approach to remove the file forcefully.
-        if test "$(md5sum /etc/apparmor.d/usr.lib.snapd.snap-confine | cut -f1 -d' ' 2>/dev/null)" = "2a38d40fe662f46fedd0aefbe78f23e9"; then
+        if test -f /etc/apparmor.d/usr.lib.snapd.snap-confine && test "$(md5sum /etc/apparmor.d/usr.lib.snapd.snap-confine | cut -f1 -d' ')" = "2a38d40fe662f46fedd0aefbe78f23e9"; then
             rm -f /etc/apparmor.d/usr.lib.snapd.snap-confine
         fi
 


### PR DESCRIPTION
The debian postinst hook performs some special case cleanup on an old
version of a configuration file. The logic there was written slightly
incorrectly and if the file was absent it would display a message to
stderr, like this:

    Setting up snapd (2.39.2+18.04) ...
    Installing new version of config file /etc/apparmor.d/usr.lib.snapd.snap-confine.real ...
    md5sum: /etc/apparmor.d/usr.lib.snapd.snap-confine: No such file or directory

This was never desired. This patch fixes this by checking if the file
exists in the first place and removing the useless redirect.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
