### PR TITLE
snapstate: add missing tests for checkGadgetOrKernel

### DIFF
--- a/tests/main/remodel-kernel/task.yaml
+++ b/tests/main/remodel-kernel/task.yaml
@@ -59,7 +59,7 @@ restore: |
         echo "properly cleanup"
         echo "see https://github.com/snapcore/snapd/pull/6620"
         echo
-        find /var/snap
+        find /var/snap -ls
         exit 1
     fi
 


### PR DESCRIPTION
There are two tests missing for the checkGadgetOrKernel when
a remodel is in progress. This was pointed out in
https://github.com/snapcore/snapd/pull/6839#discussion_r323650778

This PR adds the missing tests.
