### PR TITLE
many: fix unit tests getting stuck

### DIFF
--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -84,6 +84,8 @@ func (x *cmdUserd) runUserd() error {
 
 	ch := make(chan os.Signal, 3)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
+	defer signal.Stop(ch)
+
 	select {
 	case sig := <-ch:
 		fmt.Fprintf(Stdout, "Exiting on %s.\n", sig)
@@ -104,6 +106,8 @@ func (x *cmdUserd) runAgent() error {
 
 	ch := make(chan os.Signal, 3)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
+	defer signal.Stop(ch)
+
 	select {
 	case sig := <-ch:
 		fmt.Fprintf(Stdout, "Exiting on %s.\n", sig)

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -125,7 +125,8 @@ func (s *userdSuite) TestSessionAgentSocket(c *C) {
 		defer func() {
 			me, err := os.FindProcess(myPid)
 			c.Assert(err, IsNil)
-			me.Signal(syscall.SIGUSR1)
+			err = me.Signal(syscall.SIGUSR1)
+			c.Assert(err, IsNil)
 		}()
 
 		// Wait for command to create socket file

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -68,13 +68,29 @@ func (s *userdSuite) TestUserdBadCommandline(c *C) {
 	c.Assert(err, ErrorMatches, "too many arguments for command")
 }
 
+type mockSignal struct{}
+
+func (m *mockSignal) String() string {
+	return "<test signal>"
+}
+
+func (m *mockSignal) Signal() {}
+
 func (s *userdSuite) TestUserdDBus(c *C) {
+	sigCh := make(chan os.Signal, 1)
+	sigStopCalls := 0
+
+	restore := snap.MockSignalNotify(func(sig ...os.Signal) (chan os.Signal, func()) {
+		c.Assert(sig, DeepEquals, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
+		return sigCh, func() { sigStopCalls++ }
+	})
+	defer restore()
+
 	go func() {
 		myPid := os.Getpid()
+
 		defer func() {
-			me, err := os.FindProcess(myPid)
-			c.Assert(err, IsNil)
-			me.Signal(syscall.SIGUSR1)
+			sigCh <- &mockSignal{}
 		}()
 
 		names := map[string]bool{
@@ -106,7 +122,8 @@ func (s *userdSuite) TestUserdDBus(c *C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd"})
 	c.Assert(err, IsNil)
 	c.Check(rest, DeepEquals, []string{})
-	c.Check(strings.ToLower(s.Stdout()), Equals, "exiting on user defined signal 1.\n")
+	c.Check(strings.ToLower(s.Stdout()), Equals, "exiting on <test signal>.\n")
+	c.Check(sigStopCalls, Equals, 1)
 }
 
 func (s *userdSuite) makeAgentClient() *http.Client {
@@ -120,13 +137,18 @@ func (s *userdSuite) makeAgentClient() *http.Client {
 }
 
 func (s *userdSuite) TestSessionAgentSocket(c *C) {
+	sigCh := make(chan os.Signal, 1)
+	sigStopCalls := 0
+
+	restore := snap.MockSignalNotify(func(sig ...os.Signal) (chan os.Signal, func()) {
+		c.Assert(sig, DeepEquals, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
+		return sigCh, func() { sigStopCalls++ }
+	})
+	defer restore()
+
 	go func() {
-		myPid := os.Getpid()
 		defer func() {
-			me, err := os.FindProcess(myPid)
-			c.Assert(err, IsNil)
-			err = me.Signal(syscall.SIGUSR1)
-			c.Assert(err, IsNil)
+			sigCh <- &mockSignal{}
 		}()
 
 		// Wait for command to create socket file
@@ -148,5 +170,24 @@ func (s *userdSuite) TestSessionAgentSocket(c *C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd", "--agent"})
 	c.Assert(err, IsNil)
 	c.Check(rest, DeepEquals, []string{})
-	c.Check(strings.ToLower(s.Stdout()), Equals, "exiting on user defined signal 1.\n")
+	c.Check(strings.ToLower(s.Stdout()), Equals, "exiting on <test signal>.\n")
+	c.Check(sigStopCalls, Equals, 1)
+}
+
+func (s *userdSuite) TestSignalNotify(c *C) {
+	ch, stop := snap.SignalNotify(syscall.SIGUSR1)
+	defer stop()
+	go func() {
+		myPid := os.Getpid()
+		me, err := os.FindProcess(myPid)
+		c.Assert(err, IsNil)
+		err = me.Signal(syscall.SIGUSR1)
+		c.Assert(err, IsNil)
+	}()
+	select {
+	case sig := <-ch:
+		c.Assert(sig, Equals, syscall.SIGUSR1)
+	case <-time.After(5 * time.Second):
+		c.Fatal("signal not received within 5s")
+	}
 }

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -140,6 +140,7 @@ func (s *userdSuite) TestSessionAgentSocket(c *C) {
 		client := s.makeAgentClient()
 		response, err := client.Get("http://localhost/v1/session-info")
 		c.Assert(err, IsNil)
+		defer response.Body.Close()
 		c.Check(response.StatusCode, Equals, 200)
 	}()
 

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"os"
 	"os/user"
 	"time"
 
@@ -77,6 +78,8 @@ var (
 	FixupArg = fixupArg
 
 	InterfacesDeprecationNotice = interfacesDeprecationNotice
+
+	SignalNotify = signalNotify
 )
 
 func NewInfoWriter(w writeflusher) *infoWriter {
@@ -292,6 +295,14 @@ func MockImagePrepare(newImagePrepare func(*image.Options) error) (restore func(
 	imagePrepare = newImagePrepare
 	return func() {
 		imagePrepare = old
+	}
+}
+
+func MockSignalNotify(newSignalNotify func(sig ...os.Signal) (chan os.Signal, func())) (restore func()) {
+	old := signalNotify
+	signalNotify = newSignalNotify
+	return func() {
+		signalNotify = old
 	}
 }
 

--- a/osutil/context.go
+++ b/osutil/context.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"io"
 	"os/exec"
+	"sync"
 	"sync/atomic"
 	"syscall"
 )
@@ -58,7 +59,10 @@ func RunWithContext(ctx context.Context, cmd *exec.Cmd) error {
 	}
 
 	var ctxDone uint32
+	var wg sync.WaitGroup
 	waitDone := make(chan struct{})
+
+	wg.Add(1)
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -66,10 +70,13 @@ func RunWithContext(ctx context.Context, cmd *exec.Cmd) error {
 			cmd.Process.Kill()
 		case <-waitDone:
 		}
+		wg.Done()
 	}()
 
 	err := cmd.Wait()
 	close(waitDone)
+	wg.Wait()
+
 	if atomic.LoadUint32(&ctxDone) != 0 {
 		// do one last check to make sure the error from Wait is what we expect from Kill
 		if err, ok := err.(*exec.ExitError); ok {

--- a/run-checks
+++ b/run-checks
@@ -247,7 +247,7 @@ if [ "$UNIT" = 1 ]; then
     echo Running tests from "$PWD"
     if [ "$short" = 1 ]; then
             # shellcheck disable=SC2046
-            $goctest -short -v $(go list ./... | grep -v '/vendor/' )
+            $goctest -short -v -timeout 5m $(go list ./... | grep -v '/vendor/' )
     else
         # Prepare the coverage output profile.
         rm -rf .coverage
@@ -256,11 +256,11 @@ if [ "$UNIT" = 1 ]; then
 
         if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
             # shellcheck disable=SC2046
-            $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+            $goctest -v -timeout 5m -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
         else
             for pkg in $(go list ./... | grep -v '/vendor/' ); do
                 go test -i "$pkg"
-                $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
+                $goctest -v -timeout 5m -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
                 append_coverage .coverage/profile.out
             done
         fi

--- a/usersession/agent/session_agent_test.go
+++ b/usersession/agent/session_agent_test.go
@@ -71,6 +71,7 @@ func (s *sessionAgentSuite) TestStartStop(c *C) {
 
 	response, err := s.client.Get("http://localhost/v1/session-info")
 	c.Assert(err, IsNil)
+	defer response.Body.Close()
 	c.Check(response.StatusCode, Equals, 200)
 
 	var rst struct {


### PR DESCRIPTION
Close http.Response.Body, otherwise file descriptors are leaked.
