### PR TITLE
tests: wait_for_service shows status after actual first minute

### DIFF
--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -52,7 +52,7 @@ wait_for_service() {
             return
         fi
         # show debug output every 1min
-        if [ $(( i % 60 )) = 0 ]; then
+        if [ "$i" -gt 0 ] && [ $(( i % 60 )) = 0 ]; then
             systemctl status "$service_name" || true;
         fi
         sleep 1;


### PR DESCRIPTION
The wait_for_service function shows the status of a service once a
minute, as it waits for the service status to change. Due to a simple
mistake the status was printed at iteration zero as well, spamming logs
with useless information in a normal situation.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
