### PR TITLE
interfaces/bluetooth-control: add udev rules for BT_chrdev devices

### DIFF
--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -61,7 +61,7 @@ const bluetoothControlConnectedPlugSecComp = `
 bind
 `
 
-var bluetoothControlConnectedPlugUDev = []string{`SUBSYSTEM=="bluetooth"`}
+var bluetoothControlConnectedPlugUDev = []string{`SUBSYSTEM=="bluetooth"`, `SUBSYSTEM=="BT_chrdev"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -106,9 +106,11 @@ func (s *BluetoothControlInterfaceSuite) TestSecCompSpec(c *C) {
 func (s *BluetoothControlInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# bluetooth-control
 SUBSYSTEM=="bluetooth", TAG+="snap_other_app2"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# bluetooth-control
+SUBSYSTEM=="BT_chrdev", TAG+="snap_other_app2"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_other_app2", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_other_app2 $devpath $major:$minor"`)
 }
 


### PR DESCRIPTION
Some BT drivers from Mediatek use SUBSYSTEM BT_chrdev

Extending udev rules to support such a devices