### PR TITLE
interfaces/mount: forward SNAPD_DEBUG to ns tools

### DIFF
--- a/interfaces/mount/ns.go
+++ b/interfaces/mount/ns.go
@@ -21,6 +21,7 @@ package mount
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -44,6 +45,10 @@ func runNamespaceTool(toolName, snapName string) ([]byte, error) {
 			return nil, err
 		}
 		cmd := exec.Command(toolPath, snapName)
+		if osutil.GetenvBool("SNAPD_DEBUG") {
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "SNAPD_DEBUG=1")
+		}
 		output, err := cmd.CombinedOutput()
 		return output, err
 	}


### PR DESCRIPTION
When debugging snapd with SNAPD_DEBUG=1 it would be nice to be able to
forward that setting to snap-discard-ns and snap-update-ns. This patch
makes that happen.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
