### PR TITLE
store, image, cmd: make 'snap download' leave partials

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -140,6 +140,8 @@ func (x *cmdDownload) Execute(args []string) error {
 		Channel:   x.Channel,
 		CohortKey: x.CohortKey,
 		Revision:  revision,
+		// if something goes wrong, don't force it to start over again
+		LeavePartialOnError: true,
 	}
 	snapPath, snapInfo, err := tsto.DownloadSnap(snapName, dlOpts)
 	if err != nil {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -214,6 +214,8 @@ type DownloadOptions struct {
 	Channel   string
 	CohortKey string
 	Basename  string
+
+	LeavePartialOnError bool
 }
 
 var (
@@ -322,7 +324,8 @@ func (tsto *ToolingStore) DownloadSnap(name string, opts DownloadOptions) (targe
 		os.Exit(1)
 	}()
 
-	if err = sto.Download(context.TODO(), name, targetFn, &snap.DownloadInfo, pb, tsto.user, nil); err != nil {
+	dlOpts := &store.DownloadOptions{LeavePartialOnError: opts.LeavePartialOnError}
+	if err = sto.Download(context.TODO(), name, targetFn, &snap.DownloadInfo, pb, tsto.user, dlOpts); err != nil {
 		return "", nil, err
 	}
 

--- a/image/helpers_test.go
+++ b/image/helpers_test.go
@@ -33,6 +33,7 @@ import (
 
 func (s *imageSuite) TestDownloadOptionsString(c *check.C) {
 	for opts, str := range map[image.DownloadOptions]string{
+		{LeavePartialOnError: true}: "",
 		{}:                     "",
 		{TargetDir: "/foo"}:    `in "/foo"`,
 		{Basename: "foo"}:      `to "foo.snap"`,
@@ -78,6 +79,9 @@ func (s *imageSuite) TestDownloadOptionsValid(c *check.C) {
 			Basename: "/foo",
 		}: image.ErrPathInBase,
 	} {
+		opts.LeavePartialOnError = true
+		c.Check(opts.Validate(), check.Equals, err)
+		opts.LeavePartialOnError = false
 		c.Check(opts.Validate(), check.Equals, err)
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1380,17 +1380,11 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		if cerr := w.Close(); cerr != nil && err == nil {
 			err = cerr
 		}
-		if err != nil {
-			doRemove := dlOpts == nil || !dlOpts.LeavePartialOnError
-			if !doRemove {
-				// also do remove if the file is empty
-				if fi != nil && fi.Size() == 0 {
-					doRemove = true
-				}
-			}
-			if doRemove {
-				os.Remove(w.Name())
-			}
+		if err == nil {
+			return
+		}
+		if dlOpts == nil || !dlOpts.LeavePartialOnError || fi == nil || fi.Size() == 0 {
+			os.Remove(w.Name())
 		}
 	}()
 	if resume > 0 {


### PR DESCRIPTION
Without this change, a network error during a 'snap download' will
remove the .partial file.

While this is probably OK for snapd, as it's the simpler & safer
route¹, it's not OK for 'snap download'; the .partial should be left
so that a following 'snap download' will resume, as the user can see
and remove the file if needed.

So, this change adds a LeavePartialOnError to store.DownloadOptions,
exports it through image.DownloadOptions, and sets that to true in
cmd_download.

Also note, it explicitly makes sure it doesn't leave _empty_ partial
files, as those would just be noise.

----

1. We might want to revisit what we do in snapstate so that there also
we can resume, but it needs careful consideraiton of available space
and removing stale partial files, which is one of the hard problems.