### PR TITLE
spread.yaml: exclude vendor dir

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -409,7 +409,7 @@ exclude:
     - cmd/autom4te.cache
     - "*.o"
     - "*.a"
-
+    - ./vendor
 
 debug-each: |
     if [ "$SPREAD_DEBUG_EACH" = 1 ]; then


### PR DESCRIPTION
This specific dir was breaking local runs of spread with QEMU images of Ubuntu Core for me, because the mounted raw image that we flash to the QEMU device has limited space and couldn't fit all of the vendor dir in it.

There's more we could do with this by syncing .gitignore with the spread.yaml's exclude, but it seems that's a bit more complicated than it seems given #7576 

Feel free to close this if #7576 is fixed/updated properly first.