### PR TITLE
tests: always say 'restore: |'

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     snap set system experimental.parallel-instances=true
     install_local_as test-snapd-tools test-snapd-tools_foo
 
-restore:
+restore: |
     snap set system experimental.parallel-instances=null
 
 execute: |

--- a/tests/main/parallel-install-basic/task.yaml
+++ b/tests/main/parallel-install-basic/task.yaml
@@ -81,5 +81,5 @@ execute: |
     su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_USER_COMMON/canary'" test | MATCH canary-instance-common
     su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_USER_DATA/canary'" test | MATCH canary-instance-snap
 
-restore:
+restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-common-dirs-undo/task.yaml
+++ b/tests/main/parallel-install-common-dirs-undo/task.yaml
@@ -33,5 +33,5 @@ execute: |
     not test -d "$SNAP_MOUNT_DIR/test-snapd-service"
     not test -d "/var/snap/test-snapd-service"
 
-restore:
+restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -80,5 +80,5 @@ execute: |
     not test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
     not test -d "/var/snap/test-snapd-tools"
 
-restore:
+restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -41,5 +41,5 @@ execute: |
     snap remove basic-desktop
     test -f /var/lib/snapd/desktop/applications/basic-desktop+longname_echo.desktop
 
-restore:
+restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/system-usernames-illegal/task.yaml
+++ b/tests/main/system-usernames-illegal/task.yaml
@@ -5,7 +5,7 @@ summary: ensure unapproved user cannot be used with system-usernames
 # we can ignore these.
 systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-sid-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*]
 
-restore:
+restore: |
     # Make sure the snap is removed if the test failed and the snap was
     # installed
     snap remove test-snapd-illegal-system-username || true


### PR DESCRIPTION
YAML can be a bit deceiving, especially when it looks right on paper.
While each of the existing restore fragments were one-liners it's better
to be safe rather than sorry.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>