### PR TITLE
cmd/libsnap: don't leak memory in sc_die_on_error

### DIFF
--- a/cmd/libsnap-confine-private/error.c
+++ b/cmd/libsnap-confine-private/error.c
@@ -122,13 +122,12 @@ void sc_die_on_error(sc_error * error)
 {
 	if (error != NULL) {
 		if (strcmp(sc_error_domain(error), SC_ERRNO_DOMAIN) == 0) {
-			// Set errno just before the call to die() as it is used internally
-			errno = sc_error_code(error);
-			die("%s", sc_error_msg(error));
+			fprintf(stderr, "%s: %s\n", sc_error_msg(error), strerror(sc_error_code(error)));
 		} else {
-			errno = 0;
-			die("%s", sc_error_msg(error));
+			fprintf(stderr, "%s\n", sc_error_msg(error));
 		}
+		sc_error_free(error);
+		exit(1);
 	}
 }
 


### PR DESCRIPTION
When we die on an error object we print the reason but don't really
free the object. This leaves a trace that can be seen in, for example,
valgrind.

As good C citizens, let's free everything before we go.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
