### PR TITLE
packaging: fix symlink for snapd.session-agent.socket

### DIFF
--- a/packaging/debian-sid/snapd.links
+++ b/packaging/debian-sid/snapd.links
@@ -1,2 +1,6 @@
-../../usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
+/usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
 usr/lib/snapd/snapctl usr/bin/snapctl
+
+# This should be removed once we can rely on debhelper >= 11.5:
+#     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
+/usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,6 +1,6 @@
-../../usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
+/usr/lib/snapd/snap-device-helper  /lib/udev/snappy-app-dev
 usr/lib/snapd/snapctl usr/bin/snapctl
 
 # This should be removed once we can rely on debhelper >= 11.5:
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
-../snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
+/usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket

--- a/tests/main/debs/task.yaml
+++ b/tests/main/debs/task.yaml
@@ -12,5 +12,8 @@ execute: |
     fi
     echo "$out" | MATCH 'Built-Using:.*libcap2 \(='
 
-    echo "Ensure that the snapd.session-agent.socket symlinks is part of the deb and that it has the right (relative) target"
-    dpkg -c "$GOHOME"/snapd_*.deb |grep -- '-> \.\./snapd.session-agent.socket'
+    # not running on 14.04 because we don't have user sessions there
+    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+        echo "Ensure that the snapd.session-agent.socket symlinks is part of the deb and that it has the right (relative) target"
+        dpkg -c "$GOHOME"/snapd_*.deb |MATCH -- '-> \.\./snapd.session-agent.socket'
+    fi

--- a/tests/main/debs/task.yaml
+++ b/tests/main/debs/task.yaml
@@ -1,8 +1,9 @@
-summary: Ensure that our debs have the "built-using" header
+summary: Ensure our debs are correctly built
 
 systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 
 execute: |
+    echo "Ensure that our debs have the 'built-using' header"
     out=$(dpkg -I "$GOHOME"/snapd_*.deb)
     if [[ "$SPREAD_SYSTEM" = ubuntu-* ]]; then
         # Apparmor & seccomp is only compiled in on Ubuntu for now.
@@ -10,3 +11,6 @@ execute: |
         echo "$out" | MATCH 'Built-Using:.*libseccomp \(='
     fi
     echo "$out" | MATCH 'Built-Using:.*libcap2 \(='
+
+    echo "Ensure that the snapd.session-agent.socket symlinks is part of the deb and that it has the right (relative) target"
+    dpkg -c "$GOHOME"/snapd_*.deb |grep -- '-> \.\./snapd.session-agent.socket'


### PR DESCRIPTION
The dh_link man-page says that relative syntax is not supported
when describing the source/target in snapd.links. This PR
converts it to absolute names and dh_link will convert it back
to a (short) relative symlink.

This can be observed in e.g.
https://launchpad.net/~snappy-dev/+archive/ubuntu/edge/+sourcefiles/snapd/2.40+git1432.803f873~ubuntu18.04.1/snapd_2.40+git1432.803f873~ubuntu18.04.1.dsc
which contains the following files:
```
$ dpkg -c snapd_2.40+git1432.803f873~ubuntu18.04.1_amd64.deb |grep snapd.session-agent.socket
-rw-r--r-- root/root       152 2019-08-15 16:16 ./usr/lib/systemd/user/snapd.session-agent.socket
lrwxrwxrwx root/root         0 2019-08-15 16:16 ./usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket -> /snapd.session-agent.socket
```

It also updates the debian packaging to include the link. It was
forgoten there it seems.

This should fix a failure the broken symlink we currently see
in the snapd snap that prevents the snapd snap from getting
updated.

