### PR TITLE
tests: restore nsdelegate clobbered by LXD

### DIFF
--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -15,6 +15,11 @@ prepare: |
     ausearch --checkpoint stamp -m AVC || true
 
 restore: |
+    # Restore nsdelegate mount option clobbered by LXD.
+    if mountinfo-tool /sys/fs/cgroup/unified; then
+        mount -o remount,nsdelegate /sys/fs/cgroup/unified
+    fi
+
     setenforce "$(cat enforcing.mode)"
     rm -f stamp enforcing.mode
 


### PR DESCRIPTION
The LXD SELinux test clobbers nsdelegate option (removes it) when
invoked on Fedora where the hybrid hierarchy is mounted. Before we can
reboot after the LXD test, work around this change by restoring the flag
manually.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
