### PR TITLE
tests: change regex to validate access to cdn during snap download

### DIFF
--- a/tests/main/proxy-no-core/task.yaml
+++ b/tests/main/proxy-no-core/task.yaml
@@ -52,4 +52,4 @@ execute: |
 
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
-    check_journalctl_log 'CONNECT fastly.*.cdn.snapcraft.io' -u tinyproxy
+    check_journalctl_log 'CONNECT .*.cdn.snapcraft.io' -u tinyproxy


### PR DESCRIPTION
Store can't waranty the fastly cdn is going to be use 100% of the
downloads. This is why after a sync it was defined that the best option
is to check that the cdn is being used but not which one.

Currently we see sporadically that canonical-lgw01.cdn.snapcraft.io is
used instead of fastly making the proxy-no-core test fails.

Full log:
https://travis-ci.org/snapcore/snapd/jobs/593659116#L4396
