### PR TITLE
usersession/agent: use background context when stopping the agent

### DIFF
--- a/usersession/agent/session_agent.go
+++ b/usersession/agent/session_agent.go
@@ -120,9 +120,11 @@ var (
 	shutdownTimeout = 5 * time.Second
 )
 
+// Stop performs a graceful shutdown of the session agent and waits up to 5
+// seconds for it to complete.
 func (s *SessionAgent) Stop() error {
 	systemd.SdNotify("STOPPING=1")
-	ctx, cancel := context.WithTimeout(s.tomb.Context(nil), shutdownTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	s.tomb.Kill(s.serve.Shutdown(ctx))
 	return s.tomb.Wait()


### PR DESCRIPTION
When agent http.Serve() exits, the tomb will cancel all child contexts. Using a
child context of a tomb  (as obtained from s.tomb.Context(nil)), exposes us to a
race between http.Shutdown() observing all connections as closed, and context
being canceled by the tomb.

It is ok to use the background context, because Shutdown() is a method of a the
http.Server being closed, thus it will correctly observe the server becoming
quiescent and exit or the context will hit the timeout and a DeadlineExceeded
will be obtained.

