### PR TITLE
tests: re-enable mount-ns test on classic

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -1,9 +1,11 @@
 summary: The shape of the mount namespace on classic systems for non-classic snaps
-systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-core-16-64, ubuntu-core-18-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 # The test itself works perfectly fine but in conjunction with our leaky test
 # suite it often fails because it detects cruft left over by other tests in a
-# way that was not detected before.
-manual: true
+# way that was not detected before. Classic systems should be clear of mount
+# side-effects now. The test should be _eventually_ enabled on
+# ubuntu-core-16-64 and ubuntu-core-18-64.
+
 # The test is sensitive to backend type, which designates the used image.
 # Backends are enabled one-by-one along with the matching data set.
 backends: [google]


### PR DESCRIPTION
Over the past several weeks the test suite was cleaned up not to affect
the mount table on classic systems. We can try to re-enable the mount-ns
test there now.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
