### PR TITLE
store: download propagates options to delta download

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -141,8 +141,8 @@ func (sto *Store) SetDeltaFormat(dfmt string) {
 	sto.deltaFormat = dfmt
 }
 
-func (sto *Store) DownloadDelta(deltaName string, downloadInfo *snap.DownloadInfo, w io.ReadWriteSeeker, pbar progress.Meter, user *auth.UserState) error {
-	return sto.downloadDelta(deltaName, downloadInfo, w, pbar, user)
+func (sto *Store) DownloadDelta(deltaName string, downloadInfo *snap.DownloadInfo, w io.ReadWriteSeeker, pbar progress.Meter, user *auth.UserState, dlOpts *DownloadOptions) error {
+	return sto.downloadDelta(deltaName, downloadInfo, w, pbar, user, dlOpts)
 }
 
 func (sto *Store) DoRequest(ctx context.Context, client *http.Client, reqOptions *requestOptions, user *auth.UserState) (*http.Response, error) {

--- a/store/store.go
+++ b/store/store.go
@@ -1357,7 +1357,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		logger.Debugf("Available deltas returned by store: %v", downloadInfo.Deltas)
 
 		if len(downloadInfo.Deltas) == 1 {
-			err := s.downloadAndApplyDelta(name, targetPath, downloadInfo, pbar, user)
+			err := s.downloadAndApplyDelta(name, targetPath, downloadInfo, pbar, user, dlOpts)
 			if err == nil {
 				return nil
 			}
@@ -1650,7 +1650,7 @@ func doDowloadReqImpl(ctx context.Context, storeURL *url.URL, cdnHeader string, 
 }
 
 // downloadDelta downloads the delta for the preferred format, returning the path.
-func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo, w io.ReadWriteSeeker, pbar progress.Meter, user *auth.UserState) error {
+func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo, w io.ReadWriteSeeker, pbar progress.Meter, user *auth.UserState, dlOpts *DownloadOptions) error {
 
 	if len(downloadInfo.Deltas) != 1 {
 		return errors.New("store returned more than one download delta")
@@ -1672,7 +1672,7 @@ func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo,
 		url = deltaInfo.DownloadURL
 	}
 
-	return download(context.TODO(), deltaName, deltaInfo.Sha3_384, url, user, s, w, 0, pbar, nil)
+	return download(context.TODO(), deltaName, deltaInfo.Sha3_384, url, user, s, w, 0, pbar, dlOpts)
 }
 
 func getXdelta3Cmd(args ...string) (*exec.Cmd, error) {
@@ -1737,7 +1737,7 @@ var applyDelta = func(name string, deltaPath string, deltaInfo *snap.DeltaInfo, 
 }
 
 // downloadAndApplyDelta downloads and then applies the delta to the current snap.
-func (s *Store) downloadAndApplyDelta(name, targetPath string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) error {
+func (s *Store) downloadAndApplyDelta(name, targetPath string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, dlOpts *DownloadOptions) error {
 	deltaInfo := &downloadInfo.Deltas[0]
 
 	deltaPath := fmt.Sprintf("%s.%s-%d-to-%d.partial", targetPath, deltaInfo.Format, deltaInfo.FromRevision, deltaInfo.ToRevision)
@@ -1754,7 +1754,7 @@ func (s *Store) downloadAndApplyDelta(name, targetPath string, downloadInfo *sna
 		os.Remove(deltaPath)
 	}()
 
-	err = s.downloadDelta(deltaName, downloadInfo, w, pbar, user)
+	err = s.downloadDelta(deltaName, downloadInfo, w, pbar, user, dlOpts)
 	if err != nil {
 		return err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1046,6 +1046,7 @@ func (s *storeTestSuite) TestDownloadDelta(c *C) {
 	for _, testCase := range downloadDeltaTests {
 		sto.SetDeltaFormat(testCase.format)
 		restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, _ *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+			c.Check(dlOpts, DeepEquals, &store.DownloadOptions{IsAutoRefresh: true})
 			expectedUser := s.user
 			if testCase.useLocalUser {
 				expectedUser = s.localUser
@@ -1077,7 +1078,7 @@ func (s *storeTestSuite) TestDownloadDelta(c *C) {
 			authedUser = nil
 		}
 
-		err = sto.DownloadDelta("snapname", &testCase.info, w, nil, authedUser)
+		err = sto.DownloadDelta("snapname", &testCase.info, w, nil, authedUser, &store.DownloadOptions{IsAutoRefresh: true})
 
 		if testCase.expectError {
 			c.Assert(err, NotNil)


### PR DESCRIPTION
Without this change we were not propagating download options to the
delta download.

One could make the argument that this was a silly thing to do.
