### PR TITLE
tests: show why sbuild failed

### DIFF
--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -29,6 +29,10 @@ restore: |
     rm -f /etc/schroot/chroot.d/sid-amd64-sbuild-*
 
 debug: |
+    # There there's a log file and a symbolic link pointing to it.
+    # The non-symlink has a time-stamp and we can match on the "Z" timezone
+    # marker to find it.
+    tail -n 100 *Z.build
     cat <<EOM
     Use release-tools/debian-package-builder to interactively fix build
     issues. The debug shell created there shows the true layout of the source

--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -32,7 +32,7 @@ debug: |
     # There there's a log file and a symbolic link pointing to it.
     # The non-symlink has a time-stamp and we can match on the "Z" timezone
     # marker to find it.
-    tail -n 100 *Z.build
+    test "$(find . -maxdepth 1 -name '*Z.build' | wc -l)" -ge 1 &&  tail -n 100 *Z.build
     cat <<EOM
     Use release-tools/debian-package-builder to interactively fix build
     issues. The debug shell created there shows the true layout of the source

--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -29,7 +29,7 @@ restore: |
     rm -f /etc/schroot/chroot.d/sid-amd64-sbuild-*
 
 debug: |
-    # There there's a log file and a symbolic link pointing to it.
+    # Test that there's a log file and a symbolic link pointing to it.
     # The non-symlink has a time-stamp and we can match on the "Z" timezone
     # marker to find it.
     test "$(find . -maxdepth 1 -name '*Z.build' | wc -l)" -ge 1 &&  tail -n 100 ./*Z.build

--- a/tests/main/sbuild/task.yaml
+++ b/tests/main/sbuild/task.yaml
@@ -32,7 +32,7 @@ debug: |
     # There there's a log file and a symbolic link pointing to it.
     # The non-symlink has a time-stamp and we can match on the "Z" timezone
     # marker to find it.
-    test "$(find . -maxdepth 1 -name '*Z.build' | wc -l)" -ge 1 &&  tail -n 100 *Z.build
+    test "$(find . -maxdepth 1 -name '*Z.build' | wc -l)" -ge 1 &&  tail -n 100 ./*Z.build
     cat <<EOM
     Use release-tools/debian-package-builder to interactively fix build
     issues. The debug shell created there shows the true layout of the source


### PR DESCRIPTION
The sbuild test seems to fail sometimes, but not due to timeout that
kills the test. When that happens test logs contain absolutely nothing
useful.

Maciej suggested that we can look at the tail of the sbuild logs to do
so. In a practical run invoked with --shell-after there are two log
files:

    snapd_2.40-2_amd64-2019-08-13T09:46:14Z.build
    snapd_2.40-2_amd64.build -> snapd_2.40-2_amd64-2019-08-13T09:46:14Z.build

I don't want to be in the business of extracting that version so I just
take the one with the Z.build suffix.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
