### PR TITLE
store, ..., client: add a "website" field

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -64,6 +64,7 @@ type Snap struct {
 	CommonIDs        []string      `json:"common-ids,omitempty"`
 	MountedFrom      string        `json:"mounted-from,omitempty"`
 	CohortKey        string        `json:"cohort-key,omitempty"`
+	Website          string        `json:"website,omitempty"`
 
 	Prices      map[string]float64    `json:"prices,omitempty"`
 	Screenshots []snap.ScreenshotInfo `json:"screenshots,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -258,6 +258,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
                             {"type": "screenshot", "url":"http://example.com/shot2.png"}
                         ],
                         "cohort-key": "some-long-cohort-key",
+                        "website": "http://example.com/funky",
                         "common-ids": ["org.funky.snap"]
 		}
 	}`
@@ -302,6 +303,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 		},
 		CommonIDs: []string{"org.funky.snap"},
 		CohortKey: "some-long-cohort-key",
+		Website:   "http://example.com/funky",
 	})
 }
 

--- a/cmd/snapinfo.go
+++ b/cmd/snapinfo.go
@@ -78,6 +78,7 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info) (*client.Snap, error) {
 		Channels:    snapInfo.Channels,
 		Tracks:      snapInfo.Tracks,
 		CommonIDs:   snapInfo.CommonIDs,
+		Website:     snapInfo.Website,
 	}
 
 	return result, err

--- a/cmd/snapinfo_test.go
+++ b/cmd/snapinfo_test.go
@@ -24,7 +24,18 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
+	"github.com/snapcore/snapd/snap"
 )
+
+func (*cmdSuite) TestC2S(c *check.C) {
+	// TODO: add moar fields!
+	si := &snap.Info{
+		Website: "http://example.com/xyzzy",
+	}
+	ci, err := cmd.ClientSnapFromSnapInfo(si)
+	c.Check(err, check.IsNil)
+	c.Check(ci.Website, check.Equals, si.Website)
+}
 
 func (*cmdSuite) TestAppStatusNotes(c *check.C) {
 	ai := client.AppInfo{}

--- a/overlord/snapstate/aux_store_info.go
+++ b/overlord/snapstate/aux_store_info.go
@@ -34,7 +34,8 @@ import (
 // needed in the state, that may be stored to augment the information
 // returned for locally-installed snaps
 type auxStoreInfo struct {
-	Media snap.MediaInfos `json:"media,omitempty"`
+	Media   snap.MediaInfos `json:"media,omitempty"`
+	Website string          `json:"website,omitempty"`
 }
 
 func auxStoreInfoFilename(snapID string) string {
@@ -65,6 +66,7 @@ func retrieveAuxStoreInfo(info *snap.Info) error {
 	}
 
 	info.Media = aux.Media
+	info.Website = aux.Website
 
 	return nil
 }

--- a/overlord/snapstate/aux_store_info_test.go
+++ b/overlord/snapstate/aux_store_info_test.go
@@ -52,20 +52,24 @@ func (s *auxInfoSuite) TestAuxStoreInfoRoundTrip(c *check.C) {
 	c.Assert(osutil.FileExists(filename), check.Equals, false)
 	c.Check(snapstate.RetrieveAuxStoreInfo(info), check.IsNil)
 	c.Check(info.Media, check.HasLen, 0)
+	c.Check(info.Website, check.Equals, "")
 
-	c.Assert(snapstate.KeepAuxStoreInfo(info.SnapID, &snapstate.AuxStoreInfo{Media: media}), check.IsNil)
+	c.Assert(snapstate.KeepAuxStoreInfo(info.SnapID, &snapstate.AuxStoreInfo{Media: media, Website: "http://example.com/some-snap"}), check.IsNil)
 	c.Check(osutil.FileExists(filename), check.Equals, true)
 
 	c.Assert(snapstate.RetrieveAuxStoreInfo(info), check.IsNil)
 	c.Check(info.Media, check.HasLen, 1)
 	c.Check(info.Media, check.DeepEquals, media)
+	c.Check(info.Website, check.Equals, "http://example.com/some-snap")
 	info.Media = nil
+	info.Website = ""
 
 	c.Assert(snapstate.DiscardAuxStoreInfo(info.SnapID), check.IsNil)
 	c.Assert(osutil.FileExists(filename), check.Equals, false)
 
 	c.Check(snapstate.RetrieveAuxStoreInfo(info), check.IsNil)
 	c.Check(info.Media, check.HasLen, 0)
+	c.Check(info.Website, check.Equals, "")
 
 	c.Check(snapstate.DiscardAuxStoreInfo(info.SnapID), check.IsNil)
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1094,7 +1094,10 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 
 	if cand.SnapID != "" {
 		// write the auxiliary store info
-		aux := &auxStoreInfo{Media: snapsup.Media}
+		aux := &auxStoreInfo{
+			Media:   snapsup.Media,
+			Website: snapsup.Website,
+		}
 		if err := keepAuxStoreInfo(cand.SnapID, aux); err != nil {
 			return err
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -737,7 +737,8 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		PlugsOnly:    len(info.Slots) == 0,
 		InstanceKey:  info.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
-			Media: info.Media,
+			Media:   info.Media,
+			Website: info.Website,
 		},
 		CohortKey: opts.CohortKey,
 	}
@@ -997,7 +998,8 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			PlugsOnly:    len(update.Slots) == 0,
 			InstanceKey:  update.InstanceKey,
 			auxStoreInfo: auxStoreInfo{
-				Media: update.Media,
+				Website: update.Website,
+				Media:   update.Media,
 			},
 		}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -10411,15 +10411,17 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfo(c *C) {
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Description(), Equals, "Lots of text")
 	c.Check(info.Media, IsNil)
+	c.Check(info.Website, Equals, "")
 }
 
 func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoLoadsAuxiliaryStoreInfo(c *C) {
-	storeInfo := &snapstate.AuxStoreInfo{Media: snap.MediaInfos{
-		{
+	storeInfo := &snapstate.AuxStoreInfo{
+		Media: snap.MediaInfos{{
 			Type: "icon",
 			URL:  "http://example.com/favicon.ico",
-		},
-	}}
+		}},
+		Website: "http://example.com/",
+	}
 
 	c.Assert(snapstate.KeepAuxStoreInfo("123123123", storeInfo), IsNil)
 
@@ -10440,6 +10442,7 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoLoadsAuxiliaryStoreInfo(c *C
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Description(), Equals, "Lots of text")
 	c.Check(info.Media, DeepEquals, storeInfo.Media)
+	c.Check(info.Website, Equals, storeInfo.Website)
 }
 
 func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoParallelInstall(c *C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -242,7 +242,8 @@ type Info struct {
 
 	Publisher StoreAccount
 
-	Media MediaInfos
+	Media   MediaInfos
+	Website string
 
 	// The flattended channel map with $track/$risk
 	Channels map[string]*ChannelSnapInfo

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -51,6 +51,7 @@ type storeSnap struct {
 	Title         safejson.String    `json:"title"`
 	Type          snap.Type          `json:"type"`
 	Version       string             `json:"version"`
+	Website       string             `json:"website"`
 
 	// TODO: not yet defined: channel map
 
@@ -217,6 +218,9 @@ func copyNonZeroFrom(src, dst *storeSnap) {
 	if len(src.CommonIDs) > 0 {
 		dst.CommonIDs = src.CommonIDs
 	}
+	if len(src.Website) > 0 {
+		dst.Website = src.Website
+	}
 }
 
 func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
@@ -258,6 +262,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		info.Deltas = deltas
 	}
 	info.CommonIDs = d.CommonIDs
+	info.Website = d.Website
 
 	// fill in the plug/slot data
 	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -75,6 +75,7 @@ const (
   "title": "core",
   "type": "os",
   "version": "16-2.30",
+  "website": "http://example.com/core",
   "media": []
 }`
 
@@ -124,6 +125,7 @@ const (
   "title": "This Is The Most Fantastical Snap of Thingy",
   "type": "app",
   "version": "9.50",
+  "website": "http://example.com/thingy",
   "media": [
      {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Thingy.png"},
      {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
@@ -178,8 +180,9 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
 			Sha3_384:    "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
 			Size:        85291008,
 		},
-		Plugs: make(map[string]*snap.PlugInfo),
-		Slots: make(map[string]*snap.SlotInfo),
+		Plugs:   make(map[string]*snap.PlugInfo),
+		Slots:   make(map[string]*snap.SlotInfo),
+		Website: "http://example.com/core",
 	})
 }
 
@@ -249,6 +252,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			{Type: "screenshot", URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
 		CommonIDs: []string{"org.thingy"},
+		Website:   "http://example.com/thingy",
 	})
 
 	// validate the plugs/slots


### PR DESCRIPTION
The snap store exposes a "website" field, and we don't expose it. GUI
desktop stores need it to be at parity with the web store.
See https://bugs.launchpad.net/snapd/+bug/1838787 for details.