### PR TITLE
many: generalize assertstate.Batch to asserts.Batch, have assertstate.AddBatch

### DIFF
--- a/asserts/batch.go
+++ b/asserts/batch.go
@@ -1,0 +1,210 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Batch allows to accumulate a set of assertions possibly out of
+// prerequisite order and then add them in one go to an assertion
+// database.
+type Batch struct {
+	bs          Backstore
+	added       []Assertion
+	linearized  bool
+	unsupported func(u *Ref, err error) error
+}
+
+// NewBatch creates a new Batch to accumulate assertions to add in one
+// go to an assertion database.
+// unsupported can be used to ignore/log assertions with unsupported formats,
+// default behavior is to error on them.
+func NewBatch(unsupported func(u *Ref, err error) error) *Batch {
+	if unsupported == nil {
+		unsupported = func(_ *Ref, err error) error {
+			return err
+		}
+	}
+
+	return &Batch{
+		bs:          NewMemoryBackstore(),
+		linearized:  true, // empty list is trivially so
+		unsupported: unsupported,
+	}
+}
+
+// Add one assertion to the batch.
+func (b *Batch) Add(a Assertion) error {
+	b.linearized = false
+
+	if !a.SupportedFormat() {
+		err := &UnsupportedFormatError{Ref: a.Ref(), Format: a.Format()}
+		return b.unsupported(a.Ref(), err)
+	}
+	if err := b.bs.Put(a.Type(), a); err != nil {
+		if revErr, ok := err.(*RevisionError); ok {
+			if revErr.Current >= a.Revision() {
+				// we already got something more recent
+				return nil
+			}
+		}
+		return err
+	}
+	b.added = append(b.added, a)
+	return nil
+}
+
+// AddStream adds a stream of assertions to the batch.
+// Returns references to to the assertions effectively added.
+func (b *Batch) AddStream(r io.Reader) ([]*Ref, error) {
+	b.linearized = false
+
+	start := len(b.added)
+	dec := NewDecoder(r)
+	for {
+		a, err := dec.Decode()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := b.Add(a); err != nil {
+			return nil, err
+		}
+	}
+	added := b.added[start:]
+	if len(added) == 0 {
+		return nil, nil
+	}
+	refs := make([]*Ref, len(added))
+	for i, a := range added {
+		refs[i] = a.Ref()
+	}
+	return refs, nil
+}
+
+// Fetch adds to the batch via a driven by the fetching function
+// internal Fetcher built with trustedDB and retrieve.
+func (b *Batch) Fetch(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), fetching func(Fetcher) error) error {
+	f := NewFetcher(trustedDB, retrieve, b.Add)
+	return fetching(f)
+}
+
+// Precheck pre-checks whether adding the batch of assertions to the
+// given assertion database should fully succeed.
+func (b *Batch) Precheck(db *Database) error {
+	db = db.WithStackedBackstore(NewMemoryBackstore())
+	return b.commitTo(db)
+}
+
+// CommitTo adds the batch of assertions to the given assertion database.
+func (b *Batch) CommitTo(db *Database) error {
+	return b.commitTo(db)
+}
+
+// commitTo does a best effort of adding all the batch assertions to
+// the target database.
+func (b *Batch) commitTo(db *Database) error {
+	if err := b.linearize(db); err != nil {
+		return err
+	}
+
+	// TODO: trigger w. caller a global sanity check if something is revoked
+	// (but try to save as much possible still),
+	// or err is a check error
+
+	var errs []error
+	for _, a := range b.added {
+		err := db.Add(a)
+		if IsUnaccceptedUpdate(err) {
+			// unsupported format case is handled before
+			// be idempotent
+			// system db has already the same or newer
+			continue
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) != 0 {
+		return &commitError{errs: errs}
+	}
+	return nil
+}
+
+func (b *Batch) linearize(db *Database) error {
+	if b.linearized {
+		// nothing to do
+		return nil
+	}
+
+	// linearize using fetcher
+	linearized := make([]Assertion, 0, len(b.added))
+	retrieve := func(ref *Ref) (Assertion, error) {
+		a, err := b.bs.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
+		if IsNotFound(err) {
+			// fallback to pre-existing assertions
+			a, err = ref.Resolve(db.Find)
+		}
+		if err != nil {
+			return nil, resolveError("cannot resolve prerequisite assertion: %s", ref, err)
+		}
+		return a, nil
+	}
+	save := func(a Assertion) error {
+		linearized = append(linearized, a)
+		return nil
+	}
+	f := NewFetcher(db, retrieve, save)
+
+	for _, a := range b.added {
+		if err := f.Fetch(a.Ref()); err != nil {
+			return err
+		}
+	}
+
+	b.added = linearized
+	b.linearized = true
+	return nil
+}
+
+func resolveError(format string, ref *Ref, err error) error {
+	if IsNotFound(err) {
+		return fmt.Errorf(format, ref)
+	} else {
+		return fmt.Errorf(format+": %v", ref, err)
+	}
+}
+
+type commitError struct {
+	errs []error
+}
+
+func (e *commitError) Error() string {
+	l := []string{""}
+	for _, e := range e.errs {
+		l = append(l, e.Error())
+	}
+	return fmt.Sprintf("cannot accept some assertions:%s", strings.Join(l, "\n - "))
+}

--- a/asserts/batch.go
+++ b/asserts/batch.go
@@ -77,7 +77,7 @@ func (b *Batch) Add(a Assertion) error {
 }
 
 // AddStream adds a stream of assertions to the batch.
-// Returns references to to the assertions effectively added.
+// Returns references to the assertions effectively added.
 func (b *Batch) AddStream(r io.Reader) ([]*Ref, error) {
 	b.inPrereqOrder = false
 
@@ -106,8 +106,8 @@ func (b *Batch) AddStream(r io.Reader) ([]*Ref, error) {
 	return refs, nil
 }
 
-// Fetch adds to the batch via a driven by the fetching function
-// internal Fetcher built with trustedDB and retrieve.
+// Fetch adds to the batch by invoking fetching to drive an internal
+// Fetcher that was built with trustedDB and retrieve.
 func (b *Batch) Fetch(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), fetching func(Fetcher) error) error {
 	f := NewFetcher(trustedDB, retrieve, b.Add)
 	return fetching(f)

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -1,0 +1,463 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+)
+
+type batchSuite struct {
+	storeSigning *assertstest.StoreStack
+	dev1Acct     *asserts.Account
+
+	db *asserts.Database
+}
+
+var _ = Suite(&batchSuite{})
+
+func (s *batchSuite) SetUpTest(c *C) {
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
+
+	s.dev1Acct = assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
+	err := s.storeSigning.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+	s.db = db
+}
+
+func (s *batchSuite) snapDecl(c *C, name string, extraHeaders map[string]interface{}) *asserts.SnapDeclaration {
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      name + "-id",
+		"snap-name":    name,
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	for h, v := range extraHeaders {
+		headers[h] = v
+	}
+	decl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(decl)
+	c.Assert(err, IsNil)
+	return decl.(*asserts.SnapDeclaration)
+}
+
+func (s *batchSuite) TestAddStream(c *C) {
+	b := &bytes.Buffer{}
+	enc := asserts.NewEncoder(b)
+	// wrong order is ok
+	err := enc.Encode(s.dev1Acct)
+	c.Assert(err, IsNil)
+	enc.Encode(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+	refs, err := batch.AddStream(b)
+	c.Assert(err, IsNil)
+	c.Check(refs, DeepEquals, []*asserts.Ref{
+		{Type: asserts.AccountType, PrimaryKey: []string{s.dev1Acct.AccountID()}},
+		{Type: asserts.AccountKeyType, PrimaryKey: []string{s.storeSigning.StoreAccountKey("").PublicKeyID()}},
+	})
+
+	// noop
+	err = batch.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	err = batch.CommitTo(s.db)
+	c.Assert(err, IsNil)
+
+	devAcct, err := s.db.Find(asserts.AccountType, map[string]string{
+		"account-id": s.dev1Acct.AccountID(),
+	})
+	c.Assert(err, IsNil)
+	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
+}
+
+func (s *batchSuite) TestConsiderPreexisting(c *C) {
+	// prereq store key
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+	err = batch.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	err = batch.CommitTo(s.db)
+	c.Assert(err, IsNil)
+
+	devAcct, err := s.db.Find(asserts.AccountType, map[string]string{
+		"account-id": s.dev1Acct.AccountID(),
+	})
+	c.Assert(err, IsNil)
+	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
+}
+
+func (s *batchSuite) TestAddStreamReturnsEffectivelyAddedRefs(c *C) {
+	b := &bytes.Buffer{}
+	enc := asserts.NewEncoder(b)
+	// wrong order is ok
+	err := enc.Encode(s.dev1Acct)
+	c.Assert(err, IsNil)
+	enc.Encode(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+
+	err = batch.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	refs, err := batch.AddStream(b)
+	c.Assert(err, IsNil)
+	c.Check(refs, DeepEquals, []*asserts.Ref{
+		{Type: asserts.AccountType, PrimaryKey: []string{s.dev1Acct.AccountID()}},
+	})
+
+	err = batch.CommitTo(s.db)
+	c.Assert(err, IsNil)
+
+	devAcct, err := s.db.Find(asserts.AccountType, map[string]string{
+		"account-id": s.dev1Acct.AccountID(),
+	})
+	c.Assert(err, IsNil)
+	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
+}
+
+func (s *batchSuite) TestCommitRefusesSelfSignedKey(c *C) {
+	aKey, _ := assertstest.GenerateKey(752)
+	aSignDB := assertstest.NewSigningDB("can0nical", aKey)
+
+	aKeyEncoded, err := asserts.EncodePublicKey(aKey.PublicKey())
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"authority-id":        "can0nical",
+		"account-id":          "can0nical",
+		"public-key-sha3-384": aKey.PublicKey().ID(),
+		"name":                "default",
+		"since":               time.Now().UTC().Format(time.RFC3339),
+	}
+	acctKey, err := aSignDB.Sign(asserts.AccountKeyType, headers, aKeyEncoded, "")
+	c.Assert(err, IsNil)
+
+	headers = map[string]interface{}{
+		"authority-id": "can0nical",
+		"brand-id":     "can0nical",
+		"repair-id":    "2",
+		"summary":      "repair two",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}
+	repair, err := aSignDB.Sign(asserts.RepairType, headers, []byte("#script"), "")
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+
+	err = batch.Add(repair)
+	c.Assert(err, IsNil)
+
+	err = batch.Add(acctKey)
+	c.Assert(err, IsNil)
+
+	// this must fail
+	err = batch.CommitTo(s.db)
+	c.Assert(err, ErrorMatches, `circular assertions are not expected:.*`)
+}
+
+func (s *batchSuite) TestAddUnsupported(c *C) {
+	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 111)
+	defer restore()
+
+	batch := asserts.NewBatch(nil)
+
+	var a asserts.Assertion
+	(func() {
+		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
+		defer restore()
+		headers := map[string]interface{}{
+			"format":       "999",
+			"revision":     "1",
+			"series":       "16",
+			"snap-id":      "snap-id-1",
+			"snap-name":    "foo",
+			"publisher-id": s.dev1Acct.AccountID(),
+			"timestamp":    time.Now().Format(time.RFC3339),
+		}
+		var err error
+		a, err = s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+		c.Assert(err, IsNil)
+	})()
+
+	err := batch.Add(a)
+	c.Check(err, ErrorMatches, `proposed "snap-declaration" assertion has format 999 but 111 is latest supported`)
+}
+
+func (s *batchSuite) TestAddUnsupportedIgnore(c *C) {
+	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 111)
+	defer restore()
+
+	var uRef *asserts.Ref
+	unsupported := func(ref *asserts.Ref, _ error) error {
+		uRef = ref
+		return nil
+	}
+
+	batch := asserts.NewBatch(unsupported)
+
+	var a asserts.Assertion
+	(func() {
+		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
+		defer restore()
+		headers := map[string]interface{}{
+			"format":       "999",
+			"revision":     "1",
+			"series":       "16",
+			"snap-id":      "snap-id-1",
+			"snap-name":    "foo",
+			"publisher-id": s.dev1Acct.AccountID(),
+			"timestamp":    time.Now().Format(time.RFC3339),
+		}
+		var err error
+		a, err = s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+		c.Assert(err, IsNil)
+	})()
+
+	err := batch.Add(a)
+	c.Check(err, IsNil)
+	c.Check(uRef, DeepEquals, &asserts.Ref{
+		Type:       asserts.SnapDeclarationType,
+		PrimaryKey: []string{"16", "snap-id-1"},
+	})
+}
+
+func (s *batchSuite) TestCommitPartial(c *C) {
+	// Commit does add any successful assertion until the first error
+
+	// store key already present
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+
+	err = batch.Add(snapDeclFoo)
+	c.Assert(err, IsNil)
+	err = batch.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	// too old
+	rev := 1
+	headers := map[string]interface{}{
+		"snap-id":       "foo-id",
+		"snap-sha3-384": makeDigest(rev),
+		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
+		"snap-revision": fmt.Sprintf("%d", rev),
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Time{}.Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	err = batch.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	err = batch.CommitTo(s.db)
+	c.Check(err, ErrorMatches, `(?ms).*validity.*`)
+
+	// snap-declaration was added anyway
+	_, err = s.db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *batchSuite) TestCommitMissing(c *C) {
+	// store key already present
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+
+	err = batch.Add(snapDeclFoo)
+	c.Assert(err, IsNil)
+
+	err = batch.CommitTo(s.db)
+	c.Check(err, ErrorMatches, `cannot resolve prerequisite assertion: account.*`)
+}
+
+func (s *batchSuite) TestPrecheckPartial(c *C) {
+	// store key already present
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+
+	err = batch.Add(snapDeclFoo)
+	c.Assert(err, IsNil)
+	err = batch.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	// too old
+	rev := 1
+	headers := map[string]interface{}{
+		"snap-id":       "foo-id",
+		"snap-sha3-384": makeDigest(rev),
+		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
+		"snap-revision": fmt.Sprintf("%d", rev),
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Time{}.Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	err = batch.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	err = batch.Precheck(s.db)
+	c.Check(err, ErrorMatches, `(?ms).*validity.*`)
+
+	// nothing was added
+	_, err = s.db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(asserts.IsNotFound(err), Equals, true)
+}
+
+func (s *batchSuite) TestPrecheckHappy(c *C) {
+	// store key already present
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+
+	err = batch.Add(snapDeclFoo)
+	c.Assert(err, IsNil)
+	err = batch.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	rev := 1
+	revDigest := makeDigest(rev)
+	headers := map[string]interface{}{
+		"snap-id":       "foo-id",
+		"snap-sha3-384": revDigest,
+		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
+		"snap-revision": fmt.Sprintf("%d", rev),
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	err = batch.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	err = batch.Precheck(s.db)
+	c.Assert(err, IsNil)
+
+	// nothing was added yet
+	_, err = s.db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(asserts.IsNotFound(err), Equals, true)
+
+	// commit
+	err = batch.CommitTo(s.db)
+	c.Assert(err, IsNil)
+
+	_, err = s.db.Find(asserts.SnapRevisionType, map[string]string{
+		"snap-sha3-384": revDigest,
+	})
+	c.Check(err, IsNil)
+}
+
+func (s *batchSuite) TestFetch(c *C) {
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	s.snapDecl(c, "foo", nil)
+
+	rev := 10
+	revDigest := makeDigest(rev)
+	headers := map[string]interface{}{
+		"snap-id":       "foo-id",
+		"snap-sha3-384": revDigest,
+		"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
+		"snap-revision": fmt.Sprintf("%d", rev),
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	err = s.storeSigning.Add(snapRev)
+	c.Assert(err, IsNil)
+	ref := snapRev.Ref()
+
+	batch := asserts.NewBatch(nil)
+
+	// retrieve from storeSigning
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		return ref.Resolve(s.storeSigning.Find)
+	}
+	// fetching the snap-revision
+	fetching := func(f asserts.Fetcher) error {
+		return f.Fetch(ref)
+	}
+
+	err = batch.Fetch(s.db, retrieve, fetching)
+	c.Assert(err, IsNil)
+
+	// nothing was added yet
+	_, err = s.db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(asserts.IsNotFound(err), Equals, true)
+
+	// commit
+	err = batch.CommitTo(s.db)
+	c.Assert(err, IsNil)
+
+	_, err = s.db.Find(asserts.SnapRevisionType, map[string]string{
+		"snap-sha3-384": revDigest,
+	})
+	c.Check(err, IsNil)
+}

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -103,6 +103,15 @@ func (s *batchSuite) TestAddStream(c *C) {
 	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
 }
 
+func (s *batchSuite) TestAddEmptyStream(c *C) {
+	b := &bytes.Buffer{}
+
+	batch := asserts.NewBatch(nil)
+	refs, err := batch.AddStream(b)
+	c.Assert(err, IsNil)
+	c.Check(refs, HasLen, 0)
+}
+
 func (s *batchSuite) TestConsiderPreexisting(c *C) {
 	// prereq store key
 	err := s.db.Add(s.storeSigning.StoreAccountKey(""))

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -50,7 +50,7 @@ func getAssertTypeNames(c *Command, r *http.Request, user *auth.UserState) Respo
 }
 
 func doAssert(c *Command, r *http.Request, user *auth.UserState) Response {
-	batch := assertstate.NewBatch()
+	batch := asserts.NewBatch(nil)
 	_, err := batch.AddStream(r.Body)
 	if err != nil {
 		return BadRequest("cannot decode request body into assertions: %v", err)
@@ -60,7 +60,9 @@ func doAssert(c *Command, r *http.Request, user *auth.UserState) Response {
 	state.Lock()
 	defer state.Unlock()
 
-	if err := batch.Commit(state); err != nil {
+	if err := assertstate.AddBatch(state, batch, &assertstate.AddBatchOptions{
+		Precheck: true,
+	}); err != nil {
 		return BadRequest("assert failed: %v", err)
 	}
 	// TODO: what more info do we want to return on success?

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -24,7 +24,6 @@ package assertstate
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
@@ -42,134 +41,24 @@ func Add(s *state.State, a asserts.Assertion) error {
 	return cachedDB(s).Add(a)
 }
 
-// Batch allows to accumulate a set of assertions possibly out of prerequisite order and then add them in one go to the system assertion database.
-type Batch struct {
-	bs         asserts.Backstore
-	refs       []*asserts.Ref
-	linearized []asserts.Assertion
+type AddBatchOptions struct {
+	// Precheck indicates whether to do a full consistency check
+	// before starting adding the batch.
+	Precheck bool
 }
 
-// NewBatch creates a new Batch to accumulate assertions to add in one go to the system assertion database.
-func NewBatch() *Batch {
-	return &Batch{
-		bs:         asserts.NewMemoryBackstore(),
-		refs:       nil,
-		linearized: nil,
+// AddBatch adds the given assertion batch to the system assertion database.
+func AddBatch(s *state.State, batch *asserts.Batch, opts *AddBatchOptions) error {
+	if opts == nil {
+		opts = &AddBatchOptions{}
 	}
-}
-
-func (b *Batch) committing() error {
-	if b.linearized != nil {
-		return fmt.Errorf("internal error: cannot add to Batch while committing")
-	}
-	return nil
-}
-
-// Add one assertion to the batch.
-func (b *Batch) Add(a asserts.Assertion) error {
-	if err := b.committing(); err != nil {
-		return err
-	}
-
-	if !a.SupportedFormat() {
-		return &asserts.UnsupportedFormatError{Ref: a.Ref(), Format: a.Format()}
-	}
-	if err := b.bs.Put(a.Type(), a); err != nil {
-		if revErr, ok := err.(*asserts.RevisionError); ok {
-			if revErr.Current >= a.Revision() {
-				// we already got something more recent
-				return nil
-			}
-		}
-		return err
-	}
-	b.refs = append(b.refs, a.Ref())
-	return nil
-}
-
-// AddStream adds a stream of assertions to the batch.
-// Returns references to to the assertions effectively added.
-func (b *Batch) AddStream(r io.Reader) ([]*asserts.Ref, error) {
-	if err := b.committing(); err != nil {
-		return nil, err
-	}
-
-	start := len(b.refs)
-	dec := asserts.NewDecoder(r)
-	for {
-		a, err := dec.Decode()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		if err := b.Add(a); err != nil {
-			return nil, err
-		}
-	}
-	added := b.refs[start:]
-	if len(added) == 0 {
-		return nil, nil
-	}
-	refs := make([]*asserts.Ref, len(added))
-	copy(refs, added)
-	return refs, nil
-}
-
-func (b *Batch) commitTo(db *asserts.Database) error {
-	if err := b.linearize(db); err != nil {
-		return err
-	}
-
-	// TODO: trigger w. caller a global sanity check if something is revoked
-	// (but try to save as much possible still),
-	// or err is a check error
-	return commitTo(db, b.linearized)
-}
-
-func (b *Batch) linearize(db *asserts.Database) error {
-	if b.linearized != nil {
-		return nil
-	}
-
-	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
-		a, err := b.bs.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
-		if asserts.IsNotFound(err) {
-			// fallback to pre-existing assertions
-			a, err = ref.Resolve(db.Find)
-		}
-		if err != nil {
-			return nil, findError("cannot find %s", ref, err)
-		}
-		return a, nil
-	}
-
-	// linearize using accumFetcher
-	f := newAccumFetcher(db, retrieve)
-	for _, ref := range b.refs {
-		if err := f.Fetch(ref); err != nil {
+	db := cachedDB(s)
+	if opts.Precheck {
+		if err := batch.Precheck(db); err != nil {
 			return err
 		}
 	}
-
-	b.linearized = f.fetched
-	return nil
-}
-
-// Commit adds the batch of assertions to the system assertion database.
-func (b *Batch) Commit(st *state.State) error {
-	db := cachedDB(st)
-
-	return b.commitTo(db)
-}
-
-// Precheck pre-checks whether adding the batch of assertions to the system assertion database should fully succeed.
-func (b *Batch) Precheck(st *state.State) error {
-	db := cachedDB(st)
-	db = db.WithStackedBackstore(asserts.NewMemoryBackstore())
-
-	return b.commitTo(db)
+	return batch.CommitTo(cachedDB(s))
 }
 
 func findError(format string, ref *asserts.Ref, err error) error {

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -77,7 +77,7 @@ func commitTo(db *asserts.Database, assertions []asserts.Assertion) error {
 		if asserts.IsUnaccceptedUpdate(err) {
 			if _, ok := err.(*asserts.UnsupportedFormatError); ok {
 				// we kept the old one, but log the issue
-				logger.Noticef("Cannot update assertion: %v", err)
+				logger.Noticef("Cannot update assertion %v: %v", a.Ref(), err)
 			}
 			// be idempotent
 			// system db has already the same or newer

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -20,9 +20,6 @@
 package assertstate
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -38,63 +35,24 @@ func userFromUserID(st *state.State, userID int) (*auth.UserState, error) {
 	return auth.User(st, userID)
 }
 
-type accumFetcher struct {
-	asserts.Fetcher
-	fetched []asserts.Assertion
-}
+func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetching func(asserts.Fetcher) error) error {
+	// TODO: once we have a bulk assertion retrieval endpoint this approach will change
 
-// newAccumFetcher creates an accumFetcher used to retrieve assertions and later commit them to the system database in one go.
-func newAccumFetcher(db *asserts.Database, retrieve func(*asserts.Ref) (asserts.Assertion, error)) *accumFetcher {
-	f := &accumFetcher{}
+	db := cachedDB(s)
 
-	save := func(a asserts.Assertion) error {
-		f.fetched = append(f.fetched, a)
+	// this is a fallback in case of bugs, we ask the store
+	// to filter unsupported formats!
+	unsupported := func(ref *asserts.Ref, unsupportedErr error) error {
+		if _, err := ref.Resolve(db.Find); err != nil {
+			// nothing there yet or any other error
+			return unsupportedErr
+		}
+		// we keep the old one, but log the issue
+		logger.Noticef("Cannot update assertion %v: %v", ref, unsupportedErr)
 		return nil
 	}
 
-	f.Fetcher = asserts.NewFetcher(db, retrieve, save)
-
-	return f
-}
-
-type commitError struct {
-	errs []error
-}
-
-func (e *commitError) Error() string {
-	l := []string{""}
-	for _, e := range e.errs {
-		l = append(l, e.Error())
-	}
-	return fmt.Sprintf("cannot add some assertions to the system database:%s", strings.Join(l, "\n - "))
-}
-
-// commitTo does a best effort of adding all the fetched assertions to the system database.
-func commitTo(db *asserts.Database, assertions []asserts.Assertion) error {
-	var errs []error
-	for _, a := range assertions {
-		err := db.Add(a)
-		if asserts.IsUnaccceptedUpdate(err) {
-			if _, ok := err.(*asserts.UnsupportedFormatError); ok {
-				// we kept the old one, but log the issue
-				logger.Noticef("Cannot update assertion %v: %v", a.Ref(), err)
-			}
-			// be idempotent
-			// system db has already the same or newer
-			continue
-		}
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if len(errs) != 0 {
-		return &commitError{errs: errs}
-	}
-	return nil
-}
-
-func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetching func(asserts.Fetcher) error) error {
-	// TODO: once we have a bulk assertion retrieval endpoint this approach will change
+	b := asserts.NewBatch(unsupported)
 
 	user, err := userFromUserID(s, userID)
 	if err != nil {
@@ -108,11 +66,8 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 		return sto.Assertion(ref.Type, ref.PrimaryKey, user)
 	}
 
-	db := cachedDB(s)
-	f := newAccumFetcher(db, retrieve)
-
 	s.Unlock()
-	err = fetching(f)
+	err = b.Fetch(db, retrieve, fetching)
 	s.Lock()
 	if err != nil {
 		return err
@@ -121,5 +76,5 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	// TODO: trigger w. caller a global sanity check if a is revoked
 	// (but try to save as much possible still),
 	// or err is a check error
-	return commitTo(db, f.fetched)
+	return b.CommitTo(db)
 }

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -283,7 +283,7 @@ func populateStateFromSeedImpl(st *state.State, tm timings.Measurer) ([]*state.T
 	return tsAll, nil
 }
 
-func readAsserts(fn string, batch *assertstate.Batch) ([]*asserts.Ref, error) {
+func readAsserts(fn string, batch *asserts.Batch) ([]*asserts.Ref, error) {
 	f, err := os.Open(fn)
 	if err != nil {
 		return nil, err
@@ -317,7 +317,7 @@ func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
 
 	// collect
 	var modelRef *asserts.Ref
-	batch := assertstate.NewBatch()
+	batch := asserts.NewBatch(nil)
 	for _, fi := range dc {
 		fn := filepath.Join(assertSeedDir, fi.Name())
 		refs, err := readAsserts(fn, batch)
@@ -338,7 +338,7 @@ func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
 		return nil, fmt.Errorf("need a model assertion")
 	}
 
-	if err := batch.Commit(st); err != nil {
+	if err := assertstate.AddBatch(st, batch, nil); err != nil {
 		return nil, err
 	}
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1214,7 +1214,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedMissingSig(c *C) {
 	// try import and verify that its rejects because other assertions are
 	// missing
 	_, err := devicestate.ImportAssertionsFromSeed(st)
-	c.Assert(err, ErrorMatches, "cannot find account-key .*")
+	c.Assert(err, ErrorMatches, "cannot resolve prerequisite assertion: account-key .*")
 }
 
 func (s *FirstBootTestSuite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {


### PR DESCRIPTION
This generalizes assertstate.Batch to asserts.Batch which grows a bit more functionality. To achieve the same result, assertstate.AddBatch subsuming assertstate.Batch.Precheck/Commit is introduced.

doFetch in assertstate is also switched to use asserts.Batch which can be built by fetching for convenience.

The fallback code for dealing with receiving unsupported format assertions, which should not happen except for bugs, is reorganized.

All now unused bits in assertstate are dropped.