### PR TITLE
interfaces/firewall-control: support nft routing expressions and device groups

### DIFF
--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -81,6 +81,12 @@ unix (bind, listen) type=stream addr="@xtables",
 @{PROC}/@{pid}/net/ r,
 @{PROC}/@{pid}/net/** r,
 
+# nft accesses these for routing expressions and device groups
+/etc/iproute2/ r,
+/etc/iproute2/rt_marks r,
+/etc/iproute2/rt_realms r,
+/etc/iproute2/group r,
+
 # sysctl
 /{,usr/}{,s}bin/sysctl ixr,
 @{PROC}/sys/ r,


### PR DESCRIPTION
References:
https://forum.snapcraft.io/t/request-for-system-files-for-nftables/12035/7
