### PR TITLE
tests: use `snap debug boot-vars` in "ubuntu-core-upgrade" test

### DIFF
--- a/tests/lib/boot.sh
+++ b/tests/lib/boot.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+bootenv() {
+    if [ $# -eq 0 ]; then
+        snap debug boot-vars
+    else
+        snap debug boot-vars | grep "^$1" | sed "s/^${1}=//"
+    fi
+}
+
 GRUB_EDITENV=grub-editenv
 GRUBENV_FILE=/boot/grub/grubenv
 case "$SPREAD_SYSTEM" in
@@ -7,26 +15,6 @@ case "$SPREAD_SYSTEM" in
         GRUB_EDITENV=grub2-editenv
         ;;
 esac
-
-bootenv() {
-    if [ $# -eq 0 ]; then
-        if command -v "$GRUB_EDITENV" >/dev/null; then
-            "$GRUB_EDITENV" list
-        elif [ -s "$GRUBENV_FILE" ]; then
-            cat "$GRUBENV_FILE"
-        else
-            fw_printenv
-        fi
-    else
-        if command -v "$GRUB_EDITENV" >/dev/null; then
-            "$GRUB_EDITENV" list | grep "^$1"
-        elif [ -s "$GRUBENV_FILE" ]; then
-            grep "^$1" "$GRUBENV_FILE"
-        else
-            fw_printenv "$1"
-        fi | sed "s/^${1}=//"
-    fi
-}
 
 # unset the given var from boot configuration
 bootenv_unset() {

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -1,9 +1,6 @@
 summary: Upgrade the core snap and revert a few times
 
-# ARM devices are not supported on ubuntu-core-18 due to fw_printenv/setenv are
-# not provided by the system and as the devices boot with uboot so it is not
-# possible to get any grub information as it is done with non arm devices.
-systems: [ubuntu-core-16-*, ubuntu-core-18-32*, ubuntu-core-18-64*]
+systems: [ubuntu-core-*]
 
 # Start early as it takes a long time.
 priority: 100


### PR DESCRIPTION
This PR uses the new `snap debug boot-vars` comand to get the
boot environment. This enables us to get the boot environment
on core18 ARM systems where fw_printenv is missing, hence the
main/ubuntu-core-upgrade test can be re-enabled.

This reverts PR#7508.

