### PR TITLE
cmd/snap-update-ns: don't propagate detaching changes

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -642,6 +642,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -805,6 +806,7 @@ func (s *changeSuite) TestPerformFilesystemDetch(c *C) {
 	synth, err := chg.Perform(s.as)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `mount "none" "/target" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/target" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -1151,6 +1153,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -1298,6 +1301,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnly
 		{C: `close 4`},
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -1690,6 +1694,7 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -2082,6 +2087,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -2340,6 +2346,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithAvoidedTrespassing(c *C) {
 		{C: `close 7`},
 
 		// We're done restoring now.
+		{C: `mount "none" "/tmp/.snap/etc" "" MS_REC|MS_PRIVATE ""`},
 		{C: `unmount "/tmp/.snap/etc" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// Perform clean up after the unmount operation.
@@ -2422,5 +2429,82 @@ func (s *changeSuite) TestPerformedChangesAreTracked(c *C) {
 		{Action: update.Mount, Entry: osutil.MountEntry{Name: "device", Dir: "/target", Type: "type"}},
 		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "device", Dir: "/target", Type: "type"}},
 		{Action: update.Keep, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/target", Type: "tmpfs"}},
+	})
+}
+
+func (s *changeSuite) TestComplexPropagatingChanges(c *C) {
+	// This problem is more subtle. It is a variant of the regression test
+	// implemented in tests/regression/lp-1831010. Here, we have four directories:
+	//
+	// - $SNAP/a
+	// - $SNAP/b
+	// - $SNAP/b/c
+	// - $SNAP/d
+	//
+	// but snapd's mount profile contains only two entries:
+	//
+	// 1) recursive-bind $SNAP/a -> $SNAP/b/c  (ie, mount --rbind $SNAP/a $SNAP/b/c)
+	// 2) recursive-bind $SNAP/b -> $SNAP/d    (ie, mount --rbind $SNAP/b $SNAP/d)
+	//
+	// Both mount operations are performed under a substrate that is MS_SHARED.
+	// Therefore, due to the rules that decide upon propagation of bind mounts
+	// the propagation of the new mount entries is also shared. This is
+	// documented in section 5b of
+	// https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt.
+	//
+	// Interactive experimentation shows that the following three mount points exist
+	// after this operation, as illustrated by findmnt:
+	//
+	// TARGET                                SOURCE         FSTYPE      OPTIONS
+	// ...
+	// └─/snap/test-snapd-layout/x1          /dev/loop1     squashfs    ro,nodev,relatime
+	//   ├─/snap/test-snapd-layout/x1/b/c    /dev/loop1[/a] squashfs    ro,nodev,relatime
+	//   └─/snap/test-snapd-layout/x1/d      /dev/loop1[/b] squashfs    ro,nodev,relatime
+	//     └─/snap/test-snapd-layout/x1/d/c  /dev/loop1[/a] squashfs    ro,nodev,relatime
+	//
+	// Note that after the first mount operation only one mount point is created, namely
+	// $SNAP/a -> $SNAP/b/c. The second recursive bind mount not only creates
+	// $SNAP/b -> $SNAP/d, but also replicates $SNAP/a -> $SNAP/b/c as
+	// $SNAP/a -> $SNAP/d/c.
+	//
+	// The test will simulate a refresh of the snap from revision x1 to revision
+	// x2. When this happens the mount profile associated with x1 must be undone
+	// and the mount profile associated with x2 must be constructed. Because
+	// ordering matters, let's first consider the order of construction of x1
+	// itself. Starting from nothing, apply x1 as follows:
+	x1 := &osutil.MountProfile{
+		Entries: []osutil.MountEntry{
+			{Name: "/snap/app/x1/a", Dir: "/snap/app/x1/b/c", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+			{Name: "/snap/app/x1/b", Dir: "/snap/app/x1/d", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+		},
+	}
+	changes := update.NeededChanges(&osutil.MountProfile{}, x1)
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: update.Mount, Entry: osutil.MountEntry{Name: "/snap/app/x1/a", Dir: "/snap/app/x1/b/c", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}},
+		{Action: update.Mount, Entry: osutil.MountEntry{Name: "/snap/app/x1/b", Dir: "/snap/app/x1/d", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}},
+	})
+	// We can see that x1 is constructed in alphabetical order, first recursively
+	// bind mount at $SNAP/a the directory $SNAP/b/c, second recursively bind
+	// mount at $SNAP/b the directory $SNAP/d.
+	x2 := &osutil.MountProfile{
+		Entries: []osutil.MountEntry{
+			{Name: "/snap/app/x2/a", Dir: "/snap/app/x2/b/c", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+			{Name: "/snap/app/x2/b", Dir: "/snap/app/x2/d", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+		},
+	}
+	// When we are asked to refresh to revision x2, using the same layout, we
+	// simply undo x1 and then create x2, which apart from the difference in
+	// revision name, is exactly the same. The undo code, however, does not take
+	// the replicated mount point under consideration and therefore attempts to
+	// detach "x1/d", which normally fails with EBUSY. To counter this, the
+	// unmount operation first switches the mount point to recursive private
+	// propagation, before actually unmounting it. This ensures that propagation
+	// doesn't self-conflict, simply because there isn't any left.
+	changes = update.NeededChanges(x1, x2)
+	c.Assert(changes, DeepEquals, []*update.Change{
+		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/snap/app/x1/b", Dir: "/snap/app/x1/d", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout", "x-snapd.detach"}}},
+		{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/snap/app/x1/a", Dir: "/snap/app/x1/b/c", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout", "x-snapd.detach"}}},
+		{Action: update.Mount, Entry: osutil.MountEntry{Name: "/snap/app/x2/a", Dir: "/snap/app/x2/b/c", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}},
+		{Action: update.Mount, Entry: osutil.MountEntry{Name: "/snap/app/x2/b", Dir: "/snap/app/x2/d", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}},
 	})
 }

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -183,6 +183,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 
 	profile0 := `  # Layout /etc/foo.conf: bind-file $SNAP/foo.conf
   mount options=(bind, rw) /snap/vanguard/42/foo.conf -> /etc/foo.conf,
+  mount options=(rprivate) -> /etc/foo.conf,
   umount /etc/foo.conf,
   # Writable mimic /etc
   # .. permissions for traversing the prefix that is assumed to exist
@@ -205,10 +206,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/etc/* -> /etc/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/etc/,
   umount /tmp/.snap/etc/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /etc/,
+  mount options=(rprivate) -> /etc/*,
+  mount options=(rprivate) -> /etc/*/,
   umount /etc/,
   umount /etc/*,
   umount /etc/*/,
@@ -235,10 +240,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/snap/vanguard/42/* -> /snap/vanguard/42/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/vanguard/42/,
   umount /tmp/.snap/snap/vanguard/42/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/vanguard/42/,
+  mount options=(rprivate) -> /snap/vanguard/42/*,
+  mount options=(rprivate) -> /snap/vanguard/42/*/,
   umount /snap/vanguard/42/,
   umount /snap/vanguard/42/*,
   umount /snap/vanguard/42/*/,
@@ -247,6 +256,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 
 	profile1 := `  # Layout /usr/foo: bind $SNAP/usr/foo
   mount options=(rbind, rw) /snap/vanguard/42/usr/foo/ -> /usr/foo/,
+  mount options=(rprivate) -> /usr/foo/,
   umount /usr/foo/,
   # Writable mimic /usr
   # .. permissions for traversing the prefix that is assumed to exist
@@ -269,10 +279,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/usr/* -> /usr/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/usr/,
   umount /tmp/.snap/usr/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /usr/,
+  mount options=(rprivate) -> /usr/*,
+  mount options=(rprivate) -> /usr/*/,
   umount /usr/,
   umount /usr/*,
   umount /usr/*/,
@@ -299,10 +313,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/snap/vanguard/42/* -> /snap/vanguard/42/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/vanguard/42/,
   umount /tmp/.snap/snap/vanguard/42/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/vanguard/42/,
+  mount options=(rprivate) -> /snap/vanguard/42/*,
+  mount options=(rprivate) -> /snap/vanguard/42/*/,
   umount /snap/vanguard/42/,
   umount /snap/vanguard/42/*,
   umount /snap/vanguard/42/*/,
@@ -324,10 +342,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/snap/vanguard/42/usr/* -> /snap/vanguard/42/usr/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/vanguard/42/usr/,
   umount /tmp/.snap/snap/vanguard/42/usr/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/vanguard/42/usr/,
+  mount options=(rprivate) -> /snap/vanguard/42/usr/*,
+  mount options=(rprivate) -> /snap/vanguard/42/usr/*/,
   umount /snap/vanguard/42/usr/,
   umount /snap/vanguard/42/usr/*,
   umount /snap/vanguard/42/usr/*/,
@@ -357,10 +379,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/var/* -> /var/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/var/,
   umount /tmp/.snap/var/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /var/,
+  mount options=(rprivate) -> /var/*,
+  mount options=(rprivate) -> /var/*/,
   umount /var/,
   umount /var/*,
   umount /var/*/,
@@ -382,10 +408,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/var/cache/* -> /var/cache/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/var/cache/,
   umount /tmp/.snap/var/cache/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /var/cache/,
+  mount options=(rprivate) -> /var/cache/*,
+  mount options=(rprivate) -> /var/cache/*/,
   umount /var/cache/,
   umount /var/cache/*,
   umount /var/cache/*/,
@@ -394,6 +424,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 
 	profile3 := `  # Layout /var/tmp: type tmpfs, mode: 01777
   mount fstype=tmpfs tmpfs -> /var/tmp/,
+  mount options=(rprivate) -> /var/tmp/,
   umount /var/tmp/,
   # Writable mimic /var
   # .. permissions for traversing the prefix that is assumed to exist
@@ -416,10 +447,14 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   mount options=(bind, rw) /tmp/.snap/var/* -> /var/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/var/,
   umount /tmp/.snap/var/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /var/,
+  mount options=(rprivate) -> /var/*,
+  mount options=(rprivate) -> /var/*/,
   umount /var/,
   umount /var/*,
   umount /var/*/,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -758,6 +758,7 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
 
   # Allow the content interface to bind fonts from the host filesystem
   mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/###SNAP_INSTANCE_NAME###/*/**,
+  mount options=(rw private) -> /snap/###SNAP_INSTANCE_NAME###/*/**,
   umount /snap/###SNAP_INSTANCE_NAME###/*/**,
 
   # set up user mount namespace

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -229,6 +229,7 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 			var buf bytes.Buffer
 			fmt.Fprintf(&buf, "  # Read-write content sharing %s -> %s (w#%d)\n", plug.Ref(), slot.Ref(), i)
 			fmt.Fprintf(&buf, "  mount options=(bind, rw) %s/ -> %s/,\n", source, target)
+			fmt.Fprintf(&buf, "  mount options=(rprivate) -> %s/,\n", target)
 			fmt.Fprintf(&buf, "  umount %s/,\n", target)
 			// TODO: The assumed prefix depth could be optimized to be more
 			// precise since content sharing can only take place in a fixed
@@ -256,6 +257,7 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 			fmt.Fprintf(&buf, "  # Read-only content sharing %s -> %s (r#%d)\n", plug.Ref(), slot.Ref(), i)
 			fmt.Fprintf(&buf, "  mount options=(bind) %s/ -> %s/,\n", source, target)
 			fmt.Fprintf(&buf, "  remount options=(bind, ro) %s/,\n", target)
+			fmt.Fprintf(&buf, "  mount options=(rprivate) -> %s/,\n", target)
 			fmt.Fprintf(&buf, "  umount %s/,\n", target)
 			// Look at the TODO comment above.
 			apparmor.WritableProfile(&buf, source, 1)

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -318,6 +318,7 @@ slots:
 	profile0 := `  # Read-only content sharing consumer:content -> producer:content (r#0)
   mount options=(bind) /snap/producer/5/export/ -> /snap/consumer/7/import/,
   remount options=(bind, ro) /snap/consumer/7/import/,
+  mount options=(rprivate) -> /snap/consumer/7/import/,
   umount /snap/consumer/7/import/,
   # Writable mimic /snap/producer/5
   # .. permissions for traversing the prefix that is assumed to exist
@@ -339,10 +340,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/* -> /*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/,
   umount /tmp/.snap/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /,
+  mount options=(rprivate) -> /*,
+  mount options=(rprivate) -> /*/,
   umount /,
   umount /*,
   umount /*/,
@@ -364,10 +369,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/* -> /snap/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/,
   umount /tmp/.snap/snap/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/,
+  mount options=(rprivate) -> /snap/*,
+  mount options=(rprivate) -> /snap/*/,
   umount /snap/,
   umount /snap/*,
   umount /snap/*/,
@@ -389,10 +398,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/producer/* -> /snap/producer/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/,
   umount /tmp/.snap/snap/producer/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/producer/,
+  mount options=(rprivate) -> /snap/producer/*,
+  mount options=(rprivate) -> /snap/producer/*/,
   umount /snap/producer/,
   umount /snap/producer/*,
   umount /snap/producer/*/,
@@ -414,10 +427,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/producer/5/* -> /snap/producer/5/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/5/,
   umount /tmp/.snap/snap/producer/5/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/producer/5/,
+  mount options=(rprivate) -> /snap/producer/5/*,
+  mount options=(rprivate) -> /snap/producer/5/*/,
   umount /snap/producer/5/,
   umount /snap/producer/5/*,
   umount /snap/producer/5/*/,
@@ -441,10 +458,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/* -> /*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/,
   umount /tmp/.snap/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /,
+  mount options=(rprivate) -> /*,
+  mount options=(rprivate) -> /*/,
   umount /,
   umount /*,
   umount /*/,
@@ -466,10 +487,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/* -> /snap/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/,
   umount /tmp/.snap/snap/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/,
+  mount options=(rprivate) -> /snap/*,
+  mount options=(rprivate) -> /snap/*/,
   umount /snap/,
   umount /snap/*,
   umount /snap/*/,
@@ -491,10 +516,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/consumer/* -> /snap/consumer/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/consumer/,
   umount /tmp/.snap/snap/consumer/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/consumer/,
+  mount options=(rprivate) -> /snap/consumer/*,
+  mount options=(rprivate) -> /snap/consumer/*/,
   umount /snap/consumer/,
   umount /snap/consumer/*,
   umount /snap/consumer/*/,
@@ -516,10 +545,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/consumer/7/* -> /snap/consumer/7/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/consumer/7/,
   umount /tmp/.snap/snap/consumer/7/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/consumer/7/,
+  mount options=(rprivate) -> /snap/consumer/7/*,
+  mount options=(rprivate) -> /snap/consumer/7/*/,
   umount /snap/consumer/7/,
   umount /snap/consumer/7/*,
   umount /snap/consumer/7/*/,
@@ -577,6 +610,7 @@ slots:
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-write content sharing consumer:content -> producer:content (w#0)
   mount options=(bind, rw) /var/snap/producer/5/export/ -> /var/snap/consumer/7/import/,
+  mount options=(rprivate) -> /var/snap/consumer/7/import/,
   umount /var/snap/consumer/7/import/,
   # Writable directory /var/snap/producer/5/export
   /var/snap/producer/5/export/ rw,
@@ -640,6 +674,7 @@ slots:
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-write content sharing consumer:content -> producer:content (w#0)
   mount options=(bind, rw) /var/snap/producer/common/export/ -> /var/snap/consumer/common/import/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/,
   umount /var/snap/consumer/common/import/,
   # Writable directory /var/snap/producer/common/export
   /var/snap/producer/common/export/ rw,
@@ -738,6 +773,7 @@ slots:
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-write content sharing consumer:content -> producer:content (w#0)
   mount options=(bind, rw) /var/snap/producer/common/write-common/ -> /var/snap/consumer/common/import/write-common/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/write-common/,
   umount /var/snap/consumer/common/import/write-common/,
   # Writable directory /var/snap/producer/common/write-common
   /var/snap/producer/common/write-common/ rw,
@@ -753,6 +789,7 @@ slots:
 
 	profile1 := `  # Read-write content sharing consumer:content -> producer:content (w#1)
   mount options=(bind, rw) /var/snap/producer/2/write-data/ -> /var/snap/consumer/common/import/write-data/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/write-data/,
   umount /var/snap/consumer/common/import/write-data/,
   # Writable directory /var/snap/producer/2/write-data
   /var/snap/producer/2/write-data/ rw,
@@ -769,6 +806,7 @@ slots:
 	profile2 := `  # Read-only content sharing consumer:content -> producer:content (r#0)
   mount options=(bind) /var/snap/producer/common/read-common/ -> /var/snap/consumer/common/import/read-common/,
   remount options=(bind, ro) /var/snap/consumer/common/import/read-common/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/read-common/,
   umount /var/snap/consumer/common/import/read-common/,
   # Writable directory /var/snap/producer/common/read-common
   /var/snap/producer/common/read-common/ rw,
@@ -785,6 +823,7 @@ slots:
 	profile3 := `  # Read-only content sharing consumer:content -> producer:content (r#1)
   mount options=(bind) /var/snap/producer/2/read-data/ -> /var/snap/consumer/common/import/read-data/,
   remount options=(bind, ro) /var/snap/consumer/common/import/read-data/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/read-data/,
   umount /var/snap/consumer/common/import/read-data/,
   # Writable directory /var/snap/producer/2/read-data
   /var/snap/producer/2/read-data/ rw,
@@ -801,6 +840,7 @@ slots:
 	profile4 := `  # Read-only content sharing consumer:content -> producer:content (r#2)
   mount options=(bind) /snap/producer/2/read-snap/ -> /var/snap/consumer/common/import/read-snap/,
   remount options=(bind, ro) /var/snap/consumer/common/import/read-snap/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/read-snap/,
   umount /var/snap/consumer/common/import/read-snap/,
   # Writable mimic /snap/producer/2
   # .. permissions for traversing the prefix that is assumed to exist
@@ -822,10 +862,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/* -> /*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/,
   umount /tmp/.snap/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /,
+  mount options=(rprivate) -> /*,
+  mount options=(rprivate) -> /*/,
   umount /,
   umount /*,
   umount /*/,
@@ -847,10 +891,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/* -> /snap/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/,
   umount /tmp/.snap/snap/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/,
+  mount options=(rprivate) -> /snap/*,
+  mount options=(rprivate) -> /snap/*/,
   umount /snap/,
   umount /snap/*,
   umount /snap/*/,
@@ -872,10 +920,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/producer/* -> /snap/producer/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/,
   umount /tmp/.snap/snap/producer/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/producer/,
+  mount options=(rprivate) -> /snap/producer/*,
+  mount options=(rprivate) -> /snap/producer/*/,
   umount /snap/producer/,
   umount /snap/producer/*,
   umount /snap/producer/*/,
@@ -897,10 +949,14 @@ slots:
   mount options=(bind, rw) /tmp/.snap/snap/producer/2/* -> /snap/producer/2/*,
   # Allow unmounting the auxiliary directory.
   # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/2/,
   umount /tmp/.snap/snap/producer/2/,
   # Allow unmounting the destination directory as well as anything
   # inside.  This lets us perform the undo plan in case the writable
   # mimic fails.
+  mount options=(rprivate) -> /snap/producer/2/,
+  mount options=(rprivate) -> /snap/producer/2/*,
+  mount options=(rprivate) -> /snap/producer/2/*/,
   umount /snap/producer/2/,
   umount /snap/producer/2/*,
   umount /snap/producer/2/*/,


### PR DESCRIPTION
When snap-update-ns is unmounting something that can host additional
mount points inside, it is now using MNT_DETACH to detach the mount
point (recursively) and lazily unmount anything that is no longer used.
It can be though about like removing a reference in a garbage collected
memory management system. Unlike such systems, however, the kernel also
implements mount and unmount event *propagation*. This can replicate the
change in peer groups that receive propagation events. This can, oddly,
cause unmount loops where the kernel returns EBUSY, because the unmount
operation (even with MNT_DETACH) affects itself, in a way.

One such example is added as a test case in this patch, a fragment of which is
presented here:

    // but snapd's mount profile contains only two entries:
    //
    // 1) recursive-bind $SNAP/a -> $SNAP/b/c  (ie, mount --rbind $SNAP/a $SNAP/b/c)
    // 2) recursive-bind $SNAP/b -> $SNAP/d    (ie, mount --rbind $SNAP/b $SNAP/d)
    //
    // Both mount operations are performed under a substrate that is MS_SHARED.
    // Therefore, due to the rules that decide upon propagation of bind mounts
    // the propagation of the new mount entries is also shared. This is
    // documented in section 5b of
    // https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt.
    //
    // Interactive experimentation shows that the following three mount points exist
    // after this operation, as illustrated by findmnt:
    //
    // TARGET                                SOURCE         FSTYPE      OPTIONS
    // ...
    // └─/snap/test-snapd-layout/x1          /dev/loop1     squashfs    ro,nodev,relatime
    //   ├─/snap/test-snapd-layout/x1/b/c    /dev/loop1[/a] squashfs    ro,nodev,relatime
    //   └─/snap/test-snapd-layout/x1/d      /dev/loop1[/b] squashfs    ro,nodev,relatime
    //     └─/snap/test-snapd-layout/x1/d/c  /dev/loop1[/a] squashfs    ro,nodev,relatime
    //
    // Note that after the first mount operation only one mount point is created, namely
    // $SNAP/a -> $SNAP/b/c. The second recursive bind mount not only creates
    // $SNAP/b -> $SNAP/d, but also replicates $SNAP/a -> $SNAP/b/c as
    // $SNAP/a -> $SNAP/d/c.

When this mount profile is undone, the unmount --lazy (aka MNT_DETACH)
operation on x1/d fails with EBUSY, as explained above. The patch solves that
by changing event propagation, in the unmounted tree, to private. This idea is
hinted at in the umount(2) manual page.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
