### PR TITLE
tests: don't guess in is_classic_confinement_supported

### DIFF
--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -72,21 +72,8 @@ install_generic_consumer() {
 }
 
 is_classic_confinement_supported() {
-    case "$SPREAD_SYSTEM" in
-        ubuntu-core-*)
-            return 1
-            ;;
-        ubuntu-*|debian-*)
-            return 0
-            ;;
-        fedora-*|centos-*)
-            return 1
-            ;;
-        opensuse-*)
-            return 0
-            ;;
-        *)
-            return 0
-            ;;
-    esac
+    if snap debug sandbox-features --required=confinement-options:classic; then
+        return 0
+    fi
+    return 1
 }


### PR DESCRIPTION
Snapd can tell us if the system supports classic confinement. We don't
need to inspect SPREAD_SYSTEM to do that.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>