### PR TITLE
daemon: change /v2/download API to take "snap-name" as input

### DIFF
--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -37,8 +37,7 @@ var snapDownloadCmd = &Command{
 
 // SnapDownloadAction is used to request a snap download
 type snapDownloadAction struct {
-	Action string   `json:"action"`
-	Snaps  []string `json:"snaps,omitempty"`
+	SnapName string `json:"snap-name,omitempty"`
 }
 
 func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -51,25 +50,11 @@ func postSnapDownload(c *Command, r *http.Request, user *auth.UserState) Respons
 		return BadRequest("extra content found after download operation")
 	}
 
-	if len(action.Snaps) == 0 {
+	if action.SnapName == "" {
 		return BadRequest("download operation requires one snap name")
 	}
 
-	if len(action.Snaps) != 1 {
-		return BadRequest("download operation supports only one snap")
-	}
-
-	if action.Action == "" {
-		return BadRequest("download operation requires action")
-	}
-
-	switch action.Action {
-	case "download":
-		snapName := action.Snaps[0]
-		return streamOneSnap(c, user, snapName)
-	default:
-		return BadRequest("unknown download operation %q", action.Action)
-	}
+	return streamOneSnap(c, user, action.SnapName)
 }
 
 func streamOneSnap(c *Command, user *auth.UserState, snapName string) Response {

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -108,24 +108,9 @@ func (s *snapDownloadSuite) TestDownloadSnapErrors(c *check.C) {
 
 	for _, scen := range []scenario{
 		{
-			dataJSON: `{"action": "download"}`,
+			dataJSON: `{"snap-name": ""}`,
 			status:   400,
 			err:      "download operation requires one snap name",
-		},
-		{
-			dataJSON: `{"action": "foo", "snaps": ["foo"]}`,
-			status:   400,
-			err:      `unknown download operation "foo"`,
-		},
-		{
-			dataJSON: `{"snaps": ["foo"]}`,
-			status:   400,
-			err:      `download operation requires action`,
-		},
-		{
-			dataJSON: `{"action": "foo", "snaps": ["foo", "bar"]}`,
-			status:   400,
-			err:      `download operation supports only one snap`,
 		},
 		{
 			dataJSON: `{"}`,
@@ -159,17 +144,17 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 
 	for _, s := range []scenario{
 		{
-			dataJSON: `{"action": "download", "snaps": ["doom"]}`,
+			dataJSON: `{"snap-name": "doom"}`,
 			status:   404,
 			err:      "snap not found",
 		},
 		{
-			dataJSON: `{"action": "download", "snaps": ["download-error-trigger-snap"]}`,
+			dataJSON: `{"snap-name": "download-error-trigger-snap"}`,
 			status:   500,
 			err:      "unexpected error",
 		},
 		{
-			dataJSON: `{"action": "download", "snaps": ["bar"]}`,
+			dataJSON: `{"snap-name": "bar"}`,
 			status:   200,
 			err:      "",
 		},
@@ -179,9 +164,9 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 		rsp := daemon.SnapDownloadCmd.POST(daemon.SnapDownloadCmd, req, nil)
 
 		if s.err != "" {
-			c.Assert(rsp.(*daemon.Resp).Status, check.Equals, s.status)
+			c.Check(rsp.(*daemon.Resp).Status, check.Equals, s.status, check.Commentf("unexpected result for %v", s.dataJSON))
 			result := rsp.(*daemon.Resp).Result
-			c.Check(result.(*daemon.ErrorResult).Message, check.Matches, s.err)
+			c.Check(result.(*daemon.ErrorResult).Message, check.Matches, s.err, check.Commentf("unexpected result for %v", s.dataJSON))
 		} else {
 			c.Assert(rsp.(daemon.FileStream).SnapName, check.Equals, "bar")
 			c.Assert(rsp.(daemon.FileStream).Info.Size, check.Equals, int64(len(content)))


### PR DESCRIPTION
This changes the /v2/download API as discussed during the standup
and on irc to take a single "snap-name" and no action.

No backward compatiblity code is provided. This should be ok
because the interface was never advertised and we don't have any
matching client support yet.

Providing backward compatiblity is trivial and I am happy to
add it (requires a bit more testing code though).

