### PR TITLE
boot, bootloader, o/devicestate: boot env manip goes in boot

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -54,6 +54,8 @@ type Kernel interface {
 	ExtractKernelAssets(snap.Container) error
 }
 
+// Model carries information about the model that is relevant to boot.
+// Note *asserts.Model implements this, and that's the expected use case.
 type Model interface {
 	Kernel() string
 	Base() string
@@ -70,6 +72,7 @@ func Lookup(s snap.PlaceInfo, t snap.Type, model Model, onClassic bool) (bp Boot
 		return nil, false
 	}
 	if t != snap.TypeOS && t != snap.TypeKernel && t != snap.TypeBase {
+		// note we don't currently have anything useful to do with gadgets
 		return nil, false
 	}
 
@@ -77,6 +80,7 @@ func Lookup(s snap.PlaceInfo, t snap.Type, model Model, onClassic bool) (bp Boot
 		switch t {
 		case snap.TypeKernel:
 			if s.InstanceName() != model.Kernel() {
+				// a remodel might leave you in this state
 				return nil, false
 			}
 		case snap.TypeBase, snap.TypeOS:
@@ -171,6 +175,8 @@ func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
 	return nameAndRevno, nil
 }
 
+// nameAndRevnoFromSnap grabs the snap name and revision from the
+// value of a boot variable. E.g., foo_2.snap -> name "foo", revno 2
 func nameAndRevnoFromSnap(sn string) (*NameAndRevision, error) {
 	if sn == "" {
 		return nil, fmt.Errorf("boot variable unset")

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -173,7 +173,7 @@ func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
 
 func nameAndRevnoFromSnap(sn string) (*NameAndRevision, error) {
 	if sn == "" {
-		return nil, fmt.Errorf("unset")
+		return nil, fmt.Errorf("boot variable unset")
 	}
 	idx := strings.IndexByte(sn, '_')
 	if idx < 1 {

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -187,3 +187,54 @@ func nameAndRevnoFromSnap(sn string) (*NameAndRevision, error) {
 	}
 	return &NameAndRevision{Name: name, Revision: rev}, nil
 }
+
+// MarkBootSuccessful marks the current boot as successful. This means
+// that snappy will consider this combination of kernel/os a valid
+// target for rollback.
+//
+// The states that a boot goes through are the following:
+// - By default snap_mode is "" in which case the bootloader loads
+//   two squashfs'es denoted by variables snap_core and snap_kernel.
+// - On a refresh of core/kernel snapd will set snap_mode=try and
+//   will also set snap_try_{core,kernel} to the core/kernel that
+//   will be tried next.
+// - On reboot the bootloader will inspect the snap_mode and if the
+//   mode is set to "try" it will set "snap_mode=trying" and then
+//   try to boot the snap_try_{core,kernel}".
+// - On a successful boot snapd resets snap_mode to "" and copies
+//   snap_try_{core,kernel} to snap_{core,kernel}. The snap_try_*
+//   values are cleared afterwards.
+// - On a failing boot the bootloader will see snap_mode=trying which
+//   means snapd did not start successfully. In this case the bootloader
+//   will set snap_mode="" and the system will boot with the known good
+//   values from snap_{core,kernel}
+func MarkBootSuccessful() error {
+	bl, err := bootloader.Find()
+	if err != nil {
+		return fmt.Errorf("cannot mark boot successful: %s", err)
+	}
+	m, err := bl.GetBootVars("snap_mode", "snap_try_core", "snap_try_kernel")
+	if err != nil {
+		return err
+	}
+
+	// snap_mode goes from "" -> "try" -> "trying" -> ""
+	// so if we are not in "trying" mode, nothing to do here
+	if m["snap_mode"] != "trying" {
+		return nil
+	}
+
+	// update the boot vars
+	for _, k := range []string{"kernel", "core"} {
+		tryBootVar := fmt.Sprintf("snap_try_%s", k)
+		bootVar := fmt.Sprintf("snap_%s", k)
+		// update the boot vars
+		if m[tryBootVar] != "" {
+			m[bootVar] = m[tryBootVar]
+			m[tryBootVar] = ""
+		}
+	}
+	m["snap_mode"] = ""
+
+	return bl.SetBootVars(m)
+}

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -149,12 +149,12 @@ func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
 		return nil, fmt.Errorf("internal error: cannot find boot revision for snap type %q", t)
 	}
 
-	loader, err := bootloader.Find()
+	bloader, err := bootloader.Find()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get boot settings: %s", err)
 	}
 
-	m, err := loader.GetBootVars(bootVar, "snap_mode")
+	m, err := bloader.GetBootVars(bootVar, "snap_mode")
 	if err != nil {
 		return nil, fmt.Errorf("cannot get boot variables: %s", err)
 	}

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -125,7 +125,7 @@ func InUse(name string, rev snap.Revision) bool {
 }
 
 var (
-	ErrBootNameAndRevisionAgain = errors.New("boot revision not yet established")
+	ErrBootNameAndRevisionNotReady = errors.New("boot revision not yet established")
 )
 
 type NameAndRevision struct {
@@ -135,7 +135,7 @@ type NameAndRevision struct {
 
 // GetCurrentBoot returns the currently set name and revision for boot for the given
 // type of snap, which can be snap.TypeBase (or snap.TypeOS), or snap.TypeKernel.
-// Returns ErrBootNameAndRevisionAgain if the values are temporarily not established.
+// Returns ErrBootNameAndRevisionNotReady if the values are temporarily not established.
 func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
 	var bootVar, errName string
 	switch t {
@@ -160,7 +160,7 @@ func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
 	}
 
 	if m["snap_mode"] == "trying" {
-		return nil, ErrBootNameAndRevisionAgain
+		return nil, ErrBootNameAndRevisionNotReady
 	}
 
 	nameAndRevno, err := nameAndRevnoFromSnap(m[bootVar])

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -163,7 +163,7 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevision(c *C) {
 
 	s.loader.BootVars["snap_mode"] = "trying"
 	_, err = boot.GetCurrentBoot(snap.TypeKernel)
-	c.Check(err, Equals, boot.ErrBootNameAndRevisionAgain)
+	c.Check(err, Equals, boot.ErrBootNameAndRevisionNotReady)
 }
 
 func (s *bootSetSuite) TestCurrentBootNameAndRevisionUnhappy(c *C) {

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -168,13 +168,13 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevision(c *C) {
 
 func (s *bootSetSuite) TestCurrentBootNameAndRevisionUnhappy(c *C) {
 	_, err := boot.GetCurrentBoot(snap.TypeKernel)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot kernel: unset")
+	c.Check(err, ErrorMatches, "cannot get name and revision of boot kernel: boot variable unset")
 
 	_, err = boot.GetCurrentBoot(snap.TypeOS)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: unset")
+	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: boot variable unset")
 
 	_, err = boot.GetCurrentBoot(snap.TypeBase)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: unset")
+	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: boot variable unset")
 
 	_, err = boot.GetCurrentBoot(snap.TypeApp)
 	c.Check(err, ErrorMatches, "internal error: cannot find boot revision for snap type \"app\"")

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -61,7 +61,7 @@ func (s *baseBootSetSuite) SetUpTest(c *C) {
 type bootSetSuite struct {
 	baseBootSetSuite
 
-	loader *bootloadertest.MockBootloader
+	bootloader *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&bootSetSuite{})
@@ -69,8 +69,8 @@ var _ = Suite(&bootSetSuite{})
 func (s *bootSetSuite) SetUpTest(c *C) {
 	s.baseBootSetSuite.SetUpTest(c)
 
-	s.loader = bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(s.loader)
+	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(s.bootloader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 }
 
@@ -122,7 +122,7 @@ func (s *bootSetSuite) TestInUse(c *C) {
 		{"snap_kernel", "kernel_111.snap", "kernel", snap.R(1), false},
 		{"snap_try_kernel", "kernel_111.snap", "kernel", snap.R(1), false},
 	} {
-		s.loader.BootVars[t.bootVarKey] = t.bootVarValue
+		s.bootloader.BootVars[t.bootVarKey] = t.bootVarValue
 		c.Assert(boot.InUse(t.snapName, t.snapRev), Equals, t.inUse, Commentf("unexpected result: %s %s %v", t.snapName, t.snapRev, t.inUse))
 	}
 }
@@ -130,16 +130,16 @@ func (s *bootSetSuite) TestInUse(c *C) {
 func (s *bootSetSuite) TestInUseUnhapy(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
-	s.loader.BootVars["snap_kernel"] = "kernel_41.snap"
+	s.bootloader.BootVars["snap_kernel"] = "kernel_41.snap"
 
 	// sanity check
 	c.Check(boot.InUse("kernel", snap.R(41)), Equals, true)
 
 	// make GetVars fail
-	s.loader.GetErr = errors.New("zap")
+	s.bootloader.GetErr = errors.New("zap")
 	c.Check(boot.InUse("kernel", snap.R(41)), Equals, false)
 	c.Check(logbuf.String(), testutil.Contains, "cannot get boot vars: zap")
-	s.loader.GetErr = nil
+	s.bootloader.GetErr = nil
 
 	// make bootloader.Find fail
 	bootloader.ForceError(errors.New("broken bootloader"))
@@ -148,8 +148,8 @@ func (s *bootSetSuite) TestInUseUnhapy(c *C) {
 }
 
 func (s *bootSetSuite) TestCurrentBootNameAndRevision(c *C) {
-	s.loader.BootVars["snap_core"] = "core_2.snap"
-	s.loader.BootVars["snap_kernel"] = "canonical-pc-linux_2.snap"
+	s.bootloader.BootVars["snap_core"] = "core_2.snap"
+	s.bootloader.BootVars["snap_kernel"] = "canonical-pc-linux_2.snap"
 
 	current, err := boot.GetCurrentBoot(snap.TypeOS)
 	c.Check(err, IsNil)
@@ -161,7 +161,7 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevision(c *C) {
 	c.Check(current.Name, Equals, "canonical-pc-linux")
 	c.Check(current.Revision, Equals, snap.R(2))
 
-	s.loader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_mode"] = "trying"
 	_, err = boot.GetCurrentBoot(snap.TypeKernel)
 	c.Check(err, Equals, boot.ErrBootNameAndRevisionNotReady)
 }
@@ -180,17 +180,17 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevisionUnhappy(c *C) {
 	c.Check(err, ErrorMatches, "internal error: cannot find boot revision for snap type \"app\"")
 
 	// sanity check
-	s.loader.BootVars["snap_kernel"] = "kernel_41.snap"
+	s.bootloader.BootVars["snap_kernel"] = "kernel_41.snap"
 	current, err := boot.GetCurrentBoot(snap.TypeKernel)
 	c.Check(err, IsNil)
 	c.Check(current.Name, Equals, "kernel")
 	c.Check(current.Revision, Equals, snap.R(41))
 
 	// make GetVars fail
-	s.loader.GetErr = errors.New("zap")
+	s.bootloader.GetErr = errors.New("zap")
 	_, err = boot.GetCurrentBoot(snap.TypeKernel)
 	c.Check(err, ErrorMatches, "cannot get boot variables: zap")
-	s.loader.GetErr = nil
+	s.bootloader.GetErr = nil
 
 	// make bootloader.Find fail
 	bootloader.ForceError(errors.New("broken bootloader"))
@@ -326,9 +326,9 @@ func (s *bootSetSuite) TestLookupKernelWithModel(c *C) {
 }
 
 func (s *bootSetSuite) TestMarkBootSuccessfulAllSnap(c *C) {
-	s.loader.BootVars["snap_mode"] = "trying"
-	s.loader.BootVars["snap_try_core"] = "os1"
-	s.loader.BootVars["snap_try_kernel"] = "k1"
+	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_try_core"] = "os1"
+	s.bootloader.BootVars["snap_try_kernel"] = "k1"
 	err := boot.MarkBootSuccessful()
 	c.Assert(err, IsNil)
 
@@ -341,23 +341,23 @@ func (s *bootSetSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 		"snap_kernel": "k1",
 		"snap_core":   "os1",
 	}
-	c.Assert(s.loader.BootVars, DeepEquals, expected)
+	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 
 	// do it again, verify its still valid
 	err = boot.MarkBootSuccessful()
 	c.Assert(err, IsNil)
-	c.Assert(s.loader.BootVars, DeepEquals, expected)
+	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 }
 
 func (s *bootSetSuite) TestMarkBootSuccessfulKKernelUpdate(c *C) {
-	s.loader.BootVars["snap_mode"] = "trying"
-	s.loader.BootVars["snap_core"] = "os1"
-	s.loader.BootVars["snap_kernel"] = "k1"
-	s.loader.BootVars["snap_try_core"] = ""
-	s.loader.BootVars["snap_try_kernel"] = "k2"
+	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_core"] = "os1"
+	s.bootloader.BootVars["snap_kernel"] = "k1"
+	s.bootloader.BootVars["snap_try_core"] = ""
+	s.bootloader.BootVars["snap_try_kernel"] = "k2"
 	err := boot.MarkBootSuccessful()
 	c.Assert(err, IsNil)
-	c.Assert(s.loader.BootVars, DeepEquals, map[string]string{
+	c.Assert(s.bootloader.BootVars, DeepEquals, map[string]string{
 		// cleared
 		"snap_mode":       "",
 		"snap_try_kernel": "",

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -33,6 +33,7 @@ type coreBootParticipant struct {
 	t snap.Type
 }
 
+// ensure coreBootParticipant is a BootParticipant
 var _ BootParticipant = (*coreBootParticipant)(nil)
 
 func (bs *coreBootParticipant) SetNextBoot() error {
@@ -114,7 +115,8 @@ type coreKernel struct {
 	*coreBootParticipant
 }
 
-var _ BootParticipant = (*coreKernel)(nil)
+// ensure coreKernel is a Kernel
+var _ Kernel = (*coreKernel)(nil)
 
 func (k *coreKernel) RemoveKernelAssets() error {
 	// XXX: shouldn't we check the snap type?

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -48,7 +48,7 @@ vendor: Someone
 type coreBootSetSuite struct {
 	baseBootSetSuite
 
-	loader *bootloadertest.MockBootloader
+	bootloader *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&coreBootSetSuite{})
@@ -56,8 +56,8 @@ var _ = Suite(&coreBootSetSuite{})
 func (s *coreBootSetSuite) SetUpTest(c *C) {
 	s.baseBootSetSuite.SetUpTest(c)
 
-	s.loader = bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(s.loader)
+	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(s.bootloader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 }
 
@@ -78,11 +78,11 @@ func (s *coreBootSetSuite) TestChangeRequiresRebootError(c *C) {
 	defer restore()
 	bp := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeBase)
 
-	s.loader.GetErr = errors.New("zap")
+	s.bootloader.GetErr = errors.New("zap")
 
 	c.Check(bp.ChangeRequiresReboot(), Equals, false)
 	c.Check(logbuf.String(), testutil.Contains, `cannot get boot variables: zap`)
-	s.loader.GetErr = nil
+	s.bootloader.GetErr = nil
 	logbuf.Reset()
 
 	bootloader.ForceError(errors.New("brkn"))
@@ -91,7 +91,7 @@ func (s *coreBootSetSuite) TestChangeRequiresRebootError(c *C) {
 }
 
 func (s *coreBootSetSuite) TestSetNextBootError(c *C) {
-	s.loader.GetErr = errors.New("zap")
+	s.bootloader.GetErr = errors.New("zap")
 	err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeApp).SetNextBoot()
 	c.Check(err, ErrorMatches, `cannot set next boot: zap`)
 
@@ -110,7 +110,7 @@ func (s *coreBootSetSuite) TestSetNextBootForCore(c *C) {
 	err := bs.SetNextBoot()
 	c.Assert(err, IsNil)
 
-	v, err := s.loader.GetBootVars("snap_try_core", "snap_mode")
+	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_try_core": "core_100.snap",
@@ -130,7 +130,7 @@ func (s *coreBootSetSuite) TestSetNextBootWithBaseForCore(c *C) {
 	err := bs.SetNextBoot()
 	c.Assert(err, IsNil)
 
-	v, err := s.loader.GetBootVars("snap_try_core", "snap_mode")
+	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_try_core": "core18_1818.snap",
@@ -150,7 +150,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernel(c *C) {
 	err := bp.SetNextBoot()
 	c.Assert(err, IsNil)
 
-	v, err := s.loader.GetBootVars("snap_try_kernel", "snap_mode")
+	v, err := s.bootloader.GetBootVars("snap_try_kernel", "snap_mode")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_try_kernel": "krnl_42.snap",
@@ -160,12 +160,12 @@ func (s *coreBootSetSuite) TestSetNextBootForKernel(c *C) {
 	bootVars := map[string]string{
 		"snap_kernel":     "krnl_40.snap",
 		"snap_try_kernel": "krnl_42.snap"}
-	s.loader.SetBootVars(bootVars)
+	s.bootloader.SetBootVars(bootVars)
 	c.Check(bp.ChangeRequiresReboot(), Equals, true)
 
 	// simulate good boot
 	bootVars = map[string]string{"snap_kernel": "krnl_42.snap"}
-	s.loader.SetBootVars(bootVars)
+	s.bootloader.SetBootVars(bootVars)
 	c.Check(bp.ChangeRequiresReboot(), Equals, false)
 }
 
@@ -176,12 +176,12 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	info.Revision = snap.R(40)
 
 	bootVars := map[string]string{"snap_kernel": "krnl_40.snap"}
-	s.loader.SetBootVars(bootVars)
+	s.bootloader.SetBootVars(bootVars)
 
 	err := boot.NewCoreKernel(info).SetNextBoot()
 	c.Assert(err, IsNil)
 
-	v, err := s.loader.GetBootVars("snap_kernel")
+	v, err := s.bootloader.GetBootVars("snap_kernel")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_kernel": "krnl_40.snap",
@@ -198,12 +198,12 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C)
 		"snap_kernel":     "krnl_40.snap",
 		"snap_try_kernel": "krnl_99.snap",
 		"snap_mode":       "try"}
-	s.loader.SetBootVars(bootVars)
+	s.bootloader.SetBootVars(bootVars)
 
 	err := boot.NewCoreKernel(info).SetNextBoot()
 	c.Assert(err, IsNil)
 
-	v, err := s.loader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")
+	v, err := s.bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, map[string]string{
 		"snap_kernel":     "krnl_40.snap",
@@ -226,20 +226,20 @@ func (s *ubootBootSetSuite) forceUbootBootloader(c *C) bootloader.Bootloader {
 	err = bootloader.InstallBootConfig(mockGadgetDir)
 	c.Assert(err, IsNil)
 
-	loader, err := bootloader.Find()
+	bloader, err := bootloader.Find()
 	c.Assert(err, IsNil)
-	c.Check(loader, NotNil)
-	bootloader.Force(loader)
+	c.Check(bloader, NotNil)
+	bootloader.Force(bloader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
 	fn := filepath.Join(s.bootdir, "/uboot/uboot.env")
 	c.Assert(osutil.FileExists(fn), Equals, true)
-	return loader
+	return bloader
 }
 
 func (s *ubootBootSetSuite) TestExtractKernelAssetsAndRemoveOnUboot(c *C) {
-	loader := s.forceUbootBootloader(c)
-	c.Assert(loader, NotNil)
+	bloader := s.forceUbootBootloader(c)
+	c.Assert(bloader, NotNil)
 
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
@@ -305,19 +305,19 @@ func (s *grubBootSetSuite) forceGrubBootloader(c *C) bootloader.Bootloader {
 	err = bootloader.InstallBootConfig(mockGadgetDir)
 	c.Assert(err, IsNil)
 
-	loader, err := bootloader.Find()
+	bloader, err := bootloader.Find()
 	c.Assert(err, IsNil)
-	c.Check(loader, NotNil)
-	loader.SetBootVars(map[string]string{
+	c.Check(bloader, NotNil)
+	bloader.SetBootVars(map[string]string{
 		"snap_kernel": "kernel_41.snap",
 		"snap_core":   "core_21.snap",
 	})
-	bootloader.Force(loader)
+	bootloader.Force(bloader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
 	fn := filepath.Join(s.bootdir, "/grub/grub.cfg")
 	c.Assert(osutil.FileExists(fn), Equals, true)
-	return loader
+	return bloader
 }
 
 func (s *grubBootSetSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -89,50 +89,6 @@ func (s *bootenvTestSuite) TestForceBootloaderError(c *C) {
 	c.Check(got, IsNil)
 }
 
-func (s *bootenvTestSuite) TestMarkBootSuccessfulAllSnap(c *C) {
-	s.b.BootVars["snap_mode"] = "trying"
-	s.b.BootVars["snap_try_core"] = "os1"
-	s.b.BootVars["snap_try_kernel"] = "k1"
-	err := bootloader.MarkBootSuccessful(s.b)
-	c.Assert(err, IsNil)
-
-	expected := map[string]string{
-		// cleared
-		"snap_mode":       "",
-		"snap_try_kernel": "",
-		"snap_try_core":   "",
-		// updated
-		"snap_kernel": "k1",
-		"snap_core":   "os1",
-	}
-	c.Assert(s.b.BootVars, DeepEquals, expected)
-
-	// do it again, verify its still valid
-	err = bootloader.MarkBootSuccessful(s.b)
-	c.Assert(err, IsNil)
-	c.Assert(s.b.BootVars, DeepEquals, expected)
-}
-
-func (s *bootenvTestSuite) TestMarkBootSuccessfulKKernelUpdate(c *C) {
-	s.b.BootVars["snap_mode"] = "trying"
-	s.b.BootVars["snap_core"] = "os1"
-	s.b.BootVars["snap_kernel"] = "k1"
-	s.b.BootVars["snap_try_core"] = ""
-	s.b.BootVars["snap_try_kernel"] = "k2"
-	err := bootloader.MarkBootSuccessful(s.b)
-	c.Assert(err, IsNil)
-	c.Assert(s.b.BootVars, DeepEquals, map[string]string{
-		// cleared
-		"snap_mode":       "",
-		"snap_try_kernel": "",
-		"snap_try_core":   "",
-		// unchanged
-		"snap_core": "os1",
-		// updated
-		"snap_kernel": "k2",
-	})
-}
-
 func (s *bootenvTestSuite) TestInstallBootloaderConfigNoConfig(c *C) {
 	err := bootloader.InstallBootConfig(c.MkDir())
 	c.Assert(err, ErrorMatches, `cannot find boot config in.*`)

--- a/image/image.go
+++ b/image/image.go
@@ -812,7 +812,7 @@ func setBootvars(downloadedSnapsInfoForBootConfig map[string]*snap.Info, model *
 	// Set bootvars for kernel/core snaps so the system boots and
 	// does the first-time initialization. There is also no
 	// mounted kernel/core/base snap, but just the blobs.
-	loader, err := bootloader.Find()
+	bloader, err := bootloader.Find()
 	if err != nil {
 		return fmt.Errorf("cannot set kernel/core boot variables: %s", err)
 	}
@@ -859,7 +859,7 @@ func setBootvars(downloadedSnapsInfoForBootConfig map[string]*snap.Info, model *
 			m[bootvar] = name
 		}
 	}
-	if err := loader.SetBootVars(m); err != nil {
+	if err := bloader.SetBootVars(m); err != nil {
 		return err
 	}
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
-	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -438,11 +438,7 @@ func (m *DeviceManager) ensureBootOk() error {
 	}
 
 	if !m.bootOkRan {
-		loader, err := bootloader.Find()
-		if err != nil {
-			return fmt.Errorf(i18n.G("cannot mark boot successful: %s"), err)
-		}
-		if err := bootloader.MarkBootSuccessful(loader); err != nil {
+		if err := boot.MarkBootSuccessful(); err != nil {
 			return err
 		}
 		m.bootOkRan = true

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -487,11 +487,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core_1.snap")
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
 
 	st := s.overlord.State()
 	chg := s.makeSeedChange(c, st)
@@ -612,11 +612,11 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedHappyMultiAssertsFiles(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core_1.snap")
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
 
 	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
 
@@ -711,11 +711,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedConfigureHappy(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core_1.snap")
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
 
 	const defaultsYaml = `
 defaults:
@@ -864,11 +864,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedGadgetConnectHappy(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core_1.snap")
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
 
 	const connectionsYaml = `
 connections:
@@ -1173,11 +1173,11 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedWithBaseHappy(c *C) {
 	})
 	defer systemctlRestorer()
 
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core18_1.snap")
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core18_1.snap")
 
 	core18Fname, snapdFname, kernelFname, gadgetFname := s.makeCore18Snaps(c, nil)
 
@@ -1370,11 +1370,11 @@ snaps:
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedWrongContentProviderOrder(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core_1.snap")
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
 
 	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1529,8 +1529,8 @@ func findKind(chg *state.Change, kind string) *state.Task {
 }
 
 func (s *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderAndSplitsAcrossRestart(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
 	restore := release.MockOnClassic(false)
@@ -1579,15 +1579,15 @@ type: os
 	c.Assert(t.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 
 	// this is already set
-	c.Assert(loader.BootVars, DeepEquals, map[string]string{
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
 		"snap_try_core": "core_x1.snap",
 		"snap_mode":     "try",
 	})
 
 	// simulate successful restart happened
 	state.MockRestarting(st, state.RestartUnset)
-	loader.BootVars["snap_mode"] = ""
-	loader.SetBootBase("core_x1.snap")
+	bloader.BootVars["snap_mode"] = ""
+	bloader.SetBootBase("core_x1.snap")
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
@@ -1599,8 +1599,8 @@ type: os
 }
 
 func (s *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
 	restore := release.MockOnClassic(false)
@@ -1659,7 +1659,7 @@ type: kernel`
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 
-	c.Assert(loader.BootVars, DeepEquals, map[string]string{
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
 		"snap_try_kernel": "pc-kernel_x1.snap",
 		"snap_mode":       "try",
 	})
@@ -3402,10 +3402,10 @@ type: base`
 }
 
 func (s *mgrsSuite) TestRemodelSwitchKernelTrack(c *C) {
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	loader.SetBootKernel("pc-kernel_1.snap")
-	loader.SetBootBase("core_1.snap")
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
+	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
 
 	restore := release.MockOnClassic(false)

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -147,8 +147,8 @@ func (s *setupSuite) TestSetupDoUndoInstance(c *C) {
 func (s *setupSuite) TestSetupDoUndoKernel(c *C) {
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
@@ -174,15 +174,15 @@ type: kernel
 	snapType, err := s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
 	c.Assert(err, IsNil)
 	c.Check(snapType, Equals, snap.TypeKernel)
-	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 1)
-	c.Assert(loader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
+	c.Assert(bloader.ExtractKernelAssetsCalls, HasLen, 1)
+	c.Assert(bloader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
 
 	// undo deletes the kernel assets again
 	err = s.be.UndoSetupSnap(minInfo, "kernel", progress.Null)
 	c.Assert(err, IsNil)
-	c.Assert(loader.RemoveKernelAssetsCalls, HasLen, 1)
-	c.Assert(loader.RemoveKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
+	c.Assert(bloader.RemoveKernelAssetsCalls, HasLen, 1)
+	c.Assert(bloader.RemoveKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 }
 
 func (s *setupSuite) TestSetupDoIdempotent(c *C) {
@@ -193,8 +193,8 @@ func (s *setupSuite) TestSetupDoIdempotent(c *C) {
 
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
 	defer os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
@@ -218,14 +218,14 @@ type: kernel
 
 	_, err := s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
 	c.Assert(err, IsNil)
-	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 1)
-	c.Assert(loader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
+	c.Assert(bloader.ExtractKernelAssetsCalls, HasLen, 1)
+	c.Assert(bloader.ExtractKernelAssetsCalls[0].InstanceName(), Equals, "kernel")
 
 	// retry run
 	_, err = s.be.SetupSnap(snapPath, "kernel", &si, progress.Null)
 	c.Assert(err, IsNil)
-	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 2)
-	c.Assert(loader.ExtractKernelAssetsCalls[1].InstanceName(), Equals, "kernel")
+	c.Assert(bloader.ExtractKernelAssetsCalls, HasLen, 2)
+	c.Assert(bloader.ExtractKernelAssetsCalls[1].InstanceName(), Equals, "kernel")
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
 
 	// sanity checks
@@ -244,8 +244,8 @@ func (s *setupSuite) TestSetupUndoIdempotent(c *C) {
 
 	// kernel snaps only happen on non-classic
 	defer release.MockOnClassic(false)()
-	loader := bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(loader)
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
 	// we don't get real mounting
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
 	defer os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
@@ -287,8 +287,8 @@ type: kernel
 	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, false)
 
 	// assets got extracted and then removed again
-	c.Assert(loader.ExtractKernelAssetsCalls, HasLen, 1)
-	c.Assert(loader.RemoveKernelAssetsCalls, HasLen, 1)
+	c.Assert(bloader.ExtractKernelAssetsCalls, HasLen, 1)
+	c.Assert(bloader.RemoveKernelAssetsCalls, HasLen, 1)
 }
 
 func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1164,17 +1164,17 @@ func maybeRestart(t *state.Task, info *snap.Info) {
 		return
 	}
 
-	restartMsg := daemonRestartMessage(st, typ)
-	if restartMsg == "" {
+	restartReason := daemonRestartReason(st, typ)
+	if restartReason == "" {
 		// no message -> no restart
 		return
 	}
 
-	t.Logf(restartMsg)
+	t.Logf(restartReason)
 	st.RequestRestart(state.RestartDaemon)
 }
 
-func daemonRestartMessage(st *state.State, typ snap.Type) string {
+func daemonRestartReason(st *state.State, typ snap.Type) string {
 	if !((release.OnClassic && typ == snap.TypeOS) || typ == snap.TypeSnapd) {
 		// not interesting
 		return ""

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -438,7 +438,7 @@ func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 		}
 
 		current, err := boot.GetCurrentBoot(typ)
-		if err == boot.ErrBootNameAndRevisionAgain {
+		if err == boot.ErrBootNameAndRevisionNotReady {
 			return &state.Retry{After: 5 * time.Second}
 		}
 		if err != nil {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10952,7 +10952,7 @@ type canRemoveSuite struct {
 	st        *state.State
 	deviceCtx snapstate.DeviceContext
 
-	bs *bootloadertest.MockBootloader
+	bootloader *bootloadertest.MockBootloader
 }
 
 var _ = Suite(&canRemoveSuite{})
@@ -10962,8 +10962,8 @@ func (s *canRemoveSuite) SetUpTest(c *C) {
 	s.st = state.New(nil)
 	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: DefaultModel()}
 
-	s.bs = bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(s.bs)
+	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(s.bootloader)
 }
 
 func (s *canRemoveSuite) TearDownTest(c *C) {
@@ -11015,7 +11015,7 @@ func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *C) {
 	}
 	kernel.RealName = "kernel"
 
-	s.bs.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
+	s.bootloader.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
 
 	removeAll := false
 	c.Check(snapstate.CanRemove(s.st, kernel, &snapstate.SnapState{}, removeAll, s.deviceCtx), Equals, false)
@@ -11030,7 +11030,7 @@ func (s *canRemoveSuite) TestOstInUseIsKept(c *C) {
 	}
 	base.RealName = "core18"
 
-	s.bs.SetBootBase(fmt.Sprintf("%s_%s.snap", base.RealName, base.SideInfo.Revision))
+	s.bootloader.SetBootBase(fmt.Sprintf("%s_%s.snap", base.RealName, base.SideInfo.Revision))
 
 	removeAll := false
 	c.Check(snapstate.CanRemove(s.st, base, &snapstate.SnapState{}, removeAll, s.deviceCtx), Equals, false)
@@ -11054,7 +11054,7 @@ func (s *canRemoveSuite) TestRemoveNonModelKernelStillInUseNotOk(c *C) {
 	}
 	kernel.RealName = "other-non-model-kernel"
 
-	s.bs.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
+	s.bootloader.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
 
 	c.Check(snapstate.CanRemove(s.st, kernel, &snapstate.SnapState{}, true, s.deviceCtx), Equals, false)
 }


### PR DESCRIPTION
This change moves almost everything that looks at boot environment
variables to `boot`. The exception (for now at least) is `image`,
which is (for now and possibly intrinsically) special, and
`bootloadertest` which has a couple of convenience functions that jump
layers and might get moved to `boot` later.

It also includes a bunch of little cleanups / refactorings that were pending from previous PRs.