### PR TITLE
interfaces/wayland: on classic systems only consider the OS slot for auto-connect

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -159,7 +159,7 @@ func (iface *waylandInterface) UDevPermanentSlot(spec *udev.Specification, slot 
 }
 
 func (iface *waylandInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
-	if release.OnClassic {
+	if release.OnClassic && slot != nil {
 		// allow connection to implicit slot
 		return slot.Snap.GetType() == snap.TypeOS
 	} else {

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 
 	"strings"
@@ -157,9 +158,14 @@ func (iface *waylandInterface) UDevPermanentSlot(spec *udev.Specification, slot 
 	return nil
 }
 
-func (iface *waylandInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
-	// allow what declarations allowed
-	return true
+func (iface *waylandInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
+  if release.OnClassic {
+	  // allow connection to implicit slot
+    return slot.Snap.GetType() == snap.TypeOS
+  } else {
+    // allow what declarations allowed
+    return true
+  }
 }
 
 func init() {

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -159,13 +159,13 @@ func (iface *waylandInterface) UDevPermanentSlot(spec *udev.Specification, slot 
 }
 
 func (iface *waylandInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
-  if release.OnClassic {
-	  // allow connection to implicit slot
-    return slot.Snap.GetType() == snap.TypeOS
-  } else {
-    // allow what declarations allowed
-    return true
-  }
+	if release.OnClassic {
+		// allow connection to implicit slot
+		return slot.Snap.GetType() == snap.TypeOS
+	} else {
+		// allow what declarations allowed
+		return true
+	}
 }
 
 func init() {

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -190,8 +190,14 @@ func (s *WaylandInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *WaylandInterfaceSuite) TestAutoConnect(c *C) {
-	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
+	// On Classic, only connect to the implicit slot
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, false)
 	c.Assert(s.iface.AutoConnect(s.plugInfo, s.classicSlotInfo), Equals, true)
+
+	// On Core, can connect to app supplied slot
+	restore := release.MockOnClassic(false)
+	defer restore()
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
 }
 
 func (s *WaylandInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
interfaces/wayland: On classic systems only consider the OS slot for auto-connect.

Installing additional providers of the "wayland" interface should not inhibit auto-connection to the implicit slot.