### PR TITLE
cmd/snap: fix snap switch message

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -369,16 +369,15 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 				msg = fmt.Sprintf(i18n.G("%q left the cohort"), snap.Name)
 			}
 			fmt.Fprintln(Stdout, msg)
-			// go to next snap, skipping the temporary forward logic below for "switch" op.
-			continue
 		default:
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
 		}
-		// XXX: this makes sense only for certain operations (refresh?), but not for "switch"
-		if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
-			if sameRisk, err := isSameRisk(snap.TrackingChannel, snap.Channel); err == nil && !sameRisk {
-				// TRANSLATORS: first %s is a channel name, following %s is a snap name, last %s is a channel name again.
-				fmt.Fprintf(Stdout, i18n.G("Channel %s for %s is closed; temporarily forwarding to %s.\n"), snap.TrackingChannel, snap.Name, snap.Channel)
+		if op == "install" || op == "refresh" || op == "revert" {
+			if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
+				if sameRisk, err := isSameRisk(snap.TrackingChannel, snap.Channel); err == nil && !sameRisk {
+					// TRANSLATORS: first %s is a channel name, following %s is a snap name, last %s is a channel name again.
+					fmt.Fprintf(Stdout, i18n.G("Channel %s for %s is closed; temporarily forwarding to %s.\n"), snap.TrackingChannel, snap.Name, snap.Channel)
+				}
 			}
 		}
 	}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -369,9 +369,12 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 				msg = fmt.Sprintf(i18n.G("%q left the cohort"), snap.Name)
 			}
 			fmt.Fprintln(Stdout, msg)
+			// go to next snap, skipping the temporary forward logic below for "switch" op.
+			continue
 		default:
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
 		}
+		// XXX: this makes sense only for certain operations (refresh?), but not for "switch"
 		if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
 			if sameRisk, err := isSameRisk(snap.TrackingChannel, snap.Channel); err == nil && !sameRisk {
 				// TRANSLATORS: first %s is a channel name, following %s is a snap name, last %s is a channel name again.

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -372,7 +372,7 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 		default:
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
 		}
-		if op == "install" || op == "refresh" || op == "revert" {
+		if op == "install" || op == "refresh" {
 			if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
 				if sameRisk, err := isSameRisk(snap.TrackingChannel, snap.Channel); err == nil && !sameRisk {
 					// TRANSLATORS: first %s is a channel name, following %s is a snap name, last %s is a channel name again.

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1890,7 +1890,9 @@ func (s *SnapOpSuite) TestSwitchHappy(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"switch", "--beta", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `(?sm).*"foo" switched to the "beta" channel`)
+	c.Check(s.Stdout(), check.Equals, `"foo" switched to the "beta" channel
+
+`)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(s.srv.n, check.Equals, s.srv.total)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -943,7 +943,6 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	// tracking channel is "" in the test server
 	c.Check(s.Stdout(), check.Equals, `foo reverted to 1.0
-Channel  for foo is closed; temporarily forwarding to potato.
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/tests/main/snap-switch/task.yaml
+++ b/tests/main/snap-switch/task.yaml
@@ -4,5 +4,8 @@ execute: |
     snap install test-snapd-tools
     snap info test-snapd-tools|MATCH "tracking: +stable"
 
-    snap switch --edge test-snapd-tools
+    snap switch --edge test-snapd-tools > stdout.txt
     snap info test-snapd-tools|MATCH "tracking: +edge"
+
+    echo "Ensure we don't print incorrect and confusing information"
+    not grep "is closed; temporarily forwarding to stable." < stdout.txt


### PR DESCRIPTION
Do not to display the "Channel .. for .. is closed; temporarily forwarding to .." message with `snap switch`.

In the PR #7204 I refactored snap switch slightly to reuse existing `showDone` helper and missed the fact that this helper also prints this message under certain circumstances, apart from all the specific cases based on snap ops. With this change the output for `snap switch` will be as before #7204, except the new track/semantics are handled (thanks to `showDone` logic).

Thanks @mvo5 for the spread test.