### PR TITLE
cmd/snap, data/completion: improve completion for 'snap debug'

### DIFF
--- a/cmd/snap/cmd_debug_validate_seed.go
+++ b/cmd/snap/cmd_debug_validate_seed.go
@@ -27,8 +27,8 @@ import (
 
 type cmdValidateSeed struct {
 	Positionals struct {
-		SeedYamlPath string `positional-arg-name:"<seed-yaml-path>"`
-	} `positional-args:"true"`
+		SeedYamlPath flags.Filename `positional-arg-name:"<seed-yaml-path>"`
+	} `positional-args:"true" required:"true"`
 }
 
 func init() {
@@ -46,5 +46,5 @@ func (x *cmdValidateSeed) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	return image.ValidateSeed(x.Positionals.SeedYamlPath)
+	return image.ValidateSeed(string(x.Positionals.SeedYamlPath))
 }

--- a/data/completion/snap
+++ b/data/completion/snap
@@ -38,7 +38,7 @@ _complete_snap() {
         fi
     done
 
-    command=${words[1]}
+    command="${words[1]}"
 
     # Only split on newlines
     local IFS=$'\n'
@@ -46,7 +46,12 @@ _complete_snap() {
     # now we pass _just the bit that's being completed_ of the command
     # to snap for it to figure it out. go-flags isn't smart enough to
     # look at COMP_WORDS etc. itself.
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 snap "$command" "$cur"))
+    if [ "$command" = "debug" ]; then
+        command="${words[2]}"
+        COMPREPLY=($(GO_FLAGS_COMPLETION=1 snap debug "$command" "$cur"))
+    else
+        COMPREPLY=($(GO_FLAGS_COMPLETION=1 snap "$command" "$cur"))
+    fi
 
     case $command in
         install|info|sign-build)


### PR DESCRIPTION
Two small changes:
1. actually support tab completion of debug commands:
   without this change completion of debug was broken, always
   suggesting more debug commands
2. tag the argument of validate-seed as a file, and required
   without this change, when giving it no argument it tried to
   validate a file called "" which failed with a curious error
   message. Also completion didn't know what to offer.