### PR TITLE
tests: add test for services disabled during refresh hook

### DIFF
--- a/tests/lib/snaps/test-snapd-svcs-disable-install-hook/meta/hooks/install
+++ b/tests/lib/snaps/test-snapd-svcs-disable-install-hook/meta/hooks/install
@@ -2,5 +2,5 @@
 
 for service in simple forking; do
     echo "Disabling $service service from install hook"
-    snapctl stop --disable "test-snapd-svcs-disable-install-hook.$service"
+    snapctl stop --disable "$SNAP_NAME.$service"
 done

--- a/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/bin/forking.sh
+++ b/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/bin/forking.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sleep 60 &

--- a/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/bin/simple.sh
+++ b/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/bin/simple.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sleep 60

--- a/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/meta/hooks/post-refresh
+++ b/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/meta/hooks/post-refresh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for service in simple forking; do
+    echo "Disabling $service service from install hook"
+    snapctl stop --disable "$SNAP_NAME.$service"
+done

--- a/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-svcs-disable-refresh-hook/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-svcs-disable-refresh-hook
+version: 1.0
+apps:
+    simple:
+        daemon: simple
+        command: bin/simple.sh
+    forking:
+        daemon: forking
+        command: bin/forking.sh

--- a/tests/main/svcs-disable-post-refresh-hook/task.yaml
+++ b/tests/main/svcs-disable-post-refresh-hook/task.yaml
@@ -1,0 +1,24 @@
+summary: |
+  Check that `snapctl stop --disable` actually stops services on post-refresh
+
+execute: |
+    # shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    echo "Installing snap first time starts services"
+    install_local test-snapd-svcs-disable-refresh-hook
+
+    echo "Services are running after install hook"
+    for service in simple forking; do
+        echo "Verify that the $service service isn't running"
+        snap services | MATCH "test-snapd-svcs-disable-refresh-hook\\.$service\\s+enabled\\s+active"
+    done
+
+    echo "Refreshing the snap triggers post-refresh hook which disables the services"
+    install_local test-snapd-svcs-disable-refresh-hook
+
+    echo "Services are now disabled"
+    for service in simple forking; do
+        echo "Verify that the $service service isn't running"
+        snap services | MATCH "test-snapd-svcs-disable-refresh-hook\\.$service\\s+disabled\\s+inactive"
+    done


### PR DESCRIPTION
Add a test which ensures that services disabled during the post-refresh hook stay disabled after the refresh is complete. This complements the install hook spread test, test-snapd-svcs-disable-install-hook.

Also make a minor improvement to the test-snapd-svcs-disable-install-hook install hook.