### PR TITLE
tests: use snap info --verbose to check for base

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -123,7 +123,7 @@ reset_all_snap() {
                     systemctl start snapd.service snapd.socket
                 fi
                 if ! echo "$SKIP_REMOVE_SNAPS" | grep -w "$snap"; then
-                    if snap info "$snap" | grep -E '^type: +(base|core)'; then
+                    if snap info --verbose "$snap" | grep -E '^type: +(base|core)'; then
                         if [ -z "$remove_bases" ]; then
                             remove_bases="$snap"
                         else


### PR DESCRIPTION
Core systems were incorrectly restored, because the code that did so
relied on "snap info" to see the base of a snap. The problem is that
base is only printed when the "--verbose" flag is used.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
