### PR TITLE
interfaces/seccomp: query apparmor sandbox helper rather than aggregate info

### DIFF
--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
@@ -313,10 +314,10 @@ func generateContent(opts interfaces.ConfinementOptions, snippetForTag string, a
 	buffer.WriteString(snippetForTag)
 	buffer.WriteString(uidGidChownSyscalls)
 
-	// For systems with force-devmode we need to apply a workaround
-	// to avoid failing hooks. See description in template.go for
-	// more details.
-	if release.ReleaseInfo.ForceDevMode() {
+	// For systems with partial or missing AppArmor support we need to apply
+	// a workaround to avoid failing hooks. See description in template.go
+	// for more details.
+	if apparmor.ProbedLevel() != apparmor.Full {
 		buffer.WriteString(bindSyscallWorkaround)
 	}
 


### PR DESCRIPTION
Some snippets are added conditionally depending on AppAmor being fully supported
by the host system. Instead of querying the aggregate forced-dev-mode status,
poke the AppArmor sandbox helpers in sandbox/apparmor directly.

Make the unit test more specific.

