### PR TITLE
tests: launch the lxd images folowing the pattern ubuntu:${VERSION_ID}

### DIFF
--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -23,7 +23,10 @@ execute: |
         lxd.lxc config set core.proxy_https "$http_proxy"
     fi
 
-    lxd.lxc launch "images:ubuntu/18.04" my-ubuntu
+    # The snapd package we build as part of the tests will only run on the
+    # distro we build on. So we need to launch the right ubuntu version.
+    . /etc/os-release
+    lxd.lxc launch "ubuntu:${VERSION_ID}" my-ubuntu
 
     echo "Remove fuse to trigger the fuse sanity check"
     lxd.lxc exec my-ubuntu -- apt autoremove -y fuse

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -29,7 +29,10 @@ execute: |
         lxd.lxc config set core.proxy_https "$http_proxy"
     fi
 
-    lxd.lxc launch "images:ubuntu/18.04" my-ubuntu
+    # The snapd package we build as part of the tests will only run on the
+    # distro we build on. So we need to launch the right ubuntu version.
+    . /etc/os-release
+    lxd.lxc launch "ubuntu:${VERSION_ID}" my-ubuntu
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"


### PR DESCRIPTION
The images installed like images:ubuntu/18.04 are presenting dependency
problemes. Use the same pattern for all the tests to define the image to
use ubuntu:${VERSION_ID} getting VERSION_ID from /etc/os-release

This change fixes the dependencies issue trying to install snapd on the lxd instance.

The following packages have unmet dependencies:
 snapd : Depends: systemd but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
