### PR TITLE
gadget: add a public helper for parsing gadget metadata

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -288,10 +288,10 @@ func systemOrSnapID(s string) bool {
 	return true
 }
 
-// InfoFromMeta reads the provided gadget metadata. If constraints is nil, only the
+// InfoFromGadgetYaml reads the provided gadget metadata. If constraints is nil, only the
 // self-consistency checks are performed, otherwise rules for the classic or
 // system seed cases are enforced.
-func InfoFromMeta(gadgetYaml []byte, constraints *ModelConstraints) (*Info, error) {
+func InfoFromGadgetYaml(gadgetYaml []byte, constraints *ModelConstraints) (*Info, error) {
 	var gi Info
 
 	if err := yaml.Unmarshal(gadgetYaml, &gi); err != nil {
@@ -366,7 +366,7 @@ func ReadInfo(gadgetSnapRootDir string, constraints *ModelConstraints) (*Info, e
 		return nil, err
 	}
 
-	return InfoFromMeta(gmeta, constraints)
+	return InfoFromGadgetYaml(gmeta, constraints)
 }
 
 func fmtIndexAndName(idx int, name string) string {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1574,3 +1574,39 @@ volumes:
 		}
 	}
 }
+
+func (s *gadgetYamlTestSuite) TestGadgetReadInfoVsFromMeta(c *C) {
+	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
+	c.Assert(err, IsNil)
+
+	constraints := &gadget.ModelConstraints{
+		Classic: false,
+	}
+
+	giRead, err := gadget.ReadInfo(s.dir, constraints)
+	c.Check(err, IsNil)
+
+	giMeta, err := gadget.InfoFromMeta(gadgetYamlPC, constraints)
+	c.Check(err, IsNil)
+
+	c.Assert(giRead, DeepEquals, giMeta)
+}
+
+func (s *gadgetYamlTestSuite) TestGadgetFromMetaEmpty(c *C) {
+	classicConstraints := &gadget.ModelConstraints{
+		Classic: true,
+	}
+
+	// this is ok for classic
+	giClassic, err := gadget.InfoFromMeta([]byte(""), classicConstraints)
+	c.Check(err, IsNil)
+	c.Assert(giClassic, DeepEquals, &gadget.Info{})
+
+	coreConstraints := &gadget.ModelConstraints{
+		Classic: false,
+	}
+	// but not so much for core
+	giCore, err := gadget.InfoFromMeta([]byte(""), coreConstraints)
+	c.Check(err, ErrorMatches, "bootloader not declared in any volume")
+	c.Assert(giCore, IsNil)
+}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1586,7 +1586,7 @@ func (s *gadgetYamlTestSuite) TestGadgetReadInfoVsFromMeta(c *C) {
 	giRead, err := gadget.ReadInfo(s.dir, constraints)
 	c.Check(err, IsNil)
 
-	giMeta, err := gadget.InfoFromMeta(gadgetYamlPC, constraints)
+	giMeta, err := gadget.InfoFromGadgetYaml(gadgetYamlPC, constraints)
 	c.Check(err, IsNil)
 
 	c.Assert(giRead, DeepEquals, giMeta)
@@ -1598,7 +1598,7 @@ func (s *gadgetYamlTestSuite) TestGadgetFromMetaEmpty(c *C) {
 	}
 
 	// this is ok for classic
-	giClassic, err := gadget.InfoFromMeta([]byte(""), classicConstraints)
+	giClassic, err := gadget.InfoFromGadgetYaml([]byte(""), classicConstraints)
 	c.Check(err, IsNil)
 	c.Assert(giClassic, DeepEquals, &gadget.Info{})
 
@@ -1606,7 +1606,7 @@ func (s *gadgetYamlTestSuite) TestGadgetFromMetaEmpty(c *C) {
 		Classic: false,
 	}
 	// but not so much for core
-	giCore, err := gadget.InfoFromMeta([]byte(""), coreConstraints)
+	giCore, err := gadget.InfoFromGadgetYaml([]byte(""), coreConstraints)
 	c.Check(err, ErrorMatches, "bootloader not declared in any volume")
 	c.Assert(giCore, IsNil)
 }


### PR DESCRIPTION
Add an API for parsing the provided gadget YAML content rather than having it
read from a snap content directory. This enables use of gadget metadata when
gadget content cannot be directly accessed.
