### PR TITLE
tests: fix mountinfo-tool filtering when used with rewriting

### DIFF
--- a/tests/lib/bin/mountinfo-tool
+++ b/tests/lib/bin/mountinfo-tool
@@ -94,6 +94,9 @@ class MountInfoEntry(object):
         self.fs_type = ""
         self.mount_source = ""
         self.sb_opts = ""
+        # This field does not represent kernel state.
+        # It is a marker for an entry being matched by a filter.
+        self.matched = False
 
     def __eq__(self, other):
         # type: (object) -> Union[NotImplemented, bool]
@@ -687,6 +690,13 @@ The exit code indicates if any mount point matched the query.
         raise SystemExit(exc)
     entries = [MountInfoEntry.parse(line) for line in opts.file]
 
+    # Apply entry filtering ahead of any renumbering.
+    num_matched = 0
+    for e in entries:
+        if matches(e, filters):
+            e.matched = True
+            num_matched += 1
+
     # Build rewrite state based on reference tables. This way the entries
     # we will display can be correlated to other tables.
     rs = RewriteState()
@@ -725,9 +735,6 @@ The exit code indicates if any mount point matched the query.
     if opts.rename:
         rewrite_rename(entries, rewrite_order, rs)
 
-    # Apply entry filtering.
-    entries = [e for e in entries if matches(e, filters)]
-
     # Apply entry reordering for display.
     if opts.display_order:
 
@@ -737,6 +744,8 @@ The exit code indicates if any mount point matched the query.
 
         entries.sort(key=display_key_fn)
     for e in entries:
+        if not e.matched:
+            continue
         if attrs:
             values = []  # type: List[Any]
             for attr in attrs:
@@ -747,14 +756,15 @@ The exit code indicates if any mount point matched the query.
             print(*values)
         else:
             print(e)
-    if opts.one and len(entries) != 1:
+    if opts.one and num_matched != 1:
         raise SystemExit(
-            "--one requires exactly one match, found {}".format(len(entries))
+            "--one requires exactly one match, found {}".format(num_matched)
         )
-	# Return with an exit code indicating if anything matched.
-	# This allows mountinfo-tool to be used in scripts.
-    if len(entries) == 0:
+    # Return with an exit code indicating if anything matched.
+    # This allows mountinfo-tool to be used in scripts.
+    if num_matched == 0:
         raise SystemExit(1)
+
 
 class MountInfoEntryTests(unittest.TestCase):
 


### PR DESCRIPTION
The mountinfo-tool program has an ability to rewrite certain
non-deterministic aspects of the mount table, such as revisions in paths
like /snap/core/1234

This inadvisedly clashed with the filtering logic that allows to look
at a specific path. The rewrite would cause the filter not to match.

This patch adds a new property to each mountinfo entry object and changes
the filtering and display code so that filtering is applied early, before
rewrite. Instead of discarding elements we filtered out we simply set
the matching attribute and not display them. This is done so that
we can continue to rewrite exactly as before, producing identical
rewritten results.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
