### PR TITLE
overlord: fix TestRemodelSwitchToDifferentKernel for bootvars

### DIFF
--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -97,3 +97,7 @@ func (b *MockBootloader) SetBootKernel(kernel string) {
 func (b *MockBootloader) SetBootBase(base string) {
 	b.SetBootVars(map[string]string{"snap_core": base})
 }
+
+func (b *MockBootloader) SetTrying() {
+	b.BootVars["snap_mode"] = "trying"
+}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -429,6 +429,11 @@ func (m *DeviceManager) ensureSeedYaml() error {
 	return nil
 }
 
+// ResetBootOk is only useful for integration testing
+func (m *DeviceManager) ResetBootOk() {
+	m.bootOkRan = false
+}
+
 func (m *DeviceManager) ensureBootOk() error {
 	m.state.Lock()
 	defer m.state.Unlock()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3604,6 +3604,7 @@ version: 1.0`
 	})
 	// simulate successful system-restart bootenv updates (those
 	// vars will be cleared by snapd on a restart)
+	bloader.BootVars["snap_kernel"] = "brand-kernel_2.snap"
 	bloader.BootVars["snap_try_kernel"] = ""
 	bloader.BootVars["snap_mode"] = ""
 
@@ -3619,10 +3620,11 @@ version: 1.0`
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("upgrade-snap change failed with: %v", chg.Err()))
 
-	// bootvars are as expected
+	// bootvars are as expected (i.e. nothing has changed since this
+	// test simulated that we booted successfully)
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
 		"snap_core":       "core_1.snap",
-		"snap_kernel":     "pc-kernel_1.snap",
+		"snap_kernel":     "brand-kernel_2.snap",
 		"snap_try_kernel": "",
 		"snap_mode":       "",
 	})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3498,6 +3498,17 @@ version: 2.0`
 	c.Assert(tasks, HasLen, i+1)
 }
 
+func (ms *mgrsSuite) mockSuccessfulSystemRestart(c *C, bloader *bootloadertest.MockBootloader) {
+	st := ms.o.State()
+	state.MockRestarting(st, state.RestartUnset)
+	bloader.SetTrying()
+	ms.o.DeviceManager().ResetBootOk()
+	st.Unlock()
+	defer st.Lock()
+	err := ms.o.DeviceManager().Ensure()
+	c.Assert(err, IsNil)
+}
+
 func (ms *mgrsSuite) TestRemodelSwitchToDifferentKernel(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
@@ -3595,7 +3606,6 @@ version: 1.0`
 	c.Assert(t.Status(), Equals, state.DoingStatus)
 
 	// check that the system tries to boot the new brand kernel
-	state.MockRestarting(st, state.RestartUnset)
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
 		"snap_core":       "core_1.snap",
 		"snap_kernel":     "pc-kernel_1.snap",
@@ -3604,12 +3614,15 @@ version: 1.0`
 	})
 	// simulate successful system-restart bootenv updates (those
 	// vars will be cleared by snapd on a restart)
-	bloader.BootVars["snap_kernel"] = "brand-kernel_2.snap"
-	bloader.BootVars["snap_try_kernel"] = ""
-	bloader.BootVars["snap_mode"] = ""
-
-	// simulate successful restart happened
-	state.MockRestarting(st, state.RestartUnset)
+	ms.mockSuccessfulSystemRestart(c, bloader)
+	// bootvars are as expected
+	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":       "core_1.snap",
+		"snap_kernel":     "brand-kernel_2.snap",
+		"snap_try_core":   "",
+		"snap_try_kernel": "",
+		"snap_mode":       "",
+	})
 
 	// continue
 	st.Unlock()
@@ -3626,6 +3639,7 @@ version: 1.0`
 		"snap_core":       "core_1.snap",
 		"snap_kernel":     "brand-kernel_2.snap",
 		"snap_try_kernel": "",
+		"snap_try_core":   "",
 		"snap_mode":       "",
 	})
 


### PR DESCRIPTION
The bootvars tested in the TestRemodelSwitchToDifferentKernel are
not quite correctly mocked. When calling "state.MockRestarting()"
the code needs to clean the "snap_try_kernel" but also update
the "snap_kernel". This is what normally happens in
devicestate.DeviceManager.ensureBootOk() but the manager tests
won't run this so we need to simulate it.

This PR updates the bootvars correctly to make looking at the
test less confusing.