### PR TITLE
boot, etc: simplify BootParticipant (etc) usage

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -198,11 +198,11 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevisionUnhappy(c *C) {
 	c.Check(err, ErrorMatches, "cannot get boot settings: broken bootloader")
 }
 
-func (s *bootSetSuite) TestLookup(c *C) {
+func (s *bootSetSuite) TestParticipant(c *C) {
 	info := &snap.Info{}
 	info.RealName = "some-snap"
 
-	bp := boot.Lookup(info, snap.TypeApp, nil, false)
+	bp := boot.Participant(info, snap.TypeApp, nil, false)
 	c.Check(bp.IsTrivial(), Equals, true)
 
 	for _, typ := range []snap.Type{
@@ -210,10 +210,10 @@ func (s *bootSetSuite) TestLookup(c *C) {
 		snap.TypeOS,
 		snap.TypeBase,
 	} {
-		bp = boot.Lookup(info, typ, nil, true)
+		bp = boot.Participant(info, typ, nil, true)
 		c.Check(bp.IsTrivial(), Equals, true)
 
-		bp = boot.Lookup(info, typ, nil, false)
+		bp = boot.Participant(info, typ, nil, false)
 		c.Check(bp.IsTrivial(), Equals, false)
 
 		c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(info, typ))
@@ -224,8 +224,9 @@ type mockModel string
 
 func (s mockModel) Kernel() string { return string(s) }
 func (s mockModel) Base() string   { return string(s) }
+func (s mockModel) Classic() bool  { return s == "" }
 
-func (s *bootSetSuite) TestLookupBaseWithModel(c *C) {
+func (s *bootSetSuite) TestParticipantBaseWithModel(c *C) {
 	core := &snap.Info{SideInfo: snap.SideInfo{RealName: "core"}, SnapType: snap.TypeOS}
 	core18 := &snap.Info{SideInfo: snap.SideInfo{RealName: "core18"}, SnapType: snap.TypeBase}
 
@@ -267,10 +268,10 @@ func (s *bootSetSuite) TestLookupBaseWithModel(c *C) {
 	}
 
 	for i, t := range table {
-		bp := boot.Lookup(t.with, t.with.GetType(), t.model, true)
+		bp := boot.Participant(t.with, t.with.GetType(), t.model, true)
 		c.Check(bp.IsTrivial(), Equals, true)
 
-		bp = boot.Lookup(t.with, t.with.GetType(), t.model, false)
+		bp = boot.Participant(t.with, t.with.GetType(), t.model, false)
 		c.Check(bp.IsTrivial(), Equals, t.nop, Commentf("%d", i))
 		if !t.nop {
 			c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(t.with, t.with.GetType()))
@@ -278,7 +279,7 @@ func (s *bootSetSuite) TestLookupBaseWithModel(c *C) {
 	}
 }
 
-func (s *bootSetSuite) TestLookupKernelWithModel(c *C) {
+func (s *bootSetSuite) TestKernelWithModel(c *C) {
 	info := &snap.Info{}
 	info.RealName = "kernel"
 	expected := boot.NewCoreKernel(info)
@@ -286,7 +287,7 @@ func (s *bootSetSuite) TestLookupKernelWithModel(c *C) {
 	type tableT struct {
 		model mockModel
 		nop   bool
-		krn   boot.Kernel
+		krn   boot.BootKernel
 	}
 
 	table := []tableT{
@@ -306,10 +307,10 @@ func (s *bootSetSuite) TestLookupKernelWithModel(c *C) {
 	}
 
 	for _, t := range table {
-		krn := boot.LookupKernel(info, snap.TypeKernel, t.model, true)
+		krn := boot.Kernel(info, snap.TypeKernel, t.model, true)
 		c.Check(krn.IsTrivial(), Equals, true)
 
-		krn = boot.LookupKernel(info, snap.TypeKernel, t.model, false)
+		krn = boot.Kernel(info, snap.TypeKernel, t.model, false)
 		c.Check(krn.IsTrivial(), Equals, t.nop)
 		c.Check(krn, DeepEquals, t.krn)
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -32,5 +32,7 @@ func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type) *coreBootParticipant 
 }
 
 func NewCoreKernel(s snap.PlaceInfo) *coreKernel {
-	return &coreKernel{NewCoreBootParticipant(s, snap.TypeKernel)}
+	return &coreKernel{s}
 }
+
+type Trivial = trivial

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -118,7 +118,7 @@ type coreKernel struct {
 }
 
 // ensure coreKernel is a Kernel
-var _ Kernel = (*coreKernel)(nil)
+var _ BootKernel = (*coreKernel)(nil)
 
 func (*coreKernel) IsTrivial() bool { return false }
 

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -36,6 +36,8 @@ type coreBootParticipant struct {
 // ensure coreBootParticipant is a BootParticipant
 var _ BootParticipant = (*coreBootParticipant)(nil)
 
+func (*coreBootParticipant) IsTrivial() bool { return false }
+
 func (bs *coreBootParticipant) SetNextBoot() error {
 	bootloader, err := bootloader.Find()
 	if err != nil {
@@ -112,11 +114,13 @@ func (bs *coreBootParticipant) ChangeRequiresReboot() bool {
 }
 
 type coreKernel struct {
-	*coreBootParticipant
+	s snap.PlaceInfo
 }
 
 // ensure coreKernel is a Kernel
 var _ Kernel = (*coreKernel)(nil)
+
+func (*coreKernel) IsTrivial() bool { return false }
 
 func (k *coreKernel) RemoveKernelAssets() error {
 	// XXX: shouldn't we check the snap type?

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -146,7 +146,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernel(c *C) {
 	info.RealName = "krnl"
 	info.Revision = snap.R(42)
 
-	bp := boot.NewCoreKernel(info)
+	bp := boot.NewCoreBootParticipant(info, snap.TypeKernel)
 	err := bp.SetNextBoot()
 	c.Assert(err, IsNil)
 
@@ -178,7 +178,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	bootVars := map[string]string{"snap_kernel": "krnl_40.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	err := boot.NewCoreKernel(info).SetNextBoot()
+	err := boot.NewCoreBootParticipant(info, snap.TypeKernel).SetNextBoot()
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel")
@@ -200,7 +200,7 @@ func (s *coreBootSetSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C)
 		"snap_mode":       "try"}
 	s.bootloader.SetBootVars(bootVars)
 
-	err := boot.NewCoreKernel(info).SetNextBoot()
+	err := boot.NewCoreBootParticipant(info, snap.TypeKernel).SetNextBoot()
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")

--- a/image/image.go
+++ b/image/image.go
@@ -873,11 +873,7 @@ func extractKernelAssets(snapPath string, info *snap.Info, model *asserts.Model)
 	}
 
 	// image always runs in not-on-classic mode
-	bp, _ := boot.Lookup(info, info.GetType(), model, false)
-	kernel, ok := bp.(boot.Kernel)
-	if !ok {
-		return nil
-	}
+	kernel := boot.LookupKernel(info, info.GetType(), model, false)
 	return kernel.ExtractKernelAssets(snapf)
 }
 

--- a/image/image.go
+++ b/image/image.go
@@ -873,7 +873,7 @@ func extractKernelAssets(snapPath string, info *snap.Info, model *asserts.Model)
 	}
 
 	// image always runs in not-on-classic mode
-	kernel := boot.LookupKernel(info, info.GetType(), model, false)
+	kernel := boot.Kernel(info, info.GetType(), model, false)
 	return kernel.ExtractKernelAssets(snapf)
 }
 

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -113,7 +113,7 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model, tm timings.Meas
 		})
 	}
 
-	if err := boot.Lookup(info, info.GetType(), model, release.OnClassic).SetNextBoot(); err != nil {
+	if err := boot.Participant(info, info.GetType(), model, release.OnClassic).SetNextBoot(); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -113,10 +113,8 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model, tm timings.Meas
 		})
 	}
 
-	if bp, applicable := boot.Lookup(info, info.GetType(), model, release.OnClassic); applicable {
-		if err := bp.SetNextBoot(); err != nil {
-			return err
-		}
+	if err := boot.Lookup(info, info.GetType(), model, release.OnClassic).SetNextBoot(); err != nil {
+		return err
 	}
 
 	if err := updateCurrentSymlinks(info); err != nil {

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -76,7 +76,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 
 	t := s.GetType()
 	// TODO: maybe look into passing the model
-	if err := boot.LookupKernel(s, t, nil, release.OnClassic).ExtractKernelAssets(snapf); err != nil {
+	if err := boot.Kernel(s, t, nil, release.OnClassic).ExtractKernelAssets(snapf); err != nil {
 		return snapType, fmt.Errorf("cannot install kernel: %s", err)
 	}
 
@@ -101,7 +101,7 @@ func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progress
 	if _, err := os.Lstat(snapPath); err == nil {
 		// remove the kernel assets (if any)
 		// TODO: maybe look into passing the model
-		if err := boot.LookupKernel(s, typ, nil, release.OnClassic).RemoveKernelAssets(); err != nil {
+		if err := boot.Kernel(s, typ, nil, release.OnClassic).RemoveKernelAssets(); err != nil {
 			return err
 		}
 

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -76,11 +76,8 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 
 	t := s.GetType()
 	// TODO: maybe look into passing the model
-	bp, _ := boot.Lookup(s, t, nil, release.OnClassic)
-	if kernel, ok := bp.(boot.Kernel); ok {
-		if err := kernel.ExtractKernelAssets(snapf); err != nil {
-			return snapType, fmt.Errorf("cannot install kernel: %s", err)
-		}
+	if err := boot.LookupKernel(s, t, nil, release.OnClassic).ExtractKernelAssets(snapf); err != nil {
+		return snapType, fmt.Errorf("cannot install kernel: %s", err)
 	}
 
 	return t, nil
@@ -104,11 +101,8 @@ func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, meter progress
 	if _, err := os.Lstat(snapPath); err == nil {
 		// remove the kernel assets (if any)
 		// TODO: maybe look into passing the model
-		bp, _ := boot.Lookup(s, typ, nil, release.OnClassic)
-		if kernel, ok := bp.(boot.Kernel); ok {
-			if err := kernel.RemoveKernelAssets(); err != nil {
-				return err
-			}
+		if err := boot.LookupKernel(s, typ, nil, release.OnClassic).RemoveKernelAssets(); err != nil {
+			return err
 		}
 
 		// remove the snap

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1155,14 +1155,18 @@ func maybeRestart(t *state.Task, info *snap.Info) {
 	}
 
 	typ := info.GetType()
-	bp := boot.Lookup(info, typ, model, release.OnClassic)
-	if !bp.IsTrivial() {
-		if bp.ChangeRequiresReboot() {
-			t.Logf("Requested system restart.")
-			st.RequestRestart(state.RestartSystem)
-		}
+	bp := boot.Participant(info, typ, model, release.OnClassic)
+	if bp.ChangeRequiresReboot() {
+		t.Logf("Requested system restart.")
+		st.RequestRestart(state.RestartSystem)
 		return
 	}
+
+	// if bp is non-trivial then either we're not on classic, or the snap is
+	// snapd. So daemonRestartReason will always return "" which is what we
+	// want. If that combination stops being true and there's a situation
+	// where a non-trivial bp could return a non-empty reason, use IsTrivial
+	// to check and bail before reaching this far.
 
 	restartReason := daemonRestartReason(st, typ)
 	if restartReason == "" {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1155,8 +1155,8 @@ func maybeRestart(t *state.Task, info *snap.Info) {
 	}
 
 	typ := info.GetType()
-	bp, applicable := boot.Lookup(info, typ, model, release.OnClassic)
-	if applicable {
+	bp := boot.Lookup(info, typ, model, release.OnClassic)
+	if !bp.IsTrivial() {
 		if bp.ChangeRequiresReboot() {
 			t.Logf("Requested system restart.")
 			st.RequestRestart(state.RestartSystem)


### PR DESCRIPTION
This change simplifies using the recently introduced
boot.BootParticipant and boot.Kernel interfaces:

1. The interfaces are now called `boot.BootParticipant` and
   `boot.Kernel`, and `boot.Kernel` no longer embeds a
   `boot.BootParticipant`;

2. `boot.Lookup` is renamed and split into `boot.Participant` and
   `boot.Kernel`; and

3. `boot.Participant` (and `Kernel`) return a single element that's
    always non-nil but might be a trivial implementation of the
    interface. A caller can always call the associated methods, and
    they'll do nothing when not 'applicable'. Optionally the caller
    can check whether it's the trivial implementation by using the new
    `IsTrivial()` helper.
