### PR TITLE
cmd/model: don't show model with display-name inline w/ opts

### DIFF
--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -198,9 +198,11 @@ func (x *cmdModel) Execute(args []string) error {
 		serial = serialAssertion.HeaderString("serial")
 	}
 
-	// handle brand/brand-id (the former is only on `snap model` w/o opts)
+	// handle brand/brand-id and model/model + display-name differently on just
+	// `snap model` w/o opts
 	if x.Serial || x.Verbose {
 		fmt.Fprintf(w, "brand-id:\t%s\n", brandIDHeader)
+		fmt.Fprintf(w, "model:\t%s\n", modelHeader)
 	} else {
 		// for the model command (not --serial) we want to show a publisher
 		// style display of "brand" instead of just "brand-id"
@@ -211,12 +213,7 @@ func (x *cmdModel) Execute(args []string) error {
 		// use the longPublisher helper to format the brand store account
 		// like we do in `snap info`
 		fmt.Fprintf(w, "brand%s\t%s\n", separator, longPublisher(x.getEscapes(), storeAccount))
-	}
 
-	// handle model, on `snap model` we try to add display-name if it exists
-	if x.Serial {
-		fmt.Fprintf(w, "model:\t%s\n", modelHeader)
-	} else {
 		// for model, if there's a display-name, we show that first with the
 		// real model in parenthesis
 		if displayName := modelAssertion.HeaderString("display-name"); displayName != "" {

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -329,6 +329,34 @@ required-snaps:
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
+func (s *SnapSuite) TestModelVerboseDisplayName(c *check.C) {
+	s.RedirectClientToTestServer(
+		makeHappyTestServerHandler(
+			c,
+			simpleHappyResponder(happyModelWithDisplayNameAssertionResponse),
+			simpleHappyResponder(happySerialAssertionResponse),
+			simpleAssertionAccountResponder(happyAccountAssertionResponse),
+		))
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"model", "--verbose", "--abs-time"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `
+brand-id:        mememe
+model:           test-model
+serial:          serialserial
+architecture:    amd64
+base:            core18
+display-name:    Model Name
+gadget:          pc=18
+kernel:          pc-kernel=18
+timestamp:       2017-07-27T00:00:00Z
+required-snaps:  
+  - core
+  - hello-world
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
 func (s *SnapSuite) TestModelVerboseNoSerialYet(c *check.C) {
 	s.RedirectClientToTestServer(
 		makeHappyTestServerHandler(

--- a/tests/main/snap-model/task.yaml
+++ b/tests/main/snap-model/task.yaml
@@ -24,27 +24,18 @@ execute: |
   echo "Check that serial from \"snap known\" matches \"snap model\""
   if [ "$modelCmdSerial" != "$knownCmdSerial" ]; then
     echo "serial numbers not the same, difference is:"
-    diff -u <(echo "$knownCmdSerial") <(echo "$knownCmdSerial")
+    diff -u <(echo "$modelCmdSerial") <(echo "$knownCmdSerial")
     exit 1
   fi
 
-  modelCmdModel="$(snap model | grep -Po "model\s+\K(.*)")"
+  # the model may have a display-name so `snap model` output will be different, 
+  # so use `snap model --verbose` which will not show the display-name alongside
+  # the model
+  modelCmdModel="$(snap model --verbose | grep -Po "model\s+\K(.*)")"
   knownCmdModel="$(snap known model | grep -Po "model:\s+\K(.*)")"
   echo "Check that model from \"snap known\" matches \"snap model\""
-  if snap known model | grep -q -P '^display-name:'; then
-    # the model has a display-name so `snap model` output will be different
-    echo "note: model has a display-name in it"
-    modelDisplayName="$(snap known model | grep -Po "display-name:\s+\K(.*)")"
-    fullModelShown="$modelDisplayName ($knownCmdModel)"
-    if [ "$modelCmdModel" != "$fullModelShown" ]; then
-      echo "model not the same, difference is:"
-      diff -u <(echo "$modelCmdModel") <(echo "$fullModelShown")
-      exit 1
-    fi
-  else   
-    if [ "$modelCmdModel" != "$knownCmdModel" ]; then
-      echo "model not the same, difference is:"
-      diff -u <(echo "$modelCmdModel") <(echo "$knownCmdModel")
-      exit 1
-    fi
+  if [ "$modelCmdModel" != "$knownCmdModel" ]; then
+    echo "models not the same, difference is:"
+    diff -u <(echo "$knownCmdModel") <(echo "$modelCmdModel")
+    exit 1
   fi

--- a/tests/main/snap-model/task.yaml
+++ b/tests/main/snap-model/task.yaml
@@ -31,7 +31,7 @@ execute: |
   # the model may have a display-name so `snap model` output will be different, 
   # so use `snap model --verbose` which will not show the display-name alongside
   # the model
-  modelCmdModel="$(snap model --verbose | grep -Po "model\s+\K(.*)")"
+  modelCmdModel="$(snap model --verbose | grep -Po "model:\s+\K(.*)")"
   knownCmdModel="$(snap known model | grep -Po "model:\s+\K(.*)")"
   echo "Check that model from \"snap known\" matches \"snap model\""
   if [ "$modelCmdModel" != "$knownCmdModel" ]; then


### PR DESCRIPTION
With `snap model` we want to show the display-name with the actual model in paranthesis for easy operator (i.e. human) inspection, but with `snap model --verbose` we want the model key to be the verbatim model so it is easy to inspect the output programatically in scripts and such.

Also add a unit test for --verbose output when there's a display-name in the model assertion.

Also fix a typo in the diff output for one of the spread tests in the error condition, and simplify the spread test to always use --verbose to ensure that the model in the model assertion from `snap known` matches that from `snap model`.