### PR TITLE
interfaces/mount: discard mount ns on backend Remove

### DIFF
--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -89,7 +89,7 @@ func (b *Backend) Remove(snapName string) error {
 	if err != nil {
 		return fmt.Errorf("cannot synchronize mount configuration files for snap %q: %s", snapName, err)
 	}
-	return nil
+	return DiscardSnapNamespace(snapName)
 }
 
 // addMountProfile adds a mount profile with the given name, based on the given entries.


### PR DESCRIPTION
When a snap is removed each security backend is asked to remove the
security profiles associated with the snap in question. For the mount
backend that would just remove the desired mount namespace profile.

While this part worked correctly there was more to be done. The system
may still have the preserved mount namespace as well as the actual
applied (current) mount profiles that exist therein.

In a case where a snap was installed but the installation failed because
of a hook issue, the system would be left in a state where an existing
mount namespace would be left behind.

Related-To: https://bugs.launchpad.net/snapd/+bug/1808821
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
