### PR TITLE
tests: unmount binfmt_misc on cleanup

### DIFF
--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -18,6 +18,10 @@ restore: |
     setenforce "$(cat enforcing.mode)"
     rm -f stamp enforcing.mode
 
+    if mountinfo-tool /proc/sys/fs/binfmt_misc .fs_type=binfmt_misc; then
+        umount /proc/sys/fs/binfmt_misc
+    fi
+
 execute: |
     snap install lxd
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'


### PR DESCRIPTION
The LXD test somehow causes the binfmt_misc auto-mount to be mounted.
While I didn't check what exactly causes that (any filesystem access is
sufficient to do that) it does happen so here's a bit of cleanup for
that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
