### PR TITLE
recovery: update fde-utils

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -65,9 +65,6 @@ backends:
                 workers: 8
             - ubuntu-18.04-64:
                 workers: 6
-            - ubuntu-18.10-64:
-                image: ubuntu-1810
-                workers: 6
             - ubuntu-19.04-64:
                 workers: 6
             - ubuntu-core-16-64:

--- a/spread.yaml
+++ b/spread.yaml
@@ -64,7 +64,7 @@ backends:
             - ubuntu-16.04-64:
                 workers: 8
             - ubuntu-18.04-64:
-                workers: 6
+                workers: 8
             - ubuntu-19.04-64:
                 workers: 6
             - ubuntu-core-16-64:
@@ -76,8 +76,10 @@ backends:
 
             - debian-9-64:
                 workers: 6
+                manual: true
             - debian-sid-64:
                 workers: 6
+                manual: true
 
             - fedora-28-64:
                 workers: 4
@@ -87,6 +89,7 @@ backends:
                 manual: true
             - fedora-30-64:
                 workers: 6
+                manual: true
             - opensuse-15.0-64:
                 workers: 6
                 manual: true

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,10 +7,16 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "OwqZavm6GrNb2NsF4jJsukr2SFA=",
+			"checksumSHA1": "lIeozbKR+IUN1UnABr4VZdO7y8A=",
+			"path": "github.com/chrisccoulson/go-tpm2",
+			"revision": "bd89e9fde55680cda0016aa8aba28b558da9c760",
+			"revisionTime": "2019-08-07T10:07:39Z"
+		},
+		{
+			"checksumSHA1": "QdrT6GNvHqZhYmx8G8P8zGQ26E4=",
 			"path": "github.com/chrisccoulson/ubuntu-core-fde-utils",
-			"revision": "e5af66bace4b1f1af0b6fd445b5a894a7d6d0308",
-			"revisionTime": "2019-07-17T13:49:52Z"
+			"revision": "74b2ac214763e19a3b13bb44435266f2753d763d",
+			"revisionTime": "2019-08-07T20:13:30Z"
 		},
 		{
 			"checksumSHA1": "zg16zjZTQ9R89+UOLmEZxHgxDtM=",
@@ -29,14 +35,6 @@
 			"path": "github.com/godbus/dbus/introspect",
 			"revision": "97646858c46433e4afb3432ad28c12e968efa298",
 			"revisionTime": "2017-08-22T15:24:03Z"
-		},
-		{
-			"checksumSHA1": "CgcocRShUgwD/BXX35dGSVWG0Z0=",
-			"origin": "github.com/chrisccoulson/go-tpm",
-			"path": "github.com/google/go-tpm",
-			"revision": "9f5e4eb491faa0e349919e0ab888f9607101834c",
-			"revisionTime": "2019-07-11T10:07:55Z",
-			"tree": true
 		},
 		{
 			"checksumSHA1": "iIUYZyoanCQQTUaWsu8b+iOSPt4=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,10 +7,10 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "lIeozbKR+IUN1UnABr4VZdO7y8A=",
+			"checksumSHA1": "IOYNZxtW/NhFmYCPNKPeafVwHJU=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "bd89e9fde55680cda0016aa8aba28b558da9c760",
-			"revisionTime": "2019-08-07T10:07:39Z"
+			"revision": "24a62e9bb51191ee7a0ccca6d7bc01dbb413f572",
+			"revisionTime": "2019-08-14T14:54:33Z"
 		},
 		{
 			"checksumSHA1": "QdrT6GNvHqZhYmx8G8P8zGQ26E4=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -183,6 +183,12 @@
 			"revisionTime": "2017-06-28T23:42:41Z"
 		},
 		{
+			"checksumSHA1": "/BPi7V0excJdy6kCtptx9y1Vr5M=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "fc99dfbffb4e5ed5758a37e31dd861afe285406b",
+			"revisionTime": "2019-07-25T17:58:15Z"
+		},
+		{
 			"checksumSHA1": "9gypWnVZJEaH3jMK9KqOp4xgQD4=",
 			"path": "gopkg.in/check.v1",
 			"revision": "788fd78401277ebd861206a03c884797c6ec5541",


### PR DESCRIPTION
Update ubuntu-core-fde-utils to the latest version, and refactor
the recovery code to use the new API. Also remove unused
recovery code.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>