### PR TITLE
sanity: unmount squashfs with --lazy

### DIFF
--- a/sanity/squashfs.go
+++ b/sanity/squashfs.go
@@ -112,7 +112,7 @@ func checkSquashfsMount() error {
 	}
 
 	defer func() {
-		if output, err := exec.Command("umount", tmpMountDir).CombinedOutput(); err != nil {
+		if output, err := exec.Command("umount", "-l", tmpMountDir).CombinedOutput(); err != nil {
 			// os.RemoveAll(tmpMountDir) will fail here if umount fails
 			logger.Noticef("cannot unmount sanity check squashfs image: %v", osutil.OutputErr(output, err))
 		}

--- a/sanity/squashfs_test.go
+++ b/sanity/squashfs_test.go
@@ -51,7 +51,7 @@ func (s *sanitySuite) TestCheckSquashfsMountHappy(c *C) {
 		{"mount", "-t", "squashfs", squashfsFile, mountPoint},
 	})
 	c.Check(mockUmount.Calls(), DeepEquals, [][]string{
-		{"umount", mountPoint},
+		{"umount", "-l", mountPoint},
 	})
 }
 


### PR DESCRIPTION
While performing the mount namespace cleanup tests I noticed a
failure resulting from leaked mount point:

/dev/loop1 /tmp/sanity-mountpoint-773821774 squashfs rw,relatime ro

This looks like the sanity check for squashfs support has failed. While
I have no idea why it has failed and was unable to reproduce it easily,
it may be because something went to inspect the new mount point at the
exact moment we wanted to unmount it.

To be more robust in this case, use umount --lazy, so that we don't fail
in case there are open file descriptors.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
