### PR TITLE
 snap: revert PR#7204 as breaks `snap switch` output

### DIFF
--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1876,14 +1876,13 @@ func (s *SnapOpSuite) TestWaitServerError(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
-	s.srv.total = 4
+	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "switch",
 			"channel": "beta",
 		})
-		s.srv.trackingChannel = "beta"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
@@ -1897,7 +1896,7 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyCohort(c *check.C) {
-	s.srv.total = 4
+	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1917,7 +1916,7 @@ func (s *SnapOpSuite) TestSwitchHappyCohort(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyLeaveCohort(c *check.C) {
-	s.srv.total = 4
+	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1937,7 +1936,7 @@ func (s *SnapOpSuite) TestSwitchHappyLeaveCohort(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
-	s.srv.total = 4
+	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1945,7 +1944,6 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
 			"cohort-key": "what",
 			"channel":    "edge",
 		})
-		s.srv.trackingChannel = "edge"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)
@@ -1959,7 +1957,7 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndCohort(c *check.C) {
 }
 
 func (s *SnapOpSuite) TestSwitchHappyChannelAndLeaveCohort(c *check.C) {
-	s.srv.total = 4
+	s.srv.total = 3
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
@@ -1967,7 +1965,6 @@ func (s *SnapOpSuite) TestSwitchHappyChannelAndLeaveCohort(c *check.C) {
 			"leave-cohort": true,
 			"channel":      "edge",
 		})
-		s.srv.trackingChannel = "edge"
 	}
 
 	s.RedirectClientToTestServer(s.srv.handle)

--- a/tests/main/snap-switch/task.yaml
+++ b/tests/main/snap-switch/task.yaml
@@ -4,5 +4,8 @@ execute: |
     snap install test-snapd-tools
     snap info test-snapd-tools|MATCH "tracking: +stable"
 
-    snap switch --edge test-snapd-tools
+    snap switch --edge test-snapd-tools > stdout.txt
     snap info test-snapd-tools|MATCH "tracking: +edge"
+
+    echo "Ensure we don't print incorrect and confusing information"
+    not grep "is closed; temporarily forwarding to stable." < stdout.txt


### PR DESCRIPTION
The PR#7204 has the unintended consequence that on "snap switch"
a misleading message is printed:
```
$ snap switch test-snapd-tools --edge
"test-snapd-tools" switched to the "edge" channel

Channel edge for test-snapd-tools is closed; temporarily forwarding to stable.
```

So this PR adds a test and reverts the PR#7204 so that we can
release 2.41.