### PR TITLE
cmd/snap-confine: remove leftover condition from capability world

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -386,29 +386,25 @@ int main(int argc, char **argv)
 		    " but should be. Refusing to continue to avoid"
 		    " permission escalation attacks");
 	}
-	// TODO: check for similar situation and linux capabilities.
-	if (geteuid() == 0) {
-		if (invocation.classic_confinement) {
-			enter_classic_execution_environment();
-		} else {
-			enter_non_classic_execution_environment(&invocation,
-								&apparmor,
-								real_uid,
-								real_gid,
-								saved_gid);
-		}
-		// The rest does not so temporarily drop privs back to calling
-		// user (we'll permanently drop after loading seccomp)
-		if (setegid(real_gid) != 0)
-			die("setegid failed");
-		if (seteuid(real_uid) != 0)
-			die("seteuid failed");
-
-		if (real_gid != 0 && geteuid() == 0)
-			die("dropping privs did not work");
-		if (real_uid != 0 && getegid() == 0)
-			die("dropping privs did not work");
+	if (invocation.classic_confinement) {
+		enter_classic_execution_environment();
+	} else {
+		enter_non_classic_execution_environment(&invocation,
+							&apparmor,
+							real_uid,
+							real_gid, saved_gid);
 	}
+	// Temporarily drop privs back to calling user (we'll permanently drop
+	// after loading seccomp).
+	if (setegid(real_gid) != 0)
+		die("setegid failed");
+	if (seteuid(real_uid) != 0)
+		die("seteuid failed");
+
+	if (real_gid != 0 && geteuid() == 0)
+		die("dropping privs did not work");
+	if (real_uid != 0 && getegid() == 0)
+		die("dropping privs did not work");
 	// Ensure that the user data path exists.
 	setup_user_data();
 #if 0


### PR DESCRIPTION
At some point in time we attempted to use capabilities and a non-root
snap-confine but this work was abandoned. Recently I removed most of
the remains of that but didn't notice this one: the code that prepares
classic and non-classic execution environment was conditional on
geteuid() == 0, even though a few lines above we check and die if that
same condition is not met.

As such, remove the condition and adjust indent the affected code.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
