### PR TITLE
packaging/debian-sid: set GOCACHE to a known writable location

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -146,9 +146,9 @@ ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
 	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
 	# we must force a static build here. We need a static snap-{exec,update-ns}
 	# inside the core snap because not all bases will have a libc
-	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
-	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
-	(cd _build/bin && GOPATH=$$(pwd)/.. go build --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
+	(cd _build/bin && GOPATH=$$(pwd)/.. GOCACHE=$$(pwd)/../go-build CGO_ENABLED=0 go build $(GCCGOFLAGS) -pkgdir=$$(pwd)/std $(DH_GOPKG)/cmd/snap-exec)
+	(cd _build/bin && GOPATH=$$(pwd)/.. GOCACHE=$$(pwd)/../go-build CGO_ENABLED=0 go build $(GCCGOFLAGS) -pkgdir=$$(pwd)/std $(DH_GOPKG)/cmd/snapctl)
+	(cd _build/bin && GOPATH=$$(pwd)/.. GOCACHE=$$(pwd)/../go-build go build --ldflags '-extldflags "-static"' $(GCCGOFLAGS) -pkgdir=$$(pwd)/std $(DH_GOPKG)/cmd/snap-update-ns)
 
 	# ensure we generated a static build
 	$(shell	if ldd _build/bin/snap-exec; then false "need static build"; fi)


### PR DESCRIPTION
Go attempts to automatically cache build artifacts under $GOCACHE. This normally
defaults to $HOME/.cache/go-build. When building snapd under sbuild, $HOME is
set to a location that does not exist. The tests/main/sbuild spread job fails
with the log:

```
  + echo 'And build it normally'
  And build it normally
  + su -c 'sbuild -d sid --run-autopkgtest /home/gopath/src/github.com/snapcore/snapd/../*.dsc' test
  E: Build failure (dpkg-buildpackage died)
```

Inspecting build log manually, the following can be found:

```
  (cd _build/bin && GOPATH=$(pwd)/.. CGO_ENABLED=0 go build  github.com/snapcore/snapd/cmd/snap-exec)
  failed to initialize build cache at /sbuild-nonexistent/.cache/go-build: mkdir /sbuild-nonexistent: permission denied
  make[1]: *** [debian/rules:147: override_dh_auto_build] Error 1
  make[1]: Leaving directory '/<<PKGBUILDDIR>>'
  make: *** [debian/rules:102: build] Error 2
  dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```
