### PR TITLE
interfaces/pulseaudio: adjust to manually connect by default

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -38,6 +38,7 @@ const pulseaudioBaseDeclarationSlots = `
         - core
     deny-connection:
       on-classic: false
+    deny-auto-connection: true
 `
 
 const pulseaudioConnectedPlugAppArmor = `

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -165,7 +165,6 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"online-accounts-service": true,
 		"opengl":                  true,
 		"optical-drive":           true,
-		"pulseaudio":              true,
 		"screen-inhibit-control":  true,
 		"ubuntu-download-manager": true,
 		"unity7":                  true,

--- a/tests/manual-tests.md
+++ b/tests/manual-tests.md
@@ -169,7 +169,8 @@
    git://git.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/examples
 2. $ cd examples/simple-pulseaudio
 3. Ensure that the 'pulseaudio' interface is connected to paplay
-   $ sudo snap interfaces
+   $ sudo snap connect simple-pulseaudio:pulseaudio
+   $ sudo snap connections simple-pulseaudio
 4. Use /snap/bin/simple-pulseaudio.pactl stat and verify that you see
    valid output status from pulseaudio
 5. Use /snap/bin/simple-pulseaudio.paplay $SNAP/usr/share/sounds/alsa/Noise.wav and verify


### PR DESCRIPTION
Snaps should use audio-playback (and audio-record if they need
recording) instead of pulseaudio. Now that audio-record has been
available since 2.41 and all existing snaps in the snap store that plugs
pulseaudio have been grandfathered to have a snap declaration to
auto-connect pulseaudio, it is time to adjust pulseaudio to manually
connect.

References:
- https://forum.snapcraft.io/t/upcoming-pulseaudio-interface-deprecation/13418