### PR TITLE
gadget: helper for volume compatibility checks

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -895,3 +895,37 @@ func (s *RelativeOffset) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	*s = *ro
 	return nil
 }
+
+// IsCompatible checks whether the current and an update are compatible. Returns
+// nil or an error describing the incompatibility.
+func IsCompatible(current, new *Info) error {
+	// XXX: the only compatibility we have now is making sure that the new
+	// layout can be used on an existing volume
+	if len(new.Volumes) > 1 {
+		return fmt.Errorf("gadgets with multiple volumes are unsupported")
+	}
+
+	// XXX: the code below errors out with more than 1 volume in the current
+	// gadget, we allow this scenario in update but better bail out here and
+	// have users fix their gadgets
+	currentVol, newVol, err := resolveVolume(current, new)
+	if err != nil {
+		return err
+	}
+
+	// layout both volumes partially, without going deep into the layout of
+	// structure content, we only want to make sure that structures are
+	// comapatible
+	pCurrent, err := LayoutVolumePartially(currentVol, defaultConstraints)
+	if err != nil {
+		return fmt.Errorf("cannot lay out the old volume: %v", err)
+	}
+	pNew, err := LayoutVolumePartially(newVol, defaultConstraints)
+	if err != nil {
+		return fmt.Errorf("cannot lay out the new volume: %v", err)
+	}
+	if err := isLayoutCompatible(pCurrent, pNew); err != nil {
+		return fmt.Errorf("incompatible layout change: %v", err)
+	}
+	return nil
+}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -918,7 +918,7 @@ func IsCompatible(current, new *Info) error {
 	// comapatible
 	pCurrent, err := LayoutVolumePartially(currentVol, defaultConstraints)
 	if err != nil {
-		return fmt.Errorf("cannot lay out the old volume: %v", err)
+		return fmt.Errorf("cannot lay out the current volume: %v", err)
 	}
 	pNew, err := LayoutVolumePartially(newVol, defaultConstraints)
 	if err != nil {

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -351,3 +351,34 @@ func ShiftStructureTo(ps LaidOutStructure, offset Size) LaidOutStructure {
 	}
 	return newPs
 }
+
+func isLayoutCompatible(current, new *PartiallyLaidOutVolume) error {
+	if current.ID != new.ID {
+		return fmt.Errorf("incompatible ID change from %v to %v", current.ID, new.ID)
+	}
+	if current.EffectiveSchema() != new.EffectiveSchema() {
+		return fmt.Errorf("incompatible schema change from %v to %v",
+			current.EffectiveSchema(), new.EffectiveSchema())
+	}
+	if current.Bootloader != new.Bootloader {
+		return fmt.Errorf("incompatible bootloader change from %v to %v",
+			current.Bootloader, new.Bootloader)
+	}
+
+	// XXX: the code below asssumes both volumes have the same number of
+	// structures, this limitation may be lifter later
+	if len(current.LaidOutStructure) != len(new.LaidOutStructure) {
+		return fmt.Errorf("incompatible change in the number of structures from %v to %v",
+			len(current.LaidOutStructure), len(new.LaidOutStructure))
+	}
+
+	// at the structure level we expect the volume to be identical
+	for i := range current.LaidOutStructure {
+		from := &current.LaidOutStructure[i]
+		to := &new.LaidOutStructure[i]
+		if err := canUpdateStructure(from, to, new.EffectiveSchema()); err != nil {
+			return fmt.Errorf("incompatible structure %v change: %v", to, err)
+		}
+	}
+	return nil
+}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -100,7 +100,7 @@ func Update(old, new GadgetData, rollbackDirPath string) error {
 
 	// can update old layout to new layout
 	for _, update := range updates {
-		if err := canUpdateStructure(update.from, update.to); err != nil {
+		if err := canUpdateStructure(update.from, update.to, pNew.EffectiveSchema()); err != nil {
 			return fmt.Errorf("cannot update volume structure %v: %v", update.to, err)
 		}
 	}
@@ -155,7 +155,11 @@ func isLegacyMBRTransition(from *LaidOutStructure, to *LaidOutStructure) bool {
 	return from.Type == MBR && to.EffectiveRole() == MBR
 }
 
-func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure) error {
+func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure, schema string) error {
+	if schema == GPT && from.Name != to.Name {
+		// partition names are only effective when GPT is used
+		return fmt.Errorf("cannot change structure name from %q to %q", from.Name, to.Name)
+	}
 	if from.Size != to.Size {
 		return fmt.Errorf("cannot change structure size from %v to %v", from.Size, to.Size)
 	}


### PR DESCRIPTION
Add a helper for checking volume and structure compatibility, with primary use
in a remodel scenario.

The compatiblity check performs only a partial layout, thus missing content
cannot be detected at this stage.

While at it, make sure that structure name transition is only allowed when using
a MBR partitioning schema. In case of a GPT one, the structure name is written
to the GPT as PARTLABEL.

