### PR TITLE
snap-confine: fix return value checks for udev functions

### DIFF
--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -143,10 +143,10 @@ int snappy_udev_init(const char *security_tag, struct snappy_udev *udev_s)
 	if (udev_s->devices == NULL)
 		die("udev_enumerate_new failed");
 
-	if (udev_enumerate_add_match_tag(udev_s->devices, udev_s->tagname) != 0)
+	if (udev_enumerate_add_match_tag(udev_s->devices, udev_s->tagname) < 0)
 		die("udev_enumerate_add_match_tag");
 
-	if (udev_enumerate_scan_devices(udev_s->devices) != 0)
+	if (udev_enumerate_scan_devices(udev_s->devices) < 0)
 		die("udev_enumerate_scan failed");
 
 	udev_s->assigned = udev_enumerate_get_list_entry(udev_s->devices);


### PR DESCRIPTION
According to the man-page for the udev udev_enumerate_add_match_tag
and udev_enumerate_scan_devices functions:
```
  On success, udev_enumerate_scan_devices(),
  udev_enumerate_scan_subsystems() and udev_enumerate_add_syspath()
  return an integer greater than, or equal to, 0.
```
Our code checks for "0" only which is incorrect (according to the
man-page).

This PR fixes this - thanks to David 'DonKult' Kalnischkies.
