### PR TITLE
tests: move interfaces-contacts-service to /tmp

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -15,7 +15,7 @@ systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*]
 backends: [-autopkgtest]
 
 environment:
-    XDG: $(pwd)/xdg
+    XDG: /tmp/xdg
     XDG_CONFIG_HOME: $XDG/config
     XDG_DATA_HOME: $XDG/share
     XDG_CACHE_HOME: $XDG/cache


### PR DESCRIPTION
We see some failures about interfaces-contacts-service failing
in opensuse-tumbleweed-64. Looking at looks we see that the actual
failure happens in restore-unit each
```
2019-08-23 14:55:45 Error restoring google:opensuse-tumbleweed-64:tests/main/interfaces-contacts-service :
-----
+ '[' -e dbus-launch.pid ']'
++ cat dbus-launch.pid
+ kill 30526
++ pidof gvfsd-metadata
+ pid=
+ rm -rf /home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-contacts-service/xdg
...
+ restore_suite_each
+ rm -f /home/gopath/src/github.com/snapcore/snapd/tests/runtime-state/audit-stamp
+ '[' -f /home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-contacts-service.tar ']'
+ rm -rf /home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-contacts-service
rm: cannot remove '/home/gopath/src/github.com/snapcore/snapd/tests/main/interfaces-contacts-service/xdg/share/gvfs-metadata': Directory not empty
```

so to workaround this issue we move the xdg dir to /tmp. Its a bit unclear still *why* there is something writing to that dir during the cleanup :/
