### PR TITLE
snap: when running `snap repair` without arguments, show hint

### DIFF
--- a/cmd/snap/cmd_repair_repairs.go
+++ b/cmd/snap/cmd_repair_repairs.go
@@ -70,7 +70,7 @@ func init() {
 
 func (x *cmdShowRepair) Execute(args []string) error {
 	if len(x.Positional.Repair) == 0 {
-		return fmt.Errorf("no `<repair-id>` given, did you mean 'snap repairs' to list all repairs?")
+		return fmt.Errorf("no <repair-id> given. Try 'snap repairs' to list all repairs or specify a specific repair id.")
 	}
 
 	return runSnapRepair("show", x.Positional.Repair)

--- a/cmd/snap/cmd_repair_repairs.go
+++ b/cmd/snap/cmd_repair_repairs.go
@@ -69,6 +69,10 @@ func init() {
 }
 
 func (x *cmdShowRepair) Execute(args []string) error {
+	if len(x.Positional.Repair) == 0 {
+		return fmt.Errorf("no `<repair-id>` given, did you mean 'snap repairs' to list all repairs?")
+	}
+
 	return runSnapRepair("show", x.Positional.Repair)
 }
 

--- a/cmd/snap/cmd_repair_repairs_test.go
+++ b/cmd/snap/cmd_repair_repairs_test.go
@@ -52,6 +52,14 @@ func (s *SnapSuite) TestSnapShowRepair(c *C) {
 	})
 }
 
+func (s *SnapSuite) TestSnapShowRepairNoArgs(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"repair"})
+	c.Assert(err, ErrorMatches, "no `<repair-id>` given, did you mean 'snap repairs' to list all repairs\\?")
+}
+
 func (s *SnapSuite) TestSnapListRepairs(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/cmd/snap/cmd_repair_repairs_test.go
+++ b/cmd/snap/cmd_repair_repairs_test.go
@@ -57,7 +57,7 @@ func (s *SnapSuite) TestSnapShowRepairNoArgs(c *C) {
 	defer restore()
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"repair"})
-	c.Assert(err, ErrorMatches, "no `<repair-id>` given, did you mean 'snap repairs' to list all repairs\\?")
+	c.Assert(err, ErrorMatches, "no <repair-id> given. Try 'snap repairs' to list all repairs or specify a specific repair id.")
 }
 
 func (s *SnapSuite) TestSnapListRepairs(c *C) {


### PR DESCRIPTION
When running `snap repair` without argument we show nothing right
now. This is not very useful. This PR changes the code so that
we show a hint like:
```
$ ./snap repair
error: no `<repair-id>` given, did you mean 'snap repairs' to list all repairs?
```
