### PR TITLE
tests: clean user and group for test system-usernames-install-twice

### DIFF
--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -12,6 +12,11 @@ prepare: |
 restore: |
     snap remove test-snapd-daemon-user || true
 
+    # Clean user and group to be used on the following tests
+    userdel --force snap_daemon || true
+    groupdel snap_daemon || true
+    not getent group snap_daemon
+
 execute: |
     echo "When the snap is removed"
     snap remove test-snapd-daemon-user


### PR DESCRIPTION
This is to prevent the test system-usernames-missing-user fail trying to
create the snap_daemon group.

