### PR TITLE
tests: update system-usernames test now that opensuse-15.1 works

### DIFF
--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -8,7 +8,7 @@ environment:
     # List of expected snap install failures due to libseccomp/golang-seccomp
     # being too old. This should only reduce with time since new systems should
     # have newer libseccomp and golang-seccomp
-    EXFAIL: "amazon-linux-2-64 centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 opensuse-15\\.1-64 ubuntu-14"
+    EXFAIL: "amazon-linux-2-64 centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 ubuntu-14"
 
 prepare: |
     echo "Install helper snaps with default confinement"


### PR DESCRIPTION
Apparently opensuse 15.1 now has an updated libseccomp so this
test needs updating.

This should fix master.