### PR TITLE
spread.yaml: set centos-7-64 to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -102,6 +102,8 @@ backends:
                 storage: preserve-size
 
             - centos-7-64:
+                # 2019-08-23 mirrors breaking with 404
+                manual: true
                 workers: 6
                 image: centos-7-64
 


### PR DESCRIPTION
The centos-7-64 machines fail right now with:
```
https://mirror.steadfastnet.com/epel/7/x86_64/repodata/6bacf24db80d7dcea3c361609533e234034275167ae2fa7d7aa926535773fd24-filelists.sqlite.bz2: [Errno 14] HTTPS Error 404 - Not Found
...
```
disable it for now.
