### PR TITLE
fixme: move snapfrompid into osutils

### DIFF
--- a/osutil/pid.go
+++ b/osutil/pid.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SnapFromPid finds snap name running under given pid
+func SnapFromPid(pid int, globalRootDir string) (string, error) {
+	f, err := os.Open(fmt.Sprintf("%s/proc/%d/cgroup", globalRootDir, pid))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// we need to find a string like:
+		//   ...
+		//   7:freezer:/snap.hello-world
+		//   ...
+		// See cgroup(7) for details about the /proc/[pid]/cgroup
+		// format.
+		l := strings.Split(scanner.Text(), ":")
+		if len(l) < 3 {
+			continue
+		}
+		controllerList := l[1]
+		cgroupPath := l[2]
+		if !strings.Contains(controllerList, "freezer") {
+			continue
+		}
+		if strings.HasPrefix(cgroupPath, "/snap.") {
+			snap := strings.SplitN(filepath.Base(cgroupPath), ".", 2)[1]
+			return snap, nil
+		}
+	}
+	if scanner.Err() != nil {
+		return "", scanner.Err()
+	}
+
+	return "", fmt.Errorf("cannot find a snap for pid %v", pid)
+}

--- a/osutil/pid_test.go
+++ b/osutil/pid_test.go
@@ -27,9 +27,9 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type helpersSuite struct{}
+type pidTestSuite struct{}
 
-var _ = Suite(&helpersSuite{})
+var _ = Suite(&pidTestSuite{})
 
 var mockCgroup = []byte(`
 10:devices:/user.slice
@@ -45,7 +45,7 @@ var mockCgroup = []byte(`
 0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
 `)
 
-func (s *helpersSuite) TestSnapFromPid(c *C) {
+func (s *pidTestSuite) TestSnapFromPid(c *C) {
 	root := c.MkDir()
 
 	err := os.MkdirAll(filepath.Join(root, "proc/333"), 0755)

--- a/osutil/pid_test.go
+++ b/osutil/pid_test.go
@@ -27,7 +27,9 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type pidTestSuite struct{}
+type pidTestSuite struct {
+	rootDir string
+}
 
 var _ = Suite(&pidTestSuite{})
 
@@ -45,15 +47,17 @@ var mockCgroup = []byte(`
 0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
 `)
 
+func (s *pidTestSuite) SetUpTest(c *C) {
+	s.rootDir = c.MkDir()
+}
+
 func (s *pidTestSuite) TestSnapFromPid(c *C) {
-	root := c.MkDir()
-
-	err := os.MkdirAll(filepath.Join(root, "proc/333"), 0755)
+	err := os.MkdirAll(filepath.Join(s.rootDir, "proc/333"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(root, "proc/333/cgroup"), mockCgroup, 0755)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroup, 0755)
 	c.Assert(err, IsNil)
 
-	snap, err := SnapFromPid(333, root)
+	snap, err := SnapFromPid(333, s.rootDir)
 	c.Assert(err, IsNil)
 	c.Check(snap, Equals, "hello-world")
 }

--- a/osutil/pid_test.go
+++ b/osutil/pid_test.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+)
+
+type helpersSuite struct{}
+
+var _ = Suite(&helpersSuite{})
+
+var mockCgroup = []byte(`
+10:devices:/user.slice
+9:cpuset:/
+8:net_cls,net_prio:/
+7:freezer:/snap.hello-world
+6:perf_event:/
+5:pids:/user.slice/user-1000.slice/user@1000.service
+4:cpu,cpuacct:/
+3:memory:/
+2:blkio:/
+1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
+0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
+`)
+
+func (s *helpersSuite) TestSnapFromPid(c *C) {
+	root := c.MkDir()
+
+	err := os.MkdirAll(filepath.Join(root, "proc/333"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(root, "proc/333/cgroup"), mockCgroup, 0755)
+	c.Assert(err, IsNil)
+
+	snap, err := SnapFromPid(333, root)
+	c.Assert(err, IsNil)
+	c.Check(snap, Equals, "hello-world")
+}

--- a/usersession/userd/export_test.go
+++ b/usersession/userd/export_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/godbus/dbus"
 )
 
-var (
-	SnapFromPid = snapFromPid
-)
-
 func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() {
 	origSnapFromSender := snapFromSender
 	snapFromSender = f

--- a/usersession/userd/helpers_test.go
+++ b/usersession/userd/helpers_test.go
@@ -20,44 +20,9 @@
 package userd_test
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	. "gopkg.in/check.v1"
-
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/usersession/userd"
 )
 
 type helpersSuite struct{}
 
 var _ = Suite(&helpersSuite{})
-
-var mockCgroup = []byte(`
-10:devices:/user.slice
-9:cpuset:/
-8:net_cls,net_prio:/
-7:freezer:/snap.hello-world
-6:perf_event:/
-5:pids:/user.slice/user-1000.slice/user@1000.service
-4:cpu,cpuacct:/
-3:memory:/
-2:blkio:/
-1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
-0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
-`)
-
-func (s *helpersSuite) TestSnapFromPid(c *C) {
-	root := c.MkDir()
-	dirs.SetRootDir(root)
-
-	err := os.MkdirAll(filepath.Join(root, "proc/333"), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(root, "proc/333/cgroup"), mockCgroup, 0755)
-	c.Assert(err, IsNil)
-
-	snap, err := userd.SnapFromPid(333)
-	c.Assert(err, IsNil)
-	c.Check(snap, Equals, "hello-world")
-}

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -20,6 +20,7 @@
 package userd_test
 
 import (
+	"github.com/snapcore/snapd/dirs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -42,11 +43,14 @@ type launcherSuite struct {
 
 	mockXdgOpen           *testutil.MockCmd
 	restoreSnapFromSender func()
+	rootDir               string
 }
 
 var _ = Suite(&launcherSuite{})
 
 func (s *launcherSuite) SetUpTest(c *C) {
+	s.rootDir = c.MkDir()
+	dirs.SetRootDir(s.rootDir)
 	s.launcher = &userd.Launcher{}
 	s.mockXdgOpen = testutil.MockCommand(c, "xdg-open", "")
 	s.restoreSnapFromSender = userd.MockSnapFromSender(func(*dbus.Conn, dbus.Sender) (string, error) {
@@ -55,6 +59,7 @@ func (s *launcherSuite) SetUpTest(c *C) {
 }
 
 func (s *launcherSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
 	s.mockXdgOpen.Restore()
 	s.restoreSnapFromSender()
 }

--- a/usersession/userd/settings_test.go
+++ b/usersession/userd/settings_test.go
@@ -38,11 +38,14 @@ type settingsSuite struct {
 
 	mockXdgSettings       *testutil.MockCmd
 	restoreSnapFromSender func()
+	rootDir               string
 }
 
 var _ = Suite(&settingsSuite{})
 
 func (s *settingsSuite) SetUpTest(c *C) {
+	s.rootDir = c.MkDir()
+	dirs.SetRootDir(s.rootDir)
 	s.restoreSnapFromSender = userd.MockSnapFromSender(func(*dbus.Conn, dbus.Sender) (string, error) {
 		return "some-snap", nil
 	})

--- a/usersession/userd/settings_test.go
+++ b/usersession/userd/settings_test.go
@@ -69,6 +69,7 @@ fi
 }
 
 func (s *settingsSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
 	s.mockXdgSettings.Restore()
 	s.restoreSnapFromSender()
 }


### PR DESCRIPTION
Move SnapFromPid function from userd into osutils package. 

Changing signature of this function is essential. Dirs package is dependent on osutils and to prevent circular dependency osutils shouldn't use dirs. That's why, passing root directory as parameter solves problem. 