### PR TITLE
tests: make interfaces-contacts-services cleanup more robust

### DIFF
--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -2,10 +2,8 @@ summary: Ensure that the calendar-service interface works
 
 # Only test on classic systems.  Don't test on Ubuntu 14.04, which
 # does not ship a new enough evolution-data-server. Don't test on AMZN2.
-#
-# FIXME: disable opensuse-tumbleweed until
 # https://github.com/snapcore/snapd/pull/7230 is landed
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*]
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*]
 
 # fails in the autopkgtest env with:
 # [Wed Aug 15 16:34:12 2018] audit: type=1400

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -20,14 +20,25 @@ environment:
     XDG_DATA_HOME: $XDG/share
     XDG_CACHE_HOME: $XDG/cache
 
+debug: |
+    # debug for when the "rm -rf $XDG" in restore fails
+    systemctl status gvfs-metadata || true
+    systemctl --user status gvfs-metadata || true
+    ls -alR "$XDG/share/" || true
+    ps afx
+
 restore: |
     if [ -e dbus-launch.pid ]; then
         kill "$(cat dbus-launch.pid)"
     fi
 
+    # gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
+    # producing an error when the xdg directory is removed. So we need
+    # to stop it:
+    if systemctl --user is-active gvfs-metadata; then
+        systemctl --user stop gvfs-metadata
+    fi
     # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
-    # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
-    # producing an error when the xdg directory is removed.
     if pid="$(pidof gvfsd-metadata)"; then
         kill -9 "$pid" || true
     fi


### PR DESCRIPTION
We saw a failure in the test cleanup of interfaces-contacts-service.
The error is:
```
+ rm -rf /home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-contacts-service/xdg
rm: cannot remove '/home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-contacts-service/xdg/share/gvfs-metadata': Directory not empty
```
We already have code that deals with this but apparently its not
sufficient (anymore?).

This PR adds some debug output to ensure we have more data if
this happens again. But it also stops the gvfs-metadata user
service if its available to ensure we don't get into funny races
with systemd that may try to start/restart the service.
