### PR TITLE
tests: reboot the node when restoring after a test involving lxd

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -24,15 +24,18 @@ prepare: |
     fi
 
 restore: |
-    if  [[ "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l || echo 0)" -eq 0 ]]; then
-        exit
+    if [[ "$SPREAD_REBOOT" == 0 ]]; then
+        if  [[ "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l || echo 0)" -eq 0 ]]; then
+            exit
+        fi
+
+        lxd.lxc stop my-ubuntu --force
+        lxd.lxc delete my-ubuntu
+
+        snap remove lxd
+
+        REBOOT
     fi
-
-    lxd.lxc stop my-ubuntu --force
-    lxd.lxc delete my-ubuntu
-
-    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
-    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
 
 debug: |
     # shellcheck source=tests/lib/journalctl.sh

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -15,11 +15,10 @@ prepare: |
     ausearch --checkpoint stamp -m AVC || true
 
 restore: |
-    setenforce "$(cat enforcing.mode)"
-    rm -f stamp enforcing.mode
-
-    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
-    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+    if [[ "$SPREAD_REBOOT" == 0 ]]; then
+        rm -f stamp enforcing.mode
+        REBOOT
+    fi
 
 execute: |
     snap install lxd

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -52,14 +52,15 @@ prepare: |
     lxc exec xenial -- chown ubuntu.ubuntu /var/lib/test
 
 restore: |
-    # Remove the container we may have set up.
-    lxc stop xenial --force || true
-    lxc delete --force xenial || true
+    if [[ "$SPREAD_REBOOT" == 0 ]]; then
+        # Remove the container we may have set up.
+        lxc stop xenial --force || true
+        lxc delete --force xenial || true
 
-    snap remove lxd
+        snap remove lxd || true
 
-    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
-    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+        REBOOT
+    fi
 
 execute: |
     # Run python0 with a hello.py script and redirect the logs to /var/lib/test/hello.log


### PR DESCRIPTION
LXD makes changes to the mount namespace of the host. Make sure to reboot, so
that the next test runs with a clean state.

cc @zyga 