### PR TITLE
overlord/configstate: sort patch keys to have deterministic order with snap set

### DIFF
--- a/overlord/configstate/export_test.go
+++ b/overlord/configstate/export_test.go
@@ -20,3 +20,4 @@
 package configstate
 
 var NewConfigureHandler = newConfigureHandler
+var SortPatchKeys = sortPatchKeys

--- a/overlord/configstate/helpers.go
+++ b/overlord/configstate/helpers.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configstate
+
+import (
+	"sort"
+	"strings"
+)
+
+func sortPatchKeys(patch map[string]interface{}) []string {
+	depths := make(map[string]int, len(patch))
+	var keys []string
+	for k := range patch {
+		parts := strings.Split(k, ".")
+		depths[k] = len(parts)
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return depths[keys[i]] < depths[keys[j]]
+	})
+	return keys
+}

--- a/overlord/configstate/helpers.go
+++ b/overlord/configstate/helpers.go
@@ -25,11 +25,13 @@ import (
 )
 
 func sortPatchKeys(patch map[string]interface{}) []string {
+	if len(patch) == 0 {
+		return nil
+	}
 	depths := make(map[string]int, len(patch))
-	var keys []string
+	keys := make([]string, 0, len(patch))
 	for k := range patch {
-		parts := strings.Split(k, ".")
-		depths[k] = len(parts)
+		depths[k] = strings.Count(k, ".")
 		keys = append(keys, k)
 	}
 

--- a/overlord/configstate/helpers_test.go
+++ b/overlord/configstate/helpers_test.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configstate_test
+
+import (
+	"github.com/snapcore/snapd/overlord/configstate"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *miscSuite) TestSortPatchKeysEmpty(c *C) {
+	patch := map[string]interface{}{}
+	keys := configstate.SortPatchKeys(patch)
+	c.Assert(keys, IsNil)
+}
+
+func (s *miscSuite) TestSortPatchKeys(c *C) {
+	patch := map[string]interface{}{
+		"a.b.c":         0,
+		"a":             0,
+		"a.b.c.d":       0,
+		"q.w.e.r.t.y.u": 0,
+		"f.g":           0,
+	}
+
+	keys := configstate.SortPatchKeys(patch)
+	c.Assert(keys, DeepEquals, []string{"a", "f.g", "a.b.c", "a.b.c.d", "q.w.e.r.t.y.u"})
+}

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -112,8 +112,9 @@ func (h *configureHandler) Before() error {
 		}
 	}
 
-	for key, value := range patch {
-		if err := tr.Set(instanceName, key, value); err != nil {
+	patchKeys := sortPatchKeys(patch)
+	for _, key := range patchKeys {
+		if err := tr.Set(instanceName, key, patch[key]); err != nil {
 			return err
 		}
 	}

--- a/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
+++ b/tests/lib/snaps/snapctl-hooks/meta/hooks/configure
@@ -131,6 +131,8 @@ case $command in
   "test-get-nested")
     test_get_nested
     ;;
+  "noop")
+	;;
   "test-unset")
     test_snapctl_unset
 	;;

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -76,6 +76,6 @@ execute: |
     for _ in $(seq 50); do
         snap set snapctl-hooks command=noop one!
         snap set snapctl-hooks one.two=2 one='{"three":3}'
-        snap get snapctl-hooks -l one.two | MATCH "one.two .* 2"
-        snap get snapctl-hooks -l one.three | MATCH "one.three .* 3"
+        snap get snapctl-hooks -l one.two | MATCH "one.two[ ]*2"
+        snap get snapctl-hooks -l one.three | MATCH "one.three[ ]*3"
     done

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -73,7 +73,9 @@ execute: |
     [[ "$obtained" == *"error from within configure hook"* ]]
 
     echo "Test that the 'snap set' order is deterministic"
-    snap set snapctl-hooks command=noop one.two.three=3 one='{"four":4}' one.two='{"five":5}'
-    snap get snapctl-hooks -l one.two | MATCH "one.two.five .* 5"
-    snap get snapctl-hooks -l one.two | MATCH "one.two.three .* 3"
-    snap get snapctl-hooks -l one.four | MATCH "one.four .* 4"
+    for _ in $(seq 50); do
+        snap set snapctl-hooks command=noop one!
+        snap set snapctl-hooks one.two=2 one='{"three":3}'
+        snap get snapctl-hooks -l one.two | MATCH "one.two .* 2"
+        snap get snapctl-hooks -l one.three | MATCH "one.three .* 3"
+    done

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -71,3 +71,9 @@ execute: |
         exit 1
     fi
     [[ "$obtained" == *"error from within configure hook"* ]]
+
+    echo "Test that the 'snap set' order is deterministic"
+    snap set snapctl-hooks command=noop one.two.three=3 one='{"four":4}' one.two='{"five":5}'
+    snap get snapctl-hooks -l one.two | MATCH "one.two.five .* 5"
+    snap get snapctl-hooks -l one.two | MATCH "one.two.three .* 3"
+    snap get snapctl-hooks -l one.four | MATCH "one.four .* 4"


### PR DESCRIPTION
Sort patch keys by path "depth" to have deterministic order of multiple set ops with `snap set`.

`snap set snap-name foo='{"key1":"a"}' foo.key2="b"` currently has random outcome, because patch values in our API are carried as a map (in this case the map has "foo" and "foo.key2" keys and their corresponding values) and are processed in random order of the keys, so one value may override the other. Some time ago we decided not to change the API, but ensure the order is deterministic and always the same.
