### PR TITLE
many: address issues related to explicit/implicit channels for image building

### DIFF
--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -100,7 +100,7 @@ snaps:
     name: baz-linux
     id: bazlinuxidididididididididididid
     type: kernel
-    track: 20
+    default-channel: 20
   -
     name: brand-gadget
     id: brandgadgetdidididididididididid
@@ -151,30 +151,27 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	c.Check(model.DisplayName(), Equals, "Baz 3000")
 	c.Check(model.Architecture(), Equals, "amd64")
 	c.Check(model.GadgetSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:           "brand-gadget",
-		SnapType:       "gadget",
-		Modes:          []string{"run"},
-		DefaultChannel: "stable",
-		Presence:       "required",
+		Name:     "brand-gadget",
+		SnapType: "gadget",
+		Modes:    []string{"run"},
+		Presence: "required",
 	})
 	c.Check(model.Gadget(), Equals, "brand-gadget")
 	c.Check(model.GadgetTrack(), Equals, "")
 	c.Check(model.KernelSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:           "baz-linux",
-		SnapType:       "kernel",
-		Modes:          []string{"run"},
-		DefaultChannel: "stable",
-		Presence:       "required",
+		Name:     "baz-linux",
+		SnapType: "kernel",
+		Modes:    []string{"run"},
+		Presence: "required",
 	})
 	c.Check(model.Kernel(), Equals, "baz-linux")
 	c.Check(model.KernelTrack(), Equals, "")
 	c.Check(model.Base(), Equals, "core18")
 	c.Check(model.BaseSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:           "core18",
-		SnapType:       "base",
-		Modes:          []string{"run"},
-		DefaultChannel: "stable",
-		Presence:       "required",
+		Name:     "core18",
+		SnapType: "base",
+		Modes:    []string{"run"},
+		Presence: "required",
 	})
 	c.Check(model.Store(), Equals, "brand-store")
 	c.Check(model.Grade(), Equals, asserts.ModelGradeUnset)
@@ -184,16 +181,14 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 		model.BaseSnap(),
 		model.GadgetSnap(),
 		{
-			Name:           "foo",
-			Modes:          []string{"run"},
-			DefaultChannel: "stable",
-			Presence:       "required",
+			Name:     "foo",
+			Modes:    []string{"run"},
+			Presence: "required",
 		},
 		{
-			Name:           "bar",
-			Modes:          []string{"run"},
-			DefaultChannel: "stable",
-			Presence:       "required",
+			Name:     "bar",
+			Modes:    []string{"run"},
+			Presence: "required",
 		},
 	})
 	// essential snaps included
@@ -376,11 +371,11 @@ func (mods *modelSuite) TestDecodeKernelTrack(c *C) {
 	c.Assert(err, IsNil)
 	model := a.(*asserts.Model)
 	c.Check(model.KernelSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:     "baz-linux",
-		SnapType: "kernel",
-		Modes:    []string{"run"},
-		Track:    "18",
-		Presence: "required",
+		Name:        "baz-linux",
+		SnapType:    "kernel",
+		Modes:       []string{"run"},
+		PinnedTrack: "18",
+		Presence:    "required",
 	})
 	c.Check(model.Kernel(), Equals, "baz-linux")
 	c.Check(model.KernelTrack(), Equals, "18")
@@ -393,11 +388,11 @@ func (mods *modelSuite) TestDecodeGadgetTrack(c *C) {
 	c.Assert(err, IsNil)
 	model := a.(*asserts.Model)
 	c.Check(model.GadgetSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:     "brand-gadget",
-		SnapType: "gadget",
-		Modes:    []string{"run"},
-		Track:    "18",
-		Presence: "required",
+		Name:        "brand-gadget",
+		SnapType:    "gadget",
+		Modes:       []string{"run"},
+		PinnedTrack: "18",
+		Presence:    "required",
 	})
 	c.Check(model.Gadget(), Equals, "brand-gadget")
 	c.Check(model.GadgetTrack(), Equals, "18")
@@ -504,11 +499,10 @@ func (mods *modelSuite) TestClassicDecodeOK(c *C) {
 	c.Check(model.Classic(), Equals, true)
 	c.Check(model.Architecture(), Equals, "amd64")
 	c.Check(model.GadgetSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:           "brand-gadget",
-		SnapType:       "gadget",
-		Modes:          []string{"run"},
-		DefaultChannel: "stable",
-		Presence:       "required",
+		Name:     "brand-gadget",
+		SnapType: "gadget",
+		Modes:    []string{"run"},
+		Presence: "required",
 	})
 	c.Check(model.Gadget(), Equals, "brand-gadget")
 	c.Check(model.KernelSnap(), IsNil)
@@ -521,16 +515,14 @@ func (mods *modelSuite) TestClassicDecodeOK(c *C) {
 	c.Check(allSnaps, DeepEquals, []*asserts.ModelSnap{
 		model.GadgetSnap(),
 		{
-			Name:           "foo",
-			Modes:          []string{"run"},
-			DefaultChannel: "stable",
-			Presence:       "required",
+			Name:     "foo",
+			Modes:    []string{"run"},
+			Presence: "required",
 		},
 		{
-			Name:           "bar",
-			Modes:          []string{"run"},
-			DefaultChannel: "stable",
-			Presence:       "required",
+			Name:     "bar",
+			Modes:    []string{"run"},
+			Presence: "required",
 		},
 	})
 	// gadget included
@@ -597,27 +589,27 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 		SnapID:         "brandgadgetdidididididididididid",
 		SnapType:       "gadget",
 		Modes:          []string{"run", "ephemeral"},
-		DefaultChannel: "stable",
+		DefaultChannel: "latest/stable",
 		Presence:       "required",
 	})
 	c.Check(model.Gadget(), Equals, "brand-gadget")
 	c.Check(model.GadgetTrack(), Equals, "")
 	c.Check(model.KernelSnap(), DeepEquals, &asserts.ModelSnap{
-		Name:     "baz-linux",
-		SnapID:   "bazlinuxidididididididididididid",
-		SnapType: "kernel",
-		Modes:    []string{"run", "ephemeral"},
-		Track:    "20",
-		Presence: "required",
+		Name:           "baz-linux",
+		SnapID:         "bazlinuxidididididididididididid",
+		SnapType:       "kernel",
+		Modes:          []string{"run", "ephemeral"},
+		DefaultChannel: "20",
+		Presence:       "required",
 	})
 	c.Check(model.Kernel(), Equals, "baz-linux")
-	c.Check(model.KernelTrack(), Equals, "20")
+	c.Check(model.KernelTrack(), Equals, "")
 	c.Check(model.Base(), Equals, "core20")
 	c.Check(model.BaseSnap(), DeepEquals, &asserts.ModelSnap{
 		Name:           "core20",
 		SnapType:       "base",
 		Modes:          []string{"run", "ephemeral"},
-		DefaultChannel: "stable",
+		DefaultChannel: "latest/stable",
 		Presence:       "required",
 	})
 	c.Check(model.Store(), Equals, "brand-store")
@@ -632,7 +624,7 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 			SnapID:         "otherbasedididididididididididid",
 			SnapType:       "base",
 			Modes:          []string{"run"},
-			DefaultChannel: "stable",
+			DefaultChannel: "latest/stable",
 			Presence:       "required",
 		},
 		{
@@ -656,7 +648,7 @@ func (mods *modelSuite) TestCore20DecodeOK(c *C) {
 			SnapID:         "myappoptidididididididididididid",
 			SnapType:       "app",
 			Modes:          []string{"run"},
-			DefaultChannel: "stable",
+			DefaultChannel: "latest/stable",
 			Presence:       "optional",
 		},
 	})
@@ -678,7 +670,7 @@ func (mods *modelSuite) TestCore20ExplictBootBase(c *C) {
     name: core20
     id: core20ididididididididididididid
     type: base
-    default-channel: candidate
+    default-channel: latest/candidate
 `, 1)
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
@@ -689,7 +681,7 @@ func (mods *modelSuite) TestCore20ExplictBootBase(c *C) {
 		SnapID:         "core20ididididididididididididid",
 		SnapType:       "base",
 		Modes:          []string{"run", "ephemeral"},
-		DefaultChannel: "candidate",
+		DefaultChannel: "latest/candidate",
 		Presence:       "required",
 	})
 }
@@ -759,12 +751,9 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"type: gadget\n", "type:\n      - g\n", `"type" of snap "brand-gadget" must be a string`},
 		{"type: app\n", "type: thing\n", `"type" of snap "myappopt" must be one of must be one of app|base|gadget|kernel|core`},
 		{"modes:\n      - run\n", "modes: run\n", `"modes" of snap "other-base" must be a list of strings`},
-		{"track: 20\n", "track:\n      - x\n", `"track" of snap "baz-linux" must be a string`},
-		{"track: 20\n", "track: 20/edge\n", `invalid locked track for snap \"baz-linux\": 20/edge`},
-		{"track: 20\n", "track: 20////\n", `invalid locked track for snap \"baz-linux\": 20////`},
+		{"default-channel: 20\n", "default-channel: edge\n", `default channel for snap "baz-linux" must specify a track`},
 		{"default-channel: 2.0\n", "default-channel:\n      - x\n", `"default-channel" of snap "myapp" must be a string`},
 		{"default-channel: 2.0\n", "default-channel: 2.0/xyz/z\n", `invalid default channel for snap "myapp": invalid risk in channel name: 2.0/xyz/z`},
-		{"track: 20\n", "track: 20\n    default-channel: 20/foo\n", `snap "baz-linux" cannot specify both default channel and locked track`},
 		{"presence: optional\n", "presence:\n      - opt\n", `"presence" of snap "myappopt" must be a string`},
 		{"presence: optional\n", "presence: no\n", `"presence" of snap "myappopt" must be one of must be one of required|optional`},
 		{"OTHER", "  -\n    name: myapp\n    id: myappdididididididididididididid\n", `cannot list the same snap "myapp" multiple times`},

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -38,7 +38,7 @@ type cmdPrepareImage struct {
 		Rootdir          string
 	} `positional-args:"yes" required:"yes"`
 
-	Channel string `long:"channel" default:"stable"`
+	Channel string `long:"channel"`
 	// TODO: introduce SnapWithChannel?
 	Snaps      []string `long:"snap" value-name:"<snap>[=<channel>]"`
 	ExtraSnaps []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -47,7 +47,6 @@ func (s *SnapPrepareImageSuite) TestPrepareImageCore(c *C) {
 
 	c.Check(opts, DeepEquals, &image.Options{
 		ModelFile:       "model",
-		Channel:         "stable",
 		RootDir:         "root-dir/image",
 		GadgetUnpackDir: "root-dir/gadget",
 	})
@@ -69,7 +68,6 @@ func (s *SnapPrepareImageSuite) TestPrepareImageClassic(c *C) {
 	c.Check(opts, DeepEquals, &image.Options{
 		Classic:   true,
 		ModelFile: "model",
-		Channel:   "stable",
 		RootDir:   "root-dir",
 	})
 }
@@ -91,7 +89,6 @@ func (s *SnapPrepareImageSuite) TestPrepareImageClassicArch(c *C) {
 		Classic:      true,
 		Architecture: "i386",
 		ModelFile:    "model",
-		Channel:      "stable",
 		RootDir:      "root-dir",
 	})
 }
@@ -105,13 +102,13 @@ func (s *SnapPrepareImageSuite) TestPrepareImageExtraSnaps(c *C) {
 	r := snap.MockImagePrepare(prep)
 	defer r()
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "model", "root-dir", "--snap", "foo", "--snap", "bar=t/edge", "--snap", "local.snap", "--extra-snaps", "local2.snap", "--extra-snaps", "store-snap"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "model", "root-dir", "--channel", "candidate", "--snap", "foo", "--snap", "bar=t/edge", "--snap", "local.snap", "--extra-snaps", "local2.snap", "--extra-snaps", "store-snap"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 
 	c.Check(opts, DeepEquals, &image.Options{
 		ModelFile:       "model",
-		Channel:         "stable",
+		Channel:         "candidate",
 		RootDir:         "root-dir/image",
 		GadgetUnpackDir: "root-dir/gadget",
 		Snaps:           []string{"foo", "bar", "local.snap", "local2.snap", "store-snap"},

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1211,8 +1211,8 @@ func resolveChannel(st *state.State, snapName, newChannel string, deviceCtx Devi
 	// channel name is valid and consist of risk level or
 	// risk/branch only, do the right thing and default to risk (or
 	// risk/branch) within the pinned track
-	resChannel, err := channel.ResolveLocked(pinnedTrack, newChannel)
-	if err == channel.ErrLockedTrackSwitch {
+	resChannel, err := channel.ResolvePinned(pinnedTrack, newChannel)
+	if err == channel.ErrPinnedTrackSwitch {
 		// switching to a different track is not allowed
 		return "", fmt.Errorf("cannot switch from %s track %q as specified for the (device) model to %q", which, pinnedTrack, newChannel)
 

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -58,11 +58,10 @@ func (pol *policy16) checkSnapChannel(_ channel.Channel, whichSnap string) error
 func makeSystemSnap(snapName string) *asserts.ModelSnap {
 	// TODO: set SnapID too
 	return &asserts.ModelSnap{
-		Name:           snapName,
-		SnapType:       snapName, // same as snapName for core, snapd
-		Modes:          []string{"run"},
-		DefaultChannel: "stable",
-		Presence:       "required",
+		Name:     snapName,
+		SnapType: snapName, // same as snapName for core, snapd
+		Modes:    []string{"run"},
+		Presence: "required",
 	}
 }
 
@@ -76,6 +75,16 @@ func (pol *policy16) systemSnap() *asserts.ModelSnap {
 		snapName = "snapd"
 	}
 	return makeSystemSnap(snapName)
+}
+
+func (pol *policy16) modelSnapDefaultChannel() string {
+	// We will use latest or the current default track at image build time
+	return "stable"
+}
+
+func (pol *policy16) extraSnapDefaultChannel() string {
+	// We will use latest or the current default track at image build time
+	return "stable"
 }
 
 func (pol *policy16) checkBase(info *snap.Info, availableSnaps *naming.SnapSet) error {
@@ -147,7 +156,7 @@ func (pol *policy16) implicitSnaps(availableSnaps *naming.SnapSet) []*asserts.Mo
 
 func (pol *policy16) implicitExtraSnaps(availableSnaps *naming.SnapSet) []*OptionsSnap {
 	if len(pol.needsCore) != 0 && !availableSnaps.Contains(naming.Snap("core")) {
-		return []*OptionsSnap{{Name: "core", Channel: "stable"}}
+		return []*OptionsSnap{{Name: "core"}}
 	}
 	return nil
 }

--- a/snap/channel/channel.go
+++ b/snap/channel/channel.go
@@ -234,18 +234,18 @@ func Resolve(channel, newChannel string) (string, error) {
 	return newChannel, nil
 }
 
-var ErrLockedTrackSwitch = errors.New("cannot switch locked track")
+var ErrPinnedTrackSwitch = errors.New("cannot switch pinned track")
 
-// ResolveLocked resolves newChannel wrt a locked track, newChannel
+// ResolvePinned resolves newChannel wrt a pinned track, newChannel
 // can only be risk/branch-only or have the same track, otherwise
-// ErrLockedTrackSwitch is returned.
-func ResolveLocked(track, newChannel string) (string, error) {
+// ErrPinnedTrackSwitch is returned.
+func ResolvePinned(track, newChannel string) (string, error) {
 	if track == "" {
 		return newChannel, nil
 	}
 	ch, err := ParseVerbatim(track, "-")
 	if err != nil || !ch.VerbatimTrackOnly() {
-		return "", fmt.Errorf("invalid locked track: %s", track)
+		return "", fmt.Errorf("invalid pinned track: %s", track)
 	}
 	if newChannel == "" {
 		return track, nil
@@ -257,8 +257,8 @@ func ResolveLocked(track, newChannel string) (string, error) {
 		return trackPrefix + newChannel, nil
 	}
 	if newChannel != track && !strings.HasPrefix(newChannel, trackPrefix) {
-		// the track is locked/pinned
-		return "", ErrLockedTrackSwitch
+		// the track is pinned
+		return "", ErrPinnedTrackSwitch
 	}
 	return newChannel, nil
 }

--- a/snap/channel/channel_test.go
+++ b/snap/channel/channel_test.go
@@ -322,7 +322,7 @@ func (s *storeChannelSuite) TestResolve(c *C) {
 	}
 }
 
-func (s *storeChannelSuite) TestResolveLocked(c *C) {
+func (s *storeChannelSuite) TestResolvePinned(c *C) {
 	tests := []struct {
 		track  string
 		new    string
@@ -331,7 +331,7 @@ func (s *storeChannelSuite) TestResolveLocked(c *C) {
 	}{
 		{"", "", "", ""},
 		{"", "anytrack/stable", "anytrack/stable", ""},
-		{"track/foo", "", "", "invalid locked track: track/foo"},
+		{"track/foo", "", "", "invalid pinned track: track/foo"},
 		{"track", "", "track", ""},
 		{"track", "track", "track", ""},
 		{"track", "beta", "track/beta", ""},
@@ -339,11 +339,11 @@ func (s *storeChannelSuite) TestResolveLocked(c *C) {
 		{"track", "track/edge/branch", "track/edge/branch", ""},
 		{"track", "track/candidate", "track/candidate", ""},
 		{"track", "track/stable/branch", "track/stable/branch", ""},
-		{"track1", "track2/stable", "track2/stable", "cannot switch locked track"},
-		{"track1", "track2/stable/branch", "track2/stable/branch", "cannot switch locked track"},
+		{"track1", "track2/stable", "track2/stable", "cannot switch pinned track"},
+		{"track1", "track2/stable/branch", "track2/stable/branch", "cannot switch pinned track"},
 	}
 	for _, t := range tests {
-		r, err := channel.ResolveLocked(t.track, t.new)
+		r, err := channel.ResolvePinned(t.track, t.new)
 		tcomm := Commentf("%#v", t)
 		if t.expErr == "" {
 			c.Assert(err, IsNil, tcomm)


### PR DESCRIPTION
* no more track field in the Core 20 snaps stanza entries (Paris change)
* go back to the "pinned track" terminology now that is strictly for
  Core 18
* enforce pinned tracks when consuming Core 16/18 seeds (addresses XXX there)
* make it the seed policy responsibility to decide what to use
  as default channel if nothing is otherwise specified, for now
  keep Core 16/18 using the latest/or default track at image build
  time

* in cosiderartion of the latter point, do not pass anymore a fixed default channel 
  down from prepare-image


