### PR TITLE
 debian: re-enable systemd environment generator (2.41)

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -70,7 +70,7 @@ Depends: adduser,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
+Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), systemd (<< 237-3ubuntu10.25), ${snapd:Breaks}
 Recommends: gnupg
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -70,7 +70,7 @@ Depends: adduser,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), systemd (<< 237-3ubuntu10.25), ${snapd:Breaks}
+Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
 Recommends: gnupg
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -26,7 +26,7 @@ include /etc/os-release
 # problem on "apt purge snapd". To ensure this won't happen add the
 # right dependency on 18.04.
 ifeq (${VERSION_ID},"18.04")
-	SUBSTVARS = -Vsnapd:Breaks="apt (<< 1.6.3)"
+	SUBSTVARS = -Vsnapd:Breaks="systemd (<< 237-3ubuntu10.25), apt (<< 1.6.3)"
 endif
 # Same as above for 18.10 just a different version.
 ifeq (${VERSION_ID},"18.10")

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -26,7 +26,7 @@ include /etc/os-release
 # problem on "apt purge snapd". To ensure this won't happen add the
 # right dependency on 18.04.
 ifeq (${VERSION_ID},"18.04")
-	SUBSTVARS = -Vsnapd:Breaks="systemd (<< 237-3ubuntu10.25), apt (<< 1.6.3)"
+	SUBSTVARS = -Vsnapd:Breaks="systemd (<< 237-3ubuntu10.24), apt (<< 1.6.3)"
 endif
 # Same as above for 18.10 just a different version.
 ifeq (${VERSION_ID},"18.10")

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -246,12 +246,6 @@ override_dh_install:
 
 	$(MAKE) -C cmd install DESTDIR=$(CURDIR)/debian/tmp
 
-	# We have to disable the systemd generator on bionic because of
-	# the systemd bug LP: 1771858. Enabling it caused bug #1811233
-ifeq (${VERSION_ID},"18.04")
-	chmod -x ${CURDIR}/debian/tmp/usr/lib/systemd/system-environment-generators/snapd-env-generator
-endif
-
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
 

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -71,6 +71,9 @@ execute: |
     echo "Cleanup container"
     lxd.lxc exec my-ubuntu -- apt autoremove --purge -y snapd ubuntu-core-launcher
 
+    echo "Ensure apt is up-to-date"
+    lxd.lxc exec my-ubuntu -- apt update
+
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
     lxd.lxc file push "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"

--- a/tests/main/snap-system-env/task.yaml
+++ b/tests/main/snap-system-env/task.yaml
@@ -19,16 +19,8 @@ execute: |
     # ensure /usr/local/{,s}bin is still part of the PATH, LP: 1814355
     systemd-run --pty --wait '/usr/bin/env' | MATCH 'PATH=.*/local/.*'
     systemd-run --pty --wait '/usr/bin/env' > env.out
-    if [ "$VERSION_ID" = "18.04" ];then
-        # Only 18.10+ is fully working with the systemd generator, so for 18.04
-        # we account for /snap/bin not being in the PATH, until LP: #1771858 is
-        # fixed.
-        not MATCH 'PATH=.*/snap/bin' < env.out
-        exit 0
-    else
-        # ensure PATH is updated (and check full PATH, see LP: #1814355)
-        MATCH 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin' < env.out
-    fi
+    # ensure PATH is updated (and check full PATH, see LP: #1814355)
+    MATCH 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin' < env.out
 
     # some unit tests
     SENV=/usr/lib/systemd/system-environment-generators/snapd-env-generator


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/7031 for 2.41