### PR TITLE
interfaces/gpg-keys: Allow access to gpg-agent and creation of lockfiles

### DIFF
--- a/interfaces/builtin/gpg_keys.go
+++ b/interfaces/builtin/gpg_keys.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const gpgKeysSummary = `allows reading gpg user configuration and keys and updating gpg's random seed file`
+const gpgKeysSummary = `allows limited access to gpg-agent, reading gpg user configuration and keys and updating gpg's random seed file`
 
 const gpgKeysBaseDeclarationSlots = `
   gpg-keys:
@@ -49,6 +49,15 @@ deny @{HOME}/.gnupg/trustdb.gpg w,
 # trust to access the user's keys and the level of trust for the random_seed
 # is commensurate with accessing the private keys.
 owner @{HOME}/.gnupg/random_seed wk,
+
+# allow access to gpg-agent's extra socket for passphrase entry.
+# This socket exposes a very limited subset of gpg-agent's functionality and
+# only allows the confined application to use gpg's cryptographic functions
+# but not anything related to managing the keys (adding, trusting etc).
+owner /run/user/[0-9]*/gnupg/S.gpg-agent.extra wr,
+
+# gpg creates lockfiles on every invocation
+owner @{HOME}/.gnupg/.#lk* rwk,
 `
 
 func init() {

--- a/interfaces/builtin/gpg_keys_test.go
+++ b/interfaces/builtin/gpg_keys_test.go
@@ -83,7 +83,7 @@ func (s *GpgKeysInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, true)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, Equals, `allows reading gpg user configuration and keys and updating gpg's random seed file`)
+	c.Assert(si.Summary, Equals, `allows limited access to gpg-agent, reading gpg user configuration and keys and updating gpg's random seed file`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "gpg-keys")
 }
 


### PR DESCRIPTION
See related discussion in https://forum.snapcraft.io/t/signing-files-with-gpg-from-within-a-snap/5566/4

gpg-keys as of now is not really usable for the following reasons:

1. gpg-agent needs to be invoked for passphrase entry. At the moment, access to its socket is forbidden
2. gpg wants to create lockfiles on each invocation in ~/.gnupg. This is also not allowed as of now

This change adds apparmor policies for those two cases.

I have signed the CLA (launchpad id: ppd) ~~but have not yet received any email response.~~ and have been added to the launchpad group.