### PR TITLE
daemon: do not modify test data in user suite

### DIFF
--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -320,9 +320,13 @@ func (s *userSuite) TestPostCreateUserFromAssertion(c *check.C) {
 	c.Check(users, check.HasLen, 1)
 }
 
-func (s *userSuite) TestPostCreateUserFromAssertionWithForcePasswordChnage(c *check.C) {
-	lusers := []map[string]interface{}{goodUser}
-	lusers[0]["force-password-change"] = "true"
+func (s *userSuite) TestPostCreateUserFromAssertionWithForcePasswordChange(c *check.C) {
+	user := make(map[string]interface{})
+	for k, v := range goodUser {
+		user[k] = v
+	}
+	user["force-password-change"] = "true"
+	lusers := []map[string]interface{}{user}
 	s.makeSystemUsers(c, lusers)
 
 	// mock the calls that create the user


### PR DESCRIPTION
The test modified test data permanently for the process lifetime. When executing
tests with -count=(n > 1), other tests were affectected and failed like this:

```
----------------------------------------------------------------------
FAIL: api_users_test.go:258: userSuite.TestGetUserDetailsFromAssertionHappy

api_users_test.go:272:
    c.Check(opts, check.DeepEquals, &osutil.AddUserOptions{
        Gecos:    "foo@bar.com,Boring Guy",
        Password: "$6$salt$hash",
    })
... obtained *osutil.AddUserOptions = &osutil.AddUserOptions{Sudoer:false, ExtraUsers:false, Gecos:"foo@bar.com,Boring Guy", SSHKeys:[]string(nil), Password:"$6$salt$hash", F
orcePasswordChange:true}
... expected *osutil.AddUserOptions = &osutil.AddUserOptions{Sudoer:false, ExtraUsers:false, Gecos:"foo@bar.com,Boring Guy", SSHKeys:[]string(nil), Password:"$6$salt$hash", F
orcePasswordChange:false}
... Difference:
...     ForcePasswordChange: true != false

----------------------------------------------------------------------
FAIL: api_users_test.go:282: userSuite.TestPostCreateUserFromAssertion

api_users_test.go:304:
    rsp := postCreateUser(createUserCmd, req, nil).(*resp)
api_users_test.go:291:
    c.Check(opts.ForcePasswordChange, check.Equals, false)
... obtained bool = true
... expected bool = false

OOPS: 12 passed, 2 FAILED
--- FAIL: Test (0.26s)
FAIL
exit status 1
```

