### PR TITLE
tests: don't look for lxcfs in mountinfo

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -599,7 +599,6 @@ prepare: |
     "$TESTSLIB"/prepare-restore.sh --prepare-project
 prepare-each: |
     "$TESTSLIB"/prepare-restore.sh --prepare-project-each
-    grep -v /var/lib/lxcfs /proc/self/mountinfo
 restore: |
     "$TESTSLIB"/prepare-restore.sh --restore-project
 restore-each: |
@@ -617,7 +616,6 @@ restore-each: |
             find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
             ;;
     esac
-    grep -v /var/lib/lxcfs /proc/self/mountinfo
 suites:
     # The essential tests designed to run inside the autopkgtest
     # environment on each platform. On autopkgtest we cannot run all tests


### PR DESCRIPTION
This debug-driven check is no longer needed. It is very verbose as it
prints the mount table twice for each test task. We now understand the
situation with lxcfs and this piece of debug logic can go away.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
