### PR TITLE
tests: spam test logs less while waiting for systemd unit to stop

### DIFF
--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -67,7 +67,6 @@ systemd_stop_units() {
         if systemctl is-active "$unit"; then
             echo "Ensure the service is active before stopping it"
             retries=20
-            systemctl status "$unit" || true
             while systemctl status "$unit" | grep -q "Active: activating"; do
                 if [ $retries -eq 0 ]; then
                     echo "$unit unit not active"

--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -68,9 +68,10 @@ systemd_stop_units() {
             echo "Ensure the service is active before stopping it"
             retries=20
             systemctl status "$unit" || true
-            while systemctl status "$unit" | grep "Active: activating"; do
+            while systemctl status "$unit" | grep -q "Active: activating"; do
                 if [ $retries -eq 0 ]; then
                     echo "$unit unit not active"
+                    systemctl status "$unit" || true
                     exit 1
                 fi
                 retries=$(( retries - 1 ))


### PR DESCRIPTION
The systemd_stop_units function checks, up to 20 times, for the given
units to move out of "activating" phase before stopping them. At each
attempt it would print the full status of the unit, making logs longer.

This patch changes that so only the fainal failed status is printed.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
