### PR TITLE
boot,dirs,image: introduce boot.MakeBootable, use it in image instead of ad hoc code

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -22,10 +22,13 @@ package boot
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 )
@@ -272,4 +275,93 @@ func MarkBootSuccessful() error {
 	m["snap_mode"] = ""
 
 	return bl.SetBootVars(m)
+}
+
+// MakeBootable sets up the image filesystem with the given rootdir
+// such that it can be booted. bootWith is a map from the paths in the
+// image seed for kernel and boot base to their snap info. This
+// entails:
+//  - installing the bootloader configuration from the gadget
+//  - creating symlinks for boot snaps from seed to the runtime blob dir
+//  - setting boot env vars pointing to the revisions of the boot snaps to use
+//  - extracting kernel assets as needed by the bootloader
+func MakeBootable(model *asserts.Model, rootdir string, bootWith map[string]*snap.Info, unpackedGadgetDir string) error {
+	if len(bootWith) != 2 {
+		return fmt.Errorf("internal error: MakeBootable can only be called with exactly one kernel and exactly one core/base boot info: %v", bootWith)
+	}
+
+	// install the bootloader configuration from the gadget
+	if err := bootloader.InstallBootConfig(unpackedGadgetDir, rootdir); err != nil {
+		return err
+	}
+
+	// setup symlinks for kernel and boot base from the blob directory
+	// to the seed snaps
+
+	snapBlobDir := dirs.SnapBlobDirUnder(rootdir)
+	if err := os.MkdirAll(snapBlobDir, 0755); err != nil {
+		return err
+	}
+
+	for fn := range bootWith {
+		dst := filepath.Join(snapBlobDir, filepath.Base(fn))
+		// construct a relative symlink from the blob dir
+		// to the seed snap file
+		relSymlink, err := filepath.Rel(snapBlobDir, fn)
+		if err != nil {
+			return fmt.Errorf("cannot build symlink for boot snap: %v", err)
+		}
+		if err := os.Symlink(relSymlink, dst); err != nil {
+			return err
+		}
+	}
+
+	// Set bootvars for kernel/core snaps so the system boots and
+	// does the first-time initialization. There is also no
+	// mounted kernel/core/base snap, but just the blobs.
+	bl, err := bootloader.Find(rootdir, &bootloader.Options{
+		PrepareImageTime: true,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot set kernel/core boot variables: %s", err)
+	}
+
+	m := map[string]string{
+		"snap_mode":       "",
+		"snap_try_core":   "",
+		"snap_try_kernel": "",
+	}
+	if model.DisplayName() != "" {
+		m["snap_menuentry"] = model.DisplayName()
+	}
+
+	for fn, info := range bootWith {
+		bootvar := ""
+
+		switch info.GetType() {
+		case snap.TypeOS, snap.TypeBase:
+			bootvar = "snap_core"
+		case snap.TypeKernel:
+			snapf, err := snap.Open(fn)
+			if err != nil {
+				return err
+			}
+
+			if err := bl.ExtractKernelAssets(info, snapf); err != nil {
+				return err
+			}
+			bootvar = "snap_kernel"
+		}
+
+		if bootvar != "" {
+			name := filepath.Base(fn)
+			m[bootvar] = name
+		}
+	}
+	if err := bl.SetBootVars(m); err != nil {
+		return err
+	}
+
+	return nil
+
 }

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -21,17 +21,22 @@ package boot_test
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -358,4 +363,94 @@ func (s *bootSetSuite) TestMarkBootSuccessfulKKernelUpdate(c *C) {
 		// updated
 		"snap_kernel": "k2",
 	})
+}
+
+func (s *bootSetSuite) makeSnap(c *C, name, yaml string, revno snap.Revision) (fn string, info *snap.Info) {
+	si := &snap.SideInfo{
+		RealName: name,
+		Revision: revno,
+	}
+	fn = snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+	snapf, err := snap.Open(fn)
+	c.Assert(err, IsNil)
+	info, err = snap.ReadInfoFromSnapFile(snapf, si)
+	c.Assert(err, IsNil)
+	return fn, info
+}
+
+func (s *bootSetSuite) TestMakeBootable(c *C) {
+	dirs.SetRootDir("")
+
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core18",
+		"gadget":       "pc=18",
+		"kernel":       "pc-kernel=18",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	model := assertstest.FakeAssertion(headers).(*asserts.Model)
+
+	grubCfg := []byte("#grub cfg")
+	unpackedGadgetDir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
+	c.Assert(err, IsNil)
+
+	rootdir := c.MkDir()
+
+	seedSnapsDirs := filepath.Join(rootdir, "/var/lib/snapd/seed", "snaps")
+	err = os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	baseFn, baseInfo := s.makeSnap(c, "core18", `name: core18
+type: base
+version: 4.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := s.makeSnap(c, "pc-kernel", `name: pc-kernel
+type: kernel
+version: 4.0
+`, snap.R(5))
+	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	err = boot.MakeBootable(model, rootdir, map[string]*snap.Info{
+		kernelInSeed: kernelInfo,
+		baseInSeed:   baseInfo,
+	}, unpackedGadgetDir)
+	c.Assert(err, IsNil)
+
+	// check the bootloader config
+	m, err := s.bootloader.GetBootVars("snap_kernel", "snap_core", "snap_menuentry")
+	c.Assert(err, IsNil)
+	c.Check(m["snap_kernel"], Equals, "pc-kernel_5.snap")
+	c.Check(m["snap_core"], Equals, "core18_3.snap")
+	c.Check(m["snap_menuentry"], Equals, "My Model")
+
+	// kernel was extracted as needed
+	c.Check(s.bootloader.ExtractKernelAssetsCalls, DeepEquals, []snap.PlaceInfo{kernelInfo})
+
+	// check symlinks from snap blob dir
+	kernelBlob := filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(kernelInfo.MountFile()))
+	dst, err := os.Readlink(filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(kernelInfo.MountFile())))
+	c.Assert(err, IsNil)
+	c.Check(dst, Equals, "../seed/snaps/pc-kernel_5.snap")
+	c.Check(kernelBlob, testutil.FilePresent)
+
+	baseBlob := filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(baseInfo.MountFile()))
+	dst, err = os.Readlink(filepath.Join(dirs.SnapBlobDirUnder(rootdir), filepath.Base(baseInfo.MountFile())))
+	c.Assert(err, IsNil)
+	c.Check(dst, Equals, "../seed/snaps/core18_3.snap")
+	c.Check(baseBlob, testutil.FilePresent)
+
+	// check that the bootloader (grub here) configuration was copied
+	c.Check(filepath.Join(rootdir, "boot", "grub/grub.cfg"), testutil.FileEquals, grubCfg)
 }

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -206,6 +206,16 @@ func isInsideBaseSnap() (bool, error) {
 	return err == nil, err
 }
 
+// SnapBlobDirUnder returns the path to the snap blob dir under rootdir.
+func SnapBlobDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "snaps")
+}
+
+// SnapSeedDirUnder returns the path to the snap seed dir under rootdir.
+func SnapSeedDirUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "seed")
+}
+
 // SetRootDir allows settings a new global root directory, this is useful
 // for e.g. chroot operations
 func SetRootDir(rootdir string) {
@@ -231,7 +241,7 @@ func SetRootDir(rootdir string) {
 	SnapSeccompDir = filepath.Join(rootdir, snappyDir, "seccomp", "bpf")
 	SnapMountPolicyDir = filepath.Join(rootdir, snappyDir, "mount")
 	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")
-	SnapBlobDir = filepath.Join(rootdir, snappyDir, "snaps")
+	SnapBlobDir = SnapBlobDirUnder(rootdir)
 	SnapDesktopFilesDir = filepath.Join(rootdir, snappyDir, "desktop", "applications")
 	SnapRunDir = filepath.Join(rootdir, "/run/snapd")
 	SnapRunNsDir = filepath.Join(SnapRunDir, "/ns")
@@ -255,7 +265,7 @@ func SetRootDir(rootdir string) {
 	SnapCommandsDB = filepath.Join(SnapCacheDir, "commands.db")
 	SnapAuxStoreInfoDir = filepath.Join(SnapCacheDir, "aux")
 
-	SnapSeedDir = filepath.Join(rootdir, snappyDir, "seed")
+	SnapSeedDir = SnapSeedDirUnder(rootdir)
 	SnapDeviceDir = filepath.Join(rootdir, snappyDir, "device")
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -156,3 +156,13 @@ func (s *DirsTestSuite) TestIsCompleteShSymlink(c *C) {
 	c.Check(dirs.IsCompleteShSymlink("/etc/passwd"), Equals, false)
 	c.Check(dirs.IsCompleteShSymlink("/does-not-exist"), Equals, false)
 }
+
+func (s *DirsTestSuite) TestUnder(c *C) {
+	dirs.SetRootDir("/nowhere")
+	defer dirs.SetRootDir("")
+
+	rootdir := "/other-root"
+
+	c.Check(dirs.SnapBlobDirUnder(rootdir), Equals, "/other-root/var/lib/snapd/snaps")
+	c.Check(dirs.SnapSeedDirUnder(rootdir), Equals, "/other-root/var/lib/snapd/seed")
+}

--- a/image/export_test.go
+++ b/image/export_test.go
@@ -31,7 +31,6 @@ func MockToolingStore(sto Store) *ToolingStore {
 var (
 	LocalSnaps           = localSnaps
 	DecodeModelAssertion = decodeModelAssertion
-	DownloadUnpackGadget = downloadUnpackGadget
 	SetupSeed            = setupSeed
 	InstallCloudConfig   = installCloudConfig
 	SnapChannel          = snapChannel

--- a/image/image.go
+++ b/image/image.go
@@ -32,7 +32,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
-	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
@@ -586,14 +586,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options, local *l
 	}
 
 	if !opts.Classic {
-		// TODO: make this functionality part of the boot package?
-
-		// now do the bootloader stuff
-		if err := bootloader.InstallBootConfig(opts.GadgetUnpackDir, dirs.GlobalRootDir); err != nil {
-			return err
-		}
-
-		if err := setBootvars(seed.downloadedSnapsInfoForBootConfig, model); err != nil {
+		if err := boot.MakeBootable(model, opts.RootDir, seed.downloadedSnapsInfoForBootConfig, opts.GadgetUnpackDir); err != nil {
 			return err
 		}
 
@@ -722,19 +715,9 @@ func (s *imageSeed) add(snapName string) error {
 
 	// kernel/os/model.base are required for booting on core
 	if !opts.Classic && (typ == snap.TypeKernel || name == s.baseName) {
-		dst := filepath.Join(dirs.SnapBlobDir, filepath.Base(fn))
-		// construct a relative symlink from the blob dir
-		// to the seed file
-		relSymlink, err := filepath.Rel(dirs.SnapBlobDir, fn)
-		if err != nil {
-			return fmt.Errorf("cannot build symlink: %v", err)
-		}
-		if err := os.Symlink(relSymlink, dst); err != nil {
-			return err
-		}
 		// store the snap.Info for kernel/os/base so
-		// that the bootload can DTRT
-		s.downloadedSnapsInfoForBootConfig[dst] = info
+		// that boot.MakeBootable can DTRT
+		s.downloadedSnapsInfoForBootConfig[fn] = info
 	}
 
 	s.entries = append(s.entries, seedEntry{
@@ -803,79 +786,6 @@ func (s *imageSeed) seedYaml() *seed.Seed16 {
 	}
 
 	return &seedYaml
-}
-
-func setBootvars(downloadedSnapsInfoForBootConfig map[string]*snap.Info, model *asserts.Model) error {
-	if len(downloadedSnapsInfoForBootConfig) != 2 {
-		return fmt.Errorf("setBootvars can only be called with exactly one kernel and exactly one core/base boot info: %v", downloadedSnapsInfoForBootConfig)
-	}
-
-	// Set bootvars for kernel/core snaps so the system boots and
-	// does the first-time initialization. There is also no
-	// mounted kernel/core/base snap, but just the blobs.
-	bloader, err := bootloader.Find("", &bootloader.Options{
-		PrepareImageTime: true,
-	})
-	if err != nil {
-		return fmt.Errorf("cannot set kernel/core boot variables: %s", err)
-	}
-
-	snaps, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, "*.snap"))
-	if len(snaps) == 0 || err != nil {
-		return fmt.Errorf("internal error: cannot find core/kernel snap")
-	}
-
-	m := map[string]string{
-		"snap_mode":       "",
-		"snap_try_core":   "",
-		"snap_try_kernel": "",
-	}
-	if model.DisplayName() != "" {
-		m["snap_menuentry"] = model.DisplayName()
-	}
-
-	for _, fn := range snaps {
-		bootvar := ""
-
-		info := downloadedSnapsInfoForBootConfig[fn]
-		if info == nil {
-			// this should never happen, if it does print some
-			// debug info
-			keys := make([]string, 0, len(downloadedSnapsInfoForBootConfig))
-			for k := range downloadedSnapsInfoForBootConfig {
-				keys = append(keys, k)
-			}
-			return fmt.Errorf("cannot get download info for snap %s, available infos: %v", fn, keys)
-		}
-		switch info.GetType() {
-		case snap.TypeOS, snap.TypeBase:
-			bootvar = "snap_core"
-		case snap.TypeKernel:
-			bootvar = "snap_kernel"
-			if err := extractKernelAssets(bloader, fn, info, model); err != nil {
-				return err
-			}
-		}
-
-		if bootvar != "" {
-			name := filepath.Base(fn)
-			m[bootvar] = name
-		}
-	}
-	if err := bloader.SetBootVars(m); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func extractKernelAssets(bootloader bootloader.Bootloader, snapPath string, info *snap.Info, model *asserts.Model) error {
-	snapf, err := snap.Open(snapPath)
-	if err != nil {
-		return err
-	}
-
-	return bootloader.ExtractKernelAssets(info, snapf)
 }
 
 func copyLocalSnapFile(snapPath, targetDir string, info *snap.Info) (dstPath string, err error) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -848,7 +848,7 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"architecture":   "amd64",
 		"gadget":         "pc18",
-		"kernel":         "pc-kernel=18",
+		"kernel":         "pc-kernel",
 		"base":           "core18",
 		"required-snaps": []interface{}{"other-base"},
 	})
@@ -901,15 +901,9 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 		p := filepath.Join(rootdir, "var/lib/snapd/seed/snaps", fn)
 		c.Check(osutil.FileExists(p), Equals, true)
 
-		channel := ""
-		if name == "pc-kernel" {
-			channel = "18/stable"
-		}
-
 		c.Check(seedYaml.Snaps[i], DeepEquals, &seed.Snap16{
 			Name:       info.InstanceName(),
 			SnapID:     info.SnapID,
-			Channel:    channel,
 			File:       fn,
 			Unasserted: unasserted,
 		})
@@ -956,7 +950,6 @@ func (s *imageSuite) TestSetupSeedWithBase(c *C) {
 	c.Check(s.storeActions[2], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc-kernel",
-		Channel:      "18/stable",
 	})
 	c.Check(s.storeActions[3], DeepEquals, &store.SnapAction{
 		Action:       "download",


### PR DESCRIPTION
This also means that only boot refers to bootloader, and all use and referecences to snappy boot env variables (outside of tests) are in boot as well.

This stops as well gadget downloading being a one off by moving its unpacking close to the point of use.

It adds some tests about areas that weren't tested in image tests to double check the reorg.

Adds some helpersto dirs to compute some snapd directories with a non-default root, I expect this kind of helpers for just a few more dirs involved at image creation and not just runtime.

