### PR TITLE
cmd: add `snap debug boot-vars` that dumps the current bootvars

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -22,6 +22,7 @@ package boot
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,6 +168,23 @@ var (
 type NameAndRevision struct {
 	Name     string
 	Revision snap.Revision
+}
+
+// DebugDumpBootvars writes a dump of the bootvars to the given writer
+func DebugDumpBootvars(w io.Writer) error {
+	bloader, err := bootloader.Find("", nil)
+	if err != nil {
+		return err
+	}
+	allKeys := []string{"snap_mode", "snap_core", "snap_try_core", "snap_kernel", "snap_try_kernel"}
+	bootVars, err := bloader.GetBootVars(allKeys...)
+	if err != nil {
+		return err
+	}
+	for _, k := range allKeys {
+		fmt.Fprintf(w, "%s=%s\n", k, bootVars[k])
+	}
+	return nil
 }
 
 // GetCurrentBoot returns the currently set name and revision for boot for the given

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -22,7 +22,6 @@ package boot
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,23 +167,6 @@ var (
 type NameAndRevision struct {
 	Name     string
 	Revision snap.Revision
-}
-
-// DebugDumpBootvars writes a dump of the bootvars to the given writer
-func DebugDumpBootvars(w io.Writer) error {
-	bloader, err := bootloader.Find("", nil)
-	if err != nil {
-		return err
-	}
-	allKeys := []string{"snap_mode", "snap_core", "snap_try_core", "snap_kernel", "snap_try_kernel"}
-	bootVars, err := bloader.GetBootVars(allKeys...)
-	if err != nil {
-		return err
-	}
-	for _, k := range allKeys {
-		fmt.Fprintf(w, "%s=%s\n", k, bootVars[k])
-	}
-	return nil
 }
 
 // GetCurrentBoot returns the currently set name and revision for boot for the given

--- a/boot/debug.go
+++ b/boot/debug.go
@@ -26,8 +26,8 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 )
 
-// DumpBootvars writes a dump of the snapd bootvars to the given writer
-func DumpBootvars(w io.Writer) error {
+// DumpBootVars writes a dump of the snapd bootvars to the given writer
+func DumpBootVars(w io.Writer) error {
 	bloader, err := bootloader.Find("", nil)
 	if err != nil {
 		return err

--- a/boot/debug.go
+++ b/boot/debug.go
@@ -17,26 +17,28 @@
  *
  */
 
-package main
+package boot
 
 import (
-	"github.com/jessevdk/go-flags"
+	"fmt"
+	"io"
 
-	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
 )
 
-type cmdBootvars struct{}
-
-func init() {
-	cmd := addDebugCommand("boot-vars",
-		"(internal) obtaind snapd boot variables",
-		"(internal) obtaind snapd boot variables",
-		func() flags.Commander {
-			return &cmdBootvars{}
-		}, nil, nil)
-	cmd.hidden = true
-}
-
-func (x *cmdBootvars) Execute(args []string) error {
-	return boot.DumpBootvars(Stdout)
+// DumpBootvars writes a dump of the snapd bootvars to the given writer
+func DumpBootvars(w io.Writer) error {
+	bloader, err := bootloader.Find("", nil)
+	if err != nil {
+		return err
+	}
+	allKeys := []string{"snap_mode", "snap_core", "snap_try_core", "snap_kernel", "snap_try_kernel"}
+	bootVars, err := bloader.GetBootVars(allKeys...)
+	if err != nil {
+		return err
+	}
+	for _, k := range allKeys {
+		fmt.Fprintf(w, "%s=%s\n", k, bootVars[k])
+	}
+	return nil
 }

--- a/cmd/snap/cmd_debug_bootvars.go
+++ b/cmd/snap/cmd_debug_bootvars.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/boot"
+)
+
+type cmdBootvars struct{}
+
+func init() {
+	cmd := addDebugCommand("bootvars",
+		"(internal) obtain the bootloader variables",
+		"(internal) obtain the bootloader variables",
+		func() flags.Commander {
+			return &cmdBootvars{}
+		}, nil, nil)
+	cmd.hidden = true
+}
+
+func (x *cmdBootvars) Execute(args []string) error {
+	return boot.DebugDumpBootvars(Stdout)
+}

--- a/cmd/snap/cmd_debug_bootvars.go
+++ b/cmd/snap/cmd_debug_bootvars.go
@@ -29,8 +29,8 @@ type cmdBootvars struct{}
 
 func init() {
 	cmd := addDebugCommand("boot-vars",
-		"(internal) obtaind snapd boot variables",
-		"(internal) obtaind snapd boot variables",
+		"(internal) obtain the snapd boot variables",
+		"(internal) obtain the snapd boot variables",
 		func() flags.Commander {
 			return &cmdBootvars{}
 		}, nil, nil)
@@ -38,5 +38,5 @@ func init() {
 }
 
 func (x *cmdBootvars) Execute(args []string) error {
-	return boot.DumpBootvars(Stdout)
+	return boot.DumpBootVars(Stdout)
 }

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestDebugBootvars(c *check.C) {
 		"snap_try_kernel": "pc-kernel_4.snap",
 	}
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "bootvars"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "boot-vars"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `snap_mode=try

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+func (s *SnapSuite) TestDebugBootvars(c *check.C) {
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
+	bloader.BootVars = map[string]string{
+		"snap_mode":       "try",
+		"unrelated":       "thing",
+		"snap_core":       "core18_1.snap",
+		"snap_try_core":   "core18_2.snap",
+		"snap_kernel":     "pc-kernel_3.snap",
+		"snap_try_kernel": "pc-kernel_4.snap",
+	}
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "bootvars"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `snap_mode=try
+snap_core=core18_1.snap
+snap_try_core=core18_2.snap
+snap_kernel=pc-kernel_3.snap
+snap_try_kernel=pc-kernel_4.snap
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+}


### PR DESCRIPTION
The new debug helper `snap debug bootvars` will output the
current bootloader variables. This is useful on core18 systems
that do not have the grub-editenv/fw_getenv commands and for
bootloaders like little-kernel that do not have any tools for
this.

This will primarely be used in tests like:
https://github.com/snapcore/snapd/pull/7508

Or the test in
https://github.com/snapcore/snapd/pull/7438
