### PR TITLE
sanity: sanity check cgroup probing

### DIFF
--- a/sanity/cgroup.go
+++ b/sanity/cgroup.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sanity
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/sandbox/cgroup"
+)
+
+func init() {
+	checks = append(checks, checkCgroup)
+}
+
+func checkCgroup() error {
+	v, err := cgroup.Version()
+	if err != nil {
+		return fmt.Errorf("snapd could not probe cgroup version: %v", err)
+	}
+	if v == cgroup.Unknown {
+		return fmt.Errorf("snapd could not determine cgroup version")
+	}
+
+	return nil
+}

--- a/sanity/cgroup_test.go
+++ b/sanity/cgroup_test.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sanity_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/sanity"
+)
+
+type cgroupSuite struct{}
+
+var _ = Suite(&cgroupSuite{})
+
+func (s *cgroupSuite) TestBadCgroupProbeHappy(c *C) {
+	defer cgroup.MockVersion(cgroup.V1, nil)()
+
+	c.Check(sanity.CheckCgroup(), IsNil)
+}
+
+func (s *cgroupSuite) TestBadCgroupProbeUnknown(c *C) {
+	defer cgroup.MockVersion(cgroup.Unknown, nil)()
+
+	c.Check(sanity.CheckCgroup(), ErrorMatches, "snapd could not determine cgroup version")
+}
+
+func (s *cgroupSuite) TestBadCgroupProbeErr(c *C) {
+	defer cgroup.MockVersion(cgroup.Unknown, errors.New("nada"))()
+
+	c.Check(sanity.CheckCgroup(), ErrorMatches, "snapd could not probe cgroup version: nada")
+}

--- a/sanity/export_test.go
+++ b/sanity/export_test.go
@@ -24,6 +24,7 @@ var (
 	CheckKernelVersion  = checkKernelVersion
 	CheckApparmorUsable = checkApparmorUsable
 	CheckWSL            = checkWSL
+	CheckCgroup         = checkCgroup
 
 	CheckFuse = firstCheckFuse
 )


### PR DESCRIPTION
Make sure that cgroup was probed successfully before snapd proceeds to operate fully.

