### PR TITLE
overlord/snapstate: config revision code cleanup and extra tests

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1061,7 +1061,8 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		}
 	}
 
-	// Restore configuration of the target revision (if available; nothing happens if it's not)
+	// Restore configuration of the target revision (if available; nothing happens if it's not).
+	// We only do this on reverts (and not on refreshes).
 	if snapsup.Revert {
 		if err = config.RestoreRevisionConfig(st, snapsup.InstanceName(), snapsup.Revision()); err != nil {
 			return err

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -771,11 +771,6 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	// Make a copy of configuration of given snap revision
-	if err = config.SaveRevisionConfig(st, snapsup.InstanceName(), snapst.Current); err != nil {
-		return err
-	}
-
 	snapst.Active = false
 
 	pb := NewTaskProgressAdapterLocked(t)
@@ -978,6 +973,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
+	// find if the snap is already installed before we modify snapst below
+	isInstalled := snapst.IsInstalled()
+
 	cand := snapsup.SideInfo
 	m.backend.Candidate(cand)
 
@@ -1056,7 +1054,14 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
-	// Restore configuration of the target revision (if available) on revert
+	if isInstalled {
+		// Make a copy of configuration of current snap revision
+		if err = config.SaveRevisionConfig(st, snapsup.InstanceName(), oldCurrent); err != nil {
+			return err
+		}
+	}
+
+	// Restore configuration of the target revision (if available; nothing happens if it's not)
 	if snapsup.Revert {
 		if err = config.RestoreRevisionConfig(st, snapsup.InstanceName(), snapsup.Revision()); err != nil {
 			return err
@@ -1307,6 +1312,8 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// we need to undo potential changes to current snap configuration (e.g. if modified by post-refresh/install/configure hooks
+	// as part of failed refresh/install) by restoring the configuration of "old current".
 	if len(snapst.Sequence) > 0 {
 		if err = config.RestoreRevisionConfig(st, snapsup.InstanceName(), oldCurrent); err != nil {
 			return err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8051,6 +8051,61 @@ func (s *snapmgrTestSuite) TestRevertRestoresConfigSnapshot(c *C) {
 	c.Assert(res, Equals, "100")
 }
 
+func (s *snapmgrTestSuite) TestRefreshDoesntRestoreRevisionConfig(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	// set global configuration (affecting current snap)
+	tr := config.NewTransaction(s.state)
+	tr.Set("some-snap", "foo", "100")
+	tr.Commit()
+
+	// set per-revision config for the upcoming rev. 2, we don't expect it restored though
+	// since only revert restores revision configs.
+	s.state.Set("revision-config", map[string]interface{}{
+		"some-snap": map[string]interface{}{
+			"2": map[string]interface{}{"foo": "200"},
+		},
+	})
+
+	// simulate a refresh to rev. 2
+	chg := s.state.NewChange("update", "update some-snap")
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel", Revision: snap.R(2)}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+
+	s.state.Lock()
+	// config of rev. 1 has been stored in per-revision map
+	var cfgs map[string]interface{}
+	c.Assert(s.state.Get("revision-config", &cfgs), IsNil)
+	c.Assert(cfgs["some-snap"], DeepEquals, map[string]interface{}{
+		"1": map[string]interface{}{"foo": "100"},
+		"2": map[string]interface{}{"foo": "200"},
+	})
+
+	// config of rev. 2 hasn't been restored by refresh, old value returned
+	tr = config.NewTransaction(s.state)
+	var res string
+	c.Assert(tr.Get("some-snap", "foo", &res), IsNil)
+	c.Assert(res, Equals, "100")
+}
+
 func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/tests/lib/snaps/config-versions-v2/meta/hooks/configure
+++ b/tests/lib/snaps/config-versions-v2/meta/hooks/configure
@@ -1,2 +1,9 @@
 #!/bin/sh
 
+snapctl set configure-marker="executed-for-v2"
+
+command=$(snapctl get fail-configure)
+if [ "x$command" = "xyes" ]; then
+    echo "failing configure hook as requested"
+    exit 1
+fi

--- a/tests/lib/snaps/config-versions-v2/meta/hooks/post-refresh
+++ b/tests/lib/snaps/config-versions-v2/meta/hooks/post-refresh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+snapctl set post-refresh-hook-marker="executed-for-v2"

--- a/tests/lib/snaps/config-versions/meta/hooks/configure
+++ b/tests/lib/snaps/config-versions/meta/hooks/configure
@@ -1,2 +1,3 @@
 #!/bin/sh
 
+snapctl set configure-marker="executed-for-v1"

--- a/tests/lib/snaps/config-versions/meta/hooks/post-refresh
+++ b/tests/lib/snaps/config-versions/meta/hooks/post-refresh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+snapctl set post-refresh-hook-marker="executed-for-v1"

--- a/tests/main/config-versions/task.yaml
+++ b/tests/main/config-versions/task.yaml
@@ -22,11 +22,18 @@ execute: |
     echo "Install test snap"
     install_local config-versions
 
+    # sanity
+    snap get config-versions configure-marker | MATCH "executed-for-v1"
+
     echo "Setting config value affecting rev 1"
     snap set config-versions value=100
 
     echo "Install a new version of the test snap"
     install_local config-versions-v2
+
+    # sanity
+    snap get config-versions configure-marker | MATCH "executed-for-v2"
+    snap get config-versions post-refresh-hook-marker | MATCH "executed-for-v2"
 
     echo "Expecting config value to be carried over to the new version 2"
     verify_config_value 100
@@ -57,3 +64,13 @@ execute: |
     echo "Revert back to the rev 2"
     snap revert --revision=x2 config-versions
     verify_config_value 400
+    
+    echo "Failing refresh of rev 2"
+    snap refresh --revision=x1 config-versions
+    snap get config-versions post-refresh-hook-marker | MATCH "executed-for-v1"
+    snap get config-versions configure-marker | MATCH "executed-for-v1"
+    # force failure of v2 configure hook
+    snap set config-versions fail-configure=yes
+    snap refresh --revision=x2 config-versions || true
+    snap changes | MATCH "Error .* Refresh \"config-versions\" snap"
+    snap get config-versions post-refresh-hook-marker | MATCH "executed-for-v1"


### PR DESCRIPTION
Samuele asked me some questions about specific bits of per-revision config saving/restoring in snapstate that he found confusing, in particular about `undoLinkSnap` handler. 

I agree the lack of symmetry between saving revision config and restoring it is a bit confusing (e.g. saving happens in unlink-current-snap taks). With this PR I:
- cleaned that up by moving all these aspects to doLinkSnap / undoLinkSnap.
- added an extra unit test that ensures that config is not restored between refreshes of old revisions (this complements existing spread test). Revert case is covered by existing unit test.
- enhanced the spread test to cover the case of failing refresh to old revision because of configure hook, involving undo (it is also covered by existing unit test).
