### PR TITLE
tests: remove installed snap on restore

### DIFF
--- a/tests/main/core18-configure-hook/task.yaml
+++ b/tests/main/core18-configure-hook/task.yaml
@@ -30,3 +30,8 @@ execute: |
     fi
 
     test -e /var/snap/test-snapd-with-configure-core18/common/configure-ran
+
+restore: |
+    if snap list test-snapd-with-configure-core18; then
+        snap remove test-snapd-with-configure-core18
+    fi

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -24,3 +24,6 @@ execute: |
     echo "With the plug connected it is possible to communicate with packagekit"
     test-snapd-packagekit.pkcon backend-details | MATCH "Name:"
     test-snapd-packagekit.pkcon resolve snapd | MATCH "Installed[[:space:]]+snapd"
+
+restore: |
+    snap remove test-snapd-packagekit

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -21,3 +21,6 @@ execute: |
     snap list | MATCH ^snapd
     snap list | MATCH ^core18
     snap list | MATCH ^test-snapd-tools
+
+restore: |
+    snap remove test-snapd-tools-core18


### PR DESCRIPTION
The test snap keeps the core18 snap busy, thus preventing removal in the
suite restore section.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
