### PR TITLE
interfaces/optical-drive: additional permission needed by mir-kiosk-kodi

### DIFF
--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -46,6 +46,7 @@ const opticalDriveConnectedPlugAppArmor = `
 # Allow read access to optical drives
 /dev/sr[0-9]* r,
 /dev/scd[0-9]* r,
+owner /var/lib/snapd/hostfs/media/*/DVDVolume/{,**} r,
 # allow all generic scsi devices here and use the device cgroup to
 # differentiate optical drives
 /dev/sg[0-9]* r,


### PR DESCRIPTION
In addition to the existing `optical-drive` permissions Kodi (and possibly other apps) needs read access to `/var/lib/snapd/hostfs/media/<user>/DVDVolume/` in order to play DVDs.