### PR TITLE
tests: extend mount-ns test to handle mimics

### DIFF
--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
@@ -53,6 +53,9 @@
 1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:39 - securityfs securityfs rw
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
@@ -54,6 +54,9 @@
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
@@ -53,6 +53,9 @@
 1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:39 - securityfs securityfs rw
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
@@ -54,6 +54,9 @@
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
@@ -52,6 +52,9 @@
 1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:40 - securityfs securityfs rw
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
@@ -53,6 +53,9 @@
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 / /var/lib/snapd/hostfs rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
@@ -52,6 +52,9 @@
 1:32 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:40 - securityfs securityfs rw
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
@@ -53,6 +53,9 @@
 0:0 /tmp /tmp rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 2:0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
+1:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+2:1 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro
+1:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd /var/lib/snapd rw,relatime master:1 - ext4 /dev/sda1 rw,data=ordered
 0:0 /var/lib/snapd/hostfs /var/lib/snapd/hostfs rw,relatime - ext4 /dev/sda1 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-16.expected.txt
@@ -95,6 +95,9 @@
 2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:83 - securityfs securityfs rw
 2:31 / /tmp rw,relatime master:84 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
+2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,relatime master:1 - squashfs /dev/loop0 ro
+2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 1:1 /system-data/var/cache/apparmor /var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/cache/snapd /var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/apparmor /var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-SNAP-18.expected.txt
@@ -95,6 +95,9 @@
 2:31 / /tmp rw,relatime master:84 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
 0:0 /usr/lib/snapd /usr/lib/snapd ro,relatime master:1 - squashfs /dev/loop0 ro
+2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:3 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:61 - squashfs /dev/loop3 ro
+2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-16.expected.txt
@@ -95,6 +95,9 @@
 2:30 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:83 - securityfs securityfs rw
 2:31 / /tmp rw,relatime master:84 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
+2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,relatime master:1 - squashfs /dev/loop0 ro
+2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 1:1 /system-data/var/cache/apparmor /var/cache/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/cache/snapd /var/cache/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/apparmor /var/lib/apparmor rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/PER-USER-18.expected.txt
@@ -95,6 +95,9 @@
 2:31 / /tmp rw,relatime master:84 - tmpfs tmpfs rw
 2:31 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
 0:0 /usr/lib/snapd /usr/lib/snapd ro,relatime master:1 - squashfs /dev/loop0 ro
+2:34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:3 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:61 - squashfs /dev/loop3 ro
+2:35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:15 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-16.expected.txt
@@ -77,6 +77,9 @@
 2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
 0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:2 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
+2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-SNAP-18.expected.txt
@@ -77,6 +77,9 @@
 2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
 0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
+2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-16.expected.txt
@@ -77,6 +77,9 @@
 2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - tmpfs tmpfs rw
 0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:2 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:38 - squashfs /dev/loop2 ro
+2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/PER-USER-18.expected.txt
@@ -77,6 +77,9 @@
 2:33 / /tmp rw,relatime master:66 - tmpfs tmpfs rw
 2:33 /snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - tmpfs tmpfs rw
 0:4 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:42 - squashfs /dev/loop4 ro
+2:36 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
+0:0 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:39 - squashfs /dev/loop0 ro
+2:37 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw
 0:0 /usr/src /usr/src ro,relatime master:1 - squashfs /dev/loop0 ro
 1:1 /system-data/var/lib/extrausers /var/lib/extrausers rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered
 1:1 /system-data/var/lib/snapd /var/lib/snapd rw,relatime master:13 - ext4 /dev/sda3 rw,data=ordered

--- a/tests/main/mount-ns/test-snapd-mountinfo-core16/meta/snap.yaml
+++ b/tests/main/mount-ns/test-snapd-mountinfo-core16/meta/snap.yaml
@@ -4,6 +4,14 @@ version: 1
 architecture: [all]
 plugs:
     mount-observe:
+# This layout is designed to create a writable mimic on top of production base
+# snap, in this case core, without being extremely painful to analyze. The core
+# snap contains the directory /usr/share/gdb/auto-load which will be re-created
+# by the mimic at /usr/share/gdb. This allows us to have a test with just one
+# re-created element and without engineering a custom core for this test.
+layout:
+    /usr/share/gdb/test:
+        type: tmpfs
 apps:
     test-snapd-mountinfo-core16:
         command: bin/mountinfo

--- a/tests/main/mount-ns/test-snapd-mountinfo-core18/meta/snap.yaml
+++ b/tests/main/mount-ns/test-snapd-mountinfo-core18/meta/snap.yaml
@@ -5,6 +5,10 @@ architecture: [all]
 base: core18
 plugs:
     mount-observe:
+# Please see the comment in test-snapd-mountinfo-core16 snap for rationale.
+layout:
+    /usr/share/gdb/test:
+        type: tmpfs
 apps:
     test-snapd-mountinfo-core18:
         command: bin/mountinfo


### PR DESCRIPTION
The mount namespace test is very useful for exploring the layout of the
mount namespace used by snapd under various circumstances. The test
already covered several key combinations of the mount namespace: Ubuntu
16.04 and 18.04 both as classic and core hosts also as base snaps. The
test explored the vanilla behavior of the mount namespace, as
constructed by snap-confine.

This patch extends that test to cover the properties of writable mimic,
as created by snap-update-ns. This test is meant as a prerequisite for
the upcoming change to propagation in mount namespaces.

NOTE: This patch is also showing the effect of bug https://bugs.launchpad.net/snapd/+bug/1843423 - namely that /usr/share holds the mimic tmpfs, rather than what one might expect, /usr/share/X11.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
