### PR TITLE
daemon: add a 'prune' debug action

### DIFF
--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -297,6 +297,9 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		return SyncResponse(devicestate.CanManageRefreshes(st), nil)
 	case "connectivity":
 		return checkConnectivity(st)
+	case "prune":
+		st.Prune(0, 0, 0)
+		return SyncResponse(true, nil)
 	default:
 		return BadRequest("unknown debug action: %v", a.Action)
 	}


### PR DESCRIPTION
I had this in a stash, and it's occasionally useful, so we might as
well have it in master.

To use this, do

    sudo http snapd:///v2/debug action=prune

(with http from the snap).
