### PR TITLE
cmd/snap-update-ns: clarify sharing comment

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -241,10 +241,10 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// replicate the state of the root filesystem into the scratch directory.
 	sc_do_mount(config->rootfs_dir, scratch_dir, NULL, MS_REC | MS_BIND,
 		    NULL);
-	// Make the scratch directory recursively private. Nothing done there will
-	// be shared with any peer group, This effectively detaches us from the
-	// original namespace and coupled with pivot_root below serves as the
-	// foundation of the mount sandbox.
+	// Make the scratch directory recursively slave. Nothing done there will be
+	// shared with the initial mount namespace. This effectively detaches us,
+	// in one way, from the original namespace and coupled with pivot_root
+	// below serves as the foundation of the mount sandbox.
 	sc_do_mount("none", scratch_dir, NULL, MS_REC | MS_SLAVE, NULL);
 	// Bind mount certain directories from the host filesystem to the scratch
 	// directory. By default mount events will propagate in both into and out


### PR DESCRIPTION
When reviewing snap-confine code regarding sharing I noticed a paragraph
that was incorrect. This patch corrects it to describe the behaviour
of the code.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
