### PR TITLE
tests/main/interfaces-{calendar,contacts}-service: disable on 19.10

### DIFF
--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -5,7 +5,8 @@ summary: Ensure that the calendar-service interface works
 #
 # FIXME: disable opensuse-tumbleweed until
 # https://github.com/snapcore/snapd/pull/7230 is landed
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*]
+# ubuntu-19.10: test-snapd-eds is incompatible with eds version shipped with the distro
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*]
 
 # fails in the autopkgtest env with:
 # [Wed Aug 15 16:34:12 2018] audit: type=1400

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -3,7 +3,8 @@ summary: Ensure that the contacts-service interface works
 # Only test on classic systems.  Don't test on Ubuntu 14.04, which
 # does not ship a new enough evolution-data-server.
 # amazon: no need to run this on amazon
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*]
+# ubuntu-19.10: test-snapd-eds is incompatible with eds shipped with the distro
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*]
 
 # fails in autopkgtest environment with:
 # [Wed Aug 15 16:08:23 2018] audit: type=1400


### PR DESCRIPTION
The snap used for testing - test-snapd-eds, is built with evolution libraries
that automatically trigger dbus to spawn services with
org.gnome.evolution.dataserver.Calendar7 and
org.gnome.evolution.dataserver.AddressBook9 names (the last number probably
represents some API version).

The tests fail with the following log:
```
+ test-snapd-eds.calendar load test-calendar
error: g-dbus-error-quark[2] Unable to connect to 'test-calendar': The name org.gnome.evolution.dataserver.Calendar7 was not provided by any .service files

+ test-snapd-eds.contacts load test-address-book
error: g-dbus-error-quark[2] Unable to connect to 'test-address-book': The name org.gnome.evolution.dataserver.AddressBook9 was not provided by any .service files
```

The evolution-data-server 3.33.91-3 shipped in Ubuntu 19.10 comes with dbus
service files for names org.gnome.evolution.dataserver.AddressBook10 and
org.gnome.evolution.dataserver.Calendar8. The test snap needs an update.

@jhenstridge can you look into updating test-snapd-eds to?
