### PR TITLE
gadget: refactor ensureVolumeConsistency

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -447,7 +447,7 @@ func validateVolume(name string, vol *Volume, constraints *ModelConstraints) err
 	return validateCrossVolumeStructure(structures, knownStructures)
 }
 
-func ensureVolumeConsistencyNoConstraints(state *validationState, constraints *ModelConstraints) error {
+func ensureVolumeConsistencyNoConstraints(state *validationState) error {
 	switch {
 	case state.SystemSeed == nil && state.SystemData == nil:
 		return nil
@@ -498,7 +498,7 @@ func ensureVolumeConsistencyWithConstraints(state *validationState, constraints 
 
 func ensureVolumeConsistency(state *validationState, constraints *ModelConstraints) error {
 	if constraints == nil {
-		return ensureVolumeConsistencyNoConstraints(state, constraints)
+		return ensureVolumeConsistencyNoConstraints(state)
 	}
 	return ensureVolumeConsistencyWithConstraints(state, constraints)
 }

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -468,6 +468,9 @@ func ensureVolumeConsistencyNoConstraints(state *validationState, constraints *M
 func ensureVolumeConsistencyWithConstraints(state *validationState, constraints *ModelConstraints) error {
 	switch {
 	case state.SystemSeed == nil && state.SystemData == nil:
+		if constraints.SystemSeed {
+			return fmt.Errorf("model requires system-seed partition, but no system-seed or system-data partition found")
+		}
 		return nil
 	case state.SystemSeed != nil && state.SystemData == nil:
 		return fmt.Errorf("the system-seed role requires system-data to be defined")

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -447,40 +447,31 @@ func validateVolume(name string, vol *Volume, constraints *ModelConstraints) err
 	return validateCrossVolumeStructure(structures, knownStructures)
 }
 
-func ensureVolumeConsistency(state *validationState, constraints *ModelConstraints) error {
-	// system-seed also requires system-data
-	if state.SystemSeed != nil && state.SystemData == nil {
-		return fmt.Errorf("the system-seed role requires system-data to be defined")
-	}
-
-	if constraints == nil {
-		if state.SystemData == nil {
-			return nil
-		}
-
-		// gadget must be auto-consistent if constraints are not specified
-		if state.SystemSeed != nil {
-			if err := ensureSeedDataLabelsUnset(state); err != nil {
-				return err
-			}
-		} else {
-			if state.SystemData.Label != "" && state.SystemData.Label != ImplicitSystemDataLabel {
-				return fmt.Errorf("system-data structure must have an implicit label or %q, not %q",
-					ImplicitSystemDataLabel, state.SystemData.Label)
-			}
-		}
+func ensureVolumeConsistencyNoConstraints(state *validationState, constraints *ModelConstraints) error {
+	switch {
+	case state.SystemSeed == nil && state.SystemData == nil:
 		return nil
-	}
-
-	if state.SystemSeed != nil {
-		// error if we don't have the SystemSeed constraint but we have a system-seed structure
-		if !constraints.SystemSeed {
-			return fmt.Errorf("model does not support the system-seed role")
+	case state.SystemSeed != nil && state.SystemData == nil:
+		return fmt.Errorf("the system-seed role requires system-data to be defined")
+	case state.SystemSeed == nil && state.SystemData != nil:
+		if state.SystemData.Label != "" && state.SystemData.Label != ImplicitSystemDataLabel {
+			return fmt.Errorf("system-data structure must have an implicit label or %q, not %q", ImplicitSystemDataLabel, state.SystemData.Label)
 		}
+	case state.SystemSeed != nil && state.SystemData != nil:
 		if err := ensureSeedDataLabelsUnset(state); err != nil {
 			return err
 		}
-	} else {
+	}
+	return nil
+}
+
+func ensureVolumeConsistencyWithConstraints(state *validationState, constraints *ModelConstraints) error {
+	switch {
+	case state.SystemSeed == nil && state.SystemData == nil:
+		return nil
+	case state.SystemSeed != nil && state.SystemData == nil:
+		return fmt.Errorf("the system-seed role requires system-data to be defined")
+	case state.SystemSeed == nil && state.SystemData != nil:
 		// error if we have the SystemSeed constraint but no actual system-seed structure
 		if constraints.SystemSeed {
 			return fmt.Errorf("model requires system-seed structure, but none was found")
@@ -490,9 +481,23 @@ func ensureVolumeConsistency(state *validationState, constraints *ModelConstrain
 			return fmt.Errorf("system-data structure must have an implicit label or %q, not %q",
 				ImplicitSystemDataLabel, state.SystemData.Label)
 		}
+	case state.SystemSeed != nil && state.SystemData != nil:
+		// error if we don't have the SystemSeed constraint but we have a system-seed structure
+		if !constraints.SystemSeed {
+			return fmt.Errorf("model does not support the system-seed role")
+		}
+		if err := ensureSeedDataLabelsUnset(state); err != nil {
+			return err
+		}
 	}
-
 	return nil
+}
+
+func ensureVolumeConsistency(state *validationState, constraints *ModelConstraints) error {
+	if constraints == nil {
+		return ensureVolumeConsistencyNoConstraints(state, constraints)
+	}
+	return ensureVolumeConsistencyWithConstraints(state, constraints)
 }
 
 func ensureSeedDataLabelsUnset(state *validationState) error {


### PR DESCRIPTION
This PR refactors ensureVolumeConsistency and extracts it into
two helpers: ensureVolumeConsistency{With,No}Constraints that
each consists of truth table inspired switch/case:
```
case state.SystemSeed == nil && state.SystemData == nil:
   ...
case state.SystemSeed != nil && state.SystemData == nil:
   ...
case state.SystemSeed == nil && state.SystemData != nil:
   ...
case state.SystemSeed != nil && state.SystemData != nil:
   ...
```
and the checks happen in each of the case statements.

I find this easier to read because most of the context
is directly visible, i.e. no nested if/else that requires
to keep track of what the "else" means in the context of
the given lines. The downside is that its slightly more
verbose (but I think thats a good thing in this case).

It also helped me finding a missing test which I added,
but if people find the previous version easier to read
I'm happy to close this PR. Still worth adding the test I
think :)

Probably best viewed as a side-by-side diff. 
