### PR TITLE
interfaces/many: allow k8s/systemd-run to mount volume subPaths plus cleanups

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -533,12 +533,12 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts i
 	// Add profile for each app.
 	for _, appInfo := range snapInfo.Apps {
 		securityTag := appInfo.SecurityTag()
-		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content, spec)
+		addContent(securityTag, snapInfo, appInfo.Name, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for each hook.
 	for _, hookInfo := range snapInfo.Hooks {
 		securityTag := hookInfo.SecurityTag()
-		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content, spec)
+		addContent(securityTag, snapInfo, hookInfo.Name, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for snap-update-ns if we have any apps or hooks.
 	// If we have neither then we don't have any need to create an executing environment.
@@ -596,7 +596,7 @@ func downgradeConfinement() bool {
 	return true
 }
 
-func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]osutil.FileState, spec *Specification) {
+func addContent(securityTag string, snapInfo *snap.Info, cmdName string, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]osutil.FileState, spec *Specification) {
 	// Normally we use a specific apparmor template for all snap programs.
 	policy := defaultTemplate
 	ignoreSnippets := false
@@ -632,7 +632,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {
 		case "###VAR###":
-			return templateVariables(snapInfo, securityTag)
+			return templateVariables(snapInfo, securityTag, cmdName)
 		case "###PROFILEATTACH###":
 			return fmt.Sprintf("profile \"%s\"", securityTag)
 		case "###CHANGEPROFILE_RULE###":

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -538,7 +538,7 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts i
 	// Add profile for each hook.
 	for _, hookInfo := range snapInfo.Hooks {
 		securityTag := hookInfo.SecurityTag()
-		addContent(securityTag, snapInfo, hookInfo.Name, opts, spec.SnippetForTag(securityTag), content, spec)
+		addContent(securityTag, snapInfo, "hook."+hookInfo.Name, opts, spec.SnippetForTag(securityTag), content, spec)
 	}
 	// Add profile for snap-update-ns if we have any apps or hooks.
 	// If we have neither then we don't have any need to create an executing environment.

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -688,6 +688,7 @@ const commonPrefix = `
 @{SNAP_NAME}="samba"
 # This is a snap name with instance key
 @{SNAP_INSTANCE_NAME}="samba"
+@{SNAP_COMMAND_NAME}="smbd"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
 @{INSTALL_DIR}="/{,var/lib/snapd/}snap"`
@@ -845,6 +846,7 @@ func (s *backendSuite) TestParallelInstallCombineSnippets(c *C) {
 @{SNAP_NAME}="samba"
 # This is a snap name with instance key
 @{SNAP_INSTANCE_NAME}="samba_foo"
+@{SNAP_COMMAND_NAME}="smbd"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_5ffoo_2esmbd"
 @{INSTALL_DIR}="/{,var/lib/snapd/}snap"

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -27,14 +27,15 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// templateVariables returns text defining apparmor variables that can be used in the
-// apparmor template and by apparmor snippets.
-func templateVariables(info *snap.Info, securityTag string) string {
+// templateVariables returns text defining apparmor variables that can be used
+// in the apparmor template and by apparmor snippets.
+func templateVariables(info *snap.Info, securityTag string, cmdName string) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "# This is a snap name without the instance key\n")
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", info.SnapName())
 	fmt.Fprintf(&buf, "# This is a snap name with instance key\n")
 	fmt.Fprintf(&buf, "@{SNAP_INSTANCE_NAME}=\"%s\"\n", info.InstanceName())
+	fmt.Fprintf(&buf, "@{SNAP_COMMAND_NAME}=\"%s\"\n", cmdName)
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
 	fmt.Fprintf(&buf, "@{PROFILE_DBUS}=\"%s\"\n",
 		dbus.SafePath(securityTag))

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -158,7 +158,7 @@ const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   # kubelet peer process from this child profile. Note, this child profile
   # doesn't have 'capability sys_ptrace', so systemd-run is still not able to
   # ptrace this snap's processes.
-  ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.*,
+  ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.@{SNAP_COMMAND_NAME},
 `
 
 const kubernetesSupportConnectedPlugSeccompKubelet = `

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -133,26 +133,26 @@ deny ptrace (trace) peer=unconfined,
 # kubelet calls out to systemd-run for some mounts, but not all of them and not
 # unmounts...
 capability sys_admin,
-mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
-mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+mount /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
+mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
 
 /{,usr/}bin/mount ixr,
 /{,usr/}bin/umount ixr,
 deny /run/mount/utab rw,
-umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+umount /var/snap/@{SNAP_INSTANCE_NAME}/*/**,
 `
 
 const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   # kubelet mount rules
   capability sys_admin,
   /{,usr/}bin/mount ixr,
-  mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+  mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/*/**,
   deny /run/mount/utab rw,
 
   # For mounting volume subPaths
-  mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
-  mount options=(rw, remount, bind) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
-  umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+  mount /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
+  mount options=(rw, remount, bind) -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
+  umount /var/snap/@{SNAP_INSTANCE_NAME}/*/**,
   # When mounting a volume subPath, kubelet binds mounts on an open fd (eg,
   # /proc/.../fd/N) which triggers a ptrace 'trace' denial on the parent
   # kubelet peer process from this child profile. Note, this child profile

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -133,26 +133,26 @@ deny ptrace (trace) peer=unconfined,
 # kubelet calls out to systemd-run for some mounts, but not all of them and not
 # unmounts...
 capability sys_admin,
-mount /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
-mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
+mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
 
 /{,usr/}bin/mount ixr,
 /{,usr/}bin/umount ixr,
 deny /run/mount/utab rw,
-umount /var/snap/@{SNAP_INSTANCE_NAME}/*/**,
+umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
 `
 
 const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   # kubelet mount rules
   capability sys_admin,
   /{,usr/}bin/mount ixr,
-  mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/*/**,
+  mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
   deny /run/mount/utab rw,
 
   # For mounting volume subPaths
-  mount /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
-  mount options=(rw, remount, bind) -> /var/snap/@{SNAP_INSTANCE_NAME}/*/{,**},
-  umount /var/snap/@{SNAP_INSTANCE_NAME}/*/**,
+  mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+  mount options=(rw, remount, bind) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+  umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
   # When mounting a volume subPath, kubelet binds mounts on an open fd (eg,
   # /proc/.../fd/N) which triggers a ptrace 'trace' denial on the parent
   # kubelet peer process from this child profile. Note, this child profile

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -148,6 +148,17 @@ const kubernetesSupportConnectedPlugAppArmorKubeletSystemdRun = `
   /{,usr/}bin/mount ixr,
   mount fstype="tmpfs" tmpfs -> /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
   deny /run/mount/utab rw,
+
+  # For mounting volume subPaths
+  mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+  mount options=(rw, remount, bind) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+  umount /var/snap/@{SNAP_INSTANCE_NAME}/common/**,
+  # When mounting a volume subPath, kubelet binds mounts on an open fd (eg,
+  # /proc/.../fd/N) which triggers a ptrace 'trace' denial on the parent
+  # kubelet peer process from this child profile. Note, this child profile
+  # doesn't have 'capability sys_ptrace', so systemd-run is still not able to
+  # ptrace this snap's processes.
+  ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.*,
 `
 
 const kubernetesSupportConnectedPlugSeccompKubelet = `

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -108,7 +108,7 @@ const kubernetesSupportConnectedPlugAppArmorKubelet = `
 # Allow tracing our own processes. Note, this allows seccomp sandbox escape on
 # kernels < 4.8
 capability sys_ptrace,
-ptrace (trace) peer=snap.@{SNAP_NAME}.*,
+ptrace (trace) peer=snap.@{SNAP_INSTANCE_NAME}.*,
 
 # Allow ptracing other processes (as part of ps-style process lookups). Note,
 # the peer needs a corresponding tracedby rule. As a special case, disallow
@@ -133,8 +133,8 @@ deny ptrace (trace) peer=unconfined,
 # kubelet calls out to systemd-run for some mounts, but not all of them and not
 # unmounts...
 capability sys_admin,
-mount /var/snap/@{SNAP_NAME}/common/{,**} -> /var/snap/@{SNAP_NAME}/common/{,**},
-mount options=(rw, rshared) -> /var/snap/@{SNAP_NAME}/common/{,**},
+mount /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**} -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
+mount options=(rw, rshared) -> /var/snap/@{SNAP_INSTANCE_NAME}/common/{,**},
 
 /{,usr/}bin/mount ixr,
 /{,usr/}bin/umount ixr,


### PR DESCRIPTION
* interfaces/kubernetes-support: allow systemd-run to mount volume subPaths
* interfaces/kubernetes-support: update to use SNAP_INSTANCE_NAME consistently
* apparmor: add @{SNAP_COMMAND_NAME} variable
* interfaces/kubernetes-support: use @{SNAP_COMMAND_NAME} with systemd-run