### PR TITLE
tests: show just the last log as part of the debug output when check journal logs

### DIFF
--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -36,7 +36,7 @@ check_journalctl_log(){
     expression=$1
     shift
     # Initial checks dont print the log in the debug output
-    for iter in $(seq 9); do
+    for _ in $(seq 9); do
         if get_journalctl_log "$@" | grep -q -E "$expression"; then
             return 0
         fi

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -35,14 +35,20 @@ check_journalctl_ready(){
 check_journalctl_log(){
     expression=$1
     shift
-    for _ in $(seq 10); do
-        log=$(get_journalctl_log "$@")
-        if echo "$log" | grep -q -E "$expression"; then
+    # Initial checks dont print the log in the debug output
+    for iter in $(seq 9); do
+        if get_journalctl_log "$@" | grep -q -E "$expression"; then
             return 0
         fi
         echo "Match for \"$expression\" failed, retrying"
         sleep 1
     done
+
+    # Last check prints the log in the debug output
+    log=$(get_journalctl_log "$@")
+    if echo "$log" | grep -q -E "$expression"; then
+        return 0
+    fi
     return 1
 }
 


### PR DESCRIPTION
The idea of this change is to avoid showing all the logs in the debug
output. The change makes visible just the last log in case there is no
match.

This is an example of the big log produced: https://api.travis-ci.org/v3/job/569278195/log.txt