### PR TITLE
sandbox/cgroup: move freeze/thaw code

### DIFF
--- a/cmd/snap-update-ns/common.go
+++ b/cmd/snap-update-ns/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/cmd/snaplock"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 )
 
 type CommonProfileUpdateContext struct {
@@ -78,7 +79,7 @@ func (upCtx *CommonProfileUpdateContext) Lock() (func(), error) {
 	// introduce a symlink that would cause us to mount something other
 	// than what we expected).
 	logger.Debugf("freezing processes of snap %q", instanceName)
-	if err := freezeSnapProcesses(instanceName); err != nil {
+	if err := cgroup.FreezeSnapProcesses(instanceName); err != nil {
 		// If we cannot freeze the processes we should drop the lock.
 		lock.Close()
 		return nil, err
@@ -88,7 +89,7 @@ func (upCtx *CommonProfileUpdateContext) Lock() (func(), error) {
 		logger.Debugf("unlocking mount namespace of snap %q", instanceName)
 		lock.Close()
 		logger.Debugf("thawing processes of snap %q", instanceName)
-		thawSnapProcesses(instanceName)
+		cgroup.ThawSnapProcesses(instanceName)
 	}
 	return unlock, nil
 }

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/cmd/snaplock"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -55,7 +56,7 @@ func (s *commonSuite) TestInstanceName(c *C) {
 func (s *commonSuite) TestLock(c *C) {
 	// Mock away real freezer code, allowing test code to return an error when freezing.
 	var freezingError error
-	restore := update.MockFreezing(func(string) error { return freezingError }, func(string) error { return nil })
+	restore := cgroup.MockFreezing(func(string) error { return freezingError }, func(string) error { return nil })
 	defer restore()
 	// Mock system directories, we use the lock directory.
 	dirs.SetRootDir(s.dir)

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"syscall"
 
-	. "gopkg.in/check.v1"
-
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
 )
@@ -33,10 +31,6 @@ var (
 	// change
 	ValidateInstanceName = validateInstanceName
 	ProcessArguments     = processArguments
-
-	// freezer
-	FreezeSnapProcesses = freezeSnapProcesses
-	ThawSnapProcesses   = thawSnapProcesses
 
 	// utils
 	PlanWritableMimic = planWritableMimic
@@ -146,31 +140,6 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysFstatfs = oldFstatfs
 		sysFchdir = oldSysFchdir
 		sysLstat = oldSysLstat
-	}
-}
-
-func MockFreezerCgroupDir(c *C) (restore func()) {
-	old := freezerCgroupDir
-	freezerCgroupDir = c.MkDir()
-	return func() {
-		freezerCgroupDir = old
-	}
-}
-
-func FreezerCgroupDir() string {
-	return freezerCgroupDir
-}
-
-func MockFreezing(freeze, thaw func(snapName string) error) (restore func()) {
-	oldFreeze := freezeSnapProcesses
-	oldThaw := thawSnapProcesses
-
-	freezeSnapProcesses = freeze
-	thawSnapProcesses = thaw
-
-	return func() {
-		freezeSnapProcesses = oldFreeze
-		thawSnapProcesses = oldThaw
 	}
 }
 

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -18,6 +18,10 @@
  */
 package cgroup
 
+import (
+	. "gopkg.in/check.v1"
+)
+
 var (
 	Cgroup2SuperMagic  = cgroup2SuperMagic
 	ProbeCgroupVersion = probeCgroupVersion
@@ -37,4 +41,16 @@ func MockFsRootPath(p string) (restore func()) {
 	return func() {
 		rootPath = old
 	}
+}
+
+func MockFreezerCgroupDir(c *C) (restore func()) {
+	old := freezerCgroupDir
+	freezerCgroupDir = c.MkDir()
+	return func() {
+		freezerCgroupDir = old
+	}
+}
+
+func FreezerCgroupDir() string {
+	return freezerCgroupDir
 }

--- a/sandbox/cgroup/freezer_test.go
+++ b/sandbox/cgroup/freezer_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main_test
+package cgroup_test
 
 import (
 	"fmt"
@@ -26,7 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -35,56 +35,56 @@ type freezerSuite struct{}
 var _ = Suite(&freezerSuite{})
 
 func (s *freezerSuite) TestFreezeSnapProcesses(c *C) {
-	restore := update.MockFreezerCgroupDir(c)
+	restore := cgroup.MockFreezerCgroupDir(c)
 	defer restore()
 
 	n := "foo"                                                               // snap name
-	p := filepath.Join(update.FreezerCgroupDir(), fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
+	p := filepath.Join(cgroup.FreezerCgroupDir(), fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
 	f := filepath.Join(p, "freezer.state")                                   // freezer.state file of the cgroup
 
 	// When the freezer cgroup filesystem doesn't exist we do nothing at all.
-	c.Assert(update.FreezeSnapProcesses(n), IsNil)
+	c.Assert(cgroup.FreezeSnapProcesses(n), IsNil)
 	_, err := os.Stat(f)
 	c.Assert(os.IsNotExist(err), Equals, true)
 
 	// When the freezer cgroup filesystem exists but the particular cgroup
 	// doesn't exist we don nothing at all.
-	c.Assert(os.MkdirAll(update.FreezerCgroupDir(), 0755), IsNil)
-	c.Assert(update.FreezeSnapProcesses(n), IsNil)
+	c.Assert(os.MkdirAll(cgroup.FreezerCgroupDir(), 0755), IsNil)
+	c.Assert(cgroup.FreezeSnapProcesses(n), IsNil)
 	_, err = os.Stat(f)
 	c.Assert(os.IsNotExist(err), Equals, true)
 
 	// When the cgroup exists we write FROZEN the freezer.state file.
 	c.Assert(os.MkdirAll(p, 0755), IsNil)
-	c.Assert(update.FreezeSnapProcesses(n), IsNil)
+	c.Assert(cgroup.FreezeSnapProcesses(n), IsNil)
 	_, err = os.Stat(f)
 	c.Assert(err, IsNil)
 	c.Assert(f, testutil.FileEquals, `FROZEN`)
 }
 
 func (s *freezerSuite) TestThawSnapProcesses(c *C) {
-	restore := update.MockFreezerCgroupDir(c)
+	restore := cgroup.MockFreezerCgroupDir(c)
 	defer restore()
 
 	n := "foo"                                                               // snap name
-	p := filepath.Join(update.FreezerCgroupDir(), fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
+	p := filepath.Join(cgroup.FreezerCgroupDir(), fmt.Sprintf("snap.%s", n)) // snap freezer cgroup
 	f := filepath.Join(p, "freezer.state")                                   // freezer.state file of the cgroup
 
 	// When the freezer cgroup filesystem doesn't exist we do nothing at all.
-	c.Assert(update.ThawSnapProcesses(n), IsNil)
+	c.Assert(cgroup.ThawSnapProcesses(n), IsNil)
 	_, err := os.Stat(f)
 	c.Assert(os.IsNotExist(err), Equals, true)
 
 	// When the freezer cgroup filesystem exists but the particular cgroup
 	// doesn't exist we don nothing at all.
-	c.Assert(os.MkdirAll(update.FreezerCgroupDir(), 0755), IsNil)
-	c.Assert(update.ThawSnapProcesses(n), IsNil)
+	c.Assert(os.MkdirAll(cgroup.FreezerCgroupDir(), 0755), IsNil)
+	c.Assert(cgroup.ThawSnapProcesses(n), IsNil)
 	_, err = os.Stat(f)
 	c.Assert(os.IsNotExist(err), Equals, true)
 
 	// When the cgroup exists we write THAWED the freezer.state file.
 	c.Assert(os.MkdirAll(p, 0755), IsNil)
-	c.Assert(update.ThawSnapProcesses(n), IsNil)
+	c.Assert(cgroup.ThawSnapProcesses(n), IsNil)
 	_, err = os.Stat(f)
 	c.Assert(err, IsNil)
 	c.Assert(f, testutil.FileEquals, `THAWED`)


### PR DESCRIPTION
The introduction of sandbox/cgroup package has allowed some unification
and cleanup of the cgroup code. The remaining element was the freezer
operation used by snap-update-ns.

This patch moves the freezer code to the sandbox/cgroup package.
Existing freeze/thaw functions became public, as did the mocking helper
to control freezing. Minimal documentation for the affected functions
was added as well.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
