### PR TITLE
tests: when the backend is external skip the loop waiting for snap version

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -608,7 +608,7 @@ prepare_ubuntu_core() {
     fi
 
     # Wait for the snap command to become available.
-    if not [ "$SPREAD_BACKEND" = "external" ]; then
+    if [ "$SPREAD_BACKEND" != "external" ]; then
         for i in $(seq 120); do
             if [ "$(command -v snap)" = "/usr/bin/snap" ] && snap version | grep -q 'snapd +1337.*'; then
                 break

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -608,12 +608,14 @@ prepare_ubuntu_core() {
     fi
 
     # Wait for the snap command to become available.
-    for i in $(seq 120); do
-        if [ "$(command -v snap)" = "/usr/bin/snap" ] && snap version | grep -q 'snapd +1337.*'; then
-            break
-        fi
-        sleep 1
-    done
+    if not [ "$SPREAD_BACKEND" = "external" ]; then
+        for i in $(seq 120); do
+            if [ "$(command -v snap)" = "/usr/bin/snap" ] && snap version | grep -q 'snapd +1337.*'; then
+                break
+            fi
+            sleep 1
+        done
+    fi
 
     # Wait for seeding to finish.
     snap wait system seed.loaded


### PR DESCRIPTION
In case the backend is external it is not needed to wait until an
specific version due to all the snaps are preinstalled in teh image

Debuging on external systems I saw that we are 2 minutes iterating until
the loop finishes when this loop is not needed at all.
