### PR TITLE
interfaces/udev: account for cgroup version when reporting supported features

### DIFF
--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
@@ -165,8 +166,18 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxFeatures returns the list of features supported by snapd for mediating access to kernel devices.
 func (b *Backend) SandboxFeatures() []string {
-	return []string{
-		"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
-		"tagging",          /* Tagging dynamically associates new devices with specific snaps */
+	commonFeatures := []string{
+		"tagging", /* Tagging dynamically associates new devices with specific snaps */
 	}
+	cgroupv1Features := []string{
+		"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
+	}
+
+	if cgroup.IsUnified() {
+		// TODO: update v2 device cgroup is supported
+		return commonFeatures
+	}
+
+	features := append(cgroupv1Features, commonFeatures...)
+	return features
 }

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -170,6 +170,7 @@ func (b *Backend) SandboxFeatures() []string {
 		"tagging", /* Tagging dynamically associates new devices with specific snaps */
 	}
 	cgroupv1Features := []string{
+		"device-filtering", /* Snapd can limit device access for each snap */
 		"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
 	}
 

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
@@ -517,8 +518,17 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsRulesWithInputJoystickSub
 }
 
 func (s *backendSuite) TestSandboxFeatures(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
 		"device-cgroup-v1",
+		"tagging",
+	})
+
+	restore = cgroup.MockVersion(cgroup.V2, nil)
+	defer restore()
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
 		"tagging",
 	})
 }

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -522,6 +522,7 @@ func (s *backendSuite) TestSandboxFeatures(c *C) {
 	defer restore()
 
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
+		"device-filtering",
 		"device-cgroup-v1",
 		"tagging",
 	})


### PR DESCRIPTION
Take into account the host's cgroup version when reporting udev backend
features.
