### PR TITLE
tests: change cgroups so that LXD doesn't have to

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -465,6 +465,13 @@ prepare_project() {
     RateLimitBurst=0
 EOF
     systemctl restart systemd-journald.service
+
+    # Re-configure cgroups in a way that LXD would so that
+    # installation, use and removal of LXD does not leave any changes
+    # in the system.
+    if [ -f /sys/fs/cgroup/cpuset/cgroup.clone_children ]; then
+        echo 1 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+    fi
 }
 
 prepare_project_each() {

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -31,9 +31,6 @@ restore: |
     lxd.lxc stop my-ubuntu --force
     lxd.lxc delete my-ubuntu
 
-    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
-    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
-
 debug: |
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -18,9 +18,6 @@ restore: |
     setenforce "$(cat enforcing.mode)"
     rm -f stamp enforcing.mode
 
-    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
-    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
-
 execute: |
     snap install lxd
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -58,9 +58,6 @@ restore: |
 
     snap remove lxd
 
-    # LXD alters the configuration of the cpuset cgroup. Restore the original state.
-    echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
-
 execute: |
     # Run python0 with a hello.py script and redirect the logs to /var/lib/test/hello.log
     # Run the script as a regular user for extra (lower) permissions.


### PR DESCRIPTION
This patch sets the "clone_children" attribute on the cpuset cgroup
controller, early in the spread project-wide preparation code, in
anticipation of LXD needing this setting.

LXD alters cgroup configuration in a one-off way. Attempts to
reconfigure them back were only partially successful and also block on
a patch to spread that cannot be merged soon.

Instead of waiting, let's turn the problem around. If cgroups are
configured in a way that LXD expects up front then installing and using
LXD doesn't change anything. This allows us to keep using our mount leak
detector straight away.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
