### PR TITLE
tests: add --quiet switch to retry-tool

### DIFF
--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -41,32 +41,41 @@ attempt. On failure the exit code from the final attempt is returned.
         help="grace period between attempts (default %(default)ss)",
     )
     parser.add_argument(
+        "--quiet",
+        dest="verbose",
+        action="store_false",
+        default=True,
+        help="refrain from printing any output",
+    )
+    parser.add_argument(
         "cmd", metavar="COMMAND", nargs="...", help="command to execute"
     )
     return parser
 
 
-def run_cmd(cmd, n, wait):
-    # type: (List[Text], int, float) -> int
+def run_cmd(cmd, n, wait, verbose):
+    # type: (List[Text], int, float, bool) -> int
     retcode = 0
     for i in range(1, n + 1):
         retcode = subprocess.call(cmd)
         if retcode == 0:
             break
-        print(
-            "retry: command {} failed with code {}".format(" ".join(cmd), retcode),
-            file=sys.stderr,
-        )
-        if i < n:
+        if verbose:
             print(
-                "retry: next attempt in {} second(s) (attempt {} of {})".format(
-                    wait, i, n
-                ),
+                "retry: command {} failed with code {}".format(" ".join(cmd), retcode),
                 file=sys.stderr,
             )
+        if i < n:
+            if verbose:
+                print(
+                    "retry: next attempt in {} second(s) (attempt {} of {})".format(
+                        wait, i, n
+                    ),
+                    file=sys.stderr,
+                )
             time.sleep(wait)
     else:
-        if n > 1:
+        if verbose and n > 1:
             print(
                 "retry: command {} keeps failing after {} attempts".format(
                     " ".join(cmd), n
@@ -86,12 +95,13 @@ def main():
         parser.exit(0)
     # Return the last exit code as the exit code of this process.
     try:
-        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait)
+        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait, ns.verbose)
     except OSError as exc:
-        print(
-            "retry: cannot execute command {}: {}".format(" ".join(ns.cmd), exc),
-            file=sys.stderr,
-        )
+        if ns.verbose:
+            print(
+                "retry: cannot execute command {}: {}".format(" ".join(ns.cmd), exc),
+                file=sys.stderr,
+            )
         raise SystemExit(1)
     else:
         raise SystemExit(retcode)

--- a/tests/main/retry-tool/task.yaml
+++ b/tests/main/retry-tool/task.yaml
@@ -8,4 +8,5 @@ execute: |
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false failed with code 1"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: next attempt in 0.1 second(s) (attempt 1 of 2)"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false keeps failing after 2 attempts"
-
+    # Though all output is removed with the --quiet switch.
+    test "$(retry-tool -n 2 --wait 0.1 --quiet false 2>&1 | wc -l)" -eq 0


### PR DESCRIPTION
Pawel made a case for using retry-tool in situations where we know and
anticipate the first few attempts of a command to fail, e.g. while
waiting for some asynchronous operation to finish. In that case the
default output doesn't help much, as we routinely fail on the road to
eventual success.

For this use case, add the --quiet switch, to silence all output from
the tool itself.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
