### PR TITLE
cmd/snap-mgmt: set +x on startup

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt-selinux.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt-selinux.sh.in
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set +x
 
 SNAP_MOUNT_DIR="@SNAP_MOUNT_DIR@"
 

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -6,6 +6,7 @@
 # snapd.
 
 set -e
+set +x
 
 SNAP_MOUNT_DIR="@SNAP_MOUNT_DIR@"
 


### PR DESCRIPTION
In case snap-mgmt is called from a shell and inherit `set` settings, it
may inherit `set -x` printing lots of noise, especially from variable
assignments coming from systemd services.

This particular case happens when tests use the script to reset system
state for instance, on Amazon Linux or on Arch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
