### PR TITLE
interfaces: add cgroup-version to system-key

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -79,7 +79,7 @@ type systemKey struct {
 }
 
 // IMPORTANT: when adding/removing/changing inputs bump this
-const systemKeyVersion = 9
+const systemKeyVersion = 10
 
 var (
 	isHomeUsingNFS  = osutil.IsHomeUsingNFS

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/cmd"
@@ -33,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/sandbox/seccomp"
 )
 
@@ -73,6 +75,7 @@ type systemKey struct {
 	OverlayRoot            string   `json:"overlay-root"`
 	SecCompActions         []string `json:"seccomp-features"`
 	SeccompCompilerVersion string   `json:"seccomp-compiler-version"`
+	CgroupVersion          string   `json:"cgroup-version"`
 }
 
 var (
@@ -139,6 +142,13 @@ func generateSystemKey() (*systemKey, error) {
 		return nil, err
 	}
 	sk.SeccompCompilerVersion = string(versionInfo)
+
+	cgv, err := cgroup.Version()
+	if err != nil {
+		logger.Noticef("cannot determine cgroup version: %v", err)
+		return nil, err
+	}
+	sk.CgroupVersion = strconv.FormatInt(int64(cgv), 10)
 
 	return sk, nil
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -249,7 +249,12 @@ func (s *systemKeySuite) TestStaticVersion(c *C) {
 	//
 	// *** IF THIS FAILS, YOU NEED TO BUMP THE VERSION BEFORE "FIXING" THIS ***
 	var sk interfaces.SystemKey
+
+	// XXX: this checks needs to become smarter once we remove or change
+	// existing fields, in which case the version will gets a bump but the
+	// number of fields decreases or remains unchanged
 	c.Check(reflect.ValueOf(sk).NumField(), Equals, interfaces.SystemKeyVersion)
+
 	c.Check(fmt.Sprintf("%+v", sk), Equals, "{"+strings.Join([]string{
 		"Version:0",
 		"BuildID:",

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -260,5 +260,6 @@ func (s *systemKeySuite) TestStaticVersion(c *C) {
 		"OverlayRoot:",
 		"SecCompActions:[]",
 		"SeccompCompilerVersion:",
+		"CgroupVersion:",
 	}, " ")+"}")
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/sandbox/seccomp"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -87,6 +88,9 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 	})
 	defer restore()
 
+	restore = cgroup.MockVersion(1, nil)
+	defer restore()
+
 	err := interfaces.WriteSystemKey()
 	c.Assert(err, IsNil)
 
@@ -118,7 +122,7 @@ func (s *systemKeySuite) testInterfaceWriteSystemKey(c *C, nfsHome bool) {
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"apparmor-parser-mtime":%s,"apparmor-parser-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s,"seccomp-compiler-version":"%s"}`, s.buildID, apparmorFeaturesStr, apparmorParserMtime, apparmorParserFeaturesStr, nfsHome, overlayRoot, seccompActionsStr, seccompCompilerVersion))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"apparmor-parser-mtime":%s,"apparmor-parser-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s,"seccomp-compiler-version":"%s","cgroup-version":"1"}`, s.buildID, apparmorFeaturesStr, apparmorParserMtime, apparmorParserFeaturesStr, nfsHome, overlayRoot, seccompActionsStr, seccompCompilerVersion))
 }
 
 func (s *systemKeySuite) TestInterfaceWriteSystemKeyNoNFS(c *C) {


### PR DESCRIPTION
Since cgroup version may affect snapd functionality, make sure the currently
detected version is present in the system key.

NOTE: I did not bump the version of system key as suggested in the comment. A nicer handling of version is implemented in #7563. Once it lands I'll update this PR.
