### PR TITLE
features, overlord: make parallel-installs exported, export flags on startup

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -76,6 +76,7 @@ var featuresEnabledWhenUnset = map[SnapdFeature]bool{
 var featuresExported = map[SnapdFeature]bool{
 	PerUserMountNamespace: true,
 	RefreshAppAwareness:   true,
+	ParallelInstances:     true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -57,9 +57,10 @@ func (*featureSuite) TestKnownFeatures(c *C) {
 
 func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.Layouts.IsExported(), Equals, false)
-	c.Check(features.ParallelInstances.IsExported(), Equals, false)
 	c.Check(features.Hotplug.IsExported(), Equals, false)
 	c.Check(features.SnapdSnap.IsExported(), Equals, false)
+
+	c.Check(features.ParallelInstances.IsExported(), Equals, true)
 	c.Check(features.PerUserMountNamespace.IsExported(), Equals, true)
 	c.Check(features.RefreshAppAwareness.IsExported(), Equals, true)
 }
@@ -95,6 +96,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 func (*featureSuite) TestControlFile(c *C) {
 	c.Check(features.PerUserMountNamespace.ControlFile(), Equals, "/var/lib/snapd/features/per-user-mount-namespace")
 	c.Check(features.RefreshAppAwareness.ControlFile(), Equals, "/var/lib/snapd/features/refresh-app-awareness")
+	c.Check(features.ParallelInstances.ControlFile(), Equals, "/var/lib/snapd/features/parallel-instances")
 	// Features that are not exported don't have a control file.
 	c.Check(features.Layouts.ControlFile, PanicMatches, `cannot compute the control file of feature "layouts" because that feature is not exported`)
 }

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -99,7 +99,7 @@ func Run(tr config.Conf) error {
 	}
 
 	// Export experimental.* flags to a place easily accessible from snapd helpers.
-	if err := handleExperimentalFlags(tr); err != nil {
+	if err := ExportExperimentalFlags(tr); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -48,7 +48,7 @@ func validateExperimentalSettings(tr config.Conf) error {
 	return nil
 }
 
-func handleExperimentalFlags(tr config.Conf) error {
+func ExportExperimentalFlags(tr config.Conf) error {
 	dir := dirs.FeaturesDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/store"
 )
@@ -74,7 +75,7 @@ func MockStoreNew(new func(*store.Config, store.DeviceAndAuthContext) *store.Sto
 	}
 }
 
-func MockConfigstateInit(new func(hookmgr *hookstate.HookManager)) (restore func()) {
+func MockConfigstateInit(new func(*state.State, *hookstate.HookManager) error) (restore func()) {
 	configstateInit = new
 	return func() {
 		configstateInit = configstate.Init

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -169,7 +169,9 @@ func New(restartBehavior RestartBehavior) (*Overlord, error) {
 	o.addManager(cmdstate.Manager(s, o.runner))
 	o.addManager(snapshotstate.Manager(s, o.runner))
 
-	configstateInit(hookMgr)
+	if err := configstateInit(s, hookMgr); err != nil {
+		return nil, err
+	}
 	healthstate.Init(hookMgr)
 
 	// the shared task runner should be added last!

--- a/tests/main/experimental-features/task.yaml
+++ b/tests/main/experimental-features/task.yaml
@@ -15,3 +15,11 @@ execute: |
     # When a feature that is not exported is enabled, a file is not created.
     snap set core experimental.layouts=true
     test ! -f /var/lib/snapd/features/layouts
+
+    # Features are exported when snapd starts up
+    snap set core experimental.parallel-instances=true
+    test -f /var/lib/snapd/features/parallel-instances
+    systemctl stop snapd
+    rm /var/lib/snapd/features/parallel-instances
+    systemctl start snapd
+    test -f /var/lib/snapd/features/parallel-instances


### PR DESCRIPTION
#7302 needs to access experimental feature flags. Make sure `parallel-instances` is exported.

However, the flag can already be enabled in existing installs. Currently snapd only updates the exported feature flags when a configuration change is applied. Make sure that the exported feature flags get updated when a new version of snapd starts up.