### PR TITLE
usersession: drive by fixes for things flagged by unused or gosimple

### DIFF
--- a/usersession/agent/session_agent.go
+++ b/usersession/agent/session_agent.go
@@ -142,7 +142,7 @@ func (it *idleTracker) idleDuration() time.Duration {
 	if len(it.active) != 0 {
 		return 0
 	}
-	return time.Now().Sub(it.lastActive)
+	return time.Since(it.lastActive)
 }
 
 const (

--- a/usersession/agent/session_agent_test.go
+++ b/usersession/agent/session_agent_test.go
@@ -134,7 +134,7 @@ func (s *sessionAgentSuite) TestExitOnIdle(c *C) {
 	case <-time.After(2 * time.Second):
 		c.Fatal("agent did not exit after idle timeout expired")
 	}
-	elapsed := time.Now().Sub(startTime)
+	elapsed := time.Since(startTime)
 	if elapsed < 175*time.Millisecond || elapsed > 250*time.Millisecond {
 		// The idle timeout should have been extended when we
 		// issued a second request after 25ms.

--- a/usersession/userd/ui/kdialog_test.go
+++ b/usersession/userd/ui/kdialog_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/snapcore/snapd/usersession/userd/ui"
 )
 
-type kdialogSuite struct {
-	mock *testutil.MockCmd
-}
+type kdialogSuite struct{}
 
 var _ = Suite(&kdialogSuite{})
 

--- a/usersession/userd/ui/zenity_test.go
+++ b/usersession/userd/ui/zenity_test.go
@@ -32,9 +32,7 @@ import (
 
 func Test(t *testing.T) { TestingT(t) }
 
-type zenitySuite struct {
-	mock *testutil.MockCmd
-}
+type zenitySuite struct{}
 
 var _ = Suite(&zenitySuite{})
 

--- a/usersession/userd/userd.go
+++ b/usersession/userd/userd.go
@@ -100,10 +100,9 @@ func (ud *Userd) Start() {
 	ud.tomb.Go(func() error {
 		// Listen to keep our thread up and running. All DBus bits
 		// are running in the background
-		select {
-		case <-ud.tomb.Dying():
-			ud.conn.Close()
-		}
+		<-ud.tomb.Dying()
+		ud.conn.Close()
+
 		err := ud.tomb.Err()
 		if err != nil && err != tomb.ErrStillAlive {
 			return err


### PR DESCRIPTION
A couple of drive by fixes for things that golangci-lint flagged:

```
userd/ui/kdialog_test.go:32:2: field `mock` is unused (unused)  
        mock *testutil.MockCmd                                                         
        ^                                                                                                                                                                     
userd/ui/zenity_test.go:36:2: field `mock` is unused (unused)
        mock *testutil.MockCmd                                                         
        ^                                                                                                                                                                     
agent/session_agent.go:145:9: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)                                                           
        return time.Now().Sub(it.lastActive)                                
               ^                                                                                                                                                              
agent/session_agent_test.go:137:13: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)                                                                    
        elapsed := time.Now().Sub(startTime)                                           
                   ^                                                                   
userd/userd.go:103:3: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)                                                       
                select {                                                                                                                                                      
                ^         
```