### PR TITLE
tests: adding more spread workers for ubuntu-18.04-64

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -64,7 +64,7 @@ backends:
             - ubuntu-16.04-64:
                 workers: 8
             - ubuntu-18.04-64:
-                workers: 6
+                workers: 8
             - ubuntu-19.04-64:
                 workers: 6
             - ubuntu-core-16-64:


### PR DESCRIPTION
Based on the number of tests we run on each system, it is clear that we
need the same number of workers for bionic than it is defined for xenial

$ spread -list google:ubuntu-18.04-64 | wc -l
428
$ spread -list google:ubuntu-16.04-64 | wc -l
429
$ spread -list google:ubuntu-16.04-32 | wc -l
408
$ spread -list google:ubuntu-14.04-64 | wc -l
388
$ spread -list google:ubuntu-19.04-64 | wc -l
411
