### PR TITLE
interfaces: fix test failure in gpio_control_test

### DIFF
--- a/interfaces/builtin/gpio_control_test.go
+++ b/interfaces/builtin/gpio_control_test.go
@@ -66,13 +66,6 @@ func (s *GpioControlInterfaceSuite) TestName(c *C) {
 
 func (s *GpioControlInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
-	slotInfo := &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "some-snap"},
-		Name:      "gpio-control",
-		Interface: "gpio-control",
-	}
-	c.Assert(interfaces.BeforePrepareSlot(s.iface, slotInfo), ErrorMatches,
-		"gpio-control slots are reserved for the core snap")
 }
 
 func (s *GpioControlInterfaceSuite) TestSanitizePlug(c *C) {


### PR DESCRIPTION
After merging PR#6950 master failed because it got a new
gpio-control interface which uses the old style of testing
for os-slots. This is no longer used, see:
https://github.com/snapcore/snapd/pull/6950/files

This will un-break the current unit test failures in master.
