### PR TITLE
tests: add a runtime scripts generation to generate scripts to call functions

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -28,9 +28,6 @@ set -e
 # shellcheck source=tests/lib/state.sh
 . "$TESTSLIB/state.sh"
 
-# shellcheck source=tests/lib/systems.sh
-. "$TESTSLIB/systems.sh"
-
 
 ###
 ### Utility functions reused below.
@@ -228,6 +225,9 @@ prepare_project() {
         echo "Tests cannot run inside a container"
         exit 1
     fi
+
+    # Create runtime scripts for testing
+    "$TESTSLIB/scripts-generator.sh"
 
     # no need to modify anything further for autopkgtest
     # we want to run as pristine as possible
@@ -477,7 +477,7 @@ prepare_project_each() {
 prepare_suite() {
     # shellcheck source=tests/lib/prepare.sh
     . "$TESTSLIB"/prepare.sh
-    if is_core_system; then
+    if is-core-system; then
         prepare_ubuntu_core
     else
         prepare_classic
@@ -489,7 +489,7 @@ install_snap_profiler(){
 
     if [ "$PROFILE_SNAPS" = 1 ]; then
         profiler_snap=test-snapd-profiler
-        if is_core18_system; then
+        if is-core18-system; then
             profiler_snap=test-snapd-profiler-core18
         fi
 
@@ -520,7 +520,7 @@ prepare_suite_each() {
 
     # shellcheck source=tests/lib/prepare.sh
     . "$TESTSLIB"/prepare.sh
-    if is_classic_system; then
+    if is-classic-system; then
         prepare_each_classic
     fi
     # Check if journalctl is ready to run the test
@@ -551,7 +551,7 @@ restore_suite_each() {
         logs_file=$(echo "${logs_id}_${SPREAD_JOB}" | tr '/' '_' | tr ':' '__')
 
         profiler_snap=test-snapd-profiler
-        if is_core18_system; then
+        if is-core18-system; then
             profiler_snap=test-snapd-profiler-core18
         fi
 
@@ -566,7 +566,7 @@ restore_suite_each() {
 restore_suite() {
     # shellcheck source=tests/lib/reset.sh
     "$TESTSLIB"/reset.sh --store
-    if is_classic_system; then
+    if is-classic-system; then
         # shellcheck source=tests/lib/pkgdb.sh
         . "$TESTSLIB"/pkgdb.sh
         distro_purge_package snapd

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -12,8 +12,6 @@ set -eux
 . "$TESTSLIB/boot.sh"
 # shellcheck source=tests/lib/state.sh
 . "$TESTSLIB/state.sh"
-# shellcheck source=tests/lib/systems.sh
-. "$TESTSLIB/systems.sh"
 
 
 disable_kernel_rate_limiting() {
@@ -30,7 +28,7 @@ ensure_jq() {
         return
     fi
 
-    if is_core18_system; then
+    if is-core18-system; then
         snap install --devmode jq-core18
         snap alias jq-core18.jq jq
     else
@@ -263,7 +261,7 @@ prepare_classic() {
 
         echo "Cache the snaps profiler snap"
         if [ "$PROFILE_SNAPS" = 1 ]; then
-            if is_core18_system; then
+            if is-core18-system; then
                 cache_snaps test-snapd-profiler-core18
             else
                 cache_snaps test-snapd-profiler
@@ -335,7 +333,7 @@ setup_reflash_magic() {
 
     # we cannot use "names.sh" here because no snaps are installed yet
     core_name="core"
-    if is_core18_system; then
+    if is-core18-system; then
         snap download "--channel=${SNAPD_CHANNEL}" snapd
         core_name="core18"
     fi
@@ -356,7 +354,7 @@ setup_reflash_magic() {
     cp /usr/bin/snap "$IMAGE_HOME"
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
-    if is_core18_system; then
+    if is-core18-system; then
         repack_snapd_snap_with_deb_content "$IMAGE_HOME"
 
         # FIXME: fetch directly once its in the assertion service
@@ -421,7 +419,7 @@ EOF
 
     # on core18 we need to use the modified snapd snap and on core16
     # it is the modified core that contains our freshly build snapd
-    if is_core18_system; then
+    if is-core18-system; then
         extra_snap=("$IMAGE_HOME"/snapd_*.snap)
     else
         extra_snap=("$IMAGE_HOME"/core_*.snap)
@@ -443,7 +441,7 @@ EOF
     # mount fresh image and add all our SPREAD_PROJECT data
     kpartx -avs "$IMAGE_HOME/$IMAGE"
     # FIXME: hardcoded mapper location, parse from kpartx
-    if is_core18_system; then
+    if is-core18-system; then
         mount /dev/mapper/loop3p3 /mnt
     else
         mount /dev/mapper/loop2p3 /mnt
@@ -463,7 +461,7 @@ EOF
           /home/gopath /mnt/user-data/
         
     # now modify the image
-    if is_core18_system; then
+    if is-core18-system; then
         UNPACK_DIR="/tmp/core18-snap"
         unsquashfs -no-progress -d "$UNPACK_DIR" /var/lib/snapd/snaps/core18_*.snap
     fi
@@ -631,7 +629,7 @@ prepare_ubuntu_core() {
     done
 
     echo "Ensure the snapd snap is available"
-    if is_core18_system; then
+    if is-core18-system; then
         if ! snap list snapd; then
             echo "snapd snap on core18 is missing"
             snap list
@@ -642,7 +640,7 @@ prepare_ubuntu_core() {
     echo "Ensure rsync is available"
     if ! command -v rsync; then
         rsync_snap="test-snapd-rsync"
-        if is_core18_system; then
+        if is-core18-system; then
             rsync_snap="test-snapd-rsync-core18"
         fi
         snap install --devmode "$rsync_snap"
@@ -651,7 +649,7 @@ prepare_ubuntu_core() {
 
     echo "Ensure the core snap is cached"
     # Cache snaps
-    if is_core18_system; then
+    if is-core18-system; then
         if snap list core >& /dev/null; then
             echo "core snap on core18 should not be installed yet"
             snap list

--- a/tests/lib/scripts-generator.sh
+++ b/tests/lib/scripts-generator.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+declare -A functions_list
+
+functions_list=( 
+    ["check_journalctl_log"]="$TESTSLIB/journalctl.sh" 
+    ["get_journalctl_log"]="$TESTSLIB/journalctl.sh"
+    ["is_core_system"]="$TESTSLIB/systems.sh"
+    ["is_core18_system"]="$TESTSLIB/systems.sh"
+    ["is_classic_system"]="$TESTSLIB/systems.sh"
+    ["is_ubuntu_14_system"]="$TESTSLIB/systems.sh"    
+    )
+
+for function_name in "${!functions_list[@]}"; do
+    lib_path="${functions_list[$function_name]}"
+    file_name="$(echo "$function_name" | tr '_' '-')"
+
+    params='"$@"'
+    cat > "$TESTSLIB/bin/$file_name" <<-EOF
+#!/bin/bash
+
+# shellcheck source="$lib_path"
+. "$lib_path"
+
+$function_name $params
+EOF
+    chmod +x "$TESTSLIB/bin/$file_name"
+
+done

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -14,9 +14,6 @@ SNAPD_ACTIVE_UNITS="$RUNTIME_STATE_PATH/snapd-active-units"
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB/systemd.sh"
 
-# shellcheck source=tests/lib/systems.sh
-. "$TESTSLIB/systems.sh"
-
 delete_snapd_state() {
     rm -rf "$SNAPD_STATE_PATH"
 }
@@ -26,9 +23,9 @@ prepare_state() {
 }
 
 is_snapd_state_saved() {
-    if is_core_system && [ -d "$SNAPD_STATE_PATH"/snapd-lib ]; then
+    if is-core-system && [ -d "$SNAPD_STATE_PATH"/snapd-lib ]; then
         return 0
-    elif is_classic_system && [ -f "$SNAPD_STATE_FILE" ]; then
+    elif is-classic-system && [ -f "$SNAPD_STATE_FILE" ]; then
         return 0
     else
         return 1
@@ -36,7 +33,7 @@ is_snapd_state_saved() {
 }
 
 save_snapd_state() {
-    if is_core_system; then
+    if is-core-system; then
         boot_path="$(get_boot_path)"
         test -n "$boot_path" || return 1
 
@@ -69,7 +66,7 @@ save_snapd_state() {
         core="$(readlink -f "$SNAP_MOUNT_DIR/core/current")"
         # on 14.04 it is possible that the core snap is still mounted at this point, unmount
         # to prevent errors starting the mount unit
-        if is_ubuntu_14_system && mount | grep -q "$core"; then
+        if is-ubuntu-14-system && mount | grep -q "$core"; then
             umount "$core" || true
         fi
         for unit in $units; do
@@ -82,7 +79,7 @@ save_snapd_state() {
 }
 
 restore_snapd_state() {
-    if is_core_system; then
+    if is-core-system; then
         # we need to ensure that we also restore the boot environment
         # fully for tests that break it
         boot_path="$(get_boot_path)"

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -5,9 +5,6 @@ STORE_CONFIG=/etc/systemd/system/snapd.service.d/store.conf
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB/systemd.sh"
 
-# shellcheck source=tests/lib/journalctl.sh
-. "$TESTSLIB/journalctl.sh"
-
 _configure_store_backends(){
     systemctl stop snapd.service snapd.socket
     mkdir -p "$(dirname $STORE_CONFIG)"
@@ -80,7 +77,7 @@ setup_fake_store(){
 
     echo "fakestore service not started properly"
     ss -ntlp | grep "127.0.0.1:$PORT" || true
-    get_journalctl_log -u fakestore || true
+    get-journalctl-log -u fakestore || true
     systemctl status fakestore || true
     exit 1
 }

--- a/tests/main/auto-refresh-retry/task.yaml
+++ b/tests/main/auto-refresh-retry/task.yaml
@@ -16,9 +16,6 @@ debug: |
     ip netns pids testns || true
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "Install a snap from stable"
     snap install test-snapd-tools
   
@@ -43,7 +40,7 @@ execute: |
 
     echo "wait for auto-refresh to happen and fail"
     for _ in $(seq 120); do
-        if get_journalctl_log | MATCH "state ensure error: persistent network error"; then
+        if get-journalctl-log | MATCH "state ensure error: persistent network error"; then
             break
         fi
         echo "Ensure refresh"
@@ -51,7 +48,7 @@ execute: |
         sleep 5
     done
 
-    get_journalctl_log | MATCH "state ensure error: persistent network error"
+    get-journalctl-log | MATCH "state ensure error: persistent network error"
 
     # restart snapd with network access back
     systemctl stop snapd.{service,socket}

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -19,16 +19,13 @@ execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     echo "Auto refresh information is shown"
     output=$(snap refresh --time)
     for expected in ^schedule: ^last: ^next:; do
         echo "$output" | MATCH "$expected"
     done
 
-    if is_core_system; then
+    if is-core-system; then
         # no holding
         echo "$output" | not MATCH "^hold:"
     else

--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -6,17 +6,14 @@ prepare: |
     rm -f /var/cache/snapd/sections
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "We count how many catalog refreshes are logged before starting snapd"
-    refreshes_before="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh' || true)"
+    refreshes_before="$(get-journalctl-log -u snapd | grep -c 'Catalog refresh' || true)"
 
     systemctl restart snapd.{socket,service}
 
     echo "Ensure that catalog refresh happens on startup"
     for _ in $(seq 60); do
-        refreshes_after="$(get_journalctl_log -u snapd | grep -c 'Catalog refresh' || true)"
+        refreshes_after="$(get-journalctl-log -u snapd | grep -c 'Catalog refresh' || true)"
         if [ "$refreshes_after" -gt "$refreshes_before" ]; then
             break
         fi
@@ -27,7 +24,7 @@ execute: |
     [ "$refreshes_after" -gt "$refreshes_before" ]
 
     echo "Ensure that we don't log all catalog body data"
-    if get_journalctl_log -u snapd | MATCH "Tools for testing the snapd application"; then
+    if get-journalctl-log -u snapd | MATCH "Tools for testing the snapd application"; then
         echo "Catalog update is doing verbose http logging (it should not)."
         exit 1
     fi

--- a/tests/main/core-snap-refresh/task.yaml
+++ b/tests/main/core-snap-refresh/task.yaml
@@ -11,9 +11,6 @@ execute: |
     #shellcheck source=tests/lib/boot.sh
     . "$TESTSLIB"/boot.sh
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$SPREAD_REBOOT" = 0 ]; then
         # save current core revision
         snap list | awk "/^core / {print(\$3)}" > prevBoot
@@ -24,7 +21,7 @@ execute: |
         # check boot env vars
         snap list | awk "/^core / {print(\$3)}" > nextBoot
 
-        if is_core_system; then
+        if is-core-system; then
             test "$(bootenv snap_core)" = "core_$(cat prevBoot).snap"
             test "$(bootenv snap_try_core)" = "core_$(cat nextBoot).snap"
         fi
@@ -41,7 +38,7 @@ execute: |
         sleep 1
     done
 
-    if is_core_system; then
+    if is-core-system; then
         test "$(bootenv snap_core)" = "core_$(cat nextBoot).snap"
         test "$(bootenv snap_try_core)" = ""
     fi

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -57,13 +57,10 @@ execute: |
         exit 0
     fi
 
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "Then the snap service units concerning the gpio device must be run before and after a reboot"
     expected="Unit snap.core.interface.gpio-100.service has finished starting up"
     for i in $(seq 120); do
-        get_journalctl_log -xe --no-pager | MATCH "$expected"
+        get-journalctl-log -xe --no-pager | MATCH "$expected"
         sleep 0.5
     done
 

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -67,8 +67,6 @@ execute: |
     . "$TESTSLIB"/names.sh
     #shellcheck source=tests/lib/boot.sh
     . "$TESTSLIB"/boot.sh
-    #shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB"/journalctl.sh
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
 
@@ -92,7 +90,7 @@ execute: |
         mksnap_fast "$BUILD_DIR/unpack" failing.snap
 
         # use journalctl wrapper to grep only the logs collected while the test is running
-        if get_journalctl_log | MATCH "Waiting for system reboot"; then
+        if get-journalctl-log | MATCH "Waiting for system reboot"; then
             echo "Already waiting for system reboot, exiting..."
             exit 1
         fi
@@ -103,13 +101,13 @@ execute: |
         # use journalctl wrapper to grep only the logs collected while the test is running
         # waiting up to 100s to reach waiting for reboot
         for _ in $(seq 50); do
-            if check_journalctl_log "Waiting for system reboot"; then
+            if check-journalctl-log "Waiting for system reboot"; then
                  break
             fi
             sleep 2
         done
 
-        if ! check_journalctl_log "Waiting for system reboot"; then
+        if ! check-journalctl-log "Waiting for system reboot"; then
             echo "Taking too long to reach waiting for reboot"
             exit 1
         fi

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -16,9 +16,6 @@ restore: |
     snap logout || true
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     echo "When a snap is private it doesn't show up in the find without login and without specifying private search"
     snap find test-snapd-private | not MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
 
@@ -27,7 +24,7 @@ execute: |
 
     echo "Given account store credentials are available"
     # we don't have expect available on ubuntu-core, so the authenticated check need to be skipped on those systems
-    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ] && is_classic_system; then
+    if [ -n "$SPREAD_STORE_USER" ] && [ -n "$SPREAD_STORE_PASSWORD" ] && is-classic-system; then
         echo "And the user has logged in"
         expect -f "$TESTSLIB"/successful_login.exp
 

--- a/tests/main/install-cache/task.yaml
+++ b/tests/main/install-cache/task.yaml
@@ -1,10 +1,7 @@
 summary: Check that download caching works
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     snap install test-snapd-tools
     snap remove test-snapd-tools
     snap install test-snapd-tools
-    check_journalctl_log 'using cache for .*/test-snapd-tools.*\.snap' -u snapd
+    check-journalctl-log 'using cache for .*/test-snapd-tools.*\.snap' -u snapd

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -42,11 +42,8 @@ restore: |
     rm -rf "$HOME"/PDF "$TEST_FILE"
 
 debug: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     systemctl status cups || true
-    get_journalctl_log -u cpus || true
+    get-journalctl-log -u cpus || true
 
 execute: |
     echo "Then the plug is disconnected by default"

--- a/tests/main/interfaces-daemon-notify/task.yaml
+++ b/tests/main/interfaces-daemon-notify/task.yaml
@@ -15,9 +15,6 @@ prepare: |
     install_local test-snapd-daemon-notify
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "The interface is not connected by default"
     snap interfaces -i daemon-notify | MATCH -- "- +test-snapd-daemon-notify:daemon-notify"
 
@@ -27,11 +24,11 @@ execute: |
     echo "And the service is stopped"
     snap stop test-snapd-daemon-notify.notify
 
-    denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+    denials_before="$(get-journalctl-log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
     echo "Then after we restart the service there are no denials"
     snap start test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
-        denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+        denials_after="$(get-journalctl-log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
         if [ "$denials_before" -ne "$denials_after" ]; then
             break
         fi
@@ -50,10 +47,10 @@ execute: |
     snap stop test-snapd-daemon-notify.notify
 
     echo "Then the snap is not able to send notification messages"
-    denials_before="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+    denials_before="$(get-journalctl-log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
     snap start test-snapd-daemon-notify.notify
     for _ in $(seq 10); do
-        denials_after="$(get_journalctl_log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
+        denials_after="$(get-journalctl-log -u snap.test-snapd-daemon-notify.notify.service | grep -c 'Permission denied' || true)"
         if [ "$denials_before" -ne "$denials_after" ]; then
             break
         fi

--- a/tests/main/interfaces-home/task.yaml
+++ b/tests/main/interfaces-home/task.yaml
@@ -36,10 +36,7 @@ restore: |
     rm -f "$READABLE_FILE" "$WRITABLE_FILE" "$CREATABLE_FILE" "$HIDDEN_READABLE_FILE"
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
-    if is_core_system; then
+    if is-core-system; then
         echo "The interface is not connected by default"
         snap interfaces -i home | MATCH '^- +home-consumer:home'
 

--- a/tests/main/interfaces-hostname-control/task.yaml
+++ b/tests/main/interfaces-hostname-control/task.yaml
@@ -10,9 +10,6 @@ prepare: |
     install_local test-snapd-sh
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     hostname="$(hostname)"
 
     echo "The plug is disconnected by default"
@@ -26,7 +23,7 @@ execute: |
     [ "$hostname" = "$snap_hostname" ]
 
     # On core systems /etc/hostname is not writable
-    if is_classic_system; then
+    if is-classic-system; then
         echo "And the /etc/hostname file can be written"
         test-snapd-sh.with-hostname-control-plug -c "echo $hostname > /etc/hostname"
     fi

--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -28,12 +28,7 @@ environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
 debug: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
-    # get the full journal to see any out-of-memory errors
-    # shellcheck disable=SC2119
-    get_journalctl_log
+    get-journalctl-log
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -28,22 +28,14 @@ environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
 debug: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
-    # get the full journal to see any out-of-memory errors
-    # shellcheck disable=SC2119
-    get_journalctl_log
+    get-journalctl-log
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    
-    if is_core_system; then
+    if is-core-system; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"
     fi
 
@@ -77,12 +69,9 @@ execute: |
     done
 
 restore: |
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    
     # Remove the snaps to avoid timeout in next test
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    
-    if is_core_system; then
+    if is-core-system; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"
     fi
     snap remove "$PROVIDER_SNAP"

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -57,9 +57,6 @@ debug: |
     jq .data.auth.device /var/lib/snapd/state.json
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
@@ -78,7 +75,7 @@ execute: |
 
     echo "Then the core refresh.schedule can be set to 'managed'"
     snap set core refresh.schedule=managed
-    if get_journalctl_log -u snapd |grep 'cannot parse "managed"'; then
+    if get-journalctl-log -u snapd |grep 'cannot parse "managed"'; then
         echo "refresh.schedule=managed was not accepted as it should be"
         exit 1
     fi

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -17,9 +17,7 @@ prepare: |
     echo "Given a snap declaring a plug on the upower-observe interface is installed"
     snap install --edge test-snapd-upower-observe-consumer
 
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    if is_core_system; then
+    if is-core-system; then
         echo "And a snap providing a upower-observe slot is installed"
         snap install upower
     fi

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -35,11 +35,8 @@ restore: |
     echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
 
 debug: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     # debug output from lxd
-    get_journalctl_log -u snap.lxd.daemon.service
+    get-journalctl-log -u snap.lxd.daemon.service
 
 execute: |
     if  [[ "$(find "$GOHOME" -name 'snapd_*.deb' | wc -l || echo 0)" -eq 0 ]]; then

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -35,7 +35,5 @@ execute: |
         exit 1
     fi
 
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
     echo "Ensure we tried to retry this operation"
-    check_journalctl_log 'Retrying because of temporary net error'
+    check-journalctl-log 'Retrying because of temporary net error'

--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -50,6 +50,4 @@ execute: |
     echo "Ensure that snap install works even without an installed core to install core"
     snap install core
 
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-    check_journalctl_log 'CONNECT fastly.cdn.snapcraft.io' -u tinyproxy
+    check-journalctl-log 'CONNECT fastly.cdn.snapcraft.io' -u tinyproxy

--- a/tests/main/proxy/task.yaml
+++ b/tests/main/proxy/task.yaml
@@ -30,6 +30,4 @@ execute: |
     snap find test-snapd-tools | MATCH test-snapd-tools
 
     # check unit output
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-    check_journalctl_log 'CONNECT api.snapcraft.io' -u tinyproxy
+    check-journalctl-log 'CONNECT api.snapcraft.io' -u tinyproxy

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -21,10 +21,7 @@ restore: |
     fi
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "When the snap is refreshed"
     snap refresh --beta "$SNAP_NAME"
     echo "Then deltas are successfully applied"
-    check_journalctl_log "Successfully applied delta"
+    check-journalctl-log "Successfully applied delta"

--- a/tests/main/refresh-delta/task.yaml
+++ b/tests/main/refresh-delta/task.yaml
@@ -19,11 +19,8 @@ prepare: |
     snap install --edge "$SNAP_NAME"
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "When the snap is refreshed"
     snap refresh --beta "$SNAP_NAME"
 
     echo "Then deltas are successfully applied"
-    check_journalctl_log "Successfully applied delta"
+    check-journalctl-log "Successfully applied delta"

--- a/tests/main/refresh-devmode/task.yaml
+++ b/tests/main/refresh-devmode/task.yaml
@@ -17,11 +17,8 @@ environment:
     STORE_TYPE/remote: ${REMOTE_STORE}
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -45,11 +42,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -66,7 +60,7 @@ execute: |
     . "$TESTSLIB"/systems.sh
 
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-undo/task.yaml
+++ b/tests/main/refresh-undo/task.yaml
@@ -19,9 +19,7 @@ prepare: |
     snap pack "$TESTSLIB/snaps/$SNAP_NAME_BAD"
 
 debug: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB"/journalctl.sh
-    get_journalctl_log -u snap.test-snapd-service.service.service
+    get-journalctl-log -u snap.test-snapd-service.service.service
 
 execute: |
     wait_for_service_status() {

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -19,11 +19,8 @@ environment:
     STORE_TYPE/parallel_strict_remote,strict_remote,classic_remote: ${REMOTE_STORE}
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -61,11 +58,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -82,11 +76,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/remodel/task.yaml
+++ b/tests/main/remodel/task.yaml
@@ -10,8 +10,6 @@ prepare: |
     fi
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/assertions/*
@@ -20,7 +18,7 @@ prepare: |
     mv /var/lib/snapd/seed/assertions/model model.bak
     cp "$TESTSLIB"/assertions/developer1.account /var/lib/snapd/seed/assertions
     cp "$TESTSLIB"/assertions/developer1.account-key /var/lib/snapd/seed/assertions    
-    if is_core18_system; then
+    if is-core18-system; then
         cp "$TESTSLIB"/assertions/developer1-pc-18.model /var/lib/snapd/seed/assertions/developer1-pc.model
         cp "$TESTSLIB"/assertions/developer1-pc-18-revno2.model developer1-pc-revno2.model
         cp "$TESTSLIB"/assertions/developer1-pc-18-revno3.model developer1-pc-revno3.model
@@ -72,10 +70,8 @@ execute: |
         exit
     fi
 
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
     SNAP=test-snapd-tools
-    if is_core18_system; then
+    if is-core18-system; then
         SNAP=test-snapd-tools-core18
     fi
 

--- a/tests/main/remove-errors/task.yaml
+++ b/tests/main/remove-errors/task.yaml
@@ -3,14 +3,12 @@ summary: Check remove command errors
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
     #shellcheck source=tests/lib/names.sh
     . "$TESTSLIB/names.sh"
 
     BASE_SNAP=core
     TARGET_SNAP=test-snapd-tools
-    if is_core18_system; then
+    if is-core18-system; then
         BASE_SNAP=core18
         TARGET_SNAP=test-snapd-tools-core18
     fi

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -9,11 +9,8 @@ environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -37,11 +34,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -54,11 +48,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -6,11 +6,8 @@ environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
 
 prepare: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -34,11 +31,8 @@ prepare: |
     fi
 
 restore: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -51,11 +45,8 @@ restore: |
     fi
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     if [ "$STORE_TYPE" = "fake" ]; then
-        if is_core_system; then
+        if is-core-system; then
             exit
         fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -7,9 +7,6 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-
     echo "Install dmsetup"
     snap install --devmode --edge dmsetup
 
@@ -26,7 +23,7 @@ prepare: |
 
     # We use different filesystems to cover both: fat and ext. fat is the most
     # common fs used and we also use ext3 because fat is not available on ubuntu core 18
-    if is_core18_system; then
+    if is-core18-system; then
         mkfs.ext3 /dev/ram0
     else
         mkfs.vfat /dev/ram0

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -14,8 +14,6 @@ restore: |
     chmod 4755 /usr/lib/snapd/snap-confine
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
     # shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB/systemd.sh"
 
@@ -27,7 +25,7 @@ execute: |
     echo "Ensure we re-exec by default"
     snap list
 
-    check_journalctl_log "DEBUG: restarting into"
+    check-journalctl-log "DEBUG: restarting into"
 
     echo "Ensure snap-confine from the core snap is run"
     test-snapd-tools.echo hello

--- a/tests/main/snap-service-refresh-mode/task.yaml
+++ b/tests/main/snap-service-refresh-mode/task.yaml
@@ -12,8 +12,6 @@ debug: |
 execute: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
 
     echo "When the service snap is installed"
     install_local test-snapd-service
@@ -32,5 +30,4 @@ execute: |
 
     echo "Once the snap is removed, the service is stopped"
     snap remove test-snapd-service
-    # shellcheck disable=SC2119
-    get_journalctl_log | MATCH "stop endure"
+    get-journalctl-log | MATCH "stop endure"

--- a/tests/main/snap-service-watchdog/task.yaml
+++ b/tests/main/snap-service-watchdog/task.yaml
@@ -12,8 +12,6 @@ debug: |
 execute: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB"/journalctl.sh
 
     echo "When the service snap  is installed"
     install_local test-snapd-service-watchdog
@@ -59,4 +57,4 @@ execute: |
     # reported differently by different systemd versions
     systemctl show -p Result snap.test-snapd-service-watchdog.$service | MATCH 'Result=(watchdog|signal|core-dump)'
 
-    check_journalctl_log "systemd.*: snap.test-snapd-service-watchdog.$service.service:? [Ww]atchdog timeout" -u snap.test-snapd-service-watchdog.$service
+    check-journalctl-log "systemd.*: snap.test-snapd-service-watchdog.$service.service:? [Ww]atchdog timeout" -u snap.test-snapd-service-watchdog.$service

--- a/tests/main/snapd-reexec-snapd-snap/task.yaml
+++ b/tests/main/snapd-reexec-snapd-snap/task.yaml
@@ -16,13 +16,11 @@ execute: |
     snap set core experimental.snapd-snap=true
     snap install --edge snapd
 
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
     # installing the snapd snap should result in a daemon restart so that
     # the snapd from the snap can be used. It won't be used in this test
     # because the version of the snapd from the store is lower than the
     # version of the installed snapd.
-    check_journalctl_log "Requested daemon restart."
+    check-journalctl-log "Requested daemon restart."
 
     # We need to pretend the version of snapd in the snapd snap is the same
     # as the installed one so that it re-execs. We use a higher version in

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -38,8 +38,6 @@ execute: |
 
     # shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
 
     echo "Ensure that we do not re-exec into older versions"
     systemctl stop snapd.service snapd.socket
@@ -48,7 +46,7 @@ execute: |
     mount --bind /tmp/old-info $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/info
     systemctl start snapd.service snapd.socket
     snap list
-    check_journalctl_log 'core snap \(at .*\) is older \(.*\) than distribution package'
+    check-journalctl-log 'core snap \(at .*\) is older \(.*\) than distribution package'
 
     echo "Revert back to normal"
     systemctl stop snapd.service snapd.socket

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -30,9 +30,7 @@ execute: |
     snap set core experimental.snapd-snap=true
     snap install --dangerous /tmp/snapd_*.snap
     echo "Ensure we restarted into the snapd snap"
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-    check_journalctl_log  'restarting into "/snap/snapd/'
+    check-journalctl-log  'restarting into "/snap/snapd/'
 
     echo "Now install a core18 based snap and ensure it works"
     snap install test-snapd-tools-core18

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -12,8 +12,6 @@ prepare: |
     fi
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/assertions/*
@@ -30,7 +28,7 @@ prepare: |
     python3 ./manip_seed.py /var/lib/snapd/seed/seed.yaml
     cp "$TESTSLIB"/assertions/developer1.account /var/lib/snapd/seed/assertions
     cp "$TESTSLIB"/assertions/developer1.account-key /var/lib/snapd/seed/assertions
-    if is_core18_system; then
+    if is-core18-system; then
         cp "$TESTSLIB"/assertions/developer1-pc-18.model /var/lib/snapd/seed/assertions/developer1-pc.model
     else
         cp "$TESTSLIB"/assertions/developer1-pc.model /var/lib/snapd/seed/assertions

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -11,8 +11,6 @@ prepare: |
     fi
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
 
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/assertions/*
@@ -29,7 +27,7 @@ prepare: |
     python3 ./manip_seed.py /var/lib/snapd/seed/seed.yaml
     cp "$TESTSLIB"/assertions/developer1.account /var/lib/snapd/seed/assertions
     cp "$TESTSLIB"/assertions/developer1.account-key /var/lib/snapd/seed/assertions
-    if is_core18_system; then
+    if is-core18-system; then
         cp "$TESTSLIB"/assertions/developer1-pc-18.model /var/lib/snapd/seed/assertions/developer1-pc.model
     else
         cp "$TESTSLIB"/assertions/developer1-pc.model /var/lib/snapd/seed/assertions

--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -5,9 +5,6 @@ summary: |
 systems: [ubuntu-core-1*]
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
 
@@ -25,7 +22,7 @@ execute: |
     echo "Check we have a serial"
     snap known serial|MATCH "authority-id: canonical"
     snap known serial|MATCH "brand-id: canonical"
-    if is_core18_system; then
+    if is-core18-system; then
         snap known serial | MATCH "model: ubuntu-core-18-amd64"
     else
         snap known serial | MATCH "model: pc"

--- a/tests/main/ubuntu-core-os-release/task.yaml
+++ b/tests/main/ubuntu-core-os-release/task.yaml
@@ -3,10 +3,7 @@ summary: check that os-release is correct
 systems: [ubuntu-core-1*]
 
 execute: |
-    #shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB"/systems.sh
-
-    if is_core18_system; then
+    if is-core18-system; then
         MATCH "DISTRIB_RELEASE=18" < /etc/lsb-release
     else
         MATCH "DISTRIB_RELEASE=16" < /etc/lsb-release

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -15,18 +15,15 @@ prepare: |
     chmod 0644 "$p/meta/hooks/what"
 
 execute: |
-    # shellcheck source=tests/lib/journalctl.sh
-    . "$TESTSLIB/journalctl.sh"
-
     echo "Snap refuses to install"
     not snap try "$TESTSLIB/snaps/$SNAP" 2>error.log
     echo "The error tells you to ask the dev"
     tr -s '\n ' ' ' < error.log | MATCH 'contact developer'
 
     echo "And the journal counts the ways"
-    check_journalctl_log '"comp.sh" should be world-readable' -u snapd
-    check_journalctl_log '"bin/bar" should be executable' -u snapd
-    check_journalctl_log '"bin/foo" should be world-readable and executable' -u snapd
-    check_journalctl_log '"meta/unreadable" should be world-readable' -u snapd
-    check_journalctl_log '"meta/hooks/what" should be executable' -u snapd
-    check_journalctl_log '"bin/stahp" does not exist' -u snapd
+    check-journalctl-log '"comp.sh" should be world-readable' -u snapd
+    check-journalctl-log '"bin/bar" should be executable' -u snapd
+    check-journalctl-log '"bin/foo" should be world-readable and executable' -u snapd
+    check-journalctl-log '"meta/unreadable" should be world-readable' -u snapd
+    check-journalctl-log '"meta/hooks/what" should be executable' -u snapd
+    check-journalctl-log '"bin/stahp" does not exist' -u snapd


### PR DESCRIPTION
This generator allow us to add a new script in the bin directory just
adding it to a list. Then it is not needed anymore to source a library
because it is possible to call the binary.

The idea is to make more simple the code in the tests.