### PR TITLE
data/selinux: allow snapd to issue sigkill to journalctl

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -325,6 +325,8 @@ optional_policy(`
 # snapd runs journalctl to fetch logs
 optional_policy(`
   journalctl_run(snappy_t, snappy_roles)
+  # and kills journalctl once the logs have been fetched
+  allow snappy_t journalctl_t:process sigkill;
 ')
 
 # only pops up in cloud images where cloud-init.target is incorrectly labeled


### PR DESCRIPTION
When user runs `snap logs <service>`, snapd spawns a journalctl and forwards the
logs to the client. Once the client disconnects, snapd will kill the journalctl
process as part of the cleanup. This was not accounted for in the SELinux policy
and caused a denial, like this one, to be logged:

```
type=AVC msg=audit(1568792912.664:182): avc:  denied  { sigkill } for
         pid=2414 comm="snapd"
         scontext=system_u:system_r:snappy_t:s0
         tcontext=system_u:system_r:journalctl_t:s0
         tclass=process permissive=1
```

Update the policy to allow this action.

cc @Conan-Kudo 