### PR TITLE
gadget: rename existing and add new helpers for checking filesystem/partition presence

### DIFF
--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -103,7 +103,7 @@ func FindDeviceForStructure(ps *LaidOutStructure) (string, error) {
 // Returns the device name and an offset at which the structure content starts
 // within the device or an error.
 func FindDeviceForStructureWithFallback(ps *LaidOutStructure) (dev string, offs Size, err error) {
-	if !ps.IsBare() {
+	if ps.HasFilesystem() {
 		return "", 0, fmt.Errorf("internal error: cannot use with filesystem structures")
 	}
 
@@ -158,7 +158,7 @@ func encodeLabel(in string) string {
 // given structure. The structure must have a filesystem defined, otherwise an
 // error is raised.
 func FindMountPointForStructure(ps *LaidOutStructure) (string, error) {
-	if ps.IsBare() {
+	if !ps.HasFilesystem() {
 		return "", ErrNoFilesystemDefined
 	}
 

--- a/gadget/filesystemimage.go
+++ b/gadget/filesystemimage.go
@@ -57,7 +57,7 @@ func NewFilesystemImageWriter(contentDir string, ps *LaidOutStructure, workDir s
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
-	if ps.IsBare() {
+	if !ps.HasFilesystem() {
 		return nil, fmt.Errorf("internal error: structure has no filesystem")
 	}
 	if contentDir == "" {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1646,6 +1646,44 @@ func (s *gadgetYamlTestSuite) TestPositionedVolumeFromGadgetHappy(c *C) {
 	c.Assert(lv.LaidOutStructure, HasLen, 3)
 }
 
+func (s *gadgetYamlTestSuite) TestStructureBareFilesystem(c *C) {
+	bareType := `
+type: bare
+size: 1M`
+	mbr := `
+role: mbr
+size: 446`
+	mbrLegacy := `
+type: mbr
+size: 446`
+	fs := `
+type: 21686148-6449-6E6F-744E-656564454649
+filesystem: vfat`
+	rawFsNoneExplicit := `
+type: 21686148-6449-6E6F-744E-656564454649
+filesystem: none
+size: 1M`
+	raw := `
+type: 21686148-6449-6E6F-744E-656564454649
+size: 1M`
+	for i, tc := range []struct {
+		s           *gadget.VolumeStructure
+		hasFs       bool
+		isPartition bool
+	}{
+		{mustParseStructure(c, bareType), false, false},
+		{mustParseStructure(c, mbr), false, false},
+		{mustParseStructure(c, mbrLegacy), false, false},
+		{mustParseStructure(c, fs), true, true},
+		{mustParseStructure(c, rawFsNoneExplicit), false, true},
+		{mustParseStructure(c, raw), false, true},
+	} {
+		c.Logf("tc: %v %+v", i, tc.s)
+		c.Check(tc.s.HasFilesystem(), Equals, tc.hasFs)
+		c.Check(tc.s.IsPartition(), Equals, tc.isPartition)
+	}
+}
+
 type gadgetCompatibilityTestSuite struct{}
 
 var _ = Suite(&gadgetCompatibilityTestSuite{})

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -252,7 +252,7 @@ func getImageSize(path string) (Size, error) {
 }
 
 func layOutStructureContent(gadgetRootDir string, ps *LaidOutStructure, known map[string]*LaidOutStructure) ([]LaidOutContent, error) {
-	if !ps.IsBare() {
+	if ps.HasFilesystem() {
 		// structures with a filesystem do not need any extra layout
 		return nil, nil
 	}

--- a/gadget/mountedfilesystem.go
+++ b/gadget/mountedfilesystem.go
@@ -68,7 +68,7 @@ func NewMountedFilesystemWriter(contentDir string, ps *LaidOutStructure) (*Mount
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
-	if ps.IsBare() {
+	if !ps.HasFilesystem() {
 		return nil, fmt.Errorf("structure %v has no filesystem", ps)
 	}
 	if contentDir == "" {

--- a/gadget/offset.go
+++ b/gadget/offset.go
@@ -73,7 +73,7 @@ func (w *OffsetWriter) Write(out io.WriteSeeker) error {
 		}
 	}
 
-	if !w.ps.IsBare() {
+	if w.ps.HasFilesystem() {
 		// only raw content uses offset-writes
 		return nil
 	}

--- a/gadget/partition.go
+++ b/gadget/partition.go
@@ -74,7 +74,7 @@ func Partition(image string, pv *LaidOutVolume) error {
 	fmt.Fprintf(script, "\n")
 
 	for _, ps := range pv.LaidOutStructure {
-		if ps.Type == "bare" || ps.Type == "mbr" {
+		if !ps.IsPartition() {
 			continue
 		}
 

--- a/gadget/raw.go
+++ b/gadget/raw.go
@@ -42,8 +42,8 @@ func NewRawStructureWriter(contentDir string, ps *LaidOutStructure) (*RawStructu
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
-	if !ps.IsBare() {
-		return nil, fmt.Errorf("internal error: structure %s is not bare", ps)
+	if ps.HasFilesystem() {
+		return nil, fmt.Errorf("internal error: structure %s has a filesystem", ps)
 	}
 	if contentDir == "" {
 		return nil, fmt.Errorf("internal error: gadget content directory cannot be unset")

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -241,7 +241,7 @@ func (r *rawTestSuite) TestRawWriterFailWithNonBare(c *C) {
 	}
 
 	rw, err := gadget.NewRawStructureWriter(r.dir, ps)
-	c.Assert(err, ErrorMatches, "internal error: structure #0 is not bare")
+	c.Assert(err, ErrorMatches, "internal error: structure #0 has a filesystem")
 	c.Assert(rw, IsNil)
 }
 
@@ -280,7 +280,7 @@ func (r *rawTestSuite) TestRawUpdaterFailWithNonBare(c *C) {
 		c.Fatalf("unexpected call")
 		return "", 0, nil
 	})
-	c.Assert(err, ErrorMatches, "internal error: structure #0 is not bare")
+	c.Assert(err, ErrorMatches, "internal error: structure #0 has a filesystem")
 	c.Assert(ru, IsNil)
 }
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -184,8 +184,8 @@ func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure, schema str
 	if from.ID != to.ID {
 		return fmt.Errorf("cannot change structure ID from %q to %q", from.ID, to.ID)
 	}
-	if !to.IsBare() {
-		if from.IsBare() {
+	if to.HasFilesystem() {
+		if !from.HasFilesystem() {
 			return fmt.Errorf("cannot change a bare structure to filesystem one")
 		}
 		if from.Filesystem != to.Filesystem {
@@ -197,7 +197,7 @@ func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure, schema str
 				from.Label, to.Label)
 		}
 	} else {
-		if !from.IsBare() {
+		if from.HasFilesystem() {
 			return fmt.Errorf("cannot change a filesystem structure to a bare one")
 		}
 	}
@@ -303,7 +303,7 @@ var updaterForStructure = updaterForStructureImpl
 func updaterForStructureImpl(ps *LaidOutStructure, newRootDir, rollbackDir string) (Updater, error) {
 	var updater Updater
 	var err error
-	if ps.IsBare() {
+	if !ps.HasFilesystem() {
 		updater, err = NewRawStructureUpdater(newRootDir, ps, rollbackDir, FindDeviceForStructureWithFallback)
 	} else {
 		updater, err = NewMountedFilesystemUpdater(newRootDir, ps, rollbackDir, FindMountPointForStructure)

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -714,8 +714,9 @@ func (u *updateTestSuite) TestUpdateApplyHappy(c *C) {
 		switch updaterForStructureCalls {
 		case 0:
 			c.Check(ps.Name, Equals, "first")
-			c.Check(ps.IsBare(), Equals, true)
+			c.Check(ps.HasFilesystem(), Equals, false)
 			c.Check(ps.Size, Equals, 5*gadget.SizeMiB)
+			c.Check(ps.IsPartition(), Equals, true)
 			// non MBR start offset defaults to 1MiB
 			c.Check(ps.StartOffset, Equals, 1*gadget.SizeMiB)
 			c.Assert(ps.LaidOutContent, HasLen, 1)
@@ -723,8 +724,9 @@ func (u *updateTestSuite) TestUpdateApplyHappy(c *C) {
 			c.Check(ps.LaidOutContent[0].Size, Equals, 900*gadget.SizeKiB)
 		case 1:
 			c.Check(ps.Name, Equals, "second")
-			c.Check(ps.IsBare(), Equals, false)
+			c.Check(ps.HasFilesystem(), Equals, true)
 			c.Check(ps.Filesystem, Equals, "ext4")
+			c.Check(ps.IsPartition(), Equals, true)
 			c.Check(ps.Size, Equals, 10*gadget.SizeMiB)
 			// foo's start offset + foo's size
 			c.Check(ps.StartOffset, Equals, (1+5)*gadget.SizeMiB)

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -30,7 +30,7 @@ func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume
 	// bare structure content is checked to exist during layout
 	// make sure that filesystem content source paths exist as well
 	for _, s := range vol.LaidOutStructure {
-		if s.IsBare() {
+		if !s.HasFilesystem() {
 			continue
 		}
 		for _, c := range s.Content {


### PR DESCRIPTION
The `IsBare()` helper that checks whether a structure has a filesystem or not is
confusing, since structures without a partition table entry are also referred to
as 'bare'. Rename to helper to make the substance of its check more explicit. At
the same time, add a new helper that checks whether a structure describes a
partition.

Based on the issues raised in #7640