### PR TITLE
strutil: add OrderedSet

### DIFF
--- a/strutil/set.go
+++ b/strutil/set.go
@@ -28,7 +28,7 @@ type OrderedSet struct {
 
 // Items returns a slice of strings representing insertion order.
 //
-// Contains is O(N) in the size of the set.
+// Items is O(N) in the size of the set.
 func (o *OrderedSet) Items() []string {
 	if o.positionOf == nil {
 		return nil

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -58,20 +58,6 @@ func (o *OrderedSet) IndexOf(item string) (idx int, ok bool) {
 	return idx, ok
 }
 
-// Del removes an item from the set.
-//
-// Del is O(1) in the size of the set.
-func (o *OrderedSet) Del(item string) {
-	if o.positionOf == nil {
-		return
-	}
-
-	delete(o.positionOf, item)
-	if len(o.positionOf) == 0 {
-		o.positionOf = nil
-	}
-}
-
 // Put adds an item into the set.
 //
 // If the item was not present then it is stored and ordered after all existing

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -33,7 +33,7 @@ type OrderedSet struct {
 //
 // Items is O(N) in the size of the set.
 func (o *OrderedSet) Items() []string {
-	if o.positionOf == nil {
+	if len(o.positionOf) == 0 {
 		return nil
 	}
 	items := make([]string, len(o.positionOf))
@@ -47,7 +47,7 @@ func (o *OrderedSet) Items() []string {
 //
 // Contains is O(1) in the size of the set.
 func (o *OrderedSet) Contains(item string) bool {
-	if o.positionOf == nil {
+	if len(o.positionOf) == 0 {
 		return false
 	}
 

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -90,7 +90,7 @@ func (o *OrderedSet) Put(item string) {
 	o.positionOf[item] = len(o.positionOf)
 }
 
-// Size returns the size of the set.
+// Size returns the number of elements in the set.
 func (o *OrderedSet) Size() int {
 	return len(o.positionOf)
 }

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -21,6 +21,9 @@ package strutil
 
 // OrderedSet is a set of strings that maintains the order of insertion.
 //
+// The order of putting items into the set is retained. Putting items "a", "b"
+// and then "a", results in order "a", "b".
+//
 // External synchronization is required for safe concurrent access.
 type OrderedSet struct {
 	positionOf map[string]int

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -1,0 +1,96 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil
+
+// OrderedSet is a set of strings that maintains the order of insertion.
+//
+// External synchronization is required for safe concurrent access.
+type OrderedSet struct {
+	positionOf map[string]int
+}
+
+// Items returns a slice of strings representing insertion order.
+//
+// Contains is O(N) in the size of the set.
+func (o *OrderedSet) Items() []string {
+	if o.positionOf == nil {
+		return nil
+	}
+	items := make([]string, len(o.positionOf))
+	for item, idx := range o.positionOf {
+		items[idx] = item
+	}
+	return items
+}
+
+// Contains returns true if the set contains a given item.
+//
+// Contains is O(1) in the size of the set.
+func (o *OrderedSet) Contains(item string) bool {
+	if o.positionOf == nil {
+		return false
+	}
+
+	_, ok := o.positionOf[item]
+	return ok
+}
+
+// IndexOf returns the position of an item in the set.
+func (o *OrderedSet) IndexOf(item string) (idx int, ok bool) {
+	idx, ok = o.positionOf[item]
+	return idx, ok
+}
+
+// Del removes an item from the set.
+//
+// Delete is O(1) in the size of the set.
+func (o *OrderedSet) Del(item string) {
+	if o.positionOf == nil {
+		return
+	}
+
+	delete(o.positionOf, item)
+	if len(o.positionOf) == 0 {
+		o.positionOf = nil
+	}
+}
+
+// Put adds an item into the set.
+//
+// If the item was not present then it is stored and ordered after all existing
+// elements. If the item was already present its position is not changed.
+//
+// Put is O(1) in the size of the set.
+func (o *OrderedSet) Put(item string) {
+	if o.positionOf == nil {
+		o.positionOf = make(map[string]int)
+	}
+
+	if _, ok := o.positionOf[item]; ok {
+		return
+	}
+
+	o.positionOf[item] = len(o.positionOf)
+}
+
+// Size returns the size of the set.
+func (o *OrderedSet) Size() int {
+	return len(o.positionOf)
+}

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -60,7 +60,7 @@ func (o *OrderedSet) IndexOf(item string) (idx int, ok bool) {
 
 // Del removes an item from the set.
 //
-// Delete is O(1) in the size of the set.
+// Del is O(1) in the size of the set.
 func (o *OrderedSet) Del(item string) {
 	if o.positionOf == nil {
 		return

--- a/strutil/set.go
+++ b/strutil/set.go
@@ -47,10 +47,6 @@ func (o *OrderedSet) Items() []string {
 //
 // Contains is O(1) in the size of the set.
 func (o *OrderedSet) Contains(item string) bool {
-	if len(o.positionOf) == 0 {
-		return false
-	}
-
 	_, ok := o.positionOf[item]
 	return ok
 }

--- a/strutil/set_test.go
+++ b/strutil/set_test.go
@@ -47,10 +47,6 @@ func (s *orderedSetSuite) TestZeroValueIndexOf(c *C) {
 	c.Check(s.set.Contains("foo"), Equals, false)
 }
 
-func (s *orderedSetSuite) TestZeroValueDel(c *C) {
-	s.set.Del("foo")
-}
-
 func (s *orderedSetSuite) TestZeroValuePut(c *C) {
 	s.set.Put("foo")
 	c.Check(s.set.Contains("foo"), Equals, true)
@@ -62,18 +58,6 @@ func (s *orderedSetSuite) TestZeroValuePut(c *C) {
 
 func (s *orderedSetSuite) TestZeroValueSize(c *C) {
 	c.Assert(s.set.Size(), Equals, 0)
-}
-
-func (s *orderedSetSuite) TestDeletion(c *C) {
-	s.set.Put("foo")
-	s.set.Del("foo")
-
-	c.Assert(s.set.Items(), DeepEquals, []string(nil))
-	c.Check(s.set.Size(), Equals, 0)
-	c.Check(s.set.Contains("foo"), Equals, false)
-	idx, ok := s.set.IndexOf("foo")
-	c.Check(ok, Equals, false)
-	c.Check(idx, Equals, 0)
 }
 
 func (s *orderedSetSuite) TestDeduplication(c *C) {

--- a/strutil/set_test.go
+++ b/strutil/set_test.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/strutil"
+)
+
+type orderedSetSuite struct {
+	set strutil.OrderedSet
+}
+
+var _ = Suite(&orderedSetSuite{})
+
+func (s *orderedSetSuite) SetUpTest(c *C) {
+	s.set = strutil.OrderedSet{}
+}
+
+func (s *orderedSetSuite) TestZeroValueItems(c *C) {
+	c.Assert(s.set.Items(), HasLen, 0)
+}
+
+func (s *orderedSetSuite) TestZeroValueContains(c *C) {
+	c.Check(s.set.Contains("foo"), Equals, false)
+}
+
+func (s *orderedSetSuite) TestZeroValueIndexOf(c *C) {
+	c.Check(s.set.Contains("foo"), Equals, false)
+}
+
+func (s *orderedSetSuite) TestZeroValueDel(c *C) {
+	s.set.Del("foo")
+}
+
+func (s *orderedSetSuite) TestZeroValuePut(c *C) {
+	s.set.Put("foo")
+	c.Check(s.set.Contains("foo"), Equals, true)
+	c.Check(s.set.Items(), DeepEquals, []string{"foo"})
+	idx, ok := s.set.IndexOf("foo")
+	c.Check(ok, Equals, true)
+	c.Check(idx, Equals, 0)
+}
+
+func (s *orderedSetSuite) TestZeroValueSize(c *C) {
+	c.Assert(s.set.Size(), Equals, 0)
+}
+
+func (s *orderedSetSuite) TestDeletion(c *C) {
+	s.set.Put("foo")
+	s.set.Del("foo")
+
+	c.Assert(s.set.Items(), DeepEquals, []string(nil))
+	c.Check(s.set.Size(), Equals, 0)
+	c.Check(s.set.Contains("foo"), Equals, false)
+	idx, ok := s.set.IndexOf("foo")
+	c.Check(ok, Equals, false)
+	c.Check(idx, Equals, 0)
+}
+
+func (s *orderedSetSuite) TestDeduplication(c *C) {
+	s.set.Put("a")
+	s.set.Put("b")
+	s.set.Put("a")
+	s.set.Put("c")
+
+	c.Assert(s.set.Items(), DeepEquals, []string{"a", "b", "c"})
+	c.Check(s.set.Size(), Equals, 3)
+	c.Check(s.set.Contains("a"), Equals, true)
+	c.Check(s.set.Contains("b"), Equals, true)
+	c.Check(s.set.Contains("c"), Equals, true)
+}

--- a/strutil/set_test.go
+++ b/strutil/set_test.go
@@ -44,7 +44,8 @@ func (s *orderedSetSuite) TestZeroValueContains(c *C) {
 }
 
 func (s *orderedSetSuite) TestZeroValueIndexOf(c *C) {
-	c.Check(s.set.Contains("foo"), Equals, false)
+	_, ok := s.set.IndexOf("foo")
+	c.Check(ok, Equals, false)
 }
 
 func (s *orderedSetSuite) TestZeroValuePut(c *C) {

--- a/strutil/set_test.go
+++ b/strutil/set_test.go
@@ -48,12 +48,16 @@ func (s *orderedSetSuite) TestZeroValueIndexOf(c *C) {
 }
 
 func (s *orderedSetSuite) TestZeroValuePut(c *C) {
-	s.set.Put("foo")
-	c.Check(s.set.Contains("foo"), Equals, true)
-	c.Check(s.set.Items(), DeepEquals, []string{"foo"})
-	idx, ok := s.set.IndexOf("foo")
-	c.Check(ok, Equals, true)
-	c.Check(idx, Equals, 0)
+	items := []string{"foo", "bar", "froz"}
+	for idx, item := range items {
+		s.set.Put(item)
+		c.Check(s.set.Contains(item), Equals, true)
+		realIdx, ok := s.set.IndexOf(item)
+		c.Check(ok, Equals, true)
+		c.Check(idx, Equals, realIdx)
+		c.Check(s.set.Size(), Equals, idx+1)
+		c.Check(s.set.Items(), DeepEquals, items[:idx+1])
+	}
 }
 
 func (s *orderedSetSuite) TestZeroValueSize(c *C) {


### PR DESCRIPTION
This patch adds strutil.OrderedSet, a data structure representing a set
of strings which remembers order of inserted elements.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
