### PR TITLE
tests: set GOTRACEBACK=1 when running tests

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -259,7 +259,7 @@ if [ "$UNIT" = 1 ]; then
             GOTRACEBACK=1 $goctest -v -timeout 5m -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
         else
             for pkg in $(go list ./... | grep -v '/vendor/' ); do
-                GOTRACEBACK=1 go test -i "$pkg"
+                GOTRACEBACK=1 go test -timeout 5m -i "$pkg"
                 GOTRACEBACK=1 $goctest -v -timeout 5m -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
                 append_coverage .coverage/profile.out
             done

--- a/run-checks
+++ b/run-checks
@@ -247,7 +247,7 @@ if [ "$UNIT" = 1 ]; then
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
             # shellcheck disable=SC2046
-            $goctest -short -v $(go list ./... | grep -v '/vendor/' )
+            GOTRACEBACK=1 $goctest -short -v $(go list ./... | grep -v '/vendor/' )
     else
         # Prepare the coverage output profile.
         rm -rf .coverage
@@ -256,11 +256,11 @@ if [ "$UNIT" = 1 ]; then
 
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
             # shellcheck disable=SC2046
-            $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+            GOTRACEBACK=1 $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
         else
             for pkg in $(go list ./... | grep -v '/vendor/' ); do
-                go test -i "$pkg"
-                $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
+                GOTRACEBACK=1 go test -i "$pkg"
+                GOTRACEBACK=1 $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
                 append_coverage .coverage/profile.out
             done
         fi

--- a/run-checks
+++ b/run-checks
@@ -247,7 +247,7 @@ if [ "$UNIT" = 1 ]; then
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
             # shellcheck disable=SC2046
-            GOTRACEBACK=1 $goctest -short -v $(go list ./... | grep -v '/vendor/' )
+            GOTRACEBACK=1 $goctest -short -test.timeout 5m -v $(go list ./... | grep -v '/vendor/' )
     else
         # Prepare the coverage output profile.
         rm -rf .coverage


### PR DESCRIPTION
We're seeing panics in unit test code when invoked in travis. It seems
the test code is passing over the 10 minute watermark built into "go
test". With this patch we'll see what was going on at the time of the
failure.

Forum: https://forum.snapcraft.io/t/12513
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>