### PR TITLE
tests: verify retry-tool not retrying missing commands

### DIFF
--- a/tests/main/retry-tool/task.yaml
+++ b/tests/main/retry-tool/task.yaml
@@ -4,6 +4,9 @@ execute: |
     # code of that command.
     retry-tool true
     not retry-tool -n 1 false
+    # If the command doesn't exist it is not re-tried multiple times.
+    ( not retry-tool this-command-does-not-exist ) 2>&1 \
+        | grep -F 'retry: cannot execute command this-command-does-not-exist: [Errno 2] No such file or directory'
     # On failure it tells us about it, showing progress.
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false failed with code 1"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: next attempt in 0.1 second(s) (attempt 1 of 2)"


### PR DESCRIPTION
It's a test case I didn't add for a bug I didn't notice after posting
the initial version of retry-tool. While I did fix the bug in a quick
github edit I was still meaning to add a small test so here it is.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>