### PR TITLE
tests: support fastly-global.cdn.snapcraft.io url on proxy-no-core test

### DIFF
--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -52,4 +52,4 @@ execute: |
 
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
-    check_journalctl_log 'CONNECT fastly.cdn.snapcraft.io' -u tinyproxy
+    check_journalctl_log 'CONNECT fastly.*.cdn.snapcraft.io' -u tinyproxy


### PR DESCRIPTION
This is to fix the error when a different than fastly.cdn.snapcraft.io
url is used to connect to fastly.

Error:
+ grep -q -E 'CONNECT fastly.cdn.snapcraft.io'
+ echo '-- Logs begin at Wed 2019-09-04 17:50:01 UTC, end at Wed
2019-09-04 18:06:49 UTC. --
Sep 04 18:06:12 sep041749-291349 systemd[1]: Starting /usr/bin/python3
/home/gopath/src/github.com/snapcore/snapd/tests/lib/tinyproxy/tinyproxy.py...
Sep 04 18:06:12 sep041749-291349 systemd[1]: Started /usr/bin/python3
/home/gopath/src/github.com/snapcore/snapd/tests/lib/tinyproxy/tinyproxy.py.
Sep 04 18:06:35 sep041749-291349 python3[24606]: starting tinyproxy on
port 3128
Sep 04 18:06:35 sep041749-291349 python3[24606]: Serving HTTP on 0.0.0.0
port 3128 ...
Sep 04 18:06:35 sep041749-291349 python3[24606]: 127.0.0.1 - -
[04/Sep/2019 18:06:35] "CONNECT api.snapcraft.io:443 HTTP/1.1" 200 -
Sep 04 18:06:36 sep041749-291349 python3[24606]: 127.0.0.1 - -
[04/Sep/2019 18:06:36] "CONNECT api.snapcraft.io:443 HTTP/1.1" 200 -
Sep 04 18:06:36 sep041749-291349 python3[24606]: 127.0.0.1 - -
[04/Sep/2019 18:06:36] "CONNECT fastly-global.cdn.snapcraft.io:443
HTTP/1.1" 200 -
Sep 04 18:06:40 sep041749-291349 python3[24606]: 127.0.0.1 - -
[04/Sep/2019 18:06:40] "CONNECT api.snapcraft.io:443 HTTP/1.1" 200 -'
+ echo 'Match for "CONNECT fastly.cdn.snapcraft.io" failed, retrying'
Match for "CONNECT fastly.cdn.snapcraft.io" failed, retrying
+ sleep 1
+ return 1
