### PR TITLE
spdx: add EPL-2.0 to licenses.

### DIFF
--- a/spdx/licenses.go
+++ b/spdx/licenses.go
@@ -50,6 +50,7 @@ var osi = []string{
 	"CATOSL-1.1",
 	"CUA-OPL-1.0",
 	"EPL-1.0",
+	"EPL-2.0",
 	"ECL-1.0",
 	"ECL-2.0",
 	"EFL-1.0",


### PR DESCRIPTION
Listed as FSF Free/Libre and OSI Approved on https://spdx.org/licenses/

Signed-off-by: Roger Light <roger@atchoo.org>