### PR TITLE
spread.yaml: exclude automake cache

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -406,6 +406,7 @@ exclude:
     - cmd/snapd/snapd
     - cmd/snapctl/snapctl
     - cmd/snap-exec/snap-exec
+    - cmd/autom4te.cache
     - "*.o"
     - "*.a"
 


### PR DESCRIPTION
If you have a tree with build artefacts then testing against Debian sid
on spread fails because there are some files in the tree that causing
dpkg to report "local changes".

The error message is looks like this:

    dpkg-source: info: local changes detected, the modified files are:
     snapd/cmd/autom4te.cache/output.0
     snapd/cmd/autom4te.cache/output.1
     snapd/cmd/autom4te.cache/requests
     snapd/cmd/autom4te.cache/traces.0
     snapd/cmd/autom4te.cache/traces.1

Excluding the autom4te.cache fixes this and saves some bandwidth.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>