### PR TITLE
tests: ignore directories for go modules

### DIFF
--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -4,6 +4,12 @@ summary: test chattr
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2503
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
+environment:
+    # an empty $topsrcdir/tests/go.mod seems to break importing or building go
+    # packages referenced by their import paths while under the tests directory,
+    # need to disable go modules supportfor this test
+    GO111MODULE: off
+
 prepare: |
   go build -o toggle ./toggle.go
 

--- a/tests/main/high-user-handling/task.yaml
+++ b/tests/main/high-user-handling/task.yaml
@@ -2,6 +2,12 @@ summary: Check that the refresh data copy works.
 
 systems: [-ubuntu-core-*]
 
+environment:
+    # an empty $topsrcdir/tests/go.mod seems to break importing or building go
+    # packages referenced by their import paths while under the tests directory,
+    # need to disable go modules supportfor this test
+    GO111MODULE: off
+
 prepare: |
     useradd --uid "$(( (1<<32)-2 ))" --shell /bin/sh hightest
 

--- a/tests/main/static/task.yaml
+++ b/tests/main/static/task.yaml
@@ -4,6 +4,12 @@ summary: Check that snapd can be built without cgo
 # of the verbatim tree
 systems: [-ubuntu-core-*, -debian-sid-*]
 
+environment:
+    # an empty $topsrcdir/tests/go.mod seems to break importing or building go
+    # packages referenced by their import paths while under the tests directory,
+    # need to disable go modules supportfor this test
+    GO111MODULE: off
+
 execute: |
     CGO_ENABLED=0 go build -o snapd.static github.com/snapcore/snapd/cmd/snapd
     ldd snapd.static | MATCH 'not a dynamic executable'


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)? yes + yes

This PR has been created by a couple of people over the past couple of years (I accidentally closed #6666).

The background is when creating an application (like an agent that will operate on a device) that uses snapd as a library, it's common to want to use Go modules. However, there are a couple of files in the snapd repo that cause Go modules to stall. The recommended approach is to create an empty go.mod file that will ignore those directories: https://github.com/golang/go/wiki/Modules#can-an-additional-gomod-exclude-unnecessary-content-do-modules-have-the-equivalent-of-a-gitignore-file
 