### PR TITLE
cmd/snap-confine: keep track of snap instance name and the snap name

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -400,9 +400,21 @@ static void test_sc_snap_drop_instance_key_no_name(void)
 	g_test_trap_assert_failed();
 }
 
+static void test_sc_snap_drop_instance_key_short_dest_max(void)
+{
+	if (g_test_subprocess()) {
+		char dest[SNAP_NAME_LEN + 1] = { 0 };
+		/* 40 chars (max valid length), pretend dest is the same length, no space for terminator */
+		sc_snap_drop_instance_key("01234567890123456789012345678901234567890", dest, sizeof dest - 1);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
 static void test_sc_snap_drop_instance_key_basic(void)
 {
-	char name[41] = { 0xff };
+	char name[SNAP_NAME_LEN + 1] = { 0xff };
 
 	sc_snap_drop_instance_key("foo_bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo");
@@ -422,6 +434,11 @@ static void test_sc_snap_drop_instance_key_basic(void)
 	memset(name, 0xff, sizeof name);
 	sc_snap_drop_instance_key("foo", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo");
+
+	memset(name, 0xff, sizeof name);
+	/* 40 chars - snap name length */
+	sc_snap_drop_instance_key("0123456789012345678901234567890123456789", name, sizeof name);
+	g_assert_cmpstr(name, ==, "0123456789012345678901234567890123456789");
 }
 
 static void test_sc_snap_split_instance_name_trailing_nil(void)
@@ -450,7 +467,7 @@ static void test_sc_snap_split_instance_name_short_instance_dest(void)
 
 static void test_sc_snap_split_instance_name_basic(void)
 {
-	char name[41] = { 0xff };
+	char name[SNAP_NAME_LEN + 1] = { 0xff };
 	char instance[20] = { 0xff };
 
 	sc_snap_split_instance_name("foo_bar", name, sizeof name, instance,
@@ -552,6 +569,8 @@ static void __attribute__((constructor)) init(void)
 			test_sc_snap_drop_instance_key_short_dest);
 	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest2",
 			test_sc_snap_drop_instance_key_short_dest2);
+	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest_max",
+					test_sc_snap_drop_instance_key_short_dest_max);
 
 	g_test_add_func("/snap/sc_snap_split_instance_name/basic",
 			test_sc_snap_split_instance_name_basic);

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -359,7 +359,6 @@ static void test_sc_snap_drop_instance_key_no_dest(void)
 {
 	if (g_test_subprocess()) {
 		sc_snap_drop_instance_key("foo_bar", NULL, 0);
-		g_test_fail();
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -373,7 +372,6 @@ static void test_sc_snap_drop_instance_key_short_dest(void)
 		char dest[10] = { 0 };
 		sc_snap_drop_instance_key("foo-foo-foo-foo-foo_bar", dest,
 					  sizeof dest);
-		g_test_fail();
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -385,7 +383,6 @@ static void test_sc_snap_drop_instance_key_short_dest2(void)
 	if (g_test_subprocess()) {
 		char dest[3] = { 0 };	// "foo" sans the nil byte
 		sc_snap_drop_instance_key("foo", dest, sizeof dest);
-		g_test_fail();
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -397,7 +394,6 @@ static void test_sc_snap_drop_instance_key_no_name(void)
 	if (g_test_subprocess()) {
 		char dest[10] = { 0 };
 		sc_snap_drop_instance_key(NULL, dest, sizeof dest);
-		g_test_fail();
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -434,7 +430,6 @@ static void test_sc_snap_split_instance_name_trailing_nil(void)
 		char dest[3] = { 0 };
 		// pretend there is no place for trailing \0
 		sc_snap_split_instance_name("_", NULL, 0, dest, 0);
-		g_test_fail();
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -447,7 +442,6 @@ static void test_sc_snap_split_instance_name_short_instance_dest(void)
 		char dest[10] = { 0 };
 		sc_snap_split_instance_name("foo_barbarbarbar", NULL, 0,
 					    dest, sizeof dest);
-		g_test_fail();
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -252,7 +252,7 @@ void sc_snap_name_validate(const char *snap_name, sc_error ** errorp)
 				    "snap name must be longer than 1 character");
 		goto out;
 	}
-	if (n > 40) {
+	if (n > SNAP_NAME_LEN) {
 		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
 				    "snap name must be shorter than 40 characters");
 		goto out;

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -61,8 +61,8 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
         die("cannot run with NULL executable");
     }
 
-    /* Instance name length + 1 overflow + 1 NULL */
-    char snap_name[SNAP_INSTANCE_LEN + 1 + 1] = {0};
+    /* Instance name length + NULL termination */
+    char snap_name[SNAP_NAME_LEN + 1] = {0};
     sc_snap_drop_instance_key(snap_instance, snap_name, sizeof snap_name);
 
     /* Invocation helps to pass relevant data to various parts of snap-confine. */

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -61,6 +61,10 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
         die("cannot run with NULL executable");
     }
 
+    /* Instance name length + 1 overflow + 1 NULL */
+    char snap_name[SNAP_INSTANCE_LEN + 1 + 1] = {0};
+    sc_snap_drop_instance_key(snap_instance, snap_name, sizeof snap_name);
+
     /* Invocation helps to pass relevant data to various parts of snap-confine. */
     memset(inv, 0, sizeof *inv);
     inv->base_snap_name = sc_strdup(base_snap_name);
@@ -68,6 +72,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
     inv->executable = sc_strdup(executable);
     inv->security_tag = sc_strdup(security_tag);
     inv->snap_instance = sc_strdup(snap_instance);
+    inv->snap_name = sc_strdup(snap_name);
     inv->classic_confinement = sc_args_is_classic_confinement(args);
 
     // construct rootfs_dir based on base_snap_name
@@ -84,6 +89,7 @@ void sc_init_invocation(sc_invocation *inv, const struct sc_args *args, const ch
 void sc_cleanup_invocation(sc_invocation *inv) {
     if (inv != NULL) {
         sc_cleanup_string(&inv->snap_instance);
+        sc_cleanup_string(&inv->snap_name);
         sc_cleanup_string(&inv->base_snap_name);
         sc_cleanup_string(&inv->orig_base_snap_name);
         sc_cleanup_string(&inv->security_tag);

--- a/cmd/snap-confine/snap-confine-invocation.h
+++ b/cmd/snap-confine/snap-confine-invocation.h
@@ -29,7 +29,8 @@
  **/
 typedef struct sc_invocation {
     /* Things declared by the system. */
-    char *snap_instance;
+    char *snap_instance; /* snap instance name (<snap>_<key>) */
+    char *snap_name;     /* snap name (without instance key) */
     char *orig_base_snap_name;
     char *security_tag;
     char *executable;


### PR DESCRIPTION
Snap instance name is composed of the snap name and an optional instance key.
Keep track of both, for future use in parallel instance support code.

Extracted from #7302 
