### PR TITLE
xdgopenproxy: update test API to match upstream

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -13,10 +13,10 @@
 			"revisionTime": "2018-05-11T13:34:05Z"
 		},
 		{
-			"checksumSHA1": "h77tT8kVh8x/J5ikkZReONPUjU0=",
+			"checksumSHA1": "qwK75TRXmR/k8CiegYaeqaCDek4=",
 			"path": "github.com/godbus/dbus",
-			"revision": "97646858c46433e4afb3432ad28c12e968efa298",
-			"revisionTime": "2017-08-22T15:24:03Z"
+			"revision": "4481cbc300e2df0c0b3cecc18b6c16c6c0bb885d",
+			"revisionTime": "2019-07-26T02:52:47Z"
 		},
 		{
 			"checksumSHA1": "NrP46FPoALgKz3FY6puL3syMAAI=",

--- a/xdgopenproxy/xdgopenproxy_test.go
+++ b/xdgopenproxy/xdgopenproxy_test.go
@@ -20,6 +20,7 @@
 package xdgopenproxy_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -142,12 +143,33 @@ func (f fakeBusObject) Call(method string, flags dbus.Flags, args ...interface{}
 	return &dbus.Call{Err: err}
 }
 
+func (f fakeBusObject) CallWithContext(ctx context.Context, method string, flags dbus.Flags, args ...interface{}) *dbus.Call {
+	err := f(method, args...)
+	return &dbus.Call{Err: err}
+}
+
 func (f fakeBusObject) Go(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+	return nil
+}
+
+func (f fakeBusObject) GoWithContext(ctx context.Context, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+	return nil
+}
+
+func (f fakeBusObject) AddMatchSignal(iface, member string, options ...dbus.MatchOption) *dbus.Call {
+	return nil
+}
+
+func (f fakeBusObject) RemoveMatchSignal(iface, member string, options ...dbus.MatchOption) *dbus.Call {
 	return nil
 }
 
 func (f fakeBusObject) GetProperty(prop string) (dbus.Variant, error) {
 	return dbus.Variant{}, nil
+}
+
+func (f fakeBusObject) SetProperty(p string, v interface{}) error {
+	return nil
 }
 
 func (f fakeBusObject) Destination() string {


### PR DESCRIPTION
The upstream github.com/godbus/dbus has changed and our tests no longer compile
because the dbus.BusObject interface has gained additional methods to implement.
This patch adds a dummy implementation of the missing methods.

Fixes: https://bugs.launchpad.net/snappy/+bug/1839498
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>