### PR TITLE
tests: move restore-project-each code to existing function

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -603,19 +603,6 @@ restore: |
     "$TESTSLIB"/prepare-restore.sh --restore-project
 restore-each: |
     "$TESTSLIB"/prepare-restore.sh --restore-project-each
-    if journalctl -u snapd.service | grep -F "signal: terminated"; then exit 1; fi
-    case "$SPREAD_SYSTEM" in
-        fedora-*|centos-*)
-            # Make sure that we are not leaving behind incorrectly labeled snap
-            # files on systems supporting SELinux
-            (
-                find /root/snap -printf '%Z\t%H/%P\n' || true
-                find /home -regex '/home/[^/]*/snap\(/.*\)?' -printf '%Z\t%H/%P\n' || true
-            ) | grep -c -v snappy_home_t | MATCH "0"
-
-            find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
-            ;;
-    esac
 suites:
     # The essential tests designed to run inside the autopkgtest
     # environment on each platform. On autopkgtest we cannot run all tests

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -648,6 +648,23 @@ restore_project_each() {
 
     # Something is hosing the filesystem so look for signs of that
     not grep -F "//deleted /etc" /proc/self/mountinfo
+
+    if journalctl -u snapd.service | grep -F "signal: terminated"; then
+        exit 1;
+    fi
+
+    case "$SPREAD_SYSTEM" in
+        fedora-*|centos-*)
+            # Make sure that we are not leaving behind incorrectly labeled snap
+            # files on systems supporting SELinux
+            (
+                find /root/snap -printf '%Z\t%H/%P\n' || true
+                find /home -regex '/home/[^/]*/snap\(/.*\)?' -printf '%Z\t%H/%P\n' || true
+            ) | grep -c -v snappy_home_t | MATCH "0"
+
+            find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
+            ;;
+    esac
 }
 
 restore_project() {


### PR DESCRIPTION
We have a restore_project_each function that contains various existing
logic for restoring. We call it from restore-each spread stanza.
Just after that call there a bit more code that checks the journal
for signal-based termination messages and SELinux mislabelling.
This code belongs in the function so move it there for consistency.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
