### PR TITLE
policy: implement CanRemove policy for the snapd type

### DIFF
--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -346,8 +346,8 @@ func (s *canRemoveSuite) TestSnapdTypePolicy(c *check.C) {
 	defer restore()
 
 	// snapd cannot be removed on core
-	c.Check(policy.NewSnapdPolicy("core18").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrNotRemovable)
-	c.Check(policy.NewSnapdPolicy("").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrNotRemovable)
+	c.Check(policy.NewSnapdPolicy("core18").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrSnapdNotRemovableOnCore)
+	c.Check(policy.NewSnapdPolicy("").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrSnapdNotRemovableOnCore)
 
 	// but single revisions can be removed
 	c.Check(policy.NewSnapdPolicy("").CanRemove(s.st, snapst, snap.R(1)), check.IsNil)
@@ -366,5 +366,5 @@ func (s *canRemoveSuite) TestSnapdTypePolicy(c *check.C) {
 		Current:  snap.R(1),
 		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-snap"}},
 	})
-	c.Check(policy.NewSnapdPolicy("").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrNotRemovable)
+	c.Check(policy.NewSnapdPolicy("").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrSnapdNotYetRemovableOnClassic)
 }

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -364,7 +364,7 @@ func (s *canRemoveSuite) TestSnapdTypePolicy(c *check.C) {
 	// but it cannot be removed when there are more snaps installed
 	snapstate.Set(s.st, "other-snap", &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{&snap.SideInfo{Revision: snap.R(1), RealName: "other-snap"}},
+		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-snap"}},
 	})
 	c.Check(policy.NewSnapdPolicy("").CanRemove(s.st, snapst, snap.R(0)), check.Equals, policy.ErrNotRemovable)
 }

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -30,6 +30,7 @@ var (
 	errInUseForBoot = errors.New("snap is being used for boot")
 	errRequired     = errors.New("snap is required")
 	errIsModel      = errors.New("snap is used by the model")
+	errNotRemovable = errors.New("snap cannot be removed")
 )
 
 type inUseByErr []string

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -30,7 +30,9 @@ var (
 	errInUseForBoot = errors.New("snap is being used for boot")
 	errRequired     = errors.New("snap is required")
 	errIsModel      = errors.New("snap is used by the model")
-	errNotRemovable = errors.New("snap cannot be removed")
+
+	errSnapdNotRemovableOnCore       = errors.New("snapd required on core devices")
+	errSnapdNotYetRemovableOnClassic = errors.New("remove all other snaps first")
 )
 
 type inUseByErr []string

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -5,12 +5,14 @@ func NewBasePolicy(m string) *basePolicy     { return &basePolicy{modelBase: m} 
 func NewGadgetPolicy(m string) *gadgetPolicy { return &gadgetPolicy{modelGadget: m} }
 func NewKernelPolicy(m string) *kernelPolicy { return &kernelPolicy{modelKernel: m} }
 func NewOSPolicy(m string) *osPolicy         { return &osPolicy{modelBase: m} }
+func NewSnapdPolicy(m string) *snapdPolicy   { return &snapdPolicy{modelBase: m} }
 
 var (
 	ErrNoName       = errNoName
 	ErrInUseForBoot = errInUseForBoot
 	ErrRequired     = errRequired
 	ErrIsModel      = errIsModel
+	ErrNotRemovable = errNotRemovable
 )
 
 func InUseByErr(snaps ...string) error {

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -1,11 +1,11 @@
 package policy
 
-func NewAppPolicy() appPolicy                { return appPolicy{} }
-func NewBasePolicy(m string) *basePolicy     { return &basePolicy{modelBase: m} }
-func NewGadgetPolicy(m string) *gadgetPolicy { return &gadgetPolicy{modelGadget: m} }
-func NewKernelPolicy(m string) *kernelPolicy { return &kernelPolicy{modelKernel: m} }
-func NewOSPolicy(m string) *osPolicy         { return &osPolicy{modelBase: m} }
-func NewSnapdPolicy(m string) *snapdPolicy   { return &snapdPolicy{modelBase: m} }
+func NewAppPolicy() appPolicy                    { return appPolicy{} }
+func NewBasePolicy(m string) *basePolicy         { return &basePolicy{modelBase: m} }
+func NewGadgetPolicy(m string) *gadgetPolicy     { return &gadgetPolicy{modelGadget: m} }
+func NewKernelPolicy(m string) *kernelPolicy     { return &kernelPolicy{modelKernel: m} }
+func NewOSPolicy(m string) *osPolicy             { return &osPolicy{modelBase: m} }
+func NewSnapdPolicy(onClassic bool) *snapdPolicy { return &snapdPolicy{onClassic: onClassic} }
 
 var (
 	ErrNoName       = errNoName

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -12,7 +12,9 @@ var (
 	ErrInUseForBoot = errInUseForBoot
 	ErrRequired     = errRequired
 	ErrIsModel      = errIsModel
-	ErrNotRemovable = errNotRemovable
+
+	ErrSnapdNotRemovableOnCore       = errSnapdNotRemovableOnCore
+	ErrSnapdNotYetRemovableOnClassic = errSnapdNotYetRemovableOnClassic
 )
 
 func InUseByErr(snaps ...string) error {

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -42,7 +42,7 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 	case snap.TypeBase:
 		return &basePolicy{modelBase: model.Base()}
 	case snap.TypeSnapd:
-		return &snapdPolicy{modelBase: model.Base()}
+		return &snapdPolicy{onClassic: model.Classic()}
 	default:
 		return appPolicy{}
 	}

--- a/overlord/snapstate/policy/policy_test.go
+++ b/overlord/snapstate/policy/policy_test.go
@@ -25,6 +25,7 @@ func (s *policySuite) TestFor(c *check.C) {
 		snap.TypeGadget: policy.NewGadgetPolicy(""),
 		snap.TypeKernel: policy.NewKernelPolicy(""),
 		snap.TypeOS:     policy.NewOSPolicy(""),
+		snap.TypeSnapd:  policy.NewSnapdPolicy(""),
 	} {
 		c.Check(policy.For(typ, &asserts.Model{}), check.FitsTypeOf, pol)
 	}

--- a/overlord/snapstate/policy/policy_test.go
+++ b/overlord/snapstate/policy/policy_test.go
@@ -25,7 +25,7 @@ func (s *policySuite) TestFor(c *check.C) {
 		snap.TypeGadget: policy.NewGadgetPolicy(""),
 		snap.TypeKernel: policy.NewKernelPolicy(""),
 		snap.TypeOS:     policy.NewOSPolicy(""),
-		snap.TypeSnapd:  policy.NewSnapdPolicy(""),
+		snap.TypeSnapd:  policy.NewSnapdPolicy(false),
 	} {
 		c.Check(policy.For(typ, &asserts.Model{}), check.FitsTypeOf, pol)
 	}

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -22,12 +22,11 @@ package policy
 import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
 type snapdPolicy struct {
-	modelBase string
+	onClassic bool
 }
 
 func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
@@ -42,7 +41,7 @@ func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, re
 	}
 
 	// snapd cannot be removed on core
-	if !release.OnClassic {
+	if !p.onClassic {
 		return errSnapdNotRemovableOnCore
 	}
 

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -43,7 +43,7 @@ func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, re
 
 	// snapd cannot be removed on core
 	if !release.OnClassic {
-		return errNotRemovable
+		return errSnapdNotRemovableOnCore
 	}
 
 	// only allow snapd removal if its the last snap on a (classic) system
@@ -52,7 +52,7 @@ func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, re
 		return err
 	}
 	if numSnaps > 1 {
-		return errNotRemovable
+		return errSnapdNotYetRemovableOnClassic
 	}
 
 	return nil

--- a/tests/main/snapd-snap-removal/task.yaml
+++ b/tests/main/snapd-snap-removal/task.yaml
@@ -1,0 +1,39 @@
+summary: Ensure snapd can be removed on classic if its the last snap
+
+systems: [-ubuntu-core-*]
+
+execute: |
+    echo "Ensure we have no core"
+    systemctl stop snapd
+    #shellcheck source=tests/lib/dirs.sh
+    . "$TESTSLIB/dirs.sh"
+    $LIBEXECDIR/snapd/snap-mgmt --purge
+    systemctl start snapd
+    snap wait system seed.loaded
+    test "$(snap list | grep -v -c ^Name)" = 0
+
+    echo "Ensure we have snapd + snap + core18 installed"
+    snap install snapd
+    test "$(snap list | grep -v -c ^Name)" = 1
+    snap install core18
+    test "$(snap list | grep -v -c ^Name)" = 2
+    snap install test-snapd-tools-core18
+    test "$(snap list | grep -v -c ^Name)" = 3
+
+    echo "then we cannot remove snapd"
+    not snap remove snapd
+
+    echo "Now we remove the leaf snap"
+    snap remove test-snapd-tools-core18
+    test "$(snap list | grep -v -c ^Name)" = 2
+
+    echo "we still cannot remove snapd"
+    not snap remove snapd
+
+    echo "Now we remove core18"
+    snap remove core18
+    test "$(snap list | grep -v -c ^Name)" = 1
+
+    echo "and now we can remove snapd"
+    snap remove snapd
+    test "$(snap list | grep -v -c ^Name)" = 0


### PR DESCRIPTION
This PR implements a CanRemove policy for the snapd snap type
so that this snap can only be removed if its safe to do so.

The policy is:
- if on core devices: never allow removal
- if on classic: allow removal if snapd is the last snap
