### PR TITLE
tests/main/listing: account for dots in ~pre suffix

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -19,7 +19,7 @@ execute: |
 
     # Expressions for version and revision
     NUMERIC_VERSION="[0-9]+(\.[0-9]+)*"
-    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-f]+)?"
+    CORE_GIT_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9.]+)?(\\+git[0-9]+\\.[0-9a-f]+)?"
     SNAPD_GIT_VERSION="+[0-9.]+(~[a-z0-9]+)?(\\+git[0-9]+\\.[0-9a-z]+)?"
     FINAL_VERSION="[0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\\+[0-9]+\\.[0-9a-f]+)?"
     SIDELOAD_REV="x[0-9]+"


### PR DESCRIPTION
Currently published version 16-2.42~pre1.1 does not match the expected pattern.
