### PR TITLE
overlord/snapstate: skip catalog refresh if unseeded

### DIFF
--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -62,6 +62,17 @@ func (r *catalogRefresh) Ensure() error {
 		return nil
 	}
 
+	// if system is not seeded yet, it is first boot situation
+	// do not bother refreshing catalog, snap list is empty anyway
+	// beside there is high change device has no internet
+	var seeded bool
+	err := r.state.Get("seeded", &seeded)
+	if err == state.ErrNoState || !seeded {
+		logger.Debugf("CatalogRefresh:Ensure: skipping refresh, system is not seeded yet")
+		// not seeded yet
+		return nil
+	}
+
 	now := time.Now()
 	delay := catalogRefreshDelayBase
 	if r.nextCatalogRefresh.IsZero() {
@@ -88,7 +99,7 @@ func (r *catalogRefresh) Ensure() error {
 
 	logger.Debugf("Catalog refresh starting now; next scheduled for %s.", next)
 
-	err := refreshCatalogs(r.state, theStore)
+	err = refreshCatalogs(r.state, theStore)
 	switch err {
 	case nil:
 		logger.Debugf("Catalog refresh succeeded.")


### PR DESCRIPTION
when system is not seeded yet, catalog refresh has no meaning
- there are no snaps installed yet on the system
- we cannot assume device has internet so early at first boot

This can speed up first boot by 20 seconds if device has no network on first boot since we keep retrying on failure.