### PR TITLE
recovery: update to latest fde-utils

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,10 +7,10 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "OwqZavm6GrNb2NsF4jJsukr2SFA=",
+			"checksumSHA1": "MugammZcGwVR+gV6L1uaJczpoe0=",
 			"path": "github.com/chrisccoulson/ubuntu-core-fde-utils",
-			"revision": "e5af66bace4b1f1af0b6fd445b5a894a7d6d0308",
-			"revisionTime": "2019-07-17T13:49:52Z"
+			"revision": "2579bd98602394ece0a1e32f124c108e7fa50fe4",
+			"revisionTime": "2019-07-26T19:00:46Z"
 		},
 		{
 			"checksumSHA1": "zg16zjZTQ9R89+UOLmEZxHgxDtM=",
@@ -29,14 +29,6 @@
 			"path": "github.com/godbus/dbus/introspect",
 			"revision": "97646858c46433e4afb3432ad28c12e968efa298",
 			"revisionTime": "2017-08-22T15:24:03Z"
-		},
-		{
-			"checksumSHA1": "CgcocRShUgwD/BXX35dGSVWG0Z0=",
-			"origin": "github.com/chrisccoulson/go-tpm",
-			"path": "github.com/google/go-tpm",
-			"revision": "9f5e4eb491faa0e349919e0ab888f9607101834c",
-			"revisionTime": "2019-07-11T10:07:55Z",
-			"tree": true
 		},
 		{
 			"checksumSHA1": "iIUYZyoanCQQTUaWsu8b+iOSPt4=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,6 +7,12 @@
 			"revision": ""
 		},
 		{
+			"checksumSHA1": "QjfZTxVIeh62KZwmaNMxXIrr+4c=",
+			"path": "github.com/chrisccoulson/go-tpm2",
+			"revision": "cf8f59140d4d1a775c1ae5ac71022e0febe40018",
+			"revisionTime": "2019-08-06T19:23:27Z"
+		},
+		{
 			"checksumSHA1": "MugammZcGwVR+gV6L1uaJczpoe0=",
 			"path": "github.com/chrisccoulson/ubuntu-core-fde-utils",
 			"revision": "2579bd98602394ece0a1e32f124c108e7fa50fe4",


### PR DESCRIPTION
Update vendored ubuntu-core-fde-utils to chrisccoulson's latest version
which uses go-tpm2 instead of Google's go-tpm.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>