### PR TITLE
interfaces/firewall-control: add nf_nat_* to kmod plug

### DIFF
--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -158,6 +158,12 @@ var firewallControlConnectedPlugKmod = []string{
 	"br_netfilter",
 	"ip6table_filter",
 	"iptable_filter",
+	"nf_nat_ftp",
+	"nf_nat_irc",
+	"nf_nat_sip",
+	"nf_nat_tftp",
+	"nf_nat_pptp",
+	"nf_nat_h323",
 }
 
 func init() {

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -103,6 +103,12 @@ func (s *FirewallControlInterfaceSuite) TestKModSpec(c *C) {
 		"br_netfilter":    true,
 		"ip6table_filter": true,
 		"iptable_filter":  true,
+		"nf_nat_ftp":      true,
+		"nf_nat_irc":      true,
+		"nf_nat_sip":      true,
+		"nf_nat_tftp":     true,
+		"nf_nat_pptp":     true,
+		"nf_nat_h323":     true,
 	})
 }
 


### PR DESCRIPTION
The nf_nat_* kernel modules contain rules to be able to do NAT for some
commonly used protocols.