### PR TITLE
osutil: add osutil.Find{Uid,Gid}

### DIFF
--- a/osutil/exitcode.go
+++ b/osutil/exitcode.go
@@ -27,6 +27,8 @@ import (
 // ExitCode extract the exit code from the error of a failed cmd.Run() or the
 // original error if its not a exec.ExitError
 func ExitCode(runErr error) (e int, err error) {
+	// TODO: with golang-1.12 this becomes a bit nicer:
+	//       https://github.com/golang/go/issues/26539
 	// golang, you are kidding me, right?
 	if exitErr, ok := runErr.(*exec.ExitError); ok {
 		waitStatus := exitErr.Sys().(syscall.WaitStatus)

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -155,3 +155,15 @@ func MockUname(f func(*syscall.Utsname) error) (restore func()) {
 		syscallUname = old
 	}
 }
+
+func MockFindUid(mock func(name string) (uint64, error)) (restore func()) {
+	old := FindUid
+	FindUid = mock
+	return func() { FindUid = old }
+}
+
+func MockFindGid(mock func(name string) (uint64, error)) (restore func()) {
+	old := FindGid
+	FindGid = mock
+	return func() { FindGid = old }
+}

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -156,14 +156,10 @@ func MockUname(f func(*syscall.Utsname) error) (restore func()) {
 	}
 }
 
-func MockFindUid(mock func(name string) (uint64, error)) (restore func()) {
-	old := FindUid
-	FindUid = mock
-	return func() { FindUid = old }
-}
+var (
+	FindUidNoGetentFallback = findUidNoGetentFallback
+	FindGidNoGetentFallback = findGidNoGetentFallback
 
-func MockFindGid(mock func(name string) (uint64, error)) (restore func()) {
-	old := FindGid
-	FindGid = mock
-	return func() { FindGid = old }
-}
+	FindUidWithGetentFallback = findUidWithGetentFallback
+	FindGidWithGetentFallback = findGidWithGetentFallback
+)

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -163,3 +163,15 @@ var (
 	FindUidWithGetentFallback = findUidWithGetentFallback
 	FindGidWithGetentFallback = findGidWithGetentFallback
 )
+
+func MockFindUidNoFallback(mock func(name string) (uint64, error)) (restore func()) {
+	old := findUidNoGetentFallback
+	findUidNoGetentFallback = mock
+	return func() { findUidNoGetentFallback = old }
+}
+
+func MockFindGidNoFallback(mock func(name string) (uint64, error)) (restore func()) {
+	old := findGidNoGetentFallback
+	findGidNoGetentFallback = mock
+	return func() { findGidNoGetentFallback = old }
+}

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -24,6 +24,11 @@ import (
 	"strconv"
 )
 
+var (
+	FindUid = findUid
+	FindGid = findGid
+)
+
 // TODO: the builtin os/user functions only look at /etc/passwd and /etc/group
 // which is fine for our purposes today. In the future we may want to support
 // lookups in extrausers, which is configured via nsswitch.conf. Since snapd
@@ -33,8 +38,8 @@ import (
 //   getent passwd <user> | cut -d : -f 3
 //   getent group <group> | cut -d : -f 3
 
-// FindUid returns the identifier of the given UNIX user name.
-func FindUid(username string) (uint64, error) {
+// findUid returns the identifier of the given UNIX user name.
+func findUid(username string) (uint64, error) {
 	user, err := user.Lookup(username)
 	if err != nil {
 		return 0, err
@@ -43,8 +48,8 @@ func FindUid(username string) (uint64, error) {
 	return strconv.ParseUint(user.Uid, 10, 64)
 }
 
-// FindGid returns the identifier of the given UNIX group name.
-func FindGid(groupname string) (uint64, error) {
+// findGid returns the identifier of the given UNIX group name.
+func findGid(groupname string) (uint64, error) {
 	group, err := user.LookupGroup(groupname)
 	if err != nil {
 		return 0, err

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -55,8 +55,8 @@ func getent(name string, database string) (uint64, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// according to getent(1) the exit value of "2" means:
-		//    One or more supplied key could not be found in
-		//    the database.
+		// "One or more supplied key could not be found in the
+		// database."
 		exitCode, _ := ExitCode(err)
 		if exitCode == 2 {
 			if database == "passwd" {

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -91,7 +91,7 @@ func getent(name string, database string) (uint64, error) {
 
 	// passwd has 7 entries and group 4. In both cases, parts[2] is the id
 	parts := bytes.Split(output, []byte(":"))
-	if len(parts) < 3 {
+	if len(parts) < 4 {
 		return 0, fmt.Errorf("malformed entry: %q", output)
 	}
 

--- a/osutil/group_cgo.go
+++ b/osutil/group_cgo.go
@@ -1,0 +1,29 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build cgo
+
+/*
+ * Copyright (C) 2017-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+// The builtin os/user functions use the libc functions when compiled
+// with cgo so we use use them here.
+
+var (
+	findUid = findUidNoGetentFallback
+	findGid = findGidNoGetentFallback
+)

--- a/osutil/group_no_cgo.go
+++ b/osutil/group_no_cgo.go
@@ -6,10 +6,14 @@ package osutil
 // The builtin os/user functions only look at /etc/passwd and
 // /etc/group when building without cgo.
 //
-// So nothing configured via nsswitch.conf, like extrausers. findUid()
-// and findGid() is searched. To fix this behavior we use
-// find{Uid,Gid}WithGetentFallback() that perform a 'getent
-// <database> <name>' automatically if no local user is found.
+// So if something extra is configured via nsswitch.conf, like
+// extrausers those are not searched with the standard user.Lookup()
+// which is used in find{Uid,Gid}NoGetenvFallback.
+//
+// To fix this behavior we use find{Uid,Gid}WithGetentFallback() that
+// perform a 'getent <database> <name>' automatically if no local user
+// is found and getent will use the libc nss functions to search all
+// configured data sources.
 
 var (
 	findUid = findUidWithGetentFallback

--- a/osutil/group_no_cgo.go
+++ b/osutil/group_no_cgo.go
@@ -1,0 +1,17 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !cgo
+
+package osutil
+
+// The builtin os/user functions only look at /etc/passwd and
+// /etc/group when building without cgo.
+//
+// So nothing configured via nsswitch.conf, like extrausers. findUid()
+// and findGid() is searched. To fix this behavior we use
+// find{Uid,Gid}WithGetentFallback() that perform a 'getent
+// <database> <name>' automatically if no local user is found.
+
+var (
+	findUid = findUidWithGetentFallback
+	findGid = findGidWithGetentFallback
+)

--- a/osutil/group_test.go
+++ b/osutil/group_test.go
@@ -80,6 +80,18 @@ func (s *findUserGroupSuite) TestFindUidGetentNonexistent(c *check.C) {
 	})
 }
 
+func (s *findUserGroupSuite) TestFindUidGetentMockedOtherError(c *check.C) {
+	s.mockGetent = testutil.MockCommand(c, "getent", "exit 3")
+
+	uid, err := osutil.FindUidGetent("lakatos")
+	c.Assert(err, check.ErrorMatches, "cannot run getent: exit status 3")
+	c.Check(uid, check.Equals, uint64(0))
+	// getent should've have been called
+	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string{
+		{"getent", "passwd", "lakatos"},
+	})
+}
+
 func (s *findUserGroupSuite) TestFindUidGetentMocked(c *check.C) {
 	s.mockGetent = testutil.MockCommand(c, "getent", "echo lakatos:x:1234:5678:::")
 
@@ -121,6 +133,18 @@ func (s *findUserGroupSuite) TestFindGidGetentNonexistent(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "group: unknown group lakatos")
 	_, ok := err.(user.UnknownGroupError)
 	c.Assert(ok, check.Equals, true)
+	// getent should've have been called
+	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string{
+		{"getent", "group", "lakatos"},
+	})
+}
+
+func (s *findUserGroupSuite) TestFindGidGetentMockedOtherError(c *check.C) {
+	s.mockGetent = testutil.MockCommand(c, "getent", "exit 3")
+
+	gid, err := osutil.FindGidGetent("lakatos")
+	c.Assert(err, check.ErrorMatches, "cannot run getent: exit status 3")
+	c.Check(gid, check.Equals, uint64(0))
 	// getent should've have been called
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string{
 		{"getent", "group", "lakatos"},

--- a/osutil/group_test.go
+++ b/osutil/group_test.go
@@ -108,7 +108,7 @@ func (s *findUserGroupSuite) TestFindUidGetentMockedOtherError(c *check.C) {
 	s.mockGetent = testutil.MockCommand(c, "getent", "exit 3")
 
 	uid, err := osutil.FindUidWithGetentFallback("lakatos")
-	c.Assert(err, check.ErrorMatches, "cannot run getent: exit status 3")
+	c.Assert(err, check.ErrorMatches, "getent failed with: exit status 3")
 	c.Check(uid, check.Equals, uint64(0))
 	// getent should've have been called
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string{
@@ -195,7 +195,7 @@ func (s *findUserGroupSuite) TestFindGidGetentMockedOtherError(c *check.C) {
 	s.mockGetent = testutil.MockCommand(c, "getent", "exit 3")
 
 	gid, err := osutil.FindGidWithGetentFallback("lakatos")
-	c.Assert(err, check.ErrorMatches, "cannot run getent: exit status 3")
+	c.Assert(err, check.ErrorMatches, "getent failed with: exit status 3")
 	c.Check(gid, check.Equals, uint64(0))
 	// getent should've have been called
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string{

--- a/osutil/group_test.go
+++ b/osutil/group_test.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"os/user"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type findUserGroupSuite struct {
+	testutil.BaseTest
+}
+
+var _ = check.Suite(&findUserGroupSuite{})
+
+func (s *findUserGroupSuite) TestFindUid(c *check.C) {
+	uid, err := osutil.FindUid("root")
+	c.Assert(err, check.IsNil)
+	c.Assert(uid, check.Equals, uint64(0))
+}
+
+func (s *findUserGroupSuite) TestFindUidNonexistent(c *check.C) {
+	_, err := osutil.FindUid("lakatos")
+	c.Assert(err, check.ErrorMatches, "user: unknown user lakatos")
+	_, ok := err.(user.UnknownUserError)
+	c.Assert(ok, check.Equals, true)
+}
+
+func (s *findUserGroupSuite) TestFindGid(c *check.C) {
+	gid, err := osutil.FindGid("root")
+	c.Assert(err, check.IsNil)
+	c.Assert(gid, check.Equals, uint64(0))
+}
+
+func (s *findUserGroupSuite) TestFindGidNonexistent(c *check.C) {
+	_, err := osutil.FindGid("lakatos")
+	c.Assert(err, check.ErrorMatches, "group: unknown group lakatos")
+	_, ok := err.(user.UnknownGroupError)
+	c.Assert(ok, check.Equals, true)
+}

--- a/osutil/group_test.go
+++ b/osutil/group_test.go
@@ -111,9 +111,9 @@ func (s *findUserGroupSuite) TestFindUidGetentMockedMalformated(c *check.C) {
 }
 
 func (s *findUserGroupSuite) TestFindGidNoGetentFallback(c *check.C) {
-	uid, err := osutil.FindGidNoGetentFallback("root")
+	gid, err := osutil.FindGidNoGetentFallback("root")
 	c.Assert(err, check.IsNil)
-	c.Assert(uid, check.Equals, uint64(0))
+	c.Assert(gid, check.Equals, uint64(0))
 	// getent shouldn't have been called with FindGidNoGetentFallback()
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string(nil))
 }
@@ -126,9 +126,9 @@ func (s *findUserGroupSuite) TestFindGidNonexistent(c *check.C) {
 }
 
 func (s *findUserGroupSuite) TestFindGidWithGetentFallback(c *check.C) {
-	uid, err := osutil.FindGidWithGetentFallback("root")
+	gid, err := osutil.FindGidWithGetentFallback("root")
 	c.Assert(err, check.IsNil)
-	c.Assert(uid, check.Equals, uint64(0))
+	c.Assert(gid, check.Equals, uint64(0))
 	// getent shouldn't have been called since 'root' is in /etc/passwd
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string(nil))
 }
@@ -159,9 +159,9 @@ func (s *findUserGroupSuite) TestFindGidGetentMockedOtherError(c *check.C) {
 func (s *findUserGroupSuite) TestFindGidGetentMocked(c *check.C) {
 	s.mockGetent = testutil.MockCommand(c, "getent", "echo lakatos:x:1234:")
 
-	uid, err := osutil.FindGidWithGetentFallback("lakatos")
+	gid, err := osutil.FindGidWithGetentFallback("lakatos")
 	c.Assert(err, check.IsNil)
-	c.Check(uid, check.Equals, uint64(1234))
+	c.Check(gid, check.Equals, uint64(1234))
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string{
 		{"getent", "group", "lakatos"},
 	})

--- a/osutil/group_test.go
+++ b/osutil/group_test.go
@@ -176,7 +176,7 @@ func (s *findUserGroupSuite) TestFindGidWithGetentFallback(c *check.C) {
 	gid, err := osutil.FindGidWithGetentFallback("root")
 	c.Assert(err, check.IsNil)
 	c.Assert(gid, check.Equals, uint64(0))
-	// getent shouldn't have been called since 'root' is in /etc/passwd
+	// getent shouldn't have been called since 'root' is in /etc/group
 	c.Check(s.mockGetent.Calls(), check.DeepEquals, [][]string(nil))
 }
 

--- a/osutil/group_test.go
+++ b/osutil/group_test.go
@@ -103,6 +103,13 @@ func (s *findUserGroupSuite) TestFindUidGetentMocked(c *check.C) {
 	})
 }
 
+func (s *findUserGroupSuite) TestFindUidGetentMockedMalformated(c *check.C) {
+	s.mockGetent = testutil.MockCommand(c, "getent", "printf too:few:colons")
+
+	_, err := osutil.FindUidGetent("lakatos")
+	c.Assert(err, check.ErrorMatches, `malformed entry: "too:few:colons"`)
+}
+
 func (s *findUserGroupSuite) TestFindGid(c *check.C) {
 	uid, err := osutil.FindGid("root")
 	c.Assert(err, check.IsNil)

--- a/tests/main/user-libnss/findid.go
+++ b/tests/main/user-libnss/findid.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+func main() {
+	fnName := os.Args[1]
+	userOrGroupName := os.Args[2]
+
+	var fn func(string) (uint64, error)
+	switch fnName {
+	case "uid":
+		fn = osutil.FindUid
+	case "gid":
+		fn = osutil.FindGid
+	default:
+		log.Fatalf("unknown fnName: %q", fnName)
+	}
+	id, err := fn(userOrGroupName)
+	if err != nil {
+		log.Fatalf("fn failed: %q", err)
+	}
+	println(id)
+}

--- a/tests/main/user-libnss/findid.go
+++ b/tests/main/user-libnss/findid.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -24,5 +25,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("fn failed: %q", err)
 	}
-	println(id)
+	fmt.Println(id)
 }

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -1,10 +1,10 @@
 summary: Ensure our osutil.Find{Uid,Gid} code work with libnss
 
 description: |
-    The os/user code in go will behave different when compiled
-    with or without cgo. This is confused so we created a helper
-    osutil.Find{Uid,Gid} that automatically falls back to calling
-    getent(1) when build without cgo. This test ensures this is
+    The os/user code in go will behave differently when compiled with
+    or without cgo. This is confusing so we created the helpers
+    osutil.Find{Uid,Gid} that automatically fall back to calling
+    getent(1) when build without cgo. This test ensures these are
     working correctly.
 
 # only run on a well defined system where we know how to setup libnss
@@ -19,7 +19,7 @@ prepare: |
     sed -i 's/^group:.*compat/\0 extrausers/' /etc/nsswitch.conf
     sed -i 's/^passwd:.*compat/\0 extrausers/' /etc/nsswitch.conf
     sed -i 's/^shadow:.*compat/\0 extrausers/' /etc/nsswitch.conf
-    echo "Workaroudn silly bug that causes extrausers to crash when missing"
+    echo "Workaround silly bug that causes extrausers to crash when missing"
     for name in gshadow shadow; do
         touch /var/lib/extrausers/$name
         chmod 640 /var/lib/extrausers/$name

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -1,0 +1,42 @@
+summary: Ensure our osutil.Find{Uid,Gid} code work with libnss
+
+description: |
+    The os/user code in go will behave different when compiled
+    with or without cgo. This is confused so we created a helper
+    osutil.Find{Uid,Gid} that automatically falls back to calling
+    getent(1) when build without cgo. This test ensures this is
+    working correctly.
+
+# only run on a well defined system where we know how to setup libnss
+systems: [ubuntu-18.04-64]
+
+prepare: |
+    echo "Save nsswitch.conf"
+    cp /etc/nsswitch.conf /etc/nsswitch.conf.save
+    echo "Install extrausers"
+    apt install libnss-extrausers
+    echo "Enable libnss-extrusers"
+    sed -i 's/^group:.*compat/\0 extrausers/' /etc/nsswitch.conf
+    sed -i 's/^passwd:.*compat/\0 extrausers/' /etc/nsswitch.conf
+    sed -i 's/^shadow:.*compat/\0 extrausers/' /etc/nsswitch.conf
+    pam-auth-update --enable snappy-extrausers
+    echo "Add user"
+    adduser --extrausers --disabled-password --gecos '' --uid 9876 extratest
+
+restore: |
+    mv /etc/nsswitch.conf.save /etc/nsswitch.conf
+    apt autoremove -y libnss-extrausers
+
+execute: |
+    echo "Ensure tests run with both CGO and without"
+    su test -c 'CGO_ENABLED=1 go test github.com/snapcore/snapd/osutil'
+    su test -c 'CGO_ENABLED=0 go test github.com/snapcore/snapd/osutil'
+
+    go build -o findid ./findid.go
+    test "$(./findid uid extratest)" = "9876"
+    test "$(./findid gid extratest)" = "9876"
+
+    CGO_ENABLED=0 go build -o findid ./findid.go
+    test "$(./findid uid extratest)" = "9876"
+    test "$(./findid gid extratest)" = "9876"
+    

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -19,9 +19,14 @@ prepare: |
     sed -i 's/^group:.*compat/\0 extrausers/' /etc/nsswitch.conf
     sed -i 's/^passwd:.*compat/\0 extrausers/' /etc/nsswitch.conf
     sed -i 's/^shadow:.*compat/\0 extrausers/' /etc/nsswitch.conf
-    pam-auth-update --enable snappy-extrausers
+    echo "Workaroudn silly bug that causes extrausers to crash when missing"
+    for name in gshadow shadow; do
+        touch /var/lib/extrausers/$name
+        chmod 640 /var/lib/extrausers/$name
+        chown root:shadow /var/lib/extrausers/$name
+    done
     echo "Add user"
-    adduser --extrausers --disabled-password --gecos '' --uid 9876 extratest
+    adduser --extrausers --disabled-login --no-create-home --gecos '' --uid 9876 --shell /bin/false extratest
 
 restore: |
     mv /etc/nsswitch.conf.save /etc/nsswitch.conf
@@ -32,11 +37,10 @@ execute: |
     su test -c 'CGO_ENABLED=1 go test github.com/snapcore/snapd/osutil'
     su test -c 'CGO_ENABLED=0 go test github.com/snapcore/snapd/osutil'
 
-    go build -o findid ./findid.go
+    CGO_ENABLED=1 go build -o findid ./findid.go
     test "$(./findid uid extratest)" = "9876"
     test "$(./findid gid extratest)" = "9876"
 
     CGO_ENABLED=0 go build -o findid ./findid.go
     test "$(./findid uid extratest)" = "9876"
     test "$(./findid gid extratest)" = "9876"
-    

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -31,6 +31,7 @@ prepare: |
 restore: |
     mv /etc/nsswitch.conf.save /etc/nsswitch.conf
     apt autoremove -y libnss-extrausers
+    rm -rf /var/lib/extrausers
 
 execute: |
     echo "Ensure tests run with both CGO and without"
@@ -42,7 +43,9 @@ execute: |
 
     # sanity check
     getent passwd extratest
+    getent group extratest
 
+    echo "Run binaries (CGO, without) exercising the helpers"
     test "$(./findid-cgo uid extratest)" = "9876"
     test "$(./findid-cgo gid extratest)" = "9876"
 

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -25,6 +25,23 @@ prepare: |
         chmod 640 /var/lib/extrausers/$name
         chown root:shadow /var/lib/extrausers/$name
     done
+        cat >/usr/share/pam-configs/snappy-extrausers <<EOF
+    Name: Extrausers authentication
+    Default: yes
+    Priority: 257
+    Auth-Type: Primary
+    Auth:
+      [success=end authinfo_unavail=ignore default=die] pam_extrausers.so nodelay nullok try_first_pass
+    Auth-Initial:
+      [success=end authinfo_unavail=ignore default=die] pam_extrausers.so nodelay nullok
+    Password-Type: Primary
+    Password:
+      [success=end default=ignore] pam_extrausers.so minlen=4 sha512 use_authtok try_first_pass
+    Password-Initial:
+      [success=end default=ignore] pam_extrausers.so minlen=4 sha512
+    EOF
+    pam-auth-update --enable snappy-extrausers
+
     echo "Add user"
     adduser --extrausers --disabled-login --no-create-home --gecos '' --uid 9876 --shell /bin/false extratest
 

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -25,23 +25,6 @@ prepare: |
         chmod 640 /var/lib/extrausers/$name
         chown root:shadow /var/lib/extrausers/$name
     done
-        cat >/usr/share/pam-configs/snappy-extrausers <<EOF
-    Name: Extrausers authentication
-    Default: yes
-    Priority: 257
-    Auth-Type: Primary
-    Auth:
-      [success=end authinfo_unavail=ignore default=die] pam_extrausers.so nodelay nullok try_first_pass
-    Auth-Initial:
-      [success=end authinfo_unavail=ignore default=die] pam_extrausers.so nodelay nullok
-    Password-Type: Primary
-    Password:
-      [success=end default=ignore] pam_extrausers.so minlen=4 sha512 use_authtok try_first_pass
-    Password-Initial:
-      [success=end default=ignore] pam_extrausers.so minlen=4 sha512
-    EOF
-    pam-auth-update --enable snappy-extrausers
-
     echo "Add user"
     adduser --extrausers --disabled-login --no-create-home --gecos '' --uid 9876 --shell /bin/false extratest
 
@@ -53,6 +36,14 @@ execute: |
     echo "Ensure tests run with both CGO and without"
     su test -c 'CGO_ENABLED=1 go test github.com/snapcore/snapd/osutil'
     su test -c 'CGO_ENABLED=0 go test github.com/snapcore/snapd/osutil'
+
+    # TODO: there seem to be some caching, find a nicer way
+    for _ in $(seq 60); do
+        if ./findid uid extratest; then
+            break
+        fi
+        sleep 1
+    done
 
     CGO_ENABLED=1 go build -o findid ./findid.go
     test "$(./findid uid extratest)" = "9876"

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -37,18 +37,14 @@ execute: |
     su test -c 'CGO_ENABLED=1 go test github.com/snapcore/snapd/osutil'
     su test -c 'CGO_ENABLED=0 go test github.com/snapcore/snapd/osutil'
 
-    # TODO: there seem to be some caching, find a nicer way
-    for _ in $(seq 60); do
-        if ./findid uid extratest; then
-            break
-        fi
-        sleep 1
-    done
+    CGO_ENABLED=1 go build -o findid-cgo ./findid.go
+    CGO_ENABLED=0 go build -o findid-no-cgo ./findid.go
 
-    CGO_ENABLED=1 go build -o findid ./findid.go
-    test "$(./findid uid extratest)" = "9876"
-    test "$(./findid gid extratest)" = "9876"
+    # sanity check
+    getent passwd extratest
 
-    CGO_ENABLED=0 go build -o findid ./findid.go
-    test "$(./findid uid extratest)" = "9876"
-    test "$(./findid gid extratest)" = "9876"
+    test "$(./findid-cgo uid extratest)" = "9876"
+    test "$(./findid-cgo gid extratest)" = "9876"
+
+    test "$(./findid-no-cgo uid extratest)" = "9876"
+    test "$(./findid-no-cgo gid extratest)" = "9876"


### PR DESCRIPTION
This is split out from https://github.com/snapcore/snapd/pull/7124 and implements osutil.Find{Uid,Gid} with automatic fallback to using "getent" when compiled without cgo. 

