### PR TITLE
daemon: return "snapname_rev.snap" style when using /v2/download

### DIFF
--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -86,7 +86,7 @@ func streamOneSnap(c *Command, user *auth.UserState, snapName string) Response {
 
 	return fileStream{
 		SnapName: snapName,
-		FileName: filepath.Base(info.MountFile()),
+		Filename: filepath.Base(info.MountFile()),
 		Info:     downloadInfo,
 		stream:   r,
 	}

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -85,7 +85,7 @@ func streamOneSnap(c *Command, user *auth.UserState, snapName string) Response {
 
 	return fileStream{
 		SnapName: snapName,
-		Info:     downloadInfo,
+		Info:     info,
 		stream:   r,
 	}
 }

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/store"
@@ -85,7 +86,8 @@ func streamOneSnap(c *Command, user *auth.UserState, snapName string) Response {
 
 	return fileStream{
 		SnapName: snapName,
-		Info:     info,
+		FileName: filepath.Base(info.MountFile()),
+		Info:     downloadInfo,
 		stream:   r,
 	}
 }

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -71,6 +71,10 @@ func (s *snapDownloadSuite) SnapInfo(ctx context.Context, spec store.SnapSpec, u
 	switch spec.Name {
 	case "bar":
 		return &snap.Info{
+			SideInfo: snap.SideInfo{
+				RealName: "bar",
+				Revision: snap.R(1),
+			},
 			DownloadInfo: snap.DownloadInfo{
 				Size:            int64(len(content)),
 				AnonDownloadURL: "http://localhost/bar",
@@ -190,7 +194,7 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 			c.Assert(w.Code, check.Equals, s.status)
 			c.Assert(w.Header().Get("Content-Length"), check.Equals, expectedLength)
 			c.Assert(w.Header().Get("Content-Type"), check.Equals, "application/octet-stream")
-			c.Assert(w.Header().Get("Content-Disposition"), check.Equals, "attachment; filename=bar")
+			c.Assert(w.Header().Get("Content-Disposition"), check.Equals, "attachment; filename=bar_1.snap")
 			c.Assert(w.Body.String(), check.Equals, "SNAP")
 		}
 	}

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -251,7 +251,8 @@ func makeErrorResponder(status int) errorResponder {
 // A FileStream ServeHTTP method streams the snap
 type fileStream struct {
 	SnapName string
-	Info     *snap.Info
+	FileName string
+	Info     snap.DownloadInfo
 	stream   io.ReadCloser
 }
 
@@ -259,7 +260,7 @@ type fileStream struct {
 func (s fileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	hdr := w.Header()
 	hdr.Set("Content-Type", "application/octet-stream")
-	snapname := fmt.Sprintf("attachment; filename=%s", filepath.Base(s.Info.MountFile()))
+	snapname := fmt.Sprintf("attachment; filename=%s", s.FileName)
 	hdr.Set("Content-Disposition", snapname)
 
 	size := fmt.Sprintf("%d", s.Info.Size)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -251,7 +251,7 @@ func makeErrorResponder(status int) errorResponder {
 // A FileStream ServeHTTP method streams the snap
 type fileStream struct {
 	SnapName string
-	FileName string
+	Filename string
 	Info     snap.DownloadInfo
 	stream   io.ReadCloser
 }
@@ -260,7 +260,7 @@ type fileStream struct {
 func (s fileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	hdr := w.Header()
 	hdr.Set("Content-Type", "application/octet-stream")
-	snapname := fmt.Sprintf("attachment; filename=%s", s.FileName)
+	snapname := fmt.Sprintf("attachment; filename=%s", s.Filename)
 	hdr.Set("Content-Disposition", snapname)
 
 	size := fmt.Sprintf("%d", s.Info.Size)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -251,7 +251,7 @@ func makeErrorResponder(status int) errorResponder {
 // A FileStream ServeHTTP method streams the snap
 type fileStream struct {
 	SnapName string
-	Info     snap.DownloadInfo
+	Info     *snap.Info
 	stream   io.ReadCloser
 }
 
@@ -259,7 +259,7 @@ type fileStream struct {
 func (s fileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	hdr := w.Header()
 	hdr.Set("Content-Type", "application/octet-stream")
-	snapname := fmt.Sprintf("attachment; filename=%s", s.SnapName)
+	snapname := fmt.Sprintf("attachment; filename=%s", filepath.Base(s.Info.MountFile()))
 	hdr.Set("Content-Disposition", snapname)
 
 	size := fmt.Sprintf("%d", s.Info.Size)


### PR DESCRIPTION
This PR changs the /v2/download endpoint to return a more useful
filename for the downloaded snap. It uses the form
"snapName_rev.snap", e.g. "core_1234.snap". The old code was
just using the snap name which is a bit too limiting.

This will help with the `snap download` via the snapd API code.
