### PR TITLE
many: make per-snap mount namespace MS_SHARED

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -132,89 +132,115 @@
 
     # LP: #1668659
     mount options=(rw rbind) /snap/ -> /snap/,
-    mount options=(rw rshared) -> /snap/,
+    mount options=(rw rslave)       -> /snap/,
+    mount options=(rw rshared)      -> /snap/,
 
     # boostrapping the mount namespace
     mount options=(rw rshared) -> /,
     mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
-    mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,
-    # the next line is for classic system
+    mount options=(rw unbindable)               -> /tmp/snap.rootfs_*/,
+    # the next lines are for classic system
     mount options=(rw rbind) @SNAP_MOUNT_DIR@/*/*/ -> /tmp/snap.rootfs_*/,
-    # the next line is for core system
-    mount options=(rw rbind) / -> /tmp/snap.rootfs_*/,
+    mount options=(rw rslave) -> @SNAP_MOUNT_DIR@/*/*/,
+    mount options=(rw rshared) -> @SNAP_MOUNT_DIR@/*/*/,
+    # the next lines are for core system
     # all of the constructed rootfs is a rslave
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/,
+    # then it becomes shared for per-user mount namespaces
+    mount options=(rw rbind) / -> /tmp/snap.rootfs_*/,
+    mount options=(rw rslave)  -> /tmp/snap.rootfs_*/,
+    mount options=(rw rshared) -> /tmp/snap.rootfs_*/,
     # bidirectional mounts (for both classic and core)
     # NOTE: this doesn't capture the MERGED_USR configuration option so that
     # when a distro with merged /usr and / that uses apparmor shows up it
     # should be handled here.
     /{,run/}media/ w,
     mount options=(rw rbind) /{,run/}media/ -> /tmp/snap.rootfs_*/{,run/}media/,
+    mount options=(rshared)                 -> /tmp/snap.rootfs_*/{,run/}media/,
     /run/netns/ w,
     mount options=(rw rbind) /run/netns/ -> /tmp/snap.rootfs_*/run/netns/,
+    mount options=(rshared)              -> /tmp/snap.rootfs_*/run/netns/,
     # unidirectional mounts (only for classic system)
     mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/dev/,
+    mount options=(rw rslave)      -> /tmp/snap.rootfs_*/dev/,
+    mount options=(rw rshared)     -> /tmp/snap.rootfs_*/dev/,
 
     mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/etc/,
+    mount options=(rw rslave)      -> /tmp/snap.rootfs_*/etc/,
+    mount options=(rw rshared)     -> /tmp/snap.rootfs_*/etc/,
 
     mount options=(rw rbind) /home/ -> /tmp/snap.rootfs_*/home/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/home/,
+    mount options=(rw rslave)       -> /tmp/snap.rootfs_*/home/,
+    mount options=(rw rshared)      -> /tmp/snap.rootfs_*/home/,
 
     mount options=(rw rbind) /root/ -> /tmp/snap.rootfs_*/root/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/root/,
+    mount options=(rw rslave)       -> /tmp/snap.rootfs_*/root/,
+    mount options=(rw rshared)      -> /tmp/snap.rootfs_*/root/,
 
     mount options=(rw rbind) /proc/ -> /tmp/snap.rootfs_*/proc/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/proc/,
+    mount options=(rw rslave)       -> /tmp/snap.rootfs_*/proc/,
+    mount options=(rw rshared)      -> /tmp/snap.rootfs_*/proc/,
 
     mount options=(rw rbind) /sys/ -> /tmp/snap.rootfs_*/sys/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/sys/,
+    mount options=(rw rslave)      -> /tmp/snap.rootfs_*/sys/,
+    mount options=(rw rshared)     -> /tmp/snap.rootfs_*/sys/,
 
     mount options=(rw rbind) /tmp/ -> /tmp/snap.rootfs_*/tmp/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/tmp/,
+    mount options=(rw rslave)      -> /tmp/snap.rootfs_*/tmp/,
+    mount options=(rw rshared)     -> /tmp/snap.rootfs_*/tmp/,
 
     mount options=(rw rbind) /var/lib/snapd/ -> /tmp/snap.rootfs_*/var/lib/snapd/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/snapd/,
+    mount options=(rw rslave)                -> /tmp/snap.rootfs_*/var/lib/snapd/,
+    mount options=(rw rshared)               -> /tmp/snap.rootfs_*/var/lib/snapd/,
 
     mount options=(rw rbind) /var/snap/ -> /tmp/snap.rootfs_*/var/snap/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/snap/,
+    mount options=(rw rslave)           -> /tmp/snap.rootfs_*/var/snap/,
+    mount options=(rw rshared)          -> /tmp/snap.rootfs_*/var/snap/,
 
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/tmp/,
+    mount options=(rw rslave)          -> /tmp/snap.rootfs_*/var/tmp/,
+    mount options=(rw rshared)         -> /tmp/snap.rootfs_*/var/tmp/,
 
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/run/,
+    mount options=(rw rslave)      -> /tmp/snap.rootfs_*/run/,
+    mount options=(rw rshared)     -> /tmp/snap.rootfs_*/run/,
 
     mount options=(rw rbind) /var/lib/extrausers/ -> /tmp/snap.rootfs_*/var/lib/extrausers/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+    mount options=(rw rslave)                     -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+    mount options=(rw rshared)                    -> /tmp/snap.rootfs_*/var/lib/extrausers/,
 
     mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/modules/ -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
+    mount options=(rw rslave)                                 -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
+    mount options=(rw rshared)                                -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
 
     mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/firmware/ -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+    mount options=(rw rslave)                                  -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+    mount options=(rw rshared)                                 -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
 
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/log/,
+    mount options=(rw rslave)          -> /tmp/snap.rootfs_*/var/log/,
+    mount options=(rw rshared)         -> /tmp/snap.rootfs_*/var/log/,
 
     mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/usr/src/,
+    mount options=(rw rslave)          -> /tmp/snap.rootfs_*/usr/src/,
+    mount options=(rw rshared)         -> /tmp/snap.rootfs_*/usr/src/,
 
     mount options=(rw rbind) /mnt/ -> /tmp/snap.rootfs_*/mnt/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/mnt/,
+    mount options=(rw rslave)      -> /tmp/snap.rootfs_*/mnt/,
+    mount options=(rw rshared)     -> /tmp/snap.rootfs_*/mnt/,
 
     # allow making host snap-exec available inside base snaps
     mount options=(rw bind) @LIBEXECDIR@/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
-    mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(rw slave)              -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(rw shared)             -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     # allow making re-execed host snap-exec available inside base snaps
     mount options=(ro bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     # allow making snapd snap tools available inside base snaps
     mount options=(ro bind) @SNAP_MOUNT_DIR@/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
+    # XXX: this seems unused
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
-    mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,
+    mount options=(rw slave)                 -> /tmp/snap.rootfs_*/usr/bin/snapctl,
 
     # /etc/alternatives (classic)
     mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
@@ -227,10 +253,11 @@
     mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
     # the /snap directory
     mount options=(rw rbind) @SNAP_MOUNT_DIR@/ -> /tmp/snap.rootfs_*/snap/,
-    mount options=(rw rslave) -> /tmp/snap.rootfs_*/snap/,
+    mount options=(rw rslave)                  -> /tmp/snap.rootfs_*/snap/,
+    mount options=(rw rshared)                 -> /tmp/snap.rootfs_*/snap/,
     # pivot_root preparation and execution
     mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
-    mount options=(rw private) -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+    mount options=(rw private)                                       -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
 
     # pivot_root mediation in AppArmor is not complete. See LP: #1791711.
     # However, we can mediate the new_root and put_old to be what we expect,
@@ -242,6 +269,9 @@
     # LP: #1791711, it provides some hardening.
     audit deny /tmp/snap.rootfs_*/{var/,var/lib/,var/lib/snapd/,var/lib/snapd/hostfs/} w,
 
+    # post-pivot_root hostfs propagation change.
+    mount options=(rw rslave)                                        -> /var/lib/snapd/hostfs/,
+    mount options=(rw rshared)                                       -> /var/lib/snapd/hostfs/,
     # cleanup
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
     umount /var/lib/snapd/hostfs/sys/,

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -639,6 +639,7 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
 		{C: `close 7`},
 		{C: `close 4`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
@@ -1150,6 +1151,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
 		{C: `close 7`},
 		{C: `close 4`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
@@ -1299,6 +1301,7 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnly
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
 		{C: `close 7`},
 		{C: `close 4`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
 		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
@@ -1691,6 +1694,7 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
 		{C: `close 7`},
 		{C: `close 4`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
@@ -2084,6 +2088,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
 		{C: `close 7`},
 		{C: `close 4`},
+		{C: `mount "none" "/tmp/.snap/rofs" "" MS_REC|MS_PRIVATE ""`},
 
 		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
@@ -2289,6 +2294,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithAvoidedTrespassing(c *C) {
 		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
 		{C: `close 7`},
 		{C: `close 4`},
+		{C: `mount "none" "/tmp/.snap/etc" "" MS_REC|MS_PRIVATE ""`},
 
 		// Mount a tmpfs over /etc, re-constructing the original mode and
 		// ownership. Bind mount each original file over and detach the copy

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -482,7 +482,10 @@ func planWritableMimic(dir, neededBy string) ([]*Change, error) {
 			// The undo logic handles rbind mounts and adds x-snapd.unbind
 			// flag to them, which in turns translates to MNT_DETACH on
 			// umount2(2) system call.
-			Name: dir, Dir: safeKeepingDir, Options: []string{"rbind"}},
+			//
+			// The rprivate is here to ensure that changes made to the
+			// original directory do not propagate into or out of this view.
+			Name: dir, Dir: safeKeepingDir, Options: []string{"rprivate", "rbind"}},
 	})
 
 	// Mount tmpfs over the original directory, hiding its contents.

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -339,7 +339,7 @@ func (s *utilsSuite) TestPlanWritableMimic(c *C) {
 
 	c.Assert(changes, DeepEquals, []*update.Change{
 		// Store /foo in /tmp/.snap/foo while we set things up
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rprivate", "rbind"}}, Action: update.Mount},
 		// Put a tmpfs over /foo
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/foo/bar", "mode=0755", "uid=0", "gid=0"}}, Action: update.Mount},
 		// Bind mount files and directories over. Note that files are identified by x-snapd.kind=file option.

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -258,6 +258,7 @@ func GenWritableMimicProfile(emit func(f string, args ...interface{}), path stri
 		emit("  # Allow setting the read-only directory aside via a bind mount.\n")
 		emit("  %s rw,\n", mimicAuxPath)
 		emit("  mount options=(rbind, rw) %s -> %s,\n", mimicPath, mimicAuxPath)
+		emit("  mount options=(rprivate) -> %s,\n", mimicAuxPath)
 		emit("  # Allow mounting tmpfs over the read-only directory.\n")
 		emit("  mount fstype=tmpfs options=(rw) tmpfs -> %s,\n", mimicPath)
 		emit("  # Allow creating empty files and directories for bind mounting things\n" +

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -194,6 +193,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/etc/ rw,
   mount options=(rbind, rw) /etc/ -> /tmp/.snap/etc/,
+  mount options=(rprivate) -> /tmp/.snap/etc/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /etc/,
   # Allow creating empty files and directories for bind mounting things
@@ -228,6 +228,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/vanguard/42/ rw,
   mount options=(rbind, rw) /snap/vanguard/42/ -> /tmp/.snap/snap/vanguard/42/,
+  mount options=(rprivate) -> /tmp/.snap/snap/vanguard/42/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/,
   # Allow creating empty files and directories for bind mounting things
@@ -267,6 +268,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/usr/ rw,
   mount options=(rbind, rw) /usr/ -> /tmp/.snap/usr/,
+  mount options=(rprivate) -> /tmp/.snap/usr/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /usr/,
   # Allow creating empty files and directories for bind mounting things
@@ -301,6 +303,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/vanguard/42/ rw,
   mount options=(rbind, rw) /snap/vanguard/42/ -> /tmp/.snap/snap/vanguard/42/,
+  mount options=(rprivate) -> /tmp/.snap/snap/vanguard/42/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/,
   # Allow creating empty files and directories for bind mounting things
@@ -330,6 +333,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/vanguard/42/usr/ rw,
   mount options=(rbind, rw) /snap/vanguard/42/usr/ -> /tmp/.snap/snap/vanguard/42/usr/,
+  mount options=(rprivate) -> /tmp/.snap/snap/vanguard/42/usr/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/usr/,
   # Allow creating empty files and directories for bind mounting things
@@ -367,6 +371,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/var/ rw,
   mount options=(rbind, rw) /var/ -> /tmp/.snap/var/,
+  mount options=(rprivate) -> /tmp/.snap/var/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /var/,
   # Allow creating empty files and directories for bind mounting things
@@ -396,6 +401,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/var/cache/ rw,
   mount options=(rbind, rw) /var/cache/ -> /tmp/.snap/var/cache/,
+  mount options=(rprivate) -> /tmp/.snap/var/cache/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /var/cache/,
   # Allow creating empty files and directories for bind mounting things
@@ -435,6 +441,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/var/ rw,
   mount options=(rbind, rw) /var/ -> /tmp/.snap/var/,
+  mount options=(rprivate) -> /tmp/.snap/var/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /var/,
   # Allow creating empty files and directories for bind mounting things

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -328,6 +328,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/ rw,
   mount options=(rbind, rw) / -> /tmp/.snap/,
+  mount options=(rprivate) -> /tmp/.snap/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /,
   # Allow creating empty files and directories for bind mounting things
@@ -357,6 +358,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/ rw,
   mount options=(rbind, rw) /snap/ -> /tmp/.snap/snap/,
+  mount options=(rprivate) -> /tmp/.snap/snap/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/,
   # Allow creating empty files and directories for bind mounting things
@@ -386,6 +388,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/producer/ rw,
   mount options=(rbind, rw) /snap/producer/ -> /tmp/.snap/snap/producer/,
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/producer/,
   # Allow creating empty files and directories for bind mounting things
@@ -415,6 +418,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/producer/5/ rw,
   mount options=(rbind, rw) /snap/producer/5/ -> /tmp/.snap/snap/producer/5/,
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/5/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/producer/5/,
   # Allow creating empty files and directories for bind mounting things
@@ -446,6 +450,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/ rw,
   mount options=(rbind, rw) / -> /tmp/.snap/,
+  mount options=(rprivate) -> /tmp/.snap/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /,
   # Allow creating empty files and directories for bind mounting things
@@ -475,6 +480,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/ rw,
   mount options=(rbind, rw) /snap/ -> /tmp/.snap/snap/,
+  mount options=(rprivate) -> /tmp/.snap/snap/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/,
   # Allow creating empty files and directories for bind mounting things
@@ -504,6 +510,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/consumer/ rw,
   mount options=(rbind, rw) /snap/consumer/ -> /tmp/.snap/snap/consumer/,
+  mount options=(rprivate) -> /tmp/.snap/snap/consumer/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/consumer/,
   # Allow creating empty files and directories for bind mounting things
@@ -533,6 +540,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/consumer/7/ rw,
   mount options=(rbind, rw) /snap/consumer/7/ -> /tmp/.snap/snap/consumer/7/,
+  mount options=(rprivate) -> /tmp/.snap/snap/consumer/7/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/consumer/7/,
   # Allow creating empty files and directories for bind mounting things
@@ -850,6 +858,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/ rw,
   mount options=(rbind, rw) / -> /tmp/.snap/,
+  mount options=(rprivate) -> /tmp/.snap/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /,
   # Allow creating empty files and directories for bind mounting things
@@ -879,6 +888,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/ rw,
   mount options=(rbind, rw) /snap/ -> /tmp/.snap/snap/,
+  mount options=(rprivate) -> /tmp/.snap/snap/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/,
   # Allow creating empty files and directories for bind mounting things
@@ -908,6 +918,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/producer/ rw,
   mount options=(rbind, rw) /snap/producer/ -> /tmp/.snap/snap/producer/,
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/producer/,
   # Allow creating empty files and directories for bind mounting things
@@ -937,6 +948,7 @@ slots:
   # Allow setting the read-only directory aside via a bind mount.
   /tmp/.snap/snap/producer/2/ rw,
   mount options=(rbind, rw) /snap/producer/2/ -> /tmp/.snap/snap/producer/2/,
+  mount options=(rprivate) -> /tmp/.snap/snap/producer/2/,
   # Allow mounting tmpfs over the read-only directory.
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/producer/2/,
   # Allow creating empty files and directories for bind mounting things

--- a/tests/main/interfaces-fuse-support/task.yaml
+++ b/tests/main/interfaces-fuse-support/task.yaml
@@ -38,14 +38,15 @@ prepare: |
     mkdir -p "$MOUNT_POINT_OUTSIDE"
 
 restore: |
-    # remove the mount point
-    mounts=$(nsenter "--mount=/run/snapd/ns/$NAME.mnt" cat /proc/mounts | \
-             grep "$(basename "$MOUNT_POINT") fuse" | cut -f2 -d' ')
-    for m in $mounts; do
-        nsenter "--mount=/run/snapd/ns/$NAME.mnt" umount "$m"
-    done
+    # Unmount the filesystem mounted inside the mount namespace of the
+    # application. Due to propagation settings this is sufficient even if
+    # instances are used, where the mount point was visible under two
+    # locations, because the unmount event propagates across.
+    nsenter "--mount=/run/snapd/ns/$NAME.mnt" umount /var/snap/test-snapd-fuse-consumer/current/mount_point
+    if nsenter "--mount=/run/snapd/ns/$NAME.mnt" findmnt | grep fuse; then
+        echo "unexepcted fuse mounts left behind"
+    fi
     rm -rf "$MOUNT_POINT_OUTSIDE"
-
     if [[ "$SPREAD_VARIANT" == "parallel" ]]; then
         snap set system experimental.parallel-instances=null
     fi

--- a/tests/main/layout-symlink-bind-revert/task.yaml
+++ b/tests/main/layout-symlink-bind-revert/task.yaml
@@ -1,4 +1,8 @@
-summary: TBD
+summary: Layouts can change from one revision to another
+details: |
+    This test used to show how layouts could *not* change, in some cases, from
+    one version to another due to bugs in mount namespace mechanics. With those
+    bugs fixed the test now shows how everything behaves correctly.
 
 prepare: |
     echo "Ensure feature flag is enabled"
@@ -17,7 +21,7 @@ execute: |
 
     echo "The application is refreshed with another layout"
     snap install --dangerous ./app_2_all.snap
-    app 2>&1 | MATCH '/snap/app/x2/bin/app: 2: /snap/app/x2/bin/app: /opt/runtime/runner: not found'
+    app 2>&1 | MATCH "RUNTIME: Hello from the app"
 
     echo "The broken application is reverted"
     snap revert app 2>&1 | MATCH 'app reverted to 1'

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
@@ -1,76 +1,76 @@
-2:0 / / ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:0 / /dev rw,nosuid,relatime master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:4 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:6 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / / ro,nodev,relatime shared:1001 master:16 - squashfs /dev/loop0 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:4 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:6 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 2:0 /etc/ssl /etc/ssl ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/firmware /lib/firmware rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/firmware /lib/firmware rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:7 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:8 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:9 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1012 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1013 master:7 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1014 master:8 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:9 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1016 master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1017 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1018 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/cgmanager/fs rw,relatime shared:1019 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1020 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:14 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
-1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
-1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-1:28 / /sys/fs/fuse/connections rw,relatime master:35 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:36 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:37 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:38 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:39 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:12 / /run/rpc_pipefs rw,relatime shared:1021 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1022 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1023 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1024 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1025 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1026 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1027 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1028 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1029 master:20 - squashfs /dev/loop4 ro
+1:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1030 master:21 - sysfs sysfs rw
+1:15 / /sys/fs/cgroup rw shared:1031 master:22 - tmpfs tmpfs rw,mode=755
+1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1032 master:23 - cgroup cgroup rw,blkio
+1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1033 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1034 master:25 - cgroup cgroup rw,cpuset
+1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1035 master:26 - cgroup cgroup rw,devices
+1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1036 master:27 - cgroup cgroup rw,freezer
+1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1037 master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1038 master:29 - cgroup cgroup rw,memory
+1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1039 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1040 master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1041 master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1042 master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
+1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1043 master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1044 master:35 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1045 master:36 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1046 master:37 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1047 master:38 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1048 master:39 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1049 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime shared:1050 - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1051 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1052 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1053 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1055 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1056 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1057 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1058 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1059 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1060 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1061 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1062 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1063 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1064 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1065 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1066 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1067 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1069 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
@@ -1,77 +1,77 @@
-2:1 / / ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:0 / /dev rw,nosuid,relatime master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:4 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:6 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:1 / / ro,nodev,relatime shared:1001 master:17 - squashfs /dev/loop1 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:4 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:6 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
 2:1 /etc/ssl /etc/ssl ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/firmware /lib/firmware rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/firmware /lib/firmware rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:7 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:8 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:9 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1012 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1013 master:7 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1014 master:8 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:9 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1016 master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1017 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1018 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/cgmanager/fs rw,relatime shared:1019 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1020 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:14 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
-1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
-1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-1:28 / /sys/fs/fuse/connections rw,relatime master:35 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:36 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:37 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:38 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:39 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:12 / /run/rpc_pipefs rw,relatime shared:1021 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1022 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1023 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1024 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1025 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1026 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1027 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1028 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1029 master:20 - squashfs /dev/loop4 ro
+1:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1030 master:21 - sysfs sysfs rw
+1:15 / /sys/fs/cgroup rw shared:1031 master:22 - tmpfs tmpfs rw,mode=755
+1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1032 master:23 - cgroup cgroup rw,blkio
+1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1033 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1034 master:25 - cgroup cgroup rw,cpuset
+1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1035 master:26 - cgroup cgroup rw,devices
+1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1036 master:27 - cgroup cgroup rw,freezer
+1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1037 master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1038 master:29 - cgroup cgroup rw,memory
+1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1039 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1040 master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1041 master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1042 master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
+1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1043 master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1044 master:35 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1045 master:36 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1046 master:37 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1047 master:38 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1048 master:39 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1049 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1050 master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime shared:1051 - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1052 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1053 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1055 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1056 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1057 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1058 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1059 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1060 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1061 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1062 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1063 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1064 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1065 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1066 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1067 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1069 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1070 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
@@ -1,76 +1,76 @@
-2:0 / / ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:0 / /dev rw,nosuid,relatime master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:4 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:6 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / / ro,nodev,relatime shared:1001 master:16 - squashfs /dev/loop0 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:4 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:6 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 2:0 /etc/ssl /etc/ssl ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/firmware /lib/firmware rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/firmware /lib/firmware rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:7 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:8 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:9 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1012 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1013 master:7 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1014 master:8 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:9 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1016 master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1017 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1018 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/cgmanager/fs rw,relatime shared:1019 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1020 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:14 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
-1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
-1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-1:28 / /sys/fs/fuse/connections rw,relatime master:35 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:36 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:37 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:38 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:39 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:12 / /run/rpc_pipefs rw,relatime shared:1021 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1022 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1023 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1024 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1025 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1026 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1027 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1028 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1029 master:20 - squashfs /dev/loop4 ro
+1:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1030 master:21 - sysfs sysfs rw
+1:15 / /sys/fs/cgroup rw shared:1031 master:22 - tmpfs tmpfs rw,mode=755
+1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1032 master:23 - cgroup cgroup rw,blkio
+1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1033 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1034 master:25 - cgroup cgroup rw,cpuset
+1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1035 master:26 - cgroup cgroup rw,devices
+1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1036 master:27 - cgroup cgroup rw,freezer
+1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1037 master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1038 master:29 - cgroup cgroup rw,memory
+1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1039 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1040 master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1041 master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1042 master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
+1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1043 master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1044 master:35 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1045 master:36 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1046 master:37 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1047 master:38 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1048 master:39 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1049 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime shared:1050 - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1051 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1052 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1053 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1055 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1056 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1057 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1058 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1059 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1060 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1061 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1062 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1063 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1064 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1065 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1066 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1067 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1069 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
@@ -1,77 +1,77 @@
-2:1 / / ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:0 / /dev rw,nosuid,relatime master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:4 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:6 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:1 / / ro,nodev,relatime shared:1001 master:17 - squashfs /dev/loop1 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:2 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:3 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:4 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:5 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:6 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
 2:1 /etc/ssl /etc/ssl ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/firmware /lib/firmware rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/firmware /lib/firmware rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:7 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:8 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:9 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1012 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1013 master:7 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1014 master:8 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:9 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1016 master:10 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1017 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1018 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/cgmanager/fs rw,relatime shared:1019 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1020 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:14 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:15 / /sys/fs/cgroup rw master:22 - tmpfs tmpfs rw,mode=755
-1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
-1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-1:28 / /sys/fs/fuse/connections rw,relatime master:35 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:36 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:37 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:38 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:39 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:12 / /run/rpc_pipefs rw,relatime shared:1021 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1022 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1023 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1024 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1025 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1026 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1027 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1028 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1029 master:20 - squashfs /dev/loop4 ro
+1:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1030 master:21 - sysfs sysfs rw
+1:15 / /sys/fs/cgroup rw shared:1031 master:22 - tmpfs tmpfs rw,mode=755
+1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1032 master:23 - cgroup cgroup rw,blkio
+1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1033 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1034 master:25 - cgroup cgroup rw,cpuset
+1:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1035 master:26 - cgroup cgroup rw,devices
+1:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1036 master:27 - cgroup cgroup rw,freezer
+1:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1037 master:28 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+1:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1038 master:29 - cgroup cgroup rw,memory
+1:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1039 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1040 master:31 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+1:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1041 master:32 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+1:26 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1042 master:33 - cgroup cgroup rw,rdma,release_agent=/run/cgmanager/agents/cgm-release-agent.rdma
+1:27 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1043 master:34 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1044 master:35 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1045 master:36 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1046 master:37 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1047 master:38 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1048 master:39 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1049 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1050 master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime shared:1051 - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1052 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1053 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1055 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1056 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1057 master:11 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1058 master:12 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+1:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1059 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:12 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1060 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1061 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1062 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1063 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1064 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1065 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1066 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1067 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1069 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1070 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
@@ -1,75 +1,75 @@
-2:0 / / ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / / ro,nodev,relatime shared:1001 master:16 - squashfs /dev/loop0 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 2:0 /etc/ssl /etc/ssl ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:8 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:9 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1012 master:8 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1013 master:9 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1014 master:10 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1016 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1017 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1018 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:11 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:13 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
-1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
-1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event
-1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
-1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
-1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
-1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:39 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:40 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:11 / /run/rpc_pipefs rw,relatime shared:1019 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1020 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1021 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1022 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1023 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1024 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1025 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1026 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1027 master:20 - squashfs /dev/loop4 ro
+1:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1028 master:21 - sysfs sysfs rw
+1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1029 master:22 - tmpfs tmpfs ro,mode=755
+1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1030 master:23 - cgroup cgroup rw,blkio
+1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1031 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1032 master:25 - cgroup cgroup rw,cpuset
+1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1033 master:26 - cgroup cgroup rw,devices
+1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1034 master:27 - cgroup cgroup rw,freezer
+1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1035 master:28 - cgroup cgroup rw,hugetlb
+1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1036 master:29 - cgroup cgroup rw,memory
+1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1037 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1038 master:31 - cgroup cgroup rw,perf_event
+1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1039 master:32 - cgroup cgroup rw,pids
+1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1040 master:33 - cgroup cgroup rw,rdma
+1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1041 master:34 - cgroup cgroup rw,xattr,name=systemd
+1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1042 master:35 - cgroup2 cgroup rw,nsdelegate
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1043 master:36 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1044 master:37 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1045 master:38 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1046 master:39 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1047 master:40 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1048 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime shared:1049 - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1050 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1051 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1052 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1053 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1055 master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1056 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1057 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1058 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1059 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1060 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1061 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1062 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1063 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1064 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1065 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1066 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1067 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
@@ -1,76 +1,76 @@
-2:1 / / ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:1 / / ro,nodev,relatime shared:1001 master:17 - squashfs /dev/loop1 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
 2:1 /etc/ssl /etc/ssl ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:8 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:9 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1012 master:8 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1013 master:9 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1014 master:10 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1016 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1017 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1018 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:11 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:13 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
-1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
-1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event
-1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
-1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
-1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
-1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:39 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:40 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:11 / /run/rpc_pipefs rw,relatime shared:1019 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1020 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1021 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1022 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1023 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1024 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1025 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1026 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1027 master:20 - squashfs /dev/loop4 ro
+1:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1028 master:21 - sysfs sysfs rw
+1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1029 master:22 - tmpfs tmpfs ro,mode=755
+1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1030 master:23 - cgroup cgroup rw,blkio
+1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1031 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1032 master:25 - cgroup cgroup rw,cpuset
+1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1033 master:26 - cgroup cgroup rw,devices
+1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1034 master:27 - cgroup cgroup rw,freezer
+1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1035 master:28 - cgroup cgroup rw,hugetlb
+1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1036 master:29 - cgroup cgroup rw,memory
+1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1037 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1038 master:31 - cgroup cgroup rw,perf_event
+1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1039 master:32 - cgroup cgroup rw,pids
+1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1040 master:33 - cgroup cgroup rw,rdma
+1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1041 master:34 - cgroup cgroup rw,xattr,name=systemd
+1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1042 master:35 - cgroup2 cgroup rw,nsdelegate
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1043 master:36 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1044 master:37 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1045 master:38 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1046 master:39 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1047 master:40 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1048 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1049 master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime shared:1050 - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1051 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1052 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1053 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1055 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1056 master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1057 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1058 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1059 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1060 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1061 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1062 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1063 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1064 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1065 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1066 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1067 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1069 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
@@ -1,75 +1,75 @@
-2:0 / / ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / / ro,nodev,relatime shared:1001 master:16 - squashfs /dev/loop0 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 2:0 /etc/ssl /etc/ssl ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:8 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:9 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1012 master:8 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1013 master:9 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1014 master:10 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1016 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1017 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1018 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:11 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:13 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
-1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
-1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event
-1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
-1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
-1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
-1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:39 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:40 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:11 / /run/rpc_pipefs rw,relatime shared:1019 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1020 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1021 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1022 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1023 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1024 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1025 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1026 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1027 master:20 - squashfs /dev/loop4 ro
+1:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1028 master:21 - sysfs sysfs rw
+1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1029 master:22 - tmpfs tmpfs ro,mode=755
+1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1030 master:23 - cgroup cgroup rw,blkio
+1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1031 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1032 master:25 - cgroup cgroup rw,cpuset
+1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1033 master:26 - cgroup cgroup rw,devices
+1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1034 master:27 - cgroup cgroup rw,freezer
+1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1035 master:28 - cgroup cgroup rw,hugetlb
+1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1036 master:29 - cgroup cgroup rw,memory
+1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1037 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1038 master:31 - cgroup cgroup rw,perf_event
+1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1039 master:32 - cgroup cgroup rw,pids
+1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1040 master:33 - cgroup cgroup rw,rdma
+1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1041 master:34 - cgroup cgroup rw,xattr,name=systemd
+1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1042 master:35 - cgroup2 cgroup rw,nsdelegate
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1043 master:36 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1044 master:37 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1045 master:38 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1046 master:39 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1047 master:40 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1048 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime shared:1049 - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1050 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1051 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1052 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1053 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1055 master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1056 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1057 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1058 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1059 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1060 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1061 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1062 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1063 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1064 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1065 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1066 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1067 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
@@ -1,76 +1,76 @@
-2:1 / / ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-1:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-1:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-1:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-1:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-1:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:1 / / ro,nodev,relatime shared:1001 master:17 - squashfs /dev/loop1 ro
+1:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+1:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+1:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+1:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+1:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc rw,relatime shared:1008 master:1 - ext4 /dev/sda1 rw,data=ordered
 2:1 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
 2:1 /etc/ssl /etc/ssl ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-0:0 /home /home rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /lib/modules /lib/modules rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /home /home rw,relatime shared:1009 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /lib/modules /lib/modules rw,relatime shared:1010 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /media /media rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /mnt /mnt rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:5 / /proc rw,nosuid,nodev,noexec,relatime master:8 - proc proc rw
-1:6 / /proc/fs/nfsd rw,relatime master:9 - nfsd nfsd rw
-1:7 / /proc/sys/fs/binfmt_misc rw,relatime master:10 - binfmt_misc binfmt_misc rw
-1:8 / /proc/sys/fs/binfmt_misc rw,relatime master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-0:0 /root /root rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-1:9 / /run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
+0:0 /mnt /mnt rw,relatime shared:1011 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:5 / /proc rw,nosuid,nodev,noexec,relatime shared:1012 master:8 - proc proc rw
+1:6 / /proc/fs/nfsd rw,relatime shared:1013 master:9 - nfsd nfsd rw
+1:7 / /proc/sys/fs/binfmt_misc rw,relatime shared:1014 master:10 - binfmt_misc binfmt_misc rw
+1:8 / /proc/sys/fs/binfmt_misc rw,relatime shared:1015 master:11 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+0:0 /root /root rw,relatime shared:1016 master:1 - ext4 /dev/sda1 rw,data=ordered
+1:9 / /run rw,nosuid,noexec,relatime shared:1017 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1018 master:13 - tmpfs tmpfs rw,size=VARIABLE
 1:9 /netns /run/netns rw,nosuid,noexec,relatime shared:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:11 / /run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-0:0 /snap /snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-2:0 / /snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-1:13 / /sys rw,nosuid,nodev,noexec,relatime master:21 - sysfs sysfs rw
-1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:22 - tmpfs tmpfs ro,mode=755
-1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:23 - cgroup cgroup rw,blkio
-1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:24 - cgroup cgroup rw,cpu,cpuacct
-1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:25 - cgroup cgroup rw,cpuset
-1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:26 - cgroup cgroup rw,devices
-1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:27 - cgroup cgroup rw,freezer
-1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:28 - cgroup cgroup rw,hugetlb
-1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:29 - cgroup cgroup rw,memory
-1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:30 - cgroup cgroup rw,net_cls,net_prio
-1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:31 - cgroup cgroup rw,perf_event
-1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:32 - cgroup cgroup rw,pids
-1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:33 - cgroup cgroup rw,rdma
-1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:34 - cgroup cgroup rw,xattr,name=systemd
-1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:35 - cgroup2 cgroup rw,nsdelegate
-1:28 / /sys/fs/fuse/connections rw,relatime master:36 - fusectl fusectl rw
-1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:37 - pstore pstore rw
-1:30 / /sys/kernel/config rw,relatime master:38 - configfs configfs rw
-1:31 / /sys/kernel/debug rw,relatime master:39 - debugfs debugfs rw
-1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:40 - securityfs securityfs rw
-0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+1:11 / /run/rpc_pipefs rw,relatime shared:1019 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1020 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1021 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+0:0 /snap /snap rw,relatime shared:1022 master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 / /snap/core/1 ro,nodev,relatime shared:1023 master:16 - squashfs /dev/loop0 ro
+2:1 / /snap/core18/1 ro,nodev,relatime shared:1024 master:17 - squashfs /dev/loop1 ro
+2:2 / /snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1025 master:18 - squashfs /dev/loop2 ro
+2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1026 master:19 - squashfs /dev/loop3 ro
+2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1027 master:20 - squashfs /dev/loop4 ro
+1:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1028 master:21 - sysfs sysfs rw
+1:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1029 master:22 - tmpfs tmpfs ro,mode=755
+1:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1030 master:23 - cgroup cgroup rw,blkio
+1:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1031 master:24 - cgroup cgroup rw,cpu,cpuacct
+1:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1032 master:25 - cgroup cgroup rw,cpuset
+1:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1033 master:26 - cgroup cgroup rw,devices
+1:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1034 master:27 - cgroup cgroup rw,freezer
+1:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1035 master:28 - cgroup cgroup rw,hugetlb
+1:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1036 master:29 - cgroup cgroup rw,memory
+1:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1037 master:30 - cgroup cgroup rw,net_cls,net_prio
+1:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1038 master:31 - cgroup cgroup rw,perf_event
+1:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1039 master:32 - cgroup cgroup rw,pids
+1:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1040 master:33 - cgroup cgroup rw,rdma
+1:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1041 master:34 - cgroup cgroup rw,xattr,name=systemd
+1:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1042 master:35 - cgroup2 cgroup rw,nsdelegate
+1:28 / /sys/fs/fuse/connections rw,relatime shared:1043 master:36 - fusectl fusectl rw
+1:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1044 master:37 - pstore pstore rw
+1:30 / /sys/kernel/config rw,relatime shared:1045 master:38 - configfs configfs rw
+1:31 / /sys/kernel/debug rw,relatime shared:1046 master:39 - debugfs debugfs rw
+1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1047 master:40 - securityfs securityfs rw
+0:0 /tmp /tmp rw,relatime shared:1048 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
-2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1049 master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime shared:1050 - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1051 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime shared:1052 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src rw,relatime shared:1053 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/lib/snapd /var/lib/snapd rw,relatime shared:1054 master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:13 - tmpfs tmpfs rw,size=VARIABLE
-1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime master:14 - rpc_pipefs sunrpc rw
-1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
-2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
-2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime master:18 - squashfs /dev/loop2 ro
-2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:19 - squashfs /dev/loop3 ro
-2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:20 - squashfs /dev/loop4 ro
-0:0 /var/log /var/log rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/snap /var/snap rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
-0:0 /var/tmp /var/tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs rw,relatime shared:1055 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:1 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1056 master:2 - vfat /dev/sda15 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:9 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1057 master:12 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:10 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1058 master:13 - tmpfs tmpfs rw,size=VARIABLE
+1:11 / /var/lib/snapd/hostfs/run/rpc_pipefs rw,relatime shared:1059 master:14 - rpc_pipefs sunrpc rw
+1:9 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1060 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+1:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1061 master:15 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+2:0 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1062 master:16 - squashfs /dev/loop0 ro
+2:1 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1063 master:17 - squashfs /dev/loop1 ro
+2:2 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-classic/1 ro,nodev,relatime shared:1064 master:18 - squashfs /dev/loop2 ro
+2:3 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1065 master:19 - squashfs /dev/loop3 ro
+2:4 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1066 master:20 - squashfs /dev/loop4 ro
+0:0 /var/log /var/log rw,relatime shared:1067 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/snap /var/snap rw,relatime shared:1068 master:1 - ext4 /dev/sda1 rw,data=ordered
+0:0 /var/tmp /var/tmp rw,relatime shared:1069 master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-16.expected.txt
@@ -1,209 +1,209 @@
-0:0 / / ro,relatime master:1 - squashfs /dev/loop0 ro
-1:0 / /boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
-2:6 / /media rw,relatime master:52 - tmpfs tmpfs rw
+0:0 / / ro,relatime shared:1001 master:1 - squashfs /dev/loop0 ro
+1:0 / /boot/efi rw,relatime shared:1002 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /boot/grub rw,relatime shared:1003 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+2:0 / /dev rw,nosuid,relatime shared:1004 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1005 master:4 - hugetlbfs hugetlbfs rw
+2:2 / /dev/mqueue rw,relatime shared:1006 master:5 - mqueue mqueue rw
+2:33 /ptmx /dev/ptmx rw,relatime shared:1007 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1008 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:33 / /dev/pts rw,relatime shared:1007 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1009 master:7 - tmpfs tmpfs rw
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1010 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1011 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1012 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime shared:1013 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1014 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /etc/environment rw,relatime shared:1015 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1016 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1018 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1019 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /etc/init rw,relatime shared:1020 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /etc/init.d rw,relatime shared:1021 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1022 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1023 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1024 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1025 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1026 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1027 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime shared:1028 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1029 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /etc/ppp rw,relatime shared:1030 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime shared:1031 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime shared:1032 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime shared:1033 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime shared:1034 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime shared:1035 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime shared:1036 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime shared:1037 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime shared:1038 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime shared:1039 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1040 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1041 master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1042 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1043 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime shared:1044 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime shared:1045 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1046 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1047 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime shared:1048 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime shared:1049 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime shared:1050 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime shared:1051 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1052 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime shared:1053 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1054 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1055 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1056 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1057 master:51 - squashfs /dev/loop1 ro
+2:6 / /media rw,relatime shared:1058 master:52 - tmpfs tmpfs rw
 2:6 / /media rw,relatime shared:52 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:53 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:54 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
-1:1 /system-data/root /root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /run rw,nosuid,noexec,relatime master:57 - tmpfs tmpfs rw,mode=755
-2:10 / /run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1059 master:53 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1060 master:54 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1061 master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
+1:1 /system-data/root /root rw,relatime shared:1062 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /run rw,nosuid,noexec,relatime shared:1063 master:57 - tmpfs tmpfs rw,mode=755
+2:10 / /run rw,nosuid,noexec,relatime shared:1064 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/cgmanager/fs rw,relatime shared:1065 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1066 master:59 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:14 / /sys rw,nosuid,nodev,noexec,relatime master:68 - sysfs sysfs rw
-2:15 / /sys/fs/cgroup rw master:69 - tmpfs tmpfs rw,mode=755
-2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:70 - cgroup cgroup rw,blkio
-2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:71 - cgroup cgroup rw,cpu,cpuacct
-2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:72 - cgroup cgroup rw,cpuset,clone_children
-2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:73 - cgroup cgroup rw,devices
-2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:74 - cgroup cgroup rw,freezer
-2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:76 - cgroup cgroup rw,memory
-2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:77 - cgroup cgroup rw,net_cls,net_prio
-2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-2:27 / /sys/fs/fuse/connections rw,relatime master:81 - fusectl fusectl rw
-2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:82 - pstore pstore rw
-2:29 / /sys/kernel/debug rw,relatime master:83 - debugfs debugfs rw
-2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:84 - securityfs securityfs rw
-2:31 / /tmp rw,relatime master:85 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1067 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1068 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1069 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1070 master:61 - squashfs /dev/loop2 ro
+0:3 / /snap/core18/1 ro,nodev,relatime shared:1071 master:62 - squashfs /dev/loop3 ro
+0:4 / /snap/pc-kernel/1 ro,nodev,relatime shared:1072 master:63 - squashfs /dev/loop4 ro
+0:5 / /snap/pc/1 ro,nodev,relatime shared:1073 master:64 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1074 master:65 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1075 master:66 - squashfs /dev/loop7 ro
+0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime shared:1076 master:67 - squashfs /dev/loop8 ro
+2:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1077 master:68 - sysfs sysfs rw
+2:15 / /sys/fs/cgroup rw shared:1078 master:69 - tmpfs tmpfs rw,mode=755
+2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1079 master:70 - cgroup cgroup rw,blkio
+2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1080 master:71 - cgroup cgroup rw,cpu,cpuacct
+2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1081 master:72 - cgroup cgroup rw,cpuset,clone_children
+2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1082 master:73 - cgroup cgroup rw,devices
+2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1083 master:74 - cgroup cgroup rw,freezer
+2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1084 master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1085 master:76 - cgroup cgroup rw,memory
+2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1086 master:77 - cgroup cgroup rw,net_cls,net_prio
+2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1087 master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1088 master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1089 master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+2:27 / /sys/fs/fuse/connections rw,relatime shared:1090 master:81 - fusectl fusectl rw
+2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1091 master:82 - pstore pstore rw
+2:29 / /sys/kernel/debug rw,relatime shared:1092 master:83 - debugfs debugfs rw
+2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1093 master:84 - securityfs securityfs rw
+2:31 / /tmp rw,relatime shared:1094 master:85 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
-2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,relatime master:1 - squashfs /dev/loop0 ro
-2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-1:1 /system-data/var/cache/apparmor /var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/cache/snapd /var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/apparmor /var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/cloud rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/console-conf rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/dbus rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/dhcp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/initramfs-tools /var/lib/initramfs-tools rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/logrotate /var/lib/logrotate rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/misc rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+2:34 / /usr/share/gdb rw,relatime shared:1095 - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,relatime shared:1096 - squashfs /dev/loop0 ro
+2:35 / /usr/share/gdb/test rw,relatime shared:1097 - tmpfs tmpfs rw
+1:1 /system-data/var/cache/apparmor /var/cache/apparmor rw,relatime shared:1098 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/cache/snapd /var/cache/snapd rw,relatime shared:1099 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/apparmor /var/lib/apparmor rw,relatime shared:1100 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/cloud rw,relatime shared:1101 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/console-conf rw,relatime shared:1102 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/dbus rw,relatime shared:1103 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/dhcp rw,relatime shared:1104 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1105 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/initramfs-tools /var/lib/initramfs-tools rw,relatime shared:1106 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/logrotate /var/lib/logrotate rw,relatime shared:1107 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/misc rw,relatime shared:1108 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1109 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1110 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:52 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:53 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:57 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:31 / /var/lib/snapd/hostfs/tmp rw,relatime master:85 - tmpfs tmpfs rw
-1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:86 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:32 / /var/lib/sudo rw,relatime master:86 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/waagent /var/lib/waagent rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1111 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1112 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1113 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1114 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1115 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime shared:1116 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1117 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime shared:1118 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1119 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1120 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1121 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1122 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime shared:1123 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime shared:1124 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1125 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1126 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1127 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1128 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1129 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1130 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime shared:1131 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1132 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime shared:1133 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime shared:1134 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime shared:1135 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime shared:1136 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime shared:1137 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime shared:1138 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime shared:1139 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime shared:1140 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime shared:1141 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime shared:1142 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1143 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1144 master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1145 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1146 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime shared:1147 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime shared:1148 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1149 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1150 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime shared:1151 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime shared:1152 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime shared:1153 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime shared:1154 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1155 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime shared:1156 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1157 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1158 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1159 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1160 master:51 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1161 master:52 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1162 master:53 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1163 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1164 master:57 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1165 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1166 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1167 master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1168 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1169 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1170 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1171 master:61 - squashfs /dev/loop2 ro
+0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1172 master:62 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1173 master:63 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1174 master:64 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1175 master:65 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1176 master:66 - squashfs /dev/loop7 ro
+0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime shared:1177 master:67 - squashfs /dev/loop8 ro
+2:31 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1178 master:85 - tmpfs tmpfs rw
+1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime shared:1179 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime shared:1180 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime shared:1181 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1182 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1183 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1184 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1185 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1186 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime shared:1187 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime shared:1188 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1189 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1190 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1191 master:86 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime shared:1192 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime shared:1193 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime shared:1194 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1195 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1196 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1197 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:32 / /var/lib/sudo rw,relatime shared:1198 master:86 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed rw,relatime shared:1199 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill rw,relatime shared:1200 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/waagent /var/lib/waagent rw,relatime shared:1201 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1202 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1203 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1204 master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-18.expected.txt
@@ -1,196 +1,196 @@
-0:3 / / ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
+0:3 / / ro,nodev,relatime shared:1001 master:62 - squashfs /dev/loop3 ro
+2:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw
+2:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+2:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc ro,relatime shared:1008 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1009 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1010 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1011 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime shared:1012 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1013 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /etc/environment rw,relatime shared:1014 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1015 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1016 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1018 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /etc/init rw,relatime shared:1019 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /etc/init.d rw,relatime shared:1020 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1021 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1022 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1023 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1024 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1025 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1026 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime shared:1027 master:25 - ext4 /dev/sda3 rw,data=ordered
 0:3 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1028 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /etc/ppp rw,relatime shared:1029 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime shared:1030 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime shared:1031 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime shared:1032 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime shared:1033 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime shared:1034 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime shared:1035 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime shared:1036 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime shared:1037 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime shared:1038 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1039 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1040 master:36 - ext4 /dev/sda3 rw,data=ordered
 0:3 /etc/ssl /etc/ssl ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1041 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1042 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime shared:1043 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime shared:1044 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1045 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1046 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime shared:1047 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime shared:1048 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime shared:1049 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime shared:1050 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1051 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime shared:1052 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1053 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1054 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1055 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1056 master:51 - squashfs /dev/loop1 ro
 2:6 / /media rw,relatime shared:52 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:53 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:54 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
-1:1 /system-data/root /root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:10 / /run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1057 master:53 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1058 master:54 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1059 master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
+1:1 /system-data/root /root rw,relatime shared:1060 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:10 / /run rw,nosuid,noexec,relatime shared:1061 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/cgmanager/fs rw,relatime shared:1062 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1063 master:59 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:14 / /sys rw,nosuid,nodev,noexec,relatime master:68 - sysfs sysfs rw
-2:15 / /sys/fs/cgroup rw master:69 - tmpfs tmpfs rw,mode=755
-2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:70 - cgroup cgroup rw,blkio
-2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:71 - cgroup cgroup rw,cpu,cpuacct
-2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:72 - cgroup cgroup rw,cpuset,clone_children
-2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:73 - cgroup cgroup rw,devices
-2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:74 - cgroup cgroup rw,freezer
-2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:76 - cgroup cgroup rw,memory
-2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:77 - cgroup cgroup rw,net_cls,net_prio
-2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-2:27 / /sys/fs/fuse/connections rw,relatime master:81 - fusectl fusectl rw
-2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:82 - pstore pstore rw
-2:29 / /sys/kernel/debug rw,relatime master:83 - debugfs debugfs rw
-2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:84 - securityfs securityfs rw
-2:31 / /tmp rw,relatime master:85 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1064 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1065 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1066 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1067 master:61 - squashfs /dev/loop2 ro
+0:3 / /snap/core18/1 ro,nodev,relatime shared:1068 master:62 - squashfs /dev/loop3 ro
+0:4 / /snap/pc-kernel/1 ro,nodev,relatime shared:1069 master:63 - squashfs /dev/loop4 ro
+0:5 / /snap/pc/1 ro,nodev,relatime shared:1070 master:64 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1071 master:65 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1072 master:66 - squashfs /dev/loop7 ro
+0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime shared:1073 master:67 - squashfs /dev/loop8 ro
+2:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1074 master:68 - sysfs sysfs rw
+2:15 / /sys/fs/cgroup rw shared:1075 master:69 - tmpfs tmpfs rw,mode=755
+2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1076 master:70 - cgroup cgroup rw,blkio
+2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1077 master:71 - cgroup cgroup rw,cpu,cpuacct
+2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1078 master:72 - cgroup cgroup rw,cpuset,clone_children
+2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1079 master:73 - cgroup cgroup rw,devices
+2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1080 master:74 - cgroup cgroup rw,freezer
+2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1081 master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1082 master:76 - cgroup cgroup rw,memory
+2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1083 master:77 - cgroup cgroup rw,net_cls,net_prio
+2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1084 master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1085 master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1086 master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+2:27 / /sys/fs/fuse/connections rw,relatime shared:1087 master:81 - fusectl fusectl rw
+2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1088 master:82 - pstore pstore rw
+2:29 / /sys/kernel/debug rw,relatime shared:1089 master:83 - debugfs debugfs rw
+2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1090 master:84 - securityfs securityfs rw
+2:31 / /tmp rw,relatime shared:1091 master:85 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
-0:0 /usr/lib/snapd /usr/lib/snapd ro,relatime master:1 - squashfs /dev/loop0 ro
-2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:3 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+0:0 /usr/lib/snapd /usr/lib/snapd ro,relatime shared:1092 master:1 - squashfs /dev/loop0 ro
+2:34 / /usr/share/gdb rw,relatime shared:1093 - tmpfs tmpfs rw,mode=755
+0:3 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1094 - squashfs /dev/loop3 ro
+2:35 / /usr/share/gdb/test rw,relatime shared:1095 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src ro,relatime shared:1096 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1097 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1098 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1099 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:52 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:53 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:57 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:31 / /var/lib/snapd/hostfs/tmp rw,relatime master:85 - tmpfs tmpfs rw
-1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:86 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1100 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1101 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1102 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1103 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1104 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime shared:1105 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1106 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime shared:1107 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1108 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1109 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1110 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1111 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime shared:1112 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime shared:1113 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1114 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1115 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1116 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1117 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1118 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1119 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime shared:1120 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1121 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime shared:1122 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime shared:1123 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime shared:1124 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime shared:1125 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime shared:1126 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime shared:1127 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime shared:1128 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime shared:1129 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime shared:1130 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime shared:1131 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1132 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1133 master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1134 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1135 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime shared:1136 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime shared:1137 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1138 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1139 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime shared:1140 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime shared:1141 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime shared:1142 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime shared:1143 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1144 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime shared:1145 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1146 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1147 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1148 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1149 master:51 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1150 master:52 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1151 master:53 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1152 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1153 master:57 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1154 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1155 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1156 master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1157 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1158 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1159 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1160 master:61 - squashfs /dev/loop2 ro
+0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1161 master:62 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1162 master:63 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1163 master:64 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1164 master:65 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1165 master:66 - squashfs /dev/loop7 ro
+0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime shared:1166 master:67 - squashfs /dev/loop8 ro
+2:31 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1167 master:85 - tmpfs tmpfs rw
+1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime shared:1168 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime shared:1169 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime shared:1170 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1171 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1172 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1173 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1174 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1175 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime shared:1176 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime shared:1177 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1178 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1179 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1180 master:86 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime shared:1181 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime shared:1182 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime shared:1183 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1184 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1185 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1186 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1187 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1188 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1189 master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-16.expected.txt
@@ -1,209 +1,209 @@
-0:0 / / ro,relatime master:1 - squashfs /dev/loop0 ro
-1:0 / /boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
-2:6 / /media rw,relatime master:52 - tmpfs tmpfs rw
+0:0 / / ro,relatime shared:1001 master:1 - squashfs /dev/loop0 ro
+1:0 / /boot/efi rw,relatime shared:1002 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /boot/grub rw,relatime shared:1003 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+2:0 / /dev rw,nosuid,relatime shared:1004 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1005 master:4 - hugetlbfs hugetlbfs rw
+2:2 / /dev/mqueue rw,relatime shared:1006 master:5 - mqueue mqueue rw
+2:33 /ptmx /dev/ptmx rw,relatime shared:1007 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1008 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:33 / /dev/pts rw,relatime shared:1007 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1009 master:7 - tmpfs tmpfs rw
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1010 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1011 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1012 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime shared:1013 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1014 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /etc/environment rw,relatime shared:1015 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1016 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1018 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1019 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /etc/init rw,relatime shared:1020 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /etc/init.d rw,relatime shared:1021 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1022 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1023 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1024 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1025 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1026 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1027 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime shared:1028 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1029 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /etc/ppp rw,relatime shared:1030 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime shared:1031 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime shared:1032 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime shared:1033 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime shared:1034 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime shared:1035 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime shared:1036 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime shared:1037 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime shared:1038 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime shared:1039 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1040 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1041 master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1042 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1043 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime shared:1044 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime shared:1045 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1046 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1047 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime shared:1048 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime shared:1049 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime shared:1050 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime shared:1051 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1052 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime shared:1053 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1054 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1055 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1056 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1057 master:51 - squashfs /dev/loop1 ro
+2:6 / /media rw,relatime shared:1058 master:52 - tmpfs tmpfs rw
 2:6 / /media rw,relatime shared:52 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:53 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:54 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
-1:1 /system-data/root /root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /run rw,nosuid,noexec,relatime master:57 - tmpfs tmpfs rw,mode=755
-2:10 / /run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1059 master:53 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1060 master:54 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1061 master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
+1:1 /system-data/root /root rw,relatime shared:1062 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /run rw,nosuid,noexec,relatime shared:1063 master:57 - tmpfs tmpfs rw,mode=755
+2:10 / /run rw,nosuid,noexec,relatime shared:1064 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/cgmanager/fs rw,relatime shared:1065 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1066 master:59 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:14 / /sys rw,nosuid,nodev,noexec,relatime master:68 - sysfs sysfs rw
-2:15 / /sys/fs/cgroup rw master:69 - tmpfs tmpfs rw,mode=755
-2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:70 - cgroup cgroup rw,blkio
-2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:71 - cgroup cgroup rw,cpu,cpuacct
-2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:72 - cgroup cgroup rw,cpuset,clone_children
-2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:73 - cgroup cgroup rw,devices
-2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:74 - cgroup cgroup rw,freezer
-2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:76 - cgroup cgroup rw,memory
-2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:77 - cgroup cgroup rw,net_cls,net_prio
-2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-2:27 / /sys/fs/fuse/connections rw,relatime master:81 - fusectl fusectl rw
-2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:82 - pstore pstore rw
-2:29 / /sys/kernel/debug rw,relatime master:83 - debugfs debugfs rw
-2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:84 - securityfs securityfs rw
-2:31 / /tmp rw,relatime master:85 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1067 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1068 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1069 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1070 master:61 - squashfs /dev/loop2 ro
+0:3 / /snap/core18/1 ro,nodev,relatime shared:1071 master:62 - squashfs /dev/loop3 ro
+0:4 / /snap/pc-kernel/1 ro,nodev,relatime shared:1072 master:63 - squashfs /dev/loop4 ro
+0:5 / /snap/pc/1 ro,nodev,relatime shared:1073 master:64 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1074 master:65 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1075 master:66 - squashfs /dev/loop7 ro
+0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime shared:1076 master:67 - squashfs /dev/loop8 ro
+2:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1077 master:68 - sysfs sysfs rw
+2:15 / /sys/fs/cgroup rw shared:1078 master:69 - tmpfs tmpfs rw,mode=755
+2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1079 master:70 - cgroup cgroup rw,blkio
+2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1080 master:71 - cgroup cgroup rw,cpu,cpuacct
+2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1081 master:72 - cgroup cgroup rw,cpuset,clone_children
+2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1082 master:73 - cgroup cgroup rw,devices
+2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1083 master:74 - cgroup cgroup rw,freezer
+2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1084 master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1085 master:76 - cgroup cgroup rw,memory
+2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1086 master:77 - cgroup cgroup rw,net_cls,net_prio
+2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1087 master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1088 master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1089 master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+2:27 / /sys/fs/fuse/connections rw,relatime shared:1090 master:81 - fusectl fusectl rw
+2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1091 master:82 - pstore pstore rw
+2:29 / /sys/kernel/debug rw,relatime shared:1092 master:83 - debugfs debugfs rw
+2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1093 master:84 - securityfs securityfs rw
+2:31 / /tmp rw,relatime shared:1094 master:85 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
-2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,relatime master:1 - squashfs /dev/loop0 ro
-2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-1:1 /system-data/var/cache/apparmor /var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/cache/snapd /var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/apparmor /var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/cloud rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/console-conf rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/dbus rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/dhcp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/initramfs-tools /var/lib/initramfs-tools rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/logrotate /var/lib/logrotate rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/misc rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+2:34 / /usr/share/gdb rw,relatime shared:1095 - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,relatime shared:1096 - squashfs /dev/loop0 ro
+2:35 / /usr/share/gdb/test rw,relatime shared:1097 - tmpfs tmpfs rw
+1:1 /system-data/var/cache/apparmor /var/cache/apparmor rw,relatime shared:1098 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/cache/snapd /var/cache/snapd rw,relatime shared:1099 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/apparmor /var/lib/apparmor rw,relatime shared:1100 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/cloud rw,relatime shared:1101 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/console-conf rw,relatime shared:1102 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/dbus rw,relatime shared:1103 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/dhcp rw,relatime shared:1104 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1105 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/initramfs-tools /var/lib/initramfs-tools rw,relatime shared:1106 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/logrotate /var/lib/logrotate rw,relatime shared:1107 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/misc rw,relatime shared:1108 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1109 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1110 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:52 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:53 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:57 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:31 / /var/lib/snapd/hostfs/tmp rw,relatime master:85 - tmpfs tmpfs rw
-1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:86 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:32 / /var/lib/sudo rw,relatime master:86 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/waagent /var/lib/waagent rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1111 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1112 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1113 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1114 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1115 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime shared:1116 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1117 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime shared:1118 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1119 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1120 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1121 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1122 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime shared:1123 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime shared:1124 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1125 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1126 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1127 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1128 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1129 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1130 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime shared:1131 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1132 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime shared:1133 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime shared:1134 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime shared:1135 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime shared:1136 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime shared:1137 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime shared:1138 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime shared:1139 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime shared:1140 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime shared:1141 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime shared:1142 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1143 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1144 master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1145 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1146 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime shared:1147 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime shared:1148 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1149 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1150 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime shared:1151 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime shared:1152 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime shared:1153 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime shared:1154 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1155 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime shared:1156 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1157 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1158 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1159 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1160 master:51 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1161 master:52 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1162 master:53 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1163 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1164 master:57 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1165 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1166 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1167 master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1168 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1169 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1170 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1171 master:61 - squashfs /dev/loop2 ro
+0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1172 master:62 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1173 master:63 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1174 master:64 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1175 master:65 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1176 master:66 - squashfs /dev/loop7 ro
+0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime shared:1177 master:67 - squashfs /dev/loop8 ro
+2:31 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1178 master:85 - tmpfs tmpfs rw
+1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime shared:1179 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime shared:1180 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime shared:1181 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1182 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1183 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1184 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1185 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1186 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime shared:1187 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime shared:1188 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1189 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1190 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1191 master:86 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime shared:1192 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime shared:1193 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime shared:1194 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1195 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1196 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1197 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:32 / /var/lib/sudo rw,relatime shared:1198 master:86 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd/random-seed /var/lib/systemd/random-seed rw,relatime shared:1199 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/systemd/rfkill /var/lib/systemd/rfkill rw,relatime shared:1200 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/waagent /var/lib/waagent rw,relatime shared:1201 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1202 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1203 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1204 master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-18.expected.txt
@@ -1,196 +1,196 @@
-0:3 / / ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:33 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:33 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
+0:3 / / ro,nodev,relatime shared:1001 master:62 - squashfs /dev/loop3 ro
+2:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw
+2:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+2:33 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:33 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc ro,relatime shared:1008 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1009 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1010 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1011 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /etc/default/keyboard rw,relatime shared:1012 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1013 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /etc/environment rw,relatime shared:1014 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1015 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1016 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1018 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /etc/init rw,relatime shared:1019 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /etc/init.d rw,relatime shared:1020 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1021 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1022 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1023 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1024 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1025 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1026 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /etc/network/interfaces.d rw,relatime shared:1027 master:25 - ext4 /dev/sda3 rw,data=ordered
 0:3 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1028 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /etc/ppp rw,relatime shared:1029 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /etc/rc0.d rw,relatime shared:1030 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /etc/rc1.d rw,relatime shared:1031 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /etc/rc2.d rw,relatime shared:1032 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /etc/rc3.d rw,relatime shared:1033 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /etc/rc4.d rw,relatime shared:1034 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /etc/rc5.d rw,relatime shared:1035 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /etc/rc6.d rw,relatime shared:1036 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /etc/rcS.d rw,relatime shared:1037 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /etc/rsyslog.d rw,relatime shared:1038 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1039 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1040 master:36 - ext4 /dev/sda3 rw,data=ordered
 0:3 /etc/ssl /etc/ssl ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1041 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1042 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /etc/systemd/logind.conf.d rw,relatime shared:1043 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /etc/systemd/network rw,relatime shared:1044 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1045 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1046 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /etc/systemd/system.conf.d rw,relatime shared:1047 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /etc/systemd/timesyncd.conf rw,relatime shared:1048 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /etc/systemd/user rw,relatime shared:1049 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /etc/systemd/user.conf.d rw,relatime shared:1050 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1051 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /etc/update-motd.d rw,relatime shared:1052 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1053 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1054 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1055 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1056 master:51 - squashfs /dev/loop1 ro
 2:6 / /media rw,relatime shared:52 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:53 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:54 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
-1:1 /system-data/root /root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:10 / /run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1057 master:53 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1058 master:54 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1059 master:55 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct
+1:1 /system-data/root /root rw,relatime shared:1060 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:10 / /run rw,nosuid,noexec,relatime shared:1061 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/cgmanager/fs rw,relatime shared:1062 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1063 master:59 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:14 / /sys rw,nosuid,nodev,noexec,relatime master:68 - sysfs sysfs rw
-2:15 / /sys/fs/cgroup rw master:69 - tmpfs tmpfs rw,mode=755
-2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:70 - cgroup cgroup rw,blkio
-2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:71 - cgroup cgroup rw,cpu,cpuacct
-2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:72 - cgroup cgroup rw,cpuset,clone_children
-2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:73 - cgroup cgroup rw,devices
-2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:74 - cgroup cgroup rw,freezer
-2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
-2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:76 - cgroup cgroup rw,memory
-2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:77 - cgroup cgroup rw,net_cls,net_prio
-2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
-2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
-2:27 / /sys/fs/fuse/connections rw,relatime master:81 - fusectl fusectl rw
-2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:82 - pstore pstore rw
-2:29 / /sys/kernel/debug rw,relatime master:83 - debugfs debugfs rw
-2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:84 - securityfs securityfs rw
-2:31 / /tmp rw,relatime master:85 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1064 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /run/user/0 rw,nosuid,nodev,relatime shared:1065 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1066 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1067 master:61 - squashfs /dev/loop2 ro
+0:3 / /snap/core18/1 ro,nodev,relatime shared:1068 master:62 - squashfs /dev/loop3 ro
+0:4 / /snap/pc-kernel/1 ro,nodev,relatime shared:1069 master:63 - squashfs /dev/loop4 ro
+0:5 / /snap/pc/1 ro,nodev,relatime shared:1070 master:64 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1071 master:65 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1072 master:66 - squashfs /dev/loop7 ro
+0:8 / /snap/test-snapd-rsync/1 ro,nodev,relatime shared:1073 master:67 - squashfs /dev/loop8 ro
+2:14 / /sys rw,nosuid,nodev,noexec,relatime shared:1074 master:68 - sysfs sysfs rw
+2:15 / /sys/fs/cgroup rw shared:1075 master:69 - tmpfs tmpfs rw,mode=755
+2:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1076 master:70 - cgroup cgroup rw,blkio
+2:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1077 master:71 - cgroup cgroup rw,cpu,cpuacct
+2:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1078 master:72 - cgroup cgroup rw,cpuset,clone_children
+2:19 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1079 master:73 - cgroup cgroup rw,devices
+2:20 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1080 master:74 - cgroup cgroup rw,freezer
+2:21 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1081 master:75 - cgroup cgroup rw,hugetlb,release_agent=/run/cgmanager/agents/cgm-release-agent.hugetlb
+2:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1082 master:76 - cgroup cgroup rw,memory
+2:23 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1083 master:77 - cgroup cgroup rw,net_cls,net_prio
+2:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1084 master:78 - cgroup cgroup rw,perf_event,release_agent=/run/cgmanager/agents/cgm-release-agent.perf_event
+2:25 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1085 master:79 - cgroup cgroup rw,pids,release_agent=/run/cgmanager/agents/cgm-release-agent.pids
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1086 master:80 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+2:27 / /sys/fs/fuse/connections rw,relatime shared:1087 master:81 - fusectl fusectl rw
+2:28 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1088 master:82 - pstore pstore rw
+2:29 / /sys/kernel/debug rw,relatime shared:1089 master:83 - debugfs debugfs rw
+2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1090 master:84 - securityfs securityfs rw
+2:31 / /tmp rw,relatime shared:1091 master:85 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
-0:0 /usr/lib/snapd /usr/lib/snapd ro,relatime master:1 - squashfs /dev/loop0 ro
-2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:3 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+0:0 /usr/lib/snapd /usr/lib/snapd ro,relatime shared:1092 master:1 - squashfs /dev/loop0 ro
+2:34 / /usr/share/gdb rw,relatime shared:1093 - tmpfs tmpfs rw,mode=755
+0:3 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1094 - squashfs /dev/loop3 ro
+2:35 / /usr/share/gdb/test rw,relatime shared:1095 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src ro,relatime shared:1096 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1097 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1098 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1099 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:12 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:14 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime master:28 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime master:29 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime master:30 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime master:31 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime master:32 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime master:33 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime master:34 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime master:35 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:36 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:37 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:38 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime master:39 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime master:40 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:41 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:42 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime master:43 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime master:44 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime master:45 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime master:46 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:47 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime master:48 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:49 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:50 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:51 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:52 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:53 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:57 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:59 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:61 - squashfs /dev/loop2 ro
-0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:62 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:63 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:64 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:65 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:66 - squashfs /dev/loop7 ro
-0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime master:67 - squashfs /dev/loop8 ro
-2:31 / /var/lib/snapd/hostfs/tmp rw,relatime master:85 - tmpfs tmpfs rw
-1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:86 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1100 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1101 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1102 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1103 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1104 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/keyboard /var/lib/snapd/hostfs/etc/default/keyboard rw,relatime shared:1105 master:11 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1106 master:12 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/environment /var/lib/snapd/hostfs/etc/environment rw,relatime shared:1107 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1108 master:14 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1109 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1110 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1111 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init /var/lib/snapd/hostfs/etc/init rw,relatime shared:1112 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/init.d /var/lib/snapd/hostfs/etc/init.d rw,relatime shared:1113 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1114 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1115 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1116 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1117 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1118 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1119 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/interfaces.d /var/lib/snapd/hostfs/etc/network/interfaces.d rw,relatime shared:1120 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1121 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ppp /var/lib/snapd/hostfs/etc/ppp rw,relatime shared:1122 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc0.d /var/lib/snapd/hostfs/etc/rc0.d rw,relatime shared:1123 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc1.d /var/lib/snapd/hostfs/etc/rc1.d rw,relatime shared:1124 master:28 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc2.d /var/lib/snapd/hostfs/etc/rc2.d rw,relatime shared:1125 master:29 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc3.d /var/lib/snapd/hostfs/etc/rc3.d rw,relatime shared:1126 master:30 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc4.d /var/lib/snapd/hostfs/etc/rc4.d rw,relatime shared:1127 master:31 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc5.d /var/lib/snapd/hostfs/etc/rc5.d rw,relatime shared:1128 master:32 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rc6.d /var/lib/snapd/hostfs/etc/rc6.d rw,relatime shared:1129 master:33 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rcS.d /var/lib/snapd/hostfs/etc/rcS.d rw,relatime shared:1130 master:34 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/rsyslog.d /var/lib/snapd/hostfs/etc/rsyslog.d rw,relatime shared:1131 master:35 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1132 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1133 master:36 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1134 master:37 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1135 master:38 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/logind.conf.d /var/lib/snapd/hostfs/etc/systemd/logind.conf.d rw,relatime shared:1136 master:39 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/network /var/lib/snapd/hostfs/etc/systemd/network rw,relatime shared:1137 master:40 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1138 master:41 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1139 master:42 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system.conf.d /var/lib/snapd/hostfs/etc/systemd/system.conf.d rw,relatime shared:1140 master:43 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/timesyncd.conf /var/lib/snapd/hostfs/etc/systemd/timesyncd.conf rw,relatime shared:1141 master:44 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user /var/lib/snapd/hostfs/etc/systemd/user rw,relatime shared:1142 master:45 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/user.conf.d /var/lib/snapd/hostfs/etc/systemd/user.conf.d rw,relatime shared:1143 master:46 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1144 master:47 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/update-motd.d /var/lib/snapd/hostfs/etc/update-motd.d rw,relatime shared:1145 master:48 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1146 master:49 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1147 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1148 master:50 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1149 master:51 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1150 master:52 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1151 master:53 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1152 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1153 master:57 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1154 master:56 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/cgmanager/fs rw,relatime shared:1155 master:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1156 master:59 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1157 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:13 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1158 master:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1159 master:15 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1160 master:61 - squashfs /dev/loop2 ro
+0:3 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1161 master:62 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1162 master:63 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1163 master:64 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1164 master:65 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1165 master:66 - squashfs /dev/loop7 ro
+0:8 / /var/lib/snapd/hostfs/snap/test-snapd-rsync/1 ro,nodev,relatime shared:1166 master:67 - squashfs /dev/loop8 ro
+2:31 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1167 master:85 - tmpfs tmpfs rw
+1:1 /system-data/var/cache/apparmor /var/lib/snapd/hostfs/var/cache/apparmor rw,relatime shared:1168 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/cache/snapd /var/lib/snapd/hostfs/var/cache/snapd rw,relatime shared:1169 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/apparmor /var/lib/snapd/hostfs/var/lib/apparmor rw,relatime shared:1170 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1171 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1172 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1173 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1174 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1175 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/initramfs-tools /var/lib/snapd/hostfs/var/lib/initramfs-tools rw,relatime shared:1176 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/logrotate /var/lib/snapd/hostfs/var/lib/logrotate rw,relatime shared:1177 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1178 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1179 master:15 - ext4 /dev/sda3 rw,data=ordered
+2:32 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1180 master:86 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd/random-seed /var/lib/snapd/hostfs/var/lib/systemd/random-seed rw,relatime shared:1181 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/systemd/rfkill /var/lib/snapd/hostfs/var/lib/systemd/rfkill rw,relatime shared:1182 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/waagent /var/lib/snapd/hostfs/var/lib/waagent rw,relatime shared:1183 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1184 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1185 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1186 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1187 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1188 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1189 master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-16.expected.txt
@@ -1,151 +1,151 @@
-0:2 / / ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:35 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:35 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
+0:2 / / ro,nodev,relatime shared:1001 master:38 - squashfs /dev/loop2 ro
+2:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+2:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+2:35 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:35 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc ro,relatime shared:1008 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1009 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1010 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1011 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1012 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1013 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1014 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1015 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1016 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1018 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1019 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1020 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1021 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1022 master:20 - ext4 /dev/sda3 rw,data=ordered
 0:2 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1023 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1024 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1025 master:21 - ext4 /dev/sda3 rw,data=ordered
 0:2 /etc/ssl /etc/ssl ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1026 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1027 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /etc/systemd rw,relatime shared:1028 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1029 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1030 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1031 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1032 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1033 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1034 master:29 - squashfs /dev/loop1 ro
 2:6 / /media rw,relatime shared:30 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:31 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:32 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-1:1 /system-data/root /root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:10 / /run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1035 master:31 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1036 master:32 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1037 master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+1:1 /system-data/root /root rw,relatime shared:1038 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:10 / /run rw,nosuid,noexec,relatime shared:1039 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1040 master:36 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:13 / /sys rw,nosuid,nodev,noexec,relatime master:46 - sysfs sysfs rw
-2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:47 - tmpfs tmpfs ro,mode=755
-2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:48 - cgroup cgroup rw,blkio
-2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:49 - cgroup cgroup rw,cpu,cpuacct
-2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:50 - cgroup cgroup rw,cpuset
-2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:51 - cgroup cgroup rw,devices
-2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:52 - cgroup cgroup rw,freezer
-2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:53 - cgroup cgroup rw,hugetlb
-2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:54 - cgroup cgroup rw,memory
-2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:55 - cgroup cgroup rw,net_cls,net_prio
-2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:56 - cgroup cgroup rw,perf_event
-2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:57 - cgroup cgroup rw,pids
-2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:58 - cgroup cgroup rw,rdma
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:59 - cgroup cgroup rw,xattr,name=systemd
-2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:60 - cgroup2 cgroup rw,nsdelegate
-2:28 / /sys/fs/fuse/connections rw,relatime master:61 - fusectl fusectl rw
-2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:62 - pstore pstore rw
-2:30 / /sys/kernel/config rw,relatime master:63 - configfs configfs rw
-2:31 / /sys/kernel/debug rw,relatime master:64 - debugfs debugfs rw
-2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:65 - securityfs securityfs rw
-2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1041 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1042 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1043 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1044 master:38 - squashfs /dev/loop2 ro
+0:0 / /snap/core18/1 ro,nodev,relatime shared:1045 master:39 - squashfs /dev/loop0 ro
+0:1 / /snap/pc-kernel/1 ro,nodev,relatime shared:1046 master:40 - squashfs /dev/loop1 ro
+0:3 / /snap/pc/1 ro,nodev,relatime shared:1047 master:41 - squashfs /dev/loop3 ro
+0:4 / /snap/snapd/1 ro,nodev,relatime shared:1048 master:42 - squashfs /dev/loop4 ro
+0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1049 master:43 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1050 master:44 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1051 master:45 - squashfs /dev/loop7 ro
+2:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1052 master:46 - sysfs sysfs rw
+2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1053 master:47 - tmpfs tmpfs ro,mode=755
+2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1054 master:48 - cgroup cgroup rw,blkio
+2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1055 master:49 - cgroup cgroup rw,cpu,cpuacct
+2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1056 master:50 - cgroup cgroup rw,cpuset
+2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1057 master:51 - cgroup cgroup rw,devices
+2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1058 master:52 - cgroup cgroup rw,freezer
+2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1059 master:53 - cgroup cgroup rw,hugetlb
+2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1060 master:54 - cgroup cgroup rw,memory
+2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1061 master:55 - cgroup cgroup rw,net_cls,net_prio
+2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1062 master:56 - cgroup cgroup rw,perf_event
+2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1063 master:57 - cgroup cgroup rw,pids
+2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1064 master:58 - cgroup cgroup rw,rdma
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1065 master:59 - cgroup cgroup rw,xattr,name=systemd
+2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1066 master:60 - cgroup2 cgroup rw,nsdelegate
+2:28 / /sys/fs/fuse/connections rw,relatime shared:1067 master:61 - fusectl fusectl rw
+2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1068 master:62 - pstore pstore rw
+2:30 / /sys/kernel/config rw,relatime shared:1069 master:63 - configfs configfs rw
+2:31 / /sys/kernel/debug rw,relatime shared:1070 master:64 - debugfs debugfs rw
+2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1071 master:65 - securityfs securityfs rw
+2:33 / /tmp rw,relatime shared:1072 master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:2 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1073 master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime shared:1074 - tmpfs tmpfs rw,mode=755
+0:2 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1075 - squashfs /dev/loop2 ro
+2:37 / /usr/share/gdb/test rw,relatime shared:1076 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src ro,relatime shared:1077 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1078 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1079 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1080 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:30 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:31 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:35 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:33 / /var/lib/snapd/hostfs/tmp rw,relatime master:66 - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:67 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1081 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1082 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1083 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1084 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1085 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1086 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1087 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1088 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1089 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1090 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1091 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1092 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1093 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1094 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1095 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1096 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1097 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1098 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1099 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1100 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1101 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime shared:1102 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1103 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1104 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1105 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1106 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1107 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1108 master:29 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1109 master:30 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1110 master:31 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1111 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1112 master:35 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1113 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1114 master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1115 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1116 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1117 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1118 master:38 - squashfs /dev/loop2 ro
+0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1119 master:39 - squashfs /dev/loop0 ro
+0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1120 master:40 - squashfs /dev/loop1 ro
+0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1121 master:41 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime shared:1122 master:42 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1123 master:43 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1124 master:44 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1125 master:45 - squashfs /dev/loop7 ro
+2:33 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1126 master:66 - tmpfs tmpfs rw
+0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime shared:1127 master:42 - squashfs /dev/loop4 ro
+1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime shared:1128 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1129 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1130 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1131 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1132 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1133 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1134 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime shared:1135 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1136 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1137 master:67 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime shared:1138 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1139 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1140 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1141 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1142 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1143 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1144 master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-18.expected.txt
@@ -1,151 +1,151 @@
-0:0 / / ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:35 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:35 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
+0:0 / / ro,nodev,relatime shared:1001 master:39 - squashfs /dev/loop0 ro
+2:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+2:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+2:35 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:35 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc ro,relatime shared:1008 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1009 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1010 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1011 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1012 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1013 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1014 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1015 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1016 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1018 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1019 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1020 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1021 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1022 master:20 - ext4 /dev/sda3 rw,data=ordered
 0:0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1023 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1024 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1025 master:21 - ext4 /dev/sda3 rw,data=ordered
 0:0 /etc/ssl /etc/ssl ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1026 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1027 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /etc/systemd rw,relatime shared:1028 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1029 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1030 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1031 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1032 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1033 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1034 master:29 - squashfs /dev/loop1 ro
 2:6 / /media rw,relatime shared:30 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:31 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:32 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-1:1 /system-data/root /root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:10 / /run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1035 master:31 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1036 master:32 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1037 master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+1:1 /system-data/root /root rw,relatime shared:1038 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:10 / /run rw,nosuid,noexec,relatime shared:1039 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1040 master:36 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:13 / /sys rw,nosuid,nodev,noexec,relatime master:46 - sysfs sysfs rw
-2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:47 - tmpfs tmpfs ro,mode=755
-2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:48 - cgroup cgroup rw,blkio
-2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:49 - cgroup cgroup rw,cpu,cpuacct
-2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:50 - cgroup cgroup rw,cpuset
-2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:51 - cgroup cgroup rw,devices
-2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:52 - cgroup cgroup rw,freezer
-2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:53 - cgroup cgroup rw,hugetlb
-2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:54 - cgroup cgroup rw,memory
-2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:55 - cgroup cgroup rw,net_cls,net_prio
-2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:56 - cgroup cgroup rw,perf_event
-2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:57 - cgroup cgroup rw,pids
-2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:58 - cgroup cgroup rw,rdma
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:59 - cgroup cgroup rw,xattr,name=systemd
-2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:60 - cgroup2 cgroup rw,nsdelegate
-2:28 / /sys/fs/fuse/connections rw,relatime master:61 - fusectl fusectl rw
-2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:62 - pstore pstore rw
-2:30 / /sys/kernel/config rw,relatime master:63 - configfs configfs rw
-2:31 / /sys/kernel/debug rw,relatime master:64 - debugfs debugfs rw
-2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:65 - securityfs securityfs rw
-2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1041 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1042 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1043 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1044 master:38 - squashfs /dev/loop2 ro
+0:0 / /snap/core18/1 ro,nodev,relatime shared:1045 master:39 - squashfs /dev/loop0 ro
+0:1 / /snap/pc-kernel/1 ro,nodev,relatime shared:1046 master:40 - squashfs /dev/loop1 ro
+0:3 / /snap/pc/1 ro,nodev,relatime shared:1047 master:41 - squashfs /dev/loop3 ro
+0:4 / /snap/snapd/1 ro,nodev,relatime shared:1048 master:42 - squashfs /dev/loop4 ro
+0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1049 master:43 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1050 master:44 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1051 master:45 - squashfs /dev/loop7 ro
+2:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1052 master:46 - sysfs sysfs rw
+2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1053 master:47 - tmpfs tmpfs ro,mode=755
+2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1054 master:48 - cgroup cgroup rw,blkio
+2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1055 master:49 - cgroup cgroup rw,cpu,cpuacct
+2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1056 master:50 - cgroup cgroup rw,cpuset
+2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1057 master:51 - cgroup cgroup rw,devices
+2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1058 master:52 - cgroup cgroup rw,freezer
+2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1059 master:53 - cgroup cgroup rw,hugetlb
+2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1060 master:54 - cgroup cgroup rw,memory
+2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1061 master:55 - cgroup cgroup rw,net_cls,net_prio
+2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1062 master:56 - cgroup cgroup rw,perf_event
+2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1063 master:57 - cgroup cgroup rw,pids
+2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1064 master:58 - cgroup cgroup rw,rdma
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1065 master:59 - cgroup cgroup rw,xattr,name=systemd
+2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1066 master:60 - cgroup2 cgroup rw,nsdelegate
+2:28 / /sys/fs/fuse/connections rw,relatime shared:1067 master:61 - fusectl fusectl rw
+2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1068 master:62 - pstore pstore rw
+2:30 / /sys/kernel/config rw,relatime shared:1069 master:63 - configfs configfs rw
+2:31 / /sys/kernel/debug rw,relatime shared:1070 master:64 - debugfs debugfs rw
+2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1071 master:65 - securityfs securityfs rw
+2:33 / /tmp rw,relatime shared:1072 master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1073 master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime shared:1074 - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1075 - squashfs /dev/loop0 ro
+2:37 / /usr/share/gdb/test rw,relatime shared:1076 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src ro,relatime shared:1077 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1078 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1079 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1080 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:30 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:31 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:35 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:33 / /var/lib/snapd/hostfs/tmp rw,relatime master:66 - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:67 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1081 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1082 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1083 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1084 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1085 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1086 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1087 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1088 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1089 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1090 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1091 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1092 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1093 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1094 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1095 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1096 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1097 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1098 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1099 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1100 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1101 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime shared:1102 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1103 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1104 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1105 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1106 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1107 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1108 master:29 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1109 master:30 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1110 master:31 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1111 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1112 master:35 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1113 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1114 master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1115 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1116 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1117 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1118 master:38 - squashfs /dev/loop2 ro
+0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1119 master:39 - squashfs /dev/loop0 ro
+0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1120 master:40 - squashfs /dev/loop1 ro
+0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1121 master:41 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime shared:1122 master:42 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1123 master:43 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1124 master:44 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1125 master:45 - squashfs /dev/loop7 ro
+2:33 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1126 master:66 - tmpfs tmpfs rw
+0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime shared:1127 master:42 - squashfs /dev/loop4 ro
+1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime shared:1128 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1129 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1130 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1131 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1132 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1133 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1134 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime shared:1135 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1136 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1137 master:67 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime shared:1138 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1139 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1140 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1141 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1142 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1143 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1144 master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-16.expected.txt
@@ -1,151 +1,151 @@
-0:2 / / ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:35 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:35 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
+0:2 / / ro,nodev,relatime shared:1001 master:38 - squashfs /dev/loop2 ro
+2:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+2:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+2:35 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:35 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc ro,relatime shared:1008 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1009 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1010 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1011 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1012 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1013 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1014 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1015 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1016 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1018 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1019 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1020 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1021 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1022 master:20 - ext4 /dev/sda3 rw,data=ordered
 0:2 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1023 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1024 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1025 master:21 - ext4 /dev/sda3 rw,data=ordered
 0:2 /etc/ssl /etc/ssl ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1026 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1027 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /etc/systemd rw,relatime shared:1028 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1029 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1030 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1031 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1032 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1033 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1034 master:29 - squashfs /dev/loop1 ro
 2:6 / /media rw,relatime shared:30 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:31 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:32 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-1:1 /system-data/root /root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:10 / /run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1035 master:31 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1036 master:32 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1037 master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+1:1 /system-data/root /root rw,relatime shared:1038 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:10 / /run rw,nosuid,noexec,relatime shared:1039 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1040 master:36 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:13 / /sys rw,nosuid,nodev,noexec,relatime master:46 - sysfs sysfs rw
-2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:47 - tmpfs tmpfs ro,mode=755
-2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:48 - cgroup cgroup rw,blkio
-2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:49 - cgroup cgroup rw,cpu,cpuacct
-2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:50 - cgroup cgroup rw,cpuset
-2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:51 - cgroup cgroup rw,devices
-2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:52 - cgroup cgroup rw,freezer
-2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:53 - cgroup cgroup rw,hugetlb
-2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:54 - cgroup cgroup rw,memory
-2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:55 - cgroup cgroup rw,net_cls,net_prio
-2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:56 - cgroup cgroup rw,perf_event
-2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:57 - cgroup cgroup rw,pids
-2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:58 - cgroup cgroup rw,rdma
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:59 - cgroup cgroup rw,xattr,name=systemd
-2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:60 - cgroup2 cgroup rw,nsdelegate
-2:28 / /sys/fs/fuse/connections rw,relatime master:61 - fusectl fusectl rw
-2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:62 - pstore pstore rw
-2:30 / /sys/kernel/config rw,relatime master:63 - configfs configfs rw
-2:31 / /sys/kernel/debug rw,relatime master:64 - debugfs debugfs rw
-2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:65 - securityfs securityfs rw
-2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1041 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1042 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1043 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1044 master:38 - squashfs /dev/loop2 ro
+0:0 / /snap/core18/1 ro,nodev,relatime shared:1045 master:39 - squashfs /dev/loop0 ro
+0:1 / /snap/pc-kernel/1 ro,nodev,relatime shared:1046 master:40 - squashfs /dev/loop1 ro
+0:3 / /snap/pc/1 ro,nodev,relatime shared:1047 master:41 - squashfs /dev/loop3 ro
+0:4 / /snap/snapd/1 ro,nodev,relatime shared:1048 master:42 - squashfs /dev/loop4 ro
+0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1049 master:43 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1050 master:44 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1051 master:45 - squashfs /dev/loop7 ro
+2:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1052 master:46 - sysfs sysfs rw
+2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1053 master:47 - tmpfs tmpfs ro,mode=755
+2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1054 master:48 - cgroup cgroup rw,blkio
+2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1055 master:49 - cgroup cgroup rw,cpu,cpuacct
+2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1056 master:50 - cgroup cgroup rw,cpuset
+2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1057 master:51 - cgroup cgroup rw,devices
+2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1058 master:52 - cgroup cgroup rw,freezer
+2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1059 master:53 - cgroup cgroup rw,hugetlb
+2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1060 master:54 - cgroup cgroup rw,memory
+2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1061 master:55 - cgroup cgroup rw,net_cls,net_prio
+2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1062 master:56 - cgroup cgroup rw,perf_event
+2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1063 master:57 - cgroup cgroup rw,pids
+2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1064 master:58 - cgroup cgroup rw,rdma
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1065 master:59 - cgroup cgroup rw,xattr,name=systemd
+2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1066 master:60 - cgroup2 cgroup rw,nsdelegate
+2:28 / /sys/fs/fuse/connections rw,relatime shared:1067 master:61 - fusectl fusectl rw
+2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1068 master:62 - pstore pstore rw
+2:30 / /sys/kernel/config rw,relatime shared:1069 master:63 - configfs configfs rw
+2:31 / /sys/kernel/debug rw,relatime shared:1070 master:64 - debugfs debugfs rw
+2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1071 master:65 - securityfs securityfs rw
+2:33 / /tmp rw,relatime shared:1072 master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:2 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1073 master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime shared:1074 - tmpfs tmpfs rw,mode=755
+0:2 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1075 - squashfs /dev/loop2 ro
+2:37 / /usr/share/gdb/test rw,relatime shared:1076 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src ro,relatime shared:1077 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1078 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1079 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1080 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:30 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:31 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:35 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:33 / /var/lib/snapd/hostfs/tmp rw,relatime master:66 - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:67 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1081 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1082 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1083 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1084 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1085 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1086 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1087 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1088 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1089 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1090 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1091 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1092 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1093 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1094 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1095 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1096 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1097 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1098 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1099 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1100 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1101 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime shared:1102 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1103 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1104 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1105 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1106 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1107 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1108 master:29 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1109 master:30 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1110 master:31 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1111 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1112 master:35 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1113 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1114 master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1115 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1116 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1117 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1118 master:38 - squashfs /dev/loop2 ro
+0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1119 master:39 - squashfs /dev/loop0 ro
+0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1120 master:40 - squashfs /dev/loop1 ro
+0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1121 master:41 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime shared:1122 master:42 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1123 master:43 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1124 master:44 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1125 master:45 - squashfs /dev/loop7 ro
+2:33 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1126 master:66 - tmpfs tmpfs rw
+0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime shared:1127 master:42 - squashfs /dev/loop4 ro
+1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime shared:1128 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1129 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1130 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1131 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1132 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1133 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1134 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime shared:1135 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1136 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1137 master:67 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime shared:1138 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1139 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1140 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1141 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1142 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1143 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1144 master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-18.expected.txt
@@ -1,151 +1,151 @@
-0:0 / / ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-2:0 / /dev rw,nosuid,relatime master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
-2:1 / /dev/hugepages rw,relatime master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
-2:2 / /dev/mqueue rw,relatime master:5 - mqueue mqueue rw
-2:35 /ptmx /dev/ptmx rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:3 / /dev/pts rw,nosuid,noexec,relatime master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
-2:35 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
-2:4 / /dev/shm rw,nosuid,nodev master:7 - tmpfs tmpfs rw
-0:0 /etc /etc ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
+0:0 / / ro,nodev,relatime shared:1001 master:39 - squashfs /dev/loop0 ro
+2:0 / /dev rw,nosuid,relatime shared:1002 master:3 - devtmpfs udev rw,size=VARIABLE,nr_inodes=0,mode=755
+2:1 / /dev/hugepages rw,relatime shared:1003 master:4 - hugetlbfs hugetlbfs rw,pagesize=2M
+2:2 / /dev/mqueue rw,relatime shared:1004 master:5 - mqueue mqueue rw
+2:35 /ptmx /dev/ptmx rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:3 / /dev/pts rw,nosuid,noexec,relatime shared:1006 master:6 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+2:35 / /dev/pts rw,relatime shared:1005 - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+2:4 / /dev/shm rw,nosuid,nodev shared:1007 master:7 - tmpfs tmpfs rw
+0:0 /etc /etc ro,relatime shared:1008 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/etc/apparmor.d/cache /etc/apparmor.d/cache rw,relatime shared:1009 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /etc/cloud rw,relatime shared:1010 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /etc/dbus-1/system.d rw,relatime shared:1011 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /etc/default/swapfile rw,relatime shared:1012 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /etc/fstab rw,nosuid,noexec,relatime shared:1013 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /etc/group ro,relatime shared:1014 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /etc/gshadow ro,relatime shared:1015 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /etc/hosts rw,relatime shared:1016 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /etc/iproute2 rw,relatime shared:1017 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /etc/machine-id rw,relatime shared:1018 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /etc/modprobe.d rw,relatime shared:1019 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /etc/modules-load.d rw,relatime shared:1020 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /etc/netplan rw,relatime shared:1021 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /etc/network/if-up.d rw,relatime shared:1022 master:20 - ext4 /dev/sda3 rw,data=ordered
 0:0 /etc/nsswitch.conf /etc/nsswitch.conf ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /etc/passwd ro,relatime shared:1023 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /etc/shadow ro,relatime shared:1024 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /etc/ssh rw,relatime shared:1025 master:21 - ext4 /dev/sda3 rw,data=ordered
 0:0 /etc/ssl /etc/ssl ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
+1:1 /system-data/etc/sudoers.d /etc/sudoers.d rw,relatime shared:1026 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /etc/sysctl.d rw,relatime shared:1027 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /etc/systemd rw,relatime shared:1028 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /etc/systemd/system rw,relatime shared:1029 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /etc/udev/rules.d rw,relatime shared:1030 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /etc/writable rw,relatime shared:1031 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /home rw,relatime shared:1032 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /lib/firmware ro,relatime shared:1033 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /lib/modules ro,relatime shared:1034 master:29 - squashfs /dev/loop1 ro
 2:6 / /media rw,relatime shared:30 - tmpfs tmpfs rw
-2:7 / /mnt rw,relatime master:31 - tmpfs tmpfs rw
-2:8 / /proc rw,nosuid,nodev,noexec,relatime master:32 - proc proc rw
-2:9 / /proc/sys/fs/binfmt_misc rw,relatime master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
-1:1 /system-data/root /root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:10 / /run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:7 / /mnt rw,relatime shared:1035 master:31 - tmpfs tmpfs rw
+2:8 / /proc rw,nosuid,nodev,noexec,relatime shared:1036 master:32 - proc proc rw
+2:9 / /proc/sys/fs/binfmt_misc rw,relatime shared:1037 master:33 - autofs systemd-1 rw,fd=0,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=0
+1:1 /system-data/root /root rw,relatime shared:1038 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:10 / /run rw,nosuid,noexec,relatime shared:1039 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:1040 master:36 - tmpfs tmpfs rw,size=VARIABLE
 2:10 /netns /run/netns rw,nosuid,noexec,relatime shared:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:13 / /sys rw,nosuid,nodev,noexec,relatime master:46 - sysfs sysfs rw
-2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec master:47 - tmpfs tmpfs ro,mode=755
-2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime master:48 - cgroup cgroup rw,blkio
-2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime master:49 - cgroup cgroup rw,cpu,cpuacct
-2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime master:50 - cgroup cgroup rw,cpuset
-2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime master:51 - cgroup cgroup rw,devices
-2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime master:52 - cgroup cgroup rw,freezer
-2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime master:53 - cgroup cgroup rw,hugetlb
-2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime master:54 - cgroup cgroup rw,memory
-2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime master:55 - cgroup cgroup rw,net_cls,net_prio
-2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime master:56 - cgroup cgroup rw,perf_event
-2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime master:57 - cgroup cgroup rw,pids
-2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime master:58 - cgroup cgroup rw,rdma
-2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime master:59 - cgroup cgroup rw,xattr,name=systemd
-2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime master:60 - cgroup2 cgroup rw,nsdelegate
-2:28 / /sys/fs/fuse/connections rw,relatime master:61 - fusectl fusectl rw
-2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:62 - pstore pstore rw
-2:30 / /sys/kernel/config rw,relatime master:63 - configfs configfs rw
-2:31 / /sys/kernel/debug rw,relatime master:64 - debugfs debugfs rw
-2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:65 - securityfs securityfs rw
-2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
+2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime shared:1041 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /run/user/0 rw,nosuid,nodev,relatime shared:1042 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /snap rw,relatime shared:1043 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /snap/core/1 ro,nodev,relatime shared:1044 master:38 - squashfs /dev/loop2 ro
+0:0 / /snap/core18/1 ro,nodev,relatime shared:1045 master:39 - squashfs /dev/loop0 ro
+0:1 / /snap/pc-kernel/1 ro,nodev,relatime shared:1046 master:40 - squashfs /dev/loop1 ro
+0:3 / /snap/pc/1 ro,nodev,relatime shared:1047 master:41 - squashfs /dev/loop3 ro
+0:4 / /snap/snapd/1 ro,nodev,relatime shared:1048 master:42 - squashfs /dev/loop4 ro
+0:5 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1049 master:43 - squashfs /dev/loop5 ro
+0:6 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1050 master:44 - squashfs /dev/loop6 ro
+0:7 / /snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1051 master:45 - squashfs /dev/loop7 ro
+2:13 / /sys rw,nosuid,nodev,noexec,relatime shared:1052 master:46 - sysfs sysfs rw
+2:14 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:1053 master:47 - tmpfs tmpfs ro,mode=755
+2:15 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:1054 master:48 - cgroup cgroup rw,blkio
+2:16 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:1055 master:49 - cgroup cgroup rw,cpu,cpuacct
+2:17 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:1056 master:50 - cgroup cgroup rw,cpuset
+2:18 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:1057 master:51 - cgroup cgroup rw,devices
+2:19 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:1058 master:52 - cgroup cgroup rw,freezer
+2:20 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:1059 master:53 - cgroup cgroup rw,hugetlb
+2:21 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:1060 master:54 - cgroup cgroup rw,memory
+2:22 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:1061 master:55 - cgroup cgroup rw,net_cls,net_prio
+2:23 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:1062 master:56 - cgroup cgroup rw,perf_event
+2:24 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:1063 master:57 - cgroup cgroup rw,pids
+2:25 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:1064 master:58 - cgroup cgroup rw,rdma
+2:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:1065 master:59 - cgroup cgroup rw,xattr,name=systemd
+2:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:1066 master:60 - cgroup2 cgroup rw,nsdelegate
+2:28 / /sys/fs/fuse/connections rw,relatime shared:1067 master:61 - fusectl fusectl rw
+2:29 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:1068 master:62 - pstore pstore rw
+2:30 / /sys/kernel/config rw,relatime shared:1069 master:63 - configfs configfs rw
+2:31 / /sys/kernel/debug rw,relatime shared:1070 master:64 - debugfs debugfs rw
+2:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:1071 master:65 - securityfs securityfs rw
+2:33 / /tmp rw,relatime shared:1072 master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
-0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
-0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
-1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:0 / /var/lib/snapd/hostfs ro,relatime master:1 - squashfs /dev/loop0 ro
+0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime shared:1073 master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime shared:1074 - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime shared:1075 - squashfs /dev/loop0 ro
+2:37 / /usr/share/gdb/test rw,relatime shared:1076 - tmpfs tmpfs rw
+0:0 /usr/src /usr/src ro,relatime shared:1077 master:1 - squashfs /dev/loop0 ro
+1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime shared:1078 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime shared:1079 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:0 / /var/lib/snapd/hostfs ro,relatime shared:1080 master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda3 rw,data=ordered
-1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
-1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime master:8 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime master:9 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime master:10 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime master:11 - ext4 /dev/sda3 rw,data=ordered
-2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime master:12 - tmpfs tmpfs rw,mode=755
-1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime master:14 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime master:16 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime master:17 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime master:18 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime master:19 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime master:20 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime master:21 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime master:22 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime master:23 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime master:24 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime master:25 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime master:26 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime master:27 - ext4 /dev/sda3 rw,data=ordered
-1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime master:28 - squashfs /dev/loop1 ro
-0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime master:29 - squashfs /dev/loop1 ro
-2:6 / /var/lib/snapd/hostfs/media rw,relatime master:30 - tmpfs tmpfs rw
-2:7 / /var/lib/snapd/hostfs/mnt rw,relatime master:31 - tmpfs tmpfs rw
-1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:35 - tmpfs tmpfs rw,mode=755
-2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime master:36 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
-2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
-1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
-0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
-0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime master:40 - squashfs /dev/loop1 ro
-0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime master:41 - squashfs /dev/loop3 ro
-0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime master:43 - squashfs /dev/loop5 ro
-0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime master:44 - squashfs /dev/loop6 ro
-0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime master:45 - squashfs /dev/loop7 ro
-2:33 / /var/lib/snapd/hostfs/tmp rw,relatime master:66 - tmpfs tmpfs rw
-0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
-1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime master:67 - tmpfs tmpfs rw,mode=700
-1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/log /var/log rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/snap /var/snap rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
-1:1 /system-data/var/tmp /var/tmp rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
+1:0 / /var/lib/snapd/hostfs/boot/efi rw,relatime shared:1081 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:0 /EFI/ubuntu /var/lib/snapd/hostfs/boot/grub rw,relatime shared:1082 master:2 - vfat /dev/sda2 rw,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro
+1:1 /system-data/etc/apparmor.d/cache /var/lib/snapd/hostfs/etc/apparmor.d/cache rw,relatime shared:1083 master:8 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/cloud /var/lib/snapd/hostfs/etc/cloud rw,relatime shared:1084 master:9 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/dbus-1/system.d /var/lib/snapd/hostfs/etc/dbus-1/system.d rw,relatime shared:1085 master:10 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/default/swapfile /var/lib/snapd/hostfs/etc/default/swapfile rw,relatime shared:1086 master:11 - ext4 /dev/sda3 rw,data=ordered
+2:5 /image.fstab /var/lib/snapd/hostfs/etc/fstab rw,nosuid,noexec,relatime shared:1087 master:12 - tmpfs tmpfs rw,mode=755
+1:1 /system-data/root/test-etc/group /var/lib/snapd/hostfs/etc/group ro,relatime shared:1088 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/gshadow /var/lib/snapd/hostfs/etc/gshadow ro,relatime shared:1089 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/hosts /var/lib/snapd/hostfs/etc/hosts rw,relatime shared:1090 master:14 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/iproute2 /var/lib/snapd/hostfs/etc/iproute2 rw,relatime shared:1091 master:15 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/machine-id /var/lib/snapd/hostfs/etc/machine-id rw,relatime shared:1092 master:16 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modprobe.d /var/lib/snapd/hostfs/etc/modprobe.d rw,relatime shared:1093 master:17 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/modules-load.d /var/lib/snapd/hostfs/etc/modules-load.d rw,relatime shared:1094 master:18 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/netplan /var/lib/snapd/hostfs/etc/netplan rw,relatime shared:1095 master:19 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/network/if-up.d /var/lib/snapd/hostfs/etc/network/if-up.d rw,relatime shared:1096 master:20 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/passwd /var/lib/snapd/hostfs/etc/passwd ro,relatime shared:1097 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/root/test-etc/shadow /var/lib/snapd/hostfs/etc/shadow ro,relatime shared:1098 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/ssh /var/lib/snapd/hostfs/etc/ssh rw,relatime shared:1099 master:21 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sudoers.d /var/lib/snapd/hostfs/etc/sudoers.d rw,relatime shared:1100 master:22 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/sysctl.d /var/lib/snapd/hostfs/etc/sysctl.d rw,relatime shared:1101 master:23 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd /var/lib/snapd/hostfs/etc/systemd rw,relatime shared:1102 master:24 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/systemd/system /var/lib/snapd/hostfs/etc/systemd/system rw,relatime shared:1103 master:25 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/udev/rules.d /var/lib/snapd/hostfs/etc/udev/rules.d rw,relatime shared:1104 master:26 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/etc/writable /var/lib/snapd/hostfs/etc/writable rw,relatime shared:1105 master:27 - ext4 /dev/sda3 rw,data=ordered
+1:1 /user-data /var/lib/snapd/hostfs/home rw,relatime shared:1106 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:1 /firmware /var/lib/snapd/hostfs/lib/firmware ro,relatime shared:1107 master:28 - squashfs /dev/loop1 ro
+0:1 /modules /var/lib/snapd/hostfs/lib/modules ro,relatime shared:1108 master:29 - squashfs /dev/loop1 ro
+2:6 / /var/lib/snapd/hostfs/media rw,relatime shared:1109 master:30 - tmpfs tmpfs rw
+2:7 / /var/lib/snapd/hostfs/mnt rw,relatime shared:1110 master:31 - tmpfs tmpfs rw
+1:1 /system-data/root /var/lib/snapd/hostfs/root rw,relatime shared:1111 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:5 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1112 master:35 - tmpfs tmpfs rw,mode=755
+2:10 / /var/lib/snapd/hostfs/run rw,nosuid,noexec,relatime shared:1113 master:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:11 / /var/lib/snapd/hostfs/run/lock rw,nosuid,nodev,noexec,relatime shared:1114 master:36 - tmpfs tmpfs rw,size=VARIABLE
+2:10 /snapd/ns /var/lib/snapd/hostfs/run/snapd/ns rw,nosuid,noexec,relatime shared:1115 - tmpfs tmpfs rw,size=VARIABLE,mode=755
+2:12 / /var/lib/snapd/hostfs/run/user/0 rw,nosuid,nodev,relatime shared:1116 master:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
+1:1 /system-data/snap /var/lib/snapd/hostfs/snap rw,relatime shared:1117 master:13 - ext4 /dev/sda3 rw,data=ordered
+0:2 / /var/lib/snapd/hostfs/snap/core/1 ro,nodev,relatime shared:1118 master:38 - squashfs /dev/loop2 ro
+0:0 / /var/lib/snapd/hostfs/snap/core18/1 ro,nodev,relatime shared:1119 master:39 - squashfs /dev/loop0 ro
+0:1 / /var/lib/snapd/hostfs/snap/pc-kernel/1 ro,nodev,relatime shared:1120 master:40 - squashfs /dev/loop1 ro
+0:3 / /var/lib/snapd/hostfs/snap/pc/1 ro,nodev,relatime shared:1121 master:41 - squashfs /dev/loop3 ro
+0:4 / /var/lib/snapd/hostfs/snap/snapd/1 ro,nodev,relatime shared:1122 master:42 - squashfs /dev/loop4 ro
+0:5 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:1123 master:43 - squashfs /dev/loop5 ro
+0:6 / /var/lib/snapd/hostfs/snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:1124 master:44 - squashfs /dev/loop6 ro
+0:7 / /var/lib/snapd/hostfs/snap/test-snapd-rsync-core18/1 ro,nodev,relatime shared:1125 master:45 - squashfs /dev/loop7 ro
+2:33 / /var/lib/snapd/hostfs/tmp rw,relatime shared:1126 master:66 - tmpfs tmpfs rw
+0:4 /usr/lib/snapd /var/lib/snapd/hostfs/usr/lib/snapd ro,nodev,relatime shared:1127 master:42 - squashfs /dev/loop4 ro
+1:1 /system-data/var/cache /var/lib/snapd/hostfs/var/cache rw,relatime shared:1128 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/cloud /var/lib/snapd/hostfs/var/lib/cloud rw,relatime shared:1129 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/console-conf /var/lib/snapd/hostfs/var/lib/console-conf rw,relatime shared:1130 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dbus /var/lib/snapd/hostfs/var/lib/dbus rw,relatime shared:1131 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/dhcp /var/lib/snapd/hostfs/var/lib/dhcp rw,relatime shared:1132 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/extrausers /var/lib/snapd/hostfs/var/lib/extrausers rw,relatime shared:1133 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/misc /var/lib/snapd/hostfs/var/lib/misc rw,relatime shared:1134 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/private/systemd /var/lib/snapd/hostfs/var/lib/private/systemd rw,relatime shared:1135 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/lib/snapd /var/lib/snapd/hostfs/var/lib/snapd rw,relatime shared:1136 master:13 - ext4 /dev/sda3 rw,data=ordered
+2:34 / /var/lib/snapd/hostfs/var/lib/sudo rw,relatime shared:1137 master:67 - tmpfs tmpfs rw,mode=700
+1:1 /system-data/var/lib/systemd /var/lib/snapd/hostfs/var/lib/systemd rw,relatime shared:1138 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/lib/snapd/hostfs/var/log rw,relatime shared:1139 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/lib/snapd/hostfs/var/snap rw,relatime shared:1140 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/lib/snapd/hostfs/var/tmp rw,relatime shared:1141 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/log /var/log rw,relatime shared:1142 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/snap /var/snap rw,relatime shared:1143 master:13 - ext4 /dev/sda3 rw,data=ordered
+1:1 /system-data/var/tmp /var/tmp rw,relatime shared:1144 master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/regression/lp-1828354/task.sh
+++ b/tests/regression/lp-1828354/task.sh
@@ -1,0 +1,163 @@
+#!/bin/bash -ex
+
+# Define helpers that run a command inside the snap as root or test user.
+# The call to "su root -c" is redundant but makes for nice parity with the
+# second function below.
+as_snap_root() {
+    su root -c "snap run \"$snap.sh\" -c \"$*\""
+}
+
+as_snap_user() {
+    su test -c "snap run \"$snap.sh\" -c \"$*\""
+}
+
+# Depending on the test variant define different assert functions.
+case "$VARIANT" in
+    mimic)
+        # Define properties that should hold in at all times.
+        assert_invariant() {
+            echo "## Asserting invariant properties"
+            echo "### Existing canary files are not clobbered."
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/canary"
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/dir/canary"
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/meta/canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/canary")" = "app:canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/dir/canary")" = "app:dir/canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/meta/canary")" = "app:meta/canary"
+
+            echo "### Same as above but for snap user in per-user mount namespace."
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/canary"
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/dir/canary"
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/meta/canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/canary")" = "app:canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/dir/canary")" = "app:dir/canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/meta/canary")" = "app:meta/canary"
+        }
+
+        # Define properties that should hold when the content snap is not connected.
+        assert_disconnected() {
+            echo "## Asserting properties when content snap is disconnected"
+            echo "### The dynamically-created tmpfs directory does not exist."
+            echo "### There's no writable mimic so nothing shadows \$SNAP."
+            echo "### Mount event propagation from \$SNAP is shared (to ns:user) and slave (from ns:sys)."
+            as_snap_root /usr/bin/test ! -e "/snap/$snap/x1/tmpfs"
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1" .fs_type)" = squashfs
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one .opt_fields "/snap/$snap/x1" | sed -e 's/[0-9]\+/nnn/g')" = "shared:nnn master:nnn"
+
+            echo "### Same as above but for snap user in per-user mount namespace."
+            as_snap_user /usr/bin/test ! -e "/snap/$snap/x1/tmpfs"
+            test "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1" .fs_type)" = squashfs
+            test "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one .opt_fields "/snap/$snap/x1" | sed -e 's/[0-9]\+/nnn/g')" = "shared:nnn master:nnn"
+        }
+
+        # Define properties that should hold when the content snap connected.
+        assert_connected() {
+            echo "## Asserting properties when content snap is connected"
+            echo "### The dynamically-created tmpfs directory exists."
+            as_snap_root /usr/bin/test -d "/snap/$snap/x1/tmpfs/"
+            echo "### There's a writable mimic shadowing the original squashfs."
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- "/snap/$snap/x1" .fs_type)" = "$(printf "squashfs\ntmpfs\n")"
+
+            echo "### The content is mounted underneath and is not clobbered."
+            as_snap_root /usr/bin/test -d "/snap/$snap/x1/tmpfs/content"
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/tmpfs/content/canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/tmpfs/content/canary")" = "content:content/canary"
+
+            echo "### Same as above but for snap user in per-user mount namespace."
+            as_snap_user /usr/bin/test -d "/snap/$snap/x1/tmpfs/"
+            test "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- "/snap/$snap/x1" .fs_type)" = "$(printf "squashfs\ntmpfs\n")"
+            as_snap_user /usr/bin/test -d "/snap/$snap/x1/tmpfs/content"
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/tmpfs/content/canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/tmpfs/content/canary")" = "content:content/canary"
+
+            echo "### The block device fueling the mimic is the same in both namespaces."
+            echo "### NOTE: we don't do remapping and we expect to see the exact same numbers."
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- "/snap/$snap/x1" .fs_type=tmpfs .dev)" = \
+                 "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- "/snap/$snap/x1" .fs_type=tmpfs .dev)"
+
+            echo "### Propagation of the tmpfs is identical in both namespaces (shared:xxx)"
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1" .fs_type=tmpfs .opt_fields)" = \
+                 "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1" .fs_type=tmpfs .opt_fields)"
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one --renumber "/snap/$snap/x1" .fs_type=tmpfs .opt_fields | sed -e 's/[0-9]\+/nnn/')" = shared:nnn
+
+        }
+    ;;
+    layout)
+        # Define properties that should hold in at all times.
+        assert_invariant() {
+            echo "## Asserting invariant properties"
+            echo "### Existing canary files are not clobbered except for"
+            echo "### the file that is shadowed by layout-defined tmpfs."
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/canary"
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/meta/canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/canary")" = "app:canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/meta/canary")" = "app:meta/canary"
+            as_snap_root /usr/bin/test -d "/snap/$snap/x1/tmpfs"
+            as_snap_root /usr/bin/test ! -f "/snap/$snap/x1/tmpfs/canary"
+
+            echo "### Same as above but for snap user in per-user mount namespace."
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/canary"
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/meta/canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/canary")" = "app:canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/meta/canary")" = "app:meta/canary"
+            as_snap_user /usr/bin/test -d "/snap/$snap/x1/tmpfs"
+            as_snap_root /usr/bin/test ! -f "/snap/$snap/x1/tmpfs/canary"
+        }
+
+        # Define properties that should hold when the content snap is not connected.
+        assert_disconnected() {
+            echo "## Asserting properties when content snap is disconnected"
+            echo "### Content mount is simply gone."
+            as_snap_root /usr/bin/test ! -e "/snap/$snap/x1/tmpfs/content"
+            as_snap_user /usr/bin/test ! -e "/snap/$snap/x1/tmpfs/content"
+
+            # FIXME: the comments are not consistent with measurements. Are we doing it right?
+            echo "### Mount event propagation in ns:sys for \$SNAP/tmpfs is shared (to ns:user) and slave (from ns:sys)."
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .fs_type)" = tmpfs
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .opt_fields | sed -e 's/[0-9]\+/nnn/')" = shared:nnn
+            echo "### Mount event propagation in ns:user for \$SNAP/tmpfs is shared (to ns:user) and slave (from ns:sys)."
+            test "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .fs_type)" = tmpfs
+            test "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .opt_fields | sed -e 's/[0-9]\+/nnn/')" = shared:nnn
+        }
+
+        # Define properties that should hold when the content snap connected.
+        assert_connected() {
+            echo "## Asserting properties when content snap is connected"
+            echo "### The content is mounted underneath and is not clobbered."
+            as_snap_root /usr/bin/test -d "/snap/$snap/x1/tmpfs/content"
+            as_snap_root /usr/bin/test -f "/snap/$snap/x1/tmpfs/content/canary"
+            test "$(as_snap_root /bin/cat "/snap/$snap/x1/tmpfs/content/canary")" = "content:content/canary"
+
+            echo "### Same as above but for snap user in per-user mount namespace."
+            as_snap_user /usr/bin/test -d "/snap/$snap/x1/tmpfs/content"
+            as_snap_user /usr/bin/test -f "/snap/$snap/x1/tmpfs/content/canary"
+            test "$(as_snap_user /bin/cat "/snap/$snap/x1/tmpfs/content/canary")" = "content:content/canary"
+
+            echo "### Propagation of the tmpfs is identical in both namespaces (shared:xxx)"
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .fs_type=tmpfs .opt_fields)" = \
+                 "$(as_snap_user /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .fs_type=tmpfs .opt_fields)"
+            test "$(as_snap_root /bin/cat /proc/self/mountinfo | mountinfo-tool -f- --one "/snap/$snap/x1/tmpfs" .fs_type=tmpfs .opt_fields | sed -e 's/[0-9]\+/nnn/')" = shared:nnn
+        }
+    ;;
+esac
+
+echo "# Verify that initial state when the content is not connected is as expected."
+snap-tool snap-discard-ns "$snap"
+assert_invariant
+assert_disconnected
+
+echo "# Verify that initial state when the content connected is as expected."
+snap-tool snap-discard-ns "$snap"
+snap connect "$snap:content" test-snapd-content:content
+assert_invariant
+assert_connected
+
+echo "# Now, without discarding the mount namespace verify we can perform transitions:"
+echo "# connected -> disconnected -> connected"
+snap disconnect "$snap:content" test-snapd-content:content
+assert_invariant
+assert_disconnected
+
+snap connect "$snap:content" test-snapd-content:content
+assert_invariant
+assert_connected

--- a/tests/regression/lp-1828354/task.yaml
+++ b/tests/regression/lp-1828354/task.yaml
@@ -1,0 +1,43 @@
+summary: mount event propagation works inside snapd-created tmpfs
+details: |
+    When snapd mounts a tmpfs the sharing on the tmpfs is incorrect and breaks
+    per-user mount namespaces since events don't propagate there correctly.
+environment:
+    VARIANT/mimic: mimic
+    VARIANT/layout: layout
+    snap/mimic: test-snapd-app-mimic
+    snap/layout: test-snapd-app-layout
+prepare: |
+    # Enable persistence of per-user-mount-namespaces.
+    #
+    # This allows us to see persistent state of the per-user mount namespace.
+    # This test relies on this because otherwise per-user mount namespace is always
+    # re-created from per-snap mount namespace, on each command invocation.
+    snap set system experimental.per-user-mount-namespace=true
+
+    # Install our primary snap and connect it to mount-observe.
+    # We need the interface connection for reading mountinfo table.
+    snap pack "$snap"
+    snap install --dangerous "./${snap}_1_all.snap"
+    snap connect "$snap:mount-observe"
+
+    # Install the supporting content snap.
+    snap pack test-snapd-content
+    snap install --dangerous ./test-snapd-content_1_all.snap
+restore: |
+    snap unset system experimental.per-user-mount-namespace
+
+    rm -f "${snap}_1_all.snap"
+    snap remove "$snap"
+
+    rm -f test-snapd-content_1_all.snap
+    snap remove test-snapd-content
+
+    # Remove the private temporary directories we created.
+    rm -rf "/tmp/snap.$snap"
+execute: |
+    ./task.sh
+debug: |
+    mountinfo-tool >host.txt
+    su root -c "snap run \"$snap.sh\" -c \"cat /proc/self/mountinfo\"" | mountinfo-tool -f- >per-snap.txt
+    su test -c "snap run \"$snap.sh\" -c \"cat /proc/self/mountinfo\"" | mountinfo-tool -f- >per-user.txt

--- a/tests/regression/lp-1828354/test-snapd-app-layout/bin/sh
+++ b/tests/regression/lp-1828354/test-snapd-app-layout/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/regression/lp-1828354/test-snapd-app-layout/canary
+++ b/tests/regression/lp-1828354/test-snapd-app-layout/canary
@@ -1,0 +1,1 @@
+app:canary

--- a/tests/regression/lp-1828354/test-snapd-app-layout/meta/canary
+++ b/tests/regression/lp-1828354/test-snapd-app-layout/meta/canary
@@ -1,0 +1,1 @@
+app:meta/canary

--- a/tests/regression/lp-1828354/test-snapd-app-layout/meta/snap.yaml
+++ b/tests/regression/lp-1828354/test-snapd-app-layout/meta/snap.yaml
@@ -1,0 +1,20 @@
+name: test-snapd-app-layout
+version: 1
+summary: Snap using the content snap for shared resources
+plugs:
+    content:
+        # The content is connected beneath a tmpfs belonging to a layout.
+        target: $SNAP/tmpfs/content
+    mount-observe:
+layout:
+    # NOTE: it is essential that the $SNAP/tmpfs directory exists. This is
+    # because we only want to construct one tmpfs, the one described by the
+    # layout below, not two, where the second one would be created to allow the
+    # $SNAP/tmpfs mount point to exist. The test will exercise the tmpfs
+    # created by the layout.
+    $SNAP/tmpfs:
+        type: tmpfs
+architectures: [all]
+apps:
+    sh:
+        command: bin/sh

--- a/tests/regression/lp-1828354/test-snapd-app-layout/tmpfs/canary
+++ b/tests/regression/lp-1828354/test-snapd-app-layout/tmpfs/canary
@@ -1,0 +1,1 @@
+app:tmpfs/canary

--- a/tests/regression/lp-1828354/test-snapd-app-mimic/bin/sh
+++ b/tests/regression/lp-1828354/test-snapd-app-mimic/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/regression/lp-1828354/test-snapd-app-mimic/canary
+++ b/tests/regression/lp-1828354/test-snapd-app-mimic/canary
@@ -1,0 +1,1 @@
+app:canary

--- a/tests/regression/lp-1828354/test-snapd-app-mimic/dir/canary
+++ b/tests/regression/lp-1828354/test-snapd-app-mimic/dir/canary
@@ -1,0 +1,1 @@
+app:dir/canary

--- a/tests/regression/lp-1828354/test-snapd-app-mimic/meta/canary
+++ b/tests/regression/lp-1828354/test-snapd-app-mimic/meta/canary
@@ -1,0 +1,1 @@
+app:meta/canary

--- a/tests/regression/lp-1828354/test-snapd-app-mimic/meta/snap.yaml
+++ b/tests/regression/lp-1828354/test-snapd-app-mimic/meta/snap.yaml
@@ -1,0 +1,15 @@
+name: test-snapd-app-mimic
+version: 1
+summary: Snap using the content snap for shared resources
+plugs:
+    content:
+        # It is essential that the target directory does *NOT* exist in the snap.
+        # This is because we want snapd to create a writable mimic that replaces
+        # $SNAP/ and allows $SNAP/content to be created. The test will exercise the
+        # properties of that tmpfs.
+        target: $SNAP/tmpfs/content
+    mount-observe:
+architectures: [all]
+apps:
+    sh:
+        command: bin/sh

--- a/tests/regression/lp-1828354/test-snapd-content/content/canary
+++ b/tests/regression/lp-1828354/test-snapd-content/content/canary
@@ -1,0 +1,1 @@
+content:content/canary

--- a/tests/regression/lp-1828354/test-snapd-content/meta/snap.yaml
+++ b/tests/regression/lp-1828354/test-snapd-content/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-content
+version: 1
+summary: Snap providing shared content
+architectures: [all]
+slots:
+  content:
+    # This is an old-style, non-aggregating content slot. The "content"
+    # directory is directly mounted over the connected plug's target path. Had
+    # we used the "source:" section to hold the "read:" entry we would get the
+    # new, spool-like content slot where "content" is a sub-directory of the
+    # directory designated by the connected plug's target path.
+    read: [$SNAP/content]


### PR DESCRIPTION
When snap-confine creates the initial layout of the per-snap mount
namespace it was using MS_SLAVE in order not to propagate mount events
from that mount namespace to the initial mount namespace of the system.

This was working fine, including for updates via snap-update-ns, which
was always changing the per-snap mount namespace. It didn't fully work
for per-snap, per-user mount namespaces. This was mostly affecting
desktop applications that inhabit said namespace, but to a lesser degree
some of the other mount constructs established by snap-update-ns.

This patch changes snap-confine, so that each MS_SLAVE, is followed up
by MS_SHARED. This seems counter-intuitive, is it shared or not? The
behavior of the kernel is well documented but a little bit misleading at
first. When we first change to MS_SLAVE we are closing the propagation
channel between a mount point in the per-snap mount namespace and the
same location in the initial mount namespace. When we are subsequently
using MS_SHARED we are opening the channel to mount namespaces unshared
from our own.

Once sealed, propagation between mount namespaces cannot be
re-established. This is also visible when we carefully set up /media and
/mnt so that bi-directional sharing between those places is preserved.
We do that by never using MS_SLAVE there.

Because propagation settings are inherited by descendant mount points,
this change in snap-confine propagates to various other constructs,
specifically to the changes done by snap-update-ns, for both initial
construction as well as on-the-fly updates. All the mount points
established under shared locations remain shared.

There's one downside: this actively harms us in the code path that
constructs the writable mimic. That code recursively bind-mounts a
directory to a stub directory in /tmp/.snap/, so that we can still see
the original content, and then proceeds to re-create the original
content on top of a freshly mounted tmpfs. With the propagation settings
changed that tmpfs would also show up in the stash directory in /tmp,
therefore breaking the whole setup. To counter that, the writable mimic
construction code in snap-update-ns switched the stash mount point to
recursively private, so that prior semantics is retained.

With this change we can now observe mount changes performed in the
per-snap mount namespace propagate to the derived per-snap, per-user
mount namespace. A new spread regression test measures that for the use
case of layouts and writable mimics.

Somewhat surprisingly, an existing spread test that used to show how
layout changes from revision to revision can fail no longer fails! It
was, after all, related to propagation changes between layout elements
and content interface connections. That test is adjusted to show how the
application works in all the revisions used in the test.

Another test that was affected was performing cleanup, in the restore
section, to unmount a FUSE filesystem mounted in the per-instance view
of $SNAP_DATA, followed by the non-instance mount in the $SNAP_DATA.
With the propagation changes fixed, the unmount in either of the two
locations propagates to the other and a single unmount is sufficient.

Apart from the aforementioned changes there are some adjustments to the
apparmor policy, to allow the new uses of mount with MS_SHARED and
MS_PRIVATE. The associated unit tests are adjusted to reflect that.

All of this is coupled with a new regression test, that is reproducing
the case of a application running in the per-snap, per-user mount
namespace correctly observing all changes performed to the per-snap
mount namespace. The test uses persistent per-snap, per-user mount
namespaces to observe that as otherwise, since per-user mount namespace
persistence is not enabled by default yet, each invocation of the test
application would see a new mount namespace, constructed out of the
per-snap mount namespace, which never was affected by this issue to
begin with.

https://bugs.launchpad.net/snapd/+bug/1828354
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
