### PR TITLE
snap: explicitly forbid trying to parallel install from seed

### DIFF
--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 // SeedSnap points to a snap in the seed to install, together with
@@ -77,7 +78,7 @@ func ReadSeedYaml(fn string) (*Seed, error) {
 		if sn == nil {
 			return nil, fmt.Errorf("%s: empty element in seed", errPrefix)
 		}
-		if err := ValidateInstanceName(sn.Name); err != nil {
+		if err := naming.ValidateSnap(sn.Name); err != nil {
 			return nil, fmt.Errorf("%s: %v", errPrefix, err)
 		}
 		if sn.Channel != "" {

--- a/snap/seed_yaml_test.go
+++ b/snap/seed_yaml_test.go
@@ -125,6 +125,19 @@ snaps:
 	c.Assert(err, ErrorMatches, `cannot read seed yaml: invalid snap name: "invalid--name"`)
 }
 
+func (s *seedYamlTestSuite) TestValidateNameInstanceUnsupported(c *C) {
+	fn := filepath.Join(c.MkDir(), "seed.yaml")
+	err := ioutil.WriteFile(fn, []byte(`
+snaps:
+ - name: foo_1
+   file: ./foo.snap
+`), 0644)
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadSeedYaml(fn)
+	c.Assert(err, ErrorMatches, `cannot read seed yaml: invalid snap name: "foo_1"`)
+}
+
 func (s *seedYamlTestSuite) TestValidateNameMissing(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
 	err := ioutil.WriteFile(fn, []byte(`


### PR DESCRIPTION
As we discussed it was never intentional to allow this for now (it would need a gadget with the right option as well) and it  was not explicitly supported nor tested. Disallow this to keep complexity in check now that we are about to refactor first boot quite radically.
