### PR TITLE
tests: disable interfaces-timeserver-control on 19.10

### DIFF
--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -7,7 +7,8 @@ details: |
 # Debian sid is skipped because "timedatectl set-ntp" fails with the error:
 # "Failed to set ntp: Message recipient disconnected from message bus without replying"
 # A workaround is to make "systemctl enable --now systemd-timesyncd.service" instead
-systems: [-debian-sid-*]
+# FIXME: re-enable ubuntu-19.10 after stabelizing it
+systems: [-debian-sid-*, -ubuntu-19.10-*]
 
 prepare: |
     # shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
This test keeps failing on 19.10. Disable it for now to unblock
master.

I looked at ~10 recent spread runs where this always fails.