### PR TITLE
gadget: do not error on gadget refreshes with multiple volumes

### DIFF
--- a/gadget/update.go
+++ b/gadget/update.go
@@ -57,6 +57,15 @@ type GadgetData struct {
 // rollback directory. Should the apply step fail, the modified data is
 // recovered.
 func Update(old, new GadgetData, rollbackDirPath string) error {
+	// TODO: support multi-volume gadgets. But for now we simply
+	//       do not do any gadget updates on those. We cannot error
+	//       here because this would break refreshes of gadgets even
+	//       when they don't require any updates.
+	if len(new.Info.Volumes) != 1 || len(old.Info.Volumes) != 1 {
+		logger.Noticef("WARNING: gadget assests cannot be updated yet when multiple volumes are used")
+		return nil
+	}
+
 	oldVol, newVol, err := resolveVolume(old.Info, new.Info)
 	if err != nil {
 		return err

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -1238,15 +1238,15 @@ func (u *updateTestSuite) TestUpdaterMultiVolumesDoesNotError(c *C) {
 	multiVolume := gadget.GadgetData{
 		Info: &gadget.Info{
 			Volumes: map[string]gadget.Volume{
-				"1": gadget.Volume{},
-				"2": gadget.Volume{},
+				"1": {},
+				"2": {},
 			},
 		},
 	}
 	singleVolume := gadget.GadgetData{
 		Info: &gadget.Info{
 			Volumes: map[string]gadget.Volume{
-				"1": gadget.Volume{},
+				"1": {},
 			},
 		},
 	}


### PR DESCRIPTION
The new gadget asserts update code will check early if the gadget
contains multiple volumes. This is not supported yet and the old
code did error. However this has the unintended consequence that
any gadget update fails now when the gadget has multiple volumes
even if no gadget asset update will happen.

For now the code will just log a warning that multi-volume
gadget asset updates are not supported and continue like
before.
