### PR TITLE
[RFC] cmd/snap: special handling of snap set refresh.hold

### DIFF
--- a/tests/main/refresh-hold/task.yaml
+++ b/tests/main/refresh-hold/task.yaml
@@ -18,3 +18,9 @@ execute: |
     when_nice="$(date -d "$when" +'tomorrow at %H:%M %Z')"
     snap set core refresh.hold="$when"
     snap refresh --time | MATCH "^hold: $when_nice"
+
+    rel_when="$(date --iso-8601=seconds -d '1 hour')"
+    rel_when_nice="$(date -d "$rel_when" +'today at %H:%M %Z')"
+    # hold for one hour
+    snap set system refresh.hold=1h
+    snap refresh --time | MATCH "^hold: $rel_when_nice"


### PR DESCRIPTION
The refresh.hold settings describes the moment in time, until which refreshes
will be held. The value is formatted according to RFC3339, eg.
2019-09-13T13:00:32+02:00 and isn't especially user friendly.

Add special casing for `snap set system refresh.hold=<d>` which accespts a
duration string that can be parsed by time.Duration(), and it automatically
replaced with computed now + duration time before sending out the request.

Because it's too hard to explain that one needs to use `date --iso-8601=seconds -d '<describe when it ends>'` to produce a usable string.

Note, the change is client side only.