### PR TITLE
spread.yaml,.gitignore: sync ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-share
 tags
 .coverage
 cmd/version_generated.go
 cmd/VERSION
 *~
 *.swp
+.*.swp
 vendor/*/
 .spread-reuse*.yaml
 po/snappy.pot
@@ -12,9 +12,6 @@ po/snappy.pot
 # snap-confine bits
 *.a
 *.o
-*~
-.*.swp
-.*.swp
 .dirstamp
 # Locally built binaries
 cmd/decode-mount-opts/decode-mount-opts
@@ -28,7 +25,6 @@ cmd/snap-gdb-shim/snap-gdb-shim
 cmd/snap-mgmt/snap-mgmt
 cmd/snap-seccomp/snap-seccomp
 cmd/snap-update-ns/snap-update-ns
-cmd/snap-update-ns/unit-tests
 cmd/snapd-env-generator/snapd-env-generator
 cmd/snapd-generator/snapd-generator
 cmd/system-shutdown/system-shutdown

--- a/spread.yaml
+++ b/spread.yaml
@@ -402,13 +402,80 @@ path: /home/gopath/src/github.com/snapcore/snapd
 
 exclude:
     - .git
-    - cmd/snap/snap
-    - cmd/snapd/snapd
-    - cmd/snapctl/snapctl
-    - cmd/snap-exec/snap-exec
-    - cmd/autom4te.cache
-    - "*.o"
+
+    - tags
+    - .coverage
+    - cmd/version_generated.go
+    - cmd/VERSION
+    - "*~"
+    - "*.swp"
+    - ".*.swp"
+    - "vendor/*/"
+    - ".spread-reuse*.yaml"
+    - po/snappy.pot
+
+    # snap-confine bits
     - "*.a"
+    - "*.o"
+    - .dirstamp
+    # Locally built binaries
+    - cmd/decode-mount-opts/decode-mount-opts
+    - cmd/libsnap-confine-private/unit-tests
+    - cmd/snap-confine/snap-confine
+    - cmd/snap-confine/snap-confine-debug
+    - cmd/snap-confine/snap-confine.apparmor
+    - cmd/snap-confine/unit-tests
+    - cmd/snap-discard-ns/snap-discard-ns
+    - cmd/snap-gdb-shim/snap-gdb-shim
+    - cmd/snap-mgmt/snap-mgmt
+    - cmd/snap-seccomp/snap-seccomp
+    - cmd/snap-update-ns/snap-update-ns
+    - cmd/snapd-env-generator/snapd-env-generator
+    - cmd/snapd-generator/snapd-generator
+    - cmd/system-shutdown/system-shutdown
+    - cmd/system-shutdown/unit-tests
+
+    # manual pages
+    - "cmd/*/*.[1-9]"
+
+    # auto-generated systemd units
+    - "data/systemd/*.service"
+
+    # auto-generated dbus services
+    - "data/dbus/*.service"
+
+    - data/info
+    - data/env/snapd.sh
+
+    # test-driver
+    - "*.log"
+    - "*.trs"
+
+    - # Automake for the cmd/ parts
+    - cmd/Makefile
+    - cmd/Makefile.in
+    - "snap-confine-*.tar.gz"
+    - .deps
+
+    # Autoconf
+    - cmd/aclocal.m4
+    - cmd/autom4te.cache
+    - cmd/compile
+    - cmd/config.guess
+    - cmd/config.h
+    - cmd/config.h.in
+    - cmd/config.status
+    - cmd/config.sub
+    - cmd/configure
+    - cmd/depcomp
+    - cmd/install-sh
+    - cmd/missing
+    - cmd/stamp-h1
+    - cmd/test-driver
+
+    # Mypy
+    - .mypy
+    - .mypy_cache
 
 
 debug-each: |


### PR DESCRIPTION
Having seen more build failures against debian-sid-64 I decided to
garden the ignore lists properly. This patch updates both ignore files
to have the same things.

Some duplicates were removed. Notably one entry was also removed,
"share" caused undesired side-effects when used in spread.yaml's
exclusion list. It removed the "share" directory used in some of the
test snaps. It seems of little value in daily coding, git logs indicate
it is from the age of "git-buildpackage".

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
