### PR TITLE
rfc: introduce confinement options failsafe flag

### DIFF
--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -63,6 +63,10 @@ type ConfinementOptions struct {
 	JailMode bool
 	// Classic flag switches the core snap "chroot" off.
 	Classic bool
+	// FailSafeMode flag switches the security backend to failsafe mode.
+	// In failsafe mode some extra things happen. For instance the mount
+	// backend will discard the mount namespace and construct them anew.
+	FailSafeMode bool
 }
 
 // SecurityBackendOptions carries extra flags that affect initialization of the

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -75,6 +75,9 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 	if _, _, err := osutil.EnsureDirState(dir, glob, content); err != nil {
 		return fmt.Errorf("cannot synchronize mount configuration files for snap %q: %s", snapName, err)
 	}
+	if confinement.FailSafeMode {
+		DiscardSnapNamespace(snapName)
+	}
 	if err := UpdateSnapNamespace(snapName); err != nil {
 		return fmt.Errorf("cannot update mount namespace of snap %q: %s", snapName, err)
 	}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -294,6 +294,11 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 			return err
 		}
 		opts := confinementOptions(snapst.Flags)
+		if err := m.setupProfilesForSnap(task, tomb, snapInfo, opts, perfTimings); err != nil {
+			opts.FailSafeMode = true
+			logger.Debugf("cannot setup snap security: %s (trying again in failsafe mode)", err)
+			task.Logf("Cannot apply security profiles, retrying in fail-safe mode")
+		}
 		return m.setupProfilesForSnap(task, tomb, snapInfo, opts, perfTimings)
 	}
 }


### PR DESCRIPTION
This patch introduces a new internal confinement option flag called failsafe
mode. When a security setup fails it is attempted again in failsafe mode. This
can be used to mitigate impact of both known and unknown issues in the
interface system that, otherwise, might result in total system failure.

The first consumer of the failsafe mode is the mount backend. When the flag is
asserted the mount namespace will be discarded ahead of the setup. This allows
to nullify effects of corrupted state of a mount namespace preventing changes
from being applied.

This is both a workaround and a reliability idea. I'm sharing it with Ondra for
some experiments.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
