### PR TITLE
tests: skip centos when running interfaces-openvswitch for nigthly suite

### DIFF
--- a/tests/nightly/interfaces-openvswitch/task.yaml
+++ b/tests/nightly/interfaces-openvswitch/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the openvswitch interface works.
 
 # Openvswitch getting stuck during installation sporadically on ubuntu-14.04-64
 # Openvswitch service not available on the following systems
-systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -arch-linux-*, -ubuntu-14.04-64]
+systems: [-ubuntu-core-*, -opensuse-*, -amazon-*, -centos-*, -arch-linux-*, -ubuntu-14.04-64]
 
 details: |
     The openvswitch interface allows to task to the openvswitch socket (rw mode).


### PR DESCRIPTION
The package is not available on centos

distro_install_package --no-install-recommends openvswitch-switch
quiet: yum -y install openvswitch
quiet: exit status 1. Output follows:
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
* base: repo1.ash.innoscale.net
* epel: iad.mirror.rackspace.com
* extras: repo1.ash.innoscale.net
* updates: repo1.ash.innoscale.net
No package openvswitch available.
Error: Nothing to do
quiet: end of output.
