### PR TITLE
tests/main/many: increase kill-timeout to 5m

### DIFF
--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -1,12 +1,12 @@
 summary: |
-   Test gadget customized device initialisation and registration also on classic
+    Test gadget customized device initialisation and registration also on classic
 
 systems: [-ubuntu-core-*]
 
 environment:
     SEED_DIR: /var/lib/snapd/seed
 
-kill-timeout: 3m
+kill-timeout: 5m
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -10,7 +10,7 @@ environment:
     STORE_ADDR: localhost:11028
     SEED_DIR: /var/lib/snapd/seed
 
-kill-timeout: 3m
+kill-timeout: 5m
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -10,7 +10,7 @@ environment:
     STORE_ADDR: localhost:11028
     SEED_DIR: /var/lib/snapd/seed
 
-kill-timeout: 3m
+kill-timeout: 5m
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/snap-wait/task.yaml
+++ b/tests/main/snap-wait/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that `snap wait` works
 
-kill-timeout: 2m
+kill-timeout: 5m
 
 prepare: |
     # shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
All tests should have a minimum kill-timeout of 5 minutes, otherwise the tests
are subject to random prepare failures, etc. on slow hardware or when the
machine is overloaded or even when the network is really slow.