### PR TITLE
tests: mountinfo-tool fail if there are no matches

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -613,6 +613,8 @@ Known attributes, applicable for both filtering and display.
     parent_id:      identifier of parent mount point
     dev:            major:minor numbers of the mounted device
     root_dir:       subtree of the mounted filesystem exposed at mount_point
+
+The exit code indicates if any mount point matched the query.
     """,
         formatter_class=RawTextHelpFormatter,
     )
@@ -749,7 +751,10 @@ Known attributes, applicable for both filtering and display.
         raise SystemExit(
             "--one requires exactly one match, found {}".format(len(entries))
         )
-
+	# Return with an exit code indicating if anything matched.
+	# This allows mountinfo-tool to be used in scripts.
+    if len(entries) == 0:
+        raise SystemExit(1)
 
 class MountInfoEntryTests(unittest.TestCase):
 


### PR DESCRIPTION
This is useful for using mountinfo-tool /path/to/mountpoint
as a quick way to check if something is mounted.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
