### PR TITLE
tests/lib/lxd-snapfuse: restore mount changes introduced by LXD

### DIFF
--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -3,6 +3,9 @@ summary: Check snapfuse works
 # we just need a single system to verify this
 systems: [ubuntu-18.04-64]
 
+restore: |
+    lxd-tool undo-lxd-mount-changes
+
 execute: |
     echo "Ensure we use the snap"
     apt autoremove -y lxd


### PR DESCRIPTION
The test runs LXD, which is known to apply the mount changes that affect the
host mount namespace. Make sure to clean them up.
