### PR TITLE
cmd/snap-confine: fix group and permission of .info files

### DIFF
--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -10,8 +10,13 @@ execute: |
   # snap runs on top of the core16 runtime environment. This can be seen by
   # looking at the os-release file which will match that of ubuntu core 16.
   snap install --dangerous test-snapd-core-migration_1_all.snap
-  test-snapd-core-migration.sh -c "cat /usr/lib/os-release" | MATCH 'VERSION_ID="16"'
+  su test -c 'snap run test-snapd-core-migration.sh -c "cat /usr/lib/os-release"' | MATCH 'VERSION_ID="16"'
+
+  # The mount namespace information file is owned by root.root and has mode 0644
+  # even though the user invoking the snap command was non-root.
   MATCH 'base-snap-name=core' < /run/snapd/ns/snap.test-snapd-core-migration.info
+  test "$(stat -c '%u.%g' /run/snapd/ns/snap.test-snapd-core-migration.info)" = 0.0
+  test "$(stat -c '%a'    /run/snapd/ns/snap.test-snapd-core-migration.info)" = 644
 
   # When said snap is refreshed to use "base: core18" then, because there are
   # no active processes in that snap, the base will change correctly to core18.


### PR DESCRIPTION
The .info files stored in /run/snapd/ns were group owned by the user
first invoking "snap run" chain for a specific snap and were, in
addition, world writable, due to umask changes and usage of implicit
creation mode.

This patch fixes both of those issues and adds a check to an existing
spread test.

Fixes: https://bugs.launchpad.net/bugs/1841613
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
