### PR TITLE
tests/main/interfaces-contacts-service: disable on openSUSE Tumbleweed

### DIFF
--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -5,7 +5,8 @@ summary: Ensure that the contacts-service interface works
 # amazon: no need to run this on amazon
 # ubuntu-19.10: test-snapd-eds is incompatible with eds shipped with the distro
 # arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -arch-linux-*, -debian-sid-*]
+# opensuse-tumbleweed: test-snapd-eds is incompatible with eds version shipped with the distro
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -arch-linux-*, -debian-sid-*, -opensuse-tumbleweed-*]
 
 # fails in autopkgtest environment with:
 # [Wed Aug 15 16:08:23 2018] audit: type=1400


### PR DESCRIPTION
The test-snapd-eds snap is incompatible with eds version shipped by the distro.

```
...
+ snap connect test-snapd-eds:contacts-service
+ test-snapd-eds.contacts load test-address-book
error: g-dbus-error-quark[2] Unable to connect to 'test-address-book': The name org.gnome.evolution.dataserver.AddressBook9 was not provided by any .service files
-----
```