### PR TITLE
tests: adding support for arm devices on ubuntu-core-device-reg test

### DIFF
--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -5,6 +5,8 @@ summary: |
 systems: [ubuntu-core-1*]
 
 execute: |
+    #shellcheck source=tests/lib/names.sh
+    . "$TESTSLIB"/names.sh
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
@@ -25,10 +27,12 @@ execute: |
     echo "Check we have a serial"
     snap known serial|MATCH "authority-id: canonical"
     snap known serial|MATCH "brand-id: canonical"
-    if is_core18_system; then
+    if [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" ]; then
         snap known serial | MATCH "model: ubuntu-core-18-amd64"
-    else
+    elif [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         snap known serial | MATCH "model: pc"
+    else
+        snap known serial | MATCH "model: $gadget_name"
     fi
 
     echo "Make sure we could acquire a session macaroon"

--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -27,13 +27,16 @@ execute: |
     echo "Check we have a serial"
     snap known serial|MATCH "authority-id: canonical"
     snap known serial|MATCH "brand-id: canonical"
-    if [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" ]; then
-        snap known serial | MATCH "model: ubuntu-core-18-amd64"
-    elif [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
-        snap known serial | MATCH "model: pc"
-    else
-        snap known serial | MATCH "model: $gadget_name"
-    fi
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-18-64)
+            snap known serial | MATCH "model: ubuntu-core-18-amd64"
+            ;;
+        ubuntu-core-16-64)
+            snap known serial | MATCH "model: pc"
+            ;;
+        *)
+            snap known serial | MATCH "model: $gadget_name"
+    esac
 
     echo "Make sure we could acquire a session macaroon"
     snap find pc


### PR DESCRIPTION
This is because the test is failing on arm devices. 

Error: 
+ snap known serial
+ MATCH 'model: pc'
grep error: pattern not found, got:
type: serial
authority-id: canonical
brand-id: canonical
model: pi2