### PR TITLE
interfaces: bump system-key version (and keep on bumping)

### DIFF
--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -59,3 +59,7 @@ func MockReadBuildID(mock func(p string) (string, error)) (restore func()) {
 		readBuildID = old
 	}
 }
+
+type SystemKey = systemKey
+
+var SystemKeyVersion = systemKeyVersion

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -56,7 +56,7 @@ var (
 // Note that this key gets generated on *each* `snap run` - so it
 // *must* be cheap to calculate it (no hashes of big binaries etc).
 type systemKey struct {
-	// IMPORTANT: when adding new inputs bump this version
+	// IMPORTANT: when adding/removing/changing inputs bump this version (see below)
 	Version int `json:"version"`
 
 	// This is the build-id of the snapd that generated the profiles.
@@ -74,6 +74,9 @@ type systemKey struct {
 	SecCompActions         []string `json:"seccomp-features"`
 	SeccompCompilerVersion string   `json:"seccomp-compiler-version"`
 }
+
+// IMPORTANT: when adding/removing/changing inputs bump this
+const systemKeyVersion = 9
 
 var (
 	isHomeUsingNFS  = osutil.IsHomeUsingNFS
@@ -93,7 +96,7 @@ func generateSystemKey() (*systemKey, error) {
 	}
 
 	sk := &systemKey{
-		Version: 1,
+		Version: systemKeyVersion,
 	}
 	snapdPath, err := cmd.InternalToolPath("snapd")
 	if err != nil {


### PR DESCRIPTION
System key's type declaration had a comment rightfully stating

    // IMPORTANT: when adding new inputs bump this version

and this sage advice was then ignored by everything else.

This change:

* bumps the version to approximately the right number, as if it had
  been there from the start and bumped every time (this done by
  inspection of git log, so I might have missed something, or counted
  something twice).

* adds a static check that should catch us if we forget to bump it in
  the future.

* fixes an existing test that would fail every time we bumped the
  version :-)

HTH, HAND.
