### PR TITLE
interfaces/mount: account for cgroup version when reporting supported features

### DIFF
--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
@@ -126,8 +127,7 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxFeatures returns the list of features supported by snapd for composing mount namespaces.
 func (b *Backend) SandboxFeatures() []string {
-	return []string{
-		"freezer-cgroup-v1",       /* Snapd creates a freezer cgroup (v1) for each snap */
+	commonFeatures := []string{
 		"layouts",                 /* Mount profiles take layout data into account */
 		"mount-namespace",         /* Snapd creates a mount namespace for each snap */
 		"per-snap-persistency",    /* Per-snap profiles are persisted across invocations */
@@ -136,4 +136,15 @@ func (b *Backend) SandboxFeatures() []string {
 		"per-snap-user-profiles",  /* Per-snap profiles allow changing mount namespace of a given snap for a given user */
 		"stale-base-invalidation", /* Mount namespaces that go stale because base snap changes are automatically invalidated */
 	}
+	cgroupv1Features := []string{
+		"freezer-cgroup-v1", /* Snapd creates a freezer cgroup (v1) for each snap */
+	}
+
+	if cgroup.IsUnified() {
+		// TODO: update we get feature parity on cgroup v2
+		return commonFeatures
+	}
+
+	features := append(commonFeatures, cgroupv1Features...)
+	return features
 }

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -220,8 +221,22 @@ func (s *backendSuite) TestParallelInstanceSetup(c *C) {
 }
 
 func (s *backendSuite) TestSandboxFeatures(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
 	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
+		"layouts",
+		"mount-namespace",
+		"per-snap-persistency",
+		"per-snap-profiles",
+		"per-snap-updates",
+		"per-snap-user-profiles",
+		"stale-base-invalidation",
 		"freezer-cgroup-v1",
+	})
+
+	restore = cgroup.MockVersion(cgroup.V2, nil)
+	defer restore()
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
 		"layouts",
 		"mount-namespace",
 		"per-snap-persistency",


### PR DESCRIPTION
Take into account the host's cgroup version when reporting mount backend
features.


