### PR TITLE
snap-repair: error if run as non-root

### DIFF
--- a/cmd/snap-repair/cmd_run_test.go
+++ b/cmd/snap-repair/cmd_run_test.go
@@ -39,6 +39,8 @@ func (r *repairSuite) TestNonRoot(c *C) {
 	restore = release.MockOnClassic(false)
 	defer restore()
 
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
 	os.Args = []string{"snap-repair", "run"}
 	err := repair.Run()
 	c.Assert(err, ErrorMatches, "must be run as root")

--- a/cmd/snap-repair/cmd_run_test.go
+++ b/cmd/snap-repair/cmd_run_test.go
@@ -33,8 +33,22 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+func (r *repairSuite) TestNonRoot(c *C) {
+	restore := repair.MockOsGetuid(func() int { return 1000 })
+	defer restore()
+	restore = release.MockOnClassic(false)
+	defer restore()
+
+	os.Args = []string{"snap-repair", "run"}
+	err := repair.Run()
+	c.Assert(err, ErrorMatches, "must be run as root")
+}
+
 func (r *repairSuite) TestRun(c *C) {
-	defer release.MockOnClassic(false)()
+	restore := repair.MockOsGetuid(func() int { return 0 })
+	defer restore()
+	restore = release.MockOnClassic(false)
+	defer restore()
 
 	r1 := sysdb.InjectTrusted(r.storeSigning.Trusted)
 	defer r1()

--- a/cmd/snap-repair/export_test.go
+++ b/cmd/snap-repair/export_test.go
@@ -139,3 +139,9 @@ func NewCmdShow(args ...string) *cmdShow {
 	cmdShow.Positional.Repair = args
 	return cmdShow
 }
+
+func MockOsGetuid(f func() int) (restore func()) {
+	origOsGetuid := osGetuid
+	osGetuid = f
+	return func() { osGetuid = origOsGetuid }
+}

--- a/cmd/snap-repair/main.go
+++ b/cmd/snap-repair/main.go
@@ -67,9 +67,14 @@ func main() {
 	}
 }
 
+var osGetuid = os.Getuid
+
 func run() error {
 	if release.OnClassic {
 		return errOnClassic
+	}
+	if osGetuid() != 0 {
+		return fmt.Errorf("must be run as root")
 	}
 	httputil.SetUserAgentFromVersion(cmd.Version, "snap-repair")
 


### PR DESCRIPTION
Running snap-repair as a non-root user is not erroring but the
outputs are really confusing, e.g.:
- snap-repair list will not have a summary
- snap-repair show will show for script and output:
    "error: open .../1/r0.script: permission denied"

So instead of confusing users this PR adds an early check if
snap-repair is really run as root.

