### PR TITLE
cmd/snap-confine: allow digits in hook names

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -90,6 +90,10 @@ static void test_verify_security_tag(void)
 	g_assert_true(verify_security_tag("snap.123test.123test", "123test"));
 	g_assert_true(verify_security_tag
 		      ("snap.123test.hook.configure", "123test"));
+
+	// regression test snap.eon-edg-shb-pulseaudio.hook.connect-plug-i2c
+	g_assert_true(verify_security_tag
+		      ("snap.foo.hook.connect-plug-i2c", "foo"));
 }
 
 static void test_sc_is_hook_security_tag(void)

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -31,7 +31,7 @@
 bool verify_security_tag(const char *security_tag, const char *snap_name)
 {
 	const char *whitelist_re =
-	    "^snap\\.([a-z0-9](-?[a-z0-9])*(_[a-z0-9]{1,10})?)\\.([a-zA-Z0-9](-?[a-zA-Z0-9])*|hook\\.[a-z](-?[a-z])*)$";
+	    "^snap\\.([a-z0-9](-?[a-z0-9])*(_[a-z0-9]{1,10})?)\\.([a-zA-Z0-9](-?[a-zA-Z0-9])*|hook\\.[a-z](-?[a-z0-9])*)$";
 	regex_t re;
 	if (regcomp(&re, whitelist_re, REG_EXTENDED) != 0)
 		die("can not compile regex %s", whitelist_re);

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -159,6 +159,8 @@ func (s *ValidateSuite) TestValidateHookName(c *C) {
 		err := naming.ValidateHook(hook)
 		c.Assert(err, ErrorMatches, `invalid hook name: ".*"`)
 	}
+	// Regression test for https://bugs.launchpad.net/snapd/+bug/1638988
+	c.Assert(naming.ValidateHook("connect-plug-i2c"), IsNil)
 }
 
 func (s *ValidateSuite) TestValidateAppName(c *C) {


### PR DESCRIPTION
Interface hooks react to interface connection events. Interface names
can contain digits, for example "i2c" is a valid plug or slot name.

It was reported that interface hooks for the i2c interface were not
working. This was traced to an overly-strict validation of the snap
security tag computed for the hook by snapd, performed by snap-confine.

Fixes: https://bugs.launchpad.net/snapd/+bug/1638988
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>

