### PR TITLE
sandbox/cgroup: refactor process cgroup helper to support v2 and named hierarchies

### DIFF
--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -139,10 +139,12 @@ var mockCgroup = []byte(`
 6:perf_event:/
 5:pids:/user.slice/user-1000.slice/user@1000.service
 4:cpu,cpuacct:/
-3:memory:/
+3:memory:/memory/group
 2:blkio:/
 1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
-0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
+0:foo:/illegal/unified/entry
+0::/systemd/unified
+11:name=snapd:/snap.foo.bar
 `)
 
 func (s *cgroupSuite) TestProgGroupHappy(c *C) {
@@ -151,20 +153,32 @@ func (s *cgroupSuite) TestProgGroupHappy(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroup, 0755)
 	c.Assert(err, IsNil)
 
-	group, err := cgroup.ProcGroup(333, "freezer")
+	group, err := cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "freezer"})
 	c.Assert(err, IsNil)
 	c.Check(group, Equals, "/snap.hello-world")
 
-	group, err = cgroup.ProcGroup(333, "name=systemd")
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "memory"})
+	c.Assert(err, IsNil)
+	c.Check(group, Equals, "/memory/group")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Name: "systemd"})
 	c.Assert(err, IsNil)
 	c.Check(group, Equals, "/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Name: "snapd"})
+	c.Assert(err, IsNil)
+	c.Check(group, Equals, "/snap.foo.bar")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Unified: true})
+	c.Assert(err, IsNil)
+	c.Check(group, Equals, "/systemd/unified")
 }
 
 func (s *cgroupSuite) TestProgGroupMissingFile(c *C) {
 	err := os.MkdirAll(filepath.Join(s.rootDir, "proc/333"), 0755)
 	c.Assert(err, IsNil)
 
-	group, err := cgroup.ProcGroup(333, "freezer")
+	group, err := cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "freezer"})
 	c.Assert(err, ErrorMatches, "open .*/proc/333/cgroup: no such file or directory")
 	c.Check(group, Equals, "")
 }
@@ -179,8 +193,16 @@ func (s *cgroupSuite) TestProgGroupMissingGroup(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), noFreezerCgroup, 0755)
 	c.Assert(err, IsNil)
 
-	group, err := cgroup.ProcGroup(333, "freezer")
-	c.Assert(err, ErrorMatches, `cannot find cgroup controller "freezer" path for pid 333`)
+	group, err := cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "freezer"})
+	c.Assert(err, ErrorMatches, `cannot find controller "freezer" cgroup path for pid 333`)
+	c.Check(group, Equals, "")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Unified: true})
+	c.Assert(err, ErrorMatches, `cannot find unified hierarchy cgroup path for pid 333`)
+	c.Check(group, Equals, "")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Name: "snapd"})
+	c.Assert(err, ErrorMatches, `cannot find named hierarchy "snapd" cgroup path for pid 333`)
 	c.Check(group, Equals, "")
 }
 
@@ -195,15 +217,29 @@ func (s *cgroupSuite) TestProgGroupConfusingCpu(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroupConfusingCpu, 0755)
 	c.Assert(err, IsNil)
 
-	group, err := cgroup.ProcGroup(333, "cpu")
+	group, err := cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "cpu"})
 	c.Assert(err, IsNil)
 	c.Check(group, Equals, "/foo.many-cpu")
 
-	group, err = cgroup.ProcGroup(333, "cpuacct")
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "cpuacct"})
 	c.Assert(err, IsNil)
 	c.Check(group, Equals, "/foo.cpuacct")
 
-	group, err = cgroup.ProcGroup(333, "cpuset")
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "cpuset"})
 	c.Assert(err, IsNil)
 	c.Check(group, Equals, "/foo.many-cpu")
+}
+
+func (s *cgroupSuite) TestProgGroupBadSelector(c *C) {
+	group, err := cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "cpu", Name: "foo"})
+	c.Assert(err, ErrorMatches, `invalid group selector: named hierarchy "foo" with a controller "cpu"`)
+	c.Check(group, Equals, "")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Unified: true, Name: "foo"})
+	c.Assert(err, ErrorMatches, `invalid group selector: named hierarchy "foo" with a unified one`)
+	c.Check(group, Equals, "")
+
+	group, err = cgroup.ProcGroup(333, cgroup.GroupSelector{Controller: "cpu", Name: "foo"})
+	c.Assert(err, ErrorMatches, `invalid group selector: named hierarchy "foo" with a controller "cpu"`)
+	c.Check(group, Equals, "")
 }

--- a/usersession/userd/export_test.go
+++ b/usersession/userd/export_test.go
@@ -37,7 +37,7 @@ func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() 
 	}
 }
 
-func MockProcGroup(f func(pid int, sel cgroup.GroupSelector) (string, error)) (restore func()) {
+func MockProcGroup(f func(pid int, match cgroup.GroupMatcher) (string, error)) (restore func()) {
 	old := cgroupProcGroup
 	cgroupProcGroup = f
 	return func() {

--- a/usersession/userd/export_test.go
+++ b/usersession/userd/export_test.go
@@ -21,6 +21,8 @@ package userd
 
 import (
 	"github.com/godbus/dbus"
+
+	"github.com/snapcore/snapd/sandbox/cgroup"
 )
 
 var (
@@ -35,7 +37,7 @@ func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() 
 	}
 }
 
-func MockProcGroup(f func(pid int, ctrl string) (string, error)) (restore func()) {
+func MockProcGroup(f func(pid int, sel cgroup.GroupSelector) (string, error)) (restore func()) {
 	old := cgroupProcGroup
 	cgroupProcGroup = f
 	return func() {

--- a/usersession/userd/helpers.go
+++ b/usersession/userd/helpers.go
@@ -78,7 +78,7 @@ func snapFromPid(pid int) (string, error) {
 		return "", fmt.Errorf("not supported")
 	}
 
-	group, err := cgroupProcGroup(pid, cgroup.GroupSelector{Controller: "freezer"})
+	group, err := cgroupProcGroup(pid, cgroup.MatchV1Controller("freezer"))
 	if err != nil {
 		return "", fmt.Errorf("cannot determine cgroup path of pid %v: %v", pid, err)
 	}

--- a/usersession/userd/helpers.go
+++ b/usersession/userd/helpers.go
@@ -78,7 +78,7 @@ func snapFromPid(pid int) (string, error) {
 		return "", fmt.Errorf("not supported")
 	}
 
-	group, err := cgroupProcGroup(pid, "freezer")
+	group, err := cgroupProcGroup(pid, cgroup.GroupSelector{Controller: "freezer"})
 	if err != nil {
 		return "", fmt.Errorf("cannot determine cgroup path of pid %v: %v", pid, err)
 	}

--- a/usersession/userd/helpers_test.go
+++ b/usersession/userd/helpers_test.go
@@ -33,9 +33,10 @@ type helpersSuite struct{}
 var _ = Suite(&helpersSuite{})
 
 func (s *helpersSuite) TestSnapFromPidHappy(c *C) {
-	restore := userd.MockProcGroup(func(pid int, sel cgroup.GroupSelector) (string, error) {
+	restore := userd.MockProcGroup(func(pid int, matcher cgroup.GroupMatcher) (string, error) {
 		c.Assert(pid, Equals, 333)
-		c.Assert(sel, DeepEquals, cgroup.GroupSelector{Controller: "freezer"})
+		c.Assert(matcher, NotNil)
+		c.Assert(matcher.String(), Equals, `controller "freezer"`)
 		return "/snap.hello-world", nil
 	})
 	defer restore()
@@ -45,9 +46,10 @@ func (s *helpersSuite) TestSnapFromPidHappy(c *C) {
 }
 
 func (s *helpersSuite) TestSnapFromPidUnhappy(c *C) {
-	restore := userd.MockProcGroup(func(pid int, sel cgroup.GroupSelector) (string, error) {
+	restore := userd.MockProcGroup(func(pid int, matcher cgroup.GroupMatcher) (string, error) {
 		c.Assert(pid, Equals, 333)
-		c.Assert(sel, DeepEquals, cgroup.GroupSelector{Controller: "freezer"})
+		c.Assert(matcher, NotNil)
+		c.Assert(matcher.String(), Equals, `controller "freezer"`)
 		return "", errors.New("nada")
 	})
 	defer restore()

--- a/usersession/userd/helpers_test.go
+++ b/usersession/userd/helpers_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/usersession/userd"
 )
 
@@ -32,9 +33,9 @@ type helpersSuite struct{}
 var _ = Suite(&helpersSuite{})
 
 func (s *helpersSuite) TestSnapFromPidHappy(c *C) {
-	restore := userd.MockProcGroup(func(pid int, controller string) (string, error) {
+	restore := userd.MockProcGroup(func(pid int, sel cgroup.GroupSelector) (string, error) {
 		c.Assert(pid, Equals, 333)
-		c.Assert(controller, Equals, "freezer")
+		c.Assert(sel, DeepEquals, cgroup.GroupSelector{Controller: "freezer"})
 		return "/snap.hello-world", nil
 	})
 	defer restore()
@@ -44,9 +45,9 @@ func (s *helpersSuite) TestSnapFromPidHappy(c *C) {
 }
 
 func (s *helpersSuite) TestSnapFromPidUnhappy(c *C) {
-	restore := userd.MockProcGroup(func(pid int, controller string) (string, error) {
+	restore := userd.MockProcGroup(func(pid int, sel cgroup.GroupSelector) (string, error) {
 		c.Assert(pid, Equals, 333)
-		c.Assert(controller, Equals, "freezer")
+		c.Assert(sel, DeepEquals, cgroup.GroupSelector{Controller: "freezer"})
 		return "", errors.New("nada")
 	})
 	defer restore()


### PR DESCRIPTION
Snapd will learn about named v1 and unified v2 cgroup hierarchies. Extend the process group helper allow finding a cgroup the process belongs to using more criteria.
