### PR TITLE
interfaces: emit update-ns snippets to function

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -148,38 +148,41 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 	// Append update-ns snippets that allow constructing the layout.
 	for _, path := range paths {
 		var buf bytes.Buffer
+		emit := func(f string, args ...interface{}) {
+			fmt.Fprintf(&buf, f, args...)
+		}
 		l := si.Layout[path]
-		fmt.Fprintf(&buf, "  # Layout %s\n", l.String())
+		emit("  # Layout %s\n", l.String())
 		path := si.ExpandSnapVariables(l.Path)
 		switch {
 		case l.Bind != "":
 			bind := si.ExpandSnapVariables(l.Bind)
 			// Allow bind mounting the layout element.
-			fmt.Fprintf(&buf, "  mount options=(rbind, rw) %s/ -> %s/,\n", bind, path)
-			fmt.Fprintf(&buf, "  mount options=(rprivate) -> %s/,\n", path)
-			fmt.Fprintf(&buf, "  umount %s/,\n", path)
+			emit("  mount options=(rbind, rw) %s/ -> %s/,\n", bind, path)
+			emit("  mount options=(rprivate) -> %s/,\n", path)
+			emit("  umount %s/,\n", path)
 			// Allow constructing writable mimic in both bind-mount source and mount point.
-			WritableProfile(&buf, path, 2) // At least / and /some-top-level-directory
-			WritableProfile(&buf, bind, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
+			GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
+			GenWritableProfile(emit, bind, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
 		case l.BindFile != "":
 			bindFile := si.ExpandSnapVariables(l.BindFile)
 			// Allow bind mounting the layout element.
-			fmt.Fprintf(&buf, "  mount options=(bind, rw) %s -> %s,\n", bindFile, path)
-			fmt.Fprintf(&buf, "  mount options=(rprivate) -> %s,\n", path)
-			fmt.Fprintf(&buf, "  umount %s,\n", path)
+			emit("  mount options=(bind, rw) %s -> %s,\n", bindFile, path)
+			emit("  mount options=(rprivate) -> %s,\n", path)
+			emit("  umount %s,\n", path)
 			// Allow constructing writable mimic in both bind-mount source and mount point.
-			WritableFileProfile(&buf, path, 2)     // At least / and /some-top-level-directory
-			WritableFileProfile(&buf, bindFile, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
+			GenWritableFileProfile(emit, path, 2)     // At least / and /some-top-level-directory
+			GenWritableFileProfile(emit, bindFile, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
 		case l.Type == "tmpfs":
-			fmt.Fprintf(&buf, "  mount fstype=tmpfs tmpfs -> %s/,\n", path)
-			fmt.Fprintf(&buf, "  mount options=(rprivate) -> %s/,\n", path)
-			fmt.Fprintf(&buf, "  umount %s/,\n", path)
+			emit("  mount fstype=tmpfs tmpfs -> %s/,\n", path)
+			emit("  mount options=(rprivate) -> %s/,\n", path)
+			emit("  umount %s/,\n", path)
 			// Allow constructing writable mimic to mount point.
-			WritableProfile(&buf, path, 2) // At least / and /some-top-level-directory
+			GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
 		case l.Symlink != "":
 			// Allow constructing writable mimic to symlink parent directory.
-			fmt.Fprintf(&buf, "  %s rw,\n", path)
-			WritableProfile(&buf, path, 2) // At least / and /some-top-level-directory
+			emit("  %s rw,\n", path)
+			GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
 		}
 		spec.AddUpdateNS(buf.String())
 	}
@@ -220,9 +223,9 @@ func isProbablyPresent(path string) bool {
 	return path == "/" || path == "/snap" || path == "/var" || path == "/var/snap" || path == "/tmp" || path == "/usr" || path == "/etc"
 }
 
-// WritableMimicProfile writes apparmor rules for a writable mimic at the given path.
-func WritableMimicProfile(buf *bytes.Buffer, path string, assumedPrefixDepth int) {
-	fmt.Fprintf(buf, "  # Writable mimic %s\n", path)
+// GenWritableMimicProfile generates apparmor rules for a writable mimic at the given path.
+func GenWritableMimicProfile(emit func(f string, args ...interface{}), path string, assumedPrefixDepth int) {
+	emit("  # Writable mimic %s\n", path)
 
 	iter, err := strutil.NewPathIterator(path)
 	if err != nil {
@@ -230,10 +233,10 @@ func WritableMimicProfile(buf *bytes.Buffer, path string, assumedPrefixDepth int
 	}
 
 	// Handle the prefix that is assumed to exist first.
-	fmt.Fprintf(buf, "  # .. permissions for traversing the prefix that is assumed to exist\n")
+	emit("  # .. permissions for traversing the prefix that is assumed to exist\n")
 	for iter.Next() {
 		if iter.Depth() < assumedPrefixDepth {
-			fmt.Fprintf(buf, "  %s r,\n", iter.CurrentPath())
+			emit("  %s r,\n", iter.CurrentPath())
 		}
 	}
 
@@ -249,68 +252,68 @@ func WritableMimicProfile(buf *bytes.Buffer, path string, assumedPrefixDepth int
 		// directory path semantics.
 		mimicPath := filepath.Join(iter.CurrentBase(), iter.CurrentCleanName()) + "/"
 		mimicAuxPath := filepath.Join("/tmp/.snap", iter.CurrentPath()) + "/"
-		fmt.Fprintf(buf, "  # .. variant with mimic at %s\n", mimicPath)
-		fmt.Fprintf(buf, "  # Allow reading the mimic directory, it must exist in the first place.\n")
-		fmt.Fprintf(buf, "  %s r,\n", mimicPath)
-		fmt.Fprintf(buf, "  # Allow setting the read-only directory aside via a bind mount.\n")
-		fmt.Fprintf(buf, "  %s rw,\n", mimicAuxPath)
-		fmt.Fprintf(buf, "  mount options=(rbind, rw) %s -> %s,\n", mimicPath, mimicAuxPath)
-		fmt.Fprintf(buf, "  # Allow mounting tmpfs over the read-only directory.\n")
-		fmt.Fprintf(buf, "  mount fstype=tmpfs options=(rw) tmpfs -> %s,\n", mimicPath)
-		fmt.Fprintf(buf, "  # Allow creating empty files and directories for bind mounting things\n"+
+		emit("  # .. variant with mimic at %s\n", mimicPath)
+		emit("  # Allow reading the mimic directory, it must exist in the first place.\n")
+		emit("  %s r,\n", mimicPath)
+		emit("  # Allow setting the read-only directory aside via a bind mount.\n")
+		emit("  %s rw,\n", mimicAuxPath)
+		emit("  mount options=(rbind, rw) %s -> %s,\n", mimicPath, mimicAuxPath)
+		emit("  # Allow mounting tmpfs over the read-only directory.\n")
+		emit("  mount fstype=tmpfs options=(rw) tmpfs -> %s,\n", mimicPath)
+		emit("  # Allow creating empty files and directories for bind mounting things\n" +
 			"  # to reconstruct the now-writable parent directory.\n")
-		fmt.Fprintf(buf, "  %s*/ rw,\n", mimicAuxPath)
-		fmt.Fprintf(buf, "  %s*/ rw,\n", mimicPath)
-		fmt.Fprintf(buf, "  mount options=(rbind, rw) %s*/ -> %s*/,\n", mimicAuxPath, mimicPath)
-		fmt.Fprintf(buf, "  %s* rw,\n", mimicAuxPath)
-		fmt.Fprintf(buf, "  %s* rw,\n", mimicPath)
-		fmt.Fprintf(buf, "  mount options=(bind, rw) %s* -> %s*,\n", mimicAuxPath, mimicPath)
-		fmt.Fprintf(buf, "  # Allow unmounting the auxiliary directory.\n"+
+		emit("  %s*/ rw,\n", mimicAuxPath)
+		emit("  %s*/ rw,\n", mimicPath)
+		emit("  mount options=(rbind, rw) %s*/ -> %s*/,\n", mimicAuxPath, mimicPath)
+		emit("  %s* rw,\n", mimicAuxPath)
+		emit("  %s* rw,\n", mimicPath)
+		emit("  mount options=(bind, rw) %s* -> %s*,\n", mimicAuxPath, mimicPath)
+		emit("  # Allow unmounting the auxiliary directory.\n" +
 			"  # TODO: use fstype=tmpfs here for more strictness (LP: #1613403)\n")
-		fmt.Fprintf(buf, "  mount options=(rprivate) -> %s,\n", mimicAuxPath)
-		fmt.Fprintf(buf, "  umount %s,\n", mimicAuxPath)
-		fmt.Fprintf(buf, "  # Allow unmounting the destination directory as well as anything\n"+
-			"  # inside.  This lets us perform the undo plan in case the writable\n"+
+		emit("  mount options=(rprivate) -> %s,\n", mimicAuxPath)
+		emit("  umount %s,\n", mimicAuxPath)
+		emit("  # Allow unmounting the destination directory as well as anything\n" +
+			"  # inside.  This lets us perform the undo plan in case the writable\n" +
 			"  # mimic fails.\n")
-		fmt.Fprintf(buf, "  mount options=(rprivate) -> %s,\n", mimicPath)
-		fmt.Fprintf(buf, "  mount options=(rprivate) -> %s*,\n", mimicPath)
-		fmt.Fprintf(buf, "  mount options=(rprivate) -> %s*/,\n", mimicPath)
-		fmt.Fprintf(buf, "  umount %s,\n", mimicPath)
-		fmt.Fprintf(buf, "  umount %s*,\n", mimicPath)
-		fmt.Fprintf(buf, "  umount %s*/,\n", mimicPath)
+		emit("  mount options=(rprivate) -> %s,\n", mimicPath)
+		emit("  mount options=(rprivate) -> %s*,\n", mimicPath)
+		emit("  mount options=(rprivate) -> %s*/,\n", mimicPath)
+		emit("  umount %s,\n", mimicPath)
+		emit("  umount %s*,\n", mimicPath)
+		emit("  umount %s*/,\n", mimicPath)
 	}
 }
 
-// WritableFileProfile writes a profile for snap-update-ns for making given file writable.
-func WritableFileProfile(buf *bytes.Buffer, path string, assumedPrefixDepth int) {
+// GenWritableFileProfile writes a profile for snap-update-ns for making given file writable.
+func GenWritableFileProfile(emit func(f string, args ...interface{}), path string, assumedPrefixDepth int) {
 	if path == "/" {
 		return
 	}
 	if isProbablyWritable(path) {
-		fmt.Fprintf(buf, "  # Writable file %s\n", path)
-		fmt.Fprintf(buf, "  %s rw,\n", path)
+		emit("  # Writable file %s\n", path)
+		emit("  %s rw,\n", path)
 		for p := parent(path); !isProbablyPresent(p); p = parent(p) {
-			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+			emit("  %s/ rw,\n", p)
 		}
 	} else {
 		parentPath := parent(path)
-		WritableMimicProfile(buf, parentPath, assumedPrefixDepth)
+		GenWritableMimicProfile(emit, parentPath, assumedPrefixDepth)
 	}
 }
 
-// WritableProfile writes a profile for snap-update-ns for making given directory writable.
-func WritableProfile(buf *bytes.Buffer, path string, assumedPrefixDepth int) {
+// GenWritableProfile generates a profile for snap-update-ns for making given directory writable.
+func GenWritableProfile(emit func(f string, args ...interface{}), path string, assumedPrefixDepth int) {
 	if path == "/" {
 		return
 	}
 	if isProbablyWritable(path) {
-		fmt.Fprintf(buf, "  # Writable directory %s\n", path)
+		emit("  # Writable directory %s\n", path)
 		for p := path; !isProbablyPresent(p); p = parent(p) {
-			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+			emit("  %s/ rw,\n", p)
 		}
 	} else {
 		parentPath := parent(path)
-		WritableMimicProfile(buf, parentPath, assumedPrefixDepth)
+		GenWritableMimicProfile(emit, parentPath, assumedPrefixDepth)
 	}
 }
 

--- a/interfaces/builtin/appstream_metadata.go
+++ b/interfaces/builtin/appstream_metadata.go
@@ -78,16 +78,19 @@ func (iface *appstreamMetadataInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 
 	// Generate rules to allow snap-update-ns to do its thing
 	var buf bytes.Buffer
+	emit := func(f string, args ...interface{}) {
+		fmt.Fprintf(&buf, f, args...)
+	}
 	for _, target := range appstreamMetadataDirs {
 		source := "/var/lib/snapd/hostfs" + target
-		fmt.Fprintf(&buf, "  # Read-only access to %s\n", target)
-		fmt.Fprintf(&buf, "  mount options=(bind) %s/ -> %s/,\n", source, target)
-		fmt.Fprintf(&buf, "  remount options=(bind, ro) %s/,\n", target)
-		fmt.Fprintf(&buf, "  umount %s/,\n\n", target)
+		emit("  # Read-only access to %s\n", target)
+		emit("  mount options=(bind) %s/ -> %s/,\n", source, target)
+		emit("  remount options=(bind, ro) %s/,\n", target)
+		emit("  umount %s/,\n\n", target)
 		// Allow constructing writable mimic to mount point We
 		// expect three components to already exist: /, /usr,
 		// and /usr/share (or equivalents under /var).
-		apparmor.WritableProfile(&buf, target, 3)
+		apparmor.GenWritableProfile(emit, target, 3)
 	}
 	spec.AddUpdateNS(buf.String())
 	return nil

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -235,9 +235,12 @@ func (iface *desktopInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 
 	// Allow mounting document portal
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "  # Mount the document portal\n")
-	fmt.Fprintf(&buf, "  mount options=(bind) /run/user/[0-9]*/doc/by-app/snap.%s/ -> /run/user/[0-9]*/doc/,\n", plug.Snap().InstanceName())
-	fmt.Fprintf(&buf, "  umount /run/user/[0-9]*/doc/,\n\n")
+	emit := func(f string, args ...interface{}) {
+		fmt.Fprintf(&buf, f, args...)
+	}
+	emit("  # Mount the document portal\n")
+	emit("  mount options=(bind) /run/user/[0-9]*/doc/by-app/snap.%s/ -> /run/user/[0-9]*/doc/,\n", plug.Snap().InstanceName())
+	emit("  umount /run/user/[0-9]*/doc/,\n\n")
 	spec.AddUpdateNS(buf.String())
 
 	if !release.OnClassic {
@@ -247,13 +250,16 @@ func (iface *desktopInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 
 	// Allow mounting fonts
 	for _, dir := range iface.fontconfigDirs() {
-		var buf bytes.Buffer
 		source := "/var/lib/snapd/hostfs" + dir
 		target := dirs.StripRootDir(dir)
-		fmt.Fprintf(&buf, "  # Read-only access to %s\n", target)
-		fmt.Fprintf(&buf, "  mount options=(bind) %s/ -> %s/,\n", source, target)
-		fmt.Fprintf(&buf, "  remount options=(bind, ro) %s/,\n", target)
-		fmt.Fprintf(&buf, "  umount %s/,\n\n", target)
+		var buf bytes.Buffer
+		emit := func(f string, args ...interface{}) {
+			fmt.Fprintf(&buf, f, args...)
+		}
+		emit("  # Read-only access to %s\n", target)
+		emit("  mount options=(bind) %s/ -> %s/,\n", source, target)
+		emit("  remount options=(bind, ro) %s/,\n", target)
+		emit("  umount %s/,\n\n", target)
 		spec.AddUpdateNS(buf.String())
 	}
 


### PR DESCRIPTION
The helper function emit collects individual update-ns snippets to
buffer, just like before, but allows us to easily change that. This will
be handy in the upcoming change that de-duplicates the update-ns
snippets to reduce memory usage of apparmor_parser.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
