### PR TITLE
tests: allow test user XDG_RUNTIME_DIR to phase out

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -568,6 +568,18 @@ restore_suite_each() {
         fi
         get_journalctl_log > "${logs_dir}/${logs_file}.journal.log"
     fi
+
+    # On Arch it seems that using sudo / su for working with the test user
+    # spawns the /run/user/12345 tmpfs for XDG_RUNTIME_DIR which asynchronously
+    # cleans up itself sometime after the test but not instantly, leading to
+    # random failures in the mount leak detector. Give it a moment but don't
+    # clean it up ourselves, this should report actual test errors, if any.
+    for i in $(seq 10); do
+        if not mountinfo-tool /run/user/12345 .fs_type=tmpfs; then
+            break
+        fi
+        sleep 1
+    done
 }
 
 restore_suite() {


### PR DESCRIPTION
On Arch it seems that using sudo / su for working with the test user
spawns the /run/user/12345 tmpfs for XDG_RUNTIME_DIR which asynchronously
cleans up itself sometime after the test but not instantly, leading to
random failures in the mount leak detector. Give it a moment but don't
clean it up ourselves, this should report actual test errors, if any.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
