### PR TITLE
cmd/system-shutdown: Rename die() -> die_reboot() to fix build failures with LTO enabled

### DIFF
--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -54,7 +54,7 @@ void kmsg(const char *fmt, ...)
 }
 
 __attribute__((noreturn))
-void die(const char *msg)
+void die_reboot(const char *msg)
 {
 	if (errno == 0) {
 		kmsg("*** %s", msg);
@@ -114,7 +114,7 @@ bool umount_all(void)
 		sc_mountinfo *mounts = sc_parse_mountinfo(NULL);
 		if (!mounts) {
 			// oh dear
-			die("unable to get mount info; giving up");
+			die_reboot("unable to get mount info; giving up");
 		}
 		sc_mountinfo_entry *cur = sc_first_mountinfo_entry(mounts);
 

--- a/cmd/system-shutdown/system-shutdown-utils.h
+++ b/cmd/system-shutdown/system-shutdown-utils.h
@@ -26,7 +26,7 @@
 bool umount_all(void);
 
 __attribute__((noreturn))
-void die(const char *msg);
+void die_reboot(const char *msg);
 __attribute__((format(printf, 1, 2)))
 void kmsg(const char *fmt, ...);
 

--- a/cmd/system-shutdown/system-shutdown.c
+++ b/cmd/system-shutdown/system-shutdown.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 	 */
 
 	if (mkdir("/writable", 0755) < 0) {
-		die("cannot create directory /writable");
+		die_reboot("cannot create directory /writable");
 	}
 	// We are reading a file from /run and need to do this before unmounting
 	if (sc_read_reboot_arg(reboot_arg, sizeof reboot_arg) < 0) {
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 	} else {
 		if (mount("/oldroot/writable", "/writable", NULL, MS_MOVE, NULL)
 		    < 0) {
-			die("cannot move writable out of the way");
+			die_reboot("cannot move writable out of the way");
 		}
 
 		if (umount_all()) {


### PR DESCRIPTION
`void die(const char *msg)` from `cmd/system-shutdown/system-shutdown-utils.h` clashes with `void die(const char *fmt, ...)` from `cmd/libsnap-confine-private/utils.h`, which turns into an error when you build snap with link time optimization enabled.

This patch renames `die` to `die_reboot`, to make it clearer what it does and to resolve this ambiguity.