### PR TITLE
systemd, wrappers/services: add helpers for disabling multiple services in a snap

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -165,6 +165,7 @@ type Systemd interface {
 	DaemonReload() error
 	Enable(service string) error
 	Disable(service string) error
+	DisableMany(services []string) error
 	Start(service ...string) error
 	StartNoBlock(service ...string) error
 	Stop(service string, timeout time.Duration) error
@@ -276,6 +277,19 @@ func (s *systemd) Unmask(serviceName string) error {
 // Disable the given service
 func (s *systemd) Disable(serviceName string) error {
 	_, err := s.systemctl("--root", s.rootDir, "disable", serviceName)
+	return err
+}
+
+// DisableMany the given services
+// NOTE: if serviceNames is empty then nothing is done and nil is returned
+func (s *systemd) DisableMany(serviceNames []string) error {
+	if len(serviceNames) == 0 {
+		return nil
+	}
+	// disable them all in one go
+	_, err := s.systemctl(
+		append([]string{"--root", s.rootDir, "disable"}, serviceNames...)...,
+	)
 	return err
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -384,6 +384,18 @@ func (s *SystemdTestSuite) TestDisable(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "disable", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestDisableMany(c *C) {
+	err := New("xyzzy", SystemMode, s.rep).DisableMany([]string{"foo", "bar", "baz"})
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "disable", "foo", "bar", "baz"}})
+}
+
+func (s *SystemdTestSuite) TestDisableManyEmptyList(c *C) {
+	err := New("xyzzy", SystemMode, s.rep).DisableMany([]string{})
+	c.Assert(err, IsNil)
+	c.Check(s.argses, IsNil)
+}
+
 func (s *SystemdTestSuite) TestAvailable(c *C) {
 	err := Available()
 	c.Assert(err, IsNil)

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -335,7 +335,22 @@ func StopServices(apps []*snap.AppInfo, reason snap.ServiceStopReason, inter int
 	}
 
 	return nil
+}
 
+// DisableSnapServices disables the specific apps (which should all be services)
+func DisableSnapServices(apps []*snap.AppInfo, inter interacter) error {
+
+	sysd := systemd.New(dirs.GlobalRootDir, systemd.SystemMode, inter)
+
+	svcNames := make([]string, len(apps))
+	for i, app := range apps {
+		if !app.IsService() {
+			return fmt.Errorf("snap app %s is not a service, cannot be disabled", app.Name)
+		}
+
+		svcNames[i] = filepath.Base(app.ServiceFile())
+	}
+	return sysd.DisableMany(svcNames)
 }
 
 // RemoveSnapServices disables and removes service units for the applications from the snap which are services.


### PR DESCRIPTION
These helpers are part of a larger PR to prevent disabled services from being re-enabled upon refresh, revert and disable/enable, broken to be easier to review.