### PR TITLE
tests: update snap logs to match for multiple lines for  "running"

### DIFF
--- a/tests/main/snap-logs/task.yaml
+++ b/tests/main/snap-logs/task.yaml
@@ -16,7 +16,7 @@ execute: |
     snap logs test-snapd-service.test-snapd-other-service | MATCH "running"
 
     echo "check output lines for the logs"
-    snap logs -n=1 test-snapd-service | MATCH "running"
+    snap logs -n=1 test-snapd-service | MATCH "test-snapd-service"
     snap logs -n=all test-snapd-service | MATCH "running"
     
     echo "check -f option works"

--- a/tests/main/snap-logs/task.yaml
+++ b/tests/main/snap-logs/task.yaml
@@ -16,7 +16,7 @@ execute: |
     snap logs test-snapd-service.test-snapd-other-service | MATCH "running"
 
     echo "check output lines for the logs"
-    snap logs -n=1 test-snapd-service | MATCH "test-snapd-service"
+    snap logs -n=1 test-snapd-service | MATCH "systemd|running"
     snap logs -n=all test-snapd-service | MATCH "running"
     
     echo "check -f option works"

--- a/tests/main/snap-logs/task.yaml
+++ b/tests/main/snap-logs/task.yaml
@@ -16,7 +16,7 @@ execute: |
     snap logs test-snapd-service.test-snapd-other-service | MATCH "running"
 
     echo "check output lines for the logs"
-    snap logs -n=1 test-snapd-service | MATCH "systemd|running"
+    snap logs -n=20 test-snapd-service | MATCH "running"
     snap logs -n=all test-snapd-service | MATCH "running"
     
     echo "check -f option works"


### PR DESCRIPTION
The test assumes the only lines in the log come from the unit, but they
can also be from systemd, so the change makes sure the logs for the last
line will match for the service name which is allways included also in
systemd log lines.
