### PR TITLE
overlord/snapstate: add SetTaskSnapSetup helper + unit tests

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -81,7 +81,10 @@ func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
 // snap-setup-task Task, or to the task itself if the task does not have a
 // snap-setup-task (i.e. it _is_ the snap-setup-task)
 func SetTaskSnapSetup(t *state.Task, snapsup *SnapSetup) error {
-	if t.Has("snap-setup-task") {
+	if t.Has("snap-setup") {
+		// this is the snap-setup-task so just write to the task directly
+		t.Set("snap-setup", snapsup)
+	} else {
 		// this task isn't the snap-setup-task, so go get that and write to that
 		// one
 		var id string
@@ -95,9 +98,6 @@ func SetTaskSnapSetup(t *state.Task, snapsup *SnapSetup) error {
 			return fmt.Errorf("internal error: tasks are being pruned")
 		}
 		ts.Set("snap-setup", snapsup)
-	} else {
-		// this is the snap-setup-task so just write to the task directly
-		t.Set("snap-setup", snapsup)
 	}
 
 	return nil

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -1,0 +1,114 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/snap"
+)
+
+type handlersSuite struct {
+	baseHandlerSuite
+
+	stateBackend *witnessRestartReqStateBackend
+}
+
+var _ = Suite(&handlersSuite{})
+
+func (s *handlersSuite) SetUpTest(c *C) {
+	s.setup(c, s.stateBackend)
+
+	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+	s.AddCleanup(snap.MockSnapdSnapID("snapd-snap-id"))
+}
+
+func (s *handlersSuite) TestSetTaskSnapSetupFirstTask(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// make a new task which will be the snap-setup-task for other tasks and
+	// write a SnapSetup to it
+	t := s.state.NewTask("link-snap", "test")
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+			SnapID:   "foo-id",
+		},
+		Channel: "beta",
+		UserID:  2,
+	}
+	t.Set("snap-setup", snapsup)
+	s.state.NewChange("dummy", "...").AddTask(t)
+
+	// mutate it and rewrite it with the helper
+	snapsup.Channel = "edge"
+	err := snapstate.SetTaskSnapSetup(t, snapsup)
+	c.Assert(err, IsNil)
+
+	// get a fresh version of this task from state to check that the task's
+	/// snap-setup has the changes in it now
+	newT := s.state.Task(t.ID())
+	c.Assert(newT, Not(IsNil))
+	newsnapsup := &snapstate.SnapSetup{}
+	newT.Get("snap-setup", newsnapsup)
+	c.Assert(newsnapsup.Channel, Equals, snapsup.Channel)
+}
+
+func (s *handlersSuite) TestSetTaskSnapSetupLaterTask(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t := s.state.NewTask("link-snap", "test")
+
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+			SnapID:   "foo-id",
+		},
+		Channel: "beta",
+		UserID:  2,
+	}
+	// setup snap-setup for the first task
+	t.Set("snap-setup", snapsup)
+
+	// make a new task and reference the first one in snap-setup-task
+	t2 := s.state.NewTask("next-task-snap", "test2")
+	t2.Set("snap-setup-task", t.ID())
+
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+	chg.AddTask(t2)
+
+	// mutate it and rewrite it with the helper
+	snapsup.Channel = "edge"
+	err := snapstate.SetTaskSnapSetup(t2, snapsup)
+	c.Assert(err, IsNil)
+
+	// check that the original task's snap-setup is different now
+	newT := s.state.Task(t.ID())
+	c.Assert(newT, Not(IsNil))
+	newsnapsup := &snapstate.SnapSetup{}
+	newT.Get("snap-setup", newsnapsup)
+	c.Assert(newsnapsup.Channel, Equals, snapsup.Channel)
+}

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -70,8 +70,9 @@ func (s *handlersSuite) TestSetTaskSnapSetupFirstTask(c *C) {
 	/// snap-setup has the changes in it now
 	newT := s.state.Task(t.ID())
 	c.Assert(newT, Not(IsNil))
-	newsnapsup := &snapstate.SnapSetup{}
-	newT.Get("snap-setup", newsnapsup)
+	var newsnapsup snapstate.SnapSetup
+	err = newT.Get("snap-setup", &newsnapsup)
+	c.Assert(err, IsNil)
 	c.Assert(newsnapsup.Channel, Equals, snapsup.Channel)
 }
 
@@ -108,7 +109,8 @@ func (s *handlersSuite) TestSetTaskSnapSetupLaterTask(c *C) {
 	// check that the original task's snap-setup is different now
 	newT := s.state.Task(t.ID())
 	c.Assert(newT, Not(IsNil))
-	newsnapsup := &snapstate.SnapSetup{}
-	newT.Get("snap-setup", newsnapsup)
+	var newsnapsup snapstate.SnapSetup
+	err = newT.Get("snap-setup", &newsnapsup)
+	c.Assert(err, IsNil)
 	c.Assert(newsnapsup.Channel, Equals, snapsup.Channel)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1892,9 +1892,7 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 		removeHook := SetupRemoveHook(st, snapsup.InstanceName())
 		addNext(state.NewTaskSet(removeHook))
 		prev = removeHook
-	}
 
-	if removeAll {
 		// run disconnect hooks
 		disconnect := st.NewTask("auto-disconnect", fmt.Sprintf(i18n.G("Disconnect interfaces of snap %q"), snapsup.InstanceName()))
 		disconnect.Set("snap-setup", snapsup)


### PR DESCRIPTION
This change is part of how I ended up re-implementing https://github.com/snapcore/snapd/pull/7270.

One of the suggestions was that I use SnapSetup as short-term storage for the list of disabled services, then later on in unlink-snap commit the list to SnapState for long-term, cross-change persistence. However, a problem I encountered was that when I go to write to SnapSetup to save the disabled services from a task like `stop-snap-services`, all future tasks don't automatically get the changes that I wrote to SnapSetup. I needed a way to commit changes to SnapSetup not just to the current `snap-setup` task, but to future tasks as well, so rather than try to figure out all of the future tasks and write `snap-setup` to all of them, I figured an easy way out is to rewrite the `snap-setup` for the first task (which is where most all tasks inherit their `snap-setup` from in TaskSnapSetup). The first task is given by `snap-setup-task`, so I implemented this helper function SetSnapSetupTask to do this.

Also added some unit tests for this helper function, but since this function is generic it didn't really fit into any of the handlers_*_test.go files, so I created a new handlers_test.go file for these generic tests