### PR TITLE
snap: use deterministic paths to find the built deb

### DIFF
--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -56,6 +56,6 @@ class XBuildDeb(snapcraft.BasePlugin):
         # run the real build
         self.run(["dpkg-buildpackage"], env=env)
         # and "install" into the right place
-        snapd_deb = glob.glob("parts/snapd/snapd_*.deb")[0]
+        snapd_deb = glob.glob(os.path.join(self.partdir, "snapd_*.deb"))[0]
         self.run(["dpkg-deb", "-x", os.path.abspath(snapd_deb), self.installdir])
 


### PR DESCRIPTION
The globbing path in the plugin is using a relative path.
This can be brittle, and will break when migrating to 3.0
as CWD will be different. To avoid this issue, use the `partdir`
plugin property.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>
