### PR TITLE
tests: move "centos-7" to unstable systems (2.42)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -101,10 +101,6 @@ backends:
                 workers: 6
                 storage: preserve-size
 
-            - centos-7-64:
-                workers: 6
-                image: centos-7-64
-
     google-unstable:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
@@ -113,6 +109,9 @@ backends:
         systems:
             - ubuntu-19.10-64:
                 workers: 6
+            - centos-7-64:
+                workers: 6
+                image: centos-7-64
 
     google-sru:
         type: google


### PR DESCRIPTION
Currently centos-7 is failing a lot with the following error:
```
Failed to execute operation: Connection reset by peer
```
This is reported in https://bugs.centos.org/view.php?id=16441
but there is no fix yet. Until we know more or have a workaround
centos-7 testing should go to manual.

Backport of #7496 
