### PR TITLE
snapstate, store: handle 429s on catalog refresh a little bit better

### DIFF
--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -94,6 +94,7 @@ func (r *catalogRefresh) Ensure() error {
 		logger.Debugf("Catalog refresh succeeded.")
 	case store.ErrTooManyRequests:
 		logger.Debugf("Catalog refresh postponed.")
+		err = nil
 	default:
 		logger.Debugf("Catalog refresh failed: %v.", err)
 	}

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -88,9 +89,12 @@ func (r *catalogRefresh) Ensure() error {
 	logger.Debugf("Catalog refresh starting now; next scheduled for %s.", next)
 
 	err := refreshCatalogs(r.state, theStore)
-	if err == nil {
+	switch err {
+	case nil:
 		logger.Debugf("Catalog refresh succeeded.")
-	} else {
+	case store.ErrTooManyRequests:
+		logger.Debugf("Catalog refresh postponed.")
+	default:
 		logger.Debugf("Catalog refresh failed: %v.", err)
 	}
 	return err

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -142,7 +142,7 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshTooMany(c *C) {
 	t0 := time.Now()
 
 	err := cr7.Ensure()
-	c.Check(err, Equals, store.ErrTooManyRequests)
+	c.Check(err, IsNil) // !!
 
 	// next now has a delta (next refresh is not before t0 + delta)
 	c.Check(snapstate.NextCatalogRefresh(cr7).Before(t0.Add(snapstate.CatalogRefreshDelayWithDelta)), Equals, false)

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -43,7 +43,8 @@ import (
 type catalogStore struct {
 	storetest.Store
 
-	ops []string
+	ops     []string
+	tooMany bool
 }
 
 func (r *catalogStore) WriteCatalogs(ctx context.Context, w io.Writer, a store.SnapAdder) error {
@@ -51,6 +52,9 @@ func (r *catalogStore) WriteCatalogs(ctx context.Context, w io.Writer, a store.S
 		panic("Ensure marked context required")
 	}
 	r.ops = append(r.ops, "write-catalog")
+	if r.tooMany {
+		return store.ErrTooManyRequests
+	}
 	w.Write([]byte("pkg1\npkg2"))
 	a.AddSnap("foo", "1.0", "foo summary", []string{"foo", "meh"})
 	a.AddSnap("bar", "2.0", "bar summray", []string{"bar", "meh"})
@@ -62,6 +66,9 @@ func (r *catalogStore) Sections(ctx context.Context, _ *auth.UserState) ([]strin
 		panic("Ensure marked context required")
 	}
 	r.ops = append(r.ops, "sections")
+	if r.tooMany {
+		return nil, store.ErrTooManyRequests
+	}
 	return []string{"section1", "section2"}, nil
 }
 
@@ -124,6 +131,29 @@ func (s *catalogRefreshTestSuite) TestCatalogRefresh(c *C) {
 		"bar": `[{"snap":"bar","version":"2.0"}]`,
 		"meh": `[{"snap":"foo","version":"1.0"},{"snap":"bar","version":"2.0"}]`,
 	})
+}
+
+func (s *catalogRefreshTestSuite) TestCatalogRefreshTooMany(c *C) {
+	s.store.tooMany = true
+
+	cr7 := snapstate.NewCatalogRefresh(s.state)
+	// next is initially zero
+	c.Check(snapstate.NextCatalogRefresh(cr7).IsZero(), Equals, true)
+	t0 := time.Now()
+
+	err := cr7.Ensure()
+	c.Check(err, Equals, store.ErrTooManyRequests)
+
+	// next now has a delta (next refresh is not before t0 + delta)
+	c.Check(snapstate.NextCatalogRefresh(cr7).Before(t0.Add(snapstate.CatalogRefreshDelayWithDelta)), Equals, false)
+
+	// it tried one endpoint and bailed at the first 429
+	c.Check(s.store.ops, HasLen, 1)
+
+	// nothing got created
+	c.Check(osutil.FileExists(dirs.SnapSectionsFile), Equals, false)
+	c.Check(osutil.FileExists(dirs.SnapNamesFile), Equals, false)
+	c.Check(osutil.FileExists(dirs.SnapCommandsDB), Equals, false)
 }
 
 func (s *catalogRefreshTestSuite) TestCatalogRefreshNotNeeded(c *C) {

--- a/store/store.go
+++ b/store/store.go
@@ -175,7 +175,13 @@ type Store struct {
 	proxy  func(*http.Request) (*url.URL, error)
 }
 
+var ErrTooManyRequests = errors.New("too many requests")
+
 func respToError(resp *http.Response, msg string) error {
+	if resp.StatusCode == 429 {
+		return ErrTooManyRequests
+	}
+
 	tpl := "cannot %s: got unexpected HTTP status code %d via %s to %q"
 	if oops := resp.Header.Get("X-Oops-Id"); oops != "" {
 		tpl += " [%s]"


### PR DESCRIPTION
Without this change a 429 from the store would be treated like any
other unknown error, resulting in a rather nasty

    Catalog refresh failed: cannot decode new commands catalog: got unexpected HTTP status code 429 via GET to [...]

message in debug, and a user-unfriendly

    state ensure error: cannot decode new commands catalog: got unexpected HTTP status code 429 via GET to [...]

This change adds handling so that the debug message is simply

    Catalog reresh postponed.

and the refresh is treated as successful.
