### PR TITLE
cmd/libsnap-confine-private, cmd/s-c: use constants for snap/instance name lengths

### DIFF
--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -111,9 +111,8 @@ void sc_instance_name_validate(const char *instance_name, sc_error ** errorp)
 				  "snap instance name cannot be NULL");
 		goto out;
 	}
-	// 40 char snap_name + '_' + 10 char instance_key + 1 extra overflow + 1
-	// NULL
-	char s[53] = { 0 };
+	// instance name length + 1 extra overflow + 1 NULL
+	char s[SNAP_INSTANCE_LEN + 1 + 1] = { 0 };
 	strncpy(s, instance_name, sizeof(s) - 1);
 
 	char *t = s;
@@ -175,7 +174,7 @@ void sc_instance_key_validate(const char *instance_key, sc_error ** errorp)
 		err =
 		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
 				  "instance key must contain at least one letter or digit");
-	} else if (i > 10) {
+	} else if (i > SNAP_INSTANCE_KEY_LEN) {
 		err =
 		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_INSTANCE_KEY,
 				  "instance key must be shorter than 10 characters");

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -37,11 +37,15 @@ enum {
 	SC_SNAP_INVALID_INSTANCE_NAME = 3,
 };
 
-/* 40 char snap_name */
+/* SNAP_NAME_LEN is the maximum length of a snap name, enforced by snapd and the
+ * store. */
 #define SNAP_NAME_LEN 40
-/* 10 char instance key */
+/* SNAP_INSTANCE_KEY_LEN is the maximum length of instance key, enforced locally
+ * by snapd. */
 #define SNAP_INSTANCE_KEY_LEN 10
-/* 40 char snap_name + '_' + 10 char instance_key */
+/* SNAP_INSTANCE_LEN is the maximum length of snap instance name, composed of
+ * the snap name, separator '_' and the instance key, enforced locally by
+ * snapd. */
 #define SNAP_INSTANCE_LEN (SNAP_NAME_LEN + 1 + SNAP_INSTANCE_KEY_LEN)
 
 /**

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -37,6 +37,13 @@ enum {
 	SC_SNAP_INVALID_INSTANCE_NAME = 3,
 };
 
+/* 40 char snap_name */
+#define SNAP_NAME_LEN 40
+/* 10 char instance key */
+#define SNAP_INSTANCE_KEY_LEN 10
+/* 40 char snap_name + '_' + 10 char instance_key */
+#define SNAP_INSTANCE_LEN (SNAP_NAME_LEN + 1 + SNAP_INSTANCE_KEY_LEN)
+
 /**
  * Validate the given snap name.
  *


### PR DESCRIPTION
Extracted from #7302 
