### PR TITLE
osutil: make flock test more robust

### DIFF
--- a/osutil/flock_test.go
+++ b/osutil/flock_test.go
@@ -118,27 +118,31 @@ func (s *flockSuite) TestUsingClosedLock(c *C) {
 	c.Assert(lock.Unlock(), ErrorMatches, "bad file descriptor")
 }
 
-// Test that non-blocking
+// Test that non-blocking locking reports error on pre-acquired lock.
 func (s *flockSuite) TestLockUnlockNonblockingWorks(c *C) {
 	if os.Getenv("TRAVIS_BUILD_NUMBER") != "" {
 		c.Skip("Cannot use this under travis")
 		return
 	}
 
+	// Use the "flock" command to grab a lock for 9999 seconds in another process.
 	lockPath := filepath.Join(c.MkDir(), "lock")
 	cmd := exec.Command("flock", "--exclusive", lockPath, "sleep", "9999")
 	c.Assert(cmd.Start(), IsNil)
 	defer cmd.Process.Kill()
 
+	// Give flock some chance to create the lock file.
 	for i := 0; i < 10; i++ {
 		if osutil.FileExists(lockPath) {
 			break
 		}
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond * 300)
 	}
 
+	// Try to acquire the same lock file and see that it is busy.
 	lock, err := osutil.NewFileLock(lockPath)
 	c.Assert(err, IsNil)
+	c.Assert(lock, NotNil)
 	defer lock.Close()
 
 	c.Assert(lock.TryLock(), Equals, osutil.ErrAlreadyLocked)


### PR DESCRIPTION
I noticed that flock unit test has failed in a random run.

    -----
    FAIL: flock_test.go:122: flockSuite.TestLockUnlockNonblockingWorks

    flock_test.go:144:
        c.Assert(lock.TryLock(), Equals, osutil.ErrAlreadyLocked)
    ... obtained = nil
    ... expected *errors.errorString = &errors.errorString{s:"cannot acquire lock, already locked"} ("cannot acquire lock, already locked")
    ... runtime error: invalid memory address or nil pointer dereference

    OOPS: 236 passed, 1 FAILED
    --- FAIL: Test (1.02s)
    FAIL
    FAIL	github.com/snapcore/snapd/osutil	1.023s
    -----

Quick inspection doesn't reveal the cause but there were some red flags.
The synchronization between the test launching flock in another process
and the test itself is racy. It had up to 10ms to succeed. This may be
too short so I adjusted that to give it ample time to run on a busier
system.

What is more mysterious is the error itself, traversal of a nil pointer.
This seems to suggest that we return nil, nil - that is fail without
reporting an error - something NewFileLock just cannot do.

I've added an extra assertion for that so that if it happens, it is more
easy to deduce the cause.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
