### PR TITLE
tests: fix ubuntu-core-device-reg test for arm devices on core18

### DIFF
--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -31,6 +31,9 @@ execute: |
         ubuntu-core-18-64)
             snap known serial | MATCH "model: ubuntu-core-18-amd64"
             ;;
+        ubuntu-core-18-arm-*)
+            snap known serial | MATCH "model: ubuntu-core-18-$gadget_name"
+            ;;
         ubuntu-core-16-64)
             snap known serial | MATCH "model: pc"
             ;;


### PR DESCRIPTION
The test is currently failing on arm devices for core18.
