### PR TITLE
tests: remove locally installed revisions of core

### DIFF
--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -18,6 +18,10 @@ restore: |
     if [ -f curChg ] ; then
         snap abort "$(cat curChg)" || true
     fi
+    # Remove the revisions installed during the test.
+    # The x1 revision is the one we use initially.
+    snap remove core --revision=x2
+    snap remove core --revision=x3
 
 prepare: |
     snap list | awk "/^core / {print(\$3)}" > nextBoot


### PR DESCRIPTION
The ubuntu-core-upgrade test was leaking locally installed revisions of
the core snap. This is not captured by our automatic removal logic
because it doesn't consider revisions, only entire snaps, and because
core is protected from removal.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
