### PR TITLE
tests: moving opensuse to unstable due to catastrofic issue on the repo

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -90,10 +90,6 @@ backends:
             - opensuse-15.0-64:
                 workers: 6
                 manual: true
-            - opensuse-15.1-64:
-                workers: 6
-            - opensuse-tumbleweed-64:
-                workers: 6
             - arch-linux-64:
                 workers: 6
 
@@ -112,6 +108,10 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
+            - opensuse-15.1-64:
+                workers: 6
+            - opensuse-tumbleweed-64:
+                workers: 6
 
     google-sru:
         type: google


### PR DESCRIPTION
There was an issue with the download service on the openususe
repository. This change is temporal until the service is restored.

Error: 
Problem retrieving files from 'Cloud:Tools (openSUSE_Tumbleweed)'.
Permission to access
'http://download.opensuse.org/repositories/Cloud:/Tools/openSUSE_Tumbleweed/repodata/repomd.xml'
denied.
Please see the above error message for a hint.
Skipping repository 'Cloud:Tools (openSUSE_Tumbleweed)' because of the
above error.
Problem retrieving files from 'repo-debug'.
Permission to access
'http://download.opensuse.org/tumbleweed/repo/debug/repodata/repomd.xml'
denied.
Please see the above error message for a hint.
Skipping repository 'repo-debug' because of the above error.
Problem retrieving files from 'repo-non-oss'.
Permission to access
'http://download.opensuse.org/tumbleweed/repo/non-oss/repodata/repomd.xml'
denied.
Please see the above error message for a hint.
Skipping repository 'repo-non-oss' because of the above error.
Problem retrieving files from 'repo-oss'.
Permission to access
'http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml'
denied.
Please see the above error message for a hint.
Skipping repository 'repo-oss' because of the above error.
Problem retrieving files from 'repo-update'.
Permission to access
'http://download.opensuse.org/update/tumbleweed/repodata/repomd.xml'
denied.
Please see the above error message for a hint.
Skipping repository 'repo-update' because of the above error.
Could not refresh the repositories because of errors.
