### PR TITLE
overlord: set fake serial in TestRemodelSwitchToDifferentKernel

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3565,8 +3565,9 @@ version: 1.0`
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "can0nical",
-		Model: "my-model",
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -3621,6 +3622,13 @@ version: 1.0`
 	// ensure that we only have the tasks we checked (plus the one
 	// extra "set-model" task)
 	c.Assert(tasks, HasLen, i+1)
+
+	// ensure we did not try device registration
+	for _, t := range st.Tasks() {
+		if t.Kind() == "request-serial" {
+			c.Fatalf("test should not create a request-serial task but did")
+		}
+	}
 }
 
 func (s *mgrsSuite) TestRemodelStoreSwitch(c *C) {


### PR DESCRIPTION
This prevents the code to try to request a real serial which is
incorrect.

I would like to add a moer generic test, I was thinking that it could something like:
```
diff --git a/overlord/managers_test.go b/overlord/managers_test.go
index ec8afa8aeb..606a61abd0 100644
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -315,6 +315,14 @@ func (s *mgrsSuite) SetUpTest(c *C) {
                        Required: true,
                },
        })
+
+       mockDevicesServices := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+               c.Fatalf("device-service should not be hit: %v", r)
+       }))
+       defer mockDevicesServices.Close()
+       // this does not exist yet
+       devicestate.MockDevicesServiceURL(mockDevicesService.URL)
```
but AFAICT there is no global replace of the device service yet, it can be done per-gadget though.