### PR TITLE
tests: unmount fuse connections only if not initially mounted

### DIFF
--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -24,6 +24,10 @@ environment:
     NAME/parallel: test-snapd-fuse-consumer_foo
 
 prepare: |
+    if not mountinfo-tool /sys/fs/fuse/connections .fs_type=fusectl; then
+        touch please-unmount-fuse-connections
+    fi
+
     if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
         snap set system experimental.parallel-instances=true
     fi
@@ -45,8 +49,11 @@ restore: |
     if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
         snap set system experimental.parallel-instances=null
     fi
-    if mountinfo-tool /sys/fs/fuse/connections .fs_type=fusectl; then
-        umount /sys/fs/fuse/connections
+    if [ -e please-unmount-fuse-connections ]; then
+        if mountinfo-tool /sys/fs/fuse/connections .fs_type=fusectl; then
+            umount /sys/fs/fuse/connections
+        fi
+        rm -f please-unmount-fuse-connections
     fi
 
 execute: |


### PR DESCRIPTION
The test that checks fuse-support interface may or may not start with
FUSE filesystems present. To reliably preserve the state of the mount
table it should really check up front and not blindly unmount fuse
connections in restore.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
