### PR TITLE
interfaces: remove BeforePrepareSlot from commonInterface

### DIFF
--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -84,11 +84,6 @@ func (iface *commonInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-// BeforePrepareSlot checks and possibly modifies a slot.
-func (iface *commonInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
-	return nil
-}
-
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	if iface.usesPtraceTrace {
 		spec.SetUsesPtraceTrace()

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3720,7 +3720,7 @@ slots:
 	c.Check(ifacestate.CheckInterfaces(s.state, snapInfo, deviceCtx), ErrorMatches, "installation denied.*")
 }
 
-func (s *interfaceManagerSuite) TestCheckInterfacesAllowBasedOnSnapTypeNoSnapDecl(c *C) {
+func (s *interfaceManagerSuite) TestCheckInterfacesNoDenyIfNoDecl(c *C) {
 	deviceCtx := s.TrivialDeviceContext(c, nil)
 	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
 type: base-declaration

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -3720,7 +3720,7 @@ slots:
 	c.Check(ifacestate.CheckInterfaces(s.state, snapInfo, deviceCtx), ErrorMatches, "installation denied.*")
 }
 
-func (s *interfaceManagerSuite) TestCheckInterfacesDenySkippedWithMinimalCheckIfNoDecl(c *C) {
+func (s *interfaceManagerSuite) TestCheckInterfacesAllowBasedOnSnapTypeNoSnapDecl(c *C) {
 	deviceCtx := s.TrivialDeviceContext(c, nil)
 	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
 type: base-declaration


### PR DESCRIPTION
This is a trivial followup to #6950: remove unneeded BeforePrepareSlot method (it is optional and doesn't do anything anymore) and rename RestCheckInterfacesDenySkippedWithMinimalCheckIfNoDecl to TestCheckInterfacesAllowBasedOnSnapTypeNoSnapDecl (per Samuele's comment to the previous PR).
