### PR TITLE
cmd/snap: don't append / to snap name just because a dir exists

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -683,7 +683,7 @@ func (x *infoCmd) Execute([]string) error {
 
 	noneOK := true
 	for i, snapName := range x.Positional.Snaps {
-		snapName := norm(string(snapName))
+		snapName := string(snapName)
 		if i > 0 {
 			fmt.Fprintln(w, "---")
 		}
@@ -693,7 +693,7 @@ func (x *infoCmd) Execute([]string) error {
 		}
 
 		if diskSnap, err := clientSnapFromPath(snapName); err == nil {
-			iw.setupDiskSnap(snapName, diskSnap)
+			iw.setupDiskSnap(norm(snapName), diskSnap)
 		} else {
 			remoteSnap, resInfo, _ := x.client.FindOne(snap.InstanceSnap(snapName))
 			localSnap, _, _ := x.client.Snap(snapName)

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -8,6 +8,11 @@ prepare: |
     snap pack "$TESTSLIB"/snaps/basic
     snap install test-snapd-tools
     snap install --channel beta --devmode test-snapd-devmode
+    # ensures that an empty directory doesn't confuse things
+    mkdir -v core
+
+restore: |
+    rmdir -v core
 
 execute: |
     echo "With no arguments, errors out"


### PR DESCRIPTION
Before this change, when a user did `snap info foo` and a directory
existed, a `/` was added to `foo` as part of path normalization.

That should only be done to the function that sets up the 'disk' snap,
not for every use of the snap name.

This change fixes that.