### PR TITLE
tests: fix snapd-failover test for core18 tests on boards

### DIFF
--- a/tests/core18/snapd-failover/task.yaml
+++ b/tests/core18/snapd-failover/task.yaml
@@ -4,6 +4,12 @@ debug: |
     # dump failure data
     journalctl -u snapd.failure.service
 
+restore: |
+    # Stop snapd.failure.service in case it is active
+    if systemctl is-active snapd.failure.service | MATCH active; then
+        systemctl stop snapd.failure.service
+    fi
+
 execute: |
     echo "Testing failover handling of the snapd snap"
     current=$(readlink /snap/snapd/current)
@@ -12,7 +18,7 @@ execute: |
     echo "Verify that a random signal does not trigger the failure handling"
     echo "and snapd is just restarted"
     systemctl kill --signal=SIGSEGV snapd.service
-    systemctl status snapd.failure.service | MATCH inactive
+    systemctl is-active snapd.failure.service | MATCH inactive
     echo "Snap list is working still"
     snap list | MATCH "^snapd .* $current .*"
 
@@ -27,6 +33,12 @@ execute: |
     fi
 
     echo "And verify that snap commands still work and snapd is reverted"
+    for _ in $(seq 30); do
+        if systemctl is-active snapd.failure.service | MATCH active; then
+            break
+        fi
+        sleep 5
+    done
     snap list | MATCH "^snapd .* $current .*"
 
     echo "Verify we got the expected error message"

--- a/tests/core18/snapd-failover/task.yaml
+++ b/tests/core18/snapd-failover/task.yaml
@@ -33,12 +33,7 @@ execute: |
     fi
 
     echo "And verify that snap commands still work and snapd is reverted"
-    for _ in $(seq 30); do
-        if systemctl is-active snapd.failure.service | MATCH active; then
-            break
-        fi
-        sleep 5
-    done
+    retry-tool -n 30 --wait 5 systemctl is-active snapd.failure.service
     snap list | MATCH "^snapd .* $current .*"
 
     echo "Verify we got the expected error message"


### PR DESCRIPTION
This change fixes 2 issues:
1. The snapd.failure.service remains active after execute the test, so
when the test is executed using -repeat option it fails.
2. On boards the snap command takes a while to be active, it happens
because while the snapd service is activating. The idea is to wait a bit
until the snapd service is active again and the check for the snap
command.
