### PR TITLE
interfaces/wayland,x11: allow reading an Xwayland Xauth file. Fixes LP: #1840925.

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -56,6 +56,10 @@ owner /run/user/[0-9]*/wayland-[0-9]* rwk,
 # Allow access to common client Wayland sockets from non-snap clients
 /run/user/[0-9]*/{mesa,mutter,sdl,wayland-cursor,weston,xwayland}-shared-* rw,
 
+# Allow reading an Xwayland Xauth file
+# (see https://gitlab.gnome.org/GNOME/mutter/merge_requests/626)
+/run/user/[0-9]*/.mutter-Xwaylandauth.* r,
+
 # Allow write access to create /run/user/* to create XDG_RUNTIME_DIR (until
 # lp:1738197 is fixed). Note this is not needed if creating a session using
 # logind (as provided by the login-session-control snapd interface).

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -120,6 +120,10 @@ owner @{HOME}/.local/share/fonts/{,**} r,
 # startup.
 owner /run/user/[0-9]*/.Xauthority r,
 
+# Allow reading an Xwayland Xauth file
+# (see https://gitlab.gnome.org/GNOME/mutter/merge_requests/626)
+owner /run/user/[0-9]*/.mutter-Xwaylandauth.* r,
+
 # Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
 # raw' rule is not finely mediated by apparmor so we mediate with seccomp arg
 # filtering.


### PR DESCRIPTION
(see https://gitlab.gnome.org/GNOME/mutter/merge_requests/626)