### PR TITLE
asserts,seed/seedwriter: follow snap type sorting in the model assertion snap listings

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -81,9 +81,9 @@ func (ms *modelSnaps) list() (allSnaps []*ModelSnap, requiredWithEssentialSnaps 
 		}
 	}
 
+	addSnap(ms.kernel, 1)
 	addSnap(ms.base, 1)
 	addSnap(ms.gadget, 1)
-	addSnap(ms.kernel, 1)
 	for _, snap := range ms.snapsNoEssential {
 		addSnap(snap, 0)
 	}

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -179,9 +179,9 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	c.Check(model.Store(), Equals, "brand-store")
 	allSnaps := model.AllSnaps()
 	c.Check(allSnaps, DeepEquals, []*asserts.ModelSnap{
+		model.KernelSnap(),
 		model.BaseSnap(),
 		model.GadgetSnap(),
-		model.KernelSnap(),
 		{
 			Name:           "foo",
 			Modes:          []string{"run"},
@@ -621,9 +621,9 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 	c.Check(model.Store(), Equals, "brand-store")
 	allSnaps := model.AllSnaps()
 	c.Check(allSnaps, DeepEquals, []*asserts.ModelSnap{
+		model.KernelSnap(),
 		model.BaseSnap(),
 		model.GadgetSnap(),
-		model.KernelSnap(),
 		{
 			Name:           "other-base",
 			SnapID:         "otherbasedididididididididididid",

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -271,9 +271,9 @@ func (s *writerSuite) TestSnapsToDownloadCore16(c *C) {
 	c.Check(snaps, HasLen, 4)
 
 	c.Check(naming.SameSnap(snaps[0], naming.Snap("core")), Equals, true)
-	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc")), Equals, true)
-	// XXX c.Check(snaps[1].Channel, Equals, "edge")
-	c.Check(naming.SameSnap(snaps[2], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[2], naming.Snap("pc")), Equals, true)
+	// XXX c.Check(snaps[2].Channel, Equals, "edge")
 	c.Check(naming.SameSnap(snaps[3], naming.Snap("required")), Equals, true)
 }
 
@@ -343,10 +343,10 @@ func (s *writerSuite) TestDownloadedCore18(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(snaps, HasLen, 6)
 	c.Check(naming.SameSnap(snaps[0], naming.Snap("snapd")), Equals, true)
-	c.Check(naming.SameSnap(snaps[1], naming.Snap("core18")), Equals, true)
-	c.Check(naming.SameSnap(snaps[2], naming.Snap("pc")), Equals, true)
-	// XXX c.Check(snaps[2].Channel, Equals, "edge")
-	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[2], naming.Snap("core18")), Equals, true)
+	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc")), Equals, true)
+	// XXX c.Check(snaps[3].Channel, Equals, "edge")
 
 	for _, sn := range snaps {
 		s.fillDownloadedSnap(c, w, sn)


### PR DESCRIPTION
Mostly for consistency with first boot and it should avoid a little bit of churn down the line in image tests, once it switches to seedwriter.
