### PR TITLE
HACKING.md: update spread section, other updates

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,7 +8,8 @@ integration test framework for the integration/system level tests.
 
 ### Supported Go versions
 
-snapd is supported on Go 1.6 onwards.
+From snapd 2.38, snapd supports Go 1.9 and onwards. For earlier snapd 
+releases, snapd supports Go 1.6.
 
 ### Setting up a GOPATH
 
@@ -126,9 +127,11 @@ To run the various tests that we have to ensure a high quality source just run:
 This will check if the source format is consistent, that it builds, all tests
 work as expected and that "go vet" has nothing to complain.
 
-The source format follows the `gofmt -s` formating. Please run this on your sources files if `run-checks` complains about the format.
+The source format follows the `gofmt -s` formating. Please run this on your 
+source files if `run-checks` complains about the format.
 
-You can run individual test for a sub-package by changing into that directory and:
+You can run an individual test for a sub-package by changing into that 
+directory and:
 
     go test -check.f $testname
 
@@ -140,33 +143,64 @@ If a test hangs, you can enable verbose mode:
 
 There is more to read about the testing framework on the [website](https://labix.org/gocheck)
 
-### Running the spread tests
+### Running spread tests
 
-To run the spread tests locally you need the latest version of spread
-from https://github.com/snapcore/spread. It can be installed via:
+To run the spread tests locally via QEMU, you need the latest version of
+[spread](https://github.com/snapcore/spread). You can get spread, QEMU, and the
+build tools to build QEMU images with:
 
-    $ sudo apt install qemu-kvm autopkgtest
-    $ sudo snap install --devmode spread
+    $ sudo apt update && sudo apt install -y qemu-kvm autopkgtest
+    $ curl https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | tar -xz -C $GOPATH/bin
 
-Then setup the environment via:
+#### Building spread VM images
 
-    $ mkdir -p .spread/qemu
-    $ cd .spread/qemu
-    # For xenial (same works for yakkety/zesty)
-    $ adt-buildvm-ubuntu-cloud -r xenial
-    $ mv adt-xenial-amd64-cloud.img ubuntu-16.04.img
-    # For trusty
-    $ adt-buildvm-ubuntu-cloud -r trusty --post-command='sudo apt-get install -y --install-recommends linux-generic-lts-xenial && update-grub'
+To run the spread tests via QEMU you need to create VM images in the
+`~/.spread/qemu` directory:
+
+    $ mkdir -p ~/.spread/qemu
+    $ cd ~/.spread/qemu
+
+Assuming you are building on Ubuntu 18.04 LTS (Bionic Beaver) (or a later 
+development release like Ubuntu 19.04 (Disco Dingo)), run the following to 
+build a 64-bit Ubuntu 16.04 LTS (Xenial Xerus) VM to run the spread tests on:
+
+    $ autopkgtest-buildvm-ubuntu-cloud -r xenial
+    $ mv autopkgtest-xenial-amd64.img ubuntu-16.04-64.img
+
+To build an Ubuntu 14.04 (Trusty Tahr) based VM, use:
+
+    $ autopkgtest-buildvm-ubuntu-cloud -r trusty --post-command='sudo apt-get install -y --install-recommends linux-generic-lts-xenial && update-grub'
     $ mv adt-trusty-amd64-cloud.img ubuntu-14.04-64.img
 
+This is because we need at least 4.4+ kernel for snapd to run on Ubuntu 14.04 
+LTS, which is available through the `linux-generic-lts-xenial` package.
 
-And you can run the tests via:
+If you are running Ubuntu 16.04 LTS, use 
+`adt-buildvm-ubuntu-cloud` instead of `autopkgtest-buildvm-ubuntu-cloud` (the
+latter replaced the former in 18.04):
 
-    $ spread -v qemu:
+    $ adt-buildvm-ubuntu-cloud -r xenial
+    $ mv adt-xenial-amd64-cloud.img ubuntu-16.04-64.img
+
+#### Downloading spread VM images
+
+Alternatively, instead of building the QEMU images manually, you can download
+pre-built and somewhat maintained images from 
+[spread.zygoon.pl](spread.zygoon.pl). The images will need to be extracted 
+with `gunzip` and placed into `~/.spread/qemu` as above.
+
+#### Running spread with QEMU
+
+Finally, you can run the spread tests for Ubuntu 16.04 LTS 64-bit with:
+
+    $ spread -v qemu:ubuntu-16.04-64
+
+To run for a different system, replace `ubuntu-16.04-64` with a different system
+name.
 
 For quick reuse you can use:
 
-    $ spread -reuse qemu:
+    $ spread -reuse qemu:ubuntu-16.04-64
 
 It will print how to reuse the systems. Make sure to use
 `export REUSE_PROJECT=1` in your environment too.
@@ -200,7 +234,7 @@ To get started from a pristine tree you want to do this:
 ./mkversion.sh
 cd cmd/
 autoreconf -i -f
-./configure --prefix=/usr --libexecdir=/usr/lib/snapd --enable-nvidia-ubuntu
+./configure --prefix=/usr --libexecdir=/usr/lib/snapd
 ```
 
 This will drop makefiles and let you build stuff. You may find the `make hack`


### PR DESCRIPTION
* The command on bionic and later is autopkgtest-buildvm-ubuntu-cloud and the adt-buildvm-ubuntu-cloud command is no longer available on bionic.
* Make the assumption a user is probably running bionic and later rather than xenial which is getting close to EOL now.
* The name of the machine that spread tries to use for xenial 64-bit, is ubuntu-16.04-64.img, not ubuntu-16.04.img, the latter will be ignored.
* The spread command example should just use the image the user would have downloaded rather than have spread try and fail to launch every other system defined in spread.yaml.
* Adding a `sudo apt update` in all lines where we install apt packages is a good habit for folks who might not be aware that their apt repos need to be kept up to date.
* Add download instructions for spread images at spread.zygoon.pl. (thanks Zygmunt for hosting these!)
* Split up the Running spread tests section into different subsections, for building VMs, downloading VMs, and finally running tests with the VMs.
* Make all lines under 60 lines.
* Specify supported Go versions with snapd.
* Download spread from the AWS link rather than the snap, because spread as a snap only tries to use $HOME/snap/spread/current/.spread, rather than $HOME/.spread which is easier to document and use here.
* Delete old, unused nvidia ./configure option