### PR TITLE
tests: use `snap model` instead of `snap known model` in tests

### DIFF
--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -4,7 +4,7 @@
 gadget_name=$(snap list | grep 'gadget$' | awk '{ print $1 }')
 kernel_name=$(snap list | grep 'kernel$' | awk '{ print $1 }')
 
-core_name="$(snap model --assertion | awk '/^base: / { print $2 }' || true)"
+core_name="$(snap model --verbose | grep -Po "^base:\s+\K.*" || true)"
 if [ -z "$core_name" ]; then
     core_name="core"
 fi

--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -4,7 +4,7 @@
 gadget_name=$(snap list | grep 'gadget$' | awk '{ print $1 }')
 kernel_name=$(snap list | grep 'kernel$' | awk '{ print $1 }')
 
-core_name="$(snap known model | awk '/^base: / { print $2 }' || true)"
+core_name="$(snap model --assertion | awk '/^base: / { print $2 }' || true)"
 if [ -z "$core_name" ]; then
     core_name="core"
 fi

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -71,13 +71,13 @@ execute: |
     echo "Wait for seeding to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap known model|MATCH "model: my-classic-w-gadget"
+    snap model --assertion | MATCH "model: my-classic-w-gadget"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: developer1"
-    snap known serial|MATCH "brand-id: developer1"
-    snap known serial|MATCH "model: my-classic-w-gadget"
-    snap known serial|MATCH "serial: 7777"
+    snap model --serial --assertion|MATCH "authority-id: developer1"
+    snap model --serial --assertion|MATCH "brand-id: developer1"
+    snap model --serial --assertion|MATCH "model: my-classic-w-gadget"
+    snap model --serial --assertion|MATCH "serial: 7777"

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -71,7 +71,7 @@ execute: |
     echo "Wait for seeding to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap model --assertion | MATCH "model: my-classic-w-gadget"
+    snap model --verbose | MATCH "model:\s* my-classic-w-gadget"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -76,7 +76,7 @@ execute: |
     systemctl status snapd.seeded.service
 
     echo "Verifying the imported assertions"
-    if ! snap known model | MATCH "model: my-classic" ; then
+    if ! snap model --assertion | MATCH "model: my-classic" ; then
         echo "Model assertion was not imported on firstboot"
         exit 1
     fi

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -76,7 +76,7 @@ execute: |
     systemctl status snapd.seeded.service
 
     echo "Verifying the imported assertions"
-    if ! snap model --assertion | MATCH "model: my-classic" ; then
+    if ! snap model --verbose | MATCH "model:\s* my-classic" ; then
         echo "Model assertion was not imported on firstboot"
         exit 1
     fi

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -75,7 +75,7 @@ execute: |
     snap wait system seed.loaded
 
     echo "We have a model assertion"
-    snap model --assertion|MATCH "model: my-classic-w-gadget-18"
+    snap model --verbose|MATCH "model:\s* my-classic-w-gadget-18"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done

--- a/tests/main/classic-prepare-image-no-core/task.yaml
+++ b/tests/main/classic-prepare-image-no-core/task.yaml
@@ -75,16 +75,16 @@ execute: |
     snap wait system seed.loaded
 
     echo "We have a model assertion"
-    snap known model|MATCH "model: my-classic-w-gadget-18"
+    snap model --assertion|MATCH "model: my-classic-w-gadget-18"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: developer1"
-    snap known serial|MATCH "brand-id: developer1"
-    snap known serial|MATCH "model: my-classic-w-gadget-18"
-    snap known serial|MATCH "serial: 7777"
+    snap model --serial --assertion|MATCH "authority-id: developer1"
+    snap model --serial --assertion|MATCH "brand-id: developer1"
+    snap model --serial --assertion|MATCH "model: my-classic-w-gadget-18"
+    snap model --serial --assertion|MATCH "serial: 7777"
 
     snap list | MATCH "^basic18"
     test -f "$SEED_DIR/snaps/basic18_"*.snap

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -75,7 +75,7 @@ execute: |
     snap wait system seed.loaded
 
     echo "We have a model assertion"
-    snap model --assertion|MATCH "model: my-classic-w-gadget"
+    snap model --verbose|MATCH "model:\s* my-classic-w-gadget"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done

--- a/tests/main/classic-prepare-image/task.yaml
+++ b/tests/main/classic-prepare-image/task.yaml
@@ -75,16 +75,16 @@ execute: |
     snap wait system seed.loaded
 
     echo "We have a model assertion"
-    snap known model|MATCH "model: my-classic-w-gadget"
+    snap model --assertion|MATCH "model: my-classic-w-gadget"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: developer1"
-    snap known serial|MATCH "brand-id: developer1"
-    snap known serial|MATCH "model: my-classic-w-gadget"
-    snap known serial|MATCH "serial: 7777"
+    snap model --serial --assertion|MATCH "authority-id: developer1"
+    snap model --serial --assertion|MATCH "brand-id: developer1"
+    snap model --serial --assertion|MATCH "model: my-classic-w-gadget"
+    snap model --serial --assertion|MATCH "serial: 7777"
 
     snap list | MATCH "^basic"
     test -f "$SEED_DIR/snaps/basic_"*.snap

--- a/tests/main/classic-snapd-firstboot/task.yaml
+++ b/tests/main/classic-snapd-firstboot/task.yaml
@@ -77,7 +77,7 @@ execute: |
     systemctl status snapd.seeded.service
 
     echo "Verifying the imported assertions"
-    if ! snap model --assertion | MATCH "model: my-classic" ; then
+    if ! snap model --verbose | MATCH "model:\s* my-classic" ; then
         echo "Model assertion was not imported on firstboot"
         exit 1
     fi

--- a/tests/main/classic-snapd-firstboot/task.yaml
+++ b/tests/main/classic-snapd-firstboot/task.yaml
@@ -77,7 +77,7 @@ execute: |
     systemctl status snapd.seeded.service
 
     echo "Verifying the imported assertions"
-    if ! snap known model | MATCH "model: my-classic" ; then
+    if ! snap model --assertion | MATCH "model: my-classic" ; then
         echo "Model assertion was not imported on firstboot"
         exit 1
     fi

--- a/tests/main/generic-classic-reg/task.yaml
+++ b/tests/main/generic-classic-reg/task.yaml
@@ -13,7 +13,7 @@ execute: |
     echo "We have a model assertion"
     snap model --assertion|MATCH "series: 16"
 
-    if ! snap model --assertion|grep "brand-id: generic" ; then
+    if ! snap model --verbose|grep "brand-id:\s* generic" ; then
        echo "Not a generic model. Skipping."
        exit 0
     fi

--- a/tests/main/generic-classic-reg/task.yaml
+++ b/tests/main/generic-classic-reg/task.yaml
@@ -11,17 +11,17 @@ execute: |
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "We have a model assertion"
-    snap known model|MATCH "series: 16"
+    snap model --assertion|MATCH "series: 16"
 
-    if ! snap known model|grep "brand-id: generic" ; then
+    if ! snap model --assertion|grep "brand-id: generic" ; then
        echo "Not a generic model. Skipping."
        exit 0
     fi
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: generic"
-    snap known serial|MATCH "brand-id: generic"
-    snap known serial|MATCH "model: generic-classic"
+    snap model --serial --assertion|MATCH "authority-id: generic"
+    snap model --serial --assertion|MATCH "brand-id: generic"
+    snap model --serial --assertion|MATCH "model: generic-classic"
 
     echo "Make sure we could acquire a session macaroon"
     snap find pc

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -80,14 +80,14 @@ execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap known model|MATCH "model: my-model"
+    snap model --assertion|MATCH "model: my-model"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: developer1"
-    snap known serial|MATCH "brand-id: developer1"
-    snap known serial|MATCH "model: my-model"
-    snap known serial|MATCH "serial: Y1234"
-    snap known serial|MATCH 'mac: "00:00:00:00:ff:00"'
+    snap model --serial --assertion|MATCH "authority-id: developer1"
+    snap model --serial --assertion|MATCH "brand-id: developer1"
+    snap model --serial --assertion|MATCH "model: my-model"
+    snap model --serial --assertion|MATCH "serial: Y1234"
+    snap model --serial --assertion|MATCH 'mac: "00:00:00:00:ff:00"'

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -80,7 +80,7 @@ execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap model --assertion|MATCH "model: my-model"
+    snap model --verbose|MATCH "model:\s* my-model"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -81,7 +81,7 @@ execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap model --assertion|MATCH "model: my-model"
+    snap model --verbose|MATCH "model:\s* my-model"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -81,13 +81,13 @@ execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap known model|MATCH "model: my-model"
+    snap model --assertion|MATCH "model: my-model"
 
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: developer1"
-    snap known serial|MATCH "brand-id: developer1"
-    snap known serial|MATCH "model: my-model"
-    snap known serial|MATCH "serial: 7777"
+    snap model --serial --assertion|MATCH "authority-id: developer1"
+    snap model --serial --assertion|MATCH "brand-id: developer1"
+    snap model --serial --assertion|MATCH "model: my-model"
+    snap model --serial --assertion|MATCH "serial: 7777"

--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -16,7 +16,7 @@ execute: |
     echo "We have a model assertion"
     snap model --assertion | MATCH "series: 16"
 
-    if ! snap model --assertion | grep "brand-id: canonical" ; then
+    if ! snap model --verbose | grep "brand-id:\s+ canonical" ; then
        echo "Not a canonical model. Skipping."
        exit 0
     fi

--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -14,9 +14,9 @@ execute: |
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
 
     echo "We have a model assertion"
-    snap known model | MATCH "series: 16"    
+    snap model --assertion | MATCH "series: 16"
 
-    if ! snap known model|grep "brand-id: canonical" ; then
+    if ! snap model --assertion | grep "brand-id: canonical" ; then
        echo "Not a canonical model. Skipping."
        exit 0
     fi
@@ -25,20 +25,20 @@ execute: |
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 
     echo "Check we have a serial"
-    snap known serial|MATCH "authority-id: canonical"
-    snap known serial|MATCH "brand-id: canonical"
+    snap model --serial --assertion | MATCH "authority-id: canonical"
+    snap model --serial --assertion | MATCH "brand-id: canonical"
     case "$SPREAD_SYSTEM" in
         ubuntu-core-18-64)
-            snap known serial | MATCH "model: ubuntu-core-18-amd64"
+            snap model --serial --assertion | MATCH "model: ubuntu-core-18-amd64"
             ;;
         ubuntu-core-18-arm-*)
-            snap known serial | MATCH "model: ubuntu-core-18-$gadget_name"
+            snap model --serial --assertion | MATCH "model: ubuntu-core-18-$gadget_name"
             ;;
         ubuntu-core-16-64)
-            snap known serial | MATCH "model: pc"
+            snap model --serial --assertion | MATCH "model: pc"
             ;;
         *)
-            snap known serial | MATCH "model: $gadget_name"
+            snap model --serial --assertion | MATCH "model: $gadget_name"
     esac
 
     echo "Make sure we could acquire a session macaroon"

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -115,7 +115,7 @@ execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap model --assertion|MATCH "model: my-model-w-config"
+    snap model --verbose|MATCH "model:\s* my-model-w-config"
 
     echo "The configurable snap was installed"
     snap list|MATCH "test-snapd-with-configure"

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -115,7 +115,7 @@ execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
     echo "We have a model assertion"
-    snap known model|MATCH "model: my-model-w-config"
+    snap model --assertion|MATCH "model: my-model-w-config"
 
     echo "The configurable snap was installed"
     snap list|MATCH "test-snapd-with-configure"


### PR DESCRIPTION
We now have the `snap model` command which is more precise than
using `snap known model`. Hence switch the code over to use it.
