### PR TITLE
[RFC] client: add support for the new "/v2/assertions/%s?remote=true"

### DIFF
--- a/client/asserts.go
+++ b/client/asserts.go
@@ -57,8 +57,23 @@ func (client *Client) AssertionTypes() ([]string, error) {
 	return types.Types, nil
 }
 
+// KnownOptions represent the options of the Known call.
+type KnownOptions struct {
+	// If Remote is true, the store is queried to find the assertion
+	Remote bool
+}
+
 // Known queries assertions with type assertTypeName and matching assertion headers.
 func (client *Client) Known(assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {
+	return client.KnownOpts(assertTypeName, headers, nil)
+}
+
+// KnownOpts queries assertions with type assertTypeName and matching assertion headers and the given options.
+func (client *Client) KnownOpts(assertTypeName string, headers map[string]string, opts *KnownOptions) ([]asserts.Assertion, error) {
+	if opts == nil {
+		opts = &KnownOptions{}
+	}
+
 	path := fmt.Sprintf("/v2/assertions/%s", assertTypeName)
 	q := url.Values{}
 
@@ -66,6 +81,9 @@ func (client *Client) Known(assertTypeName string, headers map[string]string) ([
 		for k, v := range headers {
 			q.Set(k, v)
 		}
+	}
+	if opts.Remote {
+		q.Set("remote", "true")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), doTimeout)

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -64,6 +65,13 @@ func (cs *clientSuite) TestClientAssertsCallsEndpoint(c *C) {
 	_, _ = cs.cli.Known("snap-revision", nil)
 	c.Check(cs.req.Method, Equals, "GET")
 	c.Check(cs.req.URL.Path, Equals, "/v2/assertions/snap-revision")
+}
+
+func (cs *clientSuite) TestClientAssertsOptsCallsEndpoint(c *C) {
+	_, _ = cs.cli.KnownOpts("snap-revision", nil, &client.KnownOptions{Remote: true})
+	c.Check(cs.req.Method, Equals, "GET")
+	c.Check(cs.req.URL.Path, Equals, "/v2/assertions/snap-revision")
+	c.Check(cs.req.URL.Query()["remote"], DeepEquals, []string{"true"})
 }
 
 func (cs *clientSuite) TestClientAssertsCallsEndpointWithFilter(c *C) {


### PR DESCRIPTION
The daemon can query remote assertions from the store now. This
PR adds support for this to the client package.

This is a bit of an RFC - ideally we would have "Known(.., opts KnownOptions)" but this would break the client api - I'm not sure we can/should do this. If we can I'm happy to update the PR. 

This is the alternative version with an API break: https://github.com/snapcore/snapd/pull/7574 