### PR TITLE
tests: disable {contacts,calendar}-service tests on debian-sid

### DIFF
--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -7,7 +7,7 @@ summary: Ensure that the calendar-service interface works
 # https://github.com/snapcore/snapd/pull/7230 is landed
 # ubuntu-19.10: test-snapd-eds is incompatible with eds version shipped with the distro
 # arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -arch-linux-*]
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -arch-linux-*, -debian-sid-*]
 
 # fails in the autopkgtest env with:
 # [Wed Aug 15 16:34:12 2018] audit: type=1400

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -5,7 +5,7 @@ summary: Ensure that the contacts-service interface works
 # amazon: no need to run this on amazon
 # ubuntu-19.10: test-snapd-eds is incompatible with eds shipped with the distro
 # arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -arch-linux-*]
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -arch-linux-*, -debian-sid-*]
 
 # fails in autopkgtest environment with:
 # [Wed Aug 15 16:08:23 2018] audit: type=1400


### PR DESCRIPTION
As Debian has upgraded to evolution-data-server 3.34, it is no longer
compatible with the test-snapd-eds snap.
