### PR TITLE
interfaces: extend the fwupd slot to be implicit on classic

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -37,7 +37,8 @@ const fwupdBaseDeclarationSlots = `
       slot-snap-type:
         - app
         - core
-    deny-connection: true
+    deny-connection:
+      on-classic: false
     deny-auto-connection: true
 `
 
@@ -250,7 +251,11 @@ func (iface *fwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 }
 
 func (iface *fwupdInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
-	spec.AddSnippet(fwupdPermanentSlotAppArmor)
+	// Only apply slot snippet when running as application snap on
+	// classic, slot side can be system or application
+	if !implicitSystemPermanentSlot(slot) {
+		spec.AddSnippet(fwupdPermanentSlotAppArmor)
+	}
 	return nil
 }
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -231,7 +230,7 @@ func (iface *fwupdInterface) StaticInfo() interfaces.StaticInfo {
 }
 
 func (iface *fwupdInterface) DBusPermanentSlot(spec *dbus.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(fwupdPermanentSlotDBus)
 	}
 	return nil
@@ -240,7 +239,7 @@ func (iface *fwupdInterface) DBusPermanentSlot(spec *dbus.Specification, slot *s
 func (iface *fwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	var new string
-	if release.OnClassic {
+	if implicitSystemConnectedSlot(slot) {
 		new = "unconfined"
 	} else {
 		new = slotAppLabelExpr(slot)
@@ -253,11 +252,10 @@ func (iface *fwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 func (iface *fwupdInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(fwupdPermanentSlotAppArmor)
 	return nil
-
 }
 
 func (iface *fwupdInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	if !release.OnClassic {
+	if !implicitSystemConnectedSlot(slot) {
 		old := "###PLUG_SECURITY_TAGS###"
 		new := plugAppLabelExpr(plug)
 		snippet := strings.Replace(fwupdConnectedSlotAppArmor, old, new, -1)
@@ -272,7 +270,7 @@ func (iface *fwupdInterface) SecCompConnectedPlug(spec *seccomp.Specification, p
 }
 
 func (iface *fwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(fwupdPermanentSlotSecComp)
 	}
 	return nil

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -37,8 +37,7 @@ const fwupdBaseDeclarationSlots = `
       slot-snap-type:
         - app
         - core
-    deny-connection:
-      on-classic: false
+    deny-connection: true
     deny-auto-connection: true
 `
 

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -744,7 +744,6 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	noconnect := map[string]bool{
 		"content":                   true,
 		"docker":                    true,
-		"fwupd":                     true,
 		"location-control":          true,
 		"location-observe":          true,
 		"lxd":                       true,

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -592,7 +592,7 @@ var (
 		"core-support":            {"core"},
 		"dbus":                    {"app"},
 		"docker-support":          {"core"},
-		"fwupd":                   {"app"},
+		"fwupd":                   {"app", "core"},
 		"gpio":                    {"core", "gadget"},
 		"gpio-control":            {"core"},
 		"greengrass-support":      {"core"},

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -744,6 +744,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	noconnect := map[string]bool{
 		"content":                   true,
 		"docker":                    true,
+		"fwupd":                     true,
 		"location-control":          true,
 		"location-observe":          true,
 		"lxd":                       true,

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -603,6 +603,7 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 gccgo-6
                 evolution-data-server
+                fwupd
                 gnome-online-accounts
                 packagekit
                 "
@@ -611,6 +612,7 @@ pkg_dependencies_ubuntu_classic(){
         ubuntu-16.04-64)
             echo "
                 evolution-data-server
+                fwupd
                 gccgo-6
                 gnome-online-accounts
                 kpartx
@@ -626,12 +628,14 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 gccgo-8
                 evolution-data-server
+                fwupd
                 packagekit
                 "
             ;;
         ubuntu-19.04-64|ubuntu-19.10-64)
             echo "
                 evolution-data-server
+                fwupd
                 packagekit
                 "
             ;;
@@ -644,6 +648,7 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                 eatmydata
                 evolution-data-server
+                fwupd
                 net-tools
                 packagekit
                 sbuild
@@ -680,6 +685,7 @@ pkg_dependencies_fedora(){
         evolution-data-server
         expect
         fontconfig
+        fwupd
         git
         golang
         jq
@@ -707,6 +713,7 @@ pkg_dependencies_amazon(){
         dbus-x11
         expect
         fontconfig
+        fwupd
         git
         golang
         grub2-tools
@@ -734,6 +741,7 @@ pkg_dependencies_opensuse(){
         evolution-data-server
         expect
         fontconfig
+        fwupd
         git
         golang-packaging
         jq
@@ -760,6 +768,7 @@ pkg_dependencies_arch(){
     evolution-data-server
     expect
     fontconfig
+    fwupd
     git
     go
     go-tools

--- a/tests/lib/snaps/test-snapd-fwupd/bin/get-version.sh
+++ b/tests/lib/snaps/test-snapd-fwupd/bin/get-version.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+exec dbus-send --print-reply --system \
+     --dest=org.freedesktop.fwupd / \
+     org.freedesktop.DBus.Properties.Get \
+     string:org.freedesktop.fwupd string:DaemonVersion

--- a/tests/lib/snaps/test-snapd-fwupd/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-fwupd/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-fwupd
+version: 1.0
+summary: Basic fwupd interface plug test snap
+description: A based snap to access the fwupd interface
+
+apps:
+    get-version:
+        command: bin/get-version.sh
+        plugs: [fwupd]

--- a/tests/lib/snaps/test-snapd-policy-app-provider-classic/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-provider-classic/meta/snap.yaml
@@ -18,7 +18,6 @@ slots:
     interface: dbus
     bus: system
     name: test.system
-  fwupd: null
   location-control: null
   location-observe: null
   lxd: null

--- a/tests/main/interfaces-fwupd-classic/task.yaml
+++ b/tests/main/interfaces-fwupd-classic/task.yaml
@@ -5,6 +5,9 @@ systems:
     - -ubuntu-core-*
     # Fwupd is not available in the Ubuntu 14.04 archive.
     - -ubuntu-14.04-*
+    # Fwupd errors out with "FuMain: failed to get USB context: failed
+    # to init libusb: Other error [-99]"
+    - -ubuntu-16.04-32
     # Amazon Linux does not appear to have a functional fwupd
     - -amazon-linux-2-*
 

--- a/tests/main/interfaces-fwupd-classic/task.yaml
+++ b/tests/main/interfaces-fwupd-classic/task.yaml
@@ -5,6 +5,8 @@ systems:
     - -ubuntu-core-*
     # Fwupd is not available in the Ubuntu 14.04 archive.
     - -ubuntu-14.04-*
+    # Amazon Linux does not appear to have a functional fwupd
+    - -amazon-linux-2-*
 
 prepare: |
 
@@ -21,5 +23,12 @@ execute: |
     snap connect test-snapd-fwupd:fwupd
     snap connections test-snapd-fwupd | MATCH "fwupd +test-snapd-fwupd:fwupd +:fwupd +manual"
 
+    if [ "$(snap debug confinement)" = strict ] &&
+       ! grep -q AssumeAppArmorLabel /usr/share/dbus-1/system-services/org.freedesktop.fwupd.service; then
+       # We are running with strict confinement, but fwupd's D-Bus
+       # service activation file has not been annotated with
+       # AssumeAppArmorLabel=unconfined
+       systemctl start fwupd.service
+    fi
     echo "With the plug connected, we can talk to fwupd"
     test-snapd-fwupd.get-version | MATCH 'variant +string "[0-9.]+"'

--- a/tests/main/interfaces-fwupd-classic/task.yaml
+++ b/tests/main/interfaces-fwupd-classic/task.yaml
@@ -1,0 +1,25 @@
+summary: Ensure that the fwupd interface grants access to the host fwupd
+
+systems:
+    # The fwupd interface is only implicit on classic distros
+    - -ubuntu-core-*
+    # Fwupd is not available in the Ubuntu 14.04 archive.
+    - -ubuntu-14.04-*
+
+prepare: |
+
+execute: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+
+    echo "Install the test-snapd-fwupd" interface
+    install_local test-snapd-fwupd
+
+    echo "The fwupd plug is disconnected by default"
+    snap connections test-snapd-fwupd | MATCH "fwupd +test-snapd-fwupd:fwupd +- +-"
+    echo "The plug can be connected"
+    snap connect test-snapd-fwupd:fwupd
+    snap connections test-snapd-fwupd | MATCH "fwupd +test-snapd-fwupd:fwupd +:fwupd +manual"
+
+    echo "With the plug connected, we can talk to fwupd"
+    test-snapd-fwupd.get-version | MATCH 'variant +string "[0-9.]+"'


### PR DESCRIPTION
On classic systems, it is common to have the fwupd daemon installed on the host these days.  The fwupd interface is not implicit on classic though, so a fwupd client snap is effectively only installable on Ubuntu Core systems.

The desktop team would like to provide a confined graphical frontend for fwupd (either `gnome-software` or an independent tool), so switching this interface to implicit on classic is important to us.