### PR TITLE
overlord/snapstate/policy, etc: introduce policy, move canRemove to it

### DIFF
--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	_ "github.com/snapcore/snapd/overlord/snapstate/policy"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/store"

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -709,7 +709,7 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		info.Epoch = snap.Epoch{}
 	case "some-epoch-snap":
 		info.Epoch = snap.E("13")
-	case "gadget":
+	case "gadget", "brand-gadget":
 		info.SnapType = snap.TypeGadget
 	case "core":
 		info.SnapType = snap.TypeOS

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -1,0 +1,17 @@
+package snapstate
+
+import (
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type Policy interface {
+	CanRemove(st *state.State, snapst *SnapState, allRevisions bool) bool
+}
+
+var PolicyFor func(snap.Type, *asserts.Model) Policy = policyForUnset
+
+func policyForUnset(snap.Type, *asserts.Model) Policy {
+	panic("PolicyFor unset!")
+}

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -12,10 +12,8 @@ import (
 // looking at type, model, etc, we move it to Policy and look it up.
 type Policy interface {
 	// CanRemove verifies that a snap can be removed.
-	//
-	// TODO: CanRemove should also return the reason why the snap cannot
-	//       be removed to the user
-	CanRemove(st *state.State, snapst *SnapState, allRevisions bool) bool
+	// If rev is not unset, check for removing only that revision.
+	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision) error
 }
 
 var PolicyFor func(snap.Type, *asserts.Model) Policy = policyForUnset

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -6,7 +6,15 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// Policy encapsulates behaviour that varies with the details of a
+// snap installation, like the model assertion or the type of snap
+// involved in an operation. Rather than have a forest of `if`s
+// looking at type, model, etc, we move it to Policy and look it up.
 type Policy interface {
+	// CanRemove verifies that a snap can be removed.
+	//
+	// TODO: CanRemove should also return the reason why the snap cannot
+	//       be removed to the user
 	CanRemove(st *state.State, snapst *SnapState, allRevisions bool) bool
 }
 

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type basePolicy struct{}
+
+func (basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, all bool) bool {
+	name := snapst.InstanceName()
+	if name == "" {
+		panic("name unset")
+		// not installed, or something. What are you even trying to do.
+		return false
+	}
+
+	if boot.InUse(name, snapst.Current) {
+		return false
+	}
+
+	if !all {
+		return true
+	}
+
+	if snapst.Required {
+		return false
+	}
+
+	// here we use that bases can't be instantiated (InstanceName == SnapName always)
+	return !baseInUse(st, name)
+}
+
+func baseInUse(st *state.State, baseName string) bool {
+	snapStates, err := snapstate.All(st)
+	if err != nil {
+		return false
+	}
+	for name, snapst := range snapStates {
+		for _, si := range snapst.Sequence {
+			if snapInfo, err := snap.ReadInfo(name, si); err == nil {
+				if snapInfo.GetType() != snap.TypeApp {
+					continue
+				}
+				if snapInfo.Base == baseName {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -94,9 +94,9 @@ func baseUsedBy(st *state.State, baseName string) ([]string, error) {
 				if baseName != snapInfo.Base && !(alsoCore16 && snapInfo.Base == "core16") {
 					continue
 				}
+				usedBy = append(usedBy, snapInfo.InstanceName())
+				break
 			}
-			usedBy = append(usedBy, snapInfo.InstanceName())
-			break
 		}
 	}
 	return usedBy, nil

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -101,7 +101,7 @@ func baseUsedBy(st *state.State, baseName string) ([]string, error) {
 				if typ := snapInfo.GetType(); typ != snap.TypeApp && typ != snap.TypeGadget {
 					continue
 				}
-				if baseName != snapInfo.Base && !(alsoCore16 && snapInfo.Base == "core16") {
+				if !(baseName == snapInfo.Base || (alsoCore16 && snapInfo.Base == "core16")) {
 					continue
 				}
 				usedBy = append(usedBy, snapInfo.InstanceName())

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -20,6 +20,8 @@
 package policy
 
 import (
+	"sort"
+
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -99,5 +101,6 @@ func baseUsedBy(st *state.State, baseName string) ([]string, error) {
 			}
 		}
 	}
+	sort.Strings(usedBy)
 	return usedBy, nil
 }

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -31,7 +31,6 @@ type basePolicy struct{}
 func (basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, all bool) bool {
 	name := snapst.InstanceName()
 	if name == "" {
-		panic("name unset")
 		// not installed, or something. What are you even trying to do.
 		return false
 	}

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -1,0 +1,219 @@
+package policy_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/policy"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type canRemoveSuite struct {
+	testutil.BaseTest
+	st *state.State
+
+	bootloader *bootloadertest.MockBootloader
+}
+
+var _ = check.Suite(&canRemoveSuite{})
+
+func (s *canRemoveSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.st = state.New(nil)
+
+	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(s.bootloader)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *canRemoveSuite) TearDownTest(c *check.C) {
+	dirs.SetRootDir("/")
+	bootloader.Force(nil)
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *canRemoveSuite) TestAppAreOK(c *check.C) {
+	snapst := &snapstate.SnapState{}
+	c.Check(policy.NewAppPolicy().CanRemove(s.st, snapst, false), check.Equals, true)
+	c.Check(policy.NewAppPolicy().CanRemove(s.st, snapst, true), check.Equals, true)
+}
+
+func (s *canRemoveSuite) TestRequiredAppIsNotOK(c *check.C) {
+	snapst := &snapstate.SnapState{Flags: snapstate.Flags{Required: true}}
+	c.Check(policy.NewAppPolicy().CanRemove(s.st, snapst, true), check.Equals, false)
+	c.Check(policy.NewAppPolicy().CanRemove(s.st, snapst, false), check.Equals, true)
+}
+
+func (s *canRemoveSuite) TestOneGadgetRevisionIsOK(c *check.C) {
+	snapst := &snapstate.SnapState{}
+	c.Check(policy.NewGadgetPolicy().CanRemove(s.st, snapst, false), check.Equals, true)
+}
+
+func (s *canRemoveSuite) TestLastGadgetsAreNotOK(c *check.C) {
+	snapst := &snapstate.SnapState{}
+	c.Check(policy.NewGadgetPolicy().CanRemove(s.st, snapst, true), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}},
+	}
+	// model base is "" -> OS can't be removed
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, true), check.Equals, false)
+	// model kernel == snap kernel -> can't be removed
+	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, true), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}},
+	}
+
+	s.bootloader.SetBootKernel("kernel_1.snap")
+
+	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, false), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestOstInUseIsKept(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core18"}},
+	}
+	s.bootloader.SetBootBase("core18_1.snap")
+
+	c.Check(policy.NewBasePolicy().CanRemove(s.st, snapst, false), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestRemoveNonModelKernelIsOk(c *check.C) {
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-non-model-kernel"}},
+	}
+
+	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, true), check.Equals, true)
+}
+
+func (s *canRemoveSuite) TestRemoveNonModelKernelStillInUseNotOk(c *check.C) {
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-non-model-kernel"}},
+	}
+	s.bootloader.SetBootKernel("other-non-model-kernel_1.snap")
+
+	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, true), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestLastOSWithModelBaseIsOk(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+	}
+
+	c.Check(policy.NewOSPolicy("core18").CanRemove(s.st, snapst, true), check.Equals, true)
+}
+
+func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUse(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// pretend we have a snap installed that has no base (which means
+	// it needs core)
+	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0", si)
+	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si},
+		Current:  snap.R(1),
+	})
+
+	// now pretend we want to remove the core snap
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+	}
+	c.Check(policy.NewOSPolicy("core18").CanRemove(s.st, snapst, true), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestBaseUnused(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}},
+	}
+
+	c.Check(policy.NewBasePolicy().CanRemove(s.st, snapst, false), check.Equals, true)
+	c.Check(policy.NewBasePolicy().CanRemove(s.st, snapst, true), check.Equals, true)
+}
+
+func (s *canRemoveSuite) TestBaseInUse(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// pretend we have a snap installed that uses "some-base"
+	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\nbase: some-base", si)
+	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si},
+		Current:  snap.R(1),
+	})
+
+	// pretend now we want to remove "some-base"
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}},
+	}
+	c.Check(policy.NewBasePolicy().CanRemove(s.st, snapst, true), check.Equals, false)
+}
+
+func (s *canRemoveSuite) TestBaseInUseOtherRevision(c *check.C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// pretend we have a snap installed that uses "some-base"
+	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	si2 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}
+	// older revision uses base
+	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\nbase: some-base", si)
+	// new one does not
+	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\n", si2)
+	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si, si2},
+		Current:  snap.R(2),
+	})
+
+	// pretend now we want to remove "some-base"
+	snapst := &snapstate.SnapState{
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}},
+	}
+	// revision 1 requires some-base
+	c.Check(policy.NewBasePolicy().CanRemove(s.st, snapst, true), check.Equals, false)
+
+	// now pretend we want to remove the core snap
+	snapst.Sequence[0].RealName = "core"
+	// but revision 2 requires core
+	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, true), check.Equals, false)
+}

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -21,6 +21,7 @@ package policy
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -40,7 +41,9 @@ func (e inUseByErr) Error() string {
 		return "snap is being used"
 	case 1:
 		return "snap is being used by snap " + e[0] + "."
-	default:
+	case 2, 3, 4, 5:
 		return "snap is being used by snaps " + strings.Join(e[:len(e)-1], ", ") + " and " + e[len(e)-1] + "."
+	default:
+		return "snap is being used by snaps " + strings.Join(e[:5], ", ") + " and " + strconv.Itoa(len(e)-5) + " more."
 	}
 }

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -39,8 +39,8 @@ func (e inUseByErr) Error() string {
 		// how
 		return "snap is being used"
 	case 1:
-		return "snap is being used by snap " + e[0]
+		return "snap is being used by snap " + e[0] + "."
 	default:
-		return "snap is being used by snaps " + strings.Join(e[:len(e)-1], ", ") + " and " + e[len(e)-1]
+		return "snap is being used by snaps " + strings.Join(e[:len(e)-1], ", ") + " and " + e[len(e)-1] + "."
 	}
 }

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -3,5 +3,5 @@ package policy
 func NewAppPolicy() appPolicy                { return appPolicy{} }
 func NewBasePolicy() basePolicy              { return basePolicy{} }
 func NewGadgetPolicy() gadgetPolicy          { return gadgetPolicy{} }
-func NewKernelPolicy(m string) *kernelPolicy { return &kernelPolicy{modelName: m} }
-func NewOSPolicy(m string) *osPolicy         { return &osPolicy{modelName: m} }
+func NewKernelPolicy(m string) *kernelPolicy { return &kernelPolicy{modelKernel: m} }
+func NewOSPolicy(m string) *osPolicy         { return &osPolicy{modelBase: m} }

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -1,0 +1,7 @@
+package policy
+
+func NewAppPolicy() appPolicy                { return appPolicy{} }
+func NewBasePolicy() basePolicy              { return basePolicy{} }
+func NewGadgetPolicy() gadgetPolicy          { return gadgetPolicy{} }
+func NewKernelPolicy(m string) *kernelPolicy { return &kernelPolicy{modelName: m} }
+func NewOSPolicy(m string) *osPolicy         { return &osPolicy{modelName: m} }

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -1,7 +1,18 @@
 package policy
 
 func NewAppPolicy() appPolicy                { return appPolicy{} }
-func NewBasePolicy() basePolicy              { return basePolicy{} }
-func NewGadgetPolicy() gadgetPolicy          { return gadgetPolicy{} }
+func NewBasePolicy(m string) *basePolicy     { return &basePolicy{modelBase: m} }
+func NewGadgetPolicy(m string) *gadgetPolicy { return &gadgetPolicy{modelGadget: m} }
 func NewKernelPolicy(m string) *kernelPolicy { return &kernelPolicy{modelKernel: m} }
 func NewOSPolicy(m string) *osPolicy         { return &osPolicy{modelBase: m} }
+
+var (
+	ErrNoName       = errNoName
+	ErrInUseForBoot = errInUseForBoot
+	ErrRequired     = errRequired
+	ErrIsModel      = errIsModel
+)
+
+func InUseByErr(snaps ...string) error {
+	return inUseByErr(snaps)
+}

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -36,13 +36,13 @@ func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, r
 		return errNoName
 	}
 
+	if p.modelGadget != name {
+		return nil
+	}
+
 	if !rev.Unset() {
 		return nil
 	}
 
-	if p.modelGadget == name {
-		return errIsModel
-	}
-
-	return nil
+	return errIsModel
 }

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+import (
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type gadgetPolicy struct{}
+
+func (gadgetPolicy) CanRemove(_ *state.State, _ *snapstate.SnapState, all bool) bool {
+	return !all
+}

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type kernelPolicy struct {
+	modelName string
+}
+
+func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, all bool) bool {
+	name := snapst.InstanceName()
+	if name == "" {
+		panic("name unset")
+		// not installed, or something. What are you even trying to do.
+		return false
+	}
+
+	if boot.InUse(name, snapst.Current) {
+		return false
+	}
+
+	if !all {
+		return true
+	}
+
+	return p.modelName != name
+}

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -37,14 +37,16 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, re
 		return errNoName
 	}
 
-	if !rev.Unset() {
-		if boot.InUse(name, rev) {
-			return errInUseForBoot
-		}
-		return nil
-	}
-
 	if p.modelKernel == name {
+		if !rev.Unset() {
+			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
+			// it unconditionally as an extra precaution
+			if boot.InUse(name, rev) {
+				return errInUseForBoot
+			}
+			return nil
+		}
+
 		return errIsModel
 	}
 

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -26,7 +26,7 @@ import (
 )
 
 type kernelPolicy struct {
-	modelName string
+	modelKernel string
 }
 
 func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, all bool) bool {
@@ -44,5 +44,5 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, al
 		return true
 	}
 
-	return p.modelName != name
+	return p.modelKernel != name
 }

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -32,7 +32,6 @@ type kernelPolicy struct {
 func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, all bool) bool {
 	name := snapst.InstanceName()
 	if name == "" {
-		panic("name unset")
 		// not installed, or something. What are you even trying to do.
 		return false
 	}

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -33,7 +33,6 @@ type osPolicy struct {
 func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, all bool) bool {
 	name := snapst.InstanceName()
 	if name == "" {
-		panic("name unset")
 		// not installed, or something. What are you even trying to do.
 		return false
 	}

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type osPolicy struct {
+	modelName string
+}
+
+func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, all bool) bool {
+	name := snapst.InstanceName()
+	if name == "" {
+		panic("name unset")
+		// not installed, or something. What are you even trying to do.
+		return false
+	}
+
+	if boot.InUse(name, snapst.Current) {
+		return false
+	}
+
+	if !all {
+		return true
+	}
+
+	if snapst.Required {
+		return false
+	}
+
+	if name == "ubuntu-core" {
+		return true
+	}
+
+	return p.modelName != "" && !coreInUse(st)
+}
+
+func coreInUse(st *state.State) bool {
+	snapStates, err := snapstate.All(st)
+	if err != nil {
+		return err != state.ErrNoState
+	}
+	for name, snapst := range snapStates {
+		for _, si := range snapst.Sequence {
+			if snapInfo, err := snap.ReadInfo(name, si); err == nil {
+				if snapInfo.GetType() != snap.TypeApp || snapInfo.GetType() == snap.TypeSnapd {
+					continue
+				}
+				if snapInfo.Base == "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -37,19 +37,24 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return errNoName
 	}
 
-	if !rev.Unset() {
-		if boot.InUse(name, rev) {
-			return errInUseForBoot
-		}
-		return nil
-	}
-
 	if name == "ubuntu-core" {
 		return nil
 	}
 
 	if p.modelBase == "" {
+		if !rev.Unset() {
+			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
+			// it unconditionally as an extra precaution
+			if boot.InUse(name, rev) {
+				return errInUseForBoot
+			}
+			return nil
+		}
 		return errIsModel
+	}
+
+	if !rev.Unset() {
+		return nil
 	}
 
 	// a core18 system could have core required in the model due to dependencies for ex

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -34,11 +34,11 @@ func init() {
 func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 	switch typ {
 	case snap.TypeKernel:
-		return &kernelPolicy{modelName: model.Kernel()}
+		return &kernelPolicy{modelKernel: model.Kernel()}
 	case snap.TypeGadget:
 		return gadgetPolicy{}
 	case snap.TypeOS:
-		return &osPolicy{modelName: model.Base()}
+		return &osPolicy{modelBase: model.Base()}
 	case snap.TypeBase:
 		return basePolicy{}
 	default:

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package policy implements fine grained decision-making for snapstate
+package policy
+
+import (
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+func init() {
+	snapstate.PolicyFor = For
+}
+
+func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
+	switch typ {
+	case snap.TypeKernel:
+		return &kernelPolicy{modelName: model.Kernel()}
+	case snap.TypeGadget:
+		return gadgetPolicy{}
+	case snap.TypeOS:
+		return &osPolicy{modelName: model.Base()}
+	case snap.TypeBase:
+		return basePolicy{}
+	default:
+		return appPolicy{}
+	}
+}
+
+type appPolicy struct{}
+
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, all bool) bool {
+	if !all {
+		return true
+	}
+
+	return !snapst.Required
+}

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -36,11 +36,11 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 	case snap.TypeKernel:
 		return &kernelPolicy{modelKernel: model.Kernel()}
 	case snap.TypeGadget:
-		return gadgetPolicy{}
+		return &gadgetPolicy{modelGadget: model.Gadget()}
 	case snap.TypeOS:
 		return &osPolicy{modelBase: model.Base()}
 	case snap.TypeBase:
-		return basePolicy{}
+		return &basePolicy{modelBase: model.Base()}
 	default:
 		return appPolicy{}
 	}
@@ -48,10 +48,14 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 
 type appPolicy struct{}
 
-func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, all bool) bool {
-	if !all {
-		return true
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+	if !rev.Unset() {
+		return nil
 	}
 
-	return !snapst.Required
+	if snapst.Required {
+		return errRequired
+	}
+
+	return nil
 }

--- a/overlord/snapstate/policy/policy_test.go
+++ b/overlord/snapstate/policy/policy_test.go
@@ -1,0 +1,31 @@
+package policy_test
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/policy"
+	"github.com/snapcore/snapd/snap"
+)
+
+// tie testing into check (only needed once per package)
+func TestSnapManager(t *testing.T) { check.TestingT(t) }
+
+type policySuite struct{}
+
+var _ = check.Suite(&policySuite{})
+
+func (s *policySuite) TestFor(c *check.C) {
+	for typ, pol := range map[snap.Type]snapstate.Policy{
+		snap.TypeApp:    policy.NewAppPolicy(),
+		snap.TypeBase:   policy.NewBasePolicy(),
+		snap.TypeGadget: policy.NewGadgetPolicy(),
+		snap.TypeKernel: policy.NewKernelPolicy(""),
+		snap.TypeOS:     policy.NewOSPolicy(""),
+	} {
+		c.Check(policy.For(typ, &asserts.Model{}), check.FitsTypeOf, pol)
+	}
+}

--- a/overlord/snapstate/policy/policy_test.go
+++ b/overlord/snapstate/policy/policy_test.go
@@ -21,8 +21,8 @@ var _ = check.Suite(&policySuite{})
 func (s *policySuite) TestFor(c *check.C) {
 	for typ, pol := range map[snap.Type]snapstate.Policy{
 		snap.TypeApp:    policy.NewAppPolicy(),
-		snap.TypeBase:   policy.NewBasePolicy(),
-		snap.TypeGadget: policy.NewGadgetPolicy(),
+		snap.TypeBase:   policy.NewBasePolicy(""),
+		snap.TypeGadget: policy.NewGadgetPolicy(""),
 		snap.TypeKernel: policy.NewKernelPolicy(""),
 		snap.TypeOS:     policy.NewOSPolicy(""),
 	} {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -303,6 +303,14 @@ func (snapst *SnapState) CurrentInfo() (*snap.Info, error) {
 	return readInfo(name, cur, withAuxStoreInfo)
 }
 
+func (snapst *SnapState) InstanceName() string {
+	cur := snapst.CurrentSideInfo()
+	if cur == nil {
+		return ""
+	}
+	return snap.InstanceName(cur.RealName, snapst.InstanceKey)
+}
+
 func revisionInSequence(snapst *SnapState, needle snap.Revision) bool {
 	for _, si := range snapst.Sequence {
 		if si.Revision == needle {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1671,121 +1671,12 @@ func canDisable(si *snap.Info) bool {
 	return true
 }
 
-// baseInUse returns true if the given base is needed by another snap
-func baseInUse(st *state.State, base *snap.Info) bool {
-	snapStates, err := All(st)
-	if err != nil {
-		return false
-	}
-	for name, snapst := range snapStates {
-		for _, si := range snapst.Sequence {
-			if snapInfo, err := snap.ReadInfo(name, si); err == nil {
-				if snapInfo.GetType() != snap.TypeApp {
-					continue
-				}
-				if snapInfo.Base == base.SnapName() {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-// coreInUse returns true if any snap uses "core" (i.e. does not
-// declare a base
-func coreInUse(st *state.State) bool {
-	snapStates, err := All(st)
-	if err != nil {
-		return false
-	}
-	for name, snapst := range snapStates {
-		for _, si := range snapst.Sequence {
-			if snapInfo, err := snap.ReadInfo(name, si); err == nil {
-				if snapInfo.GetType() != snap.TypeApp || snapInfo.GetType() == snap.TypeSnapd {
-					continue
-				}
-				if snapInfo.Base == "" {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
 // canRemove verifies that a snap can be removed.
 //
 // TODO: canRemove should also return the reason why the snap cannot
 //       be removed to the user
 func canRemove(st *state.State, si *snap.Info, snapst *SnapState, removeAll bool, deviceCtx DeviceContext) bool {
-	// never remove anything that is used for booting
-	if boot.InUse(si.InstanceName(), si.Revision) {
-		return false
-	}
-
-	// removing single revisions is generally allowed
-	if !removeAll {
-		return true
-	}
-
-	// required snaps cannot be removed
-	if snapst.Required {
-		return false
-	}
-
-	// TODO: use Required for these too
-
-	// Gadget snaps should not be removed as they are a key
-	// building block for Gadgets. Do not remove their last
-	// revision left.
-	if si.GetType() == snap.TypeGadget {
-		return false
-	}
-
-	// Allow "ubuntu-core" removals here because we might have two
-	// core snaps installed (ubuntu-core and core). Note that
-	// ideally we would only allow the removal of "ubuntu-core" if
-	// we know that "core" is installed too and if we are part of
-	// the "ubuntu-core->core" transition. But this transition
-	// starts automatically on startup so the window of a user
-	// triggering this manually is very small.
-	//
-	// Once the ubuntu-core -> core transition has landed for some
-	// time we can remove the two lines below.
-	if si.InstanceName() == "ubuntu-core" && si.GetType() == snap.TypeOS {
-		return true
-	}
-
-	// do not allow removal of bases that are in use
-	if si.GetType() == snap.TypeBase && baseInUse(st, si) {
-		return false
-	}
-
-	// Allow snap.TypeOS removals if a different base is in use
-	//
-	// Note that removal of the boot base itself is prevented
-	// via the snapst.Required flag that is set on firstboot.
-	model := deviceCtx.Model()
-	if si.GetType() == snap.TypeOS {
-		if model.Base() != "" && !coreInUse(st) {
-			return true
-		}
-		return false
-	}
-
-	// Because of a Remodel() we may have multiple kernels. Allow
-	// removals of kernel(s) that are not model kernels (anymore).
-	if si.GetType() == snap.TypeKernel {
-		if model.Kernel() != si.InstanceName() {
-			return true
-		}
-		return false
-	}
-
-	// TODO: on classic likely let remove core even if active if it's only snap left.
-
-	return true
+	return PolicyFor(si.GetType(), deviceCtx.Model()).CanRemove(st, snapst, removeAll)
 }
 
 // RemoveFlags are used to pass additional flags to the Remove operation.

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -37,8 +37,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
@@ -7832,44 +7830,44 @@ func (s *snapmgrTestSuite) TestRemoveMissingRevisionRefused(c *C) {
 
 func (s *snapmgrTestSuite) TestRemoveRefused(c *C) {
 	si := snap.SideInfo{
-		RealName: "gadget",
+		RealName: "brand-gadget",
 		Revision: snap.R(7),
 	}
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.Set(s.state, "gadget", &snapstate.SnapState{
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
-		SnapType: "app",
+		SnapType: "gadget",
 	})
 
-	_, err := snapstate.Remove(s.state, "gadget", snap.R(0), nil)
+	_, err := snapstate.Remove(s.state, "brand-gadget", snap.R(0), nil)
 
-	c.Check(err, ErrorMatches, `snap "gadget" is not removable`)
+	c.Check(err, ErrorMatches, `snap "brand-gadget" is not removable: snap is used by the model`)
 }
 
 func (s *snapmgrTestSuite) TestRemoveRefusedLastRevision(c *C) {
 	si := snap.SideInfo{
-		RealName: "gadget",
+		RealName: "brand-gadget",
 		Revision: snap.R(7),
 	}
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.Set(s.state, "gadget", &snapstate.SnapState{
+	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:   false,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
-		SnapType: "app",
+		SnapType: "gadget",
 	})
 
-	_, err := snapstate.Remove(s.state, "gadget", snap.R(7), nil)
+	_, err := snapstate.Remove(s.state, "brand-gadget", snap.R(7), nil)
 
-	c.Check(err, ErrorMatches, `snap "gadget" is not removable`)
+	c.Check(err, ErrorMatches, `snap "brand-gadget" is not removable: snap is used by the model`)
 }
 
 func (s *snapmgrTestSuite) TestRemoveDeletesConfigOnLastRevision(c *C) {
@@ -10967,312 +10965,6 @@ func (snapStateSuite) TestDefaultContentPlugProviders(c *C) {
 	providers := snapstate.DefaultContentPlugProviders(st, info)
 	sort.Strings(providers)
 	c.Check(providers, DeepEquals, []string{"common-themes", "some-snap"})
-}
-
-type canRemoveSuite struct {
-	st        *state.State
-	deviceCtx snapstate.DeviceContext
-
-	bootloader *bootloadertest.MockBootloader
-}
-
-var _ = Suite(&canRemoveSuite{})
-
-func (s *canRemoveSuite) SetUpTest(c *C) {
-	dirs.SetRootDir(c.MkDir())
-	s.st = state.New(nil)
-	s.deviceCtx = &snapstatetest.TrivialDeviceContext{DeviceModel: DefaultModel()}
-
-	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
-	bootloader.Force(s.bootloader)
-}
-
-func (s *canRemoveSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("/")
-	bootloader.Force(nil)
-}
-
-func (s *canRemoveSuite) TestAppAreAlwaysOKToRemove(c *C) {
-	info := &snap.Info{
-		SnapType: snap.TypeApp,
-	}
-	info.RealName = "foo"
-
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: true}, false, s.deviceCtx), Equals, true)
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: true}, true, s.deviceCtx), Equals, true)
-}
-
-func (s *canRemoveSuite) TestLastGadgetsAreNotOK(c *C) {
-	info := &snap.Info{
-		SnapType: snap.TypeGadget,
-	}
-	info.RealName = "foo"
-
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{}, true, s.deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *C) {
-	os := &snap.Info{
-		SnapType: snap.TypeOS,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "os",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  os.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&os.SideInfo},
-	}
-
-	c.Check(snapstate.CanRemove(s.st, os, snapst, true, s.deviceCtx), Equals, false)
-
-	kernel := &snap.Info{
-		SnapType: snap.TypeKernel,
-		SideInfo: snap.SideInfo{
-			RealName: "kernel",
-			Revision: snap.R(1),
-		},
-	}
-	// this kernel part of the model
-	snapst.Sequence[0] = &kernel.SideInfo
-
-	c.Check(snapstate.CanRemove(s.st, kernel, snapst, true, s.deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *C) {
-	kernel := &snap.Info{
-		SnapType: snap.TypeKernel,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(3),
-			RealName: "kernel",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  kernel.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&kernel.SideInfo},
-	}
-
-	s.bootloader.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
-
-	removeAll := false
-	c.Check(snapstate.CanRemove(s.st, kernel, snapst, removeAll, s.deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestOstInUseIsKept(c *C) {
-	base := &snap.Info{
-		SnapType: snap.TypeBase,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(3),
-			RealName: "core18",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  base.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&base.SideInfo},
-	}
-
-	s.bootloader.SetBootBase(fmt.Sprintf("%s_%s.snap", base.RealName, base.SideInfo.Revision))
-
-	removeAll := false
-	c.Check(snapstate.CanRemove(s.st, base, snapst, removeAll, s.deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestRemoveNonModelKernelIsOk(c *C) {
-	kernel := &snap.Info{
-		SnapType: snap.TypeKernel,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "other-non-model-kernel",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  kernel.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&kernel.SideInfo},
-	}
-
-	c.Check(snapstate.CanRemove(s.st, kernel, snapst, true, s.deviceCtx), Equals, true)
-}
-
-func (s *canRemoveSuite) TestRemoveNonModelKernelStillInUseNotOk(c *C) {
-	kernel := &snap.Info{
-		SnapType: snap.TypeKernel,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(2),
-			RealName: "other-non-model-kernel",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  kernel.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&kernel.SideInfo},
-	}
-
-	s.bootloader.SetBootKernel(fmt.Sprintf("%s_%s.snap", kernel.RealName, kernel.SideInfo.Revision))
-
-	c.Check(snapstate.CanRemove(s.st, kernel, snapst, true, s.deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestLastOSWithModelBaseIsOk(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: ModelWithBase("core18")}
-	os := &snap.Info{
-		SnapType: snap.TypeOS,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "os",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  os.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&os.SideInfo},
-	}
-
-	c.Check(snapstate.CanRemove(s.st, os, snapst, true, deviceCtx), Equals, true)
-}
-
-func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUse(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: ModelWithBase("core18")}
-
-	// pretend we have a snap installed that has no base (which means
-	// it needs core)
-	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0", si)
-	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{si},
-		Current:  snap.R(1),
-	})
-
-	// now pretend we want to remove the core snap
-	os := &snap.Info{
-		SnapType: snap.TypeOS,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "core",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  os.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&os.SideInfo},
-	}
-	c.Check(snapstate.CanRemove(s.st, os, snapst, true, deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestOneRevisionIsOK(c *C) {
-	info := &snap.Info{
-		SnapType: snap.TypeGadget,
-	}
-	info.RealName = "foo"
-
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: true}, false, s.deviceCtx), Equals, true)
-}
-
-func (s *canRemoveSuite) TestRequiredIsNotOK(c *C) {
-	info := &snap.Info{
-		SnapType: snap.TypeApp,
-	}
-	info.RealName = "foo"
-
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: false, Flags: snapstate.Flags{Required: true}}, true, s.deviceCtx), Equals, false)
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: true, Flags: snapstate.Flags{Required: true}}, true, s.deviceCtx), Equals, false)
-	c.Check(snapstate.CanRemove(s.st, info, &snapstate.SnapState{Active: true, Flags: snapstate.Flags{Required: true}}, false, s.deviceCtx), Equals, true)
-}
-
-func (s *canRemoveSuite) TestBaseUnused(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	info := &snap.Info{
-		SnapType: snap.TypeBase,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "some-base",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  info.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&info.SideInfo},
-	}
-
-	c.Check(snapstate.CanRemove(s.st, info, snapst, false, s.deviceCtx), Equals, true)
-	c.Check(snapstate.CanRemove(s.st, info, snapst, true, s.deviceCtx), Equals, true)
-}
-
-func (s *canRemoveSuite) TestBaseInUse(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	// pretend we have a snap installed that uses "some-base"
-	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\nbase: some-base", si)
-	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{si},
-		Current:  snap.R(1),
-	})
-
-	// pretend now we want to remove "some-base"
-	info := &snap.Info{
-		SnapType: snap.TypeBase,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "some-base",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  info.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&info.SideInfo},
-	}
-	c.Check(snapstate.CanRemove(s.st, info, snapst, true, s.deviceCtx), Equals, false)
-}
-
-func (s *canRemoveSuite) TestBaseInUseOtherRevision(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	// pretend we have a snap installed that uses "some-base"
-	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	si2 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}
-	// older revision uses base
-	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\nbase: some-base", si)
-	// new one does not
-	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\n", si2)
-	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{si, si2},
-		Current:  snap.R(2),
-	})
-
-	// pretend now we want to remove "some-base"
-	info := &snap.Info{
-		SnapType: snap.TypeBase,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "some-base",
-		},
-	}
-	snapst := &snapstate.SnapState{
-		Current:  info.SideInfo.Revision,
-		Sequence: []*snap.SideInfo{&info.SideInfo},
-	}
-	// revision 1 requires some-base
-	c.Check(snapstate.CanRemove(s.st, info, snapst, true, s.deviceCtx), Equals, false)
-
-	// now pretend we want to remove the core snap
-	os := &snap.Info{
-		SnapType: snap.TypeOS,
-		SideInfo: snap.SideInfo{
-			Revision: snap.R(1),
-			RealName: "core",
-		},
-	}
-	snapst.Sequence[0] = &os.SideInfo
-	// but revision 2 requires core
-	c.Check(snapstate.CanRemove(s.st, os, snapst, true, s.deviceCtx), Equals, false)
 }
 
 func revs(seq []*snap.SideInfo) []int {


### PR DESCRIPTION
This is the first step towards having a fully fledged snapstate/policy
package where logic around type and model decisions can be placed.

For now it's connected in a rather hackish way (which we're already
using elsewhere) although the expectation is that this could change
with some major refactoring of snapstate itself.

This first bit of work moves canRemove.

The tests are a little messed up, because they are straight
translations of the existing ones which were similarly confused. I'd
like to reorganise them so they make more sense though.

In refactoring this we caught several now-obvious bugs.  Also thanks
to this it was very easy to change the API to return the *reason* you
couldn't remove something, so I did; it's not made things grow too
big. So now you get e.g.

    ~$ snap remove core18
    error: cannot remove "core18": snap "core18" is not removable: snap
           is being used by snaps black, bombsquad, cool-retro-term,
           gtk-common-themes, icdiff, shellcheck and word-salad.
