### PR TITLE
tests: add new "user-tool" helper and use in system-user tests

### DIFF
--- a/tests/lib/bin/user-tool
+++ b/tests/lib/bin/user-tool
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-set -e -x
+set -e
 
 # remove_user_with_group remove the given username from the system and also
 # cleans the group
 remove_user_with_group() {
     REMOVE_USER="$1"
+
+    if [ -z "$REMOVE_USER" ]; then
+        echo "please provide a username to remove"
+        return 1
+    fi
 
     if [ -e /var/lib/extrausers/passwd ]; then
         userdel --extrausers --force "${REMOVE_USER}" || true
@@ -24,3 +29,14 @@ remove_user_with_group() {
     not getent passwd "${REMOVE_USER}"
     not getent group "${REMOVE_USER}"
 }
+
+# main()
+case "$1" in
+    remove-with-group)
+        remove_user_with_group "$2"
+        ;;
+    *)
+        echo "unknown argument $1"
+        echo "look at the source of $0 to see what is supported (sry!)"
+        exit 1
+esac

--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -14,9 +14,7 @@ restore: |
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs
-    # shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/users.sh"
-    remove_user_with_group snap_daemon
+    user-tool remove-with-group snap_daemon
 
 execute: |
     echo "When the snap is removed"

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -22,9 +22,7 @@ restore: |
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs
-    # shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB/users.sh"
-    remove_user_with_group snap_daemon
+    user-tool remove-with-group snap_daemon
 
 execute: |
     # to accommodate different distros, we pick the LSB required 'daemon' user


### PR DESCRIPTION
This is a followup on #7288 - instead of cleaning up using a
shell function (which is a bit cumbersome to use, i.e. it needs
to be sources and shellcheck annotated) this just creates a
helper binary.