### PR TITLE
cmd/snap: fix remote snap info for parallel installed snaps

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -695,7 +695,7 @@ func (x *infoCmd) Execute([]string) error {
 		if diskSnap, err := clientSnapFromPath(snapName); err == nil {
 			iw.setupDiskSnap(snapName, diskSnap)
 		} else {
-			remoteSnap, resInfo, _ := x.client.FindOne(snapName)
+			remoteSnap, resInfo, _ := x.client.FindOne(snap.InstanceSnap(snapName))
 			localSnap, _, _ := x.client.Snap(snapName)
 			iw.setupSnap(localSnap, remoteSnap, resInfo)
 		}


### PR DESCRIPTION
When running `snap info` for a parallel installed snap, the code would ask the
store for information using the actual instance name (`<snap>_<key>`) instead of
just the snap name. This lead for remote info, such as channels, not being
displayed in the output.

Use the snap name when looking up snaps in the store.
