### PR TITLE
snap-confine.apparmor.in: harden pivot_root until we have full mediation

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -238,7 +238,7 @@
     # pivoting into a whitelisted path.
     pivot_root oldroot=/tmp/snap.rootfs_*/var/lib/snapd/hostfs/ /tmp/snap.rootfs_*/,
     # Explicitly deny creating the old_root directory in case it is
-    # inadvertantly added somewhere else. While this doesn't resolve
+    # inadvertently added somewhere else. While this doesn't resolve
     # LP: #1791711, it provides some hardening.
     audit deny /tmp/snap.rootfs_*/{var/,var/lib/,var/lib/snapd/,var/lib/snapd/hostfs/} w,
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -231,8 +231,17 @@
     # pivot_root preparation and execution
     mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
     mount options=(rw private) -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
-    # pivot_root mediation in AppArmor is not complete. See LP: #1791711
-    pivot_root,
+
+    # pivot_root mediation in AppArmor is not complete. See LP: #1791711.
+    # However, we can mediate the new_root and put_old to be what we expect,
+    # and then deny directory creation within old_root to prevent trivial
+    # pivoting into a whitelisted path.
+    pivot_root oldroot=/tmp/snap.rootfs_*/var/lib/snapd/hostfs/ /tmp/snap.rootfs_*/,
+    # Explicitly deny creating the old_root directory in case it is
+    # inadvertantly added somewhere else. While this doesn't resolve
+    # LP: #1791711, it provides some hardening.
+    audit deny /tmp/snap.rootfs_*/{var/,var/lib/,var/lib/snapd/,var/lib/snapd/hostfs/} w,
+
     # cleanup
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
     umount /var/lib/snapd/hostfs/sys/,


### PR DESCRIPTION
snap-confine uses pivot_root() (man 2 pivot_root) only when initially
setting up the mount namespace (eg, on first start of any snap's command
or after a snap-discard-ns) and it does so in a very predictable manner,
which allows the snap-confine profile to be more specific with both
new_root and put_old (oldroot) than the current bare pivot_root rule.

While this does not address LP: #1791711, it does provide a bit of
hardening until full pivot_root mediation is available in AppArmor.

References:
- https://bugs.launchpad.net/apparmor/+bug/1791711