### PR TITLE
cmd/libsnap: use cgroup.procs instead of tasks

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -84,7 +84,7 @@ bool sc_cgroup_freezer_occupied(const char *snap_name)
 	FILE *cgroup_procs SC_CLEANUP(sc_cleanup_file) = NULL;
 	cgroup_procs = fdopen(cgroup_procs_fd, "r");
 	if (cgroup_procs == NULL) {
-		die("cannot convert tasks file descriptor to FILE");
+		die("cannot convert cgroups.procs file descriptor to FILE");
 	}
 	cgroup_procs_fd = -1;	// cgroup_procs_fd will now be closed by fclose.
 

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.h
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.h
@@ -31,7 +31,7 @@
  * allows us to track processes belonging to a given snap. This makes the
  * measurement "are any processes of this snap still alive" very simple.
  *
- * The "tasks" file belonging to the cgroup contains the set of all the
+ * The "cgroup.procs" file belonging to the cgroup contains the set of all the
  * processes that originate from the given snap. Examining that file one can
  * reliably determine if the set is empty or not.
  *

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -56,25 +56,24 @@
     capability dac_read_search,
     capability dac_override,
     /sys/fs/cgroup/devices/snap{,py}.*/ w,
-    /sys/fs/cgroup/devices/snap{,py}.*/tasks w,
+    /sys/fs/cgroup/devices/snap{,py}.*/cgroup.procs w,
     /sys/fs/cgroup/devices/snap{,py}.*/devices.{allow,deny} w,
 
     # cgroup: freezer
     # Allow creating per-snap cgroup freezers and adding snap command (task)
     # invocations to the freezer. This allows for reliably enumerating all
-    # running tasks for the snap. In addition, allow enumerating processes in
-    # the cgroup to determine if it is occupied.
+    # running processes for the snap. In addition, allow enumerating processes
+    # in the cgroup to determine if it is occupied.
     /sys/fs/cgroup/freezer/ r,
     /sys/fs/cgroup/freezer/snap.*/ w,
-    /sys/fs/cgroup/freezer/snap.*/tasks w,
-    /sys/fs/cgroup/freezer/snap.*/cgroup.procs r,
+    /sys/fs/cgroup/freezer/snap.*/cgroup.procs rw,
 
     # cgroup: pids
     # allow creating per snap-security-tag hierarchy and adding snap command (task)
     # invocations to the controller.
     /sys/fs/cgroup/pids/ r,
     /sys/fs/cgroup/pids/snap.*/ w,
-    /sys/fs/cgroup/pids/snap.*/tasks w,
+    /sys/fs/cgroup/pids/snap.*/cgroup.procs w,
 
     # querying udev
     /etc/udev/udev.conf r,

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -208,7 +208,7 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 	// move ourselves into it
 	char cgroup_file[PATH_MAX] = { 0 };
 	sc_must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
-			 "tasks");
+			 "cgroup.procs");
 
 	char buf[128] = { 0 };
 	sc_must_snprintf(buf, sizeof(buf), "%i", getpid());


### PR DESCRIPTION
To associate a thread with a cgroup v1 hierarchy one needs to write the
task id of that thread to the "tasks" file. Since snap-confine is
single-threaded this has the same semantics as writing the pid to the
"cgroup.procs" file.

The advantage of cgroup.procs is that is common across both v1 and v2
so let's use that instead.

This change is applied to: freezer, pids and devices cgroups.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
