### PR TITLE
snapcraft: set license to GPL-3.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,6 +14,9 @@ version-script: |
 #type: snapd
 grade: stable
 
+passthrough:
+  license: GPL-3.0
+
 # Note that this snap is unusual in that it has no "apps" section.
 #
 # It is started via re-exec on classic systems and via special


### PR DESCRIPTION
Set snapd snap license to GPL-3.0 using the passthrough override.

The [snapcraft yaml reference docs](https://snapcraft.io/docs/snapcraft-yaml-reference) mention license is available as passthrough only.
