### PR TITLE
tests: retry checking until the written file on desktop-portal-filechooser

### DIFF
--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -52,15 +52,21 @@ execute: |
 
     echo "The confined application can write files via the portal"
     [ ! -f /tmp/file-to-write.txt ]
+
+    # TODO: workaround for testing on 18.04
     # The python code does open(path, 'w'), which attempts to truncate the
     # file if it exists. Then in fuse handlers inside document-portal, the
     # code path for when the inode exists and the caller requested O_TRUNC,
     # returns -ENOSYS, resulting in OSError:
     # [Errno 38] Function not implemented on the Python side
-    # make sure the file does not exist
-    rm -f /tmp/file-to-write.txt
+    # Creating the file beforehand prevents that.
+    touch /tmp/file-to-write.txt
+    chown test:test /tmp/file-to-write.txt
+
     as_user test-snapd-portal-client save-file "from-sandbox"
-    # Rerty checking until the file contains the written text. In particular on
+
+    # TODO: another workaround for testing on 18.04
+    # Retry checking until the file contains the written text. In particular on
     # 18.04, xdg-desktop-portal 0.11 (perhaps still the same for later
     # versions), the writes were implemented such that the client writes to a
     # fuse filesystem entry, while the portal forwards the writes to the actual


### PR DESCRIPTION
The test is failing sporadically when checking the text in the
/tmp/file-to-write.txt file. The text is written be sometimes takes a
bit of time making the test fail because of this.
