### PR TITLE
tests: add regression test for lp: #1844496

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -326,6 +326,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			err = osRemove(c.Entry.Dir)
 			logger.Debugf("remove %q (error: %v)", c.Entry.Dir, err)
 		case "", "file":
+			logger.Debugf("THIS IS THE PATCHED COPY")
 			// Detach the mount point instead of unmounting it if requested.
 			flags := umountNoFollow
 			if c.Entry.XSnapdDetach() {
@@ -343,19 +344,18 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			// Perform the raw unmount operation.
 			if err == nil {
 				err = sysUnmount(c.Entry.Dir, flags)
+				logger.Debugf("umount %q (error: %v)", c.Entry.Dir, err)
 			}
-			if err == nil {
-				as.AddChange(c)
-			}
-			logger.Debugf("umount %q (error: %v)", c.Entry.Dir, err)
 			if err != nil {
 				return err
 			}
+			as.AddChange(c)
 
 			// Open a path of the file we are considering the removal of.
 			path := c.Entry.Dir
 			var fd int
 			fd, err = OpenPath(path)
+			logger.Debugf("openPath %q (error: %v)", path, err)
 			if err != nil {
 				return err
 			}
@@ -364,6 +364,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			// Don't attempt to remove anything from squashfs.
 			var statfsBuf syscall.Statfs_t
 			err = sysFstatfs(fd, &statfsBuf)
+			logger.Debugf("fstatfs %d (error: %v)", fd, err)
 			if err != nil {
 				return err
 			}
@@ -376,6 +377,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 				// the placeholders we created.
 				var statBuf syscall.Stat_t
 				err = sysFstat(fd, &statBuf)
+				logger.Debugf("fstat %d (error: %v)", fd, err)
 				if err != nil {
 					return err
 				}
@@ -388,6 +390,7 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 			// no way to avoid a race here since there's no way to unlink a
 			// file solely by file descriptor.
 			err = osRemove(path)
+			logger.Debugf("remove %q (error: %v)", path, err)
 			// Unpack the low-level error that osRemove wraps into PathError.
 			if packed, ok := err.(*os.PathError); ok {
 				err = packed.Err

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -453,7 +453,7 @@ func planWritableMimic(dir, neededBy string) ([]*Change, error) {
 	// We need a place for "safe keeping" of what is present in the original
 	// directory as we are about to attach a tmpfs there, which will hide
 	// everything inside.
-	logger.Debugf("create-writable-mimic %q", dir)
+	logger.Debugf("plan-writable-mimic %q (for %q)", dir, neededBy)
 	safeKeepingDir := filepath.Join("/tmp/.snap/", dir)
 
 	var changes []*Change

--- a/tests/regression/lp-1844496/task.yaml
+++ b/tests/regression/lp-1844496/task.yaml
@@ -1,0 +1,13 @@
+summary: regression test for https://bugs.launchpad.net/snapd/+bug/1844496
+prepare: |
+    snap pack test-snapd-layout
+    snap install --dangerous test-snapd-layout_1_all.snap
+execute: |
+    test "$(test-snapd-layout.sh -c 'cat /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary')" = content
+    snap install --dangerous test-snapd-layout_1_all.snap
+    test "$(test-snapd-layout.sh -c 'cat /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary')" = content
+    snap install --dangerous test-snapd-layout_1_all.snap
+    test "$(test-snapd-layout.sh -c 'cat /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary')" = content
+restore: |
+    snap remove test-snapd-layout
+    rm -f test-snapd-layout_1_all.snap

--- a/tests/regression/lp-1844496/task.yaml
+++ b/tests/regression/lp-1844496/task.yaml
@@ -3,6 +3,7 @@ prepare: |
     snap pack test-snapd-layout
     snap install --dangerous test-snapd-layout_1_all.snap
 execute: |
+    export SNAP_CONFINE_DEBUG=yes
     test "$(test-snapd-layout.sh -c 'cat /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary')" = content
     snap install --dangerous test-snapd-layout_1_all.snap
     test "$(test-snapd-layout.sh -c 'cat /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary')" = content

--- a/tests/regression/lp-1844496/test-snapd-layout/bin/sh
+++ b/tests/regression/lp-1844496/test-snapd-layout/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/regression/lp-1844496/test-snapd-layout/meta/snap.yaml
+++ b/tests/regression/lp-1844496/test-snapd-layout/meta/snap.yaml
@@ -1,0 +1,11 @@
+name: test-snapd-layout
+version: 1
+base: core18
+apps:
+    sh:
+        command: bin/sh
+layout:
+    /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0:
+        bind: $SNAP/usr/lib/x86_64-linux-gnu/wpe-webkit-1.0 
+    /usr/libexec/wpe-webkit-1.0:
+        bind: $SNAP/usr/wpe-webkit-1.0

--- a/tests/regression/lp-1844496/test-snapd-layout/usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary
+++ b/tests/regression/lp-1844496/test-snapd-layout/usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary
@@ -1,0 +1,1 @@
+content


### PR DESCRIPTION
This patch contains a work-in-progress of a regression test for a bug
that may have been fixed. It is also possible the test is imperfect and
doesn't correctly capture the essence of the issue.

Related-To: https://bugs.launchpad.net/snapd/+bug/1844496
Forum: https://forum.snapcraft.io/t/snap-does-not-start-after-reboot/5750/16
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>