### PR TITLE
tests: run dbus-launch inside a systemd unit

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -48,7 +48,7 @@ execute: |
     mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
 
     echo "Setting up D-Bus session bus in a systemd unit"
-    systemd-run --unit=dbus-session --property=Type=forking -E "$(env | tr '\n' ' ')"  -r /bin/sh -c 'dbus-launch --sh-syntax > /tmp/dbus-sh'
+    systemd-run --unit=dbus-session --property=Type=forking -r /bin/sh -c "XDG_CONFIG_HOME=$XDG_CONFIG_HOME XDG_DATA_HOME=$XDG_DATA_HOME XDG_CACHE_HOME=$XDG_CACHE_HOME dbus-launch --sh-syntax > /tmp/dbus-sh"
     for _ in $(seq 20); do
         if test -e /tmp/dbus-sh; then
             break

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -24,19 +24,15 @@ environment:
 debug: |
     echo "Output process to see what might write to $XDG"
     ps uafx
+    echo "Output dbus-session"
+    systemctl status dbus-session || true
     echo "Show what is in $XDG"
     ls -alR "$XDG"
 
 restore: |
-    if [ -e dbus-launch.pid ]; then
-        kill "$(cat dbus-launch.pid)"
-    fi
-
-    # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
-    # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
-    # producing an error when the xdg directory is removed.
-    if pid="$(pidof gvfsd-metadata)"; then
-        kill -9 "$pid" || true
+    echo "Stop dbus session bus and all its children"
+    if systemctl is-active dbus-session; then
+        systemctl stop dbus-session
     fi
     rm -rf "$XDG"
 
@@ -51,9 +47,14 @@ execute: |
     fi
     mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
 
-    echo "Setting up D-Bus session bus"
-    eval "$(dbus-launch --sh-syntax)"
-    echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
+    echo "Setting up D-Bus session bus in a systemd unit"
+    systemd-run --unit=dbus-session --property=Type=forking -E "$(env | tr '\n' ' ')"  -r /bin/sh -c 'dbus-launch --sh-syntax > /tmp/dbus-sh'
+    for _ in $(seq 20); do
+        if test -e /tmp/dbus-sh; then
+            break
+        fi
+    done
+    eval "$(cat /tmp/dbus-sh)"
 
     echo "The interface is initially disconnected"
     snap interfaces -i contacts-service | MATCH -- '- +test-snapd-eds:contacts-service'

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -49,11 +49,7 @@ execute: |
 
     echo "Setting up D-Bus session bus in a systemd unit"
     systemd-run --unit=dbus-session --property=Type=forking -r /bin/sh -c "XDG_CONFIG_HOME=$XDG_CONFIG_HOME XDG_DATA_HOME=$XDG_DATA_HOME XDG_CACHE_HOME=$XDG_CACHE_HOME dbus-launch --sh-syntax > /tmp/dbus-sh"
-    for _ in $(seq 20); do
-        if test -e /tmp/dbus-sh; then
-            break
-        fi
-    done
+    retry-tool -n 20 test -e /tmp/dbus-sh
     eval "$(cat /tmp/dbus-sh)"
 
     echo "The interface is initially disconnected"


### PR DESCRIPTION
The test sometimes fails because something tries to write to
/tmp/xdg/ after the dbus-session is terminated. This PR puts
the dbus-launch command into a systemd-run created unit so that
we can kill everything that was run as part of the dbus session
which hopefully ensures we have no stray processes left when we
stop the test.

