### PR TITLE
many: simpler access to snap-seccomp version-info

### DIFF
--- a/cmd/snapd/main_test.go
+++ b/cmd/snapd/main_test.go
@@ -62,9 +62,7 @@ func (s *snapdSuite) TestSanityFailGoesIntoDegradedMode(c *C) {
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
-	restore = seccomp.MockSnapSeccompVersionInfo(func(s seccomp.Compiler) (string, error) {
-		return "abcdef 1.2.3 1234abcd -", nil
-	})
+	restore = seccomp.MockSnapSeccompVersionInfo("abcdef 1.2.3 1234abcd -")
 	defer restore()
 
 	sanityErr := fmt.Errorf("foo failed")

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -421,11 +421,10 @@ func requiresSocketcallImpl(baseSnap string) bool {
 }
 
 // MockSnapSeccompVersionInfo is for use in tests only.
-func MockSnapSeccompVersionInfo(s func(c Compiler) (string, error)) (restore func()) {
+func MockSnapSeccompVersionInfo(versionInfo string) (restore func()) {
 	old := snapSeccompVersionInfo
 	snapSeccompVersionInfo = func(c Compiler) (seccomp_compiler.VersionInfo, error) {
-		vi, err := s(c)
-		return seccomp_compiler.VersionInfo(vi), err
+		return seccomp_compiler.VersionInfo(versionInfo), nil
 	}
 	return func() {
 		snapSeccompVersionInfo = old

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -63,19 +63,19 @@ var (
 	seccompCompilerLookup  = cmd.InternalToolPath
 )
 
-func snapSeccompVersionInfoImpl(c Compiler) (string, error) {
+func snapSeccompVersionInfoImpl(c Compiler) (seccomp_compiler.VersionInfo, error) {
 	return c.VersionInfo()
 }
 
 type Compiler interface {
 	Compile(in, out string) error
-	VersionInfo() (string, error)
+	VersionInfo() (seccomp_compiler.VersionInfo, error)
 }
 
 // Backend is responsible for maintaining seccomp profiles for snap-confine.
 type Backend struct {
 	snapSeccomp Compiler
-	versionInfo string
+	versionInfo seccomp_compiler.VersionInfo
 }
 
 var globalProfileLE = []byte{
@@ -289,7 +289,7 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 	return content, nil
 }
 
-func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, addSocketcall bool, versionInfo string, uidGidChownSyscalls string) []byte {
+func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, addSocketcall bool, versionInfo seccomp_compiler.VersionInfo, uidGidChownSyscalls string) []byte {
 	var buffer bytes.Buffer
 
 	if versionInfo != "" {
@@ -344,7 +344,7 @@ func (b *Backend) SandboxFeatures() []string {
 	}
 	tags = append(tags, "bpf-argument-filtering")
 
-	if res, err := seccomp_compiler.VersionInfo(b.versionInfo).HasFeature("bpf-actlog"); err == nil && res {
+	if res, err := b.versionInfo.HasFeature("bpf-actlog"); err == nil && res {
 		tags = append(tags, "bpf-actlog")
 	}
 
@@ -423,7 +423,10 @@ func requiresSocketcallImpl(baseSnap string) bool {
 // MockSnapSeccompVersionInfo is for use in tests only.
 func MockSnapSeccompVersionInfo(s func(c Compiler) (string, error)) (restore func()) {
 	old := snapSeccompVersionInfo
-	snapSeccompVersionInfo = s
+	snapSeccompVersionInfo = func(c Compiler) (seccomp_compiler.VersionInfo, error) {
+		vi, err := s(c)
+		return seccomp_compiler.VersionInfo(vi), err
+	}
 	return func() {
 		snapSeccompVersionInfo = old
 	}

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -725,7 +726,7 @@ fi`)
 
 	sb, ok := s.Backend.(*seccomp.Backend)
 	c.Assert(ok, Equals, true)
-	c.Check(sb.VersionInfo(), Equals, "2345cdef 2.3.4 2345cdef -")
+	c.Check(sb.VersionInfo(), Equals, seccomp_compiler.VersionInfo("2345cdef 2.3.4 2345cdef -"))
 }
 
 func (s *backendSuite) TestCompilerInitUnhappy(c *C) {

--- a/interfaces/seccomp/export_test.go
+++ b/interfaces/seccomp/export_test.go
@@ -19,6 +19,10 @@
 
 package seccomp
 
+import (
+	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
+)
+
 // MockTemplate replaces seccomp template.
 //
 // NOTE: The real seccomp template is long. For testing it is convenient for
@@ -82,7 +86,7 @@ func MockSeccompCompilerLookup(f func(string) (string, error)) (restore func()) 
 	}
 }
 
-func (b *Backend) VersionInfo() string {
+func (b *Backend) VersionInfo() seccomp_compiler.VersionInfo {
 	return b.versionInfo
 }
 

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -42,7 +42,7 @@ type systemKeySuite struct {
 	tmp                    string
 	apparmorFeatures       string
 	buildID                string
-	seccompCompilerVersion string
+	seccompCompilerVersion seccomp_compiler.VersionInfo
 }
 
 var _ = Suite(&systemKeySuite{})
@@ -62,7 +62,7 @@ func (s *systemKeySuite) SetUpTest(c *C) {
 	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
 	s.buildID = "this-is-my-build-id"
 
-	s.seccompCompilerVersion = "123 2.3.3 abcdef123 -"
+	s.seccompCompilerVersion = seccomp_compiler.VersionInfo("123 2.3.3 abcdef123 -")
 	testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), fmt.Sprintf(`
 if [ "$1" = "version-info" ]; then echo "%s"; exit 0; fi
 exit 1

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -212,9 +213,7 @@ func (s *interfaceManagerSuite) SetUpTest(c *C) {
 	s.log = buf
 
 	s.BaseTest.AddCleanup(ifacestate.MockConnectRetryTimeout(0))
-	restore = interfaces.MockSeccompCompilerVersionInfo(func(_ string) (string, error) {
-		return "abcdef 1.2.3 1234abcd -", nil
-	})
+	restore = seccomp_compiler.MockCompilerVersionInfo("abcdef 1.2.3 1234abcd -")
 	s.BaseTest.AddCleanup(restore)
 }
 

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -1052,9 +1052,7 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernames(c *C) {
 	defer restore()
 
 	for _, test := range systemUsernamesTests {
-		restore = interfaces.MockSeccompCompilerVersionInfo(func(_ string) (string, error) {
-			return test.scVer, nil
-		})
+		restore = seccomp_compiler.MockCompilerVersionInfo(test.scVer)
 		defer restore()
 
 		release.OnClassic = test.classic

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -86,10 +86,10 @@ func (s *compilerSuite) TestVersionInfoValidate(c *C) {
 		v, err := compiler.VersionInfo()
 		if tc.err != "" {
 			c.Check(err, ErrorMatches, tc.err)
-			c.Check(v, Equals, "")
+			c.Check(v, Equals, seccomp.VersionInfo(""))
 		} else {
 			c.Check(err, IsNil)
-			c.Check(v, Equals, tc.exp)
+			c.Check(v, Equals, seccomp.VersionInfo(tc.exp))
 			_, err := seccomp.VersionInfo(v).LibseccompVersion()
 			c.Check(err, IsNil)
 			_, err = seccomp.VersionInfo(v).Features()
@@ -101,6 +101,25 @@ func (s *compilerSuite) TestVersionInfoValidate(c *C) {
 		cmd.Restore()
 	}
 
+}
+
+func (s *compilerSuite) TestCompilerVersionInfo(c *C) {
+	const vi = "7ac348ac9c934269214b00d1692dfa50d5d4a157 2.3.3 03e996919907bc7163bc83b95bca0ecab31300f20dfa365ea14047c698340e7c bpf-actlog"
+	cmd := testutil.MockCommand(c, "snap-seccomp", fmt.Sprintf(`echo "%s"`, vi))
+
+	vi1, err := seccomp.CompilerVersionInfo(fromCmd(c, cmd))
+	c.Check(err, IsNil)
+	c.Check(vi1, Equals, seccomp.VersionInfo(vi))
+}
+
+func (s *compilerSuite) TestEmptyVersionInfo(c *C) {
+	vi := seccomp.VersionInfo("")
+
+	_, err := vi.LibseccompVersion()
+	c.Check(err, ErrorMatches, "empty version-info")
+
+	_, err = vi.Features()
+	c.Check(err, ErrorMatches, "empty version-info")
 }
 
 func (s *compilerSuite) TestVersionInfoUnhappy(c *C) {


### PR DESCRIPTION
have seccomp.Compiler.VersionInfo return a VersionInfo, instead of string

centralize the simple case of querying for snap-seccomp version-info to seccomp.CompilerVersionInfo
