### PR TITLE
tests: fix ephemeral mount table in left over by prepare

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -523,11 +523,6 @@ prepare: |
         fi
     fi
 
-    if [[ "$SPREAD_SYSTEM" == ubuntu-* ]] && [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
-        apt-get remove --purge -y lxd lxcfs || true
-        apt-get autoremove --purge -y
-    fi
-
     if [[ "$SPREAD_SYSTEM" == debian-* ]]; then
         apt-get update && apt-get install -y eatmydata
     fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -225,7 +225,7 @@ fixup_after_lxd() {
     # +37 32 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,cpuset,clone_children
     #
     # To restore vanilla state, disable the option now.
-    if [ -e /sys/fs/cgroup/cpuset ]; then
+    if mountinfo-tool /sys/fs/cgroup/cpuset; then
         echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
     fi
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -239,7 +239,9 @@ fixup_after_lxd() {
     # To restore vanilla state, enable the option now, but only if the kernel supports that.
     # https://lore.kernel.org/patchwork/patch/803265/
     # https://github.com/systemd/systemd/commit/4095205ecccdfddb822ee8fdc44d11f2ded9be24
-    if [ "$(mountinfo-tool /sys/fs/cgroup/unified .fs_type)" = cgroup2 ] && version-tool --naive "$(uname -r)" -ge 4.13; then
+    # The kernel version must be made compatible with the strict version
+    # comparison. I chose to cut at the "-" and take the stuff before it.
+    if [ "$(mountinfo-tool /sys/fs/cgroup/unified .fs_type)" = cgroup2 ] && version-tool --strict "$(uname -r | cut -d- -f 1)" -ge 4.13; then
         mount -o remount,nsdelegate /sys/fs/cgroup/unified
     fi
 }

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -217,7 +217,7 @@ install_dependencies_from_published(){
     done
 }
 
-fixup_after_lxd() {
+undo_lxd_mount_changes() {
     # Vanilla systems have /sys/fs/cgroup/cpuset without clone_children option.
     # Using LXD to create a container enables this option, as can be seen here:
     #
@@ -254,7 +254,7 @@ prepare_project() {
     if [[ "$SPREAD_SYSTEM" == ubuntu-* ]] && [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y
-        fixup_after_lxd
+        undo_lxd_mount_changes
     fi
 
     # Check if running inside a container.
@@ -694,7 +694,7 @@ restore_project_each() {
             ;;
     esac
 
-    fixup_after_lxd
+    undo_lxd_mount_changes
 }
 
 restore_project() {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -236,7 +236,7 @@ fixup_after_lxd() {
     # +32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup rw
     #
     # To restore vanilla state, enable the option now.
-    if [ -e /sys/fs/cgroup/unified ]; then
+    if mountinfo-tool /sys/fs/cgroup/unified; then
         mount -o remount,nsdelegate /sys/fs/cgroup/unified
     fi
 }

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/HOST.expected.txt
@@ -22,7 +22,7 @@
 22 21 1:15 / /sys/fs/cgroup rw shared:22 - tmpfs tmpfs rw,mode=755
 23 22 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 24 22 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
-25 22 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
+25 22 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
 26 22 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
 27 22 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
 28 22 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
@@ -36,7 +36,7 @@
 1036 1035 1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
 1037 1036 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 1038 1036 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1039 1036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+1039 1036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 1040 1036 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 1041 1036 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 1042 1036 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
@@ -36,7 +36,7 @@
 1036 1035 1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
 1037 1036 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 1038 1036 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1039 1036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+1039 1036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 1040 1036 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 1041 1036 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 1042 1036 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-C7.expected.txt
@@ -22,7 +22,7 @@
 22 21 1:15 / /sys/fs/cgroup rw shared:22 - tmpfs tmpfs rw,mode=755
 23 22 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 24 22 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
-25 22 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
+25 22 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
 26 22 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
 27 22 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
 28 22 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
@@ -36,7 +36,7 @@
 2036 2035 1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
 2037 2036 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 2038 2036 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-2039 2036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+2039 2036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 2040 2036 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 2041 2036 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 2042 2036 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
@@ -36,7 +36,7 @@
 2036 2035 1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
 2037 2036 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 2038 2036 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-2039 2036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+2039 2036 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 2040 2036 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 2041 2036 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 2042 2036 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-C7.expected.txt
@@ -22,7 +22,7 @@
 22 21 1:15 / /sys/fs/cgroup rw shared:22 - tmpfs tmpfs rw,mode=755
 23 22 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 24 22 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
-25 22 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
+25 22 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
 26 22 1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
 27 22 1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
 28 22 1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/HOST.expected.txt
@@ -22,7 +22,7 @@
 22 21 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:22 - tmpfs tmpfs ro,mode=755
 23 22 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 24 22 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
-25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
+25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
 26 22 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
 27 22 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
 28 22 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb
@@ -32,7 +32,7 @@
 32 22 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:32 - cgroup cgroup rw,pids
 33 22 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:33 - cgroup cgroup rw,rdma
 34 22 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:34 - cgroup cgroup rw,xattr,name=systemd
-35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw
+35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw,nsdelegate
 36 21 1:28 / /sys/fs/fuse/connections rw,relatime shared:36 - fusectl fusectl rw
 37 21 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:37 - pstore pstore rw
 38 21 1:30 / /sys/kernel/config rw,relatime shared:38 - configfs configfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
@@ -34,7 +34,7 @@
 1034 1033 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
 1035 1034 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 1036 1034 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1037 1034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+1037 1034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 1038 1034 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 1039 1034 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 1040 1034 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
@@ -44,7 +44,7 @@
 1044 1034 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
 1045 1034 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
 1046 1034 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-1047 1034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw
+1047 1034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
 1048 1033 1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
 1049 1033 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
 1050 1033 1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
@@ -34,7 +34,7 @@
 1034 1033 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
 1035 1034 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 1036 1034 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1037 1034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+1037 1034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 1038 1034 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 1039 1034 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 1040 1034 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
@@ -44,7 +44,7 @@
 1044 1034 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
 1045 1034 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
 1046 1034 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-1047 1034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw
+1047 1034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
 1048 1033 1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
 1049 1033 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
 1050 1033 1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
@@ -22,7 +22,7 @@
 22 21 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:22 - tmpfs tmpfs ro,mode=755
 23 22 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 24 22 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
-25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
+25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
 26 22 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
 27 22 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
 28 22 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb
@@ -32,7 +32,7 @@
 32 22 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:32 - cgroup cgroup rw,pids
 33 22 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:33 - cgroup cgroup rw,rdma
 34 22 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:34 - cgroup cgroup rw,xattr,name=systemd
-35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw
+35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw,nsdelegate
 36 21 1:28 / /sys/fs/fuse/connections rw,relatime shared:36 - fusectl fusectl rw
 37 21 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:37 - pstore pstore rw
 38 21 1:30 / /sys/kernel/config rw,relatime shared:38 - configfs configfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
@@ -34,7 +34,7 @@
 2034 2033 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
 2035 2034 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 2036 2034 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-2037 2034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+2037 2034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 2038 2034 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 2039 2034 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 2040 2034 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
@@ -44,7 +44,7 @@
 2044 2034 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
 2045 2034 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
 2046 2034 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-2047 2034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw
+2047 2034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
 2048 2033 1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
 2049 2033 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
 2050 2033 1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
@@ -34,7 +34,7 @@
 2034 2033 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
 2035 2034 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
 2036 2034 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-2037 2034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset,clone_children
+2037 2034 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
 2038 2034 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
 2039 2034 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
 2040 2034 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
@@ -44,7 +44,7 @@
 2044 2034 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
 2045 2034 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
 2046 2034 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-2047 2034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw
+2047 2034 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
 2048 2033 1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
 2049 2033 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
 2050 2033 1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
@@ -22,7 +22,7 @@
 22 21 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:22 - tmpfs tmpfs ro,mode=755
 23 22 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 24 22 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
-25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
+25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
 26 22 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
 27 22 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
 28 22 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb
@@ -32,7 +32,7 @@
 32 22 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:32 - cgroup cgroup rw,pids
 33 22 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:33 - cgroup cgroup rw,rdma
 34 22 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:34 - cgroup cgroup rw,xattr,name=systemd
-35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw
+35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw,nsdelegate
 36 21 1:28 / /sys/fs/fuse/connections rw,relatime shared:36 - fusectl fusectl rw
 37 21 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:37 - pstore pstore rw
 38 21 1:30 / /sys/kernel/config rw,relatime shared:38 - configfs configfs rw

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -66,8 +66,8 @@ prepare: |
             # and released this test can be allowed to run on bash 4.3. Without
             # the workaround for a bug in bash REBOOT causes the spread test to
             # fail instead of asking spread to reboot the machine.
-            if version-tool --naive "$(LANG=C bash --version | head -n 1 | cut -d ' ' -f 4)" -lt 4.4; then
-                echo "SKIP: this test cannot operate on bash 4.3.x or older"
+            if version-tool --strict "$(echo "$BASH_VERSION" | cut -d. -f 1-2)" -eq 4.3; then
+                echo "SKIP: this test cannot operate on bash 4.3.x"
                 touch please-skip-this-test
                 exit 0
             fi

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -52,7 +52,37 @@ details: |
     If you see this test randomly failing it may be because it has observed
     state leaked by another test that ran on the same machine earlier in the
     spread  execution chain.
+environment:
+    MACHINE_STATE/inherit: inherit
+    MACHINE_STATE/reboot: reboot
 prepare: |
+    case "$MACHINE_STATE" in
+        inherit)
+            # The test will run with whatever the machine state was originally.
+            true
+        ;;
+        reboot)
+            # TODO: when https://github.com/snapcore/spread/pull/85 is merged
+            # and released this test can be allowed to run on bash 4.3. Without
+            # the workaround for a bug in bash REBOOT causes the spread test to
+            # fail instead of asking spread to reboot the machine.
+            case "$(LANG=C bash --version | head -n 1 | cut -d ' ' -f 4)" in
+                4.3.*)
+                echo "SKIP: this test cannot operate on bash 4.3.x"
+                touch please-skip-this-test
+                exit 0
+                ;;
+            esac
+            #
+            # The test will reboot once before performing the test. This will
+            # remove any ephemeral state that may be left in the kernel by prior
+            # test cases or by project-wide prepare that is does not persist across
+            # boots.
+            if [ "$SPREAD_REBOOT" -eq 0 ]; then
+                REBOOT
+            fi
+        ;;
+    esac
     # The --renumber and --rename options renumber and rename various
     # non-deterministic elements of the mount table. The --ref-x1000 option
     # sets a multiple of 1000 as the base value for allocated renumbered
@@ -132,6 +162,9 @@ prepare: |
     snap remove test-snapd-mountinfo-core16
     snap remove test-snapd-mountinfo-core18
 execute: |
+    if [ -e please-skip-this-test ]; then
+        exit 0
+    fi
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/HOST.expected.txt" HOST.deterministic.txt
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/PER-SNAP-16.expected.txt" PER-SNAP-16.deterministic.txt
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/PER-USER-16.expected.txt" PER-USER-16.deterministic.txt
@@ -146,6 +179,7 @@ restore: |
     rm -f test-snapd-mountinfo-classic_1_all.snap
     rm -f test-snapd-mountinfo-core16_1_all.snap
     rm -f test-snapd-mountinfo-core18-1_all.snap
+    rm -f please-skip-this-test
 debug: |
     for fname in ./*.deterministic.txt; do
         echo

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -66,13 +66,11 @@ prepare: |
             # and released this test can be allowed to run on bash 4.3. Without
             # the workaround for a bug in bash REBOOT causes the spread test to
             # fail instead of asking spread to reboot the machine.
-            case "$(LANG=C bash --version | head -n 1 | cut -d ' ' -f 4)" in
-                4.3.*)
-                echo "SKIP: this test cannot operate on bash 4.3.x"
+            if version-tool --naive "$(LANG=C bash --version | head -n 1 | cut -d ' ' -f 4)" -lt 4.4; then
+                echo "SKIP: this test cannot operate on bash 4.3.x or older"
                 touch please-skip-this-test
                 exit 0
-                ;;
-            esac
+            fi
             #
             # The test will reboot once before performing the test. This will
             # remove any ephemeral state that may be left in the kernel by prior


### PR DESCRIPTION
After fighting leaky tests for several weeks and coming up with, in my
eyes, a reliable detector of state change from test to test I was quite
surprised by the failure of tests/main/mount-ns on master, just a day
after landing the pull request re-enabling that test.

What was even more surprising was that while the failure was clearly
related to LXD, indicated by the clone_children and nsdelegate changes
(see below), the history of the machine had none of the LXD tests in it.
So what could it be?

    2019-08-28 07:45:24 Error executing google:ubuntu-18.04-64:tests/main/mount-ns :
    -----
    + diff -u google.ubuntu-18.04-64/HOST.expected.txt HOST.deterministic.txt
    --- google.ubuntu-18.04-64/HOST.expected.txt	2019-08-28 07:23:20.000000000 +0000
    +++ HOST.deterministic.txt	2019-08-28 07:45:21.314648841 +0000
    @@ -22,7 +22,7 @@
     22 21 1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:22 - tmpfs tmpfs ro,mode=755
     23 22 1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
     24 22 1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
    -25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset,clone_children
    +25 22 1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset
     26 22 1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,devices
     27 22 1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,freezer
     28 22 1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:28 - cgroup cgroup rw,hugetlb
    @@ -32,7 +32,7 @@
     32 22 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:32 - cgroup cgroup rw,pids
     33 22 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:33 - cgroup cgroup rw,rdma
     34 22 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:34 - cgroup cgroup rw,xattr,name=systemd
    -35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw
    +35 22 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:35 - cgroup2 cgroup rw,nsdelegate
     36 21 1:28 / /sys/fs/fuse/connections rw,relatime shared:36 - fusectl fusectl rw
     37 21 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:37 - pstore pstore rw
     38 21 1:30 / /sys/kernel/config rw,relatime shared:38 - configfs configfs rw

Whatever was causing this, must be related to LXD but not to the LXD
test itself. A quick inspection of the dozen-or-so tests involved in the
failed run has made me realize something. The test machine had rebooted
as a part of another test.

A quick patch, like the one seen below was enough to reproduce the
failure each time. This meant that the test machine was broken even
before *any* test had executed. How is that possible?

    diff --git a/tests/main/mount-ns/task.yaml b/tests/main/mount-ns/task.yaml
    index 14bfb30b74..1b0b9c0d5d 100644
    --- a/tests/main/mount-ns/task.yaml
    +++ b/tests/main/mount-ns/task.yaml
    @@ -53,6 +53,9 @@ details: |
         state leaked by another test that ran on the same machine earlier in the
         spread  execution chain.
     prepare: |
    +    if [ "$SPREAD_REBOOT" -eq 0 ]; then
    +        REBOOT 1
    +    fi
         # The --renumber and --rename options renumber and rename various
         # non-deterministic elements of the mount table. The --ref-x1000 option
         # sets a multiple of 1000 as the base value for allocated renumbered

So what else touches LXD? To my surprise, `spread.yaml` does. This is an
excerpt from the project-wide prepare stanza:

    if [[ "$SPREAD_SYSTEM" == ubuntu-* ]] && [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
        apt-get remove --purge -y lxd lxcfs || true
        apt-get autoremove --purge -y
    fi

So on startup, we remove / purge LXD. This means LXD was installed, did
its thing to change the mount table and we removed it, keeping the only
trace of that fact in the running kernel. As soon as we reboot the
system is in a pristine state.

This explains why the `tests/main/mount-ns` test, which was written by
observing the mount table of a spread system on the initial boot,
immediately fails if the test machine reboots before performing
measurements.

To verify this I created a small spread project which captures
measurements three times. This is the essential part of the test:

        if [ "$SPREAD_REBOOT" -eq 0 ]; then
            cat /proc/self/mountinfo > /var/tmp/mountinfo.initial
            case "$SPREAD_SYSTEM" in
                ubuntu-*)
                    apt-get remove --purge -y lxd lxcfs || true
                    apt-get autoremove --purge -y
                    ;;
            esac
            cat /proc/self/mountinfo > /var/tmp/mountinfo.post-lxd-removal
            REBOOT
        else
            cat /proc/self/mountinfo > /var/tmp/mountinfo.post-reboot
        fi

This test showed the following things:
 - removing LXD immediately unmounts /var/lib/lxcfs
 - removing LXD means that the next boot will have vanilla cgroups from
   systemd, since LXD won't change them on startup

In practice the change to cgroups that LXD is doing is:
   /sys/fs/cgroup/unified is mounted *without* nsdelegate
   /sys/fs/cgroup/cpuset has clone_children *disabled*.
Note that clone_children is only applied if LXD is actually used to
create a container.

You can see the diff of the mountinfo tables below. Note that each table
was re-written with mountinfo-tool so that it is deterministic and
comparable.

    google:ubuntu-18.04-64 ...# diff -u det.initial det.post-lxd-removal
    --- det.initial	2019-08-28 13:26:37.073255599 +0000
    +++ det.post-lxd-removal	2019-08-28 13:26:29.793015207 +0000
    @@ -36,4 +36,3 @@
     36 19 1:30 / /sys/kernel/config rw,relatime shared:36 - configfs configfs rw
     37 19 1:31 / /sys/kernel/debug rw,relatime shared:37 - debugfs debugfs rw
     38 19 1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:38 - securityfs securityfs rw
    -39 1 1:33 / /var/lib/lxcfs rw,nosuid,nodev,relatime shared:39 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other

    google:ubuntu-18.04-64 ...# diff -u det.post-lxd-removal det.post-reboot
    --- det.post-lxd-removal	2019-08-28 13:26:29.793015207 +0000
    +++ det.post-reboot	2019-08-28 13:26:21.120728849 +0000
    @@ -30,7 +30,7 @@
     30 20 1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:30 - cgroup cgroup rw,pids
     31 20 1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:31 - cgroup cgroup rw,rdma
     32 20 1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:32 - cgroup cgroup rw,xattr,name=systemd
    -33 20 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:33 - cgroup2 cgroup rw
    +33 20 1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:33 - cgroup2 cgroup rw,nsdelegate
     34 19 1:28 / /sys/fs/fuse/connections rw,relatime shared:34 - fusectl fusectl rw
     35 19 1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:35 - pstore pstore rw
     36 19 1:30 / /sys/kernel/config rw,relatime shared:36 - configfs configfs rw

So what can we do now? The primary goal is to make the mount namespace
test stable. It must not depend the number of reboots done by tests that
execute before it does.

We can achieve that in one of two ways:
 - make the device under test behave as if LXD was installed
 - make the device under test behave as if LXD was never installed

I chose option number two, simply because we have multiple distributions
that don't have LXD pre-installed so it's easier to compare their
initial state this way. As mentioned above we want to *not* have
/var/lib/lxcfs and to have /sys/fs/cgroup/unified mounted with the
nsdelegate mount option. Fortunately both are easy to achieve. In
practice we only have to handle the unified cgroup because the removal
of LXD handles lxcfs for us.

This patch performs the following changes:

1) Restore cpuset and unified cgroup hierarchy state after removing lxd
in project-wide prepare, as well as in the per-test restore, to the
values the system ships with by default. This handles both the initial
state of the system as well as the state after execution of a particular
test using LXD.

2) Adjust the mount-ns test dataset to use the now-pristine
configuration. This is done to inactive datasets as well, namely to
core.

3) Introduce a new variant of the mount-ns test that first reboots the
machine and then performs the same set of measurements. This ensures
that claim 2) is correct. There's some sour grapes here though. Due to
the bug in bash 4.3 we cannot freely reboot in 16.04 system, so there
the fix is not fully tested yet.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
