### PR TITLE
gadget: rename "boot{select,img}" -> system-boot-{select,image}

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -47,11 +47,17 @@ const (
 
 	SystemBoot = "system-boot"
 	SystemData = "system-data"
-	BootImage  = "bootimg"
-	BootSelect = "bootselect"
+
+	BootImage  = "system-boot-image"
+	BootSelect = "system-boot-select"
+
 	// ImplicitSystemDataLabel is the implicit filesystem label of structure
 	// of system-data role
 	ImplicitSystemDataLabel = "writable"
+
+	// only supported for legacy reasons
+	LegacyBootImage  = "bootimg"
+	LegacyBootSelect = "bootselect"
 )
 
 var (
@@ -595,6 +601,10 @@ func validateRole(vs *VolumeStructure, vol *Volume) error {
 		}
 	case SystemBoot, BootImage, BootSelect, "":
 		// noop
+	case LegacyBootImage, LegacyBootSelect:
+		// noop
+		// legacy role names were added in 2.42 can be removed
+		// on snapd epoch bump
 	default:
 		return fmt.Errorf("unsupported role")
 	}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -211,6 +211,42 @@ volumes:
     structure:
       - name: BOOTIMG1
         size: 25165824
+        role: system-boot-image
+        type: 27
+        content:
+          - image: boot.img
+      - name: BOOTIMG2
+        size: 25165824
+        role: system-boot-image
+        type: 27
+      - name: snapbootsel
+        size: 131072
+        role: system-boot-select
+        type: B2
+        content:
+          - image: snapbootsel.bin
+      - name: snapbootselbak
+        size: 131072
+        role: system-boot-select
+        type: B2
+        content:
+          - image: snapbootsel.bin
+      - name: writable
+        type: 83
+        filesystem: ext4
+        filesystem-label: writable
+        size: 500M
+        role: system-data
+`)
+
+var gadgetYamlLkLegacy = []byte(`
+volumes:
+  volumename:
+    schema: mbr
+    bootloader: lk
+    structure:
+      - name: BOOTIMG1
+        size: 25165824
         role: bootimg
         type: 27
         content:
@@ -648,6 +684,14 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlRPiHappy(c *C) {
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkHappy(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlLk, 0644)
+	c.Assert(err, IsNil)
+
+	_, err = gadget.ReadInfo(s.dir, false)
+	c.Assert(err, IsNil)
+}
+
+func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkLegacyHappy(c *C) {
+	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlLkLegacy, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, false)


### PR DESCRIPTION
We recently added new "boot{select,img}" roles. Unfortunately
they don't fit well into our existing naming schema for roles.

This PR switch to better names but keeps the old ones for
compatibility.

