### PR TITLE
tests: restart the journald service while preparing the test

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -501,7 +501,8 @@ prepare_suite_each() {
     echo -n "$SPREAD_JOB " >> "$RUNTIME_STATE_PATH/runs"
     # shellcheck source=tests/lib/reset.sh
     "$TESTSLIB"/reset.sh --reuse-core
-    # Reset systemd journal cursor.
+    # Restart journal log and reset systemd journal cursor.
+    systemctl restart systemd-journald.service
     start_new_journalctl_log
 
     echo "Install the snaps profiler snap"


### PR DESCRIPTION
The idea of the test is to restart the systemd-journald.service while
the test is being prepared to avoid issues which could be cause by any
test executed before as happens runnign on ubuntu 14.04 with the tests:
spread2 -order -workers 1 -debug
google:ubuntu-14.04-64:tests/main/refresh-all-undo
google:ubuntu-14.04-64:tests/main/validate-container-failures

See full log:
https://paste.ubuntu.com/p/jyBtYMbqS3/
