### PR TITLE
tests: add unstable stage for travis execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 git:
   quiet: true
-jobs:
+matrix:
   include:
     - stage: quick
       name: go 1.9/xenial static and unit test suites
@@ -82,7 +82,9 @@ jobs:
         # override the default install for language:go
         - true
       script:
-        - ./run-checks --spread-unstable || true
+        - ./run-checks --spread-unstable
+  allow_failures:
+    - name: Unstable systems
   global:
     # SPREAD_LINODE_KEY
     - secure: "bzALrfNSLwM0bjceal1PU5rFErvqVhi00Sygx8jruo6htpZay3hrC2sHCKCQKPn1kvCfHidrHX1vnomg5N+B9o25GZEYSjKSGxuvdNDfCZYqPNjMbz5y7xXYfKWgyo+xtrKRM85Nqy121SfRz3KLDvrOLwwreb+pZv8DG1WraFTd7D6rK7nLnnYNUyw665XBMFVnM8ue3Zu9496Ih/TfQXhnNpsZY8xFWte4+cH7JvVCVTs8snjoGVZi3972PzinNkfBgJa24cUzxFMfiN/AwSBXJQKdVv+FsbB4uRgXAqTNwuus7PptiPNxpWWojuhm1Qgbk0XhGIdJxyUYkmNA4UrZ3C29nIRWbuAiHJ6ZWd1ur3dqphqOcgFInltSHkpfEdlL3YK4dCa2SmJESzotUGnyowCUUCXkWdDaZmFTwyK0Y6He9oyXDK5f+/U7SFlPvok0caJCvB9HbTQR1kYdh048I/R+Ht5QrFOZPk21DYWDOYhn7SzthBDZLsaL6n5gX7Y547SsL4B35YVbpaeHzccG6Mox8rI4bqlGFvP1U5i8uXD4uQjJChlVxpmozUEMok9T5RVediJs540p5uc8DQl48Nke02tXzC/XpGAvpnXT7eiiRNW67zOj2QcIV+ni3lBj3HvZeB9cgjzLNrZSl/t9vseqnNwQWpl3V6nd/bU="

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
       script:
         - ./tests/lib/cla_check.py
     - stage: integration
-      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, 19.10, Core 16, Core 18
+      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, Core 16, Core 18
       dist: xenial
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,18 @@ jobs:
         - true
       script:
         - ./run-checks --spread-no-ubuntu
-env:
+    - stage: integration
+      name: Unstable systems
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-unstable || true
   global:
     # SPREAD_LINODE_KEY
     - secure: "bzALrfNSLwM0bjceal1PU5rFErvqVhi00Sygx8jruo6htpZay3hrC2sHCKCQKPn1kvCfHidrHX1vnomg5N+B9o25GZEYSjKSGxuvdNDfCZYqPNjMbz5y7xXYfKWgyo+xtrKRM85Nqy121SfRz3KLDvrOLwwreb+pZv8DG1WraFTd7D6rK7nLnnYNUyw665XBMFVnM8ue3Zu9496Ih/TfQXhnNpsZY8xFWte4+cH7JvVCVTs8snjoGVZi3972PzinNkfBgJa24cUzxFMfiN/AwSBXJQKdVv+FsbB4uRgXAqTNwuus7PptiPNxpWWojuhm1Qgbk0XhGIdJxyUYkmNA4UrZ3C29nIRWbuAiHJ6ZWd1ur3dqphqOcgFInltSHkpfEdlL3YK4dCa2SmJESzotUGnyowCUUCXkWdDaZmFTwyK0Y6He9oyXDK5f+/U7SFlPvok0caJCvB9HbTQR1kYdh048I/R+Ht5QrFOZPk21DYWDOYhn7SzthBDZLsaL6n5gX7Y547SsL4B35YVbpaeHzccG6Mox8rI4bqlGFvP1U5i8uXD4uQjJChlVxpmozUEMok9T5RVediJs540p5uc8DQl48Nke02tXzC/XpGAvpnXT7eiiRNW67zOj2QcIV+ni3lBj3HvZeB9cgjzLNrZSl/t9vseqnNwQWpl3V6nd/bU="

--- a/run-checks
+++ b/run-checks
@@ -63,6 +63,9 @@ case "${1:-all}" in
     --spread-no-ubuntu)
         SPREAD=no-ubuntu
         ;;
+    --spread-unstable)
+        SPREAD=unstable
+        ;;
     *)
         echo "Wrong flag ${1}. To run a single suite use --static, --unit, --spread."
         exit 1
@@ -293,6 +296,9 @@ if [ -n "$SPREAD" ]; then
             ;;
         no-ubuntu)
             spread "google:[^u]...:tests/..."
+            ;;
+        unstable)
+            spread "google-unstable:"
             ;;
         *)
             echo "Spread parameter $SPREAD not supported"

--- a/spread.yaml
+++ b/spread.yaml
@@ -106,6 +106,7 @@ backends:
                 image: centos-7-64
 
     google-unstable:
+        type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: computeengine/us-east1-b
         halt-timeout: 2h

--- a/spread.yaml
+++ b/spread.yaml
@@ -67,8 +67,6 @@ backends:
                 workers: 8
             - ubuntu-19.04-64:
                 workers: 6
-            - ubuntu-19.10-64:
-                workers: 6
             - ubuntu-core-16-64:
                 image: ubuntu-16.04-64
                 workers: 6
@@ -106,6 +104,14 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
+
+    google-unstable:
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: computeengine/us-east1-b
+        halt-timeout: 2h
+        systems:
+            - ubuntu-19.10-64:
+                workers: 6
 
     google-sru:
         type: google


### PR DESCRIPTION
This new travis stage is used for systems which are being stabilized.

The idea of this stage is to continue executing on those systems but
avoid blocking the results.

For idea is to run tests on ubuntu-19.10 until the system is finally
stable, then it should go to google backend again.
