### PR TITLE
snap-repair: add additional comment about trust in runner.Verify()

### DIFF
--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -984,6 +984,9 @@ func (run *Runner) Verify(repair *asserts.Repair, aux []asserts.Assertion) error
 		trustedBS.Put(asserts.AccountKeyType, t)
 	}
 	for _, t := range sysdb.Trusted() {
+		// we do *not* add the defalt sysdb trusted account
+		// keys here because the repair assertions have their
+		// own *dedicated* root of trust
 		if t.Type() == asserts.AccountType {
 			trustedBS.Put(asserts.AccountType, t)
 		}


### PR DESCRIPTION
Add extra comment about the fact that the repair chain of trust
is slightly different and that we deliberately do not add the
default sysdb trusted account keys to the repair tool.

