### PR TITLE
tests: add unit test for gadget defaults with a multiline string

### DIFF
--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -121,6 +121,17 @@ defaults:
       bar: baz
 `)
 
+var mockClassicGadgetMultilineDefaultsYaml = []byte(`
+defaults:
+  system:
+    something: true
+  otheridididididididididididididi:
+    foosnap:
+      multiline: |
+        foo
+        bar
+`)
+
 var mockVolumeUpdateGadgetYaml = []byte(`
 volumes:
   bootloader:
@@ -287,6 +298,22 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *
 			// keep this comment so that gofmt 1.10+ does not
 			// realign this, thus breaking our gofmt 1.9 checks
 			"otheridididididididididididididi": {"foo": map[string]interface{}{"bar": "baz"}},
+		},
+	})
+}
+
+func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {
+	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetMultilineDefaultsYaml, 0644)
+	c.Assert(err, IsNil)
+
+	ginfo, err := gadget.ReadInfo(s.dir, true)
+	c.Assert(err, IsNil)
+	c.Assert(ginfo, DeepEquals, &gadget.Info{
+		Defaults: map[string]map[string]interface{}{
+			"system": {"something": true},
+			// keep this comment so that gofmt 1.10+ does not
+			// realign this, thus breaking our gofmt 1.9 checks
+			"otheridididididididididididididi": {"foosnap": map[string]interface{}{"multiline": "foo\nbar\n"}},
 		},
 	})
 }


### PR DESCRIPTION
Add a unit test for multiline string in gadget defaults. I've created this to verify and understand https://bugs.launchpad.net/snapd/+bug/1820060 (non-issue afaict).
