### PR TITLE
snap/channel: fix unit tests, UbuntuArchitecture -> DpkgArchitecture

### DIFF
--- a/snap/channel/channel_test.go
+++ b/snap/channel/channel_test.go
@@ -136,7 +136,7 @@ func (s storeChannelSuite) TestParseVerbatim(c *C) {
 	ch, err = channel.ParseVerbatim("edge", "")
 	c.Assert(err, IsNil)
 	c.Check(ch, DeepEquals, channel.Channel{
-		Architecture: arch.UbuntuArchitecture(),
+		Architecture: arch.DpkgArchitecture(),
 		Risk:         "edge",
 	})
 	c.Check(ch.VerbatimTrackOnly(), Equals, false)


### PR DESCRIPTION
```
# github.com/snapcore/snapd/snap/channel_test [github.com/snapcore/snapd/snap/channel.test]
./channel_test.go:139:17: undefined: arch.UbuntuArchitecture
```


