### PR TITLE
sandbox/cgroup, overlord/snapstate: move helper for listing pids in group to the cgroup package

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -207,3 +207,11 @@ var (
 )
 
 type AuxStoreInfo = auxStoreInfo
+
+func MockPidsCgroupDir(dir string) (restore func()) {
+	old := pidsCgroupDir
+	pidsCgroupDir = dir
+	return func() {
+		pidsCgroupDir = old
+	}
+}

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -960,9 +960,12 @@ func (s *linkSnapSuite) TestDoUnlinkSnapRefreshHardCheckOff(c *C) {
 func (s *linkSnapSuite) testDoUnlinkSnapRefreshAwareness(c *C) *state.Change {
 	restore := release.MockOnClassic(true)
 	defer restore()
+	mockPidsCgroupDir := c.MkDir()
+	restore = snapstate.MockPidsCgroupDir(mockPidsCgroupDir)
+	defer restore()
 
 	// mock that "some-snap" has an app and that this app has pids running
-	writePids(c, filepath.Join(dirs.PidsCgroupDir, "snap.some-snap.some-app"), []int{1234})
+	writePids(c, filepath.Join(mockPidsCgroupDir, "snap.some-snap.some-app"), []int{1234})
 	snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
 		info := &snap.Info{SuggestedName: name, SideInfo: *si, SnapType: snap.TypeApp}
 		info.Apps = map[string]*snap.AppInfo{

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -920,8 +920,12 @@ func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 		}
 		return info, nil
 	})
+	mockPidsCgroupDir := c.MkDir()
+	restore := snapstate.MockPidsCgroupDir(mockPidsCgroupDir)
+	defer restore()
+
 	// And with cgroup v1 information indicating the app has a process with pid 1234.
-	writePids(c, filepath.Join(dirs.PidsCgroupDir, "snap.some-snap.app"), []int{1234})
+	writePids(c, filepath.Join(mockPidsCgroupDir, "snap.some-snap.app"), []int{1234})
 
 	// Attempt to install revision 2 of the snap.
 	snapsup := &snapstate.SnapSetup{

--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -22,8 +22,10 @@ package cgroup
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -144,6 +146,49 @@ func ProcGroup(pid int, controller string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cannot find cgroup controller %q path for pid %v", controller, pid)
+}
+
+// PidsInGroup returns the list of process ID currently registered in a given cgroup
+func PidsInGroup(hierarchyMount, groupPath string) ([]int, error) {
+	// TODO: check whether hierarchyMount looks like a valid cgroup root
+	// (i.e. at cgroup.procs exists)
+	fname := filepath.Join(hierarchyMount, groupPath, "cgroup.procs")
+	file, err := os.Open(fname)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return parsePids(bufio.NewReader(file))
+}
+
+// parsePid parses a string as a process identifier.
+func parsePid(text string) (int, error) {
+	pid, err := strconv.Atoi(text)
+	if err != nil || (err == nil && pid <= 0) {
+		return 0, fmt.Errorf("cannot parse pid %q", text)
+	}
+	return pid, err
+}
+
+// parsePids parses a list of pids, one per line, from a reader.
+func parsePids(reader io.Reader) ([]int, error) {
+	scanner := bufio.NewScanner(reader)
+	var pids []int
+	for scanner.Scan() {
+		s := scanner.Text()
+		pid, err := parsePid(s)
+		if err != nil {
+			return nil, err
+		}
+		pids = append(pids, pid)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return pids, nil
 }
 
 // MockVersion sets the reported version of cgroup support. For use in testing only

--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -207,3 +207,45 @@ func (s *cgroupSuite) TestProgGroupConfusingCpu(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(group, Equals, "/foo.many-cpu")
 }
+
+func (s *cgroupSuite) TestPidsHappy(c *C) {
+	err := os.MkdirAll(filepath.Join(s.rootDir, "group1/group2"), 0755)
+	c.Assert(err, IsNil)
+	g2Pids := []byte(`123
+234
+567
+`)
+	allPids := append(g2Pids, []byte(`999
+`)...)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "group1/cgroup.procs"), allPids, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "group1/group2/cgroup.procs"), g2Pids, 0755)
+	c.Assert(err, IsNil)
+
+	pids, err := cgroup.PidsInGroup(s.rootDir, "group1")
+	c.Assert(err, IsNil)
+	c.Assert(pids, DeepEquals, []int{123, 234, 567, 999})
+
+	pids, err = cgroup.PidsInGroup(s.rootDir, "group1/group2")
+	c.Assert(err, IsNil)
+	c.Assert(pids, DeepEquals, []int{123, 234, 567})
+
+	pids, err = cgroup.PidsInGroup(s.rootDir, "group.does.not.exist")
+	c.Assert(err, IsNil)
+	c.Assert(pids, IsNil)
+}
+
+func (s *cgroupSuite) TestPidsBadInput(c *C) {
+	err := os.MkdirAll(filepath.Join(s.rootDir, "group1"), 0755)
+	c.Assert(err, IsNil)
+	gPids := []byte(`123
+zebra
+567
+`)
+	err = ioutil.WriteFile(filepath.Join(s.rootDir, "group1/cgroup.procs"), gPids, 0755)
+	c.Assert(err, IsNil)
+
+	pids, err := cgroup.PidsInGroup(s.rootDir, "group1")
+	c.Assert(err, ErrorMatches, `cannot parse pid "zebra"`)
+	c.Assert(pids, IsNil)
+}


### PR DESCRIPTION
Part of cgroup cleanup. Move and update the helper for listing PIDs of a cgroup
from overlord/snapstate/snapstate to sandbox/cgroup.