### PR TITLE
test/lib/names.sh: make backslash escaping explicit

### DIFF
--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -4,7 +4,7 @@
 gadget_name=$(snap list | grep 'gadget$' | awk '{ print $1 }')
 kernel_name=$(snap list | grep 'kernel$' | awk '{ print $1 }')
 
-core_name="$(snap model --verbose | grep -Po "^base:\s+\K.*" || true)"
+core_name="$(snap model --verbose | grep -Po "^base:\\s+\\K.*" || true)"
 if [ -z "$core_name" ]; then
     core_name="core"
 fi


### PR DESCRIPTION
Shellcheck is complaining about this.

```
In tests/lib/names.sh line 7:
core_name="$(snap model --verbose | grep -Po "^base:\s+\K.*" || true)"
                                                    ^-- SC1117: Backslash is literal in "\s". Prefer explicit escaping: "\\s".
                                                       ^-- SC1117: Backslash is literal in "\K". Prefer explicit escaping: "\\K".
```