### PR TITLE
interfaces/network-setup-control: allow dbus netplan apply messages

### DIFF
--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -53,7 +53,8 @@ dbus (send)
     bus=system
     interface=io.netplan.Netplan
     path=/io/netplan/Netplan
-    member=Apply,
+	member=Apply
+	peer=(label=unconfined),
 
 `
 

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -46,9 +46,7 @@ const networkSetupControlConnectedPlugAppArmor = `
 /run/udev/rules.d/ rw,                 # needed for cloud-init
 /run/udev/rules.d/[0-9]*-netplan-* rw,
 
-capability net_admin,
-
-#include <abstractions/dbus-session-strict>
+#include <abstractions/dbus-strict>
 
 # Allow use of NetPlan Apply API, used to apply network configuration
 dbus (send)

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -54,8 +54,8 @@ capability net_admin,
 dbus (send)
     bus=system
     interface=io.netplan.Netplan
-	path=/io/netplan/Netplan
-	member=Apply,
+    path=/io/netplan/Netplan
+    member=Apply,
 
 `
 

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -45,6 +45,18 @@ const networkSetupControlConnectedPlugAppArmor = `
 
 /run/udev/rules.d/ rw,                 # needed for cloud-init
 /run/udev/rules.d/[0-9]*-netplan-* rw,
+
+capability net_admin,
+
+#include <abstractions/dbus-session-strict>
+
+# Allow use of NetPlan Apply API, used to apply network configuration
+dbus (send)
+    bus=system
+    interface=io.netplan.Netplan
+	path=/io/netplan/Netplan
+	member=Apply,
+
 `
 
 func init() {

--- a/tests/main/netplan-apply/fake-netplan-apply-service.py
+++ b/tests/main/netplan-apply/fake-netplan-apply-service.py
@@ -19,7 +19,7 @@ class NetplanApplyService(dbus.service.Object):
                          out_signature="b")
     def Apply(self):
         # log that we were called and always return True
-        with open(self._logfile, "a") as fp:
+        with open(self._logfile, "a+") as fp:
             fp.write("Apply called\n")
         return True
 

--- a/tests/main/netplan-apply/fake-netplan-apply-service.py
+++ b/tests/main/netplan-apply/fake-netplan-apply-service.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+from gi.repository import GLib
+import dbus.mainloop.glib
+import dbus.service
+import sys
+
+BUS_NAME = "io.netplan.Netplan"
+OBJECT_PATH = "/io/netplan/Netplan"
+DOC_IFACE = "io.netplan.Netplan"
+
+
+class NetplanApplyService(dbus.service.Object):
+    def __init__(self, connection, object_path, logfile):
+        super(NetplanApplyService, self).__init__(connection, object_path)
+        self._logfile = logfile
+
+    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
+                         out_signature="b")
+    def Apply(self):
+        # log that we were called and always return True
+        with open(self._logfile, "a") as fp:
+            fp.write("Apply called\n")
+        return True
+
+
+def main(argv):
+    logfile = argv[1]
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    main_loop = GLib.MainLoop()
+
+    bus = dbus.SystemBus()
+    # Make sure we quit when the bus shuts down
+    bus.add_signal_receiver(
+        main_loop.quit, signal_name="Disconnected",
+        path="/org/freedesktop/DBus/Local",
+        dbus_interface="org.freedesktop.DBus.Local")
+
+    NetplanApplyService(bus, OBJECT_PATH, logfile)
+
+    # Allow other services to assume our bus name
+    dbus.service.BusName(
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
+        do_not_queue=True)
+
+    main_loop.run()
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/main/netplan-apply/fake-netplan-apply-service.py
+++ b/tests/main/netplan-apply/fake-netplan-apply-service.py
@@ -12,7 +12,7 @@ DOC_IFACE = "io.netplan.Netplan"
 
 class NetplanApplyService(dbus.service.Object):
     def __init__(self, connection, object_path, logfile):
-        super(NetplanApplyService, self).__init__(connection, object_path)
+        super().__init__(connection, object_path)
         self._logfile = logfile
 
     @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",

--- a/tests/main/netplan-apply/io.netplan.Netplan.conf
+++ b/tests/main/netplan-apply/io.netplan.Netplan.conf
@@ -1,0 +1,18 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <policy user="root">
+    <allow own="io.netplan.Netplan"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="io.netplan.Netplan"
+           send_interface="io.netplan.Netplan"/>
+    <allow send_destination="io.netplan.Netplan"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
+
+</busconfig>
+

--- a/tests/main/netplan-apply/snapcraft.yaml
+++ b/tests/main/netplan-apply/snapcraft.yaml
@@ -1,0 +1,50 @@
+name: test-snapd-netplan-apply
+base: core18
+version: git
+summary: Backend-agnostic network configuration in YAML
+description: |
+  Netplan is a utility for easily configuring networking on a linux system.
+  You simply create a YAML description of the required network interfaces and
+  what each should be configured to do. From this description Netplan will
+  generate all the necessary configuration for your chosen renderer tool.
+grade: devel
+confinement: strict
+
+apps:
+  netplan:
+    command: usr/bin/python3 $SNAP/usr/sbin/netplan
+    environment:
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+    adapter: full
+    plugs:
+      - network
+      - network-bind
+      - network-setup-control
+
+parts:
+  netplan:
+    source: https://github.com/CanonicalLtd/netplan.git
+    plugin: make
+    build-packages:
+      - bash-completion
+      - libglib2.0-dev
+      - libyaml-dev
+      - uuid-dev
+      - pandoc
+      - pkg-config
+      - python3
+      - python3-coverage
+      - python3-yaml
+      - python3-netifaces
+      - python3-nose
+      - pyflakes3
+      - pep8
+      - systemd
+      - libsystemd-dev
+    stage-packages:
+      - iproute2
+      - python3
+      - python3-netifaces
+      - python3-yaml
+      - systemd
+      - libatm1

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -15,42 +15,33 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     snap install test-snapd-netplan-apply --edge
 
-    echo "temporarily installing netplan D-Bus service until SRU is done..."
-    # for now, until netplan's D-Bus has been SRU'd to the netplan.io debian 
-    # package, we will just manually install the netplan D-Bus service units
-    # into the machine from the snap and install netplan.io from the archive
-    apt update
-
-    # the netplan package was renamed nplan -> netplan.io in bionic
-    case "$SPREAD_SYSTEM" in
-        ubuntu-16*)
-            NETPLAN_APT_PKG=nplan;;
-        *)
-            NETPLAN_APT_PKG=netplan.io;;
-    esac
-
-    apt install -y $NETPLAN_APT_PKG
-
-    NETPLAN_SNAP=/snap/test-snapd-netplan-apply/current
-
-    mkdir -p /lib/netplan
-    cp $NETPLAN_SNAP/lib/netplan/netplan-dbus \
-        /lib/netplan/netplan-dbus
-    chmod +x /lib/netplan/netplan-dbus
-    mkdir -p /usr/share/dbus-1/system-services
-    cp $NETPLAN_SNAP/share/dbus-1/system-services/io.netplan.Netplan.service \
-        /usr/share/dbus-1/system-services/io.netplan.Netplan.service
-    mkdir -p /usr/share/dbus-1/system.d
-    cp $NETPLAN_SNAP/share/dbus-1/system.d/io.netplan.Netplan.conf \
-        /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
-
-restore: |
-    echo "uninstalling netplan D-Bus service"
-    rm -f /usr/lib/netplan/netplan-dbus
+    # ensure that the service file doesn't exist before running
     rm -f /usr/share/dbus-1/system-services/io.netplan.Netplan.service
     rm -f /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
 
+restore: |
+    echo "uninstalling netplan D-Bus service"
+    rm -f /usr/share/dbus-1/system-services/io.netplan.Netplan.service
+    rm -f /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+    snap remove test-snapd-netplan-apply
+
 execute: |
+    # install the dbus configuration file for our fake netplan system dbus service
+    mkdir -p /usr/share/dbus-1/system.d 
+    mkdir -p /usr/share/dbus-1/system-services
+    cp $(pwd)/io.netplan.Netplan.conf /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+
+    # install the fake netplan system dbus service
+    echo "Make the netplan service activatable"
+    cat << EOF > /usr/share/dbus-1/system-services/io.netplan.Netplan.service
+    [D-BUS Service]
+    Name=io.netplan.Netplan
+    Exec=$(pwd)/fake-netplan-apply-service.py $(pwd)/dbus-netplan-apply.log
+    User=root
+    EOF
+
+    touch dbus-netplan-apply.log
+
     echo "The interface is disconnected by default"
     snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-'
 
@@ -60,6 +51,9 @@ execute: |
         exit 1
     fi
 
+    echo "The D-Bus service was not activated"
+    not MATCH "Apply called" < dbus-netplan-apply.log
+
     echo "When the interface is connected"
     snap connect test-snapd-netplan-apply:network-setup-control
 
@@ -68,3 +62,6 @@ execute: |
         echo "Unexpected error running netplan apply"
         exit 1
     fi
+
+    echo "And the D-Bus service was activated"
+    MATCH "Apply called" < dbus-netplan-apply.log

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -39,6 +39,7 @@ prepare: |
     Name=$NETPLAN
     Exec=$(pwd)/fake-netplan-apply-service.py $(pwd)/dbus-netplan-apply.log
     User=root
+    AssumedAppArmorLabel=unconfined
     EOF
 
     touch dbus-netplan-apply.log

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -23,16 +23,6 @@ prepare: |
         fi      
     done
 
-restore: |
-    # restore the dbus service file and policy config file if the backup 
-    # exists
-    for f in system-services/io.netplan.Netplan.service system.d/io.netplan.Netplan.conf; do
-        if [ -f /usr/share/dbus-1/$f.backup ]; then
-            mv /usr/share/dbus-1/$f.backup /usr/share/dbus-1/$f
-        fi      
-    done
-
-execute: |
     # install the dbus configuration file for our fake netplan system dbus service
     mkdir -p /usr/share/dbus-1/system.d 
     mkdir -p /usr/share/dbus-1/system-services
@@ -49,6 +39,16 @@ execute: |
 
     touch dbus-netplan-apply.log
 
+restore: |
+    # restore the dbus service file and policy config file if the backup 
+    # exists
+    for f in system-services/io.netplan.Netplan.service system.d/io.netplan.Netplan.conf; do
+        if [ -f /usr/share/dbus-1/$f.backup ]; then
+            mv /usr/share/dbus-1/$f.backup /usr/share/dbus-1/$f
+        fi      
+    done
+
+execute: |
     echo "The interface is disconnected by default"
     snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-'
 

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -3,6 +3,9 @@ summary: Ensure that netplan apply works with network-setup-control
 details: |
     Netplan apply is used to apply network configuration to the system
 
+environment:
+    NETPLAN: io.netplan.Netplan
+
 # run on all classic ubuntu LTS and current dev systems 16.04+
 systems: 
     - ubuntu-16*
@@ -17,22 +20,23 @@ prepare: |
 
     # backup the dbus service file and policy config if they exist before 
     # executing
-    for f in system-services/io.netplan.Netplan.service system.d/io.netplan.Netplan.conf; do
+    for f in system-services/$NETPLAN.service system.d/$NETPLAN.conf; do
         if [ -f /usr/share/dbus-1/$f ]; then
             mv /usr/share/dbus-1/$f /usr/share/dbus-1/$f.backup
         fi      
     done
 
-    # install the dbus configuration file for our fake netplan system dbus service
+    # install the dbus policy config file and service unit for our fake netplan
+    # system dbus service
+    echo "Install the netplan D-Bus activatable system service"
     mkdir -p /usr/share/dbus-1/system.d 
     mkdir -p /usr/share/dbus-1/system-services
-    cp io.netplan.Netplan.conf /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
-
-    # install the fake netplan system dbus service
-    echo "Make the netplan service activatable"
-    cat << EOF > /usr/share/dbus-1/system-services/io.netplan.Netplan.service
+    cp $NETPLAN.conf /usr/share/dbus-1/system.d/$NETPLAN.conf
+    # generate the service file here so that we can referece the python file and
+    # the log file in this directory
+    cat << EOF > /usr/share/dbus-1/system-services/$NETPLAN.service
     [D-BUS Service]
-    Name=io.netplan.Netplan
+    Name=$NETPLAN
     Exec=$(pwd)/fake-netplan-apply-service.py $(pwd)/dbus-netplan-apply.log
     User=root
     EOF
@@ -40,9 +44,16 @@ prepare: |
     touch dbus-netplan-apply.log
 
 restore: |
-    # restore the dbus service file and policy config file if the backup 
-    # exists
-    for f in system-services/io.netplan.Netplan.service system.d/io.netplan.Netplan.conf; do
+    # kill the dbus service if it is running 
+    set +e
+    netplanDBusSvcPID=$(pgrep --full fake-netplan-apply-service.py)
+    set -e
+    if [ -n "$netplanDBusSvcPID" ]; then
+        kill -9 "$netplanDBusSvcPID"
+    fi
+
+    # restore the dbus service file and policy config file if the backup exists
+    for f in system-services/$NETPLAN.service system.d/$NETPLAN.conf; do
         if [ -f /usr/share/dbus-1/$f.backup ]; then
             mv /usr/share/dbus-1/$f.backup /usr/share/dbus-1/$f
         fi      

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -29,7 +29,7 @@ execute: |
     # install the dbus configuration file for our fake netplan system dbus service
     mkdir -p /usr/share/dbus-1/system.d 
     mkdir -p /usr/share/dbus-1/system-services
-    cp $(pwd)/io.netplan.Netplan.conf /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+    cp "$(pwd)/io.netplan.Netplan.conf" /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
 
     # install the fake netplan system dbus service
     echo "Make the netplan service activatable"

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -15,21 +15,28 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     snap install test-snapd-netplan-apply --edge
 
-    # ensure that the service file doesn't exist before running
-    rm -f /usr/share/dbus-1/system-services/io.netplan.Netplan.service
-    rm -f /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+    # backup the dbus service file and policy config if they exist before 
+    # executing
+    for f in system-services/io.netplan.Netplan.service system.d/io.netplan.Netplan.conf; do
+        if [ -f /usr/share/dbus-1/$f ]; then
+            mv /usr/share/dbus-1/$f /usr/share/dbus-1/$f.backup
+        fi      
+    done
 
 restore: |
-    echo "uninstalling netplan D-Bus service"
-    rm -f /usr/share/dbus-1/system-services/io.netplan.Netplan.service
-    rm -f /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
-    snap remove test-snapd-netplan-apply
+    # restore the dbus service file and policy config file if the backup 
+    # exists
+    for f in system-services/io.netplan.Netplan.service system.d/io.netplan.Netplan.conf; do
+        if [ -f /usr/share/dbus-1/$f.backup ]; then
+            mv /usr/share/dbus-1/$f.backup /usr/share/dbus-1/$f
+        fi      
+    done
 
 execute: |
     # install the dbus configuration file for our fake netplan system dbus service
     mkdir -p /usr/share/dbus-1/system.d 
     mkdir -p /usr/share/dbus-1/system-services
-    cp "$(pwd)/io.netplan.Netplan.conf" /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+    cp io.netplan.Netplan.conf /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
 
     # install the fake netplan system dbus service
     echo "Make the netplan service activatable"

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -46,11 +46,12 @@ prepare: |
 restore: |
     # kill the dbus service if it is running 
     set +e
-    netplanDBusSvcPID=$(pgrep --full fake-netplan-apply-service.py)
-    set -e
-    if [ -n "$netplanDBusSvcPID" ]; then
-        kill -9 "$netplanDBusSvcPID"
+    if [ -n "$(pgrep --full fake-netplan-apply-service.py)" ]; then
+        for pid in $(pgrep --full fake-netplan-apply-service.py); do
+            kill -9 "$pid"
+        done
     fi
+    set -e
 
     # restore the dbus service file and policy config file if the backup exists
     for f in system-services/$NETPLAN.service system.d/$NETPLAN.conf; do

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -1,0 +1,73 @@
+summary: Ensure that netplan apply works with network-setup-control
+
+details: |
+    Netplan apply is used to apply network configuration to the system
+
+# run on all classic ubuntu LTS and current dev systems 16.04+
+systems: 
+    - ubuntu-16*
+    - ubuntu-18*
+    - ubuntu-19*
+    - ubuntu-20*
+
+debug: |
+
+
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    snap install test-snapd-netplan-apply --edge
+
+    echo "temporarily installing netplan D-Bus service until SRU is done..."
+    # for now, until netplan's D-Bus has been SRU'd to the netplan.io debian 
+    # package, we will just manually install the netplan D-Bus service units
+    # into the machine from the snap and install netplan.io from the archive
+    apt update
+
+    # the netplan package was renamed nplan -> netplan.io in bionic
+    case "$SPREAD_SYSTEM" in
+        ubuntu-16*)
+            NETPLAN_APT_PKG=nplan;;
+        *)
+            NETPLAN_APT_PKG=netplan.io;;
+    esac
+
+    apt install -y $NETPLAN_APT_PKG
+
+    NETPLAN_SNAP=/snap/test-snapd-netplan-apply/current
+
+    mkdir -p /lib/netplan
+    cp $NETPLAN_SNAP/lib/netplan/netplan-dbus \
+        /lib/netplan/netplan-dbus
+    chmod +x /lib/netplan/netplan-dbus
+    mkdir -p /usr/share/dbus-1/system-services
+    cp $NETPLAN_SNAP/share/dbus-1/system-services/io.netplan.Netplan.service \
+        /usr/share/dbus-1/system-services/io.netplan.Netplan.service
+    mkdir -p /usr/share/dbus-1/system.d
+    cp $NETPLAN_SNAP/share/dbus-1/system.d/io.netplan.Netplan.conf \
+        /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+
+restore: |
+    echo "uninstalling netplan D-Bus service"
+    rm -f /usr/lib/netplan/netplan-dbus
+    rm -f /usr/share/dbus-1/system-services/io.netplan.Netplan.service
+    rm -f /usr/share/dbus-1/system.d/io.netplan.Netplan.conf
+
+execute: |
+    echo "The interface is disconnected by default"
+    snap interfaces -i network-setup-control | MATCH -- '^- +test-snapd-netplan-apply:network-setup-control'
+
+    echo "Running netplan apply without network-setup-control fails"
+    if test-snapd-netplan-apply.netplan apply; then
+        echo "Expected access denied error for netplan apply"
+        exit 1
+    fi
+
+    echo "When the interface is connected"
+    snap connect test-snapd-netplan-apply:network-setup-control
+
+    echo "Running netplan apply now works"
+    if ! test-snapd-netplan-apply.netplan apply; then
+        echo "Unexpected error running netplan apply"
+        exit 1
+    fi

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -10,9 +10,6 @@ systems:
     - ubuntu-19*
     - ubuntu-20*
 
-debug: |
-
-
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -55,7 +55,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-
+    snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-'
 
     echo "Running netplan apply without network-setup-control fails"
     if test-snapd-netplan-apply.netplan apply; then

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -55,7 +55,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces -i network-setup-control | MATCH -- '^- +test-snapd-netplan-apply:network-setup-control'
+    snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-
 
     echo "Running netplan apply without network-setup-control fails"
     if test-snapd-netplan-apply.netplan apply; then


### PR DESCRIPTION
This patch adds dbus accesses to allow a strictly confined `netplan apply` to call out to a D-Bus activated service that netplan will ship outside of confinement, and the service will call `netplan apply` in an unconfined manner, thus allowing it to run `systemctl` arbitrarily. 

The spread test is mostly done, the snap installed, `test-snapd-netplan-apply` is one I registered and built myself from upstream netplan master branch, with some small additions to make it strict. I have included the snapcraft.yaml source for this snap in the test dir and will request that the snap be transferred to the Canonical account.

Additionally, the spread system needs to have the D-Bus service setup outside of confinement for netplan to communicate with, so what I do in the spread test is uninstall the netplan D-Bus service if it exists, and replace it with a fake python service which just logs calls to the Apply member and always returns True. Since it has to be a system service, I was unable to get it working with the `dbus-launch` and overwriting `DBUS_SYSTEM_BUS_ADDRESS` with `DBUS_SESSION_BUS_ADDRESS` because when the service would be started, it wouldn't have permissions to request the io.netplan.Netplan name. I think this could have been resolved with some kind of policy configuration file, but I figured it was easier to just install the fake one and then remove it later than try to get it working with `dbus-launch`. Currently the spread tests are just set to run on all ubuntu classic systems except 14.04. I am not sure how to test Core yet since the rootfs would be read-only from the core snap and make it hard to overwrite the installed netplan service.

See also upstream netplan PR's: https://github.com/CanonicalLtd/netplan/pull/99 and https://github.com/CanonicalLtd/netplan/pull/93.

One additional question I had was whether we should add policy to allow executing just the `netplan` binary from the core snap? We will need to ship netplan in the core snap to ship the unconfined D-Bus service anyways, so it makes sense to me to allow applications to use the version of netplan provided by the core snap rather than have all of these network configuration agent snaps ship their own duplicated version of netplan (which could also some day get out of sync with the D-Bus service). I think yes, but I left it out of the policy for now...