### PR TITLE
many: refactor boot/boottest and move to bootloader/bootloadertest

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -27,8 +27,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/boot"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
@@ -61,7 +61,7 @@ func (s *baseBootSetSuite) SetUpTest(c *C) {
 type bootSetSuite struct {
 	baseBootSetSuite
 
-	loader *boottest.MockBootloader
+	loader *mockbootloader.MockBootloader
 }
 
 var _ = Suite(&bootSetSuite{})
@@ -69,7 +69,7 @@ var _ = Suite(&bootSetSuite{})
 func (s *bootSetSuite) SetUpTest(c *C) {
 	s.baseBootSetSuite.SetUpTest(c)
 
-	s.loader = boottest.NewMockBootloader("mock", c.MkDir())
+	s.loader = mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(s.loader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 }

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
@@ -61,7 +61,7 @@ func (s *baseBootSetSuite) SetUpTest(c *C) {
 type bootSetSuite struct {
 	baseBootSetSuite
 
-	loader *mockbootloader.MockBootloader
+	loader *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&bootSetSuite{})
@@ -69,7 +69,7 @@ var _ = Suite(&bootSetSuite{})
 func (s *bootSetSuite) SetUpTest(c *C) {
 	s.baseBootSetSuite.SetUpTest(c)
 
-	s.loader = mockbootloader.New("mock", c.MkDir())
+	s.loader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.loader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 }

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -48,7 +48,7 @@ vendor: Someone
 type coreBootSetSuite struct {
 	baseBootSetSuite
 
-	loader *mockbootloader.MockBootloader
+	loader *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&coreBootSetSuite{})
@@ -56,7 +56,7 @@ var _ = Suite(&coreBootSetSuite{})
 func (s *coreBootSetSuite) SetUpTest(c *C) {
 	s.baseBootSetSuite.SetUpTest(c)
 
-	s.loader = mockbootloader.New("mock", c.MkDir())
+	s.loader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.loader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 }

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -27,8 +27,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/boot"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -48,7 +48,7 @@ vendor: Someone
 type coreBootSetSuite struct {
 	baseBootSetSuite
 
-	loader *boottest.MockBootloader
+	loader *mockbootloader.MockBootloader
 }
 
 var _ = Suite(&coreBootSetSuite{})
@@ -56,7 +56,7 @@ var _ = Suite(&coreBootSetSuite{})
 func (s *coreBootSetSuite) SetUpTest(c *C) {
 	s.baseBootSetSuite.SetUpTest(c)
 
-	s.loader = boottest.NewMockBootloader("mock", c.MkDir())
+	s.loader = mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(s.loader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 }

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -27,8 +27,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -59,7 +59,7 @@ func (s *baseBootenvTestSuite) SetUpTest(c *C) {
 type bootenvTestSuite struct {
 	baseBootenvTestSuite
 
-	b *boottest.MockBootloader
+	b *mockbootloader.MockBootloader
 }
 
 var _ = Suite(&bootenvTestSuite{})
@@ -67,7 +67,7 @@ var _ = Suite(&bootenvTestSuite{})
 func (s *bootenvTestSuite) SetUpTest(c *C) {
 	s.baseBootenvTestSuite.SetUpTest(c)
 
-	s.b = boottest.NewMockBootloader("mocky", c.MkDir())
+	s.b = mockbootloader.New("mocky", c.MkDir())
 }
 
 func (s *bootenvTestSuite) TestForceBootloader(c *C) {

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -28,7 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -59,7 +59,7 @@ func (s *baseBootenvTestSuite) SetUpTest(c *C) {
 type bootenvTestSuite struct {
 	baseBootenvTestSuite
 
-	b *mockbootloader.MockBootloader
+	b *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&bootenvTestSuite{})
@@ -67,7 +67,7 @@ var _ = Suite(&bootenvTestSuite{})
 func (s *bootenvTestSuite) SetUpTest(c *C) {
 	s.baseBootenvTestSuite.SetUpTest(c)
 
-	s.b = mockbootloader.New("mocky", c.MkDir())
+	s.b = bootloadertest.Mock("mocky", c.MkDir())
 }
 
 func (s *bootenvTestSuite) TestForceBootloader(c *C) {

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -17,7 +17,7 @@
  *
  */
 
-package mockbootloader
+package bootloadertest
 
 import (
 	"path/filepath"
@@ -43,7 +43,7 @@ type MockBootloader struct {
 // ensure MockBootloader implements the Bootloader interface
 var _ bootloader.Bootloader = (*MockBootloader)(nil)
 
-func New(name, bootdir string) *MockBootloader {
+func Mock(name, bootdir string) *MockBootloader {
 	return &MockBootloader{
 		name:    name,
 		bootdir: bootdir,

--- a/bootloader/mockbootloader/mockbootloader.go
+++ b/bootloader/mockbootloader/mockbootloader.go
@@ -17,7 +17,7 @@
  *
  */
 
-package boottest
+package mockbootloader
 
 import (
 	"path/filepath"
@@ -25,18 +25,6 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/snap"
 )
-
-// SetBootKernel sets the current boot kernel string. Should be
-// something like "pc-kernel_1234.snap".
-func SetBootKernel(kernel string, b bootloader.Bootloader) {
-	b.SetBootVars(map[string]string{"snap_kernel": kernel})
-}
-
-// SetBootBase sets the current boot base string. Should be something
-// like "core_1234.snap".
-func SetBootBase(base string, b bootloader.Bootloader) {
-	b.SetBootVars(map[string]string{"snap_core": base})
-}
 
 // MockBootloader mocks the bootloader interface and records all
 // set/get calls.
@@ -52,7 +40,10 @@ type MockBootloader struct {
 	RemoveKernelAssetsCalls  []snap.PlaceInfo
 }
 
-func NewMockBootloader(name, bootdir string) *MockBootloader {
+// ensure MockBootloader implements the Bootloader interface
+var _ bootloader.Bootloader = (*MockBootloader)(nil)
+
+func New(name, bootdir string) *MockBootloader {
 	return &MockBootloader{
 		name:    name,
 		bootdir: bootdir,
@@ -93,4 +84,16 @@ func (b *MockBootloader) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Contai
 func (b *MockBootloader) RemoveKernelAssets(s snap.PlaceInfo) error {
 	b.RemoveKernelAssetsCalls = append(b.RemoveKernelAssetsCalls, s)
 	return nil
+}
+
+// SetBootKernel sets the current boot kernel string. Should be
+// something like "pc-kernel_1234.snap".
+func (b *MockBootloader) SetBootKernel(kernel string) {
+	b.SetBootVars(map[string]string{"snap_kernel": kernel})
+}
+
+// SetBootBase sets the current boot base string. Should be something
+// like "core_1234.snap".
+func (b *MockBootloader) SetBootBase(base string) {
+	b.SetBootVars(map[string]string{"snap_core": base})
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/osutil"
@@ -69,7 +69,7 @@ func Test(t *testing.T) { TestingT(t) }
 type imageSuite struct {
 	testutil.BaseTest
 	root       string
-	bootloader *mockbootloader.MockBootloader
+	bootloader *bootloadertest.MockBootloader
 
 	stdout *bytes.Buffer
 	stderr *bytes.Buffer
@@ -92,7 +92,7 @@ var (
 
 func (s *imageSuite) SetUpTest(c *C) {
 	s.root = c.MkDir()
-	s.bootloader = mockbootloader.New("grub", c.MkDir())
+	s.bootloader = bootloadertest.Mock("grub", c.MkDir())
 	bootloader.Force(s.bootloader)
 
 	s.BaseTest.SetUpTest(c)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -35,8 +35,8 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/osutil"
@@ -69,7 +69,7 @@ func Test(t *testing.T) { TestingT(t) }
 type imageSuite struct {
 	testutil.BaseTest
 	root       string
-	bootloader *boottest.MockBootloader
+	bootloader *mockbootloader.MockBootloader
 
 	stdout *bytes.Buffer
 	stderr *bytes.Buffer
@@ -92,7 +92,7 @@ var (
 
 func (s *imageSuite) SetUpTest(c *C) {
 	s.root = c.MkDir()
-	s.bootloader = boottest.NewMockBootloader("grub", c.MkDir())
+	s.bootloader = mockbootloader.New("grub", c.MkDir())
 	bootloader.Force(s.bootloader)
 
 	s.BaseTest.SetUpTest(c)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/httputil"
@@ -82,7 +82,7 @@ type deviceMgrSuite struct {
 	mgr     *devicestate.DeviceManager
 	db      *asserts.Database
 
-	bootloader *mockbootloader.MockBootloader
+	bootloader *bootloadertest.MockBootloader
 
 	storeSigning *assertstest.StoreStack
 	brands       *assertstest.SigningAccounts
@@ -136,7 +136,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 
 	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 
-	s.bootloader = mockbootloader.New("mock", c.MkDir())
+	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.bootloader)
 
 	s.restoreOnClassic = release.MockOnClassic(false)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -41,8 +41,8 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/httputil"
@@ -82,7 +82,7 @@ type deviceMgrSuite struct {
 	mgr     *devicestate.DeviceManager
 	db      *asserts.Database
 
-	bootloader *boottest.MockBootloader
+	bootloader *mockbootloader.MockBootloader
 
 	storeSigning *assertstest.StoreStack
 	brands       *assertstest.SigningAccounts
@@ -136,7 +136,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 
 	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 
-	s.bootloader = boottest.NewMockBootloader("mock", c.MkDir())
+	s.bootloader = mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(s.bootloader)
 
 	s.restoreOnClassic = release.MockOnClassic(false)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
@@ -487,7 +487,7 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 	loader.SetBootKernel("pc-kernel_1.snap")
@@ -612,7 +612,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedHappyMultiAssertsFiles(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 	loader.SetBootKernel("pc-kernel_1.snap")
@@ -711,7 +711,7 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedConfigureHappy(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 	loader.SetBootKernel("pc-kernel_1.snap")
@@ -864,7 +864,7 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedGadgetConnectHappy(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 	loader.SetBootKernel("pc-kernel_1.snap")
@@ -1173,7 +1173,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedWithBaseHappy(c *C) {
 	})
 	defer systemctlRestorer()
 
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 	loader.SetBootKernel("pc-kernel_1.snap")
@@ -1370,7 +1370,7 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedWrongContentProviderOrder(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 	loader.SetBootKernel("pc-kernel_1.snap")

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -33,8 +33,8 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
@@ -487,11 +487,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core_1.snap", loader)
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core_1.snap")
 
 	st := s.overlord.State()
 	chg := s.makeSeedChange(c, st)
@@ -612,11 +612,11 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedHappyMultiAssertsFiles(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core_1.snap", loader)
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core_1.snap")
 
 	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
 
@@ -711,11 +711,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedConfigureHappy(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core_1.snap", loader)
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core_1.snap")
 
 	const defaultsYaml = `
 defaults:
@@ -864,11 +864,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedGadgetConnectHappy(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core_1.snap", loader)
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core_1.snap")
 
 	const connectionsYaml = `
 connections:
@@ -1173,11 +1173,11 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedWithBaseHappy(c *C) {
 	})
 	defer systemctlRestorer()
 
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core18_1.snap", loader)
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core18_1.snap")
 
 	core18Fname, snapdFname, kernelFname, gadgetFname := s.makeCore18Snaps(c, nil)
 
@@ -1370,11 +1370,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedWrongContentProviderOrder(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core_1.snap", loader)
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core_1.snap")
 
 	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
@@ -1529,7 +1529,7 @@ func findKind(chg *state.Change, kind string) *state.Task {
 }
 
 func (s *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 
@@ -1599,7 +1599,7 @@ type: os
 }
 
 func (s *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 
@@ -3402,7 +3402,7 @@ type: base`
 }
 
 func (s *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	loader.SetBootKernel("pc-kernel_1.snap")
 	loader.SetBootBase("core_1.snap")
 	bootloader.Force(loader)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -43,8 +43,8 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
@@ -1529,7 +1529,7 @@ func findKind(chg *state.Change, kind string) *state.Task {
 }
 
 func (s *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 
@@ -1587,7 +1587,7 @@ type: os
 	// simulate successful restart happened
 	state.MockRestarting(st, state.RestartUnset)
 	loader.BootVars["snap_mode"] = ""
-	boottest.SetBootBase("core_x1.snap", loader)
+	loader.SetBootBase("core_x1.snap")
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -1599,7 +1599,7 @@ type: os
 }
 
 func (s *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 
@@ -3402,9 +3402,9 @@ type: base`
 }
 
 func (s *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
-	boottest.SetBootKernel("pc-kernel_1.snap", loader)
-	boottest.SetBootBase("core_1.snap", loader)
+	loader := mockbootloader.New("mock", c.MkDir())
+	loader.SetBootKernel("pc-kernel_1.snap")
+	loader.SetBootBase("core_1.snap")
 	bootloader.Force(loader)
 	defer bootloader.Force(nil)
 

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -27,8 +27,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -147,7 +147,7 @@ func (s *setupSuite) TestSetupDoUndoInstance(c *C) {
 func (s *setupSuite) TestSetupDoUndoKernel(c *C) {
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 
 	// we don't get real mounting
@@ -193,7 +193,7 @@ func (s *setupSuite) TestSetupDoIdempotent(c *C) {
 
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
@@ -244,7 +244,7 @@ func (s *setupSuite) TestSetupUndoIdempotent(c *C) {
 
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := boottest.NewMockBootloader("mock", c.MkDir())
+	loader := mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(loader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -28,7 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -147,7 +147,7 @@ func (s *setupSuite) TestSetupDoUndoInstance(c *C) {
 func (s *setupSuite) TestSetupDoUndoKernel(c *C) {
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 
 	// we don't get real mounting
@@ -193,7 +193,7 @@ func (s *setupSuite) TestSetupDoIdempotent(c *C) {
 
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
@@ -244,7 +244,7 @@ func (s *setupSuite) TestSetupUndoIdempotent(c *C) {
 
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := mockbootloader.New("mock", c.MkDir())
+	loader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(loader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -29,7 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -43,7 +43,7 @@ import (
 
 type bootedSuite struct {
 	testutil.BaseTest
-	bootloader *mockbootloader.MockBootloader
+	bootloader *bootloadertest.MockBootloader
 
 	o           *overlord.Overlord
 	state       *state.State
@@ -66,7 +66,7 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	// booted is not running on classic
 	release.MockOnClassic(false)
 
-	bs.bootloader = mockbootloader.New("mock", c.MkDir())
+	bs.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	bs.bootloader.SetBootKernel("canonical-pc-linux_2.snap")
 	bs.bootloader.SetBootBase("core_2.snap")
 	bootloader.Force(bs.bootloader)

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -28,8 +28,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -43,7 +43,7 @@ import (
 
 type bootedSuite struct {
 	testutil.BaseTest
-	bootloader *boottest.MockBootloader
+	bootloader *mockbootloader.MockBootloader
 
 	o           *overlord.Overlord
 	state       *state.State
@@ -66,9 +66,9 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	// booted is not running on classic
 	release.MockOnClassic(false)
 
-	bs.bootloader = boottest.NewMockBootloader("mock", c.MkDir())
-	boottest.SetBootKernel("canonical-pc-linux_2.snap", bs.bootloader)
-	boottest.SetBootBase("core_2.snap", bs.bootloader)
+	bs.bootloader = mockbootloader.New("mock", c.MkDir())
+	bs.bootloader.SetBootKernel("canonical-pc-linux_2.snap")
+	bs.bootloader.SetBootBase("core_2.snap")
 	bootloader.Force(bs.bootloader)
 
 	bs.fakeBackend = &fakeSnappyBackend{}
@@ -137,7 +137,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSSimple(c *C) {
 
 	bs.makeInstalledKernelOS(c, st)
 
-	boottest.SetBootBase("core_1.snap", bs.bootloader)
+	bs.bootloader.SetBootBase("core_1.snap")
 	err := snapstate.UpdateBootRevisions(st)
 	c.Assert(err, IsNil)
 
@@ -171,7 +171,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsKernelSimple(c *C) {
 
 	bs.makeInstalledKernelOS(c, st)
 
-	boottest.SetBootKernel("canonical-pc-linux_1.snap", bs.bootloader)
+	bs.bootloader.SetBootKernel("canonical-pc-linux_1.snap")
 	err := snapstate.UpdateBootRevisions(st)
 	c.Assert(err, IsNil)
 
@@ -205,7 +205,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsKernelErrorsEarly(c *C) {
 
 	bs.makeInstalledKernelOS(c, st)
 
-	boottest.SetBootKernel("canonical-pc-linux_99.snap", bs.bootloader)
+	bs.bootloader.SetBootKernel("canonical-pc-linux_99.snap")
 	err := snapstate.UpdateBootRevisions(st)
 	c.Assert(err, ErrorMatches, `cannot find revision 99 for snap "canonical-pc-linux"`)
 }
@@ -217,7 +217,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsEarly(c *C) {
 
 	bs.makeInstalledKernelOS(c, st)
 
-	boottest.SetBootBase("core_99.snap", bs.bootloader)
+	bs.bootloader.SetBootBase("core_99.snap")
 	err := snapstate.UpdateBootRevisions(st)
 	c.Assert(err, ErrorMatches, `cannot find revision 99 for snap "core"`)
 }
@@ -246,7 +246,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	})
 	bs.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/core/1")
 
-	boottest.SetBootBase("core_1.snap", bs.bootloader)
+	bs.bootloader.SetBootBase("core_1.snap")
 	err := snapstate.UpdateBootRevisions(st)
 	c.Assert(err, IsNil)
 
@@ -299,7 +299,7 @@ func (bs *bootedSuite) TestWaitRestartCore(c *C) {
 	c.Check(err, IsNil)
 
 	// core snap, restarted, wrong core revision, rollback!
-	boottest.SetBootBase("core_1.snap", bs.bootloader)
+	bs.bootloader.SetBootBase("core_1.snap")
 	err = snapstate.WaitRestart(task, snapsup)
 	c.Check(err, ErrorMatches, `cannot finish core installation, there was a rollback across reboot`)
 }
@@ -346,12 +346,12 @@ func (bs *bootedSuite) TestWaitRestartBootableBase(c *C) {
 
 	// core snap, restarted, right core revision, no rollback
 	bs.bootloader.BootVars["snap_mode"] = ""
-	boottest.SetBootBase("core18_2.snap", bs.bootloader)
+	bs.bootloader.SetBootBase("core18_2.snap")
 	err = snapstate.WaitRestart(task, snapsup)
 	c.Check(err, IsNil)
 
 	// core snap, restarted, wrong core revision, rollback!
-	boottest.SetBootBase("core18_1.snap", bs.bootloader)
+	bs.bootloader.SetBootBase("core18_1.snap")
 	err = snapstate.WaitRestart(task, snapsup)
 	c.Check(err, ErrorMatches, `cannot finish core18 installation, there was a rollback across reboot`)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/mockbootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
@@ -10952,7 +10952,7 @@ type canRemoveSuite struct {
 	st        *state.State
 	deviceCtx snapstate.DeviceContext
 
-	bs *mockbootloader.MockBootloader
+	bs *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&canRemoveSuite{})
@@ -10962,7 +10962,7 @@ func (s *canRemoveSuite) SetUpTest(c *C) {
 	s.st = state.New(nil)
 	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: DefaultModel()}
 
-	s.bs = mockbootloader.New("mock", c.MkDir())
+	s.bs = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.bs)
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -37,8 +37,8 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/mockbootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
@@ -10952,7 +10952,7 @@ type canRemoveSuite struct {
 	st        *state.State
 	deviceCtx snapstate.DeviceContext
 
-	bs bootloader.Bootloader
+	bs *mockbootloader.MockBootloader
 }
 
 var _ = Suite(&canRemoveSuite{})
@@ -10962,7 +10962,7 @@ func (s *canRemoveSuite) SetUpTest(c *C) {
 	s.st = state.New(nil)
 	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: DefaultModel()}
 
-	s.bs = boottest.NewMockBootloader("mock", c.MkDir())
+	s.bs = mockbootloader.New("mock", c.MkDir())
 	bootloader.Force(s.bs)
 }
 
@@ -11015,7 +11015,7 @@ func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *C) {
 	}
 	kernel.RealName = "kernel"
 
-	boottest.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision), s.bs)
+	s.bs.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
 
 	removeAll := false
 	c.Check(snapstate.CanRemove(s.st, kernel, &snapstate.SnapState{}, removeAll, s.deviceCtx), Equals, false)
@@ -11030,7 +11030,7 @@ func (s *canRemoveSuite) TestOstInUseIsKept(c *C) {
 	}
 	base.RealName = "core18"
 
-	boottest.SetBootBase(fmt.Sprintf("%s_%s.snap", base.RealName, base.SideInfo.Revision), s.bs)
+	s.bs.SetBootBase(fmt.Sprintf("%s_%s.snap", base.RealName, base.SideInfo.Revision))
 
 	removeAll := false
 	c.Check(snapstate.CanRemove(s.st, base, &snapstate.SnapState{}, removeAll, s.deviceCtx), Equals, false)
@@ -11054,7 +11054,7 @@ func (s *canRemoveSuite) TestRemoveNonModelKernelStillInUseNotOk(c *C) {
 	}
 	kernel.RealName = "other-non-model-kernel"
 
-	boottest.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision), s.bs)
+	s.bs.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
 
 	c.Check(snapstate.CanRemove(s.st, kernel, &snapstate.SnapState{}, true, s.deviceCtx), Equals, false)
 }


### PR DESCRIPTION
This is a small refactor of `boot` and `bootloader`, part of an ongoing series.

all `boot/boottest` had was MockBootloader; this moves it to `bootloader/mockbootloader`.
