### PR TITLE
snapstate: add comment to checkVersion vs strutil.VersionCompare

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -199,6 +199,7 @@ func checkAssumes(si *snap.Info) error {
 var versionExp = regexp.MustCompile(`^([1-9][0-9]*)(?:\.([0-9]+)(?:\.([0-9]+))?)?`)
 
 func checkVersion(version string) bool {
+	// double check that the input looks like a snapd version
 	req := versionExp.FindStringSubmatch(version)
 	if req == nil || req[0] != version {
 		return false
@@ -208,6 +209,10 @@ func checkVersion(version string) bool {
 		return true // Development tree.
 	}
 
+	// We could (should?) use strutil.VersionCompare here and simplify
+	// this code (see PR#7344). However this would change current
+	// behavior, i.e. "2.41~pre1" would *not* match [snapd2.41] anymore
+	// (which the code below does).
 	cur := versionExp.FindStringSubmatch(cmd.Version)
 	if cur == nil {
 		return false

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -151,6 +151,11 @@ var assumesTests = []struct {
 	version: "2.15.0",
 	error:   `.* unsupported features: snapd2\.15\.1 .*`,
 }, {
+	// Note that this is different from how strconv.VersionCompare
+	// (dpkg version numbering) would behave - it would error here
+	assumes: "[snapd2.15]",
+	version: "2.15~pre1",
+}, {
 	assumes: "[command-chain]",
 }}
 


### PR DESCRIPTION
We are using a custom version compare in snapstate.checkVersion()
which is subtly different from the way strutil.VersionCompare
works (which we use in the other places where we compare versions).

The difference is that checkVersion() does not give a special meaning to 
`~` which in the dpkg version compare we use means "lower" 
so 1.0~ is lower than 1.0.

This means an "assumes: [snapd2.41]" is satisfied by snapd version
2.41~pre1.

We need to decide if that is what we want, right now this PR just
adds a test to make this explicit and adds a note about it.

If we want to change it we can use
https://github.com/snapcore/snapd/pull/7344
