### PR TITLE
overlord/snapstate: add LastActiveDisabledServices, missingDisabledServices

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -215,3 +215,8 @@ func MockPidsCgroupDir(dir string) (restore func()) {
 		pidsCgroupDir = old
 	}
 }
+
+// link, misc handlers
+var (
+	MissingDisabledServices = missingDisabledServices
+)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1006,13 +1006,12 @@ func writeSeqFile(name string, snapst *SnapState) error {
 	return osutil.AtomicWriteFile(p, b, 0644, 0)
 }
 
-// ComputeMissingDisabledServices returns a list of services that were disabled
+// missingDisabledServices returns a list of services that were disabled
 // that are currently missing from the specific snap info (i.e. they were
 // renamed in this snap info), as well as a list of disabled services that are
 // present in this snap info
-// note that the union of the missing and found svc lists should be exactly
-// equal to st.LastActiveDisabledServices
-func ComputeMissingDisabledServices(st *SnapState, info *snap.Info) ([]string, []string, error) {
+// the first arg is the disabled services when the snap was last active
+func missingDisabledServices(svcs []string, info *snap.Info) ([]string, []string, error) {
 	// make a copy of all the previously disabled services that we will remove
 	// from, as well as an empty list to add to for the found services
 	missingSvcs := []string{}
@@ -1020,7 +1019,7 @@ func ComputeMissingDisabledServices(st *SnapState, info *snap.Info) ([]string, [
 
 	// for all the previously disabled services, check if they are in the
 	// current snap info revision as services or not
-	for _, disabledSvcName := range st.LastActiveDisabledServices {
+	for _, disabledSvcName := range svcs {
 		// check if the service is an app _and_ is a service
 		if app, ok := info.Apps[disabledSvcName]; ok && app.IsService() {
 			foundSvcs = append(foundSvcs, disabledSvcName)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1009,7 +1009,7 @@ func writeSeqFile(name string, snapst *SnapState) error {
 // missingDisabledServices returns a list of services that were disabled
 // that are currently missing from the specific snap info (i.e. they were
 // renamed in this snap info), as well as a list of disabled services that are
-// present in this snap info
+// present in this snap info.
 // the first arg is the disabled services when the snap was last active
 func missingDisabledServices(svcs []string, info *snap.Info) ([]string, []string, error) {
 	// make a copy of all the previously disabled services that we will remove

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1006,6 +1006,32 @@ func writeSeqFile(name string, snapst *SnapState) error {
 	return osutil.AtomicWriteFile(p, b, 0644, 0)
 }
 
+// ComputeMissingDisabledServices returns a list of services that were disabled
+// that are currently missing from the specific snap info (i.e. they were
+// renamed in this snap info), as well as a list of disabled services that are
+// present in this snap info
+// note that the union of the missing and found svc lists should be exactly
+// equal to st.LastActiveDisabledServices
+func ComputeMissingDisabledServices(st *SnapState, info *snap.Info) ([]string, []string, error) {
+	// make a copy of all the previously disabled services that we will remove
+	// from, as well as an empty list to add to for the found services
+	missingSvcs := []string{}
+	foundSvcs := []string{}
+
+	// for all the previously disabled services, check if they are in the
+	// current snap info revision as services or not
+	for _, disabledSvcName := range st.LastActiveDisabledServices {
+		// check if the service is an app _and_ is a service
+		if app, ok := info.Apps[disabledSvcName]; ok && app.IsService() {
+			foundSvcs = append(foundSvcs, disabledSvcName)
+		} else {
+			missingSvcs = append(missingSvcs, disabledSvcName)
+		}
+	}
+
+	return missingSvcs, foundSvcs, nil
+}
+
 func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	st := t.State()
 	st.Lock()

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -208,12 +208,9 @@ func (s *handlersSuite) TestComputeMissingDisabledServices(c *C) {
 			"some disabled services that are now apps",
 		},
 	} {
-		st := &snapstate.SnapState{
-			LastActiveDisabledServices: tt.stDisabledSvcsList,
-		}
 		info := &snap.Info{Apps: tt.apps}
 
-		missing, found, err := snapstate.ComputeMissingDisabledServices(st, info)
+		missing, found, err := snapstate.MissingDisabledServices(tt.stDisabledSvcsList, info)
 		c.Assert(missing, DeepEquals, tt.missing, Commentf(tt.comment))
 		c.Assert(found, DeepEquals, tt.found, Commentf(tt.comment))
 		c.Assert(err, Equals, tt.err, Commentf(tt.comment))

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -117,94 +117,96 @@ func (s *handlersSuite) TestSetTaskSnapSetupLaterTask(c *C) {
 
 func (s *handlersSuite) TestComputeMissingDisabledServices(c *C) {
 	for _, tt := range []struct {
+		// inputs
 		stDisabledSvcsList []string
-		missing            []string
-		found              []string
-		err                error
 		apps               map[string]*snap.AppInfo
-		comment            string
+		// outputs
+		missing []string
+		found   []string
+		err     error
+		comment string
 	}{
 		// no apps
 		{
 			[]string{},
-			[]string{},
-			[]string{},
 			nil,
+			[]string{},
+			[]string{},
 			nil,
 			"no apps",
 		},
 		// only apps, no services
 		{
 			[]string{},
-			[]string{},
-			[]string{},
-			nil,
 			map[string]*snap.AppInfo{
 				"app": {
 					Daemon: "",
 				},
 			},
+			[]string{},
+			[]string{},
+			nil,
 			"no services",
 		},
 		// services in snap, but not disabled
 		{
 			[]string{},
-			[]string{},
-			[]string{},
-			nil,
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon: "simple",
 				},
 			},
+			[]string{},
+			[]string{},
+			nil,
 			"no disabled services",
 		},
 		// all disabled services, but not present in snap
 		{
 			[]string{"svc1"},
+			nil,
 			[]string{"svc1"},
 			[]string{},
-			nil,
 			nil,
 			"all missing disabled services",
 		},
 		// all disabled services, and found in snap
 		{
 			[]string{"svc1"},
-			[]string{},
-			[]string{"svc1"},
-			nil,
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon: "simple",
 				},
 			},
+			[]string{},
+			[]string{"svc1"},
+			nil,
 			"all found disabled services",
 		},
 		// some disabled services, some missing, some present in snap
 		{
 			[]string{"svc1", "svc2"},
-			[]string{"svc2"},
-			[]string{"svc1"},
-			nil,
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon: "simple",
 				},
 			},
+			[]string{"svc2"},
+			[]string{"svc1"},
+			nil,
 			"some missing, some found disabled services",
 		},
 		// some disabled services, but app is not service
 		{
 			[]string{"svc1"},
-			[]string{"svc1"},
-			[]string{},
-			nil,
 			map[string]*snap.AppInfo{
 				"svc1": {
 					Daemon: "",
 				},
 			},
+			[]string{"svc1"},
+			[]string{},
+			nil,
 			"some disabled services that are now apps",
 		},
 	} {

--- a/overlord/snapstate/handlers_test.go
+++ b/overlord/snapstate/handlers_test.go
@@ -194,7 +194,7 @@ func (s *handlersSuite) TestComputeMissingDisabledServices(c *C) {
 			},
 			"some missing, some found disabled services",
 		},
-		// some disabled services, but is app not service
+		// some disabled services, but app is not service
 		{
 			[]string{"svc1"},
 			[]string{"svc1"},

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -133,14 +133,14 @@ type SnapState struct {
 
 	// LastActiveDisabledServices is a list of services that were disabled in
 	// this snap when it was last active - i.e. when it was disabled, before
-	// it was reverted, or before a refresh happens
+	// it was reverted, or before a refresh happens.
 	// It is set during unlink-snap and unlink-current-snap and reset during
 	// link-snap since it is only meant to be saved when snapd needs to remove
-	// systemd units
+	// systemd units.
 	// Note that to handle potential service renames, only services that exist
 	// in the snap are removed from this list on link-snap, so that we can
 	// remember services that were disabled in another revision and then renamed
-	// or otherwise removed from the snap in a future refresh
+	// or otherwise removed from the snap in a future refresh.
 	LastActiveDisabledServices []string `json:"last-active-disabled-services,omitempty"`
 
 	// Current indicates the current active revision if Active is

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -130,6 +130,19 @@ type SnapState struct {
 	SnapType string           `json:"type"` // Use Type and SetType
 	Sequence []*snap.SideInfo `json:"sequence"`
 	Active   bool             `json:"active,omitempty"`
+
+	// LastActiveDisabledServices is a list of services that were disabled in
+	// this snap when it was last active - i.e. when it was disabled, before
+	// it was reverted, or before a refresh happens
+	// It is set during unlink-snap and unlink-current-snap and reset during
+	// link-snap since it is only meant to be saved when snapd needs to remove
+	// systemd units
+	// Note that to handle potential service renames, only services that exist
+	// in the snap are removed from this list on link-snap, so that we can
+	// remember services that were disabled in another revision and then renamed
+	// or otherwise removed from the snap in a future refresh
+	LastActiveDisabledServices []string `json:"last-active-disabled-services,omitempty"`
+
 	// Current indicates the current active revision if Active is
 	// true or the last active revision if Active is false
 	// (usually while a snap is being operated on or disabled)


### PR DESCRIPTION
This is broken out from https://github.com/snapcore/snapd/pull/7431 and has 2 smallish changes that can be independently reviewed without a lot of other stuff from the big PR.

### Add LastActiveDisabledServices to SnapState. 
This field will be used for saving disabled services in the following situations:
* When we have _removed_ systemd units for a snap during a refresh, revert, or disable and thus systemd can no longer remember if the service was disabled or not.
* When we have refreshed, or reverted to a revision of the snap where a service that was previously present and disabled is no longer present in the snap and thus can't be disabled.

Note we need the second situation because if one disables a service, then refreshes to a revision where the service was renamed, and we revert back to the previous revision due to some problem, that previously disabled service will be erroneously enabled.

This is specifically _not_ a _current_ list of what services are enabled/disabled.

### Add missingDisabledServices to snapstate

This helper splits a list of disabled services (really the one saved in SnapState) into services which are present in the current snap Info (and thus should be disabled and deleted from state right now), and those which are missing from the current snap Info and should be saved in state for going to a different revision at some unknown point in the future.