### PR TITLE
interfaces: allow reading mutter Xauthority file

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -59,6 +59,7 @@ owner /run/user/[0-9]*/wayland-[0-9]* rwk,
 # Allow reading an Xwayland Xauth file
 # (see https://gitlab.gnome.org/GNOME/mutter/merge_requests/626)
 /run/user/[0-9]*/.mutter-Xwaylandauth.* r,
+/run/user/[0-9]*/mutter/Xauthority r,
 
 # Allow write access to create /run/user/* to create XDG_RUNTIME_DIR (until
 # lp:1738197 is fixed). Note this is not needed if creating a session using

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -129,6 +129,8 @@ owner /run/user/[0-9]*/.Xauthority r,
 # Allow reading an Xwayland Xauth file
 # (see https://gitlab.gnome.org/GNOME/mutter/merge_requests/626)
 owner /run/user/[0-9]*/.mutter-Xwaylandauth.* r,
+owner /run/user/[0-9]*/mutter/Xauthority r,
+
 
 # Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
 # raw' rule is not finely mediated by apparmor so we mediate with seccomp arg


### PR DESCRIPTION
On openSUSE Tumbleweed at least on version VERSION_ID="20190829",
but possible earlier, when running GNOME in Wayland mode, graphical
applications are not starting correctly.

This was traced to a missing rule describing an apparently new place for
Xauthority file.

Fixes: https://bugs.launchpad.net/snapd/+bug/1842615
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
