### PR TITLE
spread: generate delta when using google backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -34,7 +34,7 @@ environment:
     SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
     REMOTE_STORE: '$(HOST: echo "${SPREAD_REMOTE_STORE:-production}")'
     SNAPPY_USE_STAGING_STORE: '$(HOST: if [ "$SPREAD_REMOTE_STORE" = staging ]; then echo 1; else echo 0; fi)'
-    DELTA_REF: 2.39.1
+    DELTA_REF: 2.42
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PUBLISHED_VERSION: '$(HOST: echo "$SPREAD_SNAPD_PUBLISHED_VERSION")'
     HTTP_PROXY: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
@@ -461,7 +461,7 @@ repack: |
     # obtained directly from GitHub. There's nothing special about that reference,
     # other than it will often be in the local repository's history already.
     # The more recent the reference, the smaller the delta.
-    if ! echo "$SPREAD_BACKENDS" | grep linode; then
+    if ! echo "$SPREAD_BACKENDS" | grep -e linode -e google; then
         cat <&3 >&4
     elif ! git show-ref "$DELTA_REF" > /dev/null; then
         cat <&3 >&4


### PR DESCRIPTION
We never generated a delta when using google backend. This has an adverse effect
on the size of the source package being uploaded, and ends up being super
annoying on links with slow upload speed.

The patch enables delta generation for google (incl. google-unstable) and linode
backends.

In my testing, the size of the uploaded package went down from 5.5MB to 1.2MB.

While at it, the reference snapd revision is bumped to 2.42 tag.
