### PR TITLE
tests: rewrite "retry" command as retry-tool

### DIFF
--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -1,0 +1,100 @@
+#!/usr/bin/env any-python
+from __future__ import print_function, absolute_import, unicode_literals
+
+import argparse
+import subprocess
+import sys
+import time
+
+
+# Define MYPY as False and use it as a conditional for typing import. Despite
+# this declaration mypy will really treat MYPY as True when type-checking.
+# This is required so that we can import typing on Python 2.x without the
+# typing module installed. For more details see:
+# https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+MYPY = False
+if MYPY:
+    from typing import List, Text
+
+
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+Retry executes COMMAND at most N times, waiting for SECONDS between each
+attempt. On failure the exit code from the final attempt is returned.
+"""
+    )
+    parser.add_argument(
+        "-n",
+        "--attempts",
+        metavar="N",
+        type=int,
+        default=3,
+        help="number of attempts (default %(default)s)",
+    )
+    parser.add_argument(
+        "--wait",
+        metavar="SECONDS",
+        type=float,
+        default=1,
+        help="grace period between attempts (default %(default)ss)",
+    )
+    parser.add_argument(
+        "cmd", metavar="COMMAND", nargs="...", help="command to execute"
+    )
+    return parser
+
+
+def run_cmd(cmd, n, wait):
+    # type: (List[Text], int, float) -> int
+    retcode = 0
+    for i in range(1, n + 1):
+        retcode = subprocess.call(cmd)
+        if retcode == 0:
+            break
+        print(
+            "retry: command {} failed with code {}".format(" ".join(cmd), retcode),
+            file=sys.stderr,
+        )
+        if i < n:
+            print(
+                "retry: next attempt in {} second(s) (attempt {} of {})".format(
+                    wait, i, n
+                ),
+                file=sys.stderr,
+            )
+            time.sleep(wait)
+    else:
+        if n > 1:
+            print(
+                "retry: command {} keeps failing after {} attempts".format(
+                    " ".join(cmd), n
+                ),
+                file=sys.stderr,
+            )
+    return retcode
+
+
+def main():
+    # type: () -> None
+    parser = _make_parser()
+    ns = parser.parse_args()
+    # The command cannot be empty but it is difficult to express in argparse itself.
+    if len(ns.cmd) == 0:
+        parser.print_usage()
+        parser.exit(0)
+    # Return the last exit code as the exit code of this process.
+    try:
+        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait)
+    except OSError as exc:
+        print(
+            "retry: cannot execute command {}: {}".format(" ".join(ns.cmd), exc),
+            file=sys.stderr,
+        )
+    else:
+        raise SystemExit(retcode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -92,6 +92,7 @@ def main():
             "retry: cannot execute command {}: {}".format(" ".join(ns.cmd), exc),
             file=sys.stderr,
         )
+        raise SystemExit(1)
     else:
         raise SystemExit(retcode)
 

--- a/tests/main/retry-tool/task.yaml
+++ b/tests/main/retry-tool/task.yaml
@@ -1,0 +1,11 @@
+summary: smoke test for the retry test tool
+execute: |
+    # Retry runs the command that was passed as argument and returns the exit
+    # code of that command.
+    retry-tool true
+    not retry-tool -n 1 false
+    # On failure it tells us about it, showing progress.
+    retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false failed with code 1"
+    retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: next attempt in 0.1 second(s) (attempt 1 of 2)"
+    retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false keeps failing after 2 attempts"
+


### PR DESCRIPTION
Having pushed Sergio towards writing the command in Python instead of
shell I think it's on me to make sure it lands and looks right. This
patch rewrites the utility, with extra usability touches and, mainly,
correct semantics.

I added a quick spread test to showcase the features as well.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
