### PR TITLE
cmd/model: add authority-id to verbose fields

### DIFF
--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -54,14 +54,15 @@ model assertion.
 	errNoVerboseAssertion = errors.New(i18n.G("cannot use --verbose with --assertion"))
 
 	// this list is a "nice" "human" "readable" "ordering" of headers to print
-	// off, sorted in lexographical order with meta headers and primary key
-	// headers removed, and big nasty keys such as device-key-sha3-384 and
-	// device-key at the bottom
-	// it also contains both serial and model assertion headers, but we
-	// follow the same code path for both assertion types and some of the
-	// headers are shared between the two, so it still works out correctly
+	// off, sorted in lexographical order with primary key headers, some meta
+	// key headers removed, and big nasty keys such as device-key-sha3-384 and
+	// device-key at the end it also contains both serial and model assertion
+	// headers, but we follow the same code path for both assertion types and
+	// some of the headers are shared between the two, so it still works out
+	// correctly
 	niceOrdering = [...]string{
 		"architecture",
+		"authority-id",
 		"base",
 		"classic",
 		"display-name",

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -318,6 +318,7 @@ brand-id:        mememe
 model:           test-model
 serial:          serialserial
 architecture:    amd64
+authority-id:    mememe
 base:            core18
 gadget:          pc=18
 kernel:          pc-kernel=18
@@ -345,6 +346,7 @@ brand-id:        mememe
 model:           test-model
 serial:          serialserial
 architecture:    amd64
+authority-id:    mememe
 base:            core18
 display-name:    Model Name
 gadget:          pc=18
@@ -373,6 +375,7 @@ brand-id:        mememe
 model:           test-model
 serial:          -- (device not registered yet)
 architecture:    amd64
+authority-id:    mememe
 base:            core18
 gadget:          pc=18
 kernel:          pc-kernel=18
@@ -443,10 +446,11 @@ func (s *SnapSuite) TestSerialVerbose(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `
-brand-id:   my-brand
-model:      my-old-model
-serial:     serialserial
-timestamp:  2019-08-26T16:34:21-05:00
+brand-id:      my-brand
+model:         my-old-model
+serial:        serialserial
+authority-id:  my-brand
+timestamp:     2019-08-26T16:34:21-05:00
 device-key-sha3-384: |
   iqLo9doLzK8De9925UrdUyuvPbBad72OTWVE9YJXqd6nz9dKvwJ_lHP5bVxrl3VO
 device-key: |


### PR DESCRIPTION
The use case for this is our own tests specifically in https://github.com/snapcore/snapd/pull/7538 where we have this kind of thing:

https://github.com/snapcore/snapd/blob/b1b685b8255c952571ef82605d6f6cb71cbbfac5/tests/main/classic-custom-device-reg/task.yaml#L80

If we merge this, then that line can become:

```bash
snap model --verbose | MATCH "authority-id: developer1" 
```

I just didn't get a response back on my comment on @mvo5's PR, so I figured it was quicker to just open a PR and get a simple yes/no on whether we should add this. If we add this then we can use `snap model --verbose` everywhere in our tests and we don't need to use `snap model --assertion` at all.