### PR TITLE
check-pr-title.py: allow {} in pr prefix

### DIFF
--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -51,7 +51,7 @@ def check_pr_title(pr_number: int):
     # package, otherpackage/subpackage: this is a title
     # tests/regression/lp-12341234: foo
     # [RFC] foo: bar
-    if not re.match(r'[a-zA-Z0-9_\-/,. \[\]]+: .*', title):
+    if not re.match(r'[a-zA-Z0-9_\-/,. \[\]{}]+: .*', title):
         raise InvalidPRTitle(title)
 
 


### PR DESCRIPTION
This will fix PR#7301 which reads:
```
interfaces/network-{control,manager}: allow 'k' on /run/resolvconf/**
```
which is a perfectly fine name.
