### PR TITLE
tests: unmount fusectl after testing

### DIFF
--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -45,6 +45,9 @@ restore: |
     if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
         snap set system experimental.parallel-instances=null
     fi
+    if mountinfo-tool /sys/fs/fuse/connections .fs_type=fusectl; then
+        umount /sys/fs/fuse/connections
+    fi
 
 execute: |
     echo "The interface is disconnected by default"


### PR DESCRIPTION
The test that checks fuse-support interface leaks a fusectl mount point
in /sys/fs/fuse/connections, let's fix that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
