### PR TITLE
snap: cleanup some tests, clarify some errors

### DIFF
--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -606,7 +606,7 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 		for keyData, valueData := range data.(map[interface{}]interface{}) {
 			key, ok := keyData.(string)
 			if !ok {
-				err := fmt.Errorf("%s %q has attribute that is not a string (found %T)",
+				err := fmt.Errorf("%s %q has attribute key that is not a string (found %T)",
 					plugOrSlot, name, keyData)
 				return "", "", nil, err
 			}
@@ -615,6 +615,8 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 				return "", "", nil, err
 			}
 			switch key {
+			case "":
+				return "", "", nil, fmt.Errorf("%s %q has an empty attribute key", plugOrSlot, name)
 			case "interface":
 				value, ok := valueData.(string)
 				if !ok {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1862,7 +1862,6 @@ system-usernames:
   a: true
 `)
 	info, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `system username "a" has malformed definition \(found bool\)`)
 	c.Assert(info, IsNil)
 }
@@ -1874,7 +1873,6 @@ system-usernames:
   a: [b, c]
 `)
 	info, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `system username "a" has malformed definition \(found \[\]interface {}\)`)
 	c.Assert(info, IsNil)
 }
@@ -1886,7 +1884,6 @@ system-usernames:
   "": shared
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `system username cannot be empty`)
 }
 
@@ -1897,7 +1894,6 @@ system-usernames:
 - foo: shared
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `(?m)cannot parse snap.yaml:.*`)
 }
 
@@ -1930,7 +1926,6 @@ system-usernames:
     "": bar
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `system username "foo" has an empty attribute key`)
 }
 
@@ -1943,7 +1938,6 @@ system-usernames:
     1: bar
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `system username "foo" has attribute key that is not a string \(found int\)`)
 }
 
@@ -1956,7 +1950,6 @@ system-usernames:
     bar: null
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `attribute "bar" of system username "foo": invalid scalar:.*`)
 }
 
@@ -1968,6 +1961,5 @@ system-usernames:
     scope: 10
 `)
 	_, err := snap.InfoFromSnapYaml(y)
-	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `scope on system username "foo" is not a string \(found int\)`)
 }

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -441,7 +441,18 @@ plugs:
     net:
         1: ok
 `))
-	c.Assert(err, ErrorMatches, `plug "net" has attribute that is not a string \(found int\)`)
+	c.Assert(err, ErrorMatches, `plug "net" has attribute key that is not a string \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithEmptyAttributeKey(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        "": ok
+`))
+	c.Assert(err, ErrorMatches, `plug "net" has an empty attribute key`)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *C) {
@@ -854,7 +865,18 @@ slots:
     net:
         1: ok
 `))
-	c.Assert(err, ErrorMatches, `slot "net" has attribute that is not a string \(found int\)`)
+	c.Assert(err, ErrorMatches, `slot "net" has attribute key that is not a string \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithEmptyAttributeKey(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        "": ok
+`))
+	c.Assert(err, ErrorMatches, `slot "net" has an empty attribute key`)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *C) {


### PR DESCRIPTION
This is a follow up from work on system usernames:

* some tests were checking that err is NotNil when ErrorMatches is all is needed
* apply some error clarifications from the system usernames code to interface attribute code