### PR TITLE
systemd: detach rather than unmount .mount units

### DIFF
--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -89,6 +89,7 @@ What=/var/lib/snapd/snaps/foo_13.snap
 Where=%s/foo/13
 Type=squashfs
 Options=nodev,ro,x-gdu.hide
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -674,6 +674,7 @@ What=%s
 Where=%s
 Type=%s
 Options=%s
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -525,6 +525,7 @@ What=%s
 Where=/snap/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target
@@ -557,6 +558,7 @@ What=%s
 Where=/snap/snapname/x1
 Type=none
 Options=nodev,ro,x-gdu.hide,bind
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target
@@ -595,6 +597,7 @@ What=%s
 Where=/snap/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,context=system_u:object_r:snappy_snap_t:s0
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target
@@ -637,6 +640,7 @@ What=%s
 Where=/snap/snapname/123
 Type=fuse.squashfuse
 Options=nodev,ro,x-gdu.hide,allow_other
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target
@@ -675,6 +679,7 @@ What=%s
 Where=/snap/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide
+LazyUnmount=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Mount units are a thin wrapper on top of libmount mount operation.
Mounting is relatively straightforward in the sense that it doesn't give
us many options on that fundamentally change the mount operation.

Unmounting on the other hand, is more interesting. Unmounting requires
the filesystem to be no longer used. At all. This, however, is
incredibly difficult to guarantee. A process can change the current
working directory to block a filesystem. The user session can run a
filesystem indexing daemon that will open a number of file descriptors
to the files present in a mounted snap.

We've recently seen a report from a user who had a failed refresh of a
number of snaps. In both the "do" path as well as the "undo" path,
unmounting a revision of the core snap has failed with the EBUSY error,
indicating that something is still keeping the file system busy.

We have an alternative though. We can ask libmount to ask the kernel to
detach a filesystem instead. Unlike real unmounting, the associated
block device and driver is still busy. There can still be an open file
descriptor reading or writing data. At some point the file system will
become truly unused at which point the kernel will perform the regular
unmount automatically.

Traditionally using lazy unmounting (or detaching, as it has two names
in the wild) has carried the risk of breaking the filesystem as it is
possible for it to never really be idle enough to unmount for real.

Fortunately snaps don't have this problem since the underlying squashfs
is never written to. As such, using this mode has the chance of
improving upgrade reliability in face of unknown, concurrent
interactions from user-space.

Related-To: https://bugs.launchpad.net/snappy/+bug/1843286
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>