### PR TITLE
httputil: set user agent for CONNECT

### DIFF
--- a/httputil/client.go
+++ b/httputil/client.go
@@ -45,6 +45,7 @@ func NewHTTPClient(opts *ClientOptions) *http.Client {
 	if opts.Proxy != nil {
 		transport.Proxy = opts.Proxy
 	}
+	transport.ProxyConnectHeader = http.Header{"User-Agent": []string{UserAgent()}}
 
 	return &http.Client{
 		Transport: &LoggedTransport{


### PR DESCRIPTION
Without this change, https proxies would get a generic
`Go-http-client/1.1` user agent from snapd, making filtering by user
agent in the proxy harder than it needs to be.

From Go 1.8 we can ask go's http client to set that header, so this
change does that.

Fixes: lp:1779190