### PR TITLE
data/selinux: allow read on sysfs

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -395,6 +395,7 @@ allow snappy_mount_t snappy_confine_t:file { open read getattr };
 kernel_read_system_state(snappy_mount_t)
 kernel_read_net_sysctls(snappy_mount_t)
 kernel_search_network_sysctl(snappy_mount_t)
+dev_read_sysfs(snappy_mount_t)
 
 ########################################
 #
@@ -575,6 +576,7 @@ allow snappy_cli_t self:capability { dac_override };
 init_ioctl_stream_sockets(snappy_cli_t)
 kernel_read_net_sysctls(snappy_cli_t)
 kernel_search_network_sysctl(snappy_cli_t)
+dev_read_sysfs(snappy_cli_t)
 
 # talk to snapd
 snappy_stream_connect(snappy_cli_t)


### PR DESCRIPTION
Go 1.13 runtime (currently available in Fedora Rawhide) pokes `/sys/kernel/mm/transparent_hugepage/hpage_pmd_size` during setup, thus triggering the following denial:

```
----
time->Mon Jul 29 13:14:03 2019
type=AVC msg=audit(1564406043.239:221): avc:  denied  { read } for  pid=23708 comm="6" name="hpage_pmd_size" dev="sysfs" ino=2621 scontext=system_u:system_r:snappy_mount_t:s0
 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
----
time->Mon Jul 29 13:14:03 2019
type=AVC msg=audit(1564406043.239:222): avc:  denied  { open } for  pid=23708 comm="6" path="/sys/kernel/mm/transparent_hugepage/hpage_pmd_size" dev="sysfs" ino=2621 scontext
=system_u:system_r:snappy_mount_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
----
time->Mon Jul 29 13:15:15 2019
type=AVC msg=audit(1564406115.994:251): avc:  denied  { read } for  pid=24049 comm="snap" name="hpage_pmd_size" dev="sysfs" ino=2621 scontext=system_u:system_r:snappy_cli_t:s
0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
----
time->Mon Jul 29 13:15:15 2019
type=AVC msg=audit(1564406115.994:252): avc:  denied  { open } for  pid=24049 comm="snap" path="/sys/kernel/mm/transparent_hugepage/hpage_pmd_size" dev="sysfs" ino=2621 scont
ext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:sysfs_t:s0 tclass=file permissive=1
```

cc @Conan-Kudo 