### PR TITLE
tests: configure the journald service for core systems

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -446,18 +446,13 @@ prepare_project() {
     go get ./tests/lib/fakedevicesvc
     go get ./tests/lib/systemd-escape
 
-    # Disable journald rate limiting
-    mkdir -p /etc/systemd/journald.conf.d
-    # The RateLimitIntervalSec key is not supported on some systemd versions causing
-    # the journal rate limit could be considered as not valid and discarded in concecuence.
-    # RateLimitInterval key is supported in old systemd versions and in new ones as well,
-    # maintaining backward compatibility.
-    cat <<-EOF > /etc/systemd/journald.conf.d/no-rate-limit.conf
-    [Journal]
-    RateLimitInterval=0
-    RateLimitBurst=0
-EOF
-    systemctl restart systemd-journald.service
+    # On core systems, the journal service is configured once the final core system
+    # is created and booted what is done during the first test suite preparation
+    if is_classic_system; then
+        # shellcheck source=tests/lib/prepare.sh
+        . "$TESTSLIB"/prepare.sh
+        disable_journald_rate_limiting
+    fi
 }
 
 prepare_project_each() {


### PR DESCRIPTION
This change makes the same journal configuration for classic and core
systems.

Previously the configuration for the journald service was being done on
prepare_project function (prepare-restore.sh), but when the target
system is core, the prepare_project function is executed on
ubuntu-16.04-64 for core16 or ubuntu-18.04-64 for core18. It happens
because the target ubuntu-core system is created during the first test
suite preparation which happens after the prepare_project function
execution.

The idea is to configure the journald service after the ubuntu-core
system is booted.
