### PR TITLE
seed/seedwriter: cleanups and small left over todos

### DIFF
--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -44,27 +44,26 @@ type Options struct {
 	Architecture string
 }
 
-// OptionSnap represents an options-referred snap with its option values.
+// OptionsSnap represents an options-referred snap with its option values.
 // E.g. a snap passed to ubuntu-image via --snap.
 // If Name is set the snap is from the store. If Path is set the snap
 // is local at Path location.
-// XXX|TODO: for further clarity rename to OptionsSnap
-type OptionSnap struct {
+type OptionsSnap struct {
 	Name    string
 	SnapID  string
 	Path    string
 	Channel string
 }
 
-func (s *OptionSnap) SnapName() string {
+func (s *OptionsSnap) SnapName() string {
 	return s.Name
 }
 
-func (s *OptionSnap) ID() string {
+func (s *OptionsSnap) ID() string {
 	return s.SnapID
 }
 
-var _ naming.SnapRef = (*OptionSnap)(nil)
+var _ naming.SnapRef = (*OptionsSnap)(nil)
 
 // SeedSnap holds details of a snap being added to a seed.
 type SeedSnap struct {
@@ -83,7 +82,7 @@ type SeedSnap struct {
 
 	local      bool
 	modelSnap  *asserts.ModelSnap
-	optionSnap *OptionSnap
+	optionSnap *OptionsSnap
 }
 
 var _ naming.SnapRef = (*SeedSnap)(nil)
@@ -153,7 +152,7 @@ type Writer struct {
 
 	modelRefs []*asserts.Ref
 
-	// XXX optionsSnaps []*OptionSnap
+	// XXX optionsSnaps []*OptionsSnap
 
 	byNameOptSnaps *naming.SnapSet
 
@@ -293,8 +292,8 @@ func (w *Writer) checkStep(thisStep writerStep) error {
 	return nil
 }
 
-// SetOptionsSnaps accepts options-referred snaps represented as OptionSnap.
-func (w *Writer) SetOptionsSnaps(optSnaps []*OptionSnap) error {
+// SetOptionsSnaps accepts options-referred snaps represented as OptionsSnap.
+func (w *Writer) SetOptionsSnaps(optSnaps []*OptionsSnap) error {
 	if err := w.checkStep(setOptionsSnapsStep); err != nil {
 		return err
 	}
@@ -428,7 +427,7 @@ func (w *Writer) InfoDerived() error {
 		}
 
 		// in case, merge channel given by name separately
-		optSnap, _ := w.byNameOptSnaps.Lookup(sn).(*OptionSnap)
+		optSnap, _ := w.byNameOptSnaps.Lookup(sn).(*OptionsSnap)
 		if optSnap != nil && optSnap.Channel != "" {
 			if sn.optionSnap.Channel != "" {
 				if sn.optionSnap.Channel != optSnap.Channel {
@@ -470,10 +469,10 @@ const (
 
 func (w *Writer) modelSnapToSeed(modSnap *asserts.ModelSnap) (*SeedSnap, error) {
 	sn, _ := w.byRefLocalSnaps.Lookup(modSnap).(*SeedSnap)
-	var optSnap *OptionSnap
+	var optSnap *OptionsSnap
 	if sn == nil {
 		// not local, to download
-		optSnap, _ = w.byNameOptSnaps.Lookup(modSnap).(*OptionSnap)
+		optSnap, _ = w.byNameOptSnaps.Lookup(modSnap).(*OptionsSnap)
 		sn = &SeedSnap{
 			SnapRef: modSnap,
 
@@ -556,7 +555,7 @@ func (w *Writer) SnapsToDownload() (snaps []*SeedSnap, err error) {
 	// early as possible
 }
 
-func (w *Writer) resolveChannel(whichSnap string, modSnap *asserts.ModelSnap, optSnap *OptionSnap) (string, error) {
+func (w *Writer) resolveChannel(whichSnap string, modSnap *asserts.ModelSnap, optSnap *OptionsSnap) (string, error) {
 	var optChannel string
 	if optSnap != nil {
 		optChannel = optSnap.Channel

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -459,6 +459,7 @@ func (s *writerSuite) TestSnapsToDownloadDefaultChannel(c *C) {
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
 	c.Check(snaps, HasLen, 6)
 
 	for i, name := range []string{"snapd", "pc-kernel", "core18", "pc", "cont-consumer", "cont-producer"} {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -825,7 +825,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 
 		fn := filepath.Base(info.MountFile())
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
-		c.Check(osutil.FileExists(p), Equals, true)
+		c.Check(p, testutil.FilePresent)
 
 		channel := "stable"
 		switch name {
@@ -855,7 +855,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 
 	for _, fn := range []string{"model", brandAcctKeyPK + ".account-key", "my-brand.account", storeAccountKeyPK + ".account-key"} {
 		p := filepath.Join(seedAssertsDir, fn)
-		c.Check(osutil.FileExists(p), Equals, true)
+		c.Check(p, testutil.FilePresent)
 	}
 
 	c.Check(filepath.Join(seedAssertsDir, "model"), testutil.FileEquals, asserts.Encode(model))
@@ -1018,7 +1018,7 @@ func (s *writerSuite) TestLocalSnapsFullUse(c *C) {
 
 		fn := filepath.Base(info.MountFile())
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
-		c.Check(osutil.FileExists(p), Equals, true)
+		c.Check(p, testutil.FilePresent)
 
 		channel := "stable"
 		switch name {
@@ -1238,7 +1238,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicWithCore(c *C) {
 
 		fn := filepath.Base(info.MountFile())
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
-		c.Check(osutil.FileExists(p), Equals, true)
+		c.Check(p, testutil.FilePresent)
 
 		c.Check(seedYaml.Snaps[i], DeepEquals, &seed.Snap16{
 			Name:    info.SnapName(),
@@ -1308,7 +1308,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicSnapdOnly(c *C) {
 
 		fn := filepath.Base(info.MountFile())
 		p := filepath.Join(s.opts.SeedDir, "snaps", fn)
-		c.Check(osutil.FileExists(p), Equals, true)
+		c.Check(p, testutil.FilePresent)
 
 		c.Check(seedYaml.Snaps[i], DeepEquals, &seed.Snap16{
 			Name:    info.SnapName(),

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -271,16 +271,16 @@ func (s writerSuite) TestSetOptionsSnapsErrors(c *C) {
 	})
 
 	tests := []struct {
-		snaps []*seedwriter.OptionSnap
+		snaps []*seedwriter.OptionsSnap
 		err   string
 	}{
-		{[]*seedwriter.OptionSnap{{Name: "foo%&"}}, `invalid snap name: "foo%&"`},
-		{[]*seedwriter.OptionSnap{{Name: "foo_1"}}, `cannot use snap "foo_1", parallel snap instances are unsupported`},
-		{[]*seedwriter.OptionSnap{{Name: "foo"}, {Name: "foo"}}, `snap "foo" is repeated in options`},
-		{[]*seedwriter.OptionSnap{{Name: "foo", Channel: "track/foo"}}, `cannot use option channel for snap "foo": invalid risk in channel name: track/foo`},
-		{[]*seedwriter.OptionSnap{{Path: "not-a-snap"}}, `local option snap "not-a-snap" does not end in .snap`},
-		{[]*seedwriter.OptionSnap{{Path: "not-there.snap"}}, `local option snap "not-there.snap" does not exist`},
-		{[]*seedwriter.OptionSnap{{Name: "foo", Path: "foo.snap"}}, `cannot specify both name and path for option snap "foo"`},
+		{[]*seedwriter.OptionsSnap{{Name: "foo%&"}}, `invalid snap name: "foo%&"`},
+		{[]*seedwriter.OptionsSnap{{Name: "foo_1"}}, `cannot use snap "foo_1", parallel snap instances are unsupported`},
+		{[]*seedwriter.OptionsSnap{{Name: "foo"}, {Name: "foo"}}, `snap "foo" is repeated in options`},
+		{[]*seedwriter.OptionsSnap{{Name: "foo", Channel: "track/foo"}}, `cannot use option channel for snap "foo": invalid risk in channel name: track/foo`},
+		{[]*seedwriter.OptionsSnap{{Path: "not-a-snap"}}, `local option snap "not-a-snap" does not end in .snap`},
+		{[]*seedwriter.OptionsSnap{{Path: "not-there.snap"}}, `local option snap "not-there.snap" does not exist`},
+		{[]*seedwriter.OptionsSnap{{Name: "foo", Path: "foo.snap"}}, `cannot specify both name and path for option snap "foo"`},
 	}
 
 	for _, t := range tests {
@@ -303,7 +303,7 @@ func (s *writerSuite) TestSnapsToDownloadCore16(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{{Name: "pc", Channel: "edge"}})
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	_, err = w.Start(s.db, s.newFetcher)
@@ -338,7 +338,7 @@ func (s *writerSuite) TestDownloadedCore16(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{{Name: "pc", Channel: "edge"}})
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	_, err = w.Start(s.db, s.newFetcher)
@@ -377,7 +377,7 @@ func (s *writerSuite) TestDownloadedCore18(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{{Name: "pc", Channel: "edge"}})
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	_, err = w.Start(s.db, s.newFetcher)
@@ -421,7 +421,7 @@ func (s *writerSuite) TestSnapsToDownloadCore18IncompatibleTrack(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{{Name: "pc-kernel", Channel: "18.1"}})
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc-kernel", Channel: "18.1"}})
 	c.Assert(err, IsNil)
 
 	_, err = w.Start(s.db, s.newFetcher)
@@ -521,7 +521,7 @@ func (s *writerSuite) TestOutOfOrderWithLocalSnaps(c *C) {
 
 	requiredFn := s.makeLocalSnap(c, "required")
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{{Path: requiredFn}})
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
 	_, err = w.Start(s.db, s.newFetcher)
@@ -744,7 +744,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{{Name: "pc", Channel: "edge"}})
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
 	_, err = w.Start(s.db, s.newFetcher)
@@ -854,7 +854,7 @@ func (s *writerSuite) TestLocalSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
 		{Path: core18Fn},
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
@@ -895,7 +895,7 @@ func (s *writerSuite) TestLocalSnapsFullUse(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
 		{Path: core18Fn},
 		{Name: "pc-kernel", Channel: "candidate"},
 		{Path: pcFn, Channel: "edge"},
@@ -1031,7 +1031,7 @@ func (s *writerSuite) TestInfoDerivedInfosNotSet(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
 		{Path: core18Fn},
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
@@ -1065,7 +1065,7 @@ func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
 		{Path: core18Fn},
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},
@@ -1109,7 +1109,7 @@ func (s *writerSuite) TestInfoDerivedInconsistentChannel(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	err = w.SetOptionsSnaps([]*seedwriter.OptionSnap{
+	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{
 		{Path: core18Fn},
 		{Path: pcFn, Channel: "edge"},
 		{Path: pcKernelFn},


### PR DESCRIPTION
This PRs takes care of small cleanups and small left over todos, see the single commits.

The follow up takes care of the last big puzzle piece,  support for extra snaps.
