### PR TITLE
cmd/snap: use showDone helper with 'snap switch'

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -1007,7 +1007,7 @@ func (x cmdSwitch) Execute(args []string) error {
 	// some duplication between this and the two other switch-summarisers...
 	// in this one, we have three boolean things to check, meaning 2³=8 possibilities
 	// of which 3 are errors (which is why we look at this before running it)
-	if x.Cohort != "" && x.LeaveCohort {
+	if switchCohort && x.LeaveCohort {
 		// this one counts as two (no channel filter)
 		return fmt.Errorf(i18n.G("cannot specify both --cohort and --leave-cohort"))
 	}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -1008,7 +1008,7 @@ func (x cmdSwitch) Execute(args []string) error {
 
 	// we have three boolean things to check, meaning 2³=8 possibilities
 	// of which 3 are errors (which is why we look at the errors first).
-	// the remaining 5 cases are handled by showDone.
+	// the 5 valid cases are handled by showDone.
 	if switchCohort && x.LeaveCohort {
 		// this one counts as two (no channel filter)
 		return fmt.Errorf(i18n.G("cannot specify both --cohort and --leave-cohort"))

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -349,6 +349,8 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 			switchCohort := opts.CohortKey != ""
 			switchChannel := opts.Channel != ""
 			var msg string
+			// we have three boolean things to check, meaning 2³=8 possibilities,
+			// minus 3 error cases which are handled before the call to showDone.
 			switch {
 			case switchCohort && !opts.LeaveCohort && !switchChannel:
 				// TRANSLATORS: the first %q will be the (quoted) snap name, the second an ellipted cohort string
@@ -365,7 +367,7 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 			case !switchCohort && opts.LeaveCohort && !switchChannel:
 				// TRANSLATORS: %q will be the (quoted) snap name
 				msg = fmt.Sprintf(i18n.G("%q left the cohort"), snap.Name)
-			} // and that's the 8 \o/
+			}
 			fmt.Fprintln(Stdout, msg)
 		default:
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
@@ -1004,9 +1006,9 @@ func (x cmdSwitch) Execute(args []string) error {
 	switchCohort := x.Cohort != ""
 	switchChannel := x.Channel != ""
 
-	// some duplication between this and the two other switch-summarisers...
-	// in this one, we have three boolean things to check, meaning 2³=8 possibilities
-	// of which 3 are errors (which is why we look at this before running it)
+	// we have three boolean things to check, meaning 2³=8 possibilities
+	// of which 3 are errors (which is why we look at the errors first).
+	// the remaining 5 cases are handled by showDone.
 	if switchCohort && x.LeaveCohort {
 		// this one counts as two (no channel filter)
 		return fmt.Errorf(i18n.G("cannot specify both --cohort and --leave-cohort"))

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -345,6 +345,28 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 		case "revert":
 			// TRANSLATORS: first %s is a snap name, second %s is a revision
 			fmt.Fprintf(Stdout, i18n.G("%s reverted to %s\n"), snap.Name, snap.Version)
+		case "switch":
+			switchCohort := opts.CohortKey != ""
+			switchChannel := opts.Channel != ""
+			var msg string
+			switch {
+			case switchCohort && !opts.LeaveCohort && !switchChannel:
+				// TRANSLATORS: the first %q will be the (quoted) snap name, the second an ellipted cohort string
+				msg = fmt.Sprintf(i18n.G("%q switched to the %q cohort\n"), snap.Name, strutil.ElliptLeft(opts.CohortKey, 10))
+			case switchCohort && !opts.LeaveCohort && switchChannel:
+				// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel, the third an ellipted cohort string
+				msg = fmt.Sprintf(i18n.G("%q switched to the %q channel and the %q cohort\n"), snap.Name, snap.TrackingChannel, strutil.ElliptLeft(opts.CohortKey, 10))
+			case !switchCohort && !opts.LeaveCohort && switchChannel:
+				// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
+				msg = fmt.Sprintf(i18n.G("%q switched to the %q channel\n"), snap.Name, snap.TrackingChannel)
+			case !switchCohort && opts.LeaveCohort && switchChannel:
+				// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
+				msg = fmt.Sprintf(i18n.G("%q left the cohort, and switched to the %q channel"), snap.Name, snap.TrackingChannel)
+			case !switchCohort && opts.LeaveCohort && !switchChannel:
+				// TRANSLATORS: %q will be the (quoted) snap name
+				msg = fmt.Sprintf(i18n.G("%q left the cohort"), snap.Name)
+			} // and that's the 8 \o/
+			fmt.Fprintln(Stdout, msg)
 		default:
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
 		}
@@ -979,34 +1001,19 @@ func (x cmdSwitch) Execute(args []string) error {
 	name := string(x.Positional.Snap)
 	channel := string(x.Channel)
 
-	var msg string
+	switchCohort := x.Cohort != ""
+	switchChannel := x.Channel != ""
+
 	// some duplication between this and the two other switch-summarisers...
 	// in this one, we have three boolean things to check, meaning 2³=8 possibilities
 	// of which 3 are errors (which is why we look at this before running it)
-	switchCohort := x.Cohort != ""
-	switchChannel := x.Channel != ""
-	switch {
-	case switchCohort && x.LeaveCohort:
+	if x.Cohort != "" && x.LeaveCohort {
 		// this one counts as two (no channel filter)
 		return fmt.Errorf(i18n.G("cannot specify both --cohort and --leave-cohort"))
-	case switchCohort && !x.LeaveCohort && !switchChannel:
-		// TRANSLATORS: the first %q will be the (quoted) snap name, the second an ellipted cohort string
-		msg = fmt.Sprintf(i18n.G("%q switched to the %q cohort\n"), name, strutil.ElliptLeft(x.Cohort, 10))
-	case switchCohort && !x.LeaveCohort && switchChannel:
-		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel, the third an ellipted cohort string
-		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel and the %q cohort\n"), name, channel, strutil.ElliptLeft(x.Cohort, 10))
-	case !switchCohort && !x.LeaveCohort && switchChannel:
-		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
-		msg = fmt.Sprintf(i18n.G("%q switched to the %q channel\n"), name, channel)
-	case !switchCohort && x.LeaveCohort && switchChannel:
-		// TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
-		msg = fmt.Sprintf(i18n.G("%q left the cohort, and switched to the %q channel"), name, channel)
-	case !switchCohort && x.LeaveCohort && !switchChannel:
-		// TRANSLATORS: %q will be the (quoted) snap name
-		msg = fmt.Sprintf(i18n.G("%q left the cohort"), name)
-	case !switchCohort && !x.LeaveCohort && !switchChannel:
+	}
+	if !switchCohort && !x.LeaveCohort && !switchChannel {
 		return fmt.Errorf(i18n.G("nothing to switch; specify --channel (and/or one of --cohort/--leave-cohort)"))
-	} // and that's the 8 \o/
+	}
 
 	opts := &client.SnapOptions{
 		Channel:     channel,
@@ -1025,8 +1032,7 @@ func (x cmdSwitch) Execute(args []string) error {
 		return err
 	}
 
-	fmt.Fprintln(Stdout, msg)
-	return nil
+	return showDone(x.client, []string{name}, "switch", opts, nil)
 }
 
 func init() {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1876,13 +1876,14 @@ func (s *SnapOpSuite) TestWaitServerError(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
-	s.srv.total = 3
+	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "switch",
 			"channel": "beta",
 		})
+		s.srv.trackingChannel = "beta"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
@@ -1896,7 +1897,7 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyCohort(c *check.C) {
-	s.srv.total = 3
+	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1916,7 +1917,7 @@ func (s *SnapOpSuite) TestSwitchHappyCohort(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyLeaveCohort(c *check.C) {
-	s.srv.total = 3
+	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1936,7 +1937,7 @@ func (s *SnapOpSuite) TestSwitchHappyLeaveCohort(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
-	s.srv.total = 3
+	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1944,6 +1945,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
 			"cohort-key": "what",
 			"channel":    "edge",
 		})
+		s.srv.trackingChannel = "edge"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
@@ -1957,7 +1959,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyChannelAndLeaveCohort(c *check.C) {
-	s.srv.total = 3
+	s.srv.total = 4
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1965,6 +1967,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndLeaveCohort(c *check.C) {
 			"leave-cohort": true,
 			"channel":      "edge",
 		})
+		s.srv.trackingChannel = "edge"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)


### PR DESCRIPTION
Use `showDone` helper to display actual channel we switched to, rather than the requested one. This makes no difference right now, but it prepares `snap switch` for the upcoming change in channel switching semantics with regard to track and risk level, and also makes it internally consistent with the implementation of other snap ops.
