### PR TITLE
tests: measure behavior of the device cgroup

### DIFF
--- a/tests/main/cgroup-devices/task.sh
+++ b/tests/main/cgroup-devices/task.sh
@@ -71,6 +71,8 @@ echo "Verify the constraints imposed by the device cgroup made by snapd"
 # NOTE: the actual permissions may drift over time. We just care about the fact
 # that there *are* some constraints here now and there were none before.
 test 'c 1:3 rwm' = "$(head -n 1 "/sys/fs/cgroup/devices/snap.test-snapd-service.test-snapd-service/devices.list")"
+# The device cgroup made by snapd is, currently, still empty.
+test -z "$(cat "/sys/fs/cgroup/devices/snap.test-snapd-service.test-snapd-service/cgroup.procs")"
 
 echo "Restart the test service"
 # See the comment for the similar code above.

--- a/tests/main/cgroup-devices/task.sh
+++ b/tests/main/cgroup-devices/task.sh
@@ -54,7 +54,8 @@ snap connect test-snapd-service:joystick
 
 echo "Refresh the value of the main pid and the effective device cgroup after snap connect"
 # NOTE: As of snapd 2.40 the PID and cgroup are expected to be the same as before.
-pid=$(systemctl show snap.test-snapd-service.test-snapd-service.service --property=ExecMainPID | cut -d = -f 2)
+pid_check=$(systemctl show snap.test-snapd-service.test-snapd-service.service --property=ExecMainPID | cut -d = -f 2)
+test "$pid" -eq "$pid_check"
 updated_device_cgroup=$(grep devices < "/proc/$pid/cgroup" | cut -d : -f 3)
 
 echo "Verify that the main process is still in the systemd-made cgroup"

--- a/tests/main/cgroup-devices/task.sh
+++ b/tests/main/cgroup-devices/task.sh
@@ -1,0 +1,67 @@
+#!/bin/sh -ex
+echo "Install a test service"
+snap pack test-snapd-service
+snap install --dangerous ./test-snapd-service_1.0_all.snap
+
+echo "Extract the PID of the main process tracked by systemd"
+# It would be nicer to use "systemctl show --property=... --value" but it doesn't work on older systemd.
+pid=$(systemctl show snap.test-snapd-service.test-snapd-service.service --property=ExecMainPID | cut -d = -f 2)
+
+echo "Extract the device cgroup of the main process"
+effective_device_cgroup=$(grep devices < "/proc/$pid/cgroup" | cut -d : -f 3)
+# Initially, because there are no udev tags corresponding to this application,
+# snap-confine is not moving the process to a new cgroup. As such the service
+# runs in the cgroup created by systemd.
+test "$effective_device_cgroup" = /system.slice/snap.test-snapd-service.test-snapd-service.service
+
+echo "Ensure that the claim of the process is consistent with the claim of the cgroup"
+# This is just a sanity check.
+MATCH "$pid" < "/sys/fs/cgroup/devices/$effective_device_cgroup/cgroup.procs"
+
+echo "Verify the constraints imposed by the device cgroup made by systemd"
+# This may change over time as it is governed by systemd.
+test 'a *:* rwm' = "$(cat "/sys/fs/cgroup/devices/$effective_device_cgroup/devices.list")"
+
+echo "Connect the joystick interface"
+snap connect test-snapd-service:joystick
+
+echo "Refresh the value of the main pid and the effective device cgroup after snap connect"
+# NOTE: As of snapd 2.40 the PID and cgroup are expected to be the same as before.
+pid=$(systemctl show snap.test-snapd-service.test-snapd-service.service --property=ExecMainPID | cut -d = -f 2)
+effective_device_cgroup=$(grep devices < "/proc/$pid/cgroup" | cut -d : -f 3)
+
+echo "Verify that the main process is still in the systemd-made cgroup"
+test "$effective_device_cgroup" = /system.slice/snap.test-snapd-service.test-snapd-service.service
+
+echo "Verify the constraints imposed by the device cgroup made by systemd"
+test 'a *:* rwm' = "$(cat "/sys/fs/cgroup/devices/$effective_device_cgroup/devices.list")"
+
+echo "Run /bin/true via snap-confine, so that we create the device cgroup made by snapd"
+snap run --shell test-snapd-service -c /bin/true
+
+echo "Verify the constraints imposed by the device cgroup made by snapd"
+# NOTE: the actual permissions may drift over time. We just care about the fact
+# that there *are* some constraints here now and there were none before.
+test 'c 1:3 rwm' = "$(head -n 1 "/sys/fs/cgroup/devices/snap.test-snapd-service.test-snapd-service/devices.list")"
+
+echo "Restart the test service"
+# Because this service is of type "simple" it is considered "ready" instantly.
+# In reality the process needs to go through snap "run" chain to be really
+# ready. As a workaround, touch a "remove-me" file that is removed by the
+# service on startup, restart the service and the wait for the file to
+# disappear.
+touch /var/snap/test-snapd-service/common/remove-me
+systemctl restart snap.test-snapd-service.test-snapd-service.service
+for _ in $(seq 5); do
+	if [ ! -e /var/snap/test-snapd-service/common/remove-me ]; then
+		break
+	fi
+	sleep 1
+done
+
+echo "Refresh the value of the main pid and the effective device cgroup after service restart"
+pid=$(systemctl show snap.test-snapd-service.test-snapd-service.service --property=ExecMainPID | cut -d = -f 2)
+effective_device_cgroup=$(grep devices < "/proc/$pid/cgroup" | cut -d : -f 3)
+
+echo "Verify that the main process is now in the snapd-made cgroup"
+test "$effective_device_cgroup" = /snap.test-snapd-service.test-snapd-service

--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -1,0 +1,8 @@
+summary: measuring basic properties of device cgroup
+# Ubuntu 14.04 uses a custom build of an older systemd that does not
+# seem to use device cgroups for services. The test is invalid there.
+systems: [-ubuntu-14.04-*]
+execute: ./task.sh
+restore: |
+    rm -f test-snapd-service_1.0_all.snap
+    snap remove test-snapd-service

--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -1,7 +1,4 @@
 summary: measuring basic properties of device cgroup
-# Ubuntu 14.04 uses a custom build of an older systemd that does not
-# seem to use device cgroups for services. The test is invalid there.
-systems: [-ubuntu-14.04-*]
 execute: ./task.sh
 restore: |
     rm -f test-snapd-service_1.0_all.snap

--- a/tests/main/cgroup-devices/test-snapd-service/bin/service
+++ b/tests/main/cgroup-devices/test-snapd-service/bin/service
@@ -1,0 +1,6 @@
+#!/bin/sh
+rm -f "$SNAP_COMMON/remove-me"
+while true; do
+    echo "running"
+    sleep 10
+done

--- a/tests/main/cgroup-devices/test-snapd-service/meta/snap.yaml
+++ b/tests/main/cgroup-devices/test-snapd-service/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-service
+version: 1.0
+apps:
+    test-snapd-service:
+        command: bin/service
+        daemon: simple
+        plugs: [joystick]


### PR DESCRIPTION
This test checks the interaction of systemd and snap-confine with
regards to the device cgroup. Since the 2.0 release, snap-confine is
using the device cgroup to constrain access to character and block
devices. Effectively, snap-confine is stealing the process away from
systemd by moving it from the cgroup managed by systemd to one managed
by snapd.

Note that this model can only work in cgroup v1, where a process can at
a given time inhabit multiple separate cgroups.

Not all processes us the snapd-made device cgroup. If a snap is placed
in devmode or uses no interfaces that would toggle udev to tag a device
to add to the cgroup, then no additional cgroup is created or
configured.

This model lead to an overlooked conflict between how systemd and snapd
configure a process that started out without udev tagged devices, and
thus without a snapd-managed cgroup, is connected to an interface that
relies on tagging for precise confinement.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>