### PR TITLE
cmd/snap: fix snap unset help string

### DIFF
--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -40,10 +40,10 @@ snap's configuration hook returns successfully.
 
 Nested values may be modified via a dotted path:
 
-    $ snap set author.name=frank
+    $ snap set snap-name author.name=frank
 
 Configuration option may be unset with exclamation mark:
-    $ snap set author!
+    $ snap set snap-name author!
 `)
 
 type cmdSet struct {

--- a/cmd/snap/cmd_unset.go
+++ b/cmd/snap/cmd_unset.go
@@ -36,7 +36,7 @@ snap's configuration hook returns successfully.
 
 Nested values may be removed via a dotted path:
 
-	$ snap unset user.name
+	$ snap unset snap-name user.name
 `)
 
 type cmdUnset struct {


### PR DESCRIPTION
Fix an omission in snap set & unset help - snap name argument was missing in some of the examples.