### PR TITLE
tests: add version-tool for comparing versions

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -270,9 +270,11 @@ if [ "$UNIT" = 1 ]; then
         fi
     fi
 
-    # python unit test for mountinfo-tool
+    # python unit test for mountinfo-tool and version-tool
     command -v python2 && python2 ./tests/lib/bin/mountinfo-tool --run-unit-tests
     command -v python3 && python3 ./tests/lib/bin/mountinfo-tool --run-unit-tests
+    command -v python2 && python2 ./tests/lib/bin/version-tool --run-unit-tests
+    command -v python3 && python3 ./tests/lib/bin/version-tool --run-unit-tests
 fi
 
 if [ -n "$SPREAD" ]; then

--- a/tests/lib/bin/version-tool
+++ b/tests/lib/bin/version-tool
@@ -122,95 +122,6 @@ class ConsistentRelationTests(unittest.TestCase):
             consistent_relation("???", 0)
 
 
-def numeric_part_of(text):
-    # type: (Text) -> int
-    """
-    numeric_part_of returns the integer representing the numeric portion of text.
-
-    If text does not start with an natural number the result is zero. The
-    function never fails. Negative numbers are not supported because they are
-    meaningless for version numbers.
-    """
-    match = re.match("^([0-9]+)", text)
-    if match:
-        return int(match.group(1))
-    return 0
-
-
-class NumericPartOfTests(unittest.TestCase):
-    def test_simple(self):
-        # type: () -> None
-        self.assertEqual(numeric_part_of("12"), 12)
-        self.assertEqual(numeric_part_of("12-stuff"), 12)
-        self.assertEqual(numeric_part_of("stuff-12"), 0)
-        self.assertEqual(numeric_part_of("-12"), 0)
-
-
-def naive_version_cmp(a, b):
-    # type: (Text, Text) -> int
-    """
-    naive_version_cmp naively compares two version numbers.
-
-    The algorithm considers each version to be a tuple of integers. Non,
-    integer elements or element fragments are discarded.
-
-    Comparison is performed on by considering the leftmost element in each
-    tuple. First pair of numbers that are not equal determine the result of the
-    comparison. Tuples have unequal length then missing elements are
-    substituted with zero.
-
-    The return value is 0 if the version strings are equal, -1 if version a is
-    smaller or +1 if version b is smaller.
-    """
-    a_items = a.split(".")
-    b_items = b.split(".")
-    if PY2:
-        zip_longest_fn = itertools.izip_longest
-    else:
-        zip_longest_fn = itertools.zip_longest
-    for a_item, b_item in zip_longest_fn(a_items, b_items, fillvalue="0"):
-        a_val = numeric_part_of(a_item)
-        b_val = numeric_part_of(b_item)
-        delta = a_val - b_val
-        if delta != 0:
-            return 1 if delta > 0 else -1
-    return 0
-
-
-class NaiveVersionCmpTests(unittest.TestCase):
-    def test_simple(self):
-        # type: () -> None
-        self.assertEqual(naive_version_cmp("10", "10"), 0)
-        self.assertEqual(naive_version_cmp("10", "20"), -1)
-        self.assertEqual(naive_version_cmp("20", "10"), +1)
-
-    def test_many_segments(self):
-        # type: () -> None
-        self.assertEqual(naive_version_cmp("1.2.3", "1.2.3"), 0)
-        self.assertEqual(naive_version_cmp("1.2.3", "1.3.4"), -1)
-        self.assertEqual(naive_version_cmp("1.4.3", "1.2.3"), +1)
-        self.assertEqual(naive_version_cmp("1.0.0", "1.1.0"), -1)
-        self.assertEqual(naive_version_cmp("0.1.2", "1.1.2"), -1)
-
-    def test_unequal_length(self):
-        # type: () -> None
-        self.assertEqual(naive_version_cmp("1", "1.0"), 0)
-        self.assertEqual(naive_version_cmp("1", "1.2"), -1)
-        self.assertEqual(naive_version_cmp("1.2", "1"), +1)
-        self.assertEqual(naive_version_cmp("1", "1.0.1"), -1)
-        self.assertEqual(naive_version_cmp("1.1", "1.0.1"), +1)
-
-    def test_version_with_text(self):
-        # type: () -> None
-        self.assertEqual(naive_version_cmp("1-foo", "1-bar"), 0)
-        self.assertEqual(naive_version_cmp("1-foo.2-froz", "1-bar"), +1)
-        self.assertEqual(naive_version_cmp("1-foo.2-froz", "1-bar.3-quux"), -1)
-
-    def test_kernel_version(self):
-        # type: () -> None
-        self.assertEqual(naive_version_cmp("5.2.9-1-default", "4.13"), +1)
-
-
 def strict_version_cmp(a, b):
     # type: (Text, Text) -> int
     """
@@ -290,15 +201,6 @@ Relational operator is one of:
 
 Version comparison is performed using the selected algorithm.
 
-naive:
-    The algorithm considers each version to be a tuple of integers.
-    Non-integer elements or element fragments are discarded.
-
-    Comparison is performed on by considering the leftmost element in each
-    tuple. First pair of numbers that are not equal determine the result of the
-    comparison. Tuples have unequal length then missing elements are
-    substituted with zero.
-
 strict:
     The algorithm considers each version to be a tuple of integers.
     Non-integer elements are considered to be invalid version.
@@ -321,13 +223,6 @@ strict:
 
     # algorithm selection
     alg_grp = parser.add_mutually_exclusive_group(required=True)
-    alg_grp.add_argument(
-        "--naive",
-        dest="algorithm",
-        action="store_const",
-        const=naive_version_cmp,
-        help="select the naive version comparison",
-    )
     alg_grp.add_argument(
         "--strict",
         dest="algorithm",

--- a/tests/lib/bin/version-tool
+++ b/tests/lib/bin/version-tool
@@ -279,7 +279,7 @@ naive:
     rel_op_grp.add_argument(
         "-lt",
         action="store_const",
-        const="<=",
+        const="<",
         dest="rel_op",
         help="test that version-a is less than version-b",
     )

--- a/tests/lib/bin/version-tool
+++ b/tests/lib/bin/version-tool
@@ -5,6 +5,7 @@ from argparse import Action, ArgumentParser, RawTextHelpFormatter, SUPPRESS
 import itertools
 import re
 import sys
+import sys
 import unittest
 
 # PY2 is true when we're running under Python 2.x It is used for appropriate
@@ -210,6 +211,75 @@ class NaiveVersionCmpTests(unittest.TestCase):
         self.assertEqual(naive_version_cmp("5.2.9-1-default", "4.13"), +1)
 
 
+def strict_version_cmp(a, b):
+    # type: (Text, Text) -> int
+    """
+    strictly_version_cmp compares two version numbers without leeway.
+
+    The algorithm considers each version to be a tuple of integers. Non,
+    integer elements or element fragments are regarded as an error and raised
+    as ValueError.
+
+    Comparison is performed on by considering the leftmost element in each
+    tuple. First pair of numbers that are not equal determine the result of the
+    comparison. Tuples have unequal length then missing elements are
+    substituted with zero.
+
+    The return value is 0 if the version strings are equal, -1 if version a is
+    smaller or +1 if version b is smaller.
+    """
+    try:
+        a_items = [int(item, 10) for item in a.split(".")]
+    except ValueError:
+        raise ValueError("version {} is not purely numeric".format(a))
+    try:
+        b_items = [int(item, 10) for item in b.split(".")]
+    except ValueError:
+        raise ValueError("version {} is not purely numeric".format(b))
+    if PY2:
+        zip_longest_fn = itertools.izip_longest
+    else:
+        zip_longest_fn = itertools.zip_longest
+    for a_val, b_val in zip_longest_fn(a_items, b_items, fillvalue=0):
+        delta = a_val - b_val
+        if delta != 0:
+            return 1 if delta > 0 else -1
+    return 0
+
+
+class StrictVersionCmpTests(unittest.TestCase):
+    def test_simple(self):
+        # type: () -> None
+        self.assertEqual(strict_version_cmp("10", "10"), 0)
+        self.assertEqual(strict_version_cmp("10", "20"), -1)
+        self.assertEqual(strict_version_cmp("20", "10"), +1)
+
+    def test_many_segments(self):
+        # type: () -> None
+        self.assertEqual(strict_version_cmp("1.2.3", "1.2.3"), 0)
+        self.assertEqual(strict_version_cmp("1.2.3", "1.3.4"), -1)
+        self.assertEqual(strict_version_cmp("1.4.3", "1.2.3"), +1)
+        self.assertEqual(strict_version_cmp("1.0.0", "1.1.0"), -1)
+        self.assertEqual(strict_version_cmp("0.1.2", "1.1.2"), -1)
+
+    def test_unequal_length(self):
+        # type: () -> None
+        self.assertEqual(strict_version_cmp("1", "1.0"), 0)
+        self.assertEqual(strict_version_cmp("1", "1.2"), -1)
+        self.assertEqual(strict_version_cmp("1.2", "1"), +1)
+        self.assertEqual(strict_version_cmp("1", "1.0.1"), -1)
+        self.assertEqual(strict_version_cmp("1.1", "1.0.1"), +1)
+
+    def test_version_with_text(self):
+        # type: () -> None
+        with self.assertRaises(ValueError) as cm:
+            strict_version_cmp("1-foo", "1")
+        self.assertEqual(cm.exception.args, ("version 1-foo is not purely numeric",))
+        with self.assertRaises(ValueError) as cm:
+            strict_version_cmp("1.2-foo", "1.2")
+        self.assertEqual(cm.exception.args, ("version 1.2-foo is not purely numeric",))
+
+
 def _make_parser():
     # type: () -> ArgumentParser
     parser = ArgumentParser(
@@ -221,8 +291,17 @@ Relational operator is one of:
 Version comparison is performed using the selected algorithm.
 
 naive:
-    The algorithm considers each version to be a tuple of integers. Non,
-    integer elements or element fragments are discarded.
+    The algorithm considers each version to be a tuple of integers.
+    Non-integer elements or element fragments are discarded.
+
+    Comparison is performed on by considering the leftmost element in each
+    tuple. First pair of numbers that are not equal determine the result of the
+    comparison. Tuples have unequal length then missing elements are
+    substituted with zero.
+
+strict:
+    The algorithm considers each version to be a tuple of integers.
+    Non-integer elements are considered to be invalid version.
 
     Comparison is performed on by considering the leftmost element in each
     tuple. First pair of numbers that are not equal determine the result of the
@@ -246,8 +325,15 @@ naive:
         "--naive",
         dest="algorithm",
         action="store_const",
-        const="naive",
+        const=naive_version_cmp,
         help="select the naive version comparison",
+    )
+    alg_grp.add_argument(
+        "--strict",
+        dest="algorithm",
+        action="store_const",
+        const=strict_version_cmp,
+        help="select the strict version comparison",
     )
     # relation selection
     rel_op_grp = parser.add_mutually_exclusive_group(required=True)
@@ -302,24 +388,25 @@ naive:
 
 def main():
     # type: () -> None
-    parser = _make_parser()
-    opts = parser.parse_args()
-    if opts.algorithm == "naive":
-        delta = naive_version_cmp(opts.version_a, opts.version_b)
+    opts = _make_parser().parse_args()
+    try:
+        delta = opts.algorithm(opts.version_a, opts.version_b)
+    except ValueError as exc:
+        print("error: {}".format(exc), file=sys.stderr)
+        raise SystemExit(2)
     else:
-        parser.error("unsupported delta algorithm")
-    is_consistent = consistent_relation(opts.rel_op, delta)
-    if opts.verbose:
-        print(
-            "delta between {} and {} is: {}".format(
-                opts.version_a, opts.version_b, delta
+        is_consistent = consistent_relation(opts.rel_op, delta)
+        if opts.verbose:
+            print(
+                "delta between {} and {} is: {}".format(
+                    opts.version_a, opts.version_b, delta
+                )
             )
-        )
-        if is_consistent:
-            print("delta {} is consistent with {}".format(delta, opts.rel_op))
-        else:
-            print("delta {} is inconsistent with {}".format(delta, opts.rel_op))
-    raise SystemExit(0 if is_consistent else 1)
+            if is_consistent:
+                print("delta {} is consistent with {}".format(delta, opts.rel_op))
+            else:
+                print("delta {} is inconsistent with {}".format(delta, opts.rel_op))
+        raise SystemExit(0 if is_consistent else 1)
 
 
 if __name__ == "__main__":

--- a/tests/lib/bin/version-tool
+++ b/tests/lib/bin/version-tool
@@ -1,0 +1,323 @@
+#!/usr/bin/env any-python
+from __future__ import print_function, absolute_import, unicode_literals
+
+from argparse import Action, ArgumentParser, RawTextHelpFormatter, SUPPRESS
+import itertools
+import re
+import sys
+import unittest
+
+# PY2 is true when we're running under Python 2.x It is used for appropriate
+# return value selection of __str__ and __repr_ methods, which must both
+# return str, not unicode (in Python 2) and str (in Python 3). In both cases
+# the return type annotation is exactly the same, but due to unicode_literals
+# being in effect, and the fact we often use a format string (which is an
+# unicode string in Python 2), we must encode the it to byte string when
+# running under Python 2.
+PY2 = sys.version_info[0] == 2
+
+# Define MYPY as False and use it as a conditional for typing import. Despite
+# this declaration mypy will really treat MYPY as True when type-checking.
+# This is required so that we can import typing on Python 2.x without the
+# typing module installed. For more details see:
+# https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+MYPY = False
+if MYPY:
+    from typing import Any, Text, Tuple, Optional, Union, Sequence
+    from argparse import Namespace
+
+
+class _UnitTestAction(Action):
+    def __init__(
+        self,
+        option_strings,
+        dest=SUPPRESS,
+        default=SUPPRESS,
+        help="run program's unit test suite and exit",
+    ):
+        # type: (Text, Text, Text, Text) -> None
+        super(_UnitTestAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs="...",
+            help=help,
+        )
+
+    def __call__(self, parser, ns, values, option_string=None):
+        # type: (ArgumentParser, Namespace, Union[str, Sequence[Any], None], Optional[Text]) -> None
+        # We allow the caller to provide the test to invoke by giving
+        # --run-unit-tests a set of arguments.
+        argv = [sys.argv[0]]
+        if isinstance(values, list):
+            argv += values
+        unittest.main(argv=argv)
+        parser.exit()
+
+
+def consistent_relation(rel_op, delta):
+    # type: (Text, int) -> bool
+    """
+    consistent_relation returns true if the relation is consistent with delta.
+
+    The relation operator is one of ==, !=, <, <=, > or >=.
+    Delta is either 0, a positive or a negative number.
+    """
+    if rel_op == "==":
+        return delta == 0
+    elif rel_op == "!=":
+        return delta != 0
+    elif rel_op == ">":
+        return delta > 0
+    elif rel_op == ">=":
+        return delta >= 0
+    elif rel_op == "<":
+        return delta < 0
+    elif rel_op == "<=":
+        return delta <= 0
+    raise ValueError("unexpected relational operator " + rel_op)
+
+
+class ConsistentRelationTests(unittest.TestCase):
+    def test_eq(self):
+        # type: () -> None
+        self.assertFalse(consistent_relation("==", -1))
+        self.assertTrue(consistent_relation("==", 0))
+        self.assertFalse(consistent_relation("==", +1))
+
+    def test_ne(self):
+        # type: () -> None
+        self.assertTrue(consistent_relation("!=", -1))
+        self.assertFalse(consistent_relation("!=", 0))
+        self.assertTrue(consistent_relation("!=", +1))
+
+    def test_gt(self):
+        # type: () -> None
+        self.assertFalse(consistent_relation(">", -1))
+        self.assertFalse(consistent_relation(">", 0))
+        self.assertTrue(consistent_relation(">", +1))
+
+    def test_ge(self):
+        # type: () -> None
+        self.assertFalse(consistent_relation(">=", -1))
+        self.assertTrue(consistent_relation(">=", 0))
+        self.assertTrue(consistent_relation(">=", +1))
+
+    def test_lt(self):
+        # type: () -> None
+        self.assertTrue(consistent_relation("<", -1))
+        self.assertFalse(consistent_relation("<", 0))
+        self.assertFalse(consistent_relation("<", +1))
+
+    def test_le(self):
+        # type: () -> None
+        self.assertTrue(consistent_relation("<=", -1))
+        self.assertTrue(consistent_relation("<=", 0))
+        self.assertFalse(consistent_relation("<=", +1))
+
+    def test_unknown(self):
+        # type: () -> None
+        with self.assertRaises(ValueError):
+            consistent_relation("???", 0)
+
+
+def numeric_part_of(text):
+    # type: (Text) -> int
+    """
+    numeric_part_of returns the integer representing the numeric portion of text.
+
+    If text does not start with an decimal integer the result is zero. The
+    function never fails.
+    """
+    match = re.match("^([0-9]+)", text)
+    if match:
+        return int(match.group(1))
+    return 0
+
+
+class NumericPartOfTests(unittest.TestCase):
+    def test_simple(self):
+        # type: () -> None
+        self.assertEqual(numeric_part_of("12"), 12)
+        self.assertEqual(numeric_part_of("12-stuff"), 12)
+        self.assertEqual(numeric_part_of("stuff-12"), 0)
+        self.assertEqual(numeric_part_of("-12"), 0)
+
+
+def naive_version_cmp(a, b):
+    # type: (Text, Text) -> int
+    """
+    naive_version_cmp naively compares two version numbers.
+
+    The algorithm considers each version to be a tuple of integers. Non,
+    integer elements or element fragments are discarded.
+
+    Comparison is performed on by considering the leftmost element in each
+    tuple. First pair of numbers that are not equal determine the result of the
+    comparison. Tuples have unequal length then missing elements are
+    substituted with zero.
+
+    The return value is 0 if the version strings are equal, -1 if version a is
+    smaller or +1 if version b is smaller.
+    """
+    a_items = a.split(".")
+    b_items = b.split(".")
+    if PY2:
+        zip_longest_fn = itertools.izip_longest
+    else:
+        zip_longest_fn = itertools.zip_longest
+    for a_item, b_item in zip_longest_fn(a_items, b_items, fillvalue="0"):
+        a_val = numeric_part_of(a_item)
+        b_val = numeric_part_of(b_item)
+        delta = a_val - b_val
+        if delta != 0:
+            return 1 if delta > 0 else -1
+    return 0
+
+
+class NaiveVersionCmpTests(unittest.TestCase):
+    def test_simple(self):
+        # type: () -> None
+        self.assertEqual(naive_version_cmp("10", "10"), 0)
+        self.assertEqual(naive_version_cmp("10", "20"), -1)
+        self.assertEqual(naive_version_cmp("20", "10"), +1)
+
+    def test_many_segments(self):
+        # type: () -> None
+        self.assertEqual(naive_version_cmp("1.2.3", "1.2.3"), 0)
+        self.assertEqual(naive_version_cmp("1.2.3", "1.3.4"), -1)
+        self.assertEqual(naive_version_cmp("1.4.3", "1.2.3"), +1)
+
+    def test_unequal_length(self):
+        # type: () -> None
+        self.assertEqual(naive_version_cmp("1", "1.0"), 0)
+        self.assertEqual(naive_version_cmp("1", "1.2"), -1)
+        self.assertEqual(naive_version_cmp("1.2", "1"), +1)
+        self.assertEqual(naive_version_cmp("1", "1.0.1"), -1)
+        self.assertEqual(naive_version_cmp("1.1", "1.0.1"), +1)
+
+    def test_version_with_text(self):
+        # type: () -> None
+        self.assertEqual(naive_version_cmp("1-foo", "1-bar"), 0)
+        self.assertEqual(naive_version_cmp("1-foo.2-froz", "1-bar"), +1)
+        self.assertEqual(naive_version_cmp("1-foo.2-froz", "1-bar.3-quux"), -1)
+
+    def test_kernel_version(self):
+        # type: () -> None
+        self.assertEqual(naive_version_cmp("5.2.9-1-default", "4.13"), +1)
+
+
+def _make_parser():
+    # type: () -> ArgumentParser
+    parser = ArgumentParser(
+        epilog="""
+Relational operator is one of:
+
+    -eq -ne -gt -ge -lt -le
+
+Version comparison is performed using the selected algorithm.
+
+naive:
+    The algorithm considers each version to be a tuple of integers. Non,
+    integer elements or element fragments are discarded.
+
+    Comparison is performed on by considering the leftmost element in each
+    tuple. First pair of numbers that are not equal determine the result of the
+    comparison. Tuples have unequal length then missing elements are
+    substituted with zero.
+    """,
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.register("action", "unit-test", _UnitTestAction)
+    parser.add_argument("-v", "--version", action="version", version="1.0")
+    parser.add_argument(
+        "--verbose", action="store_true", help="describe comparison process"
+    )
+
+    parser.add_argument("version_a", metavar="VERSION-A")
+    parser.add_argument("version_b", metavar="VERSION-B")
+
+    # algorithm selection
+    alg_grp = parser.add_mutually_exclusive_group(required=True)
+    alg_grp.add_argument(
+        "--naive",
+        dest="algorithm",
+        action="store_const",
+        const="naive",
+        help="select the naive version comparison",
+    )
+    # relation selection
+    rel_op_grp = parser.add_mutually_exclusive_group(required=True)
+    rel_op_grp.add_argument(
+        "-eq",
+        action="store_const",
+        const="==",
+        dest="rel_op",
+        help="test that versions are equal",
+    )
+    rel_op_grp.add_argument(
+        "-ne",
+        action="store_const",
+        const="!=",
+        dest="rel_op",
+        help="test that versions are not equal",
+    )
+    rel_op_grp.add_argument(
+        "-gt",
+        action="store_const",
+        const=">",
+        dest="rel_op",
+        help="test that version-a is greater than version-b",
+    )
+    rel_op_grp.add_argument(
+        "-ge",
+        action="store_const",
+        const=">=",
+        dest="rel_op",
+        help="test that version-a is greater than or equal to version-b",
+    )
+    rel_op_grp.add_argument(
+        "-lt",
+        action="store_const",
+        const="<=",
+        dest="rel_op",
+        help="test that version-a is less than version-b",
+    )
+    rel_op_grp.add_argument(
+        "-le",
+        action="store_const",
+        const="<=",
+        dest="rel_op",
+        help="test that version-a is less than or equal to version-b",
+    )
+
+    # maintenance commands
+    maint_grp = parser.add_argument_group("maintenance commands")
+    maint_grp.add_argument("--run-unit-tests", action="unit-test", help=SUPPRESS)
+    return parser
+
+
+def main():
+    # type: () -> None
+    parser = _make_parser()
+    opts = parser.parse_args()
+    if opts.algorithm == "naive":
+        delta = naive_version_cmp(opts.version_a, opts.version_b)
+    else:
+        parser.error("unsupported delta algorithm")
+    is_consistent = consistent_relation(opts.rel_op, delta)
+    if opts.verbose:
+        print(
+            "delta between {} and {} is: {}".format(
+                opts.version_a, opts.version_b, delta
+            )
+        )
+        if is_consistent:
+            print("delta {} is consistent with {}".format(delta, opts.rel_op))
+        else:
+            print("delta {} is inconsistent with {}".format(delta, opts.rel_op))
+    raise SystemExit(0 if is_consistent else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lib/bin/version-tool
+++ b/tests/lib/bin/version-tool
@@ -187,6 +187,8 @@ class NaiveVersionCmpTests(unittest.TestCase):
         self.assertEqual(naive_version_cmp("1.2.3", "1.2.3"), 0)
         self.assertEqual(naive_version_cmp("1.2.3", "1.3.4"), -1)
         self.assertEqual(naive_version_cmp("1.4.3", "1.2.3"), +1)
+        self.assertEqual(naive_version_cmp("1.0.0", "1.1.0"), -1)
+        self.assertEqual(naive_version_cmp("0.1.2", "1.1.2"), -1)
 
     def test_unequal_length(self):
         # type: () -> None

--- a/tests/lib/bin/version-tool
+++ b/tests/lib/bin/version-tool
@@ -126,8 +126,9 @@ def numeric_part_of(text):
     """
     numeric_part_of returns the integer representing the numeric portion of text.
 
-    If text does not start with an decimal integer the result is zero. The
-    function never fails.
+    If text does not start with an natural number the result is zero. The
+    function never fails. Negative numbers are not supported because they are
+    meaningless for version numbers.
     """
     match = re.match("^([0-9]+)", text)
     if match:

--- a/tests/main/version-tool/task.yaml
+++ b/tests/main/version-tool/task.yaml
@@ -1,0 +1,33 @@
+summary: integration tests for version-tool
+execute: |
+    # ==
+    version-tool --naive 1 -eq 1
+    version-tool --naive 1 -eq 1.0
+    version-tool --naive 1.0 -eq 1
+    not version-tool --naive 1 -eq 2
+
+    # !=
+    not version-tool --naive 1.2 -ne  1.2
+    version-tool --naive 1 -ne 2
+    version-tool --naive 2 -ne 1
+
+    # < and <=
+    version-tool --naive 1 -lt 2
+    not version-tool --naive 2 -lt 1
+    version-tool --naive 1 -le 2
+    version-tool --naive 2 -le 2
+    not version-tool --naive 2 -le 1
+
+    # > and >=
+    version-tool --naive 2 -gt 1
+    not version-tool --naive 1 -gt 2
+    version-tool --naive 2 -ge 1
+    version-tool --naive 2 -ge 2
+    not version-tool --naive 1 -ge 2
+
+    # --verbose
+    version-tool --verbose --naive 1 -eq 2 | MATCH 'delta between 1 and 2 is: -1'
+    version-tool --verbose --naive 1 -eq 2 | MATCH 'delta -1 is inconsistent with =='
+
+    # --version
+    version-tool --version | MATCH 1.0

--- a/tests/main/version-tool/task.yaml
+++ b/tests/main/version-tool/task.yaml
@@ -1,34 +1,46 @@
 summary: integration tests for version-tool
 execute: |
     # ==
-    version-tool --naive 1 -eq 1
-    version-tool --naive 1 -eq 1.0
-    version-tool --naive 1.0 -eq 1
-    not version-tool --naive 1 -eq 2
+    version-tool --strict 1 -eq 1
+    version-tool --strict 1 -eq 1.0
+    version-tool --strict 1.0 -eq 1
+    not version-tool --strict 1 -eq 2
 
     # !=
-    not version-tool --naive 1.2 -ne  1.2
-    version-tool --naive 1 -ne 2
-    version-tool --naive 2 -ne 1
+    not version-tool --strict 1.2 -ne  1.2
+    version-tool --strict 1 -ne 2
+    version-tool --strict 2 -ne 1
 
     # < and <=
-    version-tool --naive 1 -lt 2
-    not version-tool --naive 2 -lt 1
-    version-tool --naive 1 -le 2
-    version-tool --naive 2 -le 2
-    not version-tool --naive 2 -le 1
+    version-tool --strict 1 -lt 2
+    not version-tool --strict 2 -lt 1
+    version-tool --strict 1 -le 2
+    version-tool --strict 2 -le 2
+    not version-tool --strict 2 -le 1
 
     # > and >=
-    version-tool --naive 2 -gt 1
-    not version-tool --naive 1 -gt 2
-    version-tool --naive 2 -ge 1
-    version-tool --naive 2 -ge 2
-    not version-tool --naive 1 -ge 2
+    version-tool --strict 2 -gt 1
+    not version-tool --strict 1 -gt 2
+    version-tool --strict 2 -ge 1
+    version-tool --strict 2 -ge 2
+    not version-tool --strict 1 -ge 2
 
     # --verbose
-    version-tool --verbose --naive 1 -eq 2 | MATCH 'delta between 1 and 2 is: -1'
-    version-tool --verbose --naive 1 -eq 2 | MATCH 'delta -1 is inconsistent with =='
+    version-tool --verbose --strict 1 -eq 2 | MATCH 'delta between 1 and 2 is: -1'
+    version-tool --verbose --strict 1 -eq 2 | MATCH 'delta -1 is inconsistent with =='
 
     # --version
     # NOTE: older python versions print the version string to stderr
     version-tool --version 2>&1 | MATCH 1.0
+
+    # The difference between --naive and --strict is that naive only looks at
+    # integer part of each version segment while strict errors on any
+    # non-integer segment.
+    version-tool --naive 1.2 -eq 1.2-foo
+    version-tool --strict 1.2 -eq 1.2-foo 2>&1 | MATCH 'error: version 1.2-foo is not purely numeric'
+    # Such invalid comparison also returns a distinct error code.
+    set +e
+    version-tool --strict 1.2 -eq 1.2-foo
+    error_code=$?
+    set -e
+    test "$error_code" -eq 2

--- a/tests/main/version-tool/task.yaml
+++ b/tests/main/version-tool/task.yaml
@@ -33,10 +33,7 @@ execute: |
     # NOTE: older python versions print the version string to stderr
     version-tool --version 2>&1 | MATCH 1.0
 
-    # The difference between --naive and --strict is that naive only looks at
-    # integer part of each version segment while strict errors on any
-    # non-integer segment.
-    version-tool --naive 1.2 -eq 1.2-foo
+    # Strict requires all version components to be integers.
     version-tool --strict 1.2 -eq 1.2-foo 2>&1 | MATCH 'error: version 1.2-foo is not purely numeric'
     # Such invalid comparison also returns a distinct error code.
     set +e

--- a/tests/main/version-tool/task.yaml
+++ b/tests/main/version-tool/task.yaml
@@ -30,4 +30,5 @@ execute: |
     version-tool --verbose --naive 1 -eq 2 | MATCH 'delta -1 is inconsistent with =='
 
     # --version
-    version-tool --version | MATCH 1.0
+    # NOTE: older python versions print the version string to stderr
+    version-tool --version 2>&1 | MATCH 1.0


### PR DESCRIPTION
I need to start comparing bash and kernel versions. I tried to hack
around in shell but it was murky and probably buggy as well. I decided
to thus write a small version comparison tool in python.

The tool can be used somewhat like the builtin "test" command. It takes
two versions, a relationship operator and an algorithm to use. An
example shell snippet using it might look like this:

    if version-tool --naive "$(uname -r)" -ge 4.13; then
        ...
    fi

Currently only one algorithm exist: naive, which is just enough to
compare kernel version numbers or bash version numbers. It looks through
the segments of each version, separated by dot, converts as much of the
segment to an integer as possible and computes the delta. Missing
segments are like segments reading zero, so 1.0 is equal to 1 but 1.2 is
smaller than 1.2.1. The tool comes with full array of unit tests and
documentation and is compatible with Python 3 and Python 2 alike.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
