### PR TITLE
tests: move debug section after restore

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -622,17 +622,17 @@ suites:
         summary: Full-system tests for snapd
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
-        debug: |
-            if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
-                systemctl status snapd.socket || true
-                journalctl -xe
-            fi
         prepare-each: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
         restore-each: |
             "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
             "$TESTSLIB"/prepare-restore.sh --restore-suite
+        debug: |
+            if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
+                systemctl status snapd.socket || true
+                journalctl -xe
+            fi
     tests/core18/:
         summary: Subset of core18 specific tests
         systems: [ubuntu-core-18-*]


### PR DESCRIPTION
This just reads nicer visually, since prepare-restore sections are
shared amongst several suites.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>