### PR TITLE
tests: make sure snapd is built against new gorilla mux

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2425,3 +2425,14 @@ func getWarnings(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	return SyncResponse(ws, nil)
 }
+
+// dummyGorillaMuxVersionCheck is not used and acts as a quick check against old gorilla mux.
+func dummyGorillaMuxVersionCheck() {
+	// this code will not build on older version of gorilla mux (i.e. gorilla mux revision
+	// 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc; the new gorilla was introduced in snapd
+	// with commit be4fc4d117c255cadd697a93f9f94e49c708f2c3) and it is here to ensure
+	// snapd is built with refreshed vendor (i.e. new gorilla). snapd would happily build
+	// against old gorilla mux but would fail in confusing ways at runtime.
+	router := mux.NewRouter()
+	_ = router.Name("foo")
+}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -41,6 +41,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorilla/mux"
 	"golang.org/x/crypto/sha3"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
@@ -7342,4 +7343,14 @@ func (s *apiSuite) TestErrToResponse(c *check.C) {
 		rsp := errToResponse(t.err, []string{"foo"}, BadRequest, "%s: %v", "ERR")
 		c.Check(rsp, check.DeepEquals, t.expectedRsp, com)
 	}
+}
+
+func (s *apiSuite) TestGorillaMuxVersionCheck(c *check.C) {
+	// this code will not build on older version of gorilla mux (i.e. gorilla mux revision
+	// 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc; the new gorilla was introduced in snapd
+	// with commit be4fc4d117c255cadd697a93f9f94e49c708f2c3) and it is here to ensure
+	// snapd is built with refreshed vendor (i.e. new gorilla). snapd would happily build
+	// against old gorilla mux but would fail in confusing ways at runtime.
+	router := mux.NewRouter()
+	_ = router.Name("foo")
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -41,7 +41,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"golang.org/x/crypto/sha3"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
@@ -7343,14 +7342,4 @@ func (s *apiSuite) TestErrToResponse(c *check.C) {
 		rsp := errToResponse(t.err, []string{"foo"}, BadRequest, "%s: %v", "ERR")
 		c.Check(rsp, check.DeepEquals, t.expectedRsp, com)
 	}
-}
-
-func (s *apiSuite) TestGorillaMuxVersionCheck(c *check.C) {
-	// this code will not build on older version of gorilla mux (i.e. gorilla mux revision
-	// 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc; the new gorilla was introduced in snapd
-	// with commit be4fc4d117c255cadd697a93f9f94e49c708f2c3) and it is here to ensure
-	// snapd is built with refreshed vendor (i.e. new gorilla). snapd would happily build
-	// against old gorilla mux but would fail in confusing ways at runtime.
-	router := mux.NewRouter()
-	_ = router.Name("foo")
 }


### PR DESCRIPTION
Some time ago a new version of gorilla/mux was introduced in vendor (commit `be4fc4d117c255cadd697a93f9f94e49c708f2c3`), however our current code succesfully compiles against the old version, and then fails in very confusing ways at runtime (experienced recently by @anonymouse64  and me), probably due to some changes in semantics of the mux API. When built against old mux, snapd & snap ops fail complaining about empty (missing) snap name argument.

This PR adds a very simple test that fails to build if one forgets to update his vendor tree - it uses one of the new mux API methods:
`./api_test.go:7355:12: router.Name undefined (type *mux.Router has no field or method Name)`
