### PR TITLE
interfaces/docker-support,kubernetes-support: misc updates for strict k8s

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -175,8 +175,22 @@ ptrace (read, trace) peer=cri-containerd.apparmor.d,
 # needed by runc for mitigation of CVE-2019-5736
 # For details see https://bugs.launchpad.net/apparmor/+bug/1820344
 / ix,
+/bin/busybox ixr,
 /bin/runc ixr,
 /pause ixr,
+
+# When kubernetes drives containerd, containerd needs access to CNI services,
+# like flanneld's subnet.env for DNS. This would ideally be snap-specific (it
+# could if the control plane was a snap), but in deployments where the control
+# plane is not a snap, it will tell flannel to use this path.
+/run/flannel/{,**} rk,
+
+# When kubernetes drives containerd, containerd needs access to various
+# secrets for the pods which are overlayed at /run/secrets/....
+# This would ideally be snap-specific (it could if the control plane was a
+# snap), but in deployments where the control plane is not a snap, it will tell
+# containerd to use this path for various account information for pods.
+/run/secrets/kubernetes.io/{,**} rk,
 `
 
 const dockerSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -175,9 +175,10 @@ ptrace (read, trace) peer=cri-containerd.apparmor.d,
 # needed by runc for mitigation of CVE-2019-5736
 # For details see https://bugs.launchpad.net/apparmor/+bug/1820344
 / ix,
-/bin/busybox ixr,
 /bin/runc ixr,
+
 /pause ixr,
+/bin/busybox ixr,
 
 # When kubernetes drives containerd, containerd needs access to CNI services,
 # like flanneld's subnet.env for DNS. This would ideally be snap-specific (it

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -136,8 +136,8 @@ capability sys_admin,
 mount /var/snap/@{SNAP_NAME}/common/{,**} -> /var/snap/@{SNAP_NAME}/common/{,**},
 mount options=(rw, rshared) -> /var/snap/@{SNAP_NAME}/common/{,**},
 
-/bin/mount ixr,
-/bin/umount ixr,
+/{,usr/}bin/mount ixr,
+/{,usr/}bin/umount ixr,
 deny /run/mount/utab rw,
 umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
 `
@@ -145,7 +145,7 @@ umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
 const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   # kubelet mount rules
   capability sys_admin,
-  /bin/mount ixr,
+  /{,usr/}bin/mount ixr,
   mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
   deny /run/mount/utab rw,
 `

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -136,6 +136,7 @@ capability sys_admin,
 mount /var/snap/@{SNAP_NAME}/common/{,**} -> /var/snap/@{SNAP_NAME}/common/{,**},
 mount options=(rw, rshared) -> /var/snap/@{SNAP_NAME}/common/{,**},
 
+/bin/mount ixr,
 /bin/umount ixr,
 deny /run/mount/utab rw,
 umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,


### PR DESCRIPTION
* interfaces/kubernetes-support: add missing /bin/mount ixr
* interfaces/kubernetes-support: use /{,usr/}bin/mount for portability
* interfaces/docker-support: various runc/containerd accesses for k8s