### PR TITLE
interfaces/serial-port: support pci bus serial-port with HotplugKey()

### DIFF
--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/hotplug"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 const serialPortSummary = `allows accessing a specific serial port`
@@ -268,7 +269,9 @@ func (iface *serialPortInterface) HotplugKey(di *hotplug.HotplugDeviceInfo) (sna
 
 func (iface *serialPortInterface) HotplugDeviceDetected(di *hotplug.HotplugDeviceInfo) (*hotplug.ProposedSlot, error) {
 	bus, _ := di.Attribute("ID_BUS")
-	if di.Subsystem() != "tty" || bus != "usb" || !serialDeviceNodePattern.MatchString(di.DeviceName()) {
+	if di.Subsystem() != "tty" ||
+		!strutil.ListContains([]string{"usb", "pci"}, bus) ||
+		!serialDeviceNodePattern.MatchString(di.DeviceName()) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Support defining a HotplugKey that uses DEVPATH as part of it's udev attribute
seeds in the key to uniquely identify the device. If the bus of the serial-port
isn't pci, or we still don't find a sufficient pair of vendor / model attributes
then bail out and try to use the default key instead.

NOTE: this is a WIP opened to see how the nested VM serial-port spread test does with this change. It doesn't seem to have broken anything locally