### PR TITLE
snapstate: increase settleTimeout in TestRemodelSwitchToDifferentKernel

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3582,7 +3582,8 @@ version: 1.0`
 	c.Assert(err, IsNil)
 
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	// regular settleTimeout is not enough on arm buildds :/
+	err = ms.o.Settle(4 * settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 	c.Assert(chg.Err(), IsNil)
@@ -3597,7 +3598,8 @@ version: 1.0`
 
 	// continue
 	st.Unlock()
-	err = ms.o.Settle(settleTimeout)
+	// regular settleTimeout is not enough on arm buildds :/
+	err = ms.o.Settle(4 * settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
We got FTBFS error on arm when building the latest snapd on armhf.
It turns out that the settle timeout is not long enough on these
slow devices and needs to be increased. With that 2.42 now builds.

