### PR TITLE
gadget, overlord/devicestate: add support for customized update policy, add remodel policy

### DIFF
--- a/gadget/update.go
+++ b/gadget/update.go
@@ -45,8 +45,8 @@ type GadgetData struct {
 	RootDir string
 }
 
-// UpdatePolicyFunc is a callback that evaluates provided pair of structures and
-// returns true when the pair should be part of an update.
+// UpdatePolicyFunc is a callback that evaluates the provided pair of structures
+// and returns true when the pair should be part of an update.
 type UpdatePolicyFunc func(from, to *LaidOutStructure) bool
 
 // Update applies the gadget update given the gadget information and data from
@@ -237,7 +237,7 @@ func defaultPolicy(from, to *LaidOutStructure) bool {
 }
 
 // RemodelUpdatePolicy implements the update policy of a remodel scenario.
-func RemodelUpdatePolicy(_, _o *LaidOutStructure) bool {
+func RemodelUpdatePolicy(_, _ *LaidOutStructure) bool {
 	return true
 }
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -45,18 +45,24 @@ type GadgetData struct {
 	RootDir string
 }
 
+// UpdatePolicyFunc is a callback that evaluates provided pair of structures and
+// returns true when the pair should be part of an update.
+type UpdatePolicyFunc func(from, to *LaidOutStructure) bool
+
 // Update applies the gadget update given the gadget information and data from
 // old and new revisions. It errors out when the update is not possible or
 // illegal, or a failure occurs at any of the steps. When there is no update, a
 // special error ErrNoUpdate is returned.
 //
-// Updates are opt-in, and are only applied to structures with a higher value of
-// Edition field in the new gadget definition.
+// Only structures selected by the update policy are part of the update. When
+// the policy is nil, a default one is used. The default policy selects
+// structures in an opt-in manner, only tructures with a higher value of Edition
+// field in the new gadget definition are part of the update.
 //
 // Data that would be modified during the update is first backed up inside the
 // rollback directory. Should the apply step fail, the modified data is
 // recovered.
-func Update(old, new GadgetData, rollbackDirPath string) error {
+func Update(old, new GadgetData, rollbackDirPath string, updatePolicy UpdatePolicyFunc) error {
 	// TODO: support multi-volume gadgets. But for now we simply
 	//       do not do any gadget updates on those. We cannot error
 	//       here because this would break refreshes of gadgets even
@@ -88,8 +94,11 @@ func Update(old, new GadgetData, rollbackDirPath string) error {
 		return fmt.Errorf("cannot apply update to volume: %v", err)
 	}
 
+	if updatePolicy == nil {
+		updatePolicy = defaultPolicy
+	}
 	// now we know which structure is which, find which ones need an update
-	updates, err := resolveUpdate(pOld, pNew)
+	updates, err := resolveUpdate(pOld, pNew, updatePolicy)
 	if err != nil {
 		return err
 	}
@@ -223,7 +232,16 @@ type updatePair struct {
 	to   *LaidOutStructure
 }
 
-func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume) (updates []updatePair, err error) {
+func defaultPolicy(from, to *LaidOutStructure) bool {
+	return to.Update.Edition > from.Update.Edition
+}
+
+// RemodelUpdatePolicy implements the update policy of a remodel scenario.
+func RemodelUpdatePolicy(_, _o *LaidOutStructure) bool {
+	return true
+}
+
+func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume, policy UpdatePolicyFunc) (updates []updatePair, err error) {
 	if len(oldVol.LaidOutStructure) != len(newVol.LaidOutStructure) {
 		return nil, errors.New("internal error: the number of structures in new and old volume definitions is different")
 	}
@@ -233,7 +251,7 @@ func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume) (updat
 		// assets are assumed to be backwards compatible, once deployed
 		// are not rolled back or replaced unless a higher edition is
 		// available
-		if newStruct.Update.Edition > oldStruct.Update.Edition {
+		if policy(&oldStruct, &newStruct) {
 			updates = append(updates, updatePair{
 				from: &oldVol.LaidOutStructure[j],
 				to:   &newVol.LaidOutStructure[j],

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -3499,9 +3499,10 @@ func setupGadgetUpdate(c *C, st *state.State) (chg *state.Change, tsk *state.Tas
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreSimple(c *C) {
 	var updateCalled bool
 	var passedRollbackDir string
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		updateCalled = true
 		passedRollbackDir = path
+		c.Check(policy, IsNil)
 		st, err := os.Stat(path)
 		c.Assert(err, IsNil)
 		m := st.Mode()
@@ -3533,7 +3534,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreSimple(c *C) {
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNoUpdateNeeded(c *C) {
 	var called bool
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		called = true
 		return gadget.ErrNoUpdate
 	})
@@ -3560,7 +3561,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreRollbackDirCreateFailed(c *C) {
 		c.Skip("this test cannot run as root (permissions are not honored)")
 	}
 
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3586,7 +3587,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreRollbackDirCreateFailed(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreUpdateFailed(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		return errors.New("gadget exploded")
 	})
 	defer restore()
@@ -3609,7 +3610,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreUpdateFailed(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNotDuringFirstboot(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3653,7 +3654,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnCoreNotDuringFirstboot(c *C) {
 }
 
 func (s *deviceMgrSuite) TestUpdateGadgetOnCoreBadGadgetYaml(c *C) {
-	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore := devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()
@@ -3713,7 +3714,7 @@ func (s *deviceMgrSuite) TestUpdateGadgetOnClassicErrorsOut(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string) error {
+	restore = devicestate.MockGadgetUpdate(func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error {
 		return errors.New("unexpected call")
 	})
 	defer restore()

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -163,7 +163,7 @@ var (
 	GadgetCurrentAndUpdate = gadgetCurrentAndUpdate
 )
 
-func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string) error) (restore func()) {
+func MockGadgetUpdate(mock func(current, update gadget.GadgetData, path string, policy gadget.UpdatePolicyFunc) error) (restore func()) {
 	old := gadgetUpdate
 	gadgetUpdate = mock
 	return func() {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -1022,7 +1022,8 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 	}
 
 	st.Unlock()
-	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir)
+	// use the default update policy
+	err = gadgetUpdate(*currentData, *updateData, snapRollbackDir, nil)
 	st.Lock()
 	if err != nil {
 		if err == gadget.ErrNoUpdate {


### PR DESCRIPTION
As part of the remodel work, add support for update policy controlled by the
caller. Should no policy be provided a default one, based on the current rules,
is used.

Add a remodel policy that enables an update for all structures.

Update devicestate to use the default policy.