### PR TITLE
cmd: unify die() across C programs

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -62,6 +62,9 @@ new_format = \
 	 libsnap-confine-private/infofile-test.c \
 	 libsnap-confine-private/infofile.c \
 	 libsnap-confine-private/infofile.h \
+	 libsnap-confine-private/panic-test.h \
+	 libsnap-confine-private/panic.c \
+	 libsnap-confine-private/panic.h \
 	 snap-confine/seccomp-support-ext.c \
 	 snap-confine/seccomp-support-ext.h \
 	 snap-confine/selinux-support.c \
@@ -129,6 +132,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/mount-opt.h \
 	libsnap-confine-private/mountinfo.c \
 	libsnap-confine-private/mountinfo.h \
+	libsnap-confine-private/panic.c \
+	libsnap-confine-private/panic.h \
 	libsnap-confine-private/privs.c \
 	libsnap-confine-private/privs.h \
 	libsnap-confine-private/secure-getenv.c \
@@ -159,6 +164,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/locking-test.c \
 	libsnap-confine-private/mount-opt-test.c \
 	libsnap-confine-private/mountinfo-test.c \
+	libsnap-confine-private/panic-test.c \
 	libsnap-confine-private/privs-test.c \
 	libsnap-confine-private/secure-getenv-test.c \
 	libsnap-confine-private/snap-test.c \

--- a/cmd/libsnap-confine-private/panic-test.c
+++ b/cmd/libsnap-confine-private/panic-test.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "panic.h"
+#include "panic.c"
+
+#include <glib.h>
+
+static void test_panic(void)
+{
+	if (g_test_subprocess()) {
+		errno = 0;
+		sc_panic("death message");
+		g_test_message("expected die not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("death message\n");
+}
+
+static void test_panic_with_errno(void)
+{
+	if (g_test_subprocess()) {
+		errno = EPERM;
+		sc_panic("death message");
+		g_test_message("expected die not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("death message: Operation not permitted\n");
+}
+
+static void custom_panic_msg(const char *fmt, va_list ap, int errno_copy)
+{
+	fprintf(stderr, "PANIC: ");
+	vfprintf(stderr, fmt, ap);
+	fprintf(stderr, " (errno: %d)", errno_copy);
+	fprintf(stderr, "\n");
+}
+
+static void custom_panic_exit(void)
+{
+	fprintf(stderr, "EXITING\n");
+	exit(2);
+}
+
+static void test_panic_customization(void)
+{
+	if (g_test_subprocess()) {
+		sc_set_panic_msg_fn(custom_panic_msg);
+		sc_set_panic_exit_fn(custom_panic_exit);
+		errno = 123;
+		sc_panic("death message");
+		g_test_message("expected die not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("PANIC: death message (errno: 123)\n"
+				  "EXITING\n");
+	// NOTE: g_test doesn't offer facilities to observe the exit code.
+}
+
+static void __attribute__((constructor)) init(void)
+{
+	g_test_add_func("/panic/panic", test_panic);
+	g_test_add_func("/panic/panic_with_errno", test_panic_with_errno);
+	g_test_add_func("/panic/panic_customization", test_panic_customization);
+}

--- a/cmd/libsnap-confine-private/panic.c
+++ b/cmd/libsnap-confine-private/panic.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "panic.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static sc_panic_exit_fn panic_exit_fn = NULL;
+static sc_panic_msg_fn panic_msg_fn = NULL;
+
+void sc_panic(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    sc_panicv(fmt, ap);
+    va_end(ap);
+}
+
+void sc_panicv(const char *fmt, va_list ap) {
+    int errno_copy = errno;
+
+    if (panic_msg_fn != NULL) {
+        panic_msg_fn(fmt, ap, errno_copy);
+    } else {
+        vfprintf(stderr, fmt, ap);
+        if (errno != 0) {
+            fprintf(stderr, ": %s\n", strerror(errno_copy));
+        } else {
+            fprintf(stderr, "\n");
+        }
+    }
+
+    if (panic_exit_fn != NULL) {
+        panic_exit_fn();
+    }
+    exit(1);
+}
+
+sc_panic_exit_fn sc_set_panic_exit_fn(sc_panic_exit_fn fn) {
+    sc_panic_exit_fn old = panic_exit_fn;
+    panic_exit_fn = fn;
+    return old;
+}
+
+sc_panic_msg_fn sc_set_panic_msg_fn(sc_panic_msg_fn fn) {
+    sc_panic_msg_fn old = panic_msg_fn;
+    panic_msg_fn = fn;
+    return old;
+}

--- a/cmd/libsnap-confine-private/panic.h
+++ b/cmd/libsnap-confine-private/panic.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SC_PANIC_H
+#define SC_PANIC_H
+
+#include <stdarg.h>
+
+/**
+ * sc_panic is an exit-with-message utility function.
+ *
+ * The function takes a printf-like format string that is formatted and printed
+ * somehow. The function then terminates the process by calling exit. Both
+ * aspects can be customized.
+ *
+ * The particular nature of the exit can be customized by calling
+ * sc_set_panic_action. The panic action is a function that is called before
+ * attempting to exit.
+ *
+ * The way the error message is formatted and printed can be customized by
+ * calling sc_set_panic_format_fn(). By default the error is printed to
+ * standard error. If the error is related to a system call failure then errno
+ * can be set to a non-zero value just prior to calling sc_panic. The value
+ * will then be used when crafting the error message.
+ **/
+__attribute__((noreturn, format(printf, 1, 2))) void sc_panic(const char *fmt, ...);
+
+/**
+ * sc_panicv is a variant of sc_panic with an argument list.
+ **/
+__attribute__((noreturn)) void sc_panicv(const char *fmt, va_list ap);
+
+/**
+ * sc_panic_exit_fn is the type of the exit function used by sc_panic().
+ **/
+typedef void (*sc_panic_exit_fn)(void);
+
+/**
+ * sc_set_panic_exit_fn sets the panic exit function.
+ *
+ * When sc_panic is called it will eventually exit the running process. Just
+ * prior to that, it will call the panic exit function, if one has been set.
+ *
+ * If exiting the process is undesired, for example while running in intrd as
+ * pid 1, during the system shutdown phase, then a process can set the panic
+ * exit function. Note that if the specified function returns then panic will
+ * proceed to call exit(3) anyway.
+ *
+ * The old exit function, if any, is returned.
+ **/
+sc_panic_exit_fn sc_set_panic_exit_fn(sc_panic_exit_fn fn);
+
+/**
+ * sc_panic_msg_fn is the type of the format function used by sc_panic().
+ **/
+typedef void (*sc_panic_msg_fn)(const char *fmt, va_list ap, int errno_copy);
+
+/**
+ * sc_set_panic_msg_fn sets the panic message function.
+ *
+ * When sc_panic is called it will attempt to print an error message to
+ * standard error. The message includes information provided by the caller: the
+ * format string, the argument vector for a printf-like function as well as a
+ * copy of the system errno value, which may be zero if the error is not
+ * originated by a system call error.
+ *
+ * If custom formatting of the error message is desired, for example while
+ * running in initrd as pid 1, during the system shutdown phase, then a process
+ * can set the panic message function. Once set the function takes over the
+ * responsibility of printing an error message (in whatever form is
+ * appropriate).
+ *
+ * The old message function, if any, is returned.
+ **/
+sc_panic_msg_fn sc_set_panic_msg_fn(sc_panic_msg_fn fn);
+
+#endif

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -23,23 +23,16 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "utils.h"
 #include "cleanup-funcs.h"
+#include "panic.h"
+#include "utils.h"
 
 void die(const char *msg, ...)
 {
-	int saved_errno = errno;
-	va_list va;
-	va_start(va, msg);
-	vfprintf(stderr, msg, va);
-	va_end(va);
-
-	if (errno != 0) {
-		fprintf(stderr, ": %s\n", strerror(saved_errno));
-	} else {
-		fprintf(stderr, "\n");
-	}
-	exit(1);
+	va_list ap;
+	va_start(ap, msg);
+	sc_panicv(msg, ap);
+	va_end(ap);
 }
 
 struct sc_bool_name {

--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -53,19 +53,6 @@ void kmsg(const char *fmt, ...)
 	va_end(va);
 }
 
-__attribute__((noreturn))
-void die(const char *msg)
-{
-	if (errno == 0) {
-		kmsg("*** %s", msg);
-	} else {
-		kmsg("*** %s: %s", msg, strerror(errno));
-	}
-	sync();
-	reboot(RB_HALT_SYSTEM);
-	exit(1);
-}
-
 int sc_read_reboot_arg(char *arg, size_t max_size)
 {
 	FILE *f;

--- a/cmd/system-shutdown/system-shutdown.c
+++ b/cmd/system-shutdown/system-shutdown.c
@@ -46,7 +46,7 @@ static void show_error(const char *fmt, va_list ap, int errno_copy)
 	fprintf(stderr, "\n");
 }
 
-static void sync_and_reboot(void)
+static void sync_and_halt(void)
 {
 	sync();
 	reboot(RB_HALT_SYSTEM);
@@ -55,7 +55,7 @@ static void sync_and_reboot(void)
 int main(int argc, char *argv[])
 {
 	sc_set_panic_msg_fn(show_error);
-	sc_set_panic_exit_fn(sync_and_reboot);
+	sc_set_panic_exit_fn(sync_and_halt);
 
 	// 256 should be more than enough...
 	char reboot_arg[256] = { 0 };

--- a/cmd/system-shutdown/system-shutdown.c
+++ b/cmd/system-shutdown/system-shutdown.c
@@ -33,9 +33,30 @@
 
 #include "system-shutdown-utils.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/panic.h"
+
+static void show_error(const char *fmt, va_list ap, int errno_copy)
+{
+	fprintf(stderr, "snapd system-shutdown helper: ");
+	fprintf(stderr, "*** ");
+	vfprintf(stderr, fmt, ap);
+	if (errno_copy != 0) {
+		fprintf(stderr, ": %s", strerror(errno_copy));
+	}
+	fprintf(stderr, "\n");
+}
+
+static void sync_and_reboot(void)
+{
+	sync();
+	reboot(RB_HALT_SYSTEM);
+}
 
 int main(int argc, char *argv[])
 {
+	sc_set_panic_msg_fn(show_error);
+	sc_set_panic_exit_fn(sync_and_reboot);
+
 	// 256 should be more than enough...
 	char reboot_arg[256] = { 0 };
 


### PR DESCRIPTION
Historically we inherited die() from ubuntu-core-launcher. It underwent a few
small changes but otherwise retained its function for print-and-quit helper.
This was true until system-shutdown was first implemented. There die existed as
a function with the same purpose but different implementation. The changes were
motivated by desire to fit the environment in which system-shutdown executes:
it runs as the last PID of the system and should not just exit. Therefore the
implementation called sync and reboot. The output of the message was also
formatted differently to fit other messages printed by the system at the same
time.

At some point, system-shutdown started to use all of libsnap-confine-private,
not just a single module. This presented a problem because now die() was
defined twice. Oddly, this went unnoticed until
https://github.com/snapcore/snapd/pull/7358 was opened, trying to resolve the
problem.

After some inspection I decided to implement the following solution. There is
only one die(), it always does what it says on the tin. Die is now implemented
with a new function, sc_panic(), which is just like die but can be tweaked in
two ways: the way the error is printed and the way the process is exited. This
is exactly what system-shutdown needed to change.

The panic module comes with simple tests and documentation. 
