### PR TITLE
tests: add check for snap_daemon user/group

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -637,6 +637,15 @@ restore_project_each() {
         exit 1
     fi
 
+    if getent passwd snap_daemon; then
+        echo "Test left the snap_daemon user behind, this should not happen"
+        exit 1
+    fi
+    if getent group snap_daemon; then
+        echo "Test left the snap_daemon group behind, this should not happen"
+        exit 1
+    fi
+
     # Something is hosing the filesystem so look for signs of that
     not grep -F "//deleted /etc" /proc/self/mountinfo
 }


### PR DESCRIPTION
Even with the cleanup via "user-tool delete-with-group" it seems
like we are still getting leftover snap_daemon users sometimes.

This PR tries to catch what test fails to cleanup.

This hopefully helps tracking down failures like https://api.travis-ci.org/v3/job/576683798/log.txt