### PR TITLE
spread: include mounts list in task debug output

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -446,6 +446,9 @@ debug-each: |
         cat "$RUNTIME_STATE_PATH/runs" || true
         echo '# free space'
         df -h || true
+        echo '# mounts'
+        # use ascii output to prevent travis from messing up the encoding
+        findmnt --ascii -o+PROPAGATION || true
     fi
 
 rename:


### PR DESCRIPTION
When a task fails, it is sometimes useful to be able to inspect the mount table.
Include the relevant output in debug-each.
