### PR TITLE
packaging: use %systemd_user_* macros to enable session agent socket according to presets

### DIFF
--- a/data/systemd-user/Makefile
+++ b/data/systemd-user/Makefile
@@ -30,10 +30,6 @@ install:: $(SYSTEMD_UNITS)
 	install -d -m 0755 $(DESTDIR)/$(SYSTEMDUSERUNITDIR)
 	install -m 0644 -t $(DESTDIR)/$(SYSTEMDUSERUNITDIR) $^
 
-install::
-	install -d -m 0755 $(DESTDIR)/$(SYSTEMDUSERUNITDIR)/sockets.target.wants
-	ln -sf ../snapd.session-agent.socket $(DESTDIR)/$(SYSTEMDUSERUNITDIR)/sockets.target.wants/snapd.session-agent.socket
-
 .PHONY: clean
 clean:
 	rm -f $(SYSTEMD_UNITS_GENERATED:.in=)

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -60,6 +60,7 @@
 %global import_path     %{provider_prefix}
 
 %global snappy_svcs     snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service
+%global snappy_user_svcs snapd.session-agent.socket
 
 # Until we have a way to add more extldflags to gobuild macro...
 %if 0%{?fedora}
@@ -727,7 +728,6 @@ popd
 %{_unitdir}/snapd.seeded.service
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
-%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 %{_datadir}/dbus-1/services/io.snapcraft.Launcher.service
 %{_datadir}/dbus-1/services/io.snapcraft.Settings.service
 %{_datadir}/polkit-1/actions/io.snapcraft.snapd.policy
@@ -803,6 +803,7 @@ popd
 %sysctl_apply 99-snap.conf
 %endif
 %systemd_post %{snappy_svcs}
+%systemd_user_post %{snappy_user_svcs}
 # If install, test if snapd socket and timer are enabled.
 # If enabled, then attempt to start them. This will silently fail
 # in chroots or other environments where services aren't expected
@@ -815,6 +816,7 @@ fi
 
 %preun
 %systemd_preun %{snappy_svcs}
+%systemd_user_preun %{snappy_user_svcs}
 
 # Remove all Snappy content if snapd is being fully uninstalled
 if [ $1 -eq 0 ]; then
@@ -823,6 +825,7 @@ fi
 
 %postun
 %systemd_postun_with_restart %{snappy_svcs}
+%systemd_user_postun %{snappy_user_svcs}
 
 %if 0%{?with_selinux}
 %triggerun -- snapd < 2.39

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -601,6 +601,8 @@ pushd ./data
               SYSTEMDSYSTEMUNITDIR="%{_unitdir}" \
               SNAP_MOUNT_DIR="%{_sharedstatedir}/snapd/snap" \
               SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd"
+# Don't package the sockets.target.wants symlink
+rm -f %{buildroot}%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 popd
 
 
@@ -803,7 +805,9 @@ popd
 %sysctl_apply 99-snap.conf
 %endif
 %systemd_post %{snappy_svcs}
+%if !(0%{?rhel} && 0%{?rhel} < 8)
 %systemd_user_post %{snappy_user_svcs}
+%endif
 # If install, test if snapd socket and timer are enabled.
 # If enabled, then attempt to start them. This will silently fail
 # in chroots or other environments where services aren't expected
@@ -816,7 +820,9 @@ fi
 
 %preun
 %systemd_preun %{snappy_svcs}
+%if !(0%{?rhel} && 0%{?rhel} < 8)
 %systemd_user_preun %{snappy_user_svcs}
+%endif
 
 # Remove all Snappy content if snapd is being fully uninstalled
 if [ $1 -eq 0 ]; then
@@ -825,7 +831,9 @@ fi
 
 %postun
 %systemd_postun_with_restart %{snappy_svcs}
+%if !(0%{?rhel} && 0%{?rhel} < 8)
 %systemd_user_postun %{snappy_user_svcs}
+%endif
 
 %if 0%{?with_selinux}
 %triggerun -- snapd < 2.39

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -601,9 +601,6 @@ pushd ./data
               SYSTEMDSYSTEMUNITDIR="%{_unitdir}" \
               SNAP_MOUNT_DIR="%{_sharedstatedir}/snapd/snap" \
               SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd"
-# Don't package the sockets.target.wants symlink: it will be set up in
-# the post-install script.
-rm -f %{buildroot}%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 popd
 
 

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -601,7 +601,8 @@ pushd ./data
               SYSTEMDSYSTEMUNITDIR="%{_unitdir}" \
               SNAP_MOUNT_DIR="%{_sharedstatedir}/snapd/snap" \
               SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd"
-# Don't package the sockets.target.wants symlink
+# Don't package the sockets.target.wants symlink: it will be set up in
+# the post-install script.
 rm -f %{buildroot}%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 popd
 

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -803,9 +803,7 @@ popd
 %sysctl_apply 99-snap.conf
 %endif
 %systemd_post %{snappy_svcs}
-%if !(0%{?rhel} && 0%{?rhel} < 8)
 %systemd_user_post %{snappy_user_svcs}
-%endif
 # If install, test if snapd socket and timer are enabled.
 # If enabled, then attempt to start them. This will silently fail
 # in chroots or other environments where services aren't expected
@@ -818,9 +816,7 @@ fi
 
 %preun
 %systemd_preun %{snappy_svcs}
-%if !(0%{?rhel} && 0%{?rhel} < 8)
 %systemd_user_preun %{snappy_user_svcs}
-%endif
 
 # Remove all Snappy content if snapd is being fully uninstalled
 if [ $1 -eq 0 ]; then
@@ -829,9 +825,7 @@ fi
 
 %postun
 %systemd_postun_with_restart %{snappy_svcs}
-%if !(0%{?rhel} && 0%{?rhel} < 8)
 %systemd_user_postun %{snappy_user_svcs}
-%endif
 
 %if 0%{?with_selinux}
 %triggerun -- snapd < 2.39

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -29,6 +29,7 @@
 # The list of systemd services we are expected to ship. Note that this does
 # not include services that are only required on core systems.
 %global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service}
+%global systemd_user_services_list snapd.session-agent.socket
 
 # Alternate snap mount directory: not used by openSUSE.
 # If this spec file is integrated into Fedora then consider
@@ -310,6 +311,7 @@ install -m 644 -D %{indigo_srcdir}/data/completion/etelpmoc.sh %{buildroot}%{_li
 %apparmor_reload /etc/apparmor.d/usr.lib.snapd.snap-confine
 %endif
 %service_add_post %{systemd_services_list}
+%systemd_user_post %{systemd_user_services_list}
 case ":$PATH:" in
     *:/snap/bin:*)
         ;;
@@ -321,12 +323,14 @@ esac
 
 %preun
 %service_del_preun %{systemd_services_list}
+%systemd_user_preun %{systemd_user_services_list}
 if [ $1 -eq 0 ]; then
     %{_libexecdir}/snapd/snap-mgmt --purge || :
 fi
 
 %postun
 %service_del_postun %{systemd_services_list}
+%systemd_user_postun %{systemd_user_services_list}
 
 %files
 
@@ -368,7 +372,6 @@ fi
 %dir %{_systemd_system_env_generator_dir}
 %dir %{_systemdgeneratordir}
 %dir %{_userunitdir}
-%dir %{_userunitdir}/sockets.target.wants
 %dir %{snap_mount_dir}
 %dir %{snap_mount_dir}/bin
 
@@ -418,7 +421,6 @@ fi
 %{_unitdir}/snapd.socket
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
-%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 
 # When apparmor is enabled there are some additional entries.
 %if %{with apparmor}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -261,9 +261,6 @@ popd
 		LIBEXECDIR=%{_libexecdir} \
 		SYSTEMDSYSTEMUNITDIR=%{_unitdir} \
 		SNAP_MOUNT_DIR=%{snap_mount_dir}
-# Don't package the sockets.target.wants symlink: it will be set up in
-# the post-install script.
-rm -f %{buildroot}%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 # Install all the C executables.
 %make_install -C %{indigo_srcdir}/cmd
 # Use the common packaging helper for bulk of installation.

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -261,6 +261,8 @@ popd
 		LIBEXECDIR=%{_libexecdir} \
 		SYSTEMDSYSTEMUNITDIR=%{_unitdir} \
 		SNAP_MOUNT_DIR=%{snap_mount_dir}
+# Don't package the sockets.target.wants symlink
+rm -f %{buildroot}%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 # Install all the C executables.
 %make_install -C %{indigo_srcdir}/cmd
 # Use the common packaging helper for bulk of installation.

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -261,7 +261,8 @@ popd
 		LIBEXECDIR=%{_libexecdir} \
 		SYSTEMDSYSTEMUNITDIR=%{_unitdir} \
 		SNAP_MOUNT_DIR=%{snap_mount_dir}
-# Don't package the sockets.target.wants symlink
+# Don't package the sockets.target.wants symlink: it will be set up in
+# the post-install script.
 rm -f %{buildroot}%{_userunitdir}/sockets.target.wants/snapd.session-agent.socket
 # Install all the C executables.
 %make_install -C %{indigo_srcdir}/cmd

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,2 +1,6 @@
 ../../usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
 usr/lib/snapd/snapctl usr/bin/snapctl
+
+# This should be removed once we can rely on debhelper >= 11.5:
+#     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
+../snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -12,10 +12,16 @@ environment:
     USER_RUNTIME_DIR: /run/user/${TEST_UID}
 
 prepare: |
+    # Ensure that snapd.session-agent.socket is enabled.  This may not
+    # be the case on distributions where presets have been used to
+    # disable it.
+    systemctl --user --global enable snapd.session-agent.socket
+
     mkdir -p "$USER_RUNTIME_DIR"
     chmod u=rwX,go= "$USER_RUNTIME_DIR"
     chown test:test "$USER_RUNTIME_DIR"
     systemctl start "user@${TEST_UID}.service"
+
     # ensure curl is available (needed for e.g. core18)
     if ! command -v curl; then
         snap install --devmode --edge test-snapd-curl

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -15,8 +15,11 @@ prepare: |
     # Ensure that snapd.session-agent.socket is enabled.  This may not
     # be the case on distributions where presets have been used to
     # disable it.
-    systemctl --user --global enable snapd.session-agent.socket
-
+    if [ ! -L /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket ] &&
+            ! systemctl --user --global is-enabled snapd.session-agent.socket; then
+        systemctl --user --global enable snapd.session-agent.socket
+        touch agent-was-enabled
+    fi
     mkdir -p "$USER_RUNTIME_DIR"
     chmod u=rwX,go= "$USER_RUNTIME_DIR"
     chown test:test "$USER_RUNTIME_DIR"
@@ -34,6 +37,10 @@ restore: |
     fi
     systemctl stop "user@${TEST_UID}.service"
     rm -rf "${USER_RUNTIME_DIR:?}"/* "${USER_RUNTIME_DIR:?}"/.[!.]*
+    if [ -f agent-was-enabled ]; then
+        systemctl --user --global disable snapd.session-agent.socket
+        rm agent-was-enabled
+    fi
 
 execute: |
     systemctl_user() {


### PR DESCRIPTION
As mentioned by @Conan-Kudo in comments on PR #6954 after merge, we shouldn't be shipping symlinks in `sockets.target.wants` to enable the socket for Fedora/OpenSUSE.  Instead we should use the `%systemd_*` macros to enable the socket at install time according to the preset policy.