### PR TITLE
gadget: do not fail the update when old gadget snap is missing bare content

### DIFF
--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -50,6 +50,17 @@ type LaidOutVolume struct {
 	RootDir string
 }
 
+// PartiallyLaidOutVolume defines the layout of volume structures, but lacks the
+// details about the layout of raw image content within the bare structures.
+type PartiallyLaidOutVolume struct {
+	*Volume
+	// SectorSize sector size of the volume
+	SectorSize Size
+	// LaidOutStructure is a list of structures within the volume, sorted
+	// by their start offsets
+	LaidOutStructure []LaidOutStructure
+}
+
 // LaidOutStructure describes a VolumeStructure that has been placed within the
 // volume
 type LaidOutStructure struct {
@@ -99,16 +110,13 @@ func (p LaidOutContent) String() string {
 	return fmt.Sprintf("#%v (source:%q)", p.Index, p.Source)
 }
 
-// LayoutVolume attempts to lay out the volume using provided constraints
-func LayoutVolume(gadgetRootDir string, volume *Volume, constraints LayoutConstraints) (*LaidOutVolume, error) {
+func layoutVolumeStructures(volume *Volume, constraints LayoutConstraints) (structures []LaidOutStructure, byName map[string]*LaidOutStructure, err error) {
 	previousEnd := Size(0)
-	farthestEnd := Size(0)
-	fartherstOffsetWrite := Size(0)
-	structures := make([]LaidOutStructure, len(volume.Structure))
-	structuresByName := make(map[string]*LaidOutStructure, len(volume.Structure))
+	structures = make([]LaidOutStructure, len(volume.Structure))
+	byName = make(map[string]*LaidOutStructure, len(volume.Structure))
 
 	if constraints.SectorSize == 0 {
-		return nil, fmt.Errorf("cannot lay out volume, invalid constraints: sector size cannot be 0")
+		return nil, nil, fmt.Errorf("cannot lay out volume, invalid constraints: sector size cannot be 0")
 	}
 
 	for idx, s := range volume.Structure {
@@ -132,20 +140,17 @@ func LayoutVolume(gadgetRootDir string, volume *Volume, constraints LayoutConstr
 
 		if ps.EffectiveRole() != MBR {
 			if s.Size%constraints.SectorSize != 0 {
-				return nil, fmt.Errorf("cannot lay out volume, structure %v size is not a multiple of sector size %v",
+				return nil, nil, fmt.Errorf("cannot lay out volume, structure %v size is not a multiple of sector size %v",
 					ps, constraints.SectorSize)
 			}
 		}
 
 		if ps.Name != "" {
-			structuresByName[ps.Name] = &ps
+			byName[ps.Name] = &ps
 		}
 
 		structures[idx] = ps
 
-		if end > farthestEnd {
-			farthestEnd = end
-		}
 		previousEnd = end
 	}
 
@@ -155,21 +160,55 @@ func LayoutVolume(gadgetRootDir string, volume *Volume, constraints LayoutConstr
 	previousEnd = Size(0)
 	for idx, ps := range structures {
 		if ps.StartOffset < previousEnd {
-			return nil, fmt.Errorf("cannot lay out volume, structure %v overlaps with preceding structure %v", ps, structures[idx-1])
+			return nil, nil, fmt.Errorf("cannot lay out volume, structure %v overlaps with preceding structure %v", ps, structures[idx-1])
 		}
 		previousEnd = ps.StartOffset + ps.Size
 
-		offsetWrite, err := resolveOffsetWrite(ps.OffsetWrite, structuresByName)
+		offsetWrite, err := resolveOffsetWrite(ps.OffsetWrite, byName)
 		if err != nil {
-			return nil, fmt.Errorf("cannot resolve offset-write of structure %v: %v", ps, err)
+			return nil, nil, fmt.Errorf("cannot resolve offset-write of structure %v: %v", ps, err)
 		}
 		structures[idx].AbsoluteOffsetWrite = offsetWrite
+	}
 
-		if offsetWrite != nil && *offsetWrite > fartherstOffsetWrite {
-			fartherstOffsetWrite = *offsetWrite
+	return structures, byName, nil
+}
+
+// LayoutVolumePartially attempts to lay out only the structures in the volume using provided constraints
+func LayoutVolumePartially(volume *Volume, constraints LayoutConstraints) (*PartiallyLaidOutVolume, error) {
+	structures, _, err := layoutVolumeStructures(volume, constraints)
+	if err != nil {
+		return nil, err
+	}
+	vol := &PartiallyLaidOutVolume{
+		Volume:           volume,
+		SectorSize:       constraints.SectorSize,
+		LaidOutStructure: structures,
+	}
+	return vol, nil
+}
+
+// LayoutVolume attempts to completely lay out the volume, that is the
+// structures and their content, using provided constraints
+func LayoutVolume(gadgetRootDir string, volume *Volume, constraints LayoutConstraints) (*LaidOutVolume, error) {
+
+	structures, byName, err := layoutVolumeStructures(volume, constraints)
+	if err != nil {
+		return nil, err
+	}
+
+	farthestEnd := Size(0)
+	fartherstOffsetWrite := Size(0)
+
+	for idx, ps := range structures {
+		if ps.AbsoluteOffsetWrite != nil && *ps.AbsoluteOffsetWrite > fartherstOffsetWrite {
+			fartherstOffsetWrite = *ps.AbsoluteOffsetWrite
+		}
+		if end := ps.StartOffset + ps.Size; end > farthestEnd {
+			farthestEnd = end
 		}
 
-		content, err := layOutStructureContent(gadgetRootDir, &structures[idx], structuresByName)
+		content, err := layOutStructureContent(gadgetRootDir, &structures[idx], byName)
 		if err != nil {
 			return nil, err
 		}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -71,8 +71,9 @@ func Update(old, new GadgetData, rollbackDirPath string) error {
 		return err
 	}
 
-	// layout old
-	pOld, err := LayoutVolume(old.RootDir, oldVol, defaultConstraints)
+	// layout old partially, without going deep into the layout of structure
+	// content
+	pOld, err := LayoutVolumePartially(oldVol, defaultConstraints)
 	if err != nil {
 		return fmt.Errorf("cannot lay out the old volume: %v", err)
 	}
@@ -200,7 +201,7 @@ func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure) error {
 	return nil
 }
 
-func canUpdateVolume(from *LaidOutVolume, to *LaidOutVolume) error {
+func canUpdateVolume(from *PartiallyLaidOutVolume, to *LaidOutVolume) error {
 	if from.ID != to.ID {
 		return fmt.Errorf("cannot change volume ID from %q to %q", from.ID, to.ID)
 	}
@@ -218,7 +219,7 @@ type updatePair struct {
 	to   *LaidOutStructure
 }
 
-func resolveUpdate(oldVol *LaidOutVolume, newVol *LaidOutVolume) (updates []updatePair, err error) {
+func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume) (updates []updatePair, err error) {
 	if len(oldVol.LaidOutStructure) != len(newVol.LaidOutStructure) {
 		return nil, errors.New("internal error: the number of structures in new and old volume definitions is different")
 	}


### PR DESCRIPTION
It was brought to our attention, that there exist gadget snaps in the wild,
where gadget YAML lists content that does not exist within the gadget snap. In
such scenario, the update would fail on the attempt to layout the old volume.

However, for the purpose of update process, we only need to identify the
structures that are to be updated. Because we backup whatever is changed during
update, we do not care much about the content of the old gadget snap. Apply more
relaxed layout processing and do not verify that the data existed int he old
gadget snap.

cc @kubiko 
