### PR TITLE
tests: moving ubuntu-19.10-64 from google-unstable to google backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -67,6 +67,8 @@ backends:
                 workers: 8
             - ubuntu-19.04-64:
                 workers: 6
+            - ubuntu-19.10-64:
+                workers: 6
             - ubuntu-core-16-64:
                 image: ubuntu-16.04-64
                 workers: 6
@@ -107,8 +109,6 @@ backends:
         location: computeengine/us-east1-b
         halt-timeout: 2h
         systems:
-            - ubuntu-19.10-64:
-                workers: 6
             - centos-7-64:
                 workers: 6
                 image: centos-7-64


### PR DESCRIPTION
As it is realeased and we have a new stable image on gce.
