### PR TITLE
packaging: use passthrough for type:snapd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,8 +10,9 @@ description: |
 version: set-by-version-script-thxbye
 version-script: |
   ./mkversion.sh --output-only
-#FIXME: enable once snapcraft understands this
-#type: snapd
+#FIXME: get rid of passthrough once snapcraft 3.x + lxd can build snapd
+passthrough:
+  type: snapd
 grade: stable
 
 # Note that this snap is unusual in that it has no "apps" section.


### PR DESCRIPTION
Temporarily use `passthrough:` to set `type: snapd` when building snapd snap with snapcraft 2.x, until failures with snapcraft 3.x and lxd on travis (PR #7092) are understood and fixed.

Note, the code that magically sets `TypeSnapd` on `infoSkeletonFromSnapYaml` is still present and will be removed in a followup once new snapd snap is in edge, because only then we can avoid hack in `repack_snapd_snap_with_deb_content()` test helper.