### PR TITLE
interfaces/net-setup-{observe,control}: add Info D-Bus method accesses

### DIFF
--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -48,7 +48,7 @@ const networkSetupControlConnectedPlugAppArmor = `
 
 #include <abstractions/dbus-strict>
 
-# Allow use of NetPlan Apply API, used to apply network configuration
+# Allow use of Netplan Apply API, used to apply network configuration
 dbus (send)
     bus=system
     interface=io.netplan.Netplan

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -56,6 +56,14 @@ dbus (send)
 	member=Apply
 	peer=(label=unconfined),
 
+# Allow use of Netplan Info API, used to get information on available netplan
+# features and version
+dbus (send)
+	bus=system
+	interface=io.netplan.Netplan
+	path=/io/netplan/Netplan
+	member=Info
+	peer=(label=unconfined),
 `
 
 func init() {

--- a/interfaces/builtin/network_setup_observe.go
+++ b/interfaces/builtin/network_setup_observe.go
@@ -40,6 +40,18 @@ const networkSetupObserveConnectedPlugAppArmor = `
 /run/NetworkManager/conf.d/{,**} r,
 /run/udev/rules.d/ r,
 /run/udev/rules.d/[0-9]*-netplan-* r,
+
+#include <abstractions/dbus-strict>
+
+# Allow use of Netplan Info API, used to get information on available netplan
+# features and version
+dbus (send)
+    bus=system
+    interface=io.netplan.Netplan
+    path=/io/netplan/Netplan
+	member=Info
+	peer=(label=unconfined),
+
 `
 
 func init() {

--- a/tests/main/netplan-apply/fake-netplan-service.py
+++ b/tests/main/netplan-apply/fake-netplan-service.py
@@ -23,6 +23,15 @@ class NetplanApplyService(dbus.service.Object):
             fp.write("Apply called\n")
         return True
 
+    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
+                         out_signature="a(sv)")
+    def Info(self):
+        # log that we were called and always return a dbus struct (i.e. python
+        # tuple) with Features in it
+        with open(self._logfile, "a+") as fp:
+            fp.write("Info called\n")
+        return [("Features", ["dhcp-use-domains", "ipv6-mtu"])]
+
 
 def main(argv):
     logfile = argv[1]

--- a/tests/main/netplan-apply/netplan-info.sh
+++ b/tests/main/netplan-apply/netplan-info.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+busctl call --system io.netplan.Netplan /io/netplan/Netplan io.netplan.Netplan Info

--- a/tests/main/netplan-apply/netplan-info.sh
+++ b/tests/main/netplan-apply/netplan-info.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-busctl call --system io.netplan.Netplan /io/netplan/Netplan io.netplan.Netplan Info
+exec busctl call --system io.netplan.Netplan /io/netplan/Netplan io.netplan.Netplan Info

--- a/tests/main/netplan-apply/snapcraft.yaml
+++ b/tests/main/netplan-apply/snapcraft.yaml
@@ -27,6 +27,7 @@ apps:
       - network
       - network-bind
       - network-setup-observe
+      - network-setup-control
 
 parts:
   info-script:

--- a/tests/main/netplan-apply/snapcraft.yaml
+++ b/tests/main/netplan-apply/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
       snapcraftctl pull
       last_committed_tag="$(git tag -l | grep -v v | sort -rV | head -n1)"
       last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/n//')"
-      last_released_tag="$(snap info ffmpeg | awk '$1 == "beta:" { print $2 }')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
       if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then

--- a/tests/main/netplan-apply/snapcraft.yaml
+++ b/tests/main/netplan-apply/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: test-snapd-netplan-apply
 base: core18
-version: git
+adopt-info: netplan
 summary: Backend-agnostic network configuration in YAML
 description: |
   Netplan is a utility for easily configuring networking on a linux system.
@@ -20,8 +20,19 @@ apps:
       - network
       - network-bind
       - network-setup-control
+  info:
+    command: netplan-info.sh
+    adapter: full
+    plugs:
+      - network
+      - network-bind
+      - network-setup-observe
 
 parts:
+  info-script:
+    plugin: dump
+    source: .
+    stage: [netplan-info.sh]
   netplan:
     source: https://github.com/CanonicalLtd/netplan.git
     plugin: make
@@ -48,3 +59,15 @@ parts:
       - python3-yaml
       - systemd
       - libatm1
+    override-pull: |
+      snapcraftctl pull
+      last_committed_tag="$(git tag -l | grep -v v | sort -rV | head -n1)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/n//')"
+      last_released_tag="$(snap info ffmpeg | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$last_committed_tag_ver"

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -92,7 +92,7 @@ execute: |
     echo "And the D-Bus service was activated"
     MATCH "Apply called" < dbus-netplan-apply.log
 
-    echo "clearing the log for the info test"
+    echo "clearing the log for the network-setup-observe info test"
     rm dbus-netplan-apply.log
     touch dbus-netplan-apply.log
 
@@ -119,3 +119,25 @@ execute: |
 
     echo "And the D-Bus service was activated"
     MATCH "Info called" < dbus-netplan-apply.log
+
+    echo "clearing the log for the network-setup-control info test"
+    rm dbus-netplan-apply.log
+    touch dbus-netplan-apply.log
+
+    echo "Running netplan info via D-Bus without network-setup-control fails"
+    if test-snapd-netplan-apply.info; then
+        echo "Expected access denied error for netplan info via D-Bus"
+        exit 1
+    fi
+
+    echo "The D-Bus service was not activated"
+    not MATCH "Info called" < dbus-netplan-apply.log
+
+    echo "When the interface is connected"
+    snap connect test-snapd-netplan-apply:network-setup-control
+
+    echo "Running netplan info via D-Bus now works"
+    if ! test-snapd-netplan-apply.info; then
+        echo "Unexpected error running netplan info via D-Bus"
+        exit 1
+    fi

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -96,6 +96,9 @@ execute: |
     rm dbus-netplan-apply.log
     touch dbus-netplan-apply.log
 
+    echo "Disconnecting network-setup-control to test network-setup-observe"
+    snap disconnect test-snapd-netplan-apply:network-setup-control
+
     echo "The network-setup-observe interface is disconnected by default"
     snap connections test-snapd-netplan-apply | MATCH 'network-setup-observe +test-snapd-netplan-apply:network-setup-observe +- +-'
 

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -6,12 +6,15 @@ details: |
 environment:
     NETPLAN: io.netplan.Netplan
 
-# run on all classic ubuntu LTS and current dev systems 16.04+
-systems: 
-    - ubuntu-16*
-    - ubuntu-18*
-    - ubuntu-19*
-    - ubuntu-20*
+# don't run on non-ubuntu systems where we won't have netplan
+systems:
+    - -debian-*
+    - -fedora-*
+    - -ubuntu-14*
+    - -opensuse-*
+    - -arch-*
+    - -amazon-*
+    - -centos-*
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
@@ -37,7 +40,7 @@ prepare: |
     cat << EOF > /usr/share/dbus-1/system-services/$NETPLAN.service
     [D-BUS Service]
     Name=$NETPLAN
-    Exec=$(pwd)/fake-netplan-apply-service.py $(pwd)/dbus-netplan-apply.log
+    Exec=$(pwd)/fake-netplan-service.py $(pwd)/dbus-netplan-apply.log
     User=root
     AssumedAppArmorLabel=unconfined
     EOF
@@ -47,8 +50,8 @@ prepare: |
 restore: |
     # kill the dbus service if it is running 
     set +e
-    if [ -n "$(pgrep --full fake-netplan-apply-service.py)" ]; then
-        for pid in $(pgrep --full fake-netplan-apply-service.py); do
+    if [ -n "$(pgrep --full fake-netplan-service.py)" ]; then
+        for pid in $(pgrep --full fake-netplan-service.py); do
             kill -9 "$pid"
         done
     fi
@@ -62,7 +65,7 @@ restore: |
     done
 
 execute: |
-    echo "The interface is disconnected by default"
+    echo "The network-setup-control interface is disconnected by default"
     snap connections test-snapd-netplan-apply | MATCH 'network-setup-control +test-snapd-netplan-apply:network-setup-control +- +-'
 
     echo "Running netplan apply without network-setup-control fails"
@@ -85,3 +88,31 @@ execute: |
 
     echo "And the D-Bus service was activated"
     MATCH "Apply called" < dbus-netplan-apply.log
+
+    echo "clearing the log for the info test"
+    rm dbus-netplan-apply.log
+    touch dbus-netplan-apply.log
+
+    echo "The network-setup-observe interface is disconnected by default"
+    snap connections test-snapd-netplan-apply | MATCH 'network-setup-observe +test-snapd-netplan-apply:network-setup-observe +- +-'
+
+    echo "Running netplan info via D-Bus without network-setup-observe fails"
+    if test-snapd-netplan-apply.info; then
+        echo "Expected access denied error for netplan info via D-Bus"
+        exit 1
+    fi
+
+    echo "The D-Bus service was not activated"
+    not MATCH "Info called" < dbus-netplan-apply.log
+
+    echo "When the interface is connected"
+    snap connect test-snapd-netplan-apply:network-setup-observe
+
+    echo "Running netplan info via D-Bus now works"
+    if ! test-snapd-netplan-apply.info; then
+        echo "Unexpected error running netplan info via D-Bus"
+        exit 1
+    fi
+
+    echo "And the D-Bus service was activated"
+    MATCH "Info called" < dbus-netplan-apply.log

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -124,6 +124,9 @@ execute: |
     rm dbus-netplan-apply.log
     touch dbus-netplan-apply.log
 
+    echo "Disconnecting network-setup-observe to test network-setup-control"
+    snap disconnect test-snapd-netplan-apply:network-setup-observe
+
     echo "Running netplan info via D-Bus without network-setup-control fails"
     if test-snapd-netplan-apply.info; then
         echo "Expected access denied error for netplan info via D-Bus"

--- a/tests/main/netplan-apply/task.yaml
+++ b/tests/main/netplan-apply/task.yaml
@@ -7,10 +7,13 @@ environment:
     NETPLAN: io.netplan.Netplan
 
 # don't run on non-ubuntu systems where we won't have netplan
+# and also don't run on ubuntu-core where we can't create the fake netplan D-Bus
+# service
 systems:
     - -debian-*
     - -fedora-*
     - -ubuntu-14*
+    - -ubuntu-core-*
     - -opensuse-*
     - -arch-*
     - -amazon-*


### PR DESCRIPTION
Also adjust the spread test for `netplan apply` working via D-Bus to also check that the D-Bus method for Info works too with network-setup-{observe,control} connected.

Also make the snapcraft.yaml file self contained (previously it needed to be built from the netplan git tree for `version: git` to work) and use some snapcrafters magic with override-pull to always build the most recent release and use that version.