### PR TITLE
overlord/configstate: special-case "null" in transaction Changes()

### DIFF
--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -77,8 +77,13 @@ func changes(cfgStr string, cfg map[string]interface{}) []string {
 			// check if we need to dive into a sub-config
 			var configm map[string]interface{}
 			if err := jsonutil.DecodeWithNumber(bytes.NewReader(*subCfg), &configm); err == nil {
-				out = append(out, changes(cfgStr+"."+k, configm)...)
-				continue
+				// curiously, json decoder decodes json.RawMessage("null") into a nil map, so no change is
+				// reported when we recurse into it. This happens when unsetting a key and the underlying
+				// config path doesn't exist.
+				if len(configm) > 0 {
+					out = append(out, changes(cfgStr+"."+k, configm)...)
+					continue
+				}
 			}
 			out = append(out, []string{cfgStr + "." + k}...)
 		default:

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -117,6 +117,7 @@ var setGetTests = [][]setGetOp{{
 	`set doc={"one":1,"two":2}`,
 	`commit`,
 	`set doc.one=null`,
+	`changes core.doc.one`,
 	`get doc={"two":2}`,
 	`getunder doc={"one":1,"two":2}`,
 	`commit`,
@@ -127,6 +128,7 @@ var setGetTests = [][]setGetOp{{
 	// Nulls via dotted path, resuling in empty map
 	`set doc={"one":{"three":3},"two":2}`,
 	`set doc.one.three=null`,
+	`changes core.doc.one.three core.doc.two`,
 	`get doc={"one":{},"two":2}`,
 	`commit`,
 	`get doc={"one":{},"two":2}`,
@@ -137,6 +139,7 @@ var setGetTests = [][]setGetOp{{
 	`set doc.three={"four":4}`,
 	`get doc={"one":1,"two":2,"three":{"four":4}}`,
 	`set doc.three={"four":null}`,
+	`changes core.doc.one core.doc.three.four core.doc.two`,
 	`get doc={"one":1,"two":2,"three":{}}`,
 	`commit`,
 	`get doc={"one":1,"two":2,"three":{}}`,
@@ -155,6 +158,7 @@ var setGetTests = [][]setGetOp{{
 	// Nulls with mutating
 	`set doc={"one":{"two":2}}`,
 	`set doc.one.two=null`,
+	`changes core.doc.one.two`,
 	`set doc.one="foo"`,
 	`get doc.one="foo"`,
 	`commit`,
@@ -178,18 +182,34 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
 	`getrootunder ={"doc":{"one":{"two":2,"three":{"four":{}}}}}`, // nils are not committed to state
 }, {
-	// Nulls, empty doc dropped
+	// Null leading to empty doc
 	`set doc={"one":1}`,
 	`set doc.one=null`,
+	`changes core.doc.one`,
 	`commit`,
 	`get doc={}`,
 }, {
 	// Nulls leading to no snap configuration
 	`set doc="foo"`,
 	`set doc=null`,
+	`changes core.doc`,
 	`commit`,
 	`get doc=-`,
 	`getroot => snap "core" has no configuration`,
+}, {
+	// set null over non-exising path
+	`set x.y.z=null`,
+	`changes core.x.y.z`,
+	`commit`,
+	`get x.y.z=-`,
+}, {
+	// set null over non-exising path with initial config
+	`set foo=bar`,
+	`commit`,
+	`set x=null`,
+	`changes core.x`,
+	`commit`,
+	`get x=-`,
 }, {
 	// Root doc
 	`set doc={"one":1,"two":2}`,

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -198,13 +198,13 @@ var setGetTests = [][]setGetOp{{
 	`get doc=-`,
 	`getroot => snap "core" has no configuration`,
 }, {
-	// set null over non-exising path
+	// set null over non-existing path
 	`set x.y.z=null`,
 	`changes core.x.y.z`,
 	`commit`,
 	`get x.y.z=-`,
 }, {
-	// set null over non-exising path with initial config
+	// set null over non-existing path with initial config
 	`set foo=bar`,
 	`commit`,
 	`set x=null`,

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -165,7 +165,7 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":"foo"}`,
 	`getunder doc={"one":"foo"}`, // nils are not committed to state
 }, {
-	// Nulls, intermediate temporary maps get dropped
+	// Nulls, intermediate temporary maps
 	`set doc={"one":{"two":2}}`,
 	`commit`,
 	`set doc.one.three.four.five=null`,
@@ -174,9 +174,10 @@ var setGetTests = [][]setGetOp{{
 	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
 	`getrootunder ={"doc":{"one":{"two":2,"three":{"four":{}}}}}`, // nils are not committed to state
 }, {
-	// Nulls, same transaction, intermediate non-existing maps get dropped
+	// Nulls, same transaction
 	`set doc={"one":{"two":2}}`,
 	`set doc.one.three.four.five=null`,
+	`changes core.doc.one.three.four.five core.doc.one.two`,
 	`get doc={"one":{"two":2,"three":{"four":{}}}}`,
 	`commit`,
 	`get doc={"one":{"two":2,"three":{"four":{}}}}`,

--- a/tests/main/snap-set-core-w-no-core/task.yaml
+++ b/tests/main/snap-set-core-w-no-core/task.yaml
@@ -27,3 +27,11 @@ execute: |
         echo "snap set core must error for unknown options"
         exit 1
     fi
+    if snap set core unknown!; then
+        echo "snap set core must error for unknown options"
+        exit 1
+    fi
+    if snap unset core unknown.option; then
+        echo "snap unset core must error for unknown options"
+        exit 1
+    fi


### PR DESCRIPTION
Transaction `Changes()` doesn't report config paths set to null (i.e. unset) if the underlying config path didn't exist. Curiously, if `*json.RawMessage("null")` leaf value is hit, json decoder succesfully unpacks it into `map[string]interface`, which drives us into recursive processing of that nil map (so nothing gets reported via Changes for the affected key).

This was affecting the validation of core config options (see `corecfg.go` - `Run(..)` function and as a result `snap unset core foo` was silently accepted.
