### PR TITLE
many: move AppArmor probing code under sandbox/apparmor

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -333,7 +333,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	spec.(*Specification).AddLayout(snapInfo)
 
 	// core on classic is special
-	if snapName == "core" && release.OnClassic && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.NoAppArmor {
+	if snapName == "core" && release.OnClassic && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.Unsupported {
 		if err := setupSnapConfineReexec(snapInfo); err != nil {
 			return fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
@@ -342,7 +342,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// Deal with the "snapd" snap - we do the setup slightly differently
 	// here because this will run both on classic and on Ubuntu Core 18
 	// systems but /etc/apparmor.d is not writable on core18 systems
-	if snapInfo.GetType() == snap.TypeSnapd && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.NoAppArmor {
+	if snapInfo.GetType() == snap.TypeSnapd && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.Unsupported {
 		if err := setupSnapConfineReexec(snapInfo); err != nil {
 			return fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
@@ -531,7 +531,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 	// When partial AppArmor is detected, use the classic template for now. We could
 	// use devmode, but that could generate confusing log entries for users running
 	// snaps on systems with partial AppArmor support.
-	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.PartialAppArmor {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.Partial {
 		// By default, downgrade confinement to the classic template when
 		// partial AppArmor support is detected. We don't want to use strict
 		// in general yet because older versions of the kernel did not
@@ -632,7 +632,7 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxFeatures returns the list of apparmor features supported by the kernel.
 func (b *Backend) SandboxFeatures() []string {
-	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.NoAppArmor {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.Unsupported {
 		return nil
 	}
 
@@ -653,7 +653,7 @@ func (b *Backend) SandboxFeatures() []string {
 
 	level := "full"
 	policy := "default"
-	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.PartialAppArmor {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.Partial {
 		level = "partial"
 
 		if downgradeConfinement() {

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timings"
@@ -62,8 +63,8 @@ var (
 	procSelfExe           = "/proc/self/exe"
 	isHomeUsingNFS        = osutil.IsHomeUsingNFS
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
-	kernelFeatures        = release.AppArmorKernelFeatures
-	parserFeatures        = release.AppArmorParserFeatures
+	kernelFeatures        = apparmor_sandbox.KernelFeatures
+	parserFeatures        = apparmor_sandbox.ParserFeatures
 )
 
 // Backend is responsible for maintaining apparmor profiles for snaps and parts of snapd.
@@ -332,7 +333,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	spec.(*Specification).AddLayout(snapInfo)
 
 	// core on classic is special
-	if snapName == "core" && release.OnClassic && release.AppArmorLevel() != release.NoAppArmor {
+	if snapName == "core" && release.OnClassic && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.NoAppArmor {
 		if err := setupSnapConfineReexec(snapInfo); err != nil {
 			return fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
@@ -341,7 +342,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// Deal with the "snapd" snap - we do the setup slightly differently
 	// here because this will run both on classic and on Ubuntu Core 18
 	// systems but /etc/apparmor.d is not writable on core18 systems
-	if snapInfo.GetType() == snap.TypeSnapd && release.AppArmorLevel() != release.NoAppArmor {
+	if snapInfo.GetType() == snap.TypeSnapd && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.NoAppArmor {
 		if err := setupSnapConfineReexec(snapInfo); err != nil {
 			return fmt.Errorf("cannot create host snap-confine apparmor configuration: %s", err)
 		}
@@ -530,7 +531,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 	// When partial AppArmor is detected, use the classic template for now. We could
 	// use devmode, but that could generate confusing log entries for users running
 	// snaps on systems with partial AppArmor support.
-	if release.AppArmorLevel() == release.PartialAppArmor {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.PartialAppArmor {
 		// By default, downgrade confinement to the classic template when
 		// partial AppArmor support is detected. We don't want to use strict
 		// in general yet because older versions of the kernel did not
@@ -631,7 +632,7 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxFeatures returns the list of apparmor features supported by the kernel.
 func (b *Backend) SandboxFeatures() []string {
-	if release.AppArmorLevel() == release.NoAppArmor {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.NoAppArmor {
 		return nil
 	}
 
@@ -652,7 +653,7 @@ func (b *Backend) SandboxFeatures() []string {
 
 	level := "full"
 	policy := "default"
-	if release.AppArmorLevel() == release.PartialAppArmor {
+	if apparmor_sandbox.ProbedLevel() == apparmor_sandbox.PartialAppArmor {
 		level = "partial"
 
 		if downgradeConfinement() {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -428,7 +428,7 @@ func (s *backendSuite) TestRemovingSnapDoesntBreakSnapsWIthPrefixName(c *C) {
 }
 
 func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 
 	snapInfo := snaptest.MockInfo(c, ifacetest.SambaYamlV1, nil)
@@ -510,7 +510,7 @@ snippet
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -550,7 +550,7 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 }
 
 func (s *backendSuite) TestCombineSnippetsChangeProfile(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -588,7 +588,7 @@ func (s *backendSuite) TestCombineSnippetsChangeProfile(c *C) {
 }
 
 func (s *backendSuite) TestParallelInstallCombineSnippets(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -635,7 +635,7 @@ profile "snap.samba_foo.smbd" (attach_disconnected,mediate_deleted) {
 }
 
 func mockPartalAppArmorOnDistro(c *C, kernelVersion string, releaseID string, releaseIDLike ...string) (restore func()) {
-	restore1 := apparmor_sandbox.MockLevel(apparmor_sandbox.PartialAppArmor)
+	restore1 := apparmor_sandbox.MockLevel(apparmor_sandbox.Partial)
 	restore2 := release.MockReleaseInfo(&release.OS{ID: releaseID, IDLike: releaseIDLike})
 	restore3 := osutil.MockKernelVersion(kernelVersion)
 	restore4 := apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
@@ -1450,7 +1450,7 @@ var nfsAndOverlaySnippetsScenarios = []nfsAndOverlaySnippetsScenario{{
 }}
 
 func (s *backendSuite) TestNFSAndOverlaySnippets(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return true, nil })
 	defer restore()
@@ -1496,7 +1496,7 @@ var casperOverlaySnippetsScenarios = []nfsAndOverlaySnippetsScenario{{
 }}
 
 func (s *backendSuite) TestCasperOverlaySnippets(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -1524,7 +1524,7 @@ func (s *backendSuite) TestNsProfile(c *C) {
 }
 
 func (s *backendSuite) TestSandboxFeatures(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockKernelFeatures(func() ([]string, error) { return []string{"foo", "bar"}, nil })
 	defer restore()
@@ -1535,7 +1535,7 @@ func (s *backendSuite) TestSandboxFeatures(c *C) {
 }
 
 func (s *backendSuite) TestSandboxFeaturesPartial(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.PartialAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Partial)
 	defer restore()
 	restore = release.MockReleaseInfo(&release.OS{ID: "opensuse-tumbleweed"})
 	defer restore()
@@ -1578,7 +1578,7 @@ apps:
 
 func (s *backendSuite) TestDowngradeConfinement(c *C) {
 
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.PartialAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Partial)
 	defer restore()
 
 	for _, tc := range []struct {
@@ -1604,7 +1604,7 @@ func (s *backendSuite) TestDowngradeConfinement(c *C) {
 func (s *backendSuite) TestPtraceTraceRule(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
 	defer restoreTemplate()
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -1749,7 +1749,7 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 func (s *backendSuite) TestHomeIxRule(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\nneedle rwkl###HOME_IX###,\n")
 	defer restoreTemplate()
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -1791,7 +1791,7 @@ func (s *backendSuite) TestHomeIxRule(c *C) {
 func (s *backendSuite) TestSystemUsernamesPolicy(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
 	defer restoreTemplate()
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 
 	snapYaml := `
@@ -1816,7 +1816,7 @@ apps:
 func (s *backendSuite) TestNoSystemUsernamesPolicy(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
 	defer restoreTemplate()
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 
 	snapYaml := `

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -427,7 +428,7 @@ func (s *backendSuite) TestRemovingSnapDoesntBreakSnapsWIthPrefixName(c *C) {
 }
 
 func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 
 	snapInfo := snaptest.MockInfo(c, ifacetest.SambaYamlV1, nil)
@@ -509,7 +510,7 @@ snippet
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -549,7 +550,7 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 }
 
 func (s *backendSuite) TestCombineSnippetsChangeProfile(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -587,7 +588,7 @@ func (s *backendSuite) TestCombineSnippetsChangeProfile(c *C) {
 }
 
 func (s *backendSuite) TestParallelInstallCombineSnippets(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -634,7 +635,7 @@ profile "snap.samba_foo.smbd" (attach_disconnected,mediate_deleted) {
 }
 
 func mockPartalAppArmorOnDistro(c *C, kernelVersion string, releaseID string, releaseIDLike ...string) (restore func()) {
-	restore1 := release.MockAppArmorLevel(release.PartialAppArmor)
+	restore1 := apparmor_sandbox.MockLevel(apparmor_sandbox.PartialAppArmor)
 	restore2 := release.MockReleaseInfo(&release.OS{ID: releaseID, IDLike: releaseIDLike})
 	restore3 := osutil.MockKernelVersion(kernelVersion)
 	restore4 := apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
@@ -1449,7 +1450,7 @@ var nfsAndOverlaySnippetsScenarios = []nfsAndOverlaySnippetsScenario{{
 }}
 
 func (s *backendSuite) TestNFSAndOverlaySnippets(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return true, nil })
 	defer restore()
@@ -1495,7 +1496,7 @@ var casperOverlaySnippetsScenarios = []nfsAndOverlaySnippetsScenario{{
 }}
 
 func (s *backendSuite) TestCasperOverlaySnippets(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -1523,7 +1524,7 @@ func (s *backendSuite) TestNsProfile(c *C) {
 }
 
 func (s *backendSuite) TestSandboxFeatures(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockKernelFeatures(func() ([]string, error) { return []string{"foo", "bar"}, nil })
 	defer restore()
@@ -1534,7 +1535,7 @@ func (s *backendSuite) TestSandboxFeatures(c *C) {
 }
 
 func (s *backendSuite) TestSandboxFeaturesPartial(c *C) {
-	restore := release.MockAppArmorLevel(release.PartialAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.PartialAppArmor)
 	defer restore()
 	restore = release.MockReleaseInfo(&release.OS{ID: "opensuse-tumbleweed"})
 	defer restore()
@@ -1577,7 +1578,7 @@ apps:
 
 func (s *backendSuite) TestDowngradeConfinement(c *C) {
 
-	restore := release.MockAppArmorLevel(release.PartialAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.PartialAppArmor)
 	defer restore()
 
 	for _, tc := range []struct {
@@ -1603,7 +1604,7 @@ func (s *backendSuite) TestDowngradeConfinement(c *C) {
 func (s *backendSuite) TestPtraceTraceRule(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
 	defer restoreTemplate()
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -1748,7 +1749,7 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 func (s *backendSuite) TestHomeIxRule(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\nneedle rwkl###HOME_IX###,\n")
 	defer restoreTemplate()
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
@@ -1790,7 +1791,7 @@ func (s *backendSuite) TestHomeIxRule(c *C) {
 func (s *backendSuite) TestSystemUsernamesPolicy(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
 	defer restoreTemplate()
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 
 	snapYaml := `
@@ -1815,7 +1816,7 @@ apps:
 func (s *backendSuite) TestNoSystemUsernamesPolicy(c *C) {
 	restoreTemplate := apparmor.MockTemplate("template\n###SNIPPETS###\n")
 	defer restoreTemplate()
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 
 	snapYaml := `

--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/systemd"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/release"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 )
 
 var All []interfaces.SecurityBackend = backends()
@@ -47,6 +47,9 @@ func backends() []interfaces.SecurityBackend {
 		&kmod.Backend{},
 	}
 
+	// TODO use something like:
+	// level, summary := apparmor.ProbeResults()
+
 	// This should be logger.Noticef but due to ordering of initialization
 	// calls, the logger is not ready at this point yet and the message goes
 	// nowhere. Per advice from other snapd developers, we just print it
@@ -57,7 +60,7 @@ func backends() []interfaces.SecurityBackend {
 	// By printing this directly we ensure it will end up the journal for the
 	// snapd.service. This aspect should be retained even after the switch to
 	// user-warning.
-	fmt.Printf("AppArmor status: %s\n", release.AppArmorSummary())
+	fmt.Printf("AppArmor status: %s\n", apparmor_sandbox.Summary())
 
 	// Enable apparmor backend if there is any level of apparmor support,
 	// including partial feature set. This will allow snap-confine to always
@@ -66,8 +69,8 @@ func backends() []interfaces.SecurityBackend {
 	//
 	// When some features are missing the backend will generate more permissive
 	// profiles that keep applications operational, in forced-devmode.
-	switch release.AppArmorLevel() {
-	case release.PartialAppArmor, release.FullAppArmor:
+	switch apparmor_sandbox.ProbedLevel() {
+	case apparmor_sandbox.PartialAppArmor, apparmor_sandbox.FullAppArmor:
 		all = append(all, &apparmor.Backend{})
 	}
 	return all

--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -70,7 +70,7 @@ func backends() []interfaces.SecurityBackend {
 	// When some features are missing the backend will generate more permissive
 	// profiles that keep applications operational, in forced-devmode.
 	switch apparmor_sandbox.ProbedLevel() {
-	case apparmor_sandbox.PartialAppArmor, apparmor_sandbox.FullAppArmor:
+	case apparmor_sandbox.Partial, apparmor_sandbox.Full:
 		all = append(all, &apparmor.Backend{})
 	}
 	return all

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -23,7 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces/backends"
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -36,8 +36,8 @@ type backendsSuite struct{}
 var _ = Suite(&backendsSuite{})
 
 func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
-	for _, level := range []release.AppArmorLevelType{release.NoAppArmor, release.UnusableAppArmor, release.PartialAppArmor, release.FullAppArmor} {
-		restore := release.MockAppArmorLevel(level)
+	for _, level := range []apparmor.AppArmorLevelType{apparmor.NoAppArmor, apparmor.UnusableAppArmor, apparmor.PartialAppArmor, apparmor.FullAppArmor} {
+		restore := apparmor.MockLevel(level)
 		defer restore()
 
 		all := backends.Backends()
@@ -46,9 +46,9 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 			names[i] = string(backend.Name())
 		}
 		switch level {
-		case release.NoAppArmor, release.UnusableAppArmor:
+		case apparmor.NoAppArmor, apparmor.UnusableAppArmor:
 			c.Assert(names, Not(testutil.Contains), "apparmor")
-		case release.PartialAppArmor, release.FullAppArmor:
+		case apparmor.PartialAppArmor, apparmor.FullAppArmor:
 			c.Assert(names, testutil.Contains, "apparmor")
 		}
 
@@ -56,7 +56,7 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 }
 
 func (s *backendsSuite) TestEssentialOrdering(c *C) {
-	restore := release.MockAppArmorLevel(release.FullAppArmor)
+	restore := apparmor.MockLevel(apparmor.FullAppArmor)
 	defer restore()
 
 	all := backends.Backends()

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -36,7 +36,7 @@ type backendsSuite struct{}
 var _ = Suite(&backendsSuite{})
 
 func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
-	for _, level := range []apparmor_sandbox.AppArmorLevelType{apparmor_sandbox.NoAppArmor, apparmor_sandbox.UnusableAppArmor, apparmor_sandbox.PartialAppArmor, apparmor_sandbox.FullAppArmor} {
+	for _, level := range []apparmor_sandbox.LevelType{apparmor_sandbox.Unsupported, apparmor_sandbox.Unusable, apparmor_sandbox.Partial, apparmor_sandbox.Full} {
 		restore := apparmor_sandbox.MockLevel(level)
 		defer restore()
 
@@ -46,9 +46,9 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 			names[i] = string(backend.Name())
 		}
 		switch level {
-		case apparmor_sandbox.NoAppArmor, apparmor_sandbox.UnusableAppArmor:
+		case apparmor_sandbox.Unsupported, apparmor_sandbox.Unusable:
 			c.Assert(names, Not(testutil.Contains), "apparmor")
-		case apparmor_sandbox.PartialAppArmor, apparmor_sandbox.FullAppArmor:
+		case apparmor_sandbox.Partial, apparmor_sandbox.Full:
 			c.Assert(names, testutil.Contains, "apparmor")
 		}
 
@@ -56,7 +56,7 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 }
 
 func (s *backendsSuite) TestEssentialOrdering(c *C) {
-	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 
 	all := backends.Backends()

--- a/interfaces/backends/backends_test.go
+++ b/interfaces/backends/backends_test.go
@@ -23,7 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces/backends"
-	"github.com/snapcore/snapd/sandbox/apparmor"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -36,8 +36,8 @@ type backendsSuite struct{}
 var _ = Suite(&backendsSuite{})
 
 func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
-	for _, level := range []apparmor.AppArmorLevelType{apparmor.NoAppArmor, apparmor.UnusableAppArmor, apparmor.PartialAppArmor, apparmor.FullAppArmor} {
-		restore := apparmor.MockLevel(level)
+	for _, level := range []apparmor_sandbox.AppArmorLevelType{apparmor_sandbox.NoAppArmor, apparmor_sandbox.UnusableAppArmor, apparmor_sandbox.PartialAppArmor, apparmor_sandbox.FullAppArmor} {
+		restore := apparmor_sandbox.MockLevel(level)
 		defer restore()
 
 		all := backends.Backends()
@@ -46,9 +46,9 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 			names[i] = string(backend.Name())
 		}
 		switch level {
-		case apparmor.NoAppArmor, apparmor.UnusableAppArmor:
+		case apparmor_sandbox.NoAppArmor, apparmor_sandbox.UnusableAppArmor:
 			c.Assert(names, Not(testutil.Contains), "apparmor")
-		case apparmor.PartialAppArmor, apparmor.FullAppArmor:
+		case apparmor_sandbox.PartialAppArmor, apparmor_sandbox.FullAppArmor:
 			c.Assert(names, testutil.Contains, "apparmor")
 		}
 
@@ -56,7 +56,7 @@ func (s *backendsSuite) TestIsAppArmorEnabled(c *C) {
 }
 
 func (s *backendsSuite) TestEssentialOrdering(c *C) {
-	restore := apparmor.MockLevel(apparmor.FullAppArmor)
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.FullAppArmor)
 	defer restore()
 
 	all := backends.Backends()

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/release"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -611,7 +612,7 @@ func (iface *dockerSupportInterface) StaticInfo() interfaces.StaticInfo {
 }
 
 var (
-	parserFeatures = release.AppArmorParserFeatures
+	parserFeatures = apparmor_sandbox.ParserFeatures
 )
 
 func (iface *dockerSupportInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 )
 
@@ -106,10 +107,10 @@ func generateSystemKey() (*systemKey, error) {
 	sk.BuildID = buildID
 
 	// Add apparmor-features (which is already sorted)
-	sk.AppArmorFeatures, _ = release.AppArmorKernelFeatures()
+	sk.AppArmorFeatures, _ = apparmor.KernelFeatures()
 
 	// Add apparmor-parser-mtime
-	sk.AppArmorParserMtime = release.AppArmorParserMtime()
+	sk.AppArmorParserMtime = apparmor.ParserMtime()
 
 	// Add if home is using NFS, if so we need to have a different
 	// security profile and if this changes we need to change our
@@ -153,7 +154,7 @@ func WriteSystemKey() error {
 	// We only want to calculate this when the mtime of the parser changes.
 	// Since we calculate the mtime() as part of generateSystemKey, we can
 	// simply unconditionally write this out here.
-	sk.AppArmorParserFeatures, _ = release.AppArmorParserFeatures()
+	sk.AppArmorParserFeatures, _ = apparmor.ParserFeatures()
 
 	sks, err := json.Marshal(sk)
 	if err != nil {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -93,15 +94,15 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	systemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)
 
-	kernelFeatures, _ := release.AppArmorKernelFeatures()
+	kernelFeatures, _ := apparmor.KernelFeatures()
 
 	apparmorFeaturesStr, err := json.Marshal(kernelFeatures)
 	c.Assert(err, IsNil)
 
-	apparmorParserMtime, err := json.Marshal(release.AppArmorParserMtime())
+	apparmorParserMtime, err := json.Marshal(apparmor.ParserMtime())
 	c.Assert(err, IsNil)
 
-	parserFeatures, _ := release.AppArmorParserFeatures()
+	parserFeatures, _ := apparmor.ParserFeatures()
 	apparmorParserFeaturesStr, err := json.Marshal(parserFeatures)
 	c.Assert(err, IsNil)
 

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -34,22 +34,6 @@ func MockOSReleasePath(filename string) (restore func()) {
 	}
 }
 
-func MockAppArmorFeaturesSysPath(path string) (restorer func()) {
-	old := appArmorFeaturesSysPath
-	appArmorFeaturesSysPath = path
-	return func() {
-		appArmorFeaturesSysPath = old
-	}
-}
-
-func MockAppArmorParserSearchPath(new string) (restore func()) {
-	oldAppArmorParserSearchPath := appArmorParserSearchPath
-	appArmorParserSearchPath = new
-	return func() {
-		appArmorParserSearchPath = oldAppArmorParserSearchPath
-	}
-}
-
 func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func()) {
 	old := ioutilReadFile
 	ioutilReadFile = newReadfile
@@ -67,22 +51,10 @@ func MockSELinuxIsEnforcing(isEnforcing func() (bool, error)) (restore func()) {
 }
 
 var (
-	ProbeAppArmorKernelFeatures = probeAppArmorKernelFeatures
-	ProbeAppArmorParserFeatures = probeAppArmorParserFeatures
-
-	RequiredAppArmorKernelFeatures  = requiredAppArmorKernelFeatures
-	RequiredAppArmorParserFeatures  = requiredAppArmorParserFeatures
-	PreferredAppArmorKernelFeatures = preferredAppArmorKernelFeatures
-	PreferredAppArmorParserFeatures = preferredAppArmorParserFeatures
-
 	IsWSL = isWSL
 
 	ProbeSELinux = probeSELinux
 )
-
-func FreshAppArmorAssessment() {
-	appArmorAssessment = &appArmorAssess{appArmorProber: &appArmorProbe{}}
-}
 
 func FreshSecCompProbe() {
 	secCompProber = &secCompProbe{}

--- a/release/release.go
+++ b/release/release.go
@@ -44,7 +44,7 @@ type OS struct {
 // ForceDevMode returns true if the distribution doesn't implement required
 // security features for confinement and devmode is forced.
 func (o *OS) ForceDevMode() bool {
-	return apparmor.ProbedLevel() != apparmor.FullAppArmor
+	return apparmor.ProbedLevel() != apparmor.Full
 }
 
 // DistroLike checks if the distribution ID or ID_LIKE matches one of the given names.
@@ -161,9 +161,9 @@ func MockReleaseInfo(osRelease *OS) (restore func()) {
 // MockForcedDevmode fake the system to believe its in a distro
 // that is in ForcedDevmode
 func MockForcedDevmode(isDevmode bool) (restore func()) {
-	level := apparmor.FullAppArmor
+	level := apparmor.Full
 	if isDevmode {
-		level = apparmor.NoAppArmor
+		level = apparmor.Unsupported
 	}
 	return apparmor.MockLevel(level)
 }

--- a/release/release.go
+++ b/release/release.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -43,7 +44,7 @@ type OS struct {
 // ForceDevMode returns true if the distribution doesn't implement required
 // security features for confinement and devmode is forced.
 func (o *OS) ForceDevMode() bool {
-	return AppArmorLevel() != FullAppArmor
+	return apparmor.ProbedLevel() != apparmor.FullAppArmor
 }
 
 // DistroLike checks if the distribution ID or ID_LIKE matches one of the given names.
@@ -160,9 +161,9 @@ func MockReleaseInfo(osRelease *OS) (restore func()) {
 // MockForcedDevmode fake the system to believe its in a distro
 // that is in ForcedDevmode
 func MockForcedDevmode(isDevmode bool) (restore func()) {
-	level := FullAppArmor
+	level := apparmor.FullAppArmor
 	if isDevmode {
-		level = NoAppArmor
+		level = apparmor.NoAppArmor
 	}
-	return MockAppArmorLevel(level)
+	return apparmor.MockLevel(level)
 }

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -17,42 +17,47 @@
  *
  */
 
-package release_test
+package apparmor_test
 
 import (
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/testutil"
 )
+
+func TestApparmor(t *testing.T) {
+	TestingT(t)
+}
 
 type apparmorSuite struct{}
 
 var _ = Suite(&apparmorSuite{})
 
 func (*apparmorSuite) TestAppArmorLevelTypeStringer(c *C) {
-	c.Check(release.UnknownAppArmor.String(), Equals, "unknown")
-	c.Check(release.NoAppArmor.String(), Equals, "none")
-	c.Check(release.UnusableAppArmor.String(), Equals, "unusable")
-	c.Check(release.PartialAppArmor.String(), Equals, "partial")
-	c.Check(release.FullAppArmor.String(), Equals, "full")
-	c.Check(release.AppArmorLevelType(42).String(), Equals, "AppArmorLevelType:42")
+	c.Check(apparmor.UnknownAppArmor.String(), Equals, "unknown")
+	c.Check(apparmor.NoAppArmor.String(), Equals, "none")
+	c.Check(apparmor.UnusableAppArmor.String(), Equals, "unusable")
+	c.Check(apparmor.PartialAppArmor.String(), Equals, "partial")
+	c.Check(apparmor.FullAppArmor.String(), Equals, "full")
+	c.Check(apparmor.AppArmorLevelType(42).String(), Equals, "AppArmorLevelType:42")
 }
 
 func (*apparmorSuite) TestMockAppArmorLevel(c *C) {
-	for _, lvl := range []release.AppArmorLevelType{release.NoAppArmor, release.UnusableAppArmor, release.PartialAppArmor, release.FullAppArmor} {
-		restore := release.MockAppArmorLevel(lvl)
-		c.Check(release.AppArmorLevel(), Equals, lvl)
-		c.Check(release.AppArmorSummary(), testutil.Contains, "mocked apparmor level: ")
-		features, err := release.AppArmorKernelFeatures()
+	for _, lvl := range []apparmor.AppArmorLevelType{apparmor.NoAppArmor, apparmor.UnusableAppArmor, apparmor.PartialAppArmor, apparmor.FullAppArmor} {
+		restore := apparmor.MockLevel(lvl)
+		c.Check(apparmor.ProbedLevel(), Equals, lvl)
+		c.Check(apparmor.Summary(), testutil.Contains, "mocked apparmor level: ")
+		features, err := apparmor.KernelFeatures()
 		c.Check(err, IsNil)
 		c.Check(features, DeepEquals, []string{"mocked-kernel-feature"})
-		features, err = release.AppArmorParserFeatures()
+		features, err = apparmor.ParserFeatures()
 		c.Check(err, IsNil)
 		c.Check(features, DeepEquals, []string{"mocked-parser-feature"})
 		restore()
@@ -62,76 +67,76 @@ func (*apparmorSuite) TestMockAppArmorLevel(c *C) {
 // Using MockAppArmorFeatures yields in apparmor assessment
 func (*apparmorSuite) TestMockAppArmorFeatures(c *C) {
 	// No apparmor in the kernel, apparmor is disabled.
-	restore := release.MockAppArmorFeatures([]string{}, os.ErrNotExist, []string{}, nil)
-	c.Check(release.AppArmorLevel(), Equals, release.NoAppArmor)
-	c.Check(release.AppArmorSummary(), Equals, "apparmor not enabled")
-	features, err := release.AppArmorKernelFeatures()
+	restore := apparmor.MockFeatures([]string{}, os.ErrNotExist, []string{}, nil)
+	c.Check(apparmor.ProbedLevel(), Equals, apparmor.NoAppArmor)
+	c.Check(apparmor.Summary(), Equals, "apparmor not enabled")
+	features, err := apparmor.KernelFeatures()
 	c.Assert(err, Equals, os.ErrNotExist)
 	c.Check(features, DeepEquals, []string{})
-	features, err = release.AppArmorParserFeatures()
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{})
 	restore()
 
 	// No apparmor_parser, apparmor is disabled.
-	restore = release.MockAppArmorFeatures([]string{}, nil, []string{}, os.ErrNotExist)
-	c.Check(release.AppArmorLevel(), Equals, release.NoAppArmor)
-	c.Check(release.AppArmorSummary(), Equals, "apparmor_parser not found")
-	features, err = release.AppArmorKernelFeatures()
+	restore = apparmor.MockFeatures([]string{}, nil, []string{}, os.ErrNotExist)
+	c.Check(apparmor.ProbedLevel(), Equals, apparmor.NoAppArmor)
+	c.Check(apparmor.Summary(), Equals, "apparmor_parser not found")
+	features, err = apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{})
-	features, err = release.AppArmorParserFeatures()
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, Equals, os.ErrNotExist)
 	c.Check(features, DeepEquals, []string{})
 	restore()
 
 	// Complete kernel features but apparmor is unusable because of missing required parser features.
-	restore = release.MockAppArmorFeatures(release.RequiredAppArmorKernelFeatures, nil, []string{}, nil)
-	c.Check(release.AppArmorLevel(), Equals, release.UnusableAppArmor)
-	c.Check(release.AppArmorSummary(), Equals, "apparmor_parser is available but required parser features are missing: unsafe")
-	features, err = release.AppArmorKernelFeatures()
+	restore = apparmor.MockFeatures(apparmor.RequiredKernelFeatures, nil, []string{}, nil)
+	c.Check(apparmor.ProbedLevel(), Equals, apparmor.UnusableAppArmor)
+	c.Check(apparmor.Summary(), Equals, "apparmor_parser is available but required parser features are missing: unsafe")
+	features, err = apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, release.RequiredAppArmorKernelFeatures)
-	features, err = release.AppArmorParserFeatures()
+	c.Check(features, DeepEquals, apparmor.RequiredKernelFeatures)
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{})
 	restore()
 
 	// Complete parser features but apparmor is unusable because of missing required kernel features.
 	// The dummy feature is there to pretend that apparmor in the kernel is not entirely disabled.
-	restore = release.MockAppArmorFeatures([]string{"dummy-feature"}, nil, release.RequiredAppArmorParserFeatures, nil)
-	c.Check(release.AppArmorLevel(), Equals, release.UnusableAppArmor)
-	c.Check(release.AppArmorSummary(), Equals, "apparmor is enabled but required kernel features are missing: file")
-	features, err = release.AppArmorKernelFeatures()
+	restore = apparmor.MockFeatures([]string{"dummy-feature"}, nil, apparmor.RequiredParserFeatures, nil)
+	c.Check(apparmor.ProbedLevel(), Equals, apparmor.UnusableAppArmor)
+	c.Check(apparmor.Summary(), Equals, "apparmor is enabled but required kernel features are missing: file")
+	features, err = apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"dummy-feature"})
-	features, err = release.AppArmorParserFeatures()
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, release.RequiredAppArmorParserFeatures)
+	c.Check(features, DeepEquals, apparmor.RequiredParserFeatures)
 	restore()
 
 	// Required kernel and parser features available, some optional features are missing though.
-	restore = release.MockAppArmorFeatures(release.RequiredAppArmorKernelFeatures, nil, release.RequiredAppArmorParserFeatures, nil)
-	c.Check(release.AppArmorLevel(), Equals, release.PartialAppArmor)
-	c.Check(release.AppArmorSummary(), Equals, "apparmor is enabled but some kernel features are missing: caps, dbus, domain, mount, namespaces, network, ptrace, signal")
-	features, err = release.AppArmorKernelFeatures()
+	restore = apparmor.MockFeatures(apparmor.RequiredKernelFeatures, nil, apparmor.RequiredParserFeatures, nil)
+	c.Check(apparmor.ProbedLevel(), Equals, apparmor.PartialAppArmor)
+	c.Check(apparmor.Summary(), Equals, "apparmor is enabled but some kernel features are missing: caps, dbus, domain, mount, namespaces, network, ptrace, signal")
+	features, err = apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, release.RequiredAppArmorKernelFeatures)
-	features, err = release.AppArmorParserFeatures()
+	c.Check(features, DeepEquals, apparmor.RequiredKernelFeatures)
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, release.RequiredAppArmorParserFeatures)
+	c.Check(features, DeepEquals, apparmor.RequiredParserFeatures)
 	restore()
 
 	// Preferred kernel and parser features available.
-	restore = release.MockAppArmorFeatures(release.PreferredAppArmorKernelFeatures, nil, release.PreferredAppArmorParserFeatures, nil)
-	c.Check(release.AppArmorLevel(), Equals, release.FullAppArmor)
-	c.Check(release.AppArmorSummary(), Equals, "apparmor is enabled and all features are available")
-	features, err = release.AppArmorKernelFeatures()
+	restore = apparmor.MockFeatures(apparmor.PreferredKernelFeatures, nil, apparmor.PreferredParserFeatures, nil)
+	c.Check(apparmor.ProbedLevel(), Equals, apparmor.FullAppArmor)
+	c.Check(apparmor.Summary(), Equals, "apparmor is enabled and all features are available")
+	features, err = apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, release.PreferredAppArmorKernelFeatures)
-	features, err = release.AppArmorParserFeatures()
+	c.Check(features, DeepEquals, apparmor.PreferredKernelFeatures)
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
-	c.Check(features, DeepEquals, release.PreferredAppArmorParserFeatures)
+	c.Check(features, DeepEquals, apparmor.PreferredParserFeatures)
 	restore()
 }
 
@@ -139,23 +144,23 @@ func (s *apparmorSuite) TestProbeAppArmorKernelFeatures(c *C) {
 	d := c.MkDir()
 
 	// Pretend that apparmor kernel features directory doesn't exist.
-	restore := release.MockAppArmorFeaturesSysPath(filepath.Join(d, "non-existent"))
+	restore := apparmor.MockFeaturesSysPath(filepath.Join(d, "non-existent"))
 	defer restore()
-	features, err := release.ProbeAppArmorKernelFeatures()
+	features, err := apparmor.ProbeKernelFeatures()
 	c.Assert(os.IsNotExist(err), Equals, true)
 	c.Check(features, DeepEquals, []string{})
 
 	// Pretend that apparmor kernel features directory exists but is empty.
-	restore = release.MockAppArmorFeaturesSysPath(d)
+	restore = apparmor.MockFeaturesSysPath(d)
 	defer restore()
-	features, err = release.ProbeAppArmorKernelFeatures()
+	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{})
 
 	// Pretend that apparmor kernel features directory contains some entries.
 	c.Assert(os.Mkdir(filepath.Join(d, "foo"), 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d, "bar"), 0755), IsNil)
-	features, err = release.ProbeAppArmorKernelFeatures()
+	features, err = apparmor.ProbeKernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"bar", "foo"})
 }
@@ -174,10 +179,10 @@ func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
 	for _, t := range testcases {
 		mockParserCmd := testutil.MockCommand(c, "apparmor_parser", fmt.Sprintf("cat > %s/stdin; %s", d, t.exit))
 		defer mockParserCmd.Restore()
-		restore := release.MockAppArmorParserSearchPath(mockParserCmd.BinDir())
+		restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
 		defer restore()
 
-		features, err := release.ProbeAppArmorParserFeatures()
+		features, err := apparmor.ProbeParserFeatures()
 		c.Assert(err, IsNil)
 		c.Check(features, DeepEquals, t.features)
 		c.Check(mockParserCmd.Calls(), DeepEquals, [][]string{{"apparmor_parser", "--preprocess"}})
@@ -187,33 +192,33 @@ func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
 	}
 
 	// Pretend that we just don't have apparmor_parser at all.
-	restore := release.MockAppArmorParserSearchPath(c.MkDir())
+	restore := apparmor.MockParserSearchPath(c.MkDir())
 	defer restore()
-	features, err := release.ProbeAppArmorParserFeatures()
+	features, err := apparmor.ProbeParserFeatures()
 	c.Check(err, Equals, os.ErrNotExist)
 	c.Check(features, DeepEquals, []string{})
 }
 
 func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {
-	release.FreshAppArmorAssessment()
+	apparmor.FreshAppArmorAssessment()
 
 	d := c.MkDir()
-	restore := release.MockAppArmorFeaturesSysPath(d)
+	restore := apparmor.MockFeaturesSysPath(d)
 	defer restore()
 	c.Assert(os.MkdirAll(filepath.Join(d, "policy"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(d, "network"), 0755), IsNil)
 
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer mockParserCmd.Restore()
-	restore = release.MockAppArmorParserSearchPath(mockParserCmd.BinDir())
+	restore = apparmor.MockParserSearchPath(mockParserCmd.BinDir())
 	defer restore()
 
-	release.AppArmorLevel()
+	apparmor.ProbedLevel()
 
-	features, err := release.AppArmorKernelFeatures()
+	features, err := apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"network", "policy"})
-	features, err = release.AppArmorParserFeatures()
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"unsafe"})
 }
@@ -222,38 +227,38 @@ func (s *apparmorSuite) TestAppArmorParserMtime(c *C) {
 	// Pretend that we have apparmor_parser.
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer mockParserCmd.Restore()
-	restore := release.MockAppArmorParserSearchPath(mockParserCmd.BinDir())
+	restore := apparmor.MockParserSearchPath(mockParserCmd.BinDir())
 	defer restore()
-	mtime := release.AppArmorParserMtime()
+	mtime := apparmor.ParserMtime()
 	fi, err := os.Stat(filepath.Join(mockParserCmd.BinDir(), "apparmor_parser"))
 	c.Assert(err, IsNil)
 	c.Check(mtime, Equals, fi.ModTime().Unix())
 
 	// Pretend that we don't have apparmor_parser.
-	restore = release.MockAppArmorParserSearchPath(c.MkDir())
+	restore = apparmor.MockParserSearchPath(c.MkDir())
 	defer restore()
-	mtime = release.AppArmorParserMtime()
+	mtime = apparmor.ParserMtime()
 	c.Check(mtime, Equals, int64(0))
 }
 
 func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
-	release.FreshAppArmorAssessment()
+	apparmor.FreshAppArmorAssessment()
 
 	d := c.MkDir()
-	restore := release.MockAppArmorFeaturesSysPath(d)
+	restore := apparmor.MockFeaturesSysPath(d)
 	defer restore()
 	c.Assert(os.MkdirAll(filepath.Join(d, "policy"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(d, "network"), 0755), IsNil)
 
 	mockParserCmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer mockParserCmd.Restore()
-	restore = release.MockAppArmorParserSearchPath(mockParserCmd.BinDir())
+	restore = apparmor.MockParserSearchPath(mockParserCmd.BinDir())
 	defer restore()
 
-	features, err := release.AppArmorKernelFeatures()
+	features, err := apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"network", "policy"})
-	features, err = release.AppArmorParserFeatures()
+	features, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
 	c.Check(features, DeepEquals, []string{"unsafe"})
 
@@ -261,13 +266,13 @@ func (s *apparmorSuite) TestFeaturesProbedOnce(c *C) {
 	err = os.RemoveAll(d)
 	c.Assert(err, IsNil)
 
-	_, err = release.AppArmorKernelFeatures()
+	_, err = apparmor.KernelFeatures()
 	c.Assert(err, IsNil)
 
 	// this makes probing fails but is not done again
 	err = os.RemoveAll(mockParserCmd.BinDir())
 	c.Assert(err, IsNil)
 
-	_, err = release.AppArmorParserFeatures()
+	_, err = apparmor.ParserFeatures()
 	c.Assert(err, IsNil)
 }

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmor
+
+func MockFeaturesSysPath(path string) (restorer func()) {
+	old := featuresSysPath
+	featuresSysPath = path
+	return func() {
+		featuresSysPath = old
+	}
+}
+
+func MockParserSearchPath(new string) (restore func()) {
+	oldAppArmorParserSearchPath := parserSearchPath
+	parserSearchPath = new
+	return func() {
+		parserSearchPath = oldAppArmorParserSearchPath
+	}
+}
+
+var (
+	ProbeKernelFeatures = probeKernelFeatures
+	ProbeParserFeatures = probeParserFeatures
+
+	RequiredKernelFeatures  = requiredKernelFeatures
+	RequiredParserFeatures  = requiredParserFeatures
+	PreferredKernelFeatures = preferredKernelFeatures
+	PreferredParserFeatures = preferredParserFeatures
+)
+
+func FreshAppArmorAssessment() {
+	appArmorAssessment = &appArmorAssess{appArmorProber: &appArmorProbe{}}
+}


### PR DESCRIPTION
Part of the changes to move the sandbox related pieces under a common github.com/snapcore/snapd/sandbox/<backend> package. This PR moves the AppArmor related bits and updates the relevant call sites.
