### PR TITLE
cmd/system-shutdown: include correct prototype for die

### DIFF
--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -33,6 +33,7 @@
 
 #include "../libsnap-confine-private/mountinfo.h"
 #include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
 
 __attribute__((format(printf, 1, 2)))
 void kmsg(const char *fmt, ...)

--- a/cmd/system-shutdown/system-shutdown-utils.h
+++ b/cmd/system-shutdown/system-shutdown-utils.h
@@ -25,8 +25,6 @@
 // no longer found writable.
 bool umount_all(void);
 
-__attribute__((noreturn))
-void die(const char *msg);
 __attribute__((format(printf, 1, 2)))
 void kmsg(const char *fmt, ...);
 

--- a/cmd/system-shutdown/system-shutdown.c
+++ b/cmd/system-shutdown/system-shutdown.c
@@ -32,8 +32,9 @@
 #include <sys/syscall.h>	// SYS_reboot
 
 #include "system-shutdown-utils.h"
-#include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/panic.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
 
 static void show_error(const char *fmt, va_list ap, int errno_copy)
 {


### PR DESCRIPTION
This is a follow up to the conflicting definition of die() problem from
several weeks ago. For whatever reason our builds were not catching the
second incompatible prototype of die(). This patch removes the leftover
and adds missing include directives.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
