### PR TITLE
tests: add debug section to interfaces-contacts-service

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -20,6 +20,12 @@ environment:
     XDG_DATA_HOME: $XDG/share
     XDG_CACHE_HOME: $XDG/cache
 
+debug: |
+    echo "Output process to see what might write to $XDG"
+    ps uafx
+    echo "Show what is in $XDG"
+    ls -alR "$XDG"
+
 restore: |
     if [ -e dbus-launch.pid ]; then
         kill "$(cat dbus-launch.pid)"


### PR DESCRIPTION
The cleanup of this tests fails sometimes in opensuse-tumbleweed-64
when trying to "rm -rf $XDG" - so something is writing this when
rm runs.

To understand a bit better what is happening this PR adds a list
of the processes and the content of XDG to the debug output.
