### PR TITLE
run-checks: allow overriding gofmt binary, show gofmt diff

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -158,7 +158,7 @@ if [ "$STATIC" = 1 ]; then
     echo Checking formatting
     fmt=""
     for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
-        s="$(gofmt -s -l "$dir" | grep -v /vendor/ || true)"
+        s="$(${GOFMT:-gofmt} -s -l -d "$dir" | grep -v /vendor/ || true)"
         if [ -n "$s" ]; then
             fmt="$s\\n$fmt"
         fi


### PR DESCRIPTION
It is useful to be able to override the gofmt binary when one uses most recent
Go while snapd is expecting 1.9 that has slightly different opinion about the
right formatting.

It also helps to be able to see the actual diff.

