### PR TITLE
tests: disable {contacts,calendar}-service tests on Arch Linux

### DIFF
--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -6,7 +6,8 @@ summary: Ensure that the calendar-service interface works
 # FIXME: disable opensuse-tumbleweed until
 # https://github.com/snapcore/snapd/pull/7230 is landed
 # ubuntu-19.10: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*]
+# arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -arch-linux-*]
 
 # fails in the autopkgtest env with:
 # [Wed Aug 15 16:34:12 2018] audit: type=1400

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -4,7 +4,8 @@ summary: Ensure that the contacts-service interface works
 # does not ship a new enough evolution-data-server.
 # amazon: no need to run this on amazon
 # ubuntu-19.10: test-snapd-eds is incompatible with eds shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*]
+# arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -arch-linux-*]
 
 # fails in autopkgtest environment with:
 # [Wed Aug 15 16:08:23 2018] audit: type=1400


### PR DESCRIPTION
As Arch has [upgraded to evolution-data-server 3.34][1], it is no longer compatible with the test-snapd-eds snap.  The rationale is essentially the same as for #7463 where the test was disabled for Ubuntu 19.10.

We are still looking into whether it is possible to do something sensible with these interfaces.

[1]: https://www.archlinux.org/packages/extra/x86_64/evolution-data-server/