### PR TITLE
gadget: skip structures with MBR role during remodel

### DIFF
--- a/gadget/update.go
+++ b/gadget/update.go
@@ -236,9 +236,10 @@ func defaultPolicy(from, to *LaidOutStructure) bool {
 	return to.Update.Edition > from.Update.Edition
 }
 
-// RemodelUpdatePolicy implements the update policy of a remodel scenario.
+// RemodelUpdatePolicy implements the update policy of a remodel scenario. The
+// policy select all non-MBR structures for the update.
 func RemodelUpdatePolicy(from, _ *LaidOutStructure) bool {
-	if !from.IsPartition() {
+	if from.EffectiveRole() == MBR {
 		return false
 	}
 	return true

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -237,7 +237,10 @@ func defaultPolicy(from, to *LaidOutStructure) bool {
 }
 
 // RemodelUpdatePolicy implements the update policy of a remodel scenario.
-func RemodelUpdatePolicy(_, _ *LaidOutStructure) bool {
+func RemodelUpdatePolicy(from, _ *LaidOutStructure) bool {
+	if !from.IsPartition() {
+		return false
+	}
 	return true
 }
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -237,7 +237,7 @@ func defaultPolicy(from, to *LaidOutStructure) bool {
 }
 
 // RemodelUpdatePolicy implements the update policy of a remodel scenario. The
-// policy select all non-MBR structures for the update.
+// policy selects all non-MBR structures for the update.
 func RemodelUpdatePolicy(from, _ *LaidOutStructure) bool {
 	if from.EffectiveRole() == MBR {
 		return false


### PR DESCRIPTION
When using a remodel update policy, skip structures that do not have a partition
table entry.
