### PR TITLE
tests: skip the ubuntu-core-upgrade on arm devices on core18

### DIFF
--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -1,6 +1,9 @@
 summary: Upgrade the core snap and revert a few times
 
-systems: [ubuntu-core-1*]
+# ARM devices are not supported on ubuntu-core-18 due to fw_printenv/setenv are
+# not provided by the system and as the devices boot with uboot so it is not
+# possible to get any grub information as it is done with non arm devices.
+systems: [ubuntu-core-16-*, ubuntu-core-18-32*, ubuntu-core-18-64*]
 
 # Start early as it takes a long time.
 priority: 100


### PR DESCRIPTION
ARM devices are not supported on ubuntu-core-18 due to
fw_printenv/setenv are not provided by the system and as the devices
boot with uboot so it is not possible to get any grub information as it
is done with non arm devices.
