### PR TITLE
interfaces/network-{control,manager}: allow 'k' on /run/resolvconf/**

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -161,7 +161,7 @@ capability setuid,
 
 # resolvconf
 /sbin/resolvconf ixr,
-/run/resolvconf/{,**} r,
+/run/resolvconf/{,**} rk,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
 /lib/resolvconf/* ix,

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -107,7 +107,7 @@ network packet,
 
 # Needed to use resolvconf from core
 /sbin/resolvconf ixr,
-/run/resolvconf/{,**} r,
+/run/resolvconf/{,**} rk,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
 /lib/resolvconf/* ix,


### PR DESCRIPTION
References:
https://bugs.launchpad.net/snapd/+bug/1840873/comments/2
