### PR TITLE
interfaces/kubernetes-support: allow use of /run/flannel

### DIFF
--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -96,6 +96,12 @@ const kubernetesSupportConnectedPlugAppArmorKubelet = `
 # Ideally this would be snap-specific
 /run/dockershim.sock rw,
 
+# Ideally this would be snap-specific (it could if the control plane was a
+# snap), but in deployments where the control plane is not a snap, it will tell
+# flannel to use this path.
+/run/flannel/{,**} rw,
+/run/flannel/** k,
+
 # allow managing pods' cgroups
 /sys/fs/cgroup/*/kubepods/{,**} rw,
 


### PR DESCRIPTION
In modern kubernetes deployments, the path to /run/flannel is determined
by the control plane. While flannel could be told to use a snap-specific
path in SNAP_COMMON or SNAP_DATA, this only works when the control plane
is also running as a snap. To support more typical mixed environments
where the control plane is not a snap and (at least some of) the workers
are snaps, allow use of the upstream standard /run/flannel path.

/run is often used for sharing resources (eg, a socket) amongst various
processes, but in the case of flannel, it is for writing out a single
file for various kubernetes worker processes to read. For this reason,
include the access in the kubernetes-support interface as opposed to a
separate slotting interface. This is also in line with modern kubernetes
deployments where flanneld is not a separate standalone service running
on the host, but instead a service running in a pod launched by kubelet.
