### PR TITLE
snap-install: add ext4,vfat creation support

### DIFF
--- a/cmd/snap-recovery/partition/mkfs.go
+++ b/cmd/snap-recovery/partition/mkfs.go
@@ -18,13 +18,19 @@
  */
 package partition
 
-type LsblkFilesystemInfo = lsblkFilesystemInfo
-type LsblkBlockDevice = lsblkBlockDevice
-type SFDiskPartitionTable = sfdiskPartitionTable
-type SFDiskPartition = sfdiskPartition
+import (
+	"fmt"
 
-var (
-	FilesystemInfo     = filesystemInfo
-	BuildPartitionList = buildPartitionList
-	MakeFilesystem     = makeFilesystem
+	"github.com/snapcore/snapd/gadget"
 )
+
+func makeFilesystem(node, label, filesystem, content string) error {
+	switch filesystem {
+	case "vfat":
+		return gadget.MkfsVfat(node, label, content)
+	case "ext4":
+		return gadget.MkfsExt4(node, label, content)
+	default:
+		return fmt.Errorf("cannot create unsupported filesystem %q", filesystem)
+	}
+}

--- a/cmd/snap-recovery/partition/mkfs_test.go
+++ b/cmd/snap-recovery/partition/mkfs_test.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package partition_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/snap-recovery/partition"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func (s *partitionTestSuite) TestMkfsUnhappy(c *C) {
+	err := partition.MakeFilesystem("/dev/node", "some-label", "unsupported-filesystem-type", "/dir/with/initial/fs/content")
+	c.Assert(err, ErrorMatches, `cannot create unsupported filesystem "unsupported-filesystem-type"`)
+}
+
+func (s *partitionTestSuite) TestMkfsVfat(c *C) {
+	mockMkfs := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer mockMkfs.Restore()
+
+	err := partition.MakeFilesystem("/dev/node", "some-label", "vfat", "")
+	c.Assert(err, IsNil)
+	// details are already tested in the gadget package
+	c.Assert(mockMkfs.Calls(), HasLen, 1)
+}
+
+func (s *partitionTestSuite) TestMkfsExt4(c *C) {
+	mockMkfs := testutil.MockCommand(c, "mkfs.ext4", "")
+	defer mockMkfs.Restore()
+
+	err := partition.MakeFilesystem("/dev/node", "some-label", "ext4", "")
+	c.Assert(err, IsNil)
+	// details are already tested in the gadget package
+	c.Assert(mockMkfs.Calls(), HasLen, 1)
+}

--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -43,10 +43,12 @@ func MkfsExt4(img, label, contentsRootDir string) error {
 		"-O", "-metadata_csum",
 		// allow uninitialized block groups
 		"-O", "uninit_bg",
+	}
+	if contentsRootDir != "" {
 		// mkfs.ext4 can populate the filesystem with contents of given
 		// root directory
 		// TODO: support e2fsprogs 1.42 without -d in Ubuntu 16.04
-		"-d", contentsRootDir,
+		mkfsArgs = append(mkfsArgs, "-d", contentsRootDir)
 	}
 	if label != "" {
 		mkfsArgs = append(mkfsArgs, "-L", label)
@@ -83,6 +85,11 @@ func MkfsVfat(img, label, contentsRootDir string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)
+	}
+
+	// if there is no content to copy we are done now
+	if contentsRootDir == "" {
+		return nil
 	}
 
 	// mkfs.vfat does not know how to populate the filesystem with contents,

--- a/gadget/mkfs_test.go
+++ b/gadget/mkfs_test.go
@@ -88,6 +88,24 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 			"foo.img",
 		},
 	})
+
+	cmd.ForgetCalls()
+
+	// no content
+	err = gadget.MkfsExt4("foo.img", "my-label", "")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-T", "default",
+			"-O", "-metadata_csum",
+			"-O", "uninit_bg",
+			"-L", "my-label",
+			"foo.img",
+		},
+	})
+
 }
 
 func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
@@ -187,4 +205,18 @@ func (m *mkfsSuite) TestMkfsVfatErrorInMcopy(c *C) {
 	c.Assert(err, ErrorMatches, "cannot populate vfat filesystem with contents: hard fail")
 	c.Assert(cmdMkfs.Calls(), HasLen, 1)
 	c.Assert(cmdMcopy.Calls(), HasLen, 1)
+}
+
+func (m *mkfsSuite) TestMkfsVfatHappyNoContents(c *C) {
+	cmdMkfs := testutil.MockCommand(c, "mkfs.vfat", "")
+	defer cmdMkfs.Restore()
+
+	cmdMcopy := testutil.MockCommand(c, "mcopy", "")
+	defer cmdMcopy.Restore()
+
+	err := gadget.MkfsVfat("foo.img", "my-label", "")
+	c.Assert(err, IsNil)
+	c.Assert(cmdMkfs.Calls(), HasLen, 1)
+	// mcopy was not called
+	c.Assert(cmdMcopy.Calls(), HasLen, 0)
 }


### PR DESCRIPTION
We'll need ext4 filesystem creation for ubuntu-data, so add that here.
Note that ubuntu-data will also require more infrastructure to be
properly created, such as cryptsetup and key sealing support.
