### PR TITLE
interfaces: k8s worker node updates

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -72,8 +72,10 @@ const dockerSupportConnectedPlugAppArmor = `
 /{,var/}run/runc/**     mrwklix,
 
 # Allow sockets/etc for containerd
-/run/containerd/{,runc/,runc/k8s.io/,runc/k8s.io/*/} rw,
-/run/containerd/runc/k8s.io/*/** rwk,
+/{,var/}run/containerd/{,runc/,runc/k8s.io/,runc/k8s.io/*/} rw,
+/{,var/}run/containerd/runc/k8s.io/*/** rwk,
+/{,var/}run/containerd/{io.containerd*/,io.containerd*/k8s.io/,io.containerd*/k8s.io/*/} rw,
+/{,var/}run/containerd/io.containerd*/*/** rwk,
 
 # Limit ipam-state to k8s
 /run/ipam-state/k8s-** rw,

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -72,6 +72,7 @@ profile systemd_run (attach_disconnected,mediate_deleted) {
   owner @{PROC}/@{pid}/environ r,
   @{PROC}/cmdline r,
   @{PROC}/sys/kernel/osrelease r,
+  @{PROC}/1/sched r,
 
   # setsockopt()
   capability net_admin,


### PR DESCRIPTION
* interfaces/kubernetes-support: allow systemd-run read on @{PROC}/1/sched
* interfaces/docker-support: also allow /run/containerd/io.containerd*