### PR TITLE
HACKING.md: clarify where "make fmt" is needed

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -243,4 +243,5 @@ version on your system and reloads the apparmor profile.
 
 ## Submitting patches
 
-Please run `make fmt` before sending your patches.
+Please run `(cd cmd; make fmt)` before sending your patches for the "C" part of
+the source code.


### PR DESCRIPTION
There was a comment in PR#7383 that the description of:

    "Please run `make fmt` before sending your patches."

in the HACKING.md is a bit unclear. This PR adds a note
that "make fmt" is only relevant for the "C" part of the
source code.
