### PR TITLE
tests: add new option "invert" to retry-tool

### DIFF
--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env any-python
 from __future__ import print_function, absolute_import, unicode_literals
 
 import argparse
@@ -69,6 +69,7 @@ def run_cmd(cmd, n, wait, verbose, invert):
             break
         # Break when the retcode is different than 0 and the check is inverted
         if not retcode == 0 and invert:
+            retcode = 0
             break
         if verbose:
             print(

--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -1,4 +1,4 @@
-#!/usr/bin/env any-python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import, unicode_literals
 
 import argparse
@@ -41,6 +41,12 @@ attempt. On failure the exit code from the final attempt is returned.
         help="grace period between attempts (default %(default)ss)",
     )
     parser.add_argument(
+        "--invert",
+        action="store_true",
+        default=False,
+        help="invert the validation of the return code",
+    )
+    parser.add_argument(
         "--quiet",
         dest="verbose",
         action="store_false",
@@ -53,16 +59,20 @@ attempt. On failure the exit code from the final attempt is returned.
     return parser
 
 
-def run_cmd(cmd, n, wait, verbose):
-    # type: (List[Text], int, float, bool) -> int
+def run_cmd(cmd, n, wait, verbose, invert):
+    # type: (List[Text], int, float, bool, bool) -> int
     retcode = 0
     for i in range(1, n + 1):
         retcode = subprocess.call(cmd)
-        if retcode == 0:
+        # Break when the retcode is 0 and the check is not inverted
+        if retcode == 0 and not invert:
+            break
+        # Break when the retcode is different than 0 and the check is inverted
+        if not retcode == 0 and invert:
             break
         if verbose:
             print(
-                "retry: command {} failed with code {}".format(" ".join(cmd), retcode),
+                "retry: command {} finished with code {}".format(" ".join(cmd), retcode),
                 file=sys.stderr,
             )
         if i < n:
@@ -95,7 +105,7 @@ def main():
         parser.exit(0)
     # Return the last exit code as the exit code of this process.
     try:
-        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait, ns.verbose)
+        retcode = run_cmd(ns.cmd, ns.attempts, ns.wait, ns.verbose, ns.invert)
     except OSError as exc:
         if ns.verbose:
             print(

--- a/tests/lib/bin/retry-tool
+++ b/tests/lib/bin/retry-tool
@@ -69,7 +69,6 @@ def run_cmd(cmd, n, wait, verbose, invert):
             break
         # Break when the retcode is different than 0 and the check is inverted
         if not retcode == 0 and invert:
-            retcode = 0
             break
         if verbose:
             print(
@@ -93,6 +92,13 @@ def run_cmd(cmd, n, wait, verbose, invert):
                 ),
                 file=sys.stderr,
             )
+
+    # Invert the retcode when invert option is set
+    if invert and retcode == 0:
+        retcode = 1
+    elif invert and not retcode == 0:
+        retcode = 0
+
     return retcode
 
 

--- a/tests/main/retry-tool/task.yaml
+++ b/tests/main/retry-tool/task.yaml
@@ -4,12 +4,19 @@ execute: |
     # code of that command.
     retry-tool true
     not retry-tool -n 1 false
+
+    # code of that command with invert option set.
+    retry-tool --invert false
+    not retry-tool -n 1 --invert true
+
     # If the command doesn't exist it is not re-tried multiple times.
     ( not retry-tool this-command-does-not-exist ) 2>&1 \
         | grep -F 'retry: cannot execute command this-command-does-not-exist: [Errno 2] No such file or directory'
+
     # On failure it tells us about it, showing progress.
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false failed with code 1"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: next attempt in 0.1 second(s) (attempt 1 of 2)"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false keeps failing after 2 attempts"
+
     # Though all output is removed with the --quiet switch.
     test "$(retry-tool -n 2 --wait 0.1 --quiet false 2>&1 | wc -l)" -eq 0

--- a/tests/main/retry-tool/task.yaml
+++ b/tests/main/retry-tool/task.yaml
@@ -14,7 +14,7 @@ execute: |
         | grep -F 'retry: cannot execute command this-command-does-not-exist: [Errno 2] No such file or directory'
 
     # On failure it tells us about it, showing progress.
-    retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false failed with code 1"
+    retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false finished with code 1"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: next attempt in 0.1 second(s) (attempt 1 of 2)"
     retry-tool -n 2 --wait 0.1 false 2>&1 | grep -F "retry: command false keeps failing after 2 attempts"
 


### PR DESCRIPTION
This is util to retry until a command returns 0, and keeps the command
passed as parameter easier to understand.

This is an example where the command will be retried until it fails:
retry-tool -n 50 --wait 1 --invert systemctl restart systemd-journald
