### PR TITLE
snapstate: validate all system-usernames before creating them

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -618,6 +618,7 @@ func checkAndCreateSystemUsernames(si *snap.Info) error {
 	}
 
 	// then create
+	// TODO: move user creation to a more appropriate place like "link-snap"
 	extrausers := !release.OnClassic
 	for _, user := range si.SystemUsernames {
 		id := supportedSystemUsernames[user.Name]

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -1030,7 +1030,13 @@ var systemUsernamesTests = []struct {
 	noRangeUser: true,
 	scVer:       "dead 2.4.1 deadbeef bpf-actlog",
 	error:       `cannot ensure users for snap "foo" required system username "snap_daemon": cannot add user/group "snapd-range-524288-root", group exists and user does not`,
-}}
+}, {
+	sysIDs:  "snap_daemon: shared\n  daemon: shared",
+	classic: true,
+	scVer:   "dead 2.4.1 deadbeef bpf-actlog",
+	error:   `snap "foo" requires unsupported system username "daemon"`,
+},
+}
 
 func (s *checkSnapSuite) TestCheckSnapSystemUsernames(c *C) {
 	for _, test := range systemUsernamesTests {
@@ -1040,6 +1046,7 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernames(c *C) {
 		restore = release.MockOnClassic(test.classic)
 		defer restore()
 
+		var osutilEnsureUserGroupCalls int
 		if test.noRangeUser {
 			restore = snapstate.MockOsutilEnsureUserGroup(func(name string, id uint32, extraUsers bool) error {
 				return fmt.Errorf(`cannot add user/group "%s", group exists and user does not`, name)
@@ -1053,6 +1060,7 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernames(c *C) {
 			})
 		} else {
 			restore = snapstate.MockOsutilEnsureUserGroup(func(name string, id uint32, extraUsers bool) error {
+				osutilEnsureUserGroupCalls++
 				return nil
 			})
 		}
@@ -1071,8 +1079,11 @@ func (s *checkSnapSuite) TestCheckSnapSystemUsernames(c *C) {
 		err = snapstate.CheckSnap(s.st, "snap-path", "foo", nil, nil, snapstate.Flags{}, nil)
 		if test.error != "" {
 			c.Check(err, ErrorMatches, test.error)
+			c.Check(osutilEnsureUserGroupCalls, Equals, 0)
 		} else {
 			c.Assert(err, IsNil)
+			// one call for the range user, one for the system user
+			c.Check(osutilEnsureUserGroupCalls, Equals, 2)
 		}
 	}
 }


### PR DESCRIPTION
The current checkSystemUsernames code is doing check and creation
at the same time. This may lead to side-effects like creating
users even if the snap cannot be installed because it contains
unsupported/illegal system-users. This showed up in the tests
when sometimes the "system-usernames-illegal" test would create
a "snap_daemon" user even though the snap itself could not be
installed.

This PR fixes it by splitting the check and creation into
two separate steps. The creation only happens if all system-users
are valid.

