### PR TITLE
mkversion.sh: fix version from git checkouts

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -47,7 +47,9 @@ fi
 # at this point we maybe in _build/src/github etc where we have no
 # debian/changelog (dh-golang only exports the sources here)
 # switch to the real source dir for the changelog parsing
-version_from_changelog="$(cd "$PKG_BUILDDIR"; dpkg-parsechangelog --show-field Version)";
+if command -v dpkg-parsechangelog >/dev/null; then
+    version_from_changelog="$(cd "$PKG_BUILDDIR"; dpkg-parsechangelog --show-field Version)";
+fi
 
 # select version based on priority
 if [ -n "$version_from_user" ]; then

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -34,31 +34,50 @@ fi
 
 # If the version is passed in as an argument to mkversion.sh, let's use that.
 if [ -n "$1" ]; then
-    v="$1"
-    o=shell
+    version_from_user="$1"
 fi
 
-if [ -z "$v" ]; then
-    # Let's try to derive the version from git..
-    if command -v git >/dev/null; then
-        # not using "--dirty" here until the following bug is fixed:
-        # https://bugs.launchpad.net/snapcraft/+bug/1662388
-        v="$(git describe --always | sed -e 's/-/+git/;y/-/./' )"
-        o=git
-    fi
+# Let's try to derive the version from git..
+if command -v git >/dev/null; then
+    # not using "--dirty" here until the following bug is fixed:
+    # https://bugs.launchpad.net/snapcraft/+bug/1662388
+    version_from_git="$(git describe --always | sed -e 's/-/+git/;y/-/./' )"
 fi
 
-if [ -z "$v" ]; then
-    # at this point we maybe in _build/src/github etc where we have no
-    # debian/changelog (dh-golang only exports the sources here)
-    # switch to the real source dir for the changelog parsing
-    v="$(cd "$PKG_BUILDDIR"; dpkg-parsechangelog --show-field Version)";
-    o=debian/changelog
-fi
+# at this point we maybe in _build/src/github etc where we have no
+# debian/changelog (dh-golang only exports the sources here)
+# switch to the real source dir for the changelog parsing
+version_from_changelog="$(cd "$PKG_BUILDDIR"; dpkg-parsechangelog --show-field Version)";
 
-if [ -z "$v" ]; then
+# select version based on priority
+if [ -n "$version_from_user" ]; then
+    # version from user always wins
+    v="$version_from_user"
+    o="user"
+elif [ -n "$version_from_git" ]; then
+    v="$version_from_git"
+    o="git"
+elif [ -n "$version_from_changelog" ]; then
+    v="$version_from_changelog"
+    o="changelog"
+else
+    echo "Cannot generate version"
     exit 1
 fi
+
+# if we don't have a user provided versions and if the version is not
+# a release (i.e. the git tag does not match the debian changelog
+# version) then we need to construct the version similar to how we do
+# it in a packaging recipe. We take the debian version from the changelog
+# and append the git revno and commit hash. A simpler approach would be
+# to git tag all pre/rc releases.
+if [ -z "$version_from_user" ] && [ "$version_from_git" != "" ] && [ "$version_from_git" != "$version_from_changelog" ]; then
+    revno=$(git describe --always --abbrev=7|cut -d- -f2)
+    commit=$(git describe --always --abbrev=7|cut -d- -f3)
+    v="${version_from_changelog}+git${revno}.${commit}"
+    o="changelog+git"
+fi
+
 
 if [ "$OUTPUT_ONLY" = true ]; then
     echo "$v"


### PR DESCRIPTION
The mkversion.sh script is used during the build of the snapd snap.
Today its a bit naive and just uses "git describe" there to
generate the version number. The downside of this is that for
pre-releases like 2.41~pre1 we may end up with a version number
lower than the version in debian/changelog if the pre release
does not have a git tag. We historically don't tag pre/rc
releases and doing so would be a bit messy (IMO) so we need
a less naive approach to generate the version number.

This PR changes the mkversion.sh script to use something
similar to what a packaging recipe does to construct a version.

On the current master this will yield:
```
2.41~pre1+git905.g5e58678
```
instead of (the output before this fix):
```
2.40+git905.g5e58678f94
```
