### PR TITLE
osutil: generalize SyncDir with FileState interface

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -101,7 +101,7 @@ func (b *Backend) Initialize() error {
 
 	// Location of the generated policy.
 	glob := "*"
-	policy := make(map[string]*osutil.FileState)
+	policy := make(map[string]osutil.FileState)
 
 	// Check if NFS is mounted at or under $HOME. Because NFS is not
 	// transparent to apparmor we must alter our profile to counter that and
@@ -109,7 +109,7 @@ func (b *Backend) Initialize() error {
 	if nfs, err := isHomeUsingNFS(); err != nil {
 		logger.Noticef("cannot determine if NFS is in use: %v", err)
 	} else if nfs {
-		policy["nfs-support"] = &osutil.FileState{
+		policy["nfs-support"] = &osutil.MemoryBlob{
 			Content: []byte(nfsSnippet),
 			Mode:    0644,
 		}
@@ -122,7 +122,7 @@ func (b *Backend) Initialize() error {
 		logger.Noticef("cannot determine if root filesystem on overlay: %v", err)
 	} else if overlayRoot != "" {
 		snippet := strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
-		policy["overlay-root"] = &osutil.FileState{
+		policy["overlay-root"] = &osutil.MemoryBlob{
 			Content: []byte(snippet),
 			Mode:    0644,
 		}
@@ -182,7 +182,7 @@ func (b *Backend) Initialize() error {
 
 // snapConfineFromSnapProfile returns the apparmor profile for
 // snap-confine in the given core/snapd snap.
-func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[string]*osutil.FileState, err error) {
+func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[string]osutil.FileState, err error) {
 	// Find the vanilla apparmor profile for snap-confine as present in the given core snap.
 
 	// We must test the ".real" suffix first, this is a workaround for
@@ -214,8 +214,8 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	patchedProfileGlob := fmt.Sprintf("snap-confine.%s.*", info.InstanceName())
 
 	// Return information for EnsureDirState that describes the re-exec profile for snap-confine.
-	content = map[string]*osutil.FileState{
-		patchedProfileName: {
+	content = map[string]osutil.FileState{
+		patchedProfileName: &osutil.MemoryBlob{
 			Content: []byte(patchedProfileText),
 			Mode:    0644,
 		},
@@ -449,8 +449,8 @@ const (
 	attachComplain = "(attach_disconnected,mediate_deleted,complain)"
 )
 
-func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts interfaces.ConfinementOptions) (content map[string]*osutil.FileState, err error) {
-	content = make(map[string]*osutil.FileState, len(snapInfo.Apps)+len(snapInfo.Hooks)+1)
+func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts interfaces.ConfinementOptions) (content map[string]osutil.FileState, err error) {
+	content = make(map[string]osutil.FileState, len(snapInfo.Apps)+len(snapInfo.Hooks)+1)
 
 	// Add profile for each app.
 	for _, appInfo := range snapInfo.Apps {
@@ -478,7 +478,7 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts i
 // This profile exists so that snap-update-ns doens't need to carry very wide, open permissions
 // that are suitable for poking holes (and writing) in nearly arbitrary places. Instead the profile
 // contains just the permissions needed to poke a hole and write to the layout-specific paths.
-func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets string, content map[string]*osutil.FileState) {
+func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets string, content map[string]osutil.FileState) {
 	// Compute the template by injecting special updateNS snippets.
 	policy := templatePattern.ReplaceAllStringFunc(updateNSTemplate, func(placeholder string) string {
 		switch placeholder {
@@ -495,7 +495,7 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 
 	// Ensure that the snap-update-ns profile is on disk.
 	profileName := nsProfile(snapInfo.InstanceName())
-	content[profileName] = &osutil.FileState{
+	content[profileName] = &osutil.MemoryBlob{
 		Content: []byte(policy),
 		Mode:    0644,
 	}
@@ -518,7 +518,7 @@ func downgradeConfinement() bool {
 	return true
 }
 
-func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState, spec *Specification) {
+func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]osutil.FileState, spec *Specification) {
 	// Normally we use a specific apparmor template for all snap programs.
 	policy := defaultTemplate
 	ignoreSnippets := false
@@ -619,7 +619,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 		return ""
 	})
 
-	content[securityTag] = &osutil.FileState{
+	content[securityTag] = &osutil.MemoryBlob{
 		Content: []byte(policy),
 		Mode:    0644,
 	}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -109,7 +109,7 @@ func (b *Backend) Initialize() error {
 	if nfs, err := isHomeUsingNFS(); err != nil {
 		logger.Noticef("cannot determine if NFS is in use: %v", err)
 	} else if nfs {
-		policy["nfs-support"] = &osutil.MemoryBlob{
+		policy["nfs-support"] = &osutil.MemoryFileState{
 			Content: []byte(nfsSnippet),
 			Mode:    0644,
 		}
@@ -122,7 +122,7 @@ func (b *Backend) Initialize() error {
 		logger.Noticef("cannot determine if root filesystem on overlay: %v", err)
 	} else if overlayRoot != "" {
 		snippet := strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
-		policy["overlay-root"] = &osutil.MemoryBlob{
+		policy["overlay-root"] = &osutil.MemoryFileState{
 			Content: []byte(snippet),
 			Mode:    0644,
 		}
@@ -215,7 +215,7 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 
 	// Return information for EnsureDirState that describes the re-exec profile for snap-confine.
 	content = map[string]osutil.FileState{
-		patchedProfileName: &osutil.MemoryBlob{
+		patchedProfileName: &osutil.MemoryFileState{
 			Content: []byte(patchedProfileText),
 			Mode:    0644,
 		},
@@ -495,7 +495,7 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 
 	// Ensure that the snap-update-ns profile is on disk.
 	profileName := nsProfile(snapInfo.InstanceName())
-	content[profileName] = &osutil.MemoryBlob{
+	content[profileName] = &osutil.MemoryFileState{
 		Content: []byte(policy),
 		Mode:    0644,
 	}
@@ -619,7 +619,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 		return ""
 	})
 
-	content[securityTag] = &osutil.MemoryBlob{
+	content[securityTag] = &osutil.MemoryFileState{
 		Content: []byte(policy),
 		Mode:    0644,
 	}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -764,7 +764,7 @@ func (s *backendSuite) TestSnapConfineProfile(c *C) {
 	c.Assert(dir, Equals, expectedProfileDir)
 	c.Assert(glob, Equals, expectedProfileGlob)
 	c.Assert(content, DeepEquals, map[string]osutil.FileState{
-		expectedProfileName: &osutil.MemoryBlob{
+		expectedProfileName: &osutil.MemoryFileState{
 			Content: []byte(expectedProfileText),
 			Mode:    0644,
 		},
@@ -799,7 +799,7 @@ func (s *backendSuite) TestSnapConfineProfileFromSnapdSnap(c *C) {
 	c.Assert(dir, Equals, expectedProfileDir)
 	c.Assert(glob, Equals, expectedProfileGlob)
 	c.Assert(content, DeepEquals, map[string]osutil.FileState{
-		expectedProfileName: &osutil.MemoryBlob{
+		expectedProfileName: &osutil.MemoryFileState{
 			Content: []byte(expectedProfileText),
 			Mode:    0644,
 		},

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -763,8 +763,8 @@ func (s *backendSuite) TestSnapConfineProfile(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(dir, Equals, expectedProfileDir)
 	c.Assert(glob, Equals, expectedProfileGlob)
-	c.Assert(content, DeepEquals, map[string]*osutil.FileState{
-		expectedProfileName: {
+	c.Assert(content, DeepEquals, map[string]osutil.FileState{
+		expectedProfileName: &osutil.MemoryBlob{
 			Content: []byte(expectedProfileText),
 			Mode:    0644,
 		},
@@ -798,8 +798,8 @@ func (s *backendSuite) TestSnapConfineProfileFromSnapdSnap(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(dir, Equals, expectedProfileDir)
 	c.Assert(glob, Equals, expectedProfileGlob)
-	c.Assert(content, DeepEquals, map[string]*osutil.FileState{
-		expectedProfileName: {
+	c.Assert(content, DeepEquals, map[string]osutil.FileState{
+		expectedProfileName: &osutil.MemoryBlob{
 			Content: []byte(expectedProfileText),
 			Mode:    0644,
 		},

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -137,7 +137,7 @@ func (b *Backend) Remove(snapName string) error {
 
 // deriveContent combines security snippets collected from all the interfaces
 // affecting a given snap into a content map applicable to EnsureDirState.
-func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (content map[string]*osutil.FileState, err error) {
+func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (content map[string]osutil.FileState, err error) {
 	for _, appInfo := range snapInfo.Apps {
 		securityTag := appInfo.SecurityTag()
 		appSnippets := spec.SnippetForTag(securityTag)
@@ -145,7 +145,7 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (conte
 			continue
 		}
 		if content == nil {
-			content = make(map[string]*osutil.FileState)
+			content = make(map[string]osutil.FileState)
 		}
 
 		addContent(securityTag, appSnippets, content)
@@ -158,7 +158,7 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (conte
 			continue
 		}
 		if content == nil {
-			content = make(map[string]*osutil.FileState)
+			content = make(map[string]osutil.FileState)
 		}
 
 		addContent(securityTag, hookSnippets, content)
@@ -167,13 +167,13 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (conte
 	return content, nil
 }
 
-func addContent(securityTag string, snippet string, content map[string]*osutil.FileState) {
+func addContent(securityTag string, snippet string, content map[string]osutil.FileState) {
 	var buffer bytes.Buffer
 	buffer.Write(xmlHeader)
 	buffer.WriteString(snippet)
 	buffer.Write(xmlFooter)
 
-	content[fmt.Sprintf("%s.conf", securityTag)] = &osutil.FileState{
+	content[fmt.Sprintf("%s.conf", securityTag)] = &osutil.MemoryBlob{
 		Content: buffer.Bytes(),
 		Mode:    0644,
 	}

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -173,7 +173,7 @@ func addContent(securityTag string, snippet string, content map[string]osutil.Fi
 	buffer.WriteString(snippet)
 	buffer.Write(xmlFooter)
 
-	content[fmt.Sprintf("%s.conf", securityTag)] = &osutil.MemoryBlob{
+	content[fmt.Sprintf("%s.conf", securityTag)] = &osutil.MemoryFileState{
 		Content: buffer.Bytes(),
 		Mode:    0644,
 	}

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -105,11 +105,11 @@ func (b *Backend) Remove(snapName string) error {
 	return err
 }
 
-func deriveContent(spec *Specification, snapInfo *snap.Info) (map[string]*osutil.FileState, []string) {
+func deriveContent(spec *Specification, snapInfo *snap.Info) (map[string]osutil.FileState, []string) {
 	if len(spec.modules) == 0 {
 		return nil, nil
 	}
-	content := make(map[string]*osutil.FileState)
+	content := make(map[string]osutil.FileState)
 	var modules []string
 	for k := range spec.modules {
 		modules = append(modules, k)
@@ -122,7 +122,7 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) (map[string]*osutil
 		buffer.WriteString(module)
 		buffer.WriteRune('\n')
 	}
-	content[fmt.Sprintf("%s.conf", snap.SecurityTag(snapInfo.InstanceName()))] = &osutil.FileState{
+	content[fmt.Sprintf("%s.conf", snap.SecurityTag(snapInfo.InstanceName()))] = &osutil.MemoryBlob{
 		Content: buffer.Bytes(),
 		Mode:    0644,
 	}

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -122,7 +122,7 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) (map[string]osutil.
 		buffer.WriteString(module)
 		buffer.WriteRune('\n')
 	}
-	content[fmt.Sprintf("%s.conf", snap.SecurityTag(snapInfo.InstanceName()))] = &osutil.MemoryBlob{
+	content[fmt.Sprintf("%s.conf", snap.SecurityTag(snapInfo.InstanceName()))] = &osutil.MemoryFileState{
 		Content: buffer.Bytes(),
 		Mode:    0644,
 	}

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -95,7 +95,7 @@ func (b *Backend) Remove(snapName string) error {
 // addMountProfile adds a mount profile with the given name, based on the given entries.
 //
 // If there are no entries no profile is generated.
-func addMountProfile(content map[string]*osutil.FileState, fname string, entries []osutil.MountEntry) {
+func addMountProfile(content map[string]osutil.FileState, fname string, entries []osutil.MountEntry) {
 	if len(entries) == 0 {
 		return
 	}
@@ -103,12 +103,12 @@ func addMountProfile(content map[string]*osutil.FileState, fname string, entries
 	for _, entry := range entries {
 		fmt.Fprintf(&buffer, "%s\n", entry)
 	}
-	content[fname] = &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}
+	content[fname] = &osutil.MemoryBlob{Content: buffer.Bytes(), Mode: 0644}
 }
 
 // deriveContent computes .fstab tables based on requests made to the specification.
-func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
-	content := make(map[string]*osutil.FileState, 2)
+func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]osutil.FileState {
+	content := make(map[string]osutil.FileState, 2)
 	snapName := snapInfo.InstanceName()
 	// Add the per-snap fstab file.
 	// This file is read by snap-update-ns in the global pass.

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -103,7 +103,7 @@ func addMountProfile(content map[string]osutil.FileState, fname string, entries 
 	for _, entry := range entries {
 		fmt.Fprintf(&buffer, "%s\n", entry)
 	}
-	content[fname] = &osutil.MemoryBlob{Content: buffer.Bytes(), Mode: 0644}
+	content[fname] = &osutil.MemoryFileState{Content: buffer.Bytes(), Mode: 0644}
 }
 
 // deriveContent computes .fstab tables based on requests made to the specification.

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -125,7 +125,7 @@ func (b *Backend) Initialize() error {
 		globalProfile = globalProfileLE
 	}
 	content := map[string]osutil.FileState{
-		fname: &osutil.MemoryBlob{Content: globalProfile, Mode: 0644},
+		fname: &osutil.MemoryFileState{Content: globalProfile, Mode: 0644},
 	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for seccomp profiles %q: %s", dir, err)
@@ -269,7 +269,7 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 		securityTag := hookInfo.SecurityTag()
 
 		path := securityTag + ".src"
-		content[path] = &osutil.MemoryBlob{
+		content[path] = &osutil.MemoryFileState{
 			Content: generateContent(opts, spec.SnippetForTag(securityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
 			Mode:    0644,
 		}
@@ -280,7 +280,7 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 		}
 		securityTag := appInfo.SecurityTag()
 		path := securityTag + ".src"
-		content[path] = &osutil.MemoryBlob{
+		content[path] = &osutil.MemoryFileState{
 			Content: generateContent(opts, spec.SnippetForTag(securityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
 			Mode:    0644,
 		}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -124,8 +124,8 @@ func (b *Backend) Initialize() error {
 	} else {
 		globalProfile = globalProfileLE
 	}
-	content := map[string]*osutil.FileState{
-		fname: {Content: globalProfile, Mode: 0644},
+	content := map[string]osutil.FileState{
+		fname: &osutil.MemoryBlob{Content: globalProfile, Mode: 0644},
 	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for seccomp profiles %q: %s", dir, err)
@@ -243,7 +243,7 @@ func uidGidChownSnippet(name string) (string, error) {
 
 // deriveContent combines security snippets collected from all the interfaces
 // affecting a given snap into a content map applicable to EnsureDirState.
-func (b *Backend) deriveContent(spec *Specification, opts interfaces.ConfinementOptions, snapInfo *snap.Info) (content map[string]*osutil.FileState, err error) {
+func (b *Backend) deriveContent(spec *Specification, opts interfaces.ConfinementOptions, snapInfo *snap.Info) (content map[string]osutil.FileState, err error) {
 	// Some base snaps and systems require the socketcall() in the default
 	// template
 	addSocketcall := requiresSocketcall(snapInfo.Base)
@@ -264,23 +264,23 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 
 	for _, hookInfo := range snapInfo.Hooks {
 		if content == nil {
-			content = make(map[string]*osutil.FileState)
+			content = make(map[string]osutil.FileState)
 		}
 		securityTag := hookInfo.SecurityTag()
 
 		path := securityTag + ".src"
-		content[path] = &osutil.FileState{
+		content[path] = &osutil.MemoryBlob{
 			Content: generateContent(opts, spec.SnippetForTag(securityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
 			Mode:    0644,
 		}
 	}
 	for _, appInfo := range snapInfo.Apps {
 		if content == nil {
-			content = make(map[string]*osutil.FileState)
+			content = make(map[string]osutil.FileState)
 		}
 		securityTag := appInfo.SecurityTag()
 		path := securityTag + ".src"
-		content[path] = &osutil.FileState{
+		content[path] = &osutil.MemoryBlob{
 			Content: generateContent(opts, spec.SnippetForTag(securityTag), addSocketcall, b.versionInfo, uidGidChownSyscalls.String()),
 			Mode:    0644,
 		}

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -133,14 +133,14 @@ func (b *Backend) SandboxFeatures() []string {
 }
 
 // deriveContent computes .service files based on requests made to the specification.
-func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
+func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]osutil.FileState {
 	services := spec.Services()
 	if len(services) == 0 {
 		return nil
 	}
-	content := make(map[string]*osutil.FileState)
+	content := make(map[string]osutil.FileState)
 	for name, service := range services {
-		content[name] = &osutil.FileState{
+		content[name] = &osutil.MemoryBlob{
 			Content: []byte(service.String()),
 			Mode:    0644,
 		}
@@ -148,7 +148,7 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.
 	return content
 }
 
-func disableRemovedServices(systemd sysd.Systemd, dir, glob string, content map[string]*osutil.FileState) error {
+func disableRemovedServices(systemd sysd.Systemd, dir, glob string, content map[string]osutil.FileState) error {
 	paths, err := filepath.Glob(filepath.Join(dir, glob))
 	if err != nil {
 		return err

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -140,7 +140,7 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]osutil.F
 	}
 	content := make(map[string]osutil.FileState)
 	for name, service := range services {
-		content[name] = &osutil.MemoryBlob{
+		content[name] = &osutil.MemoryFileState{
 			Content: []byte(service.String()),
 			Mode:    0644,
 		}

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -109,7 +109,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		buffer.WriteByte('\n')
 	}
 
-	rulesFileState := &osutil.FileState{
+	rulesFileState := &osutil.MemoryBlob{
 		Content: buffer.Bytes(),
 		Mode:    0644,
 	}

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -109,7 +109,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		buffer.WriteByte('\n')
 	}
 
-	rulesFileState := &osutil.MemoryBlob{
+	rulesFileState := &osutil.MemoryFileState{
 		Content: buffer.Bytes(),
 		Mode:    0644,
 	}

--- a/osutil/cmp.go
+++ b/osutil/cmp.go
@@ -91,9 +91,9 @@ func StreamsEqual(a, b io.Reader) bool {
 }
 
 // StreamEqual returns true if both streams have same length and content.
-func StreamEqual(readerA, readerB io.Reader, chunkSize int) (bool, error) {
+func StreamEqual(readerA, readerB io.Reader, chunkSize int) bool {
 	if readerA == readerB {
-		return true, nil
+		return true
 	}
 	if chunkSize <= 0 {
 		chunkSize = 4096
@@ -125,12 +125,12 @@ func StreamEqual(readerA, readerB io.Reader, chunkSize int) (bool, error) {
 		// unexpected for us because we don't assume they streams have equal
 		// length.
 		if errA != nil && errA != io.EOF {
-			return false, errA
+			return false
 		}
 		if errB != nil && errB != io.EOF && errB != io.ErrUnexpectedEOF {
-			return false, errB
+			return false
 		}
-		return false, nil
+		return false
 	}
-	return true, nil
+	return true
 }

--- a/osutil/cmp.go
+++ b/osutil/cmp.go
@@ -64,6 +64,9 @@ func FilesAreEqual(a, b string) bool {
 }
 
 func streamsEqualChunked(a, b io.Reader, chunkSize int) bool {
+	if a == b {
+		return true
+	}
 	if chunkSize <= 0 {
 		chunkSize = defaultChunkSize
 	}

--- a/osutil/cmp.go
+++ b/osutil/cmp.go
@@ -104,46 +104,5 @@ func StreamsEqual(a, b io.Reader) bool {
 
 // StreamEqual returns true if both streams have same length and content.
 func StreamEqual(readerA, readerB io.Reader, chunkSize int) bool {
-	// TODO: replace with StreamsEqualChunked(readerA, readerB, chunkSize)
-	if readerA == readerB {
-		return true
-	}
-	if chunkSize <= 0 {
-		chunkSize = 4096
-	}
-	bufA := make([]byte, chunkSize)
-	bufB := make([]byte, chunkSize)
-	for {
-		nA, errA := readerA.Read(bufA)
-		toReadFromB := nA
-		if toReadFromB == 0 {
-			// If we read nothing from stream A we want to get a chance to read
-			// something from B so that we can detect streams of unequal
-			// length.
-			toReadFromB = 1
-		}
-		nB, errB := io.ReadAtLeast(readerB, bufB, toReadFromB)
-		// We read the same non-empty amount from each stream.
-		if nA == nB && nA > 0 {
-			if bytes.Equal(bufA[:nA], bufB[:nB]) {
-				continue
-			}
-		}
-		// We read nothing from both streams.
-		if nA == nB && nA == 0 {
-			break
-		}
-		// Return an error except for EOF and ErrUnexpectedEOF, since those are
-		// just end-of-file indicators. Note that unexpected EOF is not really
-		// unexpected for us because we don't assume they streams have equal
-		// length.
-		if errA != nil && errA != io.EOF {
-			return false
-		}
-		if errB != nil && errB != io.EOF && errB != io.ErrUnexpectedEOF {
-			return false
-		}
-		return false
-	}
-	return true
+	return streamsEqualChunked(readerA, readerB, chunkSize)
 }

--- a/osutil/cmp.go
+++ b/osutil/cmp.go
@@ -101,8 +101,3 @@ func streamsEqualChunked(a, b io.Reader, chunkSize int) bool {
 func StreamsEqual(a, b io.Reader) bool {
 	return streamsEqualChunked(a, b, 0)
 }
-
-// StreamEqual returns true if both streams have same length and content.
-func StreamEqual(readerA, readerB io.Reader, chunkSize int) bool {
-	return streamsEqualChunked(readerA, readerB, chunkSize)
-}

--- a/osutil/cmp.go
+++ b/osutil/cmp.go
@@ -89,3 +89,48 @@ func StreamsEqual(a, b io.Reader) bool {
 		}
 	}
 }
+
+// StreamEqual returns true if both streams have same length and content.
+func StreamEqual(readerA, readerB io.Reader, chunkSize int) (bool, error) {
+	if readerA == readerB {
+		return true, nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = 4096
+	}
+	bufA := make([]byte, chunkSize)
+	bufB := make([]byte, chunkSize)
+	for {
+		nA, errA := readerA.Read(bufA)
+		toReadFromB := nA
+		if toReadFromB == 0 {
+			// If we read nothing from stream A we want to get a chance to read
+			// something from B so that we can detect streams of unequal
+			// length.
+			toReadFromB = 1
+		}
+		nB, errB := io.ReadAtLeast(readerB, bufB, toReadFromB)
+		// We read the same non-empty amount from each stream.
+		if nA == nB && nA > 0 {
+			if bytes.Equal(bufA[:nA], bufB[:nB]) {
+				continue
+			}
+		}
+		// We read nothing from both streams.
+		if nA == nB && nA == 0 {
+			break
+		}
+		// Return an error except for EOF and ErrUnexpectedEOF, since those are
+		// just end-of-file indicators. Note that unexpected EOF is not really
+		// unexpected for us because we don't assume they streams have equal
+		// length.
+		if errA != nil && errA != io.EOF {
+			return false, errA
+		}
+		if errB != nil && errB != io.EOF && errB != io.ErrUnexpectedEOF {
+			return false, errB
+		}
+		return false, nil
+	}
+	return true, nil
+}

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -20,9 +20,9 @@
 package osutil
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
-	"bytes"
 	"path/filepath"
 	"strings"
 
@@ -41,20 +41,15 @@ func (ts *CmpTestSuite) TestCmp(c *C) {
 	c.Assert(err, IsNil)
 	defer f.Close()
 
-	// pick a smaller bufsize so that the test can complete quicker
-	defer func() {
-		bufsz = defaultBufsz
-	}()
-	bufsz = 128
-
 	// test FilesAreEqual for various sizes:
 	// - bufsz not exceeded
 	// - bufsz matches file size
 	// - bufsz exceeds file size
 	canary := "1234567890123456"
-	for _, n := range []int{1, bufsz / len(canary), (bufsz / len(canary)) + 1} {
+	for _, n := range []int{1, 128 / len(canary), (128 / len(canary)) + 1} {
 		for i := 0; i < n; i++ {
-			c.Assert(FilesAreEqual(foo, foo), Equals, true)
+			// Pick a smaller buffer size so that the test can complete quicker
+			c.Assert(FilesAreEqualChunked(foo, foo, 128), Equals, true)
 			_, err := f.WriteString(canary)
 			c.Assert(err, IsNil)
 			f.Sync()

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -107,8 +107,7 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 	// Passing the same stream twice is not mishandled.
 	readerA := bytes.NewReader(nil)
 	readerB := readerA
-	eq, err := StreamEqual(readerA, readerB, 0)
-	c.Assert(err, IsNil)
+	eq := StreamEqual(readerA, readerB, 0)
 	c.Check(eq, Equals, true)
 
 	// Passing two streams with the same content works as expected. Note that
@@ -116,8 +115,7 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text))
-		eq, err = StreamEqual(readerA, readerB, chunkSize)
-		c.Assert(err, IsNil)
+		eq := StreamEqual(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, true, Commentf("chunk size %d", chunkSize))
 	}
 
@@ -127,8 +125,7 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 		comment := Commentf("chunk size %d", chunkSize)
 		readerA = bytes.NewReader([]byte(strings.ToLower(text)))
 		readerB = bytes.NewReader([]byte(strings.ToUpper(text)))
-		eq, err = StreamEqual(readerA, readerB, chunkSize)
-		c.Assert(err, IsNil, comment)
+		eq = StreamEqual(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
 
@@ -138,15 +135,13 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 		comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
-		eq, err = StreamEqual(readerA, readerB, chunkSize)
-		c.Assert(err, IsNil, comment)
+		eq = StreamEqual(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, false, comment)
 
 		// Readers passed the other way around.
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
-		eq, err = StreamEqual(readerB, readerA, chunkSize)
-		c.Assert(err, IsNil, comment)
+		eq = StreamEqual(readerB, readerA, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
 }
@@ -158,7 +153,6 @@ func (s *CmpTestSuite) TestStreamEqualWAT(c *C) {
 	readerA := bytes.NewReader([]byte(text))
 	readerB := bytes.NewReader([]byte(text[:len(text)/2]))
 
-	eq, err := StreamEqual(readerB, readerA, chunkSize)
-	c.Assert(err, IsNil, comment)
+	eq := StreamEqual(readerB, readerA, chunkSize)
 	c.Check(eq, Equals, false, comment)
 }

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -22,6 +22,7 @@ package osutil
 import (
 	"io/ioutil"
 	"os"
+	"bytes"
 	"path/filepath"
 	"strings"
 
@@ -98,4 +99,66 @@ func (ts *CmpTestSuite) TestCmpStreams(c *C) {
 	} {
 		c.Assert(StreamsEqual(strings.NewReader(x.a), strings.NewReader(x.b)), Equals, x.r)
 	}
+}
+
+func (s *CmpTestSuite) TestStreamEqual(c *C) {
+	text := "marry had a little lamb"
+
+	// Passing the same stream twice is not mishandled.
+	readerA := bytes.NewReader(nil)
+	readerB := readerA
+	eq, err := StreamEqual(readerA, readerB, 0)
+	c.Assert(err, IsNil)
+	c.Check(eq, Equals, true)
+
+	// Passing two streams with the same content works as expected. Note that
+	// we are using different block sizes to check for additional edge cases.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(text))
+		eq, err = StreamEqual(readerA, readerB, chunkSize)
+		c.Assert(err, IsNil)
+		c.Check(eq, Equals, true, Commentf("chunk size %d", chunkSize))
+	}
+
+	// Passing two streams with unequal contents but equal length works as
+	// expected.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		comment := Commentf("chunk size %d", chunkSize)
+		readerA = bytes.NewReader([]byte(strings.ToLower(text)))
+		readerB = bytes.NewReader([]byte(strings.ToUpper(text)))
+		eq, err = StreamEqual(readerA, readerB, chunkSize)
+		c.Assert(err, IsNil, comment)
+		c.Check(eq, Equals, false, comment)
+	}
+
+	// Passing two streams with different length works as expected.
+	// Note that this is not used by EnsureDirState in practice.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
+		eq, err = StreamEqual(readerA, readerB, chunkSize)
+		c.Assert(err, IsNil, comment)
+		c.Check(eq, Equals, false, comment)
+
+		// Readers passed the other way around.
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
+		eq, err = StreamEqual(readerB, readerA, chunkSize)
+		c.Assert(err, IsNil, comment)
+		c.Check(eq, Equals, false, comment)
+	}
+}
+
+func (s *CmpTestSuite) TestStreamEqualWAT(c *C) {
+	text := "marry had a little lamb"
+	chunkSize := 1
+	comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
+	readerA := bytes.NewReader([]byte(text))
+	readerB := bytes.NewReader([]byte(text[:len(text)/2]))
+
+	eq, err := StreamEqual(readerB, readerA, chunkSize)
+	c.Assert(err, IsNil, comment)
+	c.Check(eq, Equals, false, comment)
 }

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -126,6 +126,18 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 		c.Check(eq, Equals, false, comment)
 	}
 
+	// Passing two streams which differer by tail only also works as expected.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		textWithChangedTail := text[:len(text)-1] + strings.ToUpper(text[len(text)-1:])
+		c.Assert(textWithChangedTail, Not(Equals), text)
+		c.Assert(len(textWithChangedTail), Equals, len(text))
+		comment := Commentf("chunk size %d", chunkSize)
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(textWithChangedTail))
+		eq = osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
+		c.Check(eq, Equals, false, comment)
+	}
+
 	// Passing two streams with different length works as expected.
 	// Note that this is not used by EnsureDirState in practice.
 	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -100,7 +100,7 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 	text := "marry had a little lamb"
 
 	// Passing the same stream twice is not mishandled.
-	readerA := bytes.NewReader(nil)
+	readerA := bytes.NewReader([]byte(text))
 	readerB := readerA
 	eq := StreamEqual(readerA, readerB, 0)
 	c.Check(eq, Equals, true)

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -96,13 +96,13 @@ func (ts *CmpTestSuite) TestCmpStreams(c *C) {
 	}
 }
 
-func (s *CmpTestSuite) TestStreamEqual(c *C) {
+func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 	text := "marry had a little lamb"
 
 	// Passing the same stream twice is not mishandled.
 	readerA := bytes.NewReader([]byte(text))
 	readerB := readerA
-	eq := StreamEqual(readerA, readerB, 0)
+	eq := StreamsEqualChunked(readerA, readerB, 0)
 	c.Check(eq, Equals, true)
 
 	// Passing two streams with the same content works as expected. Note that
@@ -110,7 +110,7 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text))
-		eq := StreamEqual(readerA, readerB, chunkSize)
+		eq := StreamsEqualChunked(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, true, Commentf("chunk size %d", chunkSize))
 	}
 
@@ -120,7 +120,7 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 		comment := Commentf("chunk size %d", chunkSize)
 		readerA = bytes.NewReader([]byte(strings.ToLower(text)))
 		readerB = bytes.NewReader([]byte(strings.ToUpper(text)))
-		eq = StreamEqual(readerA, readerB, chunkSize)
+		eq = StreamsEqualChunked(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
 
@@ -130,24 +130,24 @@ func (s *CmpTestSuite) TestStreamEqual(c *C) {
 		comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
-		eq = StreamEqual(readerA, readerB, chunkSize)
+		eq = StreamsEqualChunked(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, false, comment)
 
 		// Readers passed the other way around.
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
-		eq = StreamEqual(readerB, readerA, chunkSize)
+		eq = StreamsEqualChunked(readerB, readerA, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
 }
 
-func (s *CmpTestSuite) TestStreamEqualWAT(c *C) {
+func (s *CmpTestSuite) TestStreamsEqualChunkedWAT(c *C) {
 	text := "marry had a little lamb"
 	chunkSize := 1
 	comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
 	readerA := bytes.NewReader([]byte(text))
 	readerB := bytes.NewReader([]byte(text[:len(text)/2]))
 
-	eq := StreamEqual(readerB, readerA, chunkSize)
+	eq := StreamsEqualChunked(readerB, readerA, chunkSize)
 	c.Check(eq, Equals, false, comment)
 }

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -140,14 +140,3 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 		c.Check(eq, Equals, false, comment)
 	}
 }
-
-func (s *CmpTestSuite) TestStreamsEqualChunkedWAT(c *C) {
-	text := "marry had a little lamb"
-	chunkSize := 1
-	comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
-	readerA := bytes.NewReader([]byte(text))
-	readerB := bytes.NewReader([]byte(text[:len(text)/2]))
-
-	eq := StreamsEqualChunked(readerB, readerA, chunkSize)
-	c.Check(eq, Equals, false, comment)
-}

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"bytes"
@@ -27,6 +27,8 @@ import (
 	"strings"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 type CmpTestSuite struct{}
@@ -49,7 +51,7 @@ func (ts *CmpTestSuite) TestCmp(c *C) {
 	for _, n := range []int{1, 128 / len(canary), (128 / len(canary)) + 1} {
 		for i := 0; i < n; i++ {
 			// Pick a smaller buffer size so that the test can complete quicker
-			c.Assert(FilesAreEqualChunked(foo, foo, 128), Equals, true)
+			c.Assert(osutil.FilesAreEqualChunked(foo, foo, 128), Equals, true)
 			_, err := f.WriteString(canary)
 			c.Assert(err, IsNil)
 			f.Sync()
@@ -65,8 +67,8 @@ func (ts *CmpTestSuite) TestCmpEmptyNeqMissing(c *C) {
 	f, err := os.Create(foo)
 	c.Assert(err, IsNil)
 	defer f.Close()
-	c.Assert(FilesAreEqual(foo, bar), Equals, false)
-	c.Assert(FilesAreEqual(bar, foo), Equals, false)
+	c.Assert(osutil.FilesAreEqual(foo, bar), Equals, false)
+	c.Assert(osutil.FilesAreEqual(bar, foo), Equals, false)
 }
 
 func (ts *CmpTestSuite) TestCmpEmptyNeqNonEmpty(c *C) {
@@ -78,8 +80,8 @@ func (ts *CmpTestSuite) TestCmpEmptyNeqNonEmpty(c *C) {
 	c.Assert(err, IsNil)
 	defer f.Close()
 	c.Assert(ioutil.WriteFile(bar, []byte("x"), 0644), IsNil)
-	c.Assert(FilesAreEqual(foo, bar), Equals, false)
-	c.Assert(FilesAreEqual(bar, foo), Equals, false)
+	c.Assert(osutil.FilesAreEqual(foo, bar), Equals, false)
+	c.Assert(osutil.FilesAreEqual(bar, foo), Equals, false)
 }
 
 func (ts *CmpTestSuite) TestCmpStreams(c *C) {
@@ -92,7 +94,7 @@ func (ts *CmpTestSuite) TestCmpStreams(c *C) {
 		{"hello", "world", false},
 		{"hello", "hell", false},
 	} {
-		c.Assert(StreamsEqual(strings.NewReader(x.a), strings.NewReader(x.b)), Equals, x.r)
+		c.Assert(osutil.StreamsEqual(strings.NewReader(x.a), strings.NewReader(x.b)), Equals, x.r)
 	}
 }
 
@@ -102,7 +104,7 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 	// Passing the same stream twice is not mishandled.
 	readerA := bytes.NewReader([]byte(text))
 	readerB := readerA
-	eq := StreamsEqualChunked(readerA, readerB, 0)
+	eq := osutil.StreamsEqualChunked(readerA, readerB, 0)
 	c.Check(eq, Equals, true)
 
 	// Passing two streams with the same content works as expected. Note that
@@ -110,7 +112,7 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text))
-		eq := StreamsEqualChunked(readerA, readerB, chunkSize)
+		eq := osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, true, Commentf("chunk size %d", chunkSize))
 	}
 
@@ -120,7 +122,7 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 		comment := Commentf("chunk size %d", chunkSize)
 		readerA = bytes.NewReader([]byte(strings.ToLower(text)))
 		readerB = bytes.NewReader([]byte(strings.ToUpper(text)))
-		eq = StreamsEqualChunked(readerA, readerB, chunkSize)
+		eq = osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
 
@@ -130,13 +132,13 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 		comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
-		eq = StreamsEqualChunked(readerA, readerB, chunkSize)
+		eq = osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
 		c.Check(eq, Equals, false, comment)
 
 		// Readers passed the other way around.
 		readerA = bytes.NewReader([]byte(text))
 		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
-		eq = StreamsEqualChunked(readerB, readerA, chunkSize)
+		eq = osutil.StreamsEqualChunked(readerB, readerA, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
 }

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -32,6 +32,11 @@ import (
 	"github.com/snapcore/snapd/osutil/sys"
 )
 
+var (
+	StreamsEqualChunked  = streamsEqualChunked
+	FilesAreEqualChunked = filesAreEqualChunked
+)
+
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {
 	realUserLookup := userLookup
 	userLookup = mock

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -67,14 +67,14 @@ func (fcref FileReferencePlusMode) State() (io.ReadCloser, int64, os.FileMode, e
 	return reader, size, fcref.Mode, nil
 }
 
-// MemoryBlob describes the desired content by providing an in-memory copy.
-type MemoryBlob struct {
+// MemoryFileState describes the desired content by providing an in-memory copy.
+type MemoryFileState struct {
 	Content []byte
 	Mode    os.FileMode
 }
 
 // State returns a reader of the in-memory contents of a file, along with other meta-data.
-func (blob *MemoryBlob) State() (io.ReadCloser, int64, os.FileMode, error) {
+func (blob *MemoryFileState) State() (io.ReadCloser, int64, os.FileMode, error) {
 	return ioutil.NopCloser(bytes.NewReader(blob.Content)), int64(len(blob.Content)), blob.Mode, nil
 }
 

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -22,16 +22,60 @@ package osutil
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
 )
 
-// FileState describes the expected content and meta data of a single file.
-type FileState struct {
+// FileState is an interface for conveying the desired state of a some file.
+type FileState interface {
+	State() (reader io.ReadCloser, size int64, mode os.FileMode, err error)
+}
+
+// FileReference describes the desired content by referencing an existing file.
+type FileReference struct {
+	Path string
+}
+
+// State returns a reader of the referenced file, along with other meta-data.
+func (fref FileReference) State() (io.ReadCloser, int64, os.FileMode, error) {
+	file, err := os.Open(fref.Path)
+	if err != nil {
+		return nil, 0, os.FileMode(0), err
+	}
+	fi, err := file.Stat()
+	if err != nil {
+		return nil, 0, os.FileMode(0), err
+	}
+	return file, fi.Size(), fi.Mode(), nil
+}
+
+// FileContentReference describes the desired content by referencing an existing file and providing custom mode.
+type FileContentReference struct {
+	FileReference
+	Mode os.FileMode
+}
+
+// State returns a reader of the referenced file, substituting the mode.
+func (fcref FileContentReference) State() (io.ReadCloser, int64, os.FileMode, error) {
+	reader, size, _, err := fcref.FileReference.State()
+	if err != nil {
+		return nil, 0, os.FileMode(0), err
+	}
+	return reader, size, fcref.Mode, nil
+}
+
+// MemoryBlob describes the desired content by providing an in-memory copy.
+type MemoryBlob struct {
 	Content []byte
 	Mode    os.FileMode
+}
+
+// State returns a reader of the in-memory contents of a file, along with other meta-data.
+func (blob *MemoryBlob) State() (io.ReadCloser, int64, os.FileMode, error) {
+	return ioutil.NopCloser(bytes.NewReader(blob.Content)), int64(len(blob.Content)), blob.Mode, nil
 }
 
 // ErrSameState is returned when the state of a file has not changed.
@@ -63,7 +107,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 // exhausted.
 //
 // In all cases, the function returns the first error it has encountered.
-func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileState) (changed, removed []string, err error) {
+func EnsureDirStateGlobs(dir string, globs []string, content map[string]FileState) (changed, removed []string, err error) {
 	// Check syntax before doing anything.
 	if _, index, err := matchAny(globs, "foo"); err != nil {
 		return nil, nil, fmt.Errorf("internal error: EnsureDirState got invalid pattern %q: %s", globs[index], err)
@@ -143,36 +187,91 @@ func matchAny(globs []string, path string) (ok bool, index int, err error) {
 // EnsureDirState ensures that directory content matches expectations.
 //
 // This is like EnsureDirStateGlobs but it only supports one glob at a time.
-func EnsureDirState(dir string, glob string, content map[string]*FileState) (changed, removed []string, err error) {
+func EnsureDirState(dir string, glob string, content map[string]FileState) (changed, removed []string, err error) {
 	return EnsureDirStateGlobs(dir, []string{glob}, content)
 }
 
-// Equals returns whether the file exists in the expected state.
-func (fileState *FileState) Equals(filePath string) (bool, error) {
-	stat, err := os.Stat(filePath)
+// fileStateEqualTo returns whether the file exists in the expected state.
+func fileStateEqualTo(filePath string, state FileState) (bool, error) {
+	other := &FileReference{Path: filePath}
+
+	// Open views to both files so that we can compare them.
+	readerA, sizeA, modeA, err := state.State()
+	if err != nil {
+		return false, err
+	}
+	defer readerA.Close()
+
+	readerB, sizeB, modeB, err := other.State()
 	if err != nil {
 		if os.IsNotExist(err) {
-			// not existing is not an error
+			// Not existing is not an error
 			return false, nil
 		}
 		return false, err
 	}
-	if stat.Mode().Perm() == fileState.Mode.Perm() && stat.Size() == int64(len(fileState.Content)) {
-		content, err := ioutil.ReadFile(filePath)
-		if err != nil {
-			return false, err
-		}
-		if bytes.Equal(content, fileState.Content) {
-			return true, nil
-		}
+	defer readerB.Close()
+
+	// If the files have different size or different mode they are not
+	// identical and need to be re-created. Mode change could be optimized to
+	// avoid re-writing the whole file.
+	if modeA.Perm() != modeB.Perm() || sizeA != sizeB {
+		return false, nil
 	}
-	return false, nil
+	// The files have the same size so they might be identical.
+	// Do a block-wise comparison to determine that.
+	return StreamEqual(readerA, readerB, 0)
 }
 
-// EnsureFileState ensures that the file is in the expected state. It will not attempt
-// to remove the file if no content is provided.
-func EnsureFileState(filePath string, fileState *FileState) error {
-	equal, err := fileState.Equals(filePath)
+// StreamEqual returns true if both streams have same length and content.
+func StreamEqual(readerA, readerB io.Reader, chunkSize int) (bool, error) {
+	if readerA == readerB {
+		return true, nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = 4096
+	}
+	bufA := make([]byte, chunkSize)
+	bufB := make([]byte, chunkSize)
+	for {
+		nA, errA := readerA.Read(bufA)
+		toReadFromB := nA
+		if toReadFromB == 0 {
+			// If we read nothing from stream A we want to get a chance to read
+			// something from B so that we can detect streams of unequal
+			// length.
+			toReadFromB = 1
+		}
+		nB, errB := io.ReadAtLeast(readerB, bufB, toReadFromB)
+		// We read the same non-empty amount from each stream.
+		if nA == nB && nA > 0 {
+			if bytes.Equal(bufA[:nA], bufB[:nB]) {
+				continue
+			}
+		}
+		// We read nothing from both streams.
+		if nA == nB && nA == 0 {
+			break
+		}
+		// Return an error except for EOF and ErrUnexpectedEOF, since those are
+		// just end-of-file indicators. Note that unexpected EOF is not really
+		// unexpected for us because we don't assume they streams have equal
+		// length.
+		if errA != nil && errA != io.EOF {
+			return false, errA
+		}
+		if errB != nil && errB != io.EOF && errB != io.ErrUnexpectedEOF {
+			return false, errB
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+// EnsureFileState ensures that the file is in the expected state. It will not
+// attempt to remove the file if no content is provided.
+func EnsureFileState(filePath string, state FileState) error {
+	equal, err := fileStateEqualTo(filePath, state)
 	if err != nil {
 		return err
 	}
@@ -180,5 +279,9 @@ func EnsureFileState(filePath string, fileState *FileState) error {
 		// Return a special error if the file doesn't need to be changed
 		return ErrSameState
 	}
-	return AtomicWriteFile(filePath, fileState.Content, fileState.Mode, 0)
+	reader, _, mode, err := state.State()
+	if err != nil {
+		return err
+	}
+	return AtomicWrite(filePath, reader, mode, 0)
 }

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -52,14 +52,14 @@ func (fref FileReference) State() (io.ReadCloser, int64, os.FileMode, error) {
 	return file, fi.Size(), fi.Mode(), nil
 }
 
-// FileContentReference describes the desired content by referencing an existing file and providing custom mode.
-type FileContentReference struct {
+// FileReferencePlusMode describes the desired content by referencing an existing file and providing custom mode.
+type FileReferencePlusMode struct {
 	FileReference
 	Mode os.FileMode
 }
 
 // State returns a reader of the referenced file, substituting the mode.
-func (fcref FileContentReference) State() (io.ReadCloser, int64, os.FileMode, error) {
+func (fcref FileReferencePlusMode) State() (io.ReadCloser, int64, os.FileMode, error) {
 	reader, size, _, err := fcref.FileReference.State()
 	if err != nil {
 		return nil, 0, os.FileMode(0), err

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -220,7 +220,7 @@ func fileStateEqualTo(filePath string, state FileState) (bool, error) {
 	}
 	// The files have the same size so they might be identical.
 	// Do a block-wise comparison to determine that.
-	return StreamEqual(readerA, readerB, 0), nil
+	return streamsEqualChunked(readerA, readerB, 0), nil
 }
 
 // EnsureFileState ensures that the file is in the expected state. It will not

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -220,7 +220,7 @@ func fileStateEqualTo(filePath string, state FileState) (bool, error) {
 	}
 	// The files have the same size so they might be identical.
 	// Do a block-wise comparison to determine that.
-	return StreamEqual(readerA, readerB, 0)
+	return StreamEqual(readerA, readerB, 0), nil
 }
 
 // EnsureFileState ensures that the file is in the expected state. It will not

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -47,7 +47,7 @@ func (s *EnsureDirStateSuite) TestVerifiesExpectedFiles(c *C) {
 	err := ioutil.WriteFile(name, []byte("expected"), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
-		"expected.snap": &osutil.MemoryBlob{Content: []byte("expected"), Mode: 0600},
+		"expected.snap": &osutil.MemoryFileState{Content: []byte("expected"), Mode: 0600},
 	})
 	c.Assert(err, IsNil)
 	// Report says that nothing has changed
@@ -71,8 +71,8 @@ func (s *EnsureDirStateSuite) TestTwoPatterns(c *C) {
 	c.Assert(err, IsNil)
 
 	changed, removed, err := osutil.EnsureDirStateGlobs(s.dir, []string{"*.snap", "*.snap-update-ns"}, map[string]osutil.FileState{
-		"expected.snap":           &osutil.MemoryBlob{Content: []byte("expected-1"), Mode: 0600},
-		"expected.snap-update-ns": &osutil.MemoryBlob{Content: []byte("expected-2"), Mode: 0600},
+		"expected.snap":           &osutil.MemoryFileState{Content: []byte("expected-1"), Mode: 0600},
+		"expected.snap-update-ns": &osutil.MemoryFileState{Content: []byte("expected-2"), Mode: 0600},
 	})
 	c.Assert(err, IsNil)
 	// Report says that nothing has changed
@@ -104,7 +104,7 @@ func (s *EnsureDirStateSuite) TestMultipleMatches(c *C) {
 func (s *EnsureDirStateSuite) TestCreatesMissingFiles(c *C) {
 	name := filepath.Join(s.dir, "missing.snap")
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
-		"missing.snap": &osutil.MemoryBlob{Content: []byte(`content`), Mode: 0600},
+		"missing.snap": &osutil.MemoryFileState{Content: []byte(`content`), Mode: 0600},
 	})
 	c.Assert(err, IsNil)
 	// Created file is reported
@@ -151,7 +151,7 @@ func (s *EnsureDirStateSuite) TestCorrectsFilesWithDifferentSize(c *C) {
 	err := ioutil.WriteFile(name, []byte(``), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
-		"differing.snap": &osutil.MemoryBlob{Content: []byte(`Hello World`), Mode: 0600},
+		"differing.snap": &osutil.MemoryFileState{Content: []byte(`Hello World`), Mode: 0600},
 	})
 	c.Assert(err, IsNil)
 	// changed file is reported
@@ -170,7 +170,7 @@ func (s *EnsureDirStateSuite) TestCorrectsFilesWithSameSize(c *C) {
 	err := ioutil.WriteFile(name, []byte("evil"), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
-		"differing.snap": &osutil.MemoryBlob{Content: []byte("good"), Mode: 0600},
+		"differing.snap": &osutil.MemoryFileState{Content: []byte("good"), Mode: 0600},
 	})
 	c.Assert(err, IsNil)
 	// changed file is reported
@@ -191,7 +191,7 @@ func (s *EnsureDirStateSuite) TestFixesFilesWithBadPermissions(c *C) {
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
 		// NOTE: we want the file to be private
-		"sensitive.snap": &osutil.MemoryBlob{Content: []byte("password"), Mode: 0600},
+		"sensitive.snap": &osutil.MemoryFileState{Content: []byte("password"), Mode: 0600},
 	})
 	c.Assert(err, IsNil)
 	// changed file is reported
@@ -206,12 +206,12 @@ func (s *EnsureDirStateSuite) TestFixesFilesWithBadPermissions(c *C) {
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalFileLocation(c *C) {
-	_, _, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{"subdir/file.snap": &osutil.MemoryBlob{}})
+	_, _, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{"subdir/file.snap": &osutil.MemoryFileState{}})
 	c.Assert(err, ErrorMatches, `internal error: EnsureDirState got filename "subdir/file.snap" which has a path component`)
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalFileName(c *C) {
-	_, _, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{"without-namespace": &osutil.MemoryBlob{}})
+	_, _, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{"without-namespace": &osutil.MemoryFileState{}})
 	c.Assert(err, ErrorMatches, `internal error: EnsureDirState got filename "without-namespace" which doesn't match the glob pattern "\*\.snap"`)
 }
 
@@ -231,8 +231,8 @@ func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {
 	c.Assert(err, IsNil)
 	// Try to ensure directory state
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
-		"prior.snap": &osutil.MemoryBlob{Content: []byte("data"), Mode: 0600},
-		"clash.snap": &osutil.MemoryBlob{Content: []byte("data"), Mode: 0600},
+		"prior.snap": &osutil.MemoryFileState{Content: []byte("data"), Mode: 0600},
+		"clash.snap": &osutil.MemoryFileState{Content: []byte("data"), Mode: 0600},
 	})
 	c.Assert(changed, HasLen, 0)
 	c.Assert(removed, DeepEquals, []string{"clash.snap", "prior.snap"})

--- a/osutil/synctree.go
+++ b/osutil/synctree.go
@@ -87,7 +87,7 @@ func matchAnyComponent(globs []string, path string) (ok bool, index int) {
 //
 // A list of changed and removed files is returned, as relative paths
 // to the base directory.
-func EnsureTreeState(baseDir string, globs []string, content map[string]map[string]*FileState) (changed, removed []string, err error) {
+func EnsureTreeState(baseDir string, globs []string, content map[string]map[string]FileState) (changed, removed []string, err error) {
 	// Sanity check globs before doing anything
 	if _, index, err := matchAny(globs, "foo"); err != nil {
 		return nil, nil, fmt.Errorf("internal error: EnsureTreeState got invalid pattern %q: %s", globs[index], err)

--- a/osutil/synctree_test.go
+++ b/osutil/synctree_test.go
@@ -47,7 +47,7 @@ func (s *EnsureTreeStateSuite) TestVerifiesExpectedFiles(c *C) {
 	c.Assert(ioutil.WriteFile(name, []byte("expected"), 0600), IsNil)
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo/bar": {
-			"expected.snap": &osutil.MemoryBlob{Content: []byte("expected"), Mode: 0600},
+			"expected.snap": &osutil.MemoryFileState{Content: []byte("expected"), Mode: 0600},
 		},
 	})
 	c.Assert(err, IsNil)
@@ -66,10 +66,10 @@ func (s *EnsureTreeStateSuite) TestCreatesMissingFiles(c *C) {
 
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo": {
-			"missing1.snap": &osutil.MemoryBlob{Content: []byte(`content-1`), Mode: 0600},
+			"missing1.snap": &osutil.MemoryFileState{Content: []byte(`content-1`), Mode: 0600},
 		},
 		"bar": {
-			"missing2.snap": &osutil.MemoryBlob{Content: []byte(`content-2`), Mode: 0600},
+			"missing2.snap": &osutil.MemoryFileState{Content: []byte(`content-2`), Mode: 0600},
 		},
 	})
 	c.Assert(err, IsNil)
@@ -143,7 +143,7 @@ func (s *EnsureTreeStateSuite) TestErrorsOnDirectoryPathsMatchingGlobs(c *C) {
 func (s *EnsureTreeStateSuite) TestErrorsOnFilenamesWithSlashes(c *C) {
 	_, _, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo": {
-			"dir/file1.snap": &osutil.MemoryBlob{Content: []byte(`content-1`), Mode: 0600},
+			"dir/file1.snap": &osutil.MemoryFileState{Content: []byte(`content-1`), Mode: 0600},
 		},
 	})
 	c.Check(err, ErrorMatches, `internal error: EnsureTreeState got filename "dir/file1.snap" in "foo", which has a path component`)
@@ -152,7 +152,7 @@ func (s *EnsureTreeStateSuite) TestErrorsOnFilenamesWithSlashes(c *C) {
 func (s *EnsureTreeStateSuite) TestErrorsOnFilenamesNotMatchingGlobs(c *C) {
 	_, _, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo": {
-			"file1.not-snap": &osutil.MemoryBlob{Content: []byte(`content-1`), Mode: 0600},
+			"file1.not-snap": &osutil.MemoryFileState{Content: []byte(`content-1`), Mode: 0600},
 		},
 	})
 	c.Check(err, ErrorMatches, `internal error: EnsureTreeState got filename "file1.not-snap" in "foo", which doesn't match any glob patterns \["\*.snap"\]`)
@@ -170,7 +170,7 @@ func (s *EnsureTreeStateSuite) TestRemovesFilesOnError(c *C) {
 
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo": {
-			"file1.snap": &osutil.MemoryBlob{Content: []byte(`content-1`), Mode: 0600},
+			"file1.snap": &osutil.MemoryFileState{Content: []byte(`content-1`), Mode: 0600},
 		},
 	})
 	c.Check(err, ErrorMatches, `remove .*/bar/dir.snap: directory not empty`)

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -64,7 +64,7 @@ func ExportExperimentalFlags(tr config.Conf) error {
 			return err
 		}
 		if isEnabled {
-			content[feature.String()] = &osutil.MemoryBlob{Mode: 0644}
+			content[feature.String()] = &osutil.MemoryFileState{Mode: 0644}
 		}
 	}
 	_, _, err := osutil.EnsureDirState(dir, "*", content)

--- a/overlord/configstate/configcore/experimental.go
+++ b/overlord/configstate/configcore/experimental.go
@@ -54,7 +54,7 @@ func ExportExperimentalFlags(tr config.Conf) error {
 		return err
 	}
 	features := features.KnownFeatures()
-	content := make(map[string]*osutil.FileState, len(features))
+	content := make(map[string]osutil.FileState, len(features))
 	for _, feature := range features {
 		if !feature.IsExported() {
 			continue
@@ -64,7 +64,7 @@ func ExportExperimentalFlags(tr config.Conf) error {
 			return err
 		}
 		if isEnabled {
-			content[feature.String()] = &osutil.FileState{Mode: 0644}
+			content[feature.String()] = &osutil.MemoryBlob{Mode: 0644}
 		}
 	}
 	_, _, err := osutil.EnsureDirState(dir, "*", content)

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -61,9 +61,9 @@ func handleNetworkConfiguration(tr config.Conf) error {
 	default:
 		return fmt.Errorf("unsupported disable-ipv6 option: %q", output)
 	}
-	dirContent := map[string]*osutil.FileState{}
+	dirContent := map[string]osutil.FileState{}
 	if content.Len() > 0 {
-		dirContent[name] = &osutil.FileState{
+		dirContent[name] = &osutil.MemoryBlob{
 			Content: content.Bytes(),
 			Mode:    0644,
 		}

--- a/overlord/configstate/configcore/network.go
+++ b/overlord/configstate/configcore/network.go
@@ -63,7 +63,7 @@ func handleNetworkConfiguration(tr config.Conf) error {
 	}
 	dirContent := map[string]osutil.FileState{}
 	if content.Len() > 0 {
-		dirContent[name] = &osutil.MemoryBlob{
+		dirContent[name] = &osutil.MemoryFileState{
 			Content: content.Bytes(),
 			Mode:    0644,
 		}

--- a/overlord/configstate/configcore/watchdog.go
+++ b/overlord/configstate/configcore/watchdog.go
@@ -51,7 +51,7 @@ func updateWatchdogConfig(config map[string]uint) error {
 		// We order the variables to have predictable output
 		sort.Strings(configStr)
 		content := "[Manager]\n" + strings.Join(configStr, "")
-		dirContent[name] = &osutil.MemoryBlob{
+		dirContent[name] = &osutil.MemoryFileState{
 			Content: []byte(content),
 			Mode:    0644,
 		}

--- a/overlord/configstate/configcore/watchdog.go
+++ b/overlord/configstate/configcore/watchdog.go
@@ -39,7 +39,7 @@ func init() {
 func updateWatchdogConfig(config map[string]uint) error {
 	dir := dirs.SnapSystemdConfDir
 	name := "10-snapd-watchdog.conf"
-	dirContent := make(map[string]*osutil.FileState, 1)
+	dirContent := make(map[string]osutil.FileState, 1)
 
 	configStr := []string{}
 	for k, v := range config {
@@ -51,7 +51,7 @@ func updateWatchdogConfig(config map[string]uint) error {
 		// We order the variables to have predictable output
 		sort.Strings(configStr)
 		content := "[Manager]\n" + strings.Join(configStr, "")
-		dirContent[name] = &osutil.FileState{
+		dirContent[name] = &osutil.MemoryBlob{
 			Content: []byte(content),
 			Mode:    0644,
 		}

--- a/overlord/snapstate/cookies.go
+++ b/overlord/snapstate/cookies.go
@@ -80,9 +80,9 @@ func (m *SnapManager) SyncCookies(st *state.State) error {
 		}
 	}
 
-	content := make(map[string]*osutil.FileState)
+	content := make(map[string]osutil.FileState)
 	for cookie, snap := range snapCookies {
-		content[fmt.Sprintf("snap.%s", snap)] = &osutil.FileState{
+		content[fmt.Sprintf("snap.%s", snap)] = &osutil.MemoryBlob{
 			Content: []byte(cookie),
 			Mode:    0600,
 		}

--- a/overlord/snapstate/cookies.go
+++ b/overlord/snapstate/cookies.go
@@ -82,7 +82,7 @@ func (m *SnapManager) SyncCookies(st *state.State) error {
 
 	content := make(map[string]osutil.FileState)
 	for cookie, snap := range snapCookies {
-		content[fmt.Sprintf("snap.%s", snap)] = &osutil.MemoryBlob{
+		content[fmt.Sprintf("snap.%s", snap)] = &osutil.MemoryFileState{
 			Content: []byte(cookie),
 			Mode:    0600,
 		}

--- a/overlord/snapstate/readme.go
+++ b/overlord/snapstate/readme.go
@@ -53,7 +53,7 @@ func snapReadme() string {
 func writeSnapReadme() error {
 	const fname = "README"
 	content := map[string]osutil.FileState{
-		fname: &osutil.MemoryBlob{Content: []byte(snapReadme()), Mode: 0444},
+		fname: &osutil.MemoryFileState{Content: []byte(snapReadme()), Mode: 0444},
 	}
 	if err := os.MkdirAll(dirs.SnapMountDir, 0755); err != nil {
 		return err

--- a/overlord/snapstate/readme.go
+++ b/overlord/snapstate/readme.go
@@ -52,8 +52,8 @@ func snapReadme() string {
 
 func writeSnapReadme() error {
 	const fname = "README"
-	content := map[string]*osutil.FileState{
-		fname: {Content: []byte(snapReadme()), Mode: 0444},
+	content := map[string]osutil.FileState{
+		fname: &osutil.MemoryBlob{Content: []byte(snapReadme()), Mode: 0444},
 	}
 	if err := os.MkdirAll(dirs.SnapMountDir, 0755); err != nil {
 		return err

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -59,7 +59,7 @@ WantedBy=snapd.service
 	fullPath := filepath.Join(dirs.SnapServicesDir, unit)
 
 	err := osutil.EnsureFileState(fullPath,
-		&osutil.MemoryBlob{
+		&osutil.MemoryFileState{
 			Content: content,
 			Mode:    0644,
 		},
@@ -122,7 +122,7 @@ func writeSnapdServicesOnCore(s *snap.Info, inter interacter) error {
 		}
 		content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf(`ExecStart=%s$1`, s.MountDir())))
 
-		snapdUnits[filepath.Base(unit)] = &osutil.MemoryBlob{
+		snapdUnits[filepath.Base(unit)] = &osutil.MemoryFileState{
 			Content: content,
 			Mode:    st.Mode(),
 		}
@@ -164,7 +164,7 @@ func writeSnapdServicesOnCore(s *snap.Info, inter interacter) error {
 		// Some units (like the snapd.system-shutdown.service) cannot
 		// be started. Others like "snapd.seeded.service" are started
 		// as dependencies of snapd.service.
-		if bytes.Contains(snapdUnits[unit].(*osutil.MemoryBlob).Content, []byte("X-Snapd-Snap: do-not-start")) {
+		if bytes.Contains(snapdUnits[unit].(*osutil.MemoryFileState).Content, []byte("X-Snapd-Snap: do-not-start")) {
 			continue
 		}
 		// Ensure to only restart if the unit was previously
@@ -242,7 +242,7 @@ func writeSnapdUserServicesOnCore(s *snap.Info, inter interacter) error {
 		}
 		content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf(`ExecStart=%s$1`, s.MountDir())))
 
-		snapdUnits[filepath.Base(unit)] = &osutil.MemoryBlob{
+		snapdUnits[filepath.Base(unit)] = &osutil.MemoryFileState{
 			Content: content,
 			Mode:    st.Mode(),
 		}

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -59,7 +59,7 @@ WantedBy=snapd.service
 	fullPath := filepath.Join(dirs.SnapServicesDir, unit)
 
 	err := osutil.EnsureFileState(fullPath,
-		&osutil.FileState{
+		&osutil.MemoryBlob{
 			Content: content,
 			Mode:    0644,
 		},
@@ -110,7 +110,7 @@ func writeSnapdServicesOnCore(s *snap.Info, inter interacter) error {
 	units := append(socketUnits, serviceUnits...)
 	units = append(units, timerUnits...)
 
-	snapdUnits := make(map[string]*osutil.FileState, len(units)+1)
+	snapdUnits := make(map[string]osutil.FileState, len(units)+1)
 	for _, unit := range units {
 		st, err := os.Stat(unit)
 		if err != nil {
@@ -122,7 +122,7 @@ func writeSnapdServicesOnCore(s *snap.Info, inter interacter) error {
 		}
 		content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf(`ExecStart=%s$1`, s.MountDir())))
 
-		snapdUnits[filepath.Base(unit)] = &osutil.FileState{
+		snapdUnits[filepath.Base(unit)] = &osutil.MemoryBlob{
 			Content: content,
 			Mode:    st.Mode(),
 		}
@@ -164,7 +164,7 @@ func writeSnapdServicesOnCore(s *snap.Info, inter interacter) error {
 		// Some units (like the snapd.system-shutdown.service) cannot
 		// be started. Others like "snapd.seeded.service" are started
 		// as dependencies of snapd.service.
-		if bytes.Contains(snapdUnits[unit].Content, []byte("X-Snapd-Snap: do-not-start")) {
+		if bytes.Contains(snapdUnits[unit].(*osutil.MemoryBlob).Content, []byte("X-Snapd-Snap: do-not-start")) {
 			continue
 		}
 		// Ensure to only restart if the unit was previously
@@ -230,7 +230,7 @@ func writeSnapdUserServicesOnCore(s *snap.Info, inter interacter) error {
 	}
 	units := append(serviceUnits, socketUnits...)
 
-	snapdUnits := make(map[string]*osutil.FileState, len(units)+1)
+	snapdUnits := make(map[string]osutil.FileState, len(units)+1)
 	for _, unit := range units {
 		st, err := os.Stat(unit)
 		if err != nil {
@@ -242,7 +242,7 @@ func writeSnapdUserServicesOnCore(s *snap.Info, inter interacter) error {
 		}
 		content = execStartRe.ReplaceAll(content, []byte(fmt.Sprintf(`ExecStart=%s$1`, s.MountDir())))
 
-		snapdUnits[filepath.Base(unit)] = &osutil.FileState{
+		snapdUnits[filepath.Base(unit)] = &osutil.MemoryBlob{
 			Content: content,
 			Mode:    st.Mode(),
 		}

--- a/wrappers/icons.go
+++ b/wrappers/icons.go
@@ -83,7 +83,7 @@ func deriveIconContent(instanceName string, rootDir string, icons []string) (con
 		}
 		// rename icons to match snap instance name
 		base = instancePrefix + base[len(snapPrefix):]
-		dirContent[base] = &osutil.FileContentReference{
+		dirContent[base] = &osutil.FileReferencePlusMode{
 			FileReference: osutil.FileReference{Path: filepath.Join(rootDir, iconFile)},
 			Mode:          0644,
 		}


### PR DESCRIPTION
The directory synchronization code grew out of the desire to have a set
of files described by a glob and short, in-memory contents be reflected
to the disk in an efficient and predictable way.

Recently this code has started to be used to install icon themes shipped
by snaps. This means it may be used to coerce snapd to read arbitrary
amount of data into memory.

This address this issue by generalizing the directory sync APIs to take
an interface instead of a concrete representation of the desired file.

There are now three concrete implementations, one that keeps the content
in memory, just like before, called MemoryFileState and two new ones:
FileReference and FileReferencePlusMode. Those both refer to an existing
file for content, opening up the possibility to refer to large files.
They only differ in the treatment of file mode, either mirroring the
mode of the file being referred or using a fixed mode, respectively.

Behind the scenes the EnsureFileState function will no longer read all
of the file into memory. Instead if will use FileReference to stream it,
chunk by chunk, in an attempt to see if the file is identical to what we
expected.

On top of that, if the file is not the same and the caller has provided
a FileReference or FileReferencePlusMode, the logic that writes a new
file and replaces the original is also using streaming, again saving a
in-memory copy.

This way we can now process files of arbitrary size using fixed amount
of memory. This involves the new icon wrapper which has been switched to
use FileReferencePlusMode.

The patch contains some verbose automatic changes around the code using
maps of FileState structure to replace them with maps of FileState
interface instead.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
