### PR TITLE
tests: explicitly restore after using LXD

### DIFF
--- a/tests/lib/bin/lxd-tool
+++ b/tests/lib/bin/lxd-tool
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+case "${1:-}" in
+    undo-lxd-mount-changes)
+        # Vanilla systems have /sys/fs/cgroup/cpuset without clone_children option.
+        # Using LXD to create a container enables this option, as can be seen here:
+        #
+        # -37 32 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,cpuset
+        # +37 32 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,cpuset,clone_children
+        #
+        # To restore vanilla state, disable the option now.
+        if [ "$(mountinfo-tool /sys/fs/cgroup/cpuset .fs_type)" = cgroup ]; then
+            echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
+        fi
+
+        # Vanilla system have /sys/fs/cgroup/unified mounted with the nsdelegate
+        # option which is available since kernel 4.13 Using LXD to create a
+        # container disables this options, as can be seen here:
+        #
+        # -32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup rw,nsdelegate
+        # +32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup rw
+        #
+        # To restore vanilla state, enable the option now, but only if the kernel supports that.
+        # https://lore.kernel.org/patchwork/patch/803265/
+        # https://github.com/systemd/systemd/commit/4095205ecccdfddb822ee8fdc44d11f2ded9be24
+        # The kernel version must be made compatible with the strict version
+        # comparison. I chose to cut at the "-" and take the stuff before it.
+        if [ "$(mountinfo-tool /sys/fs/cgroup/unified .fs_type)" = cgroup2 ] && version-tool --strict "$(uname -r | cut -d- -f 1)" -ge 4.13; then
+            mount -o remount,nsdelegate /sys/fs/cgroup/unified
+        fi
+        ;;
+    *)
+        echo "lxd-tool: unknown command $*" >&2
+        exit 1
+        ;;
+esac

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -204,35 +204,6 @@ install_dependencies_from_published(){
     done
 }
 
-undo_lxd_mount_changes() {
-    # Vanilla systems have /sys/fs/cgroup/cpuset without clone_children option.
-    # Using LXD to create a container enables this option, as can be seen here:
-    #
-    # -37 32 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,cpuset
-    # +37 32 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,cpuset,clone_children
-    #
-    # To restore vanilla state, disable the option now.
-    if mountinfo-tool /sys/fs/cgroup/cpuset; then
-        echo 0 > /sys/fs/cgroup/cpuset/cgroup.clone_children
-    fi
-
-    # Vanilla system have /sys/fs/cgroup/unified mounted with the nsdelegate
-    # option which is available since kernel 4.13 Using LXD to create a
-    # container disables this options, as can be seen here:
-    #
-    # -32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup rw,nsdelegate
-    # +32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup rw
-    #
-    # To restore vanilla state, enable the option now, but only if the kernel supports that.
-    # https://lore.kernel.org/patchwork/patch/803265/
-    # https://github.com/systemd/systemd/commit/4095205ecccdfddb822ee8fdc44d11f2ded9be24
-    # The kernel version must be made compatible with the strict version
-    # comparison. I chose to cut at the "-" and take the stuff before it.
-    if [ "$(mountinfo-tool /sys/fs/cgroup/unified .fs_type)" = cgroup2 ] && version-tool --strict "$(uname -r | cut -d- -f 1)" -ge 4.13; then
-        mount -o remount,nsdelegate /sys/fs/cgroup/unified
-    fi
-}
-
 ###
 ### Prepare / restore functions for {project,suite}
 ###
@@ -241,7 +212,7 @@ prepare_project() {
     if [[ "$SPREAD_SYSTEM" == ubuntu-* ]] && [[ "$SPREAD_SYSTEM" != ubuntu-core-* ]]; then
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y
-        undo_lxd_mount_changes
+        lxd-tool undo-lxd-mount-changes
     fi
 
     # Check if running inside a container.
@@ -673,8 +644,6 @@ restore_project_each() {
             find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
             ;;
     esac
-
-    undo_lxd_mount_changes
 }
 
 restore_project() {

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -40,3 +40,5 @@ execute: |
     fi
     MATCH 'The "fuse" filesystem is required' < err.txt
 
+restore: |
+    lxd-tool undo-lxd-mount-changes

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -31,6 +31,8 @@ restore: |
     lxd.lxc stop my-ubuntu --force
     lxd.lxc delete my-ubuntu
 
+    lxd-tool undo-lxd-mount-changes
+
 debug: |
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -27,6 +27,8 @@ restore: |
         umount /proc/sys/fs/binfmt_misc
     fi
 
+    lxd-tool undo-lxd-mount-changes
+
 execute: |
     snap install lxd
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'

--- a/tests/nightly/install-snaps/task.yaml
+++ b/tests/nightly/install-snaps/task.yaml
@@ -88,6 +88,10 @@ restore: |
         unlink /snap
     fi
 
+    if [ "$SNAP" = lxd ]; then
+        lxd-tool undo-lxd-mount-changes
+    fi
+
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -57,6 +57,7 @@ restore: |
     lxc delete --force xenial || true
 
     snap remove lxd
+    lxd-tool undo-lxd-mount-changes
 
 execute: |
     # Run python0 with a hello.py script and redirect the logs to /var/lib/test/hello.log


### PR DESCRIPTION
The origin of the bug this patch fixes is in misunderstanding how spread
restore works. Spread has project, suite and task level commands. In
addition, it has "-each" variant of some of those, like
restore-suite-each and restore-project-each that run for each task in a
suite and project respectively. The problem is ordering.

I had incorrectly assumed that the order is that project-each commands
run immediately after the commands specified in a particular task.yaml.
This is false. Those actually run last. The result was that the leak
detector ran before some of the restore logic, detecting a leak for
something that we already know about!

Instead of putting the restore code in both project each and suite each,
so that at least one copy runs "early enough", I decided to undo the
whole magic restore property by bringing this special-case fix to five
tests that actually need it.

I moved the restore code to "lxd-tool" under the sub-command name
"undo-lxd-mount-changes". The tool is invoked in project-prepare as well
as in the tests that use LXD.

I prefer to do it this way to show the cost of restore right in the
tests that actually need it and to save it from all the tests that don't
require special restore operations.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
