### PR TITLE
tests: debian sid now ships new seccomp, adjust tests

### DIFF
--- a/tests/main/system-usernames-illegal/task.yaml
+++ b/tests/main/system-usernames-illegal/task.yaml
@@ -3,7 +3,7 @@ summary: ensure unapproved user cannot be used with system-usernames
 # List of expected snap install failures due to libseccomp/golang-seccomp being
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these.
-systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-sid-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*]
+systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*]
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -4,7 +4,7 @@ summary: ensure snap can be installed twice (reusing the created groups)
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-sid-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 prepare: |
     snap install --edge test-snapd-daemon-user

--- a/tests/main/system-usernames-missing-user/task.yaml
+++ b/tests/main/system-usernames-missing-user/task.yaml
@@ -4,7 +4,7 @@ summary: ensure snap fails to install if one of user or group doesn't exist
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-sid-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -fedora-29-*, -fedora-30-*, -opensuse-15.0-*, -opensuse-15.1-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 prepare: |
     groupadd --system snap_daemon

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -8,7 +8,7 @@ environment:
     # List of expected snap install failures due to libseccomp/golang-seccomp
     # being too old. This should only reduce with time since new systems should
     # have newer libseccomp and golang-seccomp
-    EXFAIL: "amazon-linux-2-64 centos-7-64 debian-9-64 debian-sid-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 opensuse-15\\.1-64 ubuntu-14"
+    EXFAIL: "amazon-linux-2-64 centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 opensuse-15\\.1-64 ubuntu-14"
 
 prepare: |
     echo "Install helper snaps with default confinement"


### PR DESCRIPTION
The system-usersnames tests currently fails on Debian Sid with the
following message:

    + echo ''\''debian-sid-64'\'' now has support. Please update this test'
    'debian-sid-64' now has support. Please update this test
    + exit 1

The relevant change is in
https://metadata.ftp-master.debian.org/changelogs/main/g/golang-github-seccomp-libseccomp-golang/golang-github-seccomp-libseccomp-golang_0.9.0-2_changelog,
specifically:

    [ Michael Vogt ]
    * debian/patches/06e7a2-fix-multi-args.patch:
    - Cherry pick 06e7a29 to fix incorrect argument filtering when
      using multiple arguments

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
