### PR TITLE
spread.yaml: drop exclude list, use .gitignore

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -400,16 +400,8 @@ backends:
 
 path: /home/gopath/src/github.com/snapcore/snapd
 
-exclude:
-    - .git
-    - cmd/snap/snap
-    - cmd/snapd/snapd
-    - cmd/snapctl/snapctl
-    - cmd/snap-exec/snap-exec
-    - cmd/autom4te.cache
-    - "*.o"
-    - "*.a"
-    - ./vendor
+# See https://github.com/snapcore/spread/pull/89 for context.
+include: [.]
 
 debug-each: |
     if [ "$SPREAD_DEBUG_EACH" = 1 ]; then


### PR DESCRIPTION
Having seen more build failures against debian-sid-64 I decided to
garden the ignore list to work correctly.

I ended up digging much deeper than I expected for something that seemed
like a simple change.

This change relies on https://github.com/snapcore/spread/pull/89 --
without it one still needs to garden each exclude list and make sure
they contain the same intent, encoded differently.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
