### PR TITLE
interfaces/misc: updates for k8s 1.15 (and greengrass test)

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -625,7 +625,7 @@ func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	if !release.OnClassic {
 		spec.AddSnippet(dockerSupportConnectedPlugAppArmorCore)
 	}
-	spec.UsesPtraceTrace()
+	spec.SetUsesPtraceTrace()
 	return nil
 }
 

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -46,17 +46,16 @@ const dockerSupportBaseDeclarationSlots = `
 `
 
 const dockerSupportConnectedPlugAppArmorCore = `
-# these accesses are necessary for Ubuntu Core 16 and 18, likely due to the version 
-# of apparmor or the kernel which doesn't resolve the upper layer of an 
-# overlayfs mount correctly
-# the accesses show up as runc trying to read from
+# These accesses are necessary for Ubuntu Core 16 and 18, likely due to the
+# version of apparmor or the kernel which doesn't resolve the upper layer of an
+# overlayfs mount correctly the accesses show up as runc trying to read from
 # /system-data/var/snap/docker/common/var-lib-docker/overlay2/$SHA/diff/
 /system-data/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/common/{,**/} rwl,
 /system-data/var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/@{SNAP_REVISION}/{,**/} rwl,
 `
 
 const dockerSupportConnectedPlugAppArmor = `
-# Description: allow operating as the Docker daemon. This policy is
+# Description: allow operating as the Docker daemon/containerd. This policy is
 # intentionally not restrictive and is here to help guard against programming
 # errors and not for security confinement. The Docker daemon by design requires
 # extensive access to the system and cannot be effectively confined against
@@ -64,15 +63,24 @@ const dockerSupportConnectedPlugAppArmor = `
 
 #include <abstractions/dbus-strict>
 
-# Allow sockets
+# Allow sockets/etc for docker
 /{,var/}run/docker.sock rw,
 /{,var/}run/docker/     rw,
 /{,var/}run/docker/**   mrwklix,
 /{,var/}run/runc/       rw,
 /{,var/}run/runc/**     mrwklix,
 
+# Allow sockets/etc for containerd
+/run/containerd/{,runc/,runc/k8s.io/,runc/k8s.io/*/} rw,
+/run/containerd/runc/k8s.io/*/** rwk,
+
+# Limit ipam-state to k8s
+/run/ipam-state/k8s-** rw,
+/run/ipam-state/k8s-*/lock k,
+
 # Socket for docker-container-shim
 unix (bind,listen) type=stream addr="@/containerd-shim/moby/*/shim.sock\x00",
+unix (bind,listen) type=stream addr="@/containerd-shim/k8s.io/*/shim.sock\x00",
 
 /{,var/}run/mount/utab r,
 
@@ -138,9 +146,16 @@ pivot_root,
 /sys/kernel/security/apparmor/{,**} r,
 
 # use 'privileged-containers: true' to support --security-opts
+
+# defaults for docker-default
 change_profile unsafe /** -> docker-default,
 signal (send) peer=docker-default,
 ptrace (read, trace) peer=docker-default,
+
+# defaults for containerd
+change_profile unsafe /** -> cri-containerd.apparmor.d,
+signal (send) peer=cri-containerd.apparmor.d,
+ptrace (read, trace) peer=cri-containerd.apparmor.d,
 
 # Graph (storage) driver bits
 /{dev,run}/shm/aufs.xino mrw,
@@ -157,7 +172,8 @@ ptrace (read, trace) peer=docker-default,
 # needed by runc for mitigation of CVE-2019-5736
 # For details see https://bugs.launchpad.net/apparmor/+bug/1820344
 / ix,
-/bin/runc rix,
+/bin/runc ixr,
+/pause ixr,
 `
 
 const dockerSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -178,6 +178,7 @@ func (s *DockerSupportInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.docker.app"})
 	c.Check(spec.SnippetForTag("snap.docker.app"), testutil.Contains, "/sys/fs/cgroup/*/docker/   rw,\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, true)
 }
 
 func (s *DockerSupportInterfaceSuite) TestSecCompSpec(c *C) {

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -95,6 +95,7 @@ func (s *GreengrassSupportInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "mount options=(rw, bind) /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/** ,\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, true)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestSecCompSpec(c *C) {

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -203,14 +203,14 @@ func (iface *kubernetesSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	case "kubelet":
 		systemd_run_extra = kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun
 		snippet += kubernetesSupportConnectedPlugAppArmorKubelet
-		spec.UsesPtraceTrace()
+		spec.SetUsesPtraceTrace()
 	case "kubeproxy":
 		snippet += kubernetesSupportConnectedPlugAppArmorKubeproxy
 	default:
 		systemd_run_extra = kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun
 		snippet += kubernetesSupportConnectedPlugAppArmorKubelet
 		snippet += kubernetesSupportConnectedPlugAppArmorKubeproxy
-		spec.UsesPtraceTrace()
+		spec.SetUsesPtraceTrace()
 	}
 
 	old := "###KUBERNETES_SUPPORT_SYSTEMD_RUN###"

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -67,17 +67,23 @@ profile systemd_run (attach_disconnected,mediate_deleted) {
   # Common rules for kubernetes use of systemd_run
   #include <abstractions/base>
 
-  /usr/bin/systemd-run r,
+  /{,usr/}bin/systemd-run rm,
   owner @{PROC}/@{pid}/stat r,
   owner @{PROC}/@{pid}/environ r,
   @{PROC}/cmdline r,
+  @{PROC}/sys/kernel/osrelease r,
 
   # setsockopt()
   capability net_admin,
 
+  # ptrace 'trace' is coarse and not required for using the systemd private
+  # socket, and while the child profile omits 'capability sys_ptrace', skip
+  # for now since it isn't strictly required.
+  deny ptrace trace peer=unconfined,
   /run/systemd/private rw,
-  /bin/true ixr,
-  ptrace trace peer=unconfined,
+
+  /{,usr/}bin/true ixr,
+  @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/@{SNAP_REVISION}/{,usr/}bin/true ixr,
 ###KUBERNETES_SUPPORT_SYSTEMD_RUN###
 }
 `

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -163,6 +163,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Allow running as the kubeproxy service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.default"), testutil.Contains, "# kubelet mount rules\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, true)
 
 	// kubeproxy should have only its rules
 	spec = &apparmor.Specification{}
@@ -174,6 +175,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), Not(testutil.Contains), "# Allow running as the kubelet service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), testutil.Contains, "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubeproxy"), Not(testutil.Contains), "# kubelet mount rules\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, false)
 
 	// kubelet should have only its rules
 	spec = &apparmor.Specification{}
@@ -185,6 +187,7 @@ func (s *KubernetesSupportInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), Not(testutil.Contains), "# Allow running as the kubeproxy service\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# Common rules for kubernetes use of systemd_run\n")
 	c.Check(spec.SnippetForTag("snap.kubernetes-support.kubelet"), testutil.Contains, "# kubelet mount rules\n")
+	c.Check(spec.UsesPtraceTrace(), Equals, true)
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestSecCompConnectedPlug(c *C) {


### PR DESCRIPTION
microk8s and upstream k8s has moved to containerd and made various other changes. In updating the policy, discovered that docker-support and kubernetes-support were uses the Getter for UsesPtraceTrace so adjust to use Setter instead and update tests accordingly (adding extra test to greengrass-support in passing).

* interfaces/kubernetes-support: update for k8s 1.15 
* interfaces/docker-support: updates for newer containerd 
* interfaces/docker,kubernetes-support: use SetUsesPtraceTrace()
* interfaces/greengrass-support: adjust testsuite to verify UsesPtraceTrace