### PR TITLE
overlord/many: switch order of check snap parameters

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -139,7 +139,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 	return true, nil
 }
 
-func checkGadgetOrKernel(st *state.State, _ snap.Container, snapInfo, curInfo *snap.Info, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
+func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
 	kind := ""
 	var snapType snap.Type
 	var getName func(*asserts.Model) string

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1838,7 +1838,7 @@ func (s *deviceMgrSuite) TestCheckGadget(c *C) {
 	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 
-	err := devicestate.CheckGadgetOrKernel(s.state, nil, gadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err := devicestate.CheckGadgetOrKernel(s.state, gadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install gadget "other-gadget", model assertion requests "gadget"`)
 
 	// brand gadget
@@ -1857,25 +1857,25 @@ func (s *deviceMgrSuite) TestCheckGadget(c *C) {
 	s.setupSnapDecl(c, otherGadgetInfo, "other-brand")
 
 	// install brand gadget ok
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, brandGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, brandGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// install canonical gadget ok
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, canonicalGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, canonicalGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// install other gadget fails
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install gadget "gadget" published by "other-brand" for model by "my-brand"`)
 
 	// unasserted installation of other works
 	otherGadgetInfo.SnapID = ""
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// parallel install fails
 	otherGadgetInfo.InstanceKey = "foo"
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install "gadget_foo", parallel installation of kernel or gadget snaps is not supported`)
 }
 
@@ -1895,7 +1895,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassic(c *C) {
 	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 
-	err := devicestate.CheckGadgetOrKernel(s.state, nil, gadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err := devicestate.CheckGadgetOrKernel(s.state, gadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install gadget "other-gadget", model assertion requests "gadget"`)
 
 	// brand gadget
@@ -1914,20 +1914,20 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassic(c *C) {
 	s.setupSnapDecl(c, otherGadgetInfo, "other-brand")
 
 	// install brand gadget ok
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, brandGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, brandGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// install canonical gadget ok
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, canonicalGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, canonicalGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// install other gadget fails
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install gadget "gadget" published by "other-brand" for model by "my-brand"`)
 
 	// unasserted installation of other works
 	otherGadgetInfo.SnapID = ""
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherGadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherGadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 }
 
@@ -1946,7 +1946,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassicGadgetNotSpecified(c *C) {
 	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 
-	err := devicestate.CheckGadgetOrKernel(s.state, nil, gadgetInfo, nil, snapstate.Flags{}, deviceCtx)
+	err := devicestate.CheckGadgetOrKernel(s.state, gadgetInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install gadget snap on classic if not requested by the model`)
 }
 
@@ -1957,7 +1957,7 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 
 	// not on classic
 	release.OnClassic = true
-	err := devicestate.CheckGadgetOrKernel(s.state, nil, kernelInfo, nil, snapstate.Flags{}, nil)
+	err := devicestate.CheckGadgetOrKernel(s.state, kernelInfo, nil, nil, snapstate.Flags{}, nil)
 	c.Check(err, ErrorMatches, `cannot install a kernel snap on classic`)
 	release.OnClassic = false
 
@@ -1970,7 +1970,7 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	})
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model}
 
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, kernelInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, kernelInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install kernel "lnrk", model assertion requests "krnl"`)
 
 	// brand kernel
@@ -1989,25 +1989,25 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	s.setupSnapDecl(c, otherKrnlInfo, "other-brand")
 
 	// install brand kernel ok
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, brandKrnlInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, brandKrnlInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// install canonical kernel ok
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, canonicalKrnlInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, canonicalKrnlInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// install other kernel fails
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherKrnlInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherKrnlInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install kernel "krnl" published by "other-brand" for model by "my-brand"`)
 
 	// unasserted installation of other works
 	otherKrnlInfo.SnapID = ""
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherKrnlInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherKrnlInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, IsNil)
 
 	// parallel install fails
 	otherKrnlInfo.InstanceKey = "foo"
-	err = devicestate.CheckGadgetOrKernel(s.state, nil, otherKrnlInfo, nil, snapstate.Flags{}, deviceCtx)
+	err = devicestate.CheckGadgetOrKernel(s.state, otherKrnlInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install "krnl_foo", parallel installation of kernel or gadget snaps is not supported`)
 }
 

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -485,7 +485,7 @@ func delayedCrossMgrInit() {
 	once.Do(func() {
 		// hook interface checks into snapstate installation logic
 
-		snapstate.AddCheckSnapCallback(func(st *state.State, _ snap.Container, snapInfo, _ *snap.Info, _ snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
+		snapstate.AddCheckSnapCallback(func(st *state.State, snapInfo, _ *snap.Info, _ snap.Container, _ snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
 			return CheckInterfaces(st, snapInfo, deviceCtx)
 		})
 

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -373,7 +373,7 @@ func checkSnap(st *state.State, snapFilePath, instanceName string, si *snap.Side
 	// allow registered checks to run first as they may produce more
 	// precise errors
 	for _, check := range checkSnapCallbacks {
-		err := check(st, c, s, curInfo, flags, deviceCtx)
+		err := check(st, s, curInfo, c, flags, deviceCtx)
 		if err != nil {
 			return err
 		}
@@ -387,7 +387,7 @@ func checkSnap(st *state.State, snapFilePath, instanceName string, si *snap.Side
 }
 
 // CheckSnapCallback defines callbacks for checking a snap for installation or refresh.
-type CheckSnapCallback func(st *state.State, snapf snap.Container, snap, curSnap *snap.Info, flags Flags, deviceCtx DeviceContext) error
+type CheckSnapCallback func(st *state.State, snap, curSnap *snap.Info, snapf snap.Container, flags Flags, deviceCtx DeviceContext) error
 
 var checkSnapCallbacks []CheckSnapCallback
 
@@ -404,7 +404,7 @@ func MockCheckSnapCallbacks(checks []CheckSnapCallback) (restore func()) {
 	}
 }
 
-func checkSnapdName(st *state.State, _ snap.Container, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
+func checkSnapdName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
 	if snapInfo.GetType() != snap.TypeSnapd {
 		// not a relevant check
 		return nil
@@ -416,7 +416,7 @@ func checkSnapdName(st *state.State, _ snap.Container, snapInfo, curInfo *snap.I
 	return nil
 }
 
-func checkCoreName(st *state.State, _ snap.Container, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
+func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
 	if snapInfo.GetType() != snap.TypeOS {
 		// not a relevant check
 		return nil
@@ -452,7 +452,7 @@ func checkCoreName(st *state.State, _ snap.Container, snapInfo, curInfo *snap.In
 	return nil
 }
 
-func checkGadgetOrKernel(st *state.State, _ snap.Container, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
+func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
 	typ := snapInfo.GetType()
 	kind := ""
 	var whichName func(*asserts.Model) string
@@ -513,7 +513,7 @@ func checkGadgetOrKernel(st *state.State, _ snap.Container, snapInfo, curInfo *s
 	return nil
 }
 
-func checkBases(st *state.State, _ snap.Container, snapInfo, curInfo *snap.Info, flags Flags, deviceCtx DeviceContext) error {
+func checkBases(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, flags Flags, deviceCtx DeviceContext) error {
 	// check if this is relevant
 	if snapInfo.GetType() != snap.TypeApp && snapInfo.GetType() != snap.TypeGadget {
 		return nil
@@ -546,7 +546,7 @@ func checkBases(st *state.State, _ snap.Container, snapInfo, curInfo *snap.Info,
 	return fmt.Errorf("cannot find required base %q", snapInfo.Base)
 }
 
-func checkEpochs(_ *state.State, _ snap.Container, snapInfo, curInfo *snap.Info, _ Flags, deviceCtx DeviceContext) error {
+func checkEpochs(_ *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, _ Flags, deviceCtx DeviceContext) error {
 	if curInfo == nil {
 		return nil
 	}
@@ -577,7 +577,7 @@ func earlyEpochCheck(info *snap.Info, snapst *SnapState) error {
 		return err
 	}
 
-	return checkEpochs(nil, nil, info, cur, Flags{}, nil)
+	return checkEpochs(nil, info, cur, nil, Flags{}, nil)
 }
 
 // check that the listed system users are valid

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -211,7 +211,7 @@ version: 1.0`
 	defer r1()
 
 	checkCbCalled := false
-	checkCb := func(st *state.State, sf snap.Container, s, cur *snap.Info, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
+	checkCb := func(st *state.State, s, cur *snap.Info, sf snap.Container, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
 		c.Assert(sf, NotNil)
 		data, err := sf.ReadFile("canary")
 		c.Assert(err, IsNil)
@@ -244,7 +244,7 @@ version: 1.0`
 	defer restore()
 
 	fail := errors.New("bad snap")
-	checkCb := func(st *state.State, _ snap.Container, s, cur *snap.Info, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
+	checkCb := func(st *state.State, s, cur *snap.Info, _ snap.Container, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
 		return fail
 	}
 	r2 := snapstate.MockCheckSnapCallbacks(nil)
@@ -817,7 +817,7 @@ version: 1.0`
 	defer r1()
 
 	checkCbCalled := false
-	checkCb := func(st *state.State, sf snap.Container, s, cur *snap.Info, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
+	checkCb := func(st *state.State, s, cur *snap.Info, sf snap.Container, flags snapstate.Flags, deviceCtx snapstate.DeviceContext) error {
 		c.Assert(sf, NotNil)
 		c.Assert(s.InstanceName(), Equals, "foo_instance")
 		c.Assert(s.SnapName(), Equals, "foo")


### PR DESCRIPTION
The snap container is an ancillary parameter, make it come after the most
important ones.

Followup on #7602 