### PR TITLE
 wrappers/services.go: add disabled svc list arg to AddSnapServices

### DIFF
--- a/overlord/patch/patch5.go
+++ b/overlord/patch/patch5.go
@@ -71,7 +71,7 @@ func patch5(st *state.State) error {
 			return err
 		}
 
-		err = wrappers.AddSnapServices(info, log)
+		err = wrappers.AddSnapServices(info, nil, log)
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -160,7 +160,7 @@ func generateWrappers(s *snap.Info) (err error) {
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)
 
 	// add the daemons from the snap.yaml
-	if err = wrappers.AddSnapServices(s, progress.Null); err != nil {
+	if err = wrappers.AddSnapServices(s, nil, progress.Null); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, func(s *snap.Info) error {

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -91,7 +92,7 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCore(c *C) {
 
 	info := makeMockSnapdSnap(c)
 	// add the snapd service
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	// check that snapd.service is created
@@ -170,7 +171,7 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnClassic(c *C) {
 
 	info := makeMockSnapdSnap(c)
 	// add the snapd service
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	// check that snapd services were *not* created

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -218,7 +218,7 @@ func (s *servicesTestSuite) TestServicesEnableState(c *C) {
 				exit 0
 				;;
 			*)
-				echo "unexpected service $*"
+				echo "unexpected is-enabled of service $2"
 				exit 2
 				;;
 			esac
@@ -273,7 +273,7 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 				exit 1
 				;;
 			*)
-				echo "unexpected service $*"
+				echo "unexpected is-enabled of service $2"
 				exit 2
 				;;
 			esac
@@ -312,11 +312,15 @@ func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServices(c *C) {
 		enable)
 			case "$2" in 
 				"snap.hello-snap.svc1.service")
-					echo "unexpected enable"
+					echo "unexpected enable of disabled service $2"
 					exit 1
-				;;
+					;;
 				"snap.hello-snap.svc2.service")
 					exit 0
+					;;
+				*)
+					echo "unexpected enable of service $2"
+					exit 1
 					;;
 			esac
 			;;
@@ -364,7 +368,7 @@ func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServicesNowApp(c *C) 
 					exit 0
 					;;
 				*)
-					echo "unexpected enable"
+					echo "unexpected enable of service $2"
 					exit 1
 					;;
 			esac
@@ -418,7 +422,7 @@ func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServicesMissing(c *C)
 					exit 0
 					;;
 				*)
-					echo "unexpected enable"
+					echo "unexpected enable of service $2"
 					exit 1
 					;;
 			esac

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -31,6 +31,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -78,7 +79,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--root", dirs.GlobalRootDir, "enable", filepath.Base(svcFile)},
@@ -131,7 +132,7 @@ func (s *servicesTestSuite) TestRemoveSnapWithSocketsRemovesSocketsService(c *C)
       listen-stream: $SNAP_COMMON/sock2.socket
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	err = wrappers.StopServices(info.Services(), "", &progress.Null, s.perfTimings)
@@ -171,7 +172,7 @@ apps:
    daemon: forking
 `, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	sysdLog = nil
@@ -294,6 +295,163 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 	})
 }
 
+func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServices(c *C) {
+	info := snaptest.MockSnap(c, packageHello+`
+ svc2:
+  command: bin/hello
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
+
+	s.systemctlRestorer()
+	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
+	if [ "$1" = "--root" ]; then
+	    shift 2
+	fi
+
+	case "$1" in
+		enable)
+			case "$2" in 
+				"snap.hello-snap.svc1.service")
+					echo "unexpected enable"
+					exit 1
+				;;
+				"snap.hello-snap.svc2.service")
+					exit 0
+					;;
+			esac
+			;;
+		daemon-reload)
+			exit 0
+			;;
+	    *)
+	        echo "unexpected op $*"
+	        exit 2
+	esac
+	exit 2
+	`)
+	defer r.Restore()
+
+	// svc1 will be disabled
+	disabledSvcs := []string{"svc1"}
+
+	err := wrappers.AddSnapServices(info, disabledSvcs, progress.Null)
+	c.Assert(err, IsNil)
+
+	// only svc2 should be enabled
+	c.Assert(r.Calls(), DeepEquals, [][]string{
+		{"systemctl", "--root", s.tempdir, "enable", "snap.hello-snap.svc2.service"},
+		{"systemctl", "daemon-reload"},
+	})
+}
+
+func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServicesNowApp(c *C) {
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
+
+	// mock the logger
+	buf, loggerRestore := logger.MockLogger()
+	defer loggerRestore()
+
+	s.systemctlRestorer()
+	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
+	if [ "$1" = "--root" ]; then
+	    shift 2
+	fi
+
+	case "$1" in
+		enable)
+			case "$2" in 
+				"snap.hello-snap.svc1.service")
+					exit 0
+					;;
+				*)
+					echo "unexpected enable"
+					exit 1
+					;;
+			esac
+			;;
+		daemon-reload)
+			exit 0
+			;;
+	    *)
+	        echo "unexpected op $*"
+	        exit 2
+	esac
+	exit 2
+	`)
+	defer r.Restore()
+
+	svcs := []string{"hello"}
+
+	err := wrappers.AddSnapServices(info, svcs, progress.Null)
+	c.Assert(err, IsNil)
+
+	// check the log for the notice
+	c.Assert(buf.String(), Matches, `.*previously disabled service hello is now an app and not a service\n.*`)
+
+	// the cleanup of AddSnapServices will remove written service files and then
+	// call reload, but note that we should catch any non-svc apps before
+	// actually enabling them, so we just see a daemon-reload call and not any
+	// enable calls
+	c.Assert(r.Calls(), DeepEquals, [][]string{
+		{"systemctl", "--root", s.tempdir, "enable", "snap.hello-snap.svc1.service"},
+		{"systemctl", "daemon-reload"},
+	})
+}
+
+func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServicesMissing(c *C) {
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
+
+	// mock the logger
+	buf, loggerRestore := logger.MockLogger()
+	defer loggerRestore()
+
+	s.systemctlRestorer()
+	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
+	if [ "$1" = "--root" ]; then
+	    shift 2
+	fi
+
+	case "$1" in
+		enable)
+			case "$2" in 
+				"snap.hello-snap.svc1.service")
+					exit 0
+					;;
+				*)
+					echo "unexpected enable"
+					exit 1
+					;;
+			esac
+			;;
+		daemon-reload)
+			exit 0
+			;;
+	    *)
+	        echo "unexpected op $*"
+	        exit 2
+	esac
+	exit 2
+	`)
+	defer r.Restore()
+
+	svcs := []string{"old-disabled-svc"}
+
+	err := wrappers.AddSnapServices(info, svcs, progress.Null)
+	c.Assert(err, IsNil)
+
+	// check the log for the notice
+	c.Assert(buf.String(), Matches, `.*previously disabled service old-disabled-svc no longer exists\n.*`)
+
+	// the cleanup of AddSnapServices will remove written service files and then
+	// call reload, but note that we should catch any non-svc apps before
+	// actually enabling them, so we just see a daemon-reload call and not any
+	// enable calls
+	c.Assert(r.Calls(), DeepEquals, [][]string{
+		{"systemctl", "--root", s.tempdir, "enable", "snap.hello-snap.svc1.service"},
+		{"systemctl", "daemon-reload"},
+	})
+}
+
 func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
 	var sysdLog []string
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
@@ -316,7 +474,7 @@ func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
       listen-stream: $SNAP_DATA/sock2.socket
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	sysdLog = nil
@@ -387,7 +545,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailCreateCleanup(c *C) {
   daemon: potato
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, ".*potato.*")
 
 	// the services are cleaned up
@@ -452,7 +610,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailEnableCleanup(c *C) {
   daemon: simple
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
 
 	// the services are cleaned up
@@ -500,7 +658,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesStartFailOnSystemdReloadClea
   daemon: simple
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, progress.Null)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
 
 	// the services are cleaned up
@@ -536,7 +694,7 @@ func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
 	sock2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock2.socket")
 	sock3File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock3.socket")
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	expected := fmt.Sprintf(
@@ -779,7 +937,7 @@ func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {
 		},
 	}}
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	for _, check := range checks {
@@ -819,7 +977,7 @@ func (s *servicesTestSuite) TestServiceWatchdog(c *C) {
 `
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc2.service"))
@@ -849,7 +1007,7 @@ apps:
 	info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 	survivorFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.survive-snap.survivor.service")
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"--root", dirs.GlobalRootDir, "enable", filepath.Base(survivorFile)},
@@ -901,7 +1059,7 @@ apps:
 		info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 
 		s.sysdLog = nil
-		err := wrappers.AddSnapServices(info, nil)
+		err := wrappers.AddSnapServices(info, nil, progress.Null)
 		c.Assert(err, IsNil)
 		c.Check(s.sysdLog, DeepEquals, [][]string{
 			{"--root", dirs.GlobalRootDir, "enable", filepath.Base(survivorFile)},
@@ -1013,7 +1171,7 @@ func (s *servicesTestSuite) TestAddRemoveSnapWithTimersAddsRemovesTimerFiles(c *
   timer: 10:00-12:00
 `, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	app := info.Apps["svc2"]
@@ -1060,7 +1218,7 @@ func (s *servicesTestSuite) TestFailedAddSnapCleansUp(c *C) {
 	})
 	defer r()
 
-	err := wrappers.AddSnapServices(info, &progress.Null)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, NotNil)
 
 	c.Logf("services dir: %v", dirs.SnapServicesDir)
@@ -1102,7 +1260,7 @@ apps:
 
 	for i, info := range []*snap.Info{onlyServices, onlySockets, onlyTimers} {
 		s.sysdLog = nil
-		err := wrappers.AddSnapServices(info, &progress.Null)
+		err := wrappers.AddSnapServices(info, nil, progress.Null)
 		c.Assert(err, IsNil)
 		reloads := 0
 		c.Logf("calls: %v", s.sysdLog)
@@ -1143,7 +1301,7 @@ apps:
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 	c.Assert(s.sysdLog, HasLen, 2, Commentf("len: %v calls: %v", len(s.sysdLog), s.sysdLog))
 	c.Check(s.sysdLog, DeepEquals, [][]string{
@@ -1163,7 +1321,7 @@ func (s *servicesTestSuite) TestServiceRestartDelay(c *C) {
 `
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
-	err := wrappers.AddSnapServices(info, nil)
+	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc2.service"))


### PR DESCRIPTION
* AddSnapServices now takes a list of disabled services that shouldn't be enabled at all, so don't enable any of the services from that list. Also check the disabled services provided to AddSnapServices to log messages if any of the services are not services anymore or if they don't exist anymore. We should be noticing these things before it gets here, but in case it doesn't, we shouldn't fail here because those things aren't fatal.
* Add unit tests for happy path of AddSnapServices and for the unhappy cases which just check that we log a message about the inconsistency. In the full bugfix where we use this function, this will be verified before being passed here, so it shouldn't hit that codepath under normal circumstances.
* Also drive-by update to use progress.Null consistently everywhere we call AddSnapServices in the tests

This currently is unused anywhere, but will eventually be used to prevent disabled services from being re-enabled in snapstate.

Re-opening of https://github.com/snapcore/snapd/pull/7428