### PR TITLE
tests: pass --remove to userdel on core

### DIFF
--- a/tests/lib/bin/user-tool
+++ b/tests/lib/bin/user-tool
@@ -19,7 +19,7 @@ def remove_user_with_group(user_name):
     # type: (Text) -> None
     """remove the user and group with the same name, if present."""
     if os.path.exists("/var/lib/extrausers/passwd"):
-        subprocess.call(["userdel", "--extrausers", "--force", user_name])
+        subprocess.call(["userdel", "--extrausers", "--force", "--remove", user_name])
     else:
         subprocess.call(["userdel", "--force", "--remove", user_name])
         # Some systems do not set "USERGROUPS_ENAB yes" so we need to cleanup


### PR DESCRIPTION
This is a follow up that fixes a bug in the original shell
implementation. On core we lacked the --remove switch that removes the
user directory. This patch fixes it.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

