### PR TITLE
cmd/snap-confine: implement snap-device-helper internally

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -38,8 +38,6 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libudev.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libseccomp.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcap.so* mr,
-    # Needed to run /usr/bin/sh for snap-device-helper.
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libtinfo.so* mr,
 
     @LIBEXECDIR@/snap-confine mr,
 
@@ -55,8 +53,11 @@
     capability sys_admin,
     capability dac_read_search,
     capability dac_override,
-    /sys/fs/cgroup/devices/snap{,py}.*/ w,
-    /sys/fs/cgroup/devices/snap{,py}.*/tasks w,
+    /sys/fs/cgroup/ r,
+    /sys/fs/cgroup/devices/ r,
+    /sys/fs/cgroup/devices/snap{,py}.*/ rw,
+    /sys/fs/cgroup/devices/snap{,py}.*/tasks w, # drop
+    /sys/fs/cgroup/devices/snap{,py}.*/cgroup.procs w,
     /sys/fs/cgroup/devices/snap{,py}.*/devices.{allow,deny} w,
 
     # cgroup: freezer
@@ -79,8 +80,6 @@
     # querying udev
     /etc/udev/udev.conf r,
     /sys/**/uevent r,
-    /usr/lib/snapd/snap-device-helper ixr, # drop
-    /{,usr/}lib/udev/snappy-app-dev ixr, # drop
     /run/udev/** rw,
     /{,usr/}bin/tr ixr,
     /usr/lib/locale/** r,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -572,11 +572,8 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 	// Init and check rootfs_dir, apply any fallback behaviors.
 	sc_check_rootfs_dir(inv);
 
-	/** Populate and join the device control group. */
-	struct snappy_udev udev_s;
-	if (snappy_udev_init(inv->security_tag, &udev_s) == 0)
-		setup_devices_cgroup(inv->security_tag, &udev_s);
-	snappy_udev_cleanup(&udev_s);
+	/** Conditionally create, populate and join the device cgroup. */
+	sc_setup_device_cgroup(inv->security_tag);
 
 	/**
 	 * is_normal_mode controls if we should pivot into the base snap.

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,290 +18,350 @@
 
 #include <ctype.h>
 #include <errno.h>
-#include <limits.h>
-#include <sys/sysmacros.h>
-#include <sched.h>
+#include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
+#include <libudev.h>
+
+#include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/snap.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 #include "udev-support.h"
 
-static void
-_run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
-			       const char *path, unsigned major, unsigned minor)
+/* Allow access to common devices. */
+static void sc_udev_allow_common(int devices_allow_fd)
 {
-	int status = 0;
-	pid_t pid = fork();
-	if (pid < 0) {
-		die("cannot fork support process for device cgroup assignment");
-	}
-	if (pid == 0) {
-		uid_t real_uid, effective_uid, saved_uid;
-		if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0)
-			die("cannot get real, effective and saved user IDs");
-		// can't update the cgroup unless the real_uid is 0, euid as
-		// 0 is not enough
-		if (real_uid != 0 && effective_uid == 0)
-			if (setuid(0) != 0)
-				die("cannot set user ID to zero");
-		char buf[64] = { 0 };
-		// pass snappy-add-dev an empty environment so the
-		// user-controlled environment can't be used to subvert
-		// snappy-add-dev
-		char *env[] = { NULL };
-		if (minor == UINT_MAX) {
-			sc_must_snprintf(buf, sizeof(buf), "%u:*", major);
-		} else {
-			sc_must_snprintf(buf, sizeof(buf), "%u:%u", major,
-					 minor);
-		}
-		debug("running snap-device-helper add %s %s %s",
-		      udev_s->tagname, path, buf);
-		// This code runs inside the core snap. We have two paths
-		// for the udev helper.
-		//
-		// First try new "snap-device-helper" path first but
-		// when running against an older core snap fallback to
-		// the old name.
-		if (access("/usr/lib/snapd/snap-device-helper", X_OK) == 0)
-			execle("/usr/lib/snapd/snap-device-helper",
-			       "/usr/lib/snapd/snap-device-helper", "add",
-			       udev_s->tagname, path, buf, NULL, env);
-		else if (access("/usr/libexec/snapd/snap-device-helper", X_OK) == 0)
-			execle("/usr/libexec/snapd/snap-device-helper",
-			       "/usr/libexec/snapd/snap-device-helper", "add",
-			       udev_s->tagname, path, buf, NULL, env);
-		else
-			execle("/lib/udev/snappy-app-dev",
-			       "/lib/udev/snappy-app-dev", "add",
-			       udev_s->tagname, path, buf, NULL, env);
-		die("execl failed");
-	}
-	if (waitpid(pid, &status, 0) < 0)
-		die("waitpid failed");
-	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
-		die("child exited with status %i", WEXITSTATUS(status));
-	else if (WIFSIGNALED(status))
-		die("child died with signal %i", WTERMSIG(status));
+	/* The devices we add here have static number allocation.
+	 * https://www.kernel.org/doc/html/v4.11/admin-guide/devices.html */
+	dprintf(devices_allow_fd, "c 1:3 rwm");	// /dev/null
+	dprintf(devices_allow_fd, "c 1:5 rwm");	// /dev/zero
+	dprintf(devices_allow_fd, "c 1:7 rwm");	// /dev/full
+	dprintf(devices_allow_fd, "c 1:8 rwm");	// /dev/random
+	dprintf(devices_allow_fd, "c 1:9 rwm");	// /dev/urandom
+	dprintf(devices_allow_fd, "c 5:0 rwm");	// /dev/tty
+	dprintf(devices_allow_fd, "c 5:1 rwm");	// /dev/console
+	dprintf(devices_allow_fd, "c 5:2 rwm");	// /dev/ptmx
 }
 
-void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path)
+/** Allow access to current and future PTY slaves.
+ *
+ * We unconditionally add them since we use a devpts newinstance. Unix98 PTY
+ * slaves major are 136-143.
+ *
+ * See also:
+ * https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
+ **/
+static void sc_udev_allow_pty_slaves(int devices_allow_fd)
 {
-	if (udev_s == NULL)
-		die("snappy_udev is NULL");
-	if (udev_s->udev == NULL)
-		die("snappy_udev->udev is NULL");
-	if (udev_s->tagname_len == 0
-	    || udev_s->tagname_len >= MAX_BUF
-	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len
-	    || udev_s->tagname[udev_s->tagname_len] != '\0')
-		die("snappy_udev->tagname has invalid length");
-
-	debug("%s: %s %s", __func__, path, udev_s->tagname);
-
-	struct udev_device *d =
-	    udev_device_new_from_syspath(udev_s->udev, path);
-	if (d == NULL)
-		die("cannot find device from syspath %s", path);
-	dev_t devnum = udev_device_get_devnum(d);
-	udev_device_unref(d);
-
-	_run_snappy_app_dev_add_majmin(udev_s, path, major(devnum),
-				       minor(devnum));
-}
-
-/*
- * snappy_udev_init() - setup the snappy_udev structure. Return 0 if devices
- * are assigned, else return -1. Callers should use snappy_udev_cleanup() to
- * cleanup.
- */
-int snappy_udev_init(const char *security_tag, struct snappy_udev *udev_s)
-{
-	debug("%s", __func__);
-	int rc = 0;
-
-	udev_s->tagname[0] = '\0';
-	udev_s->tagname_len = 0;
-	// TAG+="snap_<security tag>" (udev doesn't like '.' in the tag name)
-	udev_s->tagname_len = sc_must_snprintf(udev_s->tagname, MAX_BUF,
-					       "%s", security_tag);
-	for (size_t i = 0; i < udev_s->tagname_len; i++)
-		if (udev_s->tagname[i] == '.')
-			udev_s->tagname[i] = '_';
-
-	udev_s->udev = udev_new();
-	if (udev_s->udev == NULL)
-		die("udev_new failed");
-
-	udev_s->devices = udev_enumerate_new(udev_s->udev);
-	if (udev_s->devices == NULL)
-		die("udev_enumerate_new failed");
-
-	if (udev_enumerate_add_match_tag(udev_s->devices, udev_s->tagname) != 0)
-		die("udev_enumerate_add_match_tag");
-
-	if (udev_enumerate_scan_devices(udev_s->devices) != 0)
-		die("udev_enumerate_scan failed");
-
-	udev_s->assigned = udev_enumerate_get_list_entry(udev_s->devices);
-	if (udev_s->assigned == NULL)
-		rc = -1;
-
-	return rc;
-}
-
-void snappy_udev_cleanup(struct snappy_udev *udev_s)
-{
-	// udev_s->assigned does not need to be unreferenced since it is a
-	// pointer into udev_s->devices
-	if (udev_s->devices != NULL)
-		udev_enumerate_unref(udev_s->devices);
-	if (udev_s->udev != NULL)
-		udev_unref(udev_s->udev);
-}
-
-void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
-{
-	debug("%s", __func__);
-	// Devices that must always be present
-	const char *static_devices[] = {
-		"/sys/class/mem/null",
-		"/sys/class/mem/full",
-		"/sys/class/mem/zero",
-		"/sys/class/mem/random",
-		"/sys/class/mem/urandom",
-		"/sys/class/tty/tty",
-		"/sys/class/tty/console",
-		"/sys/class/tty/ptmx",
-		NULL,
-	};
-
-	if (udev_s == NULL)
-		die("snappy_udev is NULL");
-	if (udev_s->udev == NULL)
-		die("snappy_udev->udev is NULL");
-	if (udev_s->devices == NULL)
-		die("snappy_udev->devices is NULL");
-	if (udev_s->assigned == NULL)
-		die("snappy_udev->assigned is NULL");
-	if (udev_s->tagname_len == 0
-	    || udev_s->tagname_len >= MAX_BUF
-	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len
-	    || udev_s->tagname[udev_s->tagname_len] != '\0')
-		die("snappy_udev->tagname has invalid length");
-
-	// create devices cgroup controller
-	char cgroup_dir[PATH_MAX] = { 0 };
-
-	sc_must_snprintf(cgroup_dir, sizeof(cgroup_dir),
-			 "/sys/fs/cgroup/devices/%s/", security_tag);
-
-	if (mkdir(cgroup_dir, 0755) < 0 && errno != EEXIST)
-		die("cannot create cgroup hierarchy %s", cgroup_dir);
-
-	// move ourselves into it
-	char cgroup_file[PATH_MAX] = { 0 };
-	sc_must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
-			 "tasks");
-
-	char buf[128] = { 0 };
-	sc_must_snprintf(buf, sizeof(buf), "%i", getpid());
-	write_string_to_file(cgroup_file, buf);
-
-	// deny by default. Write 'a' to devices.deny to remove all existing
-	// devices that were added in previous launcher invocations, then add
-	// the static and assigned devices. This ensures that at application
-	// launch the cgroup only has what is currently assigned.
-	sc_must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
-			 "devices.deny");
-	write_string_to_file(cgroup_file, "a");
-
-	// add the common devices
-	for (int i = 0; static_devices[i] != NULL; i++)
-		run_snappy_app_dev_add(udev_s, static_devices[i]);
-
-	// add glob for current and future PTY slaves. We unconditionally add
-	// them since we use a devpts newinstance. Unix98 PTY slaves major
-	// are 136-143.
-	// https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
 	for (unsigned pty_major = 136; pty_major <= 143; pty_major++) {
-		// '/dev/pts/slaves' is only used for debugging and by
-		// /usr/lib/snapd/snap-device-helper to determine if it is a block
-		// device, so just use something to indicate what the
-		// addition is for
-		_run_snappy_app_dev_add_majmin(udev_s, "/dev/pts/slaves",
-					       pty_major, UINT_MAX);
+		dprintf(devices_allow_fd, "c %u:* rwm", pty_major);
 	}
+}
 
-	// nvidia modules are proprietary and therefore aren't in sysfs and
-	// can't be udev tagged. For now, just add existing nvidia devices to
-	// the cgroup unconditionally (AppArmor will still mediate the access).
-	// We'll want to rethink this if snapd needs to mediate access to other
-	// proprietary devices.
-	//
-	// Device major and minor numbers are described in (though nvidia-uvm
-	// currently isn't listed):
-	// https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
-	char nv_path[15] = { 0 };	// /dev/nvidiaXXX
-	const char *nvctl_path = "/dev/nvidiactl";
-	const char *nvuvm_path = "/dev/nvidia-uvm";
-	const char *nvidia_modeset_path = "/dev/nvidia-modeset";
-
+/** Allow access to NVidia devices.
+ *
+ * NVidia modules are proprietary and therefore aren't in sysfs and can't be
+ * udev tagged. For now, just add existing nvidia devices to the cgroup
+ * unconditionally (AppArmor will still mediate the access).  We'll want to
+ * rethink this if snapd needs to mediate access to other proprietary devices.
+ *
+ * Device major and minor numbers are described in (though nvidia-uvm currently
+ * isn't listed):
+ *
+ * https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
+ **/
+static void sc_udev_allow_nvidia(int devices_allow_fd)
+{
 	struct stat sbuf;
 
-	// /dev/nvidia0 through /dev/nvidia254
+	/* Allow access to /dev/nvidia0 through /dev/nvidia254 */
 	for (unsigned nv_minor = 0; nv_minor < 255; nv_minor++) {
+		char nv_path[15] = { 0 };	// /dev/nvidiaXXX
 		sc_must_snprintf(nv_path, sizeof(nv_path), "/dev/nvidia%u",
 				 nv_minor);
 
-		// Stop trying to find devices after one is not found. In this
-		// manner, we'll add /dev/nvidia0 and /dev/nvidia1 but stop
-		// trying to find nvidia3 - nvidia254 if nvidia2 is not found.
+		/* Stop trying to find devices after one is not found. In this manner,
+		 * we'll add /dev/nvidia0 and /dev/nvidia1 but stop trying to find
+		 * nvidia3 - nvidia254 if nvidia2 is not found. */
 		if (stat(nv_path, &sbuf) != 0) {
 			break;
 		}
-		_run_snappy_app_dev_add_majmin(udev_s, nv_path,
-					       major(sbuf.st_rdev),
-					       minor(sbuf.st_rdev));
+		dprintf(devices_allow_fd, "c %u:%u rwm", major(sbuf.st_rdev),
+			minor(sbuf.st_rdev));
 	}
 
-	// /dev/nvidiactl
-	if (stat(nvctl_path, &sbuf) == 0) {
-		_run_snappy_app_dev_add_majmin(udev_s, nvctl_path,
-					       major(sbuf.st_rdev),
-					       minor(sbuf.st_rdev));
+	if (stat("/dev/nvidiactl", &sbuf) == 0) {
+		dprintf(devices_allow_fd, "c %u:%u rwm", major(sbuf.st_rdev),
+			minor(sbuf.st_rdev));
 	}
-	// /dev/nvidia-uvm
-	if (stat(nvuvm_path, &sbuf) == 0) {
-		_run_snappy_app_dev_add_majmin(udev_s, nvuvm_path,
-					       major(sbuf.st_rdev),
-					       minor(sbuf.st_rdev));
+	if (stat("/dev/nvidia-uvm", &sbuf) == 0) {
+		dprintf(devices_allow_fd, "c %u:%u rwm", major(sbuf.st_rdev),
+			minor(sbuf.st_rdev));
 	}
-	// /dev/nvidia-modeset
-	if (stat(nvidia_modeset_path, &sbuf) == 0) {
-		_run_snappy_app_dev_add_majmin(udev_s, nvidia_modeset_path,
-					       major(sbuf.st_rdev),
-					       minor(sbuf.st_rdev));
+	if (stat("/dev/nvidia-modeset", &sbuf) == 0) {
+		dprintf(devices_allow_fd, "c %u:%u rwm", major(sbuf.st_rdev),
+			minor(sbuf.st_rdev));
 	}
-	// /dev/uhid isn't represented in sysfs, so add it to the device cgroup
-	// if it exists and let AppArmor handle the mediation
+}
+
+/**
+ * Allow access to /dev/uhid.
+ *
+ * Currently /dev/uhid isn't represented in sysfs, so add it to the device
+ * cgroup if it exists and let AppArmor handle the mediation.
+ **/
+static void sc_udev_allow_uhid(int devices_allow_fd)
+{
+	struct stat sbuf;
+
 	if (stat("/dev/uhid", &sbuf) == 0) {
-		_run_snappy_app_dev_add_majmin(udev_s, "/dev/uhid",
-					       major(sbuf.st_rdev),
-					       minor(sbuf.st_rdev));
+		dprintf(devices_allow_fd, "c %u:%u rwm", major(sbuf.st_rdev),
+			minor(sbuf.st_rdev));
 	}
-	// add the assigned devices
-	while (udev_s->assigned != NULL) {
-		const char *path = udev_list_entry_get_name(udev_s->assigned);
-		if (path == NULL)
+}
+
+/**
+ * Allow access to assigned devices.
+ *
+ * The snapd udev security backend uses udev rules to tag matching devices with
+ * tags corresponding to snap applications. Here we interrogate udev and allow
+ * access to all assigned devices.
+ **/
+static void sc_udev_allow_assigned(int devices_allow_fd, struct udev *udev,
+				   struct udev_list_entry *assigned)
+{
+	for (struct udev_list_entry * entry = assigned; entry != NULL;
+	     entry = udev_list_entry_get_next(entry)) {
+		const char *path = udev_list_entry_get_name(entry);
+		if (path == NULL) {
 			die("udev_list_entry_get_name failed");
-		run_snappy_app_dev_add(udev_s, path);
-		udev_s->assigned = udev_list_entry_get_next(udev_s->assigned);
+		}
+		struct udev_device *device =
+		    udev_device_new_from_syspath(udev, path);
+		if (device == NULL) {
+			die("cannot find device from syspath %s", path);
+		}
+		dev_t devnum = udev_device_get_devnum(device);
+		char type_c = strstr(path, "/block/") != NULL ? 'b' : 'c';
+		dprintf(devices_allow_fd, "%c %u:%u rwm", type_c, major(devnum),
+			minor(devnum));
+
+		udev_device_unref(device);
 	}
+}
+
+static void sc_udev_setup_acls(int devices_allow_fd, int devices_deny_fd,
+			       struct udev *udev,
+			       struct udev_list_entry *assigned)
+{
+	/* Deny device access by default.
+	 *
+	 * Write 'a' to devices.deny to remove all existing devices that were added
+	 * in previous launcher invocations, then add the static and assigned
+	 * devices. This ensures that at application launch the cgroup only has
+	 * what is currently assigned. */
+	dprintf(devices_deny_fd, "a");
+
+	/* Allow access to various devices. */
+	sc_udev_allow_common(devices_allow_fd);
+	sc_udev_allow_pty_slaves(devices_allow_fd);
+	sc_udev_allow_nvidia(devices_allow_fd);
+	sc_udev_allow_uhid(devices_allow_fd);
+	sc_udev_allow_assigned(devices_allow_fd, udev, assigned);
+}
+
+static char *sc_udev_mangle_security_tag(const char *security_tag)
+{
+	char *udev_tag = sc_strdup(security_tag);
+	for (char *c = strchr(udev_tag, '.'); c != NULL; c = strchr(c, '.')) {
+		*c = '_';
+	}
+	return udev_tag;
+}
+
+static void sc_cleanup_udev(struct udev **udev)
+{
+	if (udev != NULL && *udev != NULL) {
+		udev_unref(*udev);
+		*udev = NULL;
+	}
+}
+
+static void sc_cleanup_udev_enumerate(struct udev_enumerate **enumerate)
+{
+	if (enumerate != NULL && *enumerate != NULL) {
+		udev_enumerate_unref(*enumerate);
+		*enumerate = NULL;
+	}
+}
+
+typedef struct sc_cgroup_fds {
+	int devices_allow_fd;
+	int devices_deny_fd;
+	int cgroup_procs_fd;
+} sc_cgroup_fds;
+
+static sc_cgroup_fds sc_udev_open_cgroup_v1(const char *security_tag)
+{
+	sc_cgroup_fds fds = { -1, -1, -1 };
+
+	/* Open /sys/fs/cgroup */
+	const char *cgroup_path = "/sys/fs/cgroup";
+	int SC_CLEANUP(sc_cleanup_close) cgroup_fd = -1;
+	cgroup_fd = open(cgroup_path,
+			 O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+	if (cgroup_fd < 0 && errno == ENOENT) {
+		if (errno == ENOENT) {
+			/* This system does not support cgroups. */
+			return fds;
+		}
+		die("cannot open %s", cgroup_path);
+	}
+
+	/* Open devices relative to /sys/fs/cgroup */
+	const char *devices_relpath = "devices";
+	int SC_CLEANUP(sc_cleanup_close) devices_fd = -1;
+	devices_fd = openat(cgroup_fd, devices_relpath,
+			    O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+	if (devices_fd < 0) {
+		if (errno == ENOENT) {
+			/* This system does not support the device cgroup. */
+			return fds;
+		}
+		die("cannot open %s/%s", cgroup_path, devices_relpath);
+	}
+
+	/* Open snap.$SNAP_NAME.$APP_NAME relative to /sys/fs/cgroup/devices,
+	 * creating the directory if necessary. Note that we always chown the
+	 * resulting directory to root:root. */
+	const char *security_tag_relpath = security_tag;
+	if (mkdirat(devices_fd, security_tag_relpath, 0755) < 0) {
+		if (errno != EEXIST) {
+			die("cannot create directory %s/%s/%s", cgroup_path,
+			    devices_relpath, security_tag_relpath);
+		}
+	}
+
+	int SC_CLEANUP(sc_cleanup_close) security_tag_fd = -1;
+	security_tag_fd = openat(devices_fd, security_tag_relpath,
+				 O_RDONLY | O_DIRECTORY | O_CLOEXEC |
+				 O_NOFOLLOW);
+	if (security_tag_fd < 0) {
+		die("cannot open %s/%s/%s", cgroup_path, devices_relpath,
+		    security_tag_relpath);
+	}
+	if (fchown(security_tag_fd, 0, 0) < 0) {
+		die("cannot chown %s/%s/%s to root:root", cgroup_path,
+		    devices_relpath, security_tag_relpath);
+	}
+
+	/* Open devices.allow relative to /sys/fs/cgroup/devices/snap.$SNAP_NAME.$APP_NAME */
+	const char *devices_allow_relpath = "devices.allow";
+	int devices_allow_fd = -1;
+	devices_allow_fd = openat(security_tag_fd, devices_allow_relpath,
+				  O_WRONLY | O_CLOEXEC | O_NOFOLLOW);
+	if (devices_allow_fd < 0) {
+		die("cannot open %s/%s/%s/%s", cgroup_path, devices_relpath,
+		    security_tag_relpath, devices_allow_relpath);
+	}
+
+	/* Open devices.deny relative to /sys/fs/cgroup/devices/snap.$SNAP_NAME.$APP_NAME */
+	const char *devices_deny_relpath = "devices.deny";
+	int devices_deny_fd = -1;
+	devices_deny_fd = openat(security_tag_fd, devices_deny_relpath,
+				 O_WRONLY | O_CLOEXEC | O_NOFOLLOW);
+	if (devices_deny_fd < 0) {
+		die("cannot open %s/%s/%s/%s", cgroup_path, devices_relpath,
+		    security_tag_relpath, devices_deny_relpath);
+	}
+
+	/* Open cgroup.procs relative to /sys/fs/cgroup/devices/snap.$SNAP_NAME.$APP_NAME */
+	const char *cgroup_procs_relpath = "cgroup.procs";
+	int cgroup_procs_fd = -1;
+	cgroup_procs_fd = openat(security_tag_fd, cgroup_procs_relpath,
+				 O_WRONLY | O_CLOEXEC | O_NOFOLLOW);
+	if (cgroup_procs_fd < 0) {
+		die("cannot open %s/%s/%s/%s", cgroup_path, devices_relpath,
+		    security_tag_relpath, cgroup_procs_relpath);
+	}
+
+	/* Everything worked so pack the result and "move" the descriptors over so
+	 * that they are not closed by the cleanup functions. */
+	fds.devices_allow_fd = devices_allow_fd;
+	fds.devices_deny_fd = devices_deny_fd;
+	fds.cgroup_procs_fd = cgroup_procs_fd;
+	devices_allow_fd = -1;
+	devices_deny_fd = -1;
+	cgroup_procs_fd = -1;
+	return fds;
+}
+
+static void sc_cleanup_cgroup_fds(sc_cgroup_fds * fds)
+{
+	if (fds != NULL) {
+		sc_cleanup_close(&fds->devices_allow_fd);
+		sc_cleanup_close(&fds->devices_deny_fd);
+		sc_cleanup_close(&fds->cgroup_procs_fd);
+	}
+}
+
+void sc_setup_device_cgroup(const char *security_tag)
+{
+	/* Derive the udev tag from the snap security tag.
+	 *
+	 * Because udev does not allow for dots in tag names, those are replaced by
+	 * underscores in snapd. We just match that behavior. */
+	char *udev_tag SC_CLEANUP(sc_cleanup_string) = NULL;
+	udev_tag = sc_udev_mangle_security_tag(security_tag);
+
+	/* Use udev APIs to talk to udev-the-daemon to determine the list of
+	 * "devices" with that tag assigned. The list may be empty, in which case
+	 * there's no udev tagging in effect and we must refrain from constructing
+	 * the cgroup as it would interfere with the execution of a program. */
+	struct udev SC_CLEANUP(sc_cleanup_udev) * udev = NULL;
+	udev = udev_new();
+	if (udev == NULL) {
+		die("cannot connect to udev");
+	}
+	struct udev_enumerate SC_CLEANUP(sc_cleanup_udev_enumerate) * devices =
+	    NULL;
+	devices = udev_enumerate_new(udev);
+	if (devices == NULL) {
+		die("cannot create udev device enumeration");
+	}
+	if (udev_enumerate_add_match_tag(devices, udev_tag) != 0) {
+		die("cannot add tag match to udev device enumeration");
+	}
+	if (udev_enumerate_scan_devices(devices) != 0) {
+		die("cannot enumerate udev devices");
+	}
+	/* NOTE: udev_list_entry is bound to life-cycle of the used udev_enumerate */
+	struct udev_list_entry *assigned;
+	assigned = udev_enumerate_get_list_entry(devices);
+	if (assigned == NULL) {
+		/* NOTE: Nothing is assigned, don't create or use the device cgroup. */
+		debug("no devices tagged with %s, skipping device cgroup setup",
+		      udev_tag);
+		return;
+	}
+
+	sc_cgroup_fds SC_CLEANUP(sc_cleanup_cgroup_fds) fds = { -1, -1, -1 };
+	fds = sc_udev_open_cgroup_v1(security_tag);
+	if (fds.cgroup_procs_fd < 0) {
+		debug("cgroup v1 unavailable, skipping device cgroup setup");
+		return;
+	}
+	/* Setup the device group access control list */
+	sc_udev_setup_acls(fds.devices_allow_fd, fds.devices_deny_fd,
+			   udev, assigned);
+
+	/* Move ourselves to the device cgroup */
+	dprintf(fds.cgroup_procs_fd, "%i", getpid());
+	debug("associated snap application process with device cgroup %s",
+	      security_tag);
 }

--- a/cmd/snap-confine/udev-support.h
+++ b/cmd/snap-confine/udev-support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,23 +18,6 @@
 #ifndef SNAP_CONFINE_UDEV_SUPPORT_H
 #define SNAP_CONFINE_UDEV_SUPPORT_H
 
-#include <stddef.h>
-
-#include <libudev.h>
-
-#define MAX_BUF 1000
-
-struct snappy_udev {
-	struct udev *udev;
-	struct udev_enumerate *devices;
-	struct udev_list_entry *assigned;
-	char tagname[MAX_BUF];
-	size_t tagname_len;
-};
-
-void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path);
-int snappy_udev_init(const char *security_tag, struct snappy_udev *udev_s);
-void snappy_udev_cleanup(struct snappy_udev *udev_s);
-void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s);
+void sc_setup_device_cgroup(const char *security_tag);
 
 #endif

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -105,12 +105,6 @@ update_core_snap_for_classic_reexec() {
     rm squashfs-root/usr/lib/snapd/* squashfs-root/usr/bin/snap
     # and copy in the current libexec
     cp -a "$LIBEXECDIR"/snapd/* squashfs-root/usr/lib/snapd/
-    case "$SPREAD_SYSTEM" in
-        fedora-*|centos-*|amazon-*)
-            # RPM can rewrite shebang to #!/usr/bin/sh
-            sed -i -e '1 s;#!/usr/bin/sh;#!/bin/sh;' squashfs-root/usr/lib/snapd/snap-device-helper
-            ;;
-    esac
     # also the binaries themselves
     cp -a /usr/bin/snap squashfs-root/usr/bin/
     # make sure bin/snapctl is a symlink to lib/


### PR DESCRIPTION
This patch begins the cleanup of snap-confine's handling of udev
tagging. The script snap-device-helper had two roles:

1) Invoked by udev to dynamically add and remove device group ACLs
in response to udev hotplug events.
2) Invoked by snap-confine to configure the device cgroup.

The second role is discarded. Instead snap-confine now implements the
relevant logic itself. This "logic" is literally:

    dprintf(devices_allow_fd, "%c %u:%u", block_device ? 'b' : 'c',
	dev_major, dev_minor);

Doing so in C allows us to spare countless fork + exec combos, which
also fork for various parts of the script, making snap executing a
little bit faster.

In addition, since the snap-device-helper script is now only invoked by
udev in the initial mount namespace, we no longer have to worry about
the script interpreter. As such the packaging for some distributions is
adjusted to disable our previous workarounds.

This step opens the path towards cgroup v2 support, although much more
work is still required there.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
