### PR TITLE
tests/classic-custom-device-reg: disable on opensuse-15 and fedora-30

### DIFF
--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -1,7 +1,8 @@
 summary: |
-   Test gadget customized device initialisation and registration also on classic
+    Test gadget customized device initialisation and registration also on classic
 
-systems: [-ubuntu-core-*]
+# the test is unable to download the core snap on opensuse and fedora 30
+systems: [-ubuntu-core-*, -opensuse-15.1-64, -fedora-30-64]
 
 environment:
     SEED_DIR: /var/lib/snapd/seed


### PR DESCRIPTION
These tests have frequently failed to prepare with the following output:
```
+ snap download --edge core
Fetching snap "core"

<kill-timeout reached>
```

See full output: https://pastebin.ubuntu.com/p/cbPkYj3TS2/