### PR TITLE
sandbox/seccomp: move the remaining sandbox bits to a corresponding sandbox package

### DIFF
--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -46,14 +46,14 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
-	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
+	"github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timings"
 )
 
 var (
-	kernelFeatures         = release.SecCompActions
+	kernelFeatures         = seccomp.Actions
 	dpkgKernelArchitecture = arch.DpkgKernelArchitecture
 	releaseInfoId          = release.ReleaseInfo.ID
 	releaseInfoVersionId   = release.ReleaseInfo.VersionID
@@ -63,19 +63,19 @@ var (
 	seccompCompilerLookup  = cmd.InternalToolPath
 )
 
-func snapSeccompVersionInfoImpl(c Compiler) (seccomp_compiler.VersionInfo, error) {
+func snapSeccompVersionInfoImpl(c Compiler) (seccomp.VersionInfo, error) {
 	return c.VersionInfo()
 }
 
 type Compiler interface {
 	Compile(in, out string) error
-	VersionInfo() (seccomp_compiler.VersionInfo, error)
+	VersionInfo() (seccomp.VersionInfo, error)
 }
 
 // Backend is responsible for maintaining seccomp profiles for snap-confine.
 type Backend struct {
 	snapSeccomp Compiler
-	versionInfo seccomp_compiler.VersionInfo
+	versionInfo seccomp.VersionInfo
 }
 
 var globalProfileLE = []byte{
@@ -135,7 +135,7 @@ func (b *Backend) Initialize() error {
 		return fmt.Errorf("cannot synchronize global seccomp profile: %s", err)
 	}
 
-	b.snapSeccomp, err = seccomp_compiler.New(seccompCompilerLookup)
+	b.snapSeccomp, err = seccomp.New(seccompCompilerLookup)
 	if err != nil {
 		return fmt.Errorf("cannot initialize seccomp profile compiler: %v", err)
 	}
@@ -289,7 +289,7 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 	return content, nil
 }
 
-func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, addSocketcall bool, versionInfo seccomp_compiler.VersionInfo, uidGidChownSyscalls string) []byte {
+func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, addSocketcall bool, versionInfo seccomp.VersionInfo, uidGidChownSyscalls string) []byte {
 	var buffer bytes.Buffer
 
 	if versionInfo != "" {
@@ -304,7 +304,7 @@ func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, a
 	if opts.DevMode && !opts.JailMode {
 		// NOTE: This is understood by snap-confine
 		buffer.WriteString("@complain\n")
-		if !release.SecCompSupportsAction("log") {
+		if !seccomp.SupportsAction("log") {
 			buffer.WriteString("# complain mode logging unavailable\n")
 		}
 	}
@@ -423,8 +423,8 @@ func requiresSocketcallImpl(baseSnap string) bool {
 // MockSnapSeccompVersionInfo is for use in tests only.
 func MockSnapSeccompVersionInfo(versionInfo string) (restore func()) {
 	old := snapSeccompVersionInfo
-	snapSeccompVersionInfo = func(c Compiler) (seccomp_compiler.VersionInfo, error) {
-		return seccomp_compiler.VersionInfo(versionInfo), nil
+	snapSeccompVersionInfo = func(c Compiler) (seccomp.VersionInfo, error) {
+		return seccomp.VersionInfo(versionInfo), nil
 	}
 	return func() {
 		snapSeccompVersionInfo = old

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -135,7 +135,7 @@ func (b *Backend) Initialize() error {
 		return fmt.Errorf("cannot synchronize global seccomp profile: %s", err)
 	}
 
-	b.snapSeccomp, err = seccomp.New(seccompCompilerLookup)
+	b.snapSeccomp, err = seccomp.NewCompiler(seccompCompilerLookup)
 	if err != nil {
 		return fmt.Errorf("cannot initialize seccomp profile compiler: %v", err)
 	}

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
-	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
+	seccomp_sandbox "github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -318,7 +318,7 @@ var combineSnippetsScenarios = []combineSnippetsScenario{{
 func (s *backendSuite) TestCombineSnippets(c *C) {
 	restore := release.MockForcedDevmode(false)
 	defer restore()
-	restore = release.MockSecCompActions([]string{"log"})
+	restore = seccomp_sandbox.MockActions([]string{"log"})
 	defer restore()
 	restore = seccomp.MockRequiresSocketcall(func(string) bool { return false })
 	defer restore()
@@ -430,7 +430,7 @@ apps:
   `
 
 func (s *backendSuite) TestSystemKeyRetLogSupported(c *C) {
-	restore := release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
+	restore := seccomp_sandbox.MockActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
 	defer restore()
 
 	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{DevMode: true}, "", ifacetest.SambaYamlV1, 0)
@@ -450,7 +450,7 @@ func (s *backendSuite) TestSystemKeyRetLogSupported(c *C) {
 }
 
 func (s *backendSuite) TestSystemKeyRetLogUnsupported(c *C) {
-	restore := release.MockSecCompActions([]string{"allow", "errno", "kill", "trace", "trap"})
+	restore := seccomp_sandbox.MockActions([]string{"allow", "errno", "kill", "trace", "trap"})
 	defer restore()
 
 	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{DevMode: true}, "", ifacetest.SambaYamlV1, 0)
@@ -627,7 +627,7 @@ func (s *backendSuite) TestRequiresSocketcallNotForcedViaBaseSnap(c *C) {
 func (s *backendSuite) TestRebuildsWithVersionInfoWhenNeeded(c *C) {
 	restore := release.MockForcedDevmode(false)
 	defer restore()
-	restore = release.MockSecCompActions([]string{"log"})
+	restore = seccomp_sandbox.MockActions([]string{"log"})
 	defer restore()
 	restore = seccomp.MockRequiresSocketcall(func(string) bool { return false })
 	defer restore()
@@ -726,7 +726,7 @@ fi`)
 
 	sb, ok := s.Backend.(*seccomp.Backend)
 	c.Assert(ok, Equals, true)
-	c.Check(sb.VersionInfo(), Equals, seccomp_compiler.VersionInfo("2345cdef 2.3.4 2345cdef -"))
+	c.Check(sb.VersionInfo(), Equals, seccomp_sandbox.VersionInfo("2345cdef 2.3.4 2345cdef -"))
 }
 
 func (s *backendSuite) TestCompilerInitUnhappy(c *C) {

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -32,9 +32,8 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
+	"github.com/snapcore/snapd/sandbox/seccomp"
 )
 
 // ErrSystemKeyIncomparableVersions indicates that the system-key
@@ -83,8 +82,8 @@ var (
 	readBuildID = osutil.ReadBuildID
 )
 
-func seccompCompilerVersionInfo(path string) (seccomp_compiler.VersionInfo, error) {
-	return seccomp_compiler.CompilerVersionInfo(func(name string) (string, error) { return filepath.Join(path, name), nil })
+func seccompCompilerVersionInfo(path string) (seccomp.VersionInfo, error) {
+	return seccomp.CompilerVersionInfo(func(name string) (string, error) { return filepath.Join(path, name), nil })
 }
 
 func generateSystemKey() (*systemKey, error) {
@@ -132,7 +131,7 @@ func generateSystemKey() (*systemKey, error) {
 	}
 
 	// Add seccomp-features
-	sk.SecCompActions = release.SecCompActions()
+	sk.SecCompActions = seccomp.Actions()
 
 	versionInfo, err := seccompCompilerVersionInfo(filepath.Dir(snapdPath))
 	if err != nil {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -31,9 +31,8 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	seccomp_compiler "github.com/snapcore/snapd/sandbox/seccomp"
+	"github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -43,7 +42,7 @@ type systemKeySuite struct {
 	tmp                    string
 	apparmorFeatures       string
 	buildID                string
-	seccompCompilerVersion seccomp_compiler.VersionInfo
+	seccompCompilerVersion seccomp.VersionInfo
 }
 
 var _ = Suite(&systemKeySuite{})
@@ -63,13 +62,13 @@ func (s *systemKeySuite) SetUpTest(c *C) {
 	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
 	s.buildID = "this-is-my-build-id"
 
-	s.seccompCompilerVersion = seccomp_compiler.VersionInfo("123 2.3.3 abcdef123 -")
+	s.seccompCompilerVersion = seccomp.VersionInfo("123 2.3.3 abcdef123 -")
 	testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), fmt.Sprintf(`
 if [ "$1" = "version-info" ]; then echo "%s"; exit 0; fi
 exit 1
 `, s.seccompCompilerVersion))
 
-	s.AddCleanup(release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"}))
+	s.AddCleanup(seccomp.MockActions([]string{"allow", "errno", "kill", "log", "trace", "trap"}))
 }
 
 func (s *systemKeySuite) TearDownTest(c *C) {
@@ -106,10 +105,10 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	apparmorParserFeaturesStr, err := json.Marshal(parserFeatures)
 	c.Assert(err, IsNil)
 
-	seccompActionsStr, err := json.Marshal(release.SecCompActions())
+	seccompActionsStr, err := json.Marshal(seccomp.Actions())
 	c.Assert(err, IsNil)
 
-	compiler, err := seccomp_compiler.New(func(name string) (string, error) {
+	compiler, err := seccomp.New(func(name string) (string, error) {
 		return filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), nil
 	})
 	c.Assert(err, IsNil)

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -108,7 +108,7 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	seccompActionsStr, err := json.Marshal(seccomp.Actions())
 	c.Assert(err, IsNil)
 
-	compiler, err := seccomp.New(func(name string) (string, error) {
+	compiler, err := seccomp.NewCompiler(func(name string) (string, error) {
 		return filepath.Join(dirs.DistroLibExecDir, "snap-seccomp"), nil
 	})
 	c.Assert(err, IsNil)

--- a/sandbox/seccomp/compiler.go
+++ b/sandbox/seccomp/compiler.go
@@ -45,9 +45,9 @@ type Compiler struct {
 	snapSeccomp string
 }
 
-// New returns a wrapper for the compiler binary. The path to the binary is
+// NewCompiler returns a wrapper for the compiler binary. The path to the binary is
 // looked up using the lookupTool helper.
-func New(lookupTool func(name string) (string, error)) (*Compiler, error) {
+func NewCompiler(lookupTool func(name string) (string, error)) (*Compiler, error) {
 	if lookupTool == nil {
 		panic("lookup tool func not provided")
 	}
@@ -81,7 +81,7 @@ func (c *Compiler) VersionInfo() (VersionInfo, error) {
 }
 
 var compilerVersionInfoImpl = func(lookupTool func(name string) (string, error)) (VersionInfo, error) {
-	c, err := New(lookupTool)
+	c, err := NewCompiler(lookupTool)
 	if err != nil {
 		return VersionInfo(""), err
 	}
@@ -107,7 +107,7 @@ func MockCompilerVersionInfo(versionInfo string) (restore func()) {
 
 var errEmptyVersionInfo = errors.New("empty version-info")
 
-// VersionInfo represents information about the seccomp compilter
+// VersionInfo represents information about the seccomp compiler
 type VersionInfo string
 
 // LibseccompVersion parses VersionInfo and provides the libseccomp version

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -80,7 +80,7 @@ func (s *compilerSuite) TestVersionInfoValidate(c *C) {
 	} {
 		c.Logf("tc: %v", i)
 		cmd := testutil.MockCommand(c, "snap-seccomp", fmt.Sprintf("echo \"%s\"", tc.v))
-		compiler, err := seccomp.New(fromCmd(c, cmd))
+		compiler, err := seccomp.NewCompiler(fromCmd(c, cmd))
 		c.Assert(err, IsNil)
 
 		v, err := compiler.VersionInfo()
@@ -128,7 +128,7 @@ if [ "$1" = "version-info" ]; then echo "unknown command version-info"; exit 1; 
 exit 0
 `)
 	defer cmd.Restore()
-	compiler, err := seccomp.New(fromCmd(c, cmd))
+	compiler, err := seccomp.NewCompiler(fromCmd(c, cmd))
 	c.Assert(err, IsNil)
 
 	_, err = compiler.VersionInfo()
@@ -144,7 +144,7 @@ if [ "$1" = "compile" ]; then exit 0; fi
 exit 1
 `)
 	defer cmd.Restore()
-	compiler, err := seccomp.New(fromCmd(c, cmd))
+	compiler, err := seccomp.NewCompiler(fromCmd(c, cmd))
 	c.Assert(err, IsNil)
 
 	err = compiler.Compile("foo.src", "foo.bin")
@@ -160,7 +160,7 @@ if [ "$1" = "compile" ]; then echo "i will not"; exit 1; fi
 exit 0
 `)
 	defer cmd.Restore()
-	compiler, err := seccomp.New(fromCmd(c, cmd))
+	compiler, err := seccomp.NewCompiler(fromCmd(c, cmd))
 	c.Assert(err, IsNil)
 
 	err = compiler.Compile("foo.src", "foo.bin")
@@ -171,11 +171,11 @@ exit 0
 }
 
 func (s *compilerSuite) TestCompilerNewUnhappy(c *C) {
-	compiler, err := seccomp.New(func(name string) (string, error) { return "", errors.New("failed") })
+	compiler, err := seccomp.NewCompiler(func(name string) (string, error) { return "", errors.New("failed") })
 	c.Assert(err, ErrorMatches, "failed")
 	c.Assert(compiler, IsNil)
 
-	c.Assert(func() { seccomp.New(nil) }, PanicMatches, "lookup tool func not provided")
+	c.Assert(func() { seccomp.NewCompiler(nil) }, PanicMatches, "lookup tool func not provided")
 }
 
 func (s *compilerSuite) TestLibseccompVersion(c *C) {

--- a/sandbox/seccomp/export_test.go
+++ b/sandbox/seccomp/export_test.go
@@ -17,22 +17,7 @@
  *
  */
 
-package release
-
-var (
-	ReadOSRelease = readOSRelease
-)
-
-func MockOSReleasePath(filename string) (restore func()) {
-	old := osReleasePath
-	oldFallback := fallbackOsReleasePath
-	osReleasePath = filename
-	fallbackOsReleasePath = filename
-	return func() {
-		osReleasePath = old
-		fallbackOsReleasePath = oldFallback
-	}
-}
+package seccomp
 
 func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func()) {
 	old := ioutilReadFile
@@ -42,6 +27,6 @@ func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func
 	}
 }
 
-var (
-	IsWSL = isWSL
-)
+func FreshSecCompProbe() {
+	secCompProber = &secCompProbe{}
+}

--- a/sandbox/seccomp/seccomp_test.go
+++ b/sandbox/seccomp/seccomp_test.go
@@ -17,14 +17,14 @@
  *
  */
 
-package release_test
+package seccomp_test
 
 import (
 	"io"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/seccomp"
 )
 
 type seccompSuite struct{}
@@ -32,38 +32,38 @@ type seccompSuite struct{}
 var _ = Suite(&seccompSuite{})
 
 func (s *seccompSuite) TestInterfaceSystemKey(c *C) {
-	reset := release.MockSecCompActions([]string{})
+	reset := seccomp.MockActions([]string{})
 	defer reset()
-	c.Check(release.SecCompActions(), DeepEquals, []string{})
+	c.Check(seccomp.Actions(), DeepEquals, []string{})
 
-	reset = release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
+	reset = seccomp.MockActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
 	defer reset()
-	c.Check(release.SecCompActions(), DeepEquals, []string{"allow", "errno", "kill", "log", "trace", "trap"})
+	c.Check(seccomp.Actions(), DeepEquals, []string{"allow", "errno", "kill", "log", "trace", "trap"})
 }
 
 func (s *seccompSuite) TestSecCompSupportsAction(c *C) {
-	reset := release.MockSecCompActions([]string{})
+	reset := seccomp.MockActions([]string{})
 	defer reset()
-	c.Check(release.SecCompSupportsAction("log"), Equals, false)
+	c.Check(seccomp.SupportsAction("log"), Equals, false)
 
-	reset = release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
+	reset = seccomp.MockActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
 	defer reset()
-	c.Check(release.SecCompSupportsAction("log"), Equals, true)
+	c.Check(seccomp.SupportsAction("log"), Equals, true)
 }
 
 func (s *seccompSuite) TestProbe(c *C) {
-	release.FreshSecCompProbe()
-	r1 := release.MockIoutilReadfile(func(string) ([]byte, error) {
+	seccomp.FreshSecCompProbe()
+	r1 := seccomp.MockIoutilReadfile(func(string) ([]byte, error) {
 		return []byte("a b\n"), nil
 	})
 	defer r1()
 
-	c.Check(release.SecCompActions(), DeepEquals, []string{"a", "b"})
+	c.Check(seccomp.Actions(), DeepEquals, []string{"a", "b"})
 
-	r2 := release.MockIoutilReadfile(func(string) ([]byte, error) {
+	r2 := seccomp.MockIoutilReadfile(func(string) ([]byte, error) {
 		return nil, io.ErrUnexpectedEOF
 	})
 	defer r2()
 
-	c.Check(release.SecCompActions(), DeepEquals, []string{"a", "b"})
+	c.Check(seccomp.Actions(), DeepEquals, []string{"a", "b"})
 }


### PR DESCRIPTION
This is the last part of the series that moves the sandbox related code to the corresponding subpackage under `sandbox`. The PR moves the seccomp related APIs to `sandbox/seccomp` package.

At the same time, apply a little rename `seccomp.New()` -> `seccomp.NewCompiler()`.