### PR TITLE
packaging/ubuntu-16.04: provide a way to reset snapd without purging

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -126,4 +126,6 @@ if [ "$1" = "purge" ]; then
     rm -rf /var/lib/snapd
 fi
 
+[ -n "${SNAPD_RESET_HACK}" ] && exit 0
+
 #DEBHELPER#


### PR DESCRIPTION
There is sometimes a need to "reset" snapd without going to the full
extent of purging the package. Because it's hard for postrm to execute
code outside of itself (because that code will have been removed before
it is been invoked!) it's more practical to have a way to invoke the
reset code that lives in postrm without having the generic debhelper
postrm damage the installation by e.g. removing all the apparmor rules.

That's all a long winded justification for a very simple code change: if
SNAPD_RESET_HACK is set in the environment, exit before getting to the
debhelper-inserted code. Then a reset is as simple as:

SNAPD_RESET_HACK=1 /var/lib/dpkg/info/snapd.postrm purge

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
