### PR TITLE
api,timings: report duration via Doing column for ensure/startup

### DIFF
--- a/cmd/snap/cmd_debug_timings.go
+++ b/cmd/snap/cmd_debug_timings.go
@@ -125,7 +125,7 @@ func (x *cmdChangeTimings) printChangeTimings(w io.Writer, timing *timingsData) 
 
 func (x *cmdChangeTimings) printEnsureTimings(w io.Writer, timings []*timingsData) error {
 	for _, td := range timings {
-		printTiming(w, x.Verbose, 0, x.EnsureTag, "", "-", "-", "", "")
+		printTiming(w, x.Verbose, 0, x.EnsureTag, "", formatDuration(td.TotalDuration), "-", "", "")
 		for _, t := range td.EnsureTimings {
 			printTiming(w, x.Verbose, t.Level+1, "", "", formatDuration(t.Duration), "-", t.Label, t.Summary)
 		}
@@ -140,7 +140,7 @@ func (x *cmdChangeTimings) printEnsureTimings(w io.Writer, timings []*timingsDat
 
 func (x *cmdChangeTimings) printStartupTimings(w io.Writer, timings []*timingsData) error {
 	for _, td := range timings {
-		printTiming(w, x.Verbose, 0, x.StartupTag, "", "-", "-", "", "")
+		printTiming(w, x.Verbose, 0, x.StartupTag, "", formatDuration(td.TotalDuration), "-", "", "")
 		for _, t := range td.StartupTimings {
 			printTiming(w, x.Verbose, t.Level+1, "", "", formatDuration(t.Duration), "-", t.Label, t.Summary)
 		}
@@ -152,7 +152,9 @@ type timingsData struct {
 	ChangeID       string   `json:"change-id"`
 	EnsureTimings  []Timing `json:"ensure-timings,omitempty"`
 	StartupTimings []Timing `json:"startup-timings,omitempty"`
-	ChangeTimings  map[string]struct {
+
+	TotalDuration time.Duration `json:"total-duration,omitempty"`
+	ChangeTimings map[string]struct {
 		DoingTime      time.Duration `json:"doing-time,omitempty"`
 		UndoingTime    time.Duration `json:"undoing-time,omitempty"`
 		DoingTimings   []Timing      `json:"doing-timings,omitempty"`

--- a/cmd/snap/cmd_debug_timings.go
+++ b/cmd/snap/cmd_debug_timings.go
@@ -149,12 +149,11 @@ func (x *cmdChangeTimings) printStartupTimings(w io.Writer, timings []*timingsDa
 }
 
 type timingsData struct {
-	ChangeID       string   `json:"change-id"`
-	EnsureTimings  []Timing `json:"ensure-timings,omitempty"`
-	StartupTimings []Timing `json:"startup-timings,omitempty"`
-
-	TotalDuration time.Duration `json:"total-duration,omitempty"`
-	ChangeTimings map[string]struct {
+	ChangeID       string        `json:"change-id"`
+	EnsureTimings  []Timing      `json:"ensure-timings,omitempty"`
+	StartupTimings []Timing      `json:"startup-timings,omitempty"`
+	TotalDuration  time.Duration `json:"total-duration,omitempty"`
+	ChangeTimings  map[string]struct {
 		DoingTime      time.Duration `json:"doing-time,omitempty"`
 		UndoingTime    time.Duration `json:"undoing-time,omitempty"`
 		DoingTimings   []Timing      `json:"doing-timings,omitempty"`

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -93,7 +93,9 @@ type changeTimings struct {
 }
 
 type debugTimings struct {
-	ChangeID       string                    `json:"change-id"`
+	ChangeID string `json:"change-id"`
+	// total duration of the activity - present for ensure and startup timings only
+	TotalDuration  time.Duration             `json:"total-duration,omitempty"`
 	EnsureTimings  []*timings.TimingJSON     `json:"ensure-timings,omitempty"`
 	StartupTimings []*timings.TimingJSON     `json:"startup-timings,omitempty"`
 	ChangeTimings  map[string]*changeTimings `json:"change-timings,omitempty"`
@@ -168,6 +170,7 @@ func collectEnsureTimings(st *state.State, ensureTag string, allEnsures bool) ([
 			ChangeID:      ensureChangeID,
 			ChangeTimings: changeTimings,
 			EnsureTimings: ensureTm.NestedTimings,
+			TotalDuration: ensureTm.Duration,
 		}
 		responseData = append(responseData, debugTm)
 	}
@@ -195,6 +198,7 @@ func collectStartupTimings(st *state.State, startupTag string, allStarts bool) (
 	for _, startTm := range starts[first:] {
 		debugTm := &debugTimings{
 			StartupTimings: startTm.NestedTimings,
+			TotalDuration:  startTm.Duration,
 		}
 		responseData = append(responseData, debugTm)
 	}

--- a/daemon/api_debug_test.go
+++ b/daemon/api_debug_test.go
@@ -238,6 +238,7 @@ func (s *postDebugSuite) TestGetDebugTimingsEnsureLatest(c *check.C) {
 	tmData := dataJSON[0].(map[string]interface{})
 	c.Check(tmData["change-id"], check.DeepEquals, "2")
 	c.Check(tmData["change-timings"], check.NotNil)
+	c.Check(tmData["total-duration"], check.NotNil)
 }
 
 func (s *postDebugSuite) TestGetDebugTimingsEnsureAll(c *check.C) {
@@ -247,10 +248,12 @@ func (s *postDebugSuite) TestGetDebugTimingsEnsureAll(c *check.C) {
 	tmData := dataJSON[0].(map[string]interface{})
 	c.Check(tmData["change-id"], check.DeepEquals, "1")
 	c.Check(tmData["change-timings"], check.NotNil)
+	c.Check(tmData["total-duration"], check.NotNil)
 
 	tmData = dataJSON[1].(map[string]interface{})
 	c.Check(tmData["change-id"], check.DeepEquals, "2")
 	c.Check(tmData["change-timings"], check.NotNil)
+	c.Check(tmData["total-duration"], check.NotNil)
 }
 
 func (s *postDebugSuite) TestGetDebugTimingsError(c *check.C) {

--- a/tests/main/snap-debug-timings/task.yaml
+++ b/tests/main/snap-debug-timings/task.yaml
@@ -9,4 +9,3 @@ execute: |
 
     echo "There is timing data available for it"
     snap debug timings --last=install | MATCH 'Done +[0-9]+'
-

--- a/timings/state.go
+++ b/timings/state.go
@@ -49,6 +49,7 @@ type rootTimingsJSON struct {
 type TimingsInfo struct {
 	Tags          map[string]string
 	NestedTimings []*TimingJSON
+	Duration      time.Duration
 }
 
 // Maximum number of timings to keep in state. It can be changed only while holding state lock.
@@ -159,7 +160,8 @@ func Get(st *state.State, maxLevel int, filter func(tags map[string]string) bool
 			continue
 		}
 		res := &TimingsInfo{
-			Tags: tm.Tags,
+			Tags:     tm.Tags,
+			Duration: timeDuration(tm.StartTime, tm.StopTime),
 		}
 		// negative maxLevel means no level filtering, take all nested timings
 		if maxLevel < 0 {

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -405,6 +405,7 @@ func (s *timingsSuite) TestGet(c *C) {
 	c.Check(tm, DeepEquals, []*timings.TimingsInfo{
 		{
 			Tags: map[string]string{"foo": "1"},
+			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-1", Summary: "...", Duration: 3000000},
 				{Level: 1, Label: "nested measurement", Summary: "...", Duration: 1000000},
@@ -417,18 +418,21 @@ func (s *timingsSuite) TestGet(c *C) {
 	c.Check(tmOnlyLevel0, DeepEquals, []*timings.TimingsInfo{
 		{
 			Tags: map[string]string{"foo": "0"},
+			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-0", Summary: "...", Duration: 3000000},
 			},
 		},
 		{
 			Tags: map[string]string{"foo": "1"},
+			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-1", Summary: "...", Duration: 3000000},
 			},
 		},
 		{
 			Tags: map[string]string{"foo": "2"},
+			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-2", Summary: "...", Duration: 3000000},
 			},

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -404,7 +404,7 @@ func (s *timingsSuite) TestGet(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(tm, DeepEquals, []*timings.TimingsInfo{
 		{
-			Tags: map[string]string{"foo": "1"},
+			Tags:     map[string]string{"foo": "1"},
 			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-1", Summary: "...", Duration: 3000000},
@@ -417,21 +417,21 @@ func (s *timingsSuite) TestGet(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(tmOnlyLevel0, DeepEquals, []*timings.TimingsInfo{
 		{
-			Tags: map[string]string{"foo": "0"},
+			Tags:     map[string]string{"foo": "0"},
 			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-0", Summary: "...", Duration: 3000000},
 			},
 		},
 		{
-			Tags: map[string]string{"foo": "1"},
+			Tags:     map[string]string{"foo": "1"},
 			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-1", Summary: "...", Duration: 3000000},
 			},
 		},
 		{
-			Tags: map[string]string{"foo": "2"},
+			Tags:     map[string]string{"foo": "2"},
 			Duration: 3000000,
 			NestedTimings: []*timings.TimingJSON{
 				{Level: 0, Label: "doing something-2", Summary: "...", Duration: 3000000},


### PR DESCRIPTION
Report duration time for timings of "ensure" and "startup" activities. This relies on already collected "duration" attribute stored for the root entries of the timings in the state, so it's backwards compatible as far as state is concerned (new code against old state will report them).

The change is only at the protocol level of the debug API and snap debug timings client code.

Example (the 3876ms value is new there, "-" would be reported by old code):
```
$ snap debug timings --startup=ifacemgr --verbose
ID        Status        Doing      Undoing  Label                   Summary
ifacemgr               3876ms            -
 ^                        5ms            -  setup-security-backend    setup security backend "apparmor" for snap "http"
 ^                        5ms            -  setup-security-backend    setup security backend "apparmor" for snap "nano-strict"
 ^                        7ms            -  setup-security-backend    setup security backend "apparmor" for ....
```

This PR also updates the affected tests with better test data, I found out that `--all` flag wasn't really tested properly due to bad test data (code was fine, was just a test issue).