### PR TITLE
tests: simplify interfaces-account-control test

### DIFF
--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -27,11 +27,8 @@ restore: |
     snap remove "$TSNAP"
 
 execute: |
-    #shellcheck source=tests/lib/dirs.sh
-    . "$TESTSLIB"/dirs.sh
-
-    "$SNAP_MOUNT_DIR"/bin/"$TSNAP".useradd --extrausers alice
-    echo alice:password | "$SNAP_MOUNT_DIR"/bin/"$TSNAP".chpasswd
+    snap run "$TSNAP".useradd --extrausers alice
+    echo alice:password | snap run "$TSNAP".chpasswd
 
     # User deletion is unsupported yet on Core: https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1659534
-    # $SNAP_MOUNT_DIR/bin/"$TSNAP".userdel --extrausers alice
+    # snap run $TSNAP".userdel --extrausers alice


### PR DESCRIPTION
The test used some weird way to run the commands, using their full
path instead of directly or via "snap run snap.app".

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
