### PR TITLE
tests: fix removal of snaps on ubuntu-core

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -109,7 +109,15 @@ reset_all_snap() {
                 if ! systemctl status snapd.service snapd.socket >/dev/null; then
                     systemctl start snapd.service snapd.socket
                 fi
-                if ! echo "$SKIP_REMOVE_SNAPS" | grep -w "$snap"; then
+                # Check if a snap should be kept, there's a list of those in spread.yaml.
+                keep=0
+                for precious_snap in $SKIP_REMOVE_SNAPS; do
+                    if [ "$snap" = "$precious_snap" ]; then
+                        keep=1
+                        break
+                    fi
+                done
+                if [ "$keep" -eq 0 ]; then
                     if snap info --verbose "$snap" | grep -E '^type: +(base|core)'; then
                         if [ -z "$remove_bases" ]; then
                             remove_bases="$snap"


### PR DESCRIPTION
The removal loop checks the snap to be removed against what's in
$SKIP_REMOVE_LIST. In practice, unless customized, it contains
' test-snapd-rsync test-snapd-rsync-core18' (with a leading space
coming from a small bug in spread.yaml).

The code then uses grep -w to check for _word match_, as defined by
grep, against the name of the snap to be removed. If there is no match
the code proceeds to remove the snap.

The problem is that grep -w is considers dashes to be word terminators.
Leading to the test-snapd-rsync-core18 snap keeping core18 perpetually
installed, causing leakage across tests.

    echo ' test-snapd-rsync test-snapd-rsync-core18' | grep -w core18
     test-snapd-rsync test-snapd-rsync-core18
    echo $?
    0

The fix is loop over the $SKIP_REMOVE_SNAPS lists, which is currently
always non-empty, and to check for snap name equality.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
