### PR TITLE
daemon: allow /v2/assertions/{assertType} to query store

### DIFF
--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -62,18 +62,17 @@ func parseHeadersFormatOptionsFromURL(q url.Values) (*daemonAssertOptions, error
 	res := daemonAssertOptions{}
 	res.headers = make(map[string]string)
 	for k := range q {
-		if k == "remote" {
-			v := q.Get(k)
+		v := q.Get(k)
+		switch k {
+		case "remote":
 			switch v {
 			case "true", "false":
 				res.remote, _ = strconv.ParseBool(v)
 			default:
 				return nil, errors.New(`"remote" query parameter when used must be set to "true" or "false" or left unset`)
 			}
-			continue
-		}
-		if k == "json" {
-			switch q.Get(k) {
+		case "json":
+			switch v {
 			case "false":
 				res.jsonResult = false
 			case "headers":
@@ -84,9 +83,9 @@ func parseHeadersFormatOptionsFromURL(q url.Values) (*daemonAssertOptions, error
 			default:
 				return nil, errors.New(`"json" query parameter when used must be set to "true" or "headers"`)
 			}
-			continue
+		default:
+			res.headers[k] = v
 		}
-		res.headers[k] = q.Get(k)
 	}
 
 	return &res, nil

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -21,8 +21,10 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -48,17 +50,28 @@ var (
 // a helper type for parsing the options specified to /v2/assertions and other
 // such endpoints that can either do JSON or assertion depending on the value
 // of the the URL query parameters
-type daemonAssertFormatOptions struct {
+type daemonAssertOptions struct {
 	jsonResult  bool
 	headersOnly bool
+	remote      bool
 	headers     map[string]string
 }
 
 // helper for parsing url query options into formatting option vars
-func parseHeadersFormatOptionsFromURL(q url.Values) (*daemonAssertFormatOptions, error) {
-	res := daemonAssertFormatOptions{}
+func parseHeadersFormatOptionsFromURL(q url.Values) (*daemonAssertOptions, error) {
+	res := daemonAssertOptions{}
 	res.headers = make(map[string]string)
 	for k := range q {
+		if k == "remote" {
+			v := q.Get(k)
+			switch v {
+			case "true", "false":
+				res.remote, _ = strconv.ParseBool(v)
+			default:
+				return nil, errors.New(`"remote" query parameter when used must be set to "true" or "false" or left unset`)
+			}
+			continue
+		}
 		if k == "json" {
 			switch q.Get(k) {
 			case "false":
@@ -108,6 +121,29 @@ func doAssert(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 }
 
+func assertsFindOneRemote(c *Command, at *asserts.AssertionType, headers map[string]string, user *auth.UserState) ([]asserts.Assertion, error) {
+	primaryKeys, err := asserts.PrimaryKeyFromHeaders(at, headers)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query remote assertion: %v", err)
+	}
+	sto := getStore(c)
+	as, err := sto.Assertion(at, primaryKeys, user)
+	if err != nil {
+		return nil, err
+	}
+
+	return []asserts.Assertion{as}, nil
+}
+
+func assertsFindManyInState(c *Command, at *asserts.AssertionType, headers map[string]string, opts *daemonAssertOptions) ([]asserts.Assertion, error) {
+	state := c.d.overlord.State()
+	state.Lock()
+	db := assertstate.DB(state)
+	state.Unlock()
+
+	return db.FindMany(at, opts.headers)
+}
+
 func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response {
 	assertTypeName := muxVars(r)["assertType"]
 	assertType := asserts.Type(assertTypeName)
@@ -118,12 +154,13 @@ func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response
 	if err != nil {
 		return BadRequest(err.Error())
 	}
-	state := c.d.overlord.State()
-	state.Lock()
-	db := assertstate.DB(state)
-	state.Unlock()
 
-	assertions, err := db.FindMany(assertType, opts.headers)
+	var assertions []asserts.Assertion
+	if opts.remote {
+		assertions, err = assertsFindOneRemote(c, assertType, opts.headers, user)
+	} else {
+		assertions, err = assertsFindManyInState(c, assertType, opts.headers, opts)
+	}
 	if err != nil && !asserts.IsNotFound(err) {
 		return InternalError("searching assertions failed: %v", err)
 	}

--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -38,6 +38,9 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -47,6 +50,9 @@ type assertsSuite struct {
 
 	storeSigning    *assertstest.StoreStack
 	trustedRestorer func()
+
+	storetest.Store
+	mockAssertionFn func(at *asserts.AssertionType, headers []string, user *auth.UserState) (asserts.Assertion, error)
 }
 
 var _ = check.Suite(&assertsSuite{})
@@ -61,13 +67,18 @@ func (s *assertsSuite) SetUpTest(c *check.C) {
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.trustedRestorer = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
-	assertstate.Manager(s.o.State(), s.o.TaskRunner())
+	st := s.o.State()
+	st.Lock()
+	snapstate.ReplaceStore(st, s)
+	st.Unlock()
+	assertstate.Manager(st, s.o.TaskRunner())
 }
 
 func (s *assertsSuite) TearDownTest(c *check.C) {
 	s.trustedRestorer()
 	s.o = nil
 	s.d = nil
+	s.mockAssertionFn = nil
 }
 
 func (s *assertsSuite) TestGetAsserts(c *check.C) {
@@ -268,11 +279,20 @@ func (s *assertsSuite) TestAssertsInvalidType(c *check.C) {
 }
 
 func (s *assertsSuite) TestAssertsFindManyJSONFilter(c *check.C) {
+	s.testAssertsFindManyJSONFilter(c, "/v2/assertions/account?json=true&username=developer1")
+}
+
+func (s *assertsSuite) TestAssertsFindManyJSONFilterRemoteIsFalse(c *check.C) {
+	// setting "remote=false" is the defalt and should not change anything
+	s.testAssertsFindManyJSONFilter(c, "/v2/assertions/account?json=true&username=developer1&remote=false")
+}
+
+func (s *assertsSuite) testAssertsFindManyJSONFilter(c *check.C, urlPath string) {
 	acct := assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
 	s.addAsserts(acct)
 
 	// Execute
-	req, err := http.NewRequest("POST", "/v2/assertions/account?json=true&username=developer1", nil)
+	req, err := http.NewRequest("POST", urlPath, nil)
 	c.Assert(err, check.IsNil)
 	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
 		return map[string]string{"assertType": "account"}
@@ -432,4 +452,69 @@ func (s *assertsSuite) TestAssertsFindManyJSONNopFilter(c *check.C) {
 	c.Check(a1.(*asserts.Account).AccountID(), check.Equals, acct.AccountID())
 	_, err = dec.Decode()
 	c.Check(err, check.Equals, io.EOF)
+}
+
+func (s *assertsSuite) TestAssertsFindManyRemoteInvalidParam(c *check.C) {
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account-key?remote=invalid&account-id=can0nical", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account-key"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 400, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	var rsp daemon.Resp
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Type, check.Equals, daemon.ResponseTypeError)
+	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
+		"message": `"remote" query parameter when used must be set to "true" or "false" or left unset`,
+	})
+}
+
+func (s *assertsSuite) Assertion(at *asserts.AssertionType, headers []string, user *auth.UserState) (asserts.Assertion, error) {
+	return s.mockAssertionFn(at, headers, user)
+}
+
+func (s *assertsSuite) TestAssertsFindManyRemote(c *check.C) {
+	var assertFnCalled int
+	s.mockAssertionFn = func(at *asserts.AssertionType, headers []string, user *auth.UserState) (asserts.Assertion, error) {
+		assertFnCalled++
+		c.Assert(at.Name, check.Equals, "account")
+		c.Assert(headers, check.DeepEquals, []string{"can0nical"})
+		return assertstest.NewAccount(s.storeSigning, "some-developer", nil, ""), nil
+	}
+
+	acct := assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
+	s.addAsserts(acct)
+
+	// Execute
+	req, err := http.NewRequest("POST", "/v2/assertions/account?remote=true&account-id=can0nical", nil)
+	c.Assert(err, check.IsNil)
+	defer daemon.MockMuxVars(func(*http.Request) map[string]string {
+		return map[string]string{"assertType": "account"}
+	})()
+
+	rec := httptest.NewRecorder()
+	daemon.AssertsFindManyCmd.GET(daemon.AssertsFindManyCmd, req, nil).ServeHTTP(rec, req)
+	// Verify
+	c.Check(assertFnCalled, check.Equals, 1)
+	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
+
+	data := rec.Body.Bytes()
+	c.Check(string(data), check.Matches, `(?ms)type: account
+authority-id: can0nical
+account-id: [a-zA-Z0-9]+
+display-name: Some-developer
+timestamp: .*
+username: some-developer
+validation: unproven
+.*
+`)
+
 }


### PR DESCRIPTION
This adds a new option "remote=true" to the
/v2/assertions/{assertType} endpoint. This will force
the daemon to search the store instead of the local asserts
database.

This will be needed for the `snap download <foo>` feature
that does the downloading via the snapd daemon.
