### PR TITLE
cmd/snap-confine: apply global mount namespace initialization for confined and classic snaps

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -390,6 +390,29 @@ int main(int argc, char **argv)
 	}
 	// TODO: check for similar situation and linux capabilities.
 	if (geteuid() == 0) {
+		/* snap-confine uses privately-shared /run/snapd/ns to store bind-mounted
+		 * mount namespaces of each snap. In the case that snap-confine is invoked
+		 * from the mount namespace it typically constructs, the said directory
+		 * does not contain mount entries for preserved namespaces as those are
+		 * only visible in the main, outer namespace.
+		 *
+		 * In order to operate in such an environment snap-confine must first
+		 * re-associate its own process with another namespace in which the
+		 * /run/snapd/ns directory is visible. The most obvious candidate is pid
+		 * one, which definitely doesn't run in a snap-specific namespace, has a
+		 * predictable PID and is long lived.
+		 */
+		sc_reassociate_with_pid1_mount_ns();
+		// Do global initialization:
+		int global_lock_fd = sc_lock_global();
+		// Ensure that "/" or "/snap" is mounted with the
+		// "shared" option on legacy systems, see LP:#1668659
+		debug("ensuring that snap mount directory is shared");
+		sc_ensure_shared_snap_mount();
+		debug("unsharing snap namespace directory");
+		sc_initialize_mount_ns();
+		sc_unlock(global_lock_fd);
+
 		if (invocation.classic_confinement) {
 			enter_classic_execution_environment();
 		} else {
@@ -533,29 +556,6 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 						    gid_t real_gid,
 						    gid_t saved_gid)
 {
-	/* snap-confine uses privately-shared /run/snapd/ns to store bind-mounted
-	 * mount namespaces of each snap. In the case that snap-confine is invoked
-	 * from the mount namespace it typically constructs, the said directory
-	 * does not contain mount entries for preserved namespaces as those are
-	 * only visible in the main, outer namespace.
-	 *
-	 * In order to operate in such an environment snap-confine must first
-	 * re-associate its own process with another namespace in which the
-	 * /run/snapd/ns directory is visible. The most obvious candidate is pid
-	 * one, which definitely doesn't run in a snap-specific namespace, has a
-	 * predictable PID and is long lived.
-	 */
-	sc_reassociate_with_pid1_mount_ns();
-	// Do global initialization:
-	int global_lock_fd = sc_lock_global();
-	// ensure that "/" or "/snap" is mounted with the
-	// "shared" option, see LP:#1668659
-	debug("ensuring that snap mount directory is shared");
-	sc_ensure_shared_snap_mount();
-	debug("unsharing snap namespace directory");
-	sc_initialize_mount_ns();
-	sc_unlock(global_lock_fd);
-
 	// Find and open snap-update-ns and snap-discard-ns from the same
 	// path as where we (snap-confine) were called.
 	int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-C7.expected.txt
@@ -12,6 +12,7 @@
 12 11 1:10 / /run/cgmanager/fs rw,relatime shared:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
 13 11 1:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:13 - tmpfs tmpfs rw,size=VARIABLE
 14 11 1:12 / /run/rpc_pipefs rw,relatime shared:14 - rpc_pipefs sunrpc rw
+1000 11 1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
 15 11 1:13 / /run/user/0 rw,nosuid,nodev,relatime shared:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
 16 1 2:0 / /snap/core/1 ro,nodev,relatime shared:16 - squashfs /dev/loop0 ro
 17 1 2:1 / /snap/core18/1 ro,nodev,relatime shared:17 - squashfs /dev/loop1 ro

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-C7.expected.txt
@@ -12,6 +12,7 @@
 12 11 1:10 / /run/cgmanager/fs rw,relatime shared:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
 13 11 1:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:13 - tmpfs tmpfs rw,size=VARIABLE
 14 11 1:12 / /run/rpc_pipefs rw,relatime shared:14 - rpc_pipefs sunrpc rw
+1000 11 1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
 15 11 1:13 / /run/user/0 rw,nosuid,nodev,relatime shared:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
 16 1 2:0 / /snap/core/1 ro,nodev,relatime shared:16 - squashfs /dev/loop0 ro
 17 1 2:1 / /snap/core18/1 ro,nodev,relatime shared:17 - squashfs /dev/loop1 ro

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-C7.expected.txt
@@ -12,6 +12,7 @@
 12 1 1:9 / /run rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 13 12 1:10 / /run/lock rw,nosuid,nodev,noexec,relatime shared:13 - tmpfs tmpfs rw,size=VARIABLE
 14 12 1:11 / /run/rpc_pipefs rw,relatime shared:14 - rpc_pipefs sunrpc rw
+1000 12 1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
 15 12 1:12 / /run/user/0 rw,nosuid,nodev,relatime shared:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
 16 1 2:0 / /snap/core/1 ro,nodev,relatime shared:16 - squashfs /dev/loop0 ro
 17 1 2:1 / /snap/core18/1 ro,nodev,relatime shared:17 - squashfs /dev/loop1 ro

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-C7.expected.txt
@@ -12,6 +12,7 @@
 12 1 1:9 / /run rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 13 12 1:10 / /run/lock rw,nosuid,nodev,noexec,relatime shared:13 - tmpfs tmpfs rw,size=VARIABLE
 14 12 1:11 / /run/rpc_pipefs rw,relatime shared:14 - rpc_pipefs sunrpc rw
+1000 12 1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
 15 12 1:12 / /run/user/0 rw,nosuid,nodev,relatime shared:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
 16 1 2:0 / /snap/core/1 ro,nodev,relatime shared:16 - squashfs /dev/loop0 ro
 17 1 2:1 / /snap/core18/1 ro,nodev,relatime shared:17 - squashfs /dev/loop1 ro


### PR DESCRIPTION
Extracted from #7302 

With parallel instances of classic snaps, the basic initialization of mount namespace (creating /run/snapd/ns, switching it to private propagation) can now happen globally for confined and classic snaps.