### PR TITLE
tests: restore dpkg selections after upgrade-from-2.15 test

### DIFF
--- a/tests/lib/bin/apt-tool
+++ b/tests/lib/bin/apt-tool
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+import sys
+
+import apt
+
+
+def checkpoint():
+    pkgs = set()
+    cache = apt.Cache()
+    for pkg in cache:
+        if pkg.is_installed:
+            pkgs.add(pkg.name)
+    for name in sorted(pkgs):
+        print(name)
+
+
+def restore(fname):
+    desired = set([line.strip() for line in open(fname)])
+            
+    cache = apt.Cache()
+    for pkg in cache:
+        if pkg.is_installed and not pkg.name in desired:
+            print("removing", pkg)
+            pkg.mark_delete(auto_fix=False)
+        if not pkg.is_installed and pkg.name in desired:
+            print("installing", pkg)
+            pkg.mark_install(auto_fix=False, auto_install=False)
+    cache.commit()
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "checkpoint":
+        checkpoint()
+    elif sys.argv[1] == "restore":
+        restore(sys.argv[2])

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -3,7 +3,7 @@ summary: Ensure upgrades from snapd 2.15 work
 systems: [ubuntu-16.04-64]
 
 prepare: |
-    dpkg --get-selections > selections
+    apt-tool checkpoint > installed.pkgs
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
     distro_purge_package snapd
@@ -17,8 +17,8 @@ restore: |
     fi
     distro_install_build_snapd
 
-    dpkg --set-selections < selections
-    rm -f selections
+    apt-tool restore installed.pkgs
+    rm -f installed.pkgs
 
 execute: |
     #shellcheck source=tests/lib/systemd.sh

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -3,6 +3,7 @@ summary: Ensure upgrades from snapd 2.15 work
 systems: [ubuntu-16.04-64]
 
 prepare: |
+    dpkg --get-selections > selections
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
     distro_purge_package snapd
@@ -15,6 +16,9 @@ restore: |
         distro_purge_package snapd
     fi
     distro_install_build_snapd
+
+    dpkg --set-selections < selections
+    rm -f selections
 
 execute: |
     #shellcheck source=tests/lib/systemd.sh


### PR DESCRIPTION
While investigating other test issue I briefly looked at how tests
affect the set of installed packages and noticed a huge spike in the
upgrade-from-2.15 test. While I don't have the data on hand anymore I
have a patch that I wrote at the time, to save and restore dpkg
selections.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
