### PR TITLE
o/ifacestate,interfaces,interfaces/policy: slots-per-plug: *

### DIFF
--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -361,9 +361,9 @@ func (c *AttributeConstraints) Check(attrer Attrer, ctx AttrMatchContext) error 
 }
 
 // SideArityConstraint specifies a constraint for the overall arity of
-// the opposite connected set of slots for a plug, respectively plugs
-// for a slot.
-// It is used to express parsed slots-per-plug, respectively plugs-per-slot
+// the set of connected slots for a given plug or the set of
+// connected plugs for a given slot.
+// It is used to express parsed slots-per-plug and plugs-per-slot
 // constraints.
 // See https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
 type SideArityConstraint struct {
@@ -387,7 +387,7 @@ func compileSideArityConstraint(context *subruleContext, which string, v interfa
 		return a, fmt.Errorf("%s cannot specify a %s constraint, they apply only to allow-*connection", context, which)
 	}
 	x, ok := v.(string)
-	if !ok {
+	if !ok || len(x) == 0 {
 		return a, fmt.Errorf("%s in %s must be an integer >=1 or *", which, context)
 	}
 	if x == "*" {
@@ -413,7 +413,7 @@ func normalizeSideArityConstraints(context *subruleContext, c sideArityConstrain
 		return
 	}
 	any := SideArityConstraint{N: -1}
-	// normalized plugs-per-slots is always *
+	// normalized plugs-per-slot is always *
 	c.setPlugsPerSlot(any)
 	slotsPerPlug := c.slotsPerPlug()
 	if context.autoConnection() {

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -183,9 +183,10 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 
 		// check base declaration
 		cand := s.connectCand(c, iface.Name(), "", "")
-		err := cand.CheckAutoConnect()
+		arity, err := cand.CheckAutoConnect()
 		if expected {
 			c.Check(err, IsNil, comm)
+			c.Check(arity.SlotsPerPlugAny(), Equals, false)
 		} else {
 			c.Check(err, NotNil, comm)
 		}
@@ -216,11 +217,12 @@ func (s *baseDeclSuite) TestInterimAutoConnectionHome(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 	cand := s.connectCand(c, "home", "", "")
-	err := cand.CheckAutoConnect()
+	arity, err := cand.CheckAutoConnect()
 	c.Check(err, IsNil)
+	c.Check(arity.SlotsPerPlugAny(), Equals, false)
 
 	release.OnClassic = false
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, ErrorMatches, `auto-connection denied by slot rule of interface \"home\"`)
 }
 
@@ -237,14 +239,14 @@ plugs:
 	err := cand.Check()
 	c.Check(err, NotNil)
 
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 
 	release.OnClassic = false
 	err = cand.Check()
 	c.Check(err, NotNil)
 
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 }
 
@@ -261,21 +263,22 @@ plugs:
 	c.Check(err, IsNil)
 
 	// Same as TestInterimAutoConnectionHome()
-	err = cand.CheckAutoConnect()
+	arity, err := cand.CheckAutoConnect()
 	c.Check(err, IsNil)
+	c.Check(arity.SlotsPerPlugAny(), Equals, false)
 
 	release.OnClassic = false
 	err = cand.Check()
 	c.Check(err, IsNil)
 
 	// Same as TestInterimAutoConnectionHome()
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionSnapdControl(c *C) {
 	cand := s.connectCand(c, "snapd-control", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"snapd-control\"")
 
@@ -287,15 +290,16 @@ plugs:
 
 	lxdDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = lxdDecl
-	err = cand.CheckAutoConnect()
+	arity, err := cand.CheckAutoConnect()
 	c.Check(err, IsNil)
+	c.Check(arity.SlotsPerPlugAny(), Equals, false)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionContent(c *C) {
 	// random snaps cannot connect with content
 	// (Sanitize* will now also block this)
 	cand := s.connectCand(c, "content", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 
 	slotDecl1 := s.mockSnapDecl(c, "slot-snap", "slot-snap-id", "pub1", "")
@@ -320,13 +324,14 @@ plugs:
 `)
 	cand.SlotSnapDeclaration = slotDecl1
 	cand.PlugSnapDeclaration = plugDecl1
-	err = cand.CheckAutoConnect()
+	arity, err := cand.CheckAutoConnect()
 	c.Check(err, IsNil)
+	c.Check(arity.SlotsPerPlugAny(), Equals, false)
 
 	// different publisher, same content
 	cand.SlotSnapDeclaration = slotDecl1
 	cand.PlugSnapDeclaration = plugDecl2
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 
 	// same publisher, different content
@@ -346,14 +351,14 @@ plugs:
 `)
 	cand.SlotSnapDeclaration = slotDecl1
 	cand.PlugSnapDeclaration = plugDecl1
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionLxdSupportOverride(c *C) {
 	// by default, don't auto-connect
 	cand := s.connectCand(c, "lxd-support", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 
 	plugsSlots := `
@@ -364,7 +369,7 @@ plugs:
 
 	lxdDecl := s.mockSnapDecl(c, "lxd", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = lxdDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
@@ -378,14 +383,14 @@ plugs:
 
 	lxdDecl := s.mockSnapDecl(c, "notlxd", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = lxdDecl
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection not allowed by plug rule of interface \"lxd-support\" for \"notlxd\" snap")
 }
 
 func (s *baseDeclSuite) TestAutoConnectionKernelModuleControlOverride(c *C) {
 	cand := s.connectCand(c, "kernel-module-control", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"kernel-module-control\"")
 
@@ -397,13 +402,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionDockerSupportOverride(c *C) {
 	cand := s.connectCand(c, "docker-support", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"docker-support\"")
 
@@ -415,13 +420,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionClassicSupportOverride(c *C) {
 	cand := s.connectCand(c, "classic-support", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"classic-support\"")
 
@@ -433,13 +438,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "classic", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionKubernetesSupportOverride(c *C) {
 	cand := s.connectCand(c, "kubernetes-support", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"kubernetes-support\"")
 
@@ -451,13 +456,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionGreengrassSupportOverride(c *C) {
 	cand := s.connectCand(c, "greengrass-support", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"greengrass-support\"")
 
@@ -469,13 +474,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionMultipassSupportOverride(c *C) {
 	cand := s.connectCand(c, "multipass-support", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"multipass-support\"")
 
@@ -487,13 +492,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "multipass-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionBlockDevicesOverride(c *C) {
 	cand := s.connectCand(c, "block-devices", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"block-devices\"")
 
@@ -505,13 +510,13 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionPackagekitControlOverride(c *C) {
 	cand := s.connectCand(c, "packagekit-control", "", "")
-	err := cand.CheckAutoConnect()
+	_, err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection denied by plug rule of interface \"packagekit-control\"")
 
@@ -523,7 +528,7 @@ plugs:
 
 	snapDecl := s.mockSnapDecl(c, "some-snap", "J60k4JY0HppjwOjW8dZdYc8obXKxujRu", "canonical", plugsSlots)
 	cand.PlugSnapDeclaration = snapDecl
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
@@ -560,8 +565,9 @@ plugs:
 
 		cand := s.connectCand(c, iface.Name(), "", "")
 		cand.PlugSnapDeclaration = snapDecl
-		err := cand.CheckAutoConnect()
+		arity, err := cand.CheckAutoConnect()
 		c.Check(err, IsNil)
+		c.Check(arity.SlotsPerPlugAny(), Equals, false)
 	}
 }
 
@@ -945,7 +951,7 @@ plugs:
 	err := cand.Check()
 	c.Check(err, NotNil)
 
-	err = cand.CheckAutoConnect()
+	_, err = cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 }
 
@@ -992,7 +998,7 @@ plugs:
 		cand := s.connectCand(c, "optical-drive", "", plugYaml)
 		err := cand.Check()
 		c.Check(err, checker)
-		err = cand.CheckAutoConnect()
+		_, err = cand.CheckAutoConnect()
 		c.Check(err, checker)
 	}
 

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -304,6 +304,11 @@ func checkPlugInstallationAltConstraints(ic *InstallCandidate, plug *snap.PlugIn
 	return firstErr
 }
 
+// sideArity carries relevant arity constraints for successful
+// allow-auto-connection rules. It implements policy.SideArity.
+// ATM only slots-per-plug might have an interesting non-default
+// value.
+// See: https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
 type sideArity struct {
 	slotsPerPlug asserts.SideArityConstraint
 }

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -152,19 +152,19 @@ func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	return nil
 }
 
-func checkPlugConnectionAltConstraints(connc *ConnectCandidate, altConstraints []*asserts.PlugConnectionConstraints) error {
+func checkPlugConnectionAltConstraints(connc *ConnectCandidate, altConstraints []*asserts.PlugConnectionConstraints) (*asserts.PlugConnectionConstraints, error) {
 	var firstErr error
 	// OR of constraints
 	for _, constraints := range altConstraints {
 		err := checkPlugConnectionConstraints1(connc, constraints)
 		if err == nil {
-			return nil
+			return constraints, nil
 		}
 		if firstErr == nil {
 			firstErr = err
 		}
 	}
-	return firstErr
+	return nil, firstErr
 }
 
 func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.SlotConnectionConstraints) error {
@@ -195,19 +195,19 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	return nil
 }
 
-func checkSlotConnectionAltConstraints(connc *ConnectCandidate, altConstraints []*asserts.SlotConnectionConstraints) error {
+func checkSlotConnectionAltConstraints(connc *ConnectCandidate, altConstraints []*asserts.SlotConnectionConstraints) (*asserts.SlotConnectionConstraints, error) {
 	var firstErr error
 	// OR of constraints
 	for _, constraints := range altConstraints {
 		err := checkSlotConnectionConstraints1(connc, constraints)
 		if err == nil {
-			return nil
+			return constraints, nil
 		}
 		if firstErr == nil {
 			firstErr = err
 		}
 	}
-	return firstErr
+	return nil, firstErr
 }
 
 func checkSnapTypeSlotInstallationConstraints1(ic *InstallCandidateMinimalCheck, slot *snap.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
@@ -302,4 +302,16 @@ func checkPlugInstallationAltConstraints(ic *InstallCandidate, plug *snap.PlugIn
 		}
 	}
 	return firstErr
+}
+
+type sideArity struct {
+	slotsPerPlug asserts.SideArityConstraint
+}
+
+func (a sideArity) SlotsPerPlugOne() bool {
+	return a.slotsPerPlug.N == 1
+}
+
+func (a sideArity) SlotsPerPlugAny() bool {
+	return a.slotsPerPlug.Any()
 }

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -264,7 +264,8 @@ func (connc *ConnectCandidate) CheckAutoConnect() (interfaces.SideArity, error) 
 		return nil, err
 	}
 	if arity == nil {
-		// shouldn't happen but be safe
+		// shouldn't happen but be safe, the callers should be able
+		// to assume arity to be non nil
 		arity = sideArity{asserts.SideArityConstraint{N: 1}}
 	}
 	return arity, nil

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -176,7 +176,7 @@ func (connc *ConnectCandidate) slotPublisherID() string {
 	return "" // never a valid publisher-id
 }
 
-func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, snapRule bool) error {
+func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, snapRule bool) (interfaces.SideArity, error) {
 	context := ""
 	if snapRule {
 		context = fmt.Sprintf(" for %q snap", connc.PlugSnapDeclaration.SnapName())
@@ -187,16 +187,18 @@ func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule
 		denyConst = rule.DenyAutoConnection
 		allowConst = rule.AllowAutoConnection
 	}
-	if checkPlugConnectionAltConstraints(connc, denyConst) == nil {
-		return fmt.Errorf("%s denied by plug rule of interface %q%s", kind, connc.Plug.Interface(), context)
+	if _, err := checkPlugConnectionAltConstraints(connc, denyConst); err == nil {
+		return nil, fmt.Errorf("%s denied by plug rule of interface %q%s", kind, connc.Plug.Interface(), context)
 	}
-	if checkPlugConnectionAltConstraints(connc, allowConst) != nil {
-		return fmt.Errorf("%s not allowed by plug rule of interface %q%s", kind, connc.Plug.Interface(), context)
+
+	allowedConstraints, err := checkPlugConnectionAltConstraints(connc, allowConst)
+	if err != nil {
+		return nil, fmt.Errorf("%s not allowed by plug rule of interface %q%s", kind, connc.Plug.Interface(), context)
 	}
-	return nil
+	return sideArity{allowedConstraints.SlotsPerPlug}, nil
 }
 
-func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, snapRule bool) error {
+func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, snapRule bool) (interfaces.SideArity, error) {
 	context := ""
 	if snapRule {
 		context = fmt.Sprintf(" for %q snap", connc.SlotSnapDeclaration.SnapName())
@@ -207,25 +209,27 @@ func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule
 		denyConst = rule.DenyAutoConnection
 		allowConst = rule.AllowAutoConnection
 	}
-	if checkSlotConnectionAltConstraints(connc, denyConst) == nil {
-		return fmt.Errorf("%s denied by slot rule of interface %q%s", kind, connc.Plug.Interface(), context)
+	if _, err := checkSlotConnectionAltConstraints(connc, denyConst); err == nil {
+		return nil, fmt.Errorf("%s denied by slot rule of interface %q%s", kind, connc.Plug.Interface(), context)
 	}
-	if checkSlotConnectionAltConstraints(connc, allowConst) != nil {
-		return fmt.Errorf("%s not allowed by slot rule of interface %q%s", kind, connc.Plug.Interface(), context)
+
+	allowedConstraints, err := checkSlotConnectionAltConstraints(connc, allowConst)
+	if err != nil {
+		return nil, fmt.Errorf("%s not allowed by slot rule of interface %q%s", kind, connc.Plug.Interface(), context)
 	}
-	return nil
+	return sideArity{allowedConstraints.SlotsPerPlug}, nil
 }
 
-func (connc *ConnectCandidate) check(kind string) error {
+func (connc *ConnectCandidate) check(kind string) (interfaces.SideArity, error) {
 	baseDecl := connc.BaseDeclaration
 	if baseDecl == nil {
-		return fmt.Errorf("internal error: improperly initialized ConnectCandidate")
+		return nil, fmt.Errorf("internal error: improperly initialized ConnectCandidate")
 	}
 
 	iface := connc.Plug.Interface()
 
 	if connc.Slot.Interface() != iface {
-		return fmt.Errorf("cannot connect mismatched plug interface %q to slot interface %q", iface, connc.Slot.Interface())
+		return nil, fmt.Errorf("cannot connect mismatched plug interface %q to slot interface %q", iface, connc.Slot.Interface())
 	}
 
 	if plugDecl := connc.PlugSnapDeclaration; plugDecl != nil {
@@ -244,17 +248,26 @@ func (connc *ConnectCandidate) check(kind string) error {
 	if rule := baseDecl.SlotRule(iface); rule != nil {
 		return connc.checkSlotRule(kind, rule, false)
 	}
-	return nil
+	return nil, nil
 }
 
 // Check checks whether the connection is allowed.
 func (connc *ConnectCandidate) Check() error {
-	return connc.check("connection")
+	_, err := connc.check("connection")
+	return err
 }
 
 // CheckAutoConnect checks whether the connection is allowed to auto-connect.
-func (connc *ConnectCandidate) CheckAutoConnect() error {
-	return connc.check("auto-connection")
+func (connc *ConnectCandidate) CheckAutoConnect() (interfaces.SideArity, error) {
+	arity, err := connc.check("auto-connection")
+	if err != nil {
+		return nil, err
+	}
+	if arity == nil {
+		// shouldn't happen but be safe
+		arity = sideArity{asserts.SideArityConstraint{N: 1}}
+	}
+	return arity, nil
 }
 
 // InstallCandidateMinimalCheck represents a candidate snap installed with --dangerous flag that should pass minimum checks

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -1111,6 +1111,9 @@ func (r *Repository) DisconnectSnap(snapName string) ([]string, error) {
 }
 
 // SideArity conveys the arity constraints for an allowed auto-connection.
+// ATM only slots-per-plug might have an interesting non-default
+// value.
+// See: https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
 type SideArity interface {
 	SlotsPerPlugAny() bool
 	// TODO: consider PlugsPerSlot*

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1846,7 +1846,7 @@ plugs:
 	c.Assert(err, IsNil)
 
 	// Both slots could auto-connect
-	seenProcucers := make(map[string]bool)
+	seenProducers := make(map[string]bool)
 	candidateSlots, arities := repo.AutoConnectCandidateSlots("consumer", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 2)
 	c.Assert(arities, HasLen, 2)
@@ -1861,9 +1861,9 @@ plugs:
 		case "producer2":
 			c.Check(arities[i].SlotsPerPlugAny(), Equals, true)
 		}
-		seenProcucers[producerName] = true
+		seenProducers[producerName] = true
 	}
-	c.Check(seenProcucers, DeepEquals, map[string]bool{
+	c.Check(seenProducers, DeepEquals, map[string]bool{
 		"producer1": true,
 		"producer2": true,
 	})

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -21,6 +21,7 @@ package interfaces_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -1683,6 +1684,14 @@ func (s *RepositorySuite) TestSnapSpecificationFailureWithPermanentSnippets(c *C
 	c.Assert(spec, IsNil)
 }
 
+type testSideArity struct {
+	sideSnapName string
+}
+
+func (a *testSideArity) SlotsPerPlugAny() bool {
+	return strings.HasSuffix(a.sideSnapName, "2")
+}
+
 func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlots(c *C) {
 	// Add two interfaces, one with automatic connections, one with manual
 	repo := s.emptyRepo
@@ -1691,8 +1700,8 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlots(c *C) {
 	err = repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "manual"})
 	c.Assert(err, IsNil)
 
-	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
-		return slot.Interface() == "auto", nil
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, SideArity, error) {
+		return slot.Interface() == "auto", &testSideArity{plug.Snap().InstanceName()}, nil
 	}
 
 	// Add a pair of snaps with plugs/slots using those two interfaces
@@ -1716,11 +1725,13 @@ slots:
 	err = repo.AddSnap(consumer)
 	c.Assert(err, IsNil)
 
-	candidateSlots := repo.AutoConnectCandidateSlots("consumer", "auto", policyCheck)
+	candidateSlots, arities := repo.AutoConnectCandidateSlots("consumer", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Snap.InstanceName(), Equals, "producer")
 	c.Check(candidateSlots[0].Interface, Equals, "auto")
 	c.Check(candidateSlots[0].Name, Equals, "auto")
+	c.Assert(arities, HasLen, 1)
+	c.Check(arities[0].SlotsPerPlugAny(), Equals, false)
 
 	candidatePlugs := repo.AutoConnectCandidatePlugs("producer", "auto", policyCheck)
 	c.Assert(candidatePlugs, HasLen, 1)
@@ -1735,8 +1746,8 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlotsSymmetry(c *C) {
 	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "auto"})
 	c.Assert(err, IsNil)
 
-	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
-		return slot.Interface() == "auto", nil
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, SideArity, error) {
+		return slot.Interface() == "auto", &testSideArity{plug.Snap().InstanceName()}, nil
 	}
 
 	// Add a producer snap for "auto"
@@ -1773,22 +1784,89 @@ plugs:
 	c.Assert(err, IsNil)
 
 	// Both can auto-connect
-	candidateSlots := repo.AutoConnectCandidateSlots("consumer1", "auto", policyCheck)
+	candidateSlots, arities := repo.AutoConnectCandidateSlots("consumer1", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Snap.InstanceName(), Equals, "producer")
 	c.Check(candidateSlots[0].Interface, Equals, "auto")
 	c.Check(candidateSlots[0].Name, Equals, "auto")
+	c.Assert(arities, HasLen, 1)
+	c.Check(arities[0].SlotsPerPlugAny(), Equals, false)
 
-	candidateSlots = repo.AutoConnectCandidateSlots("consumer2", "auto", policyCheck)
+	candidateSlots, arities = repo.AutoConnectCandidateSlots("consumer2", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Snap.InstanceName(), Equals, "producer")
 	c.Check(candidateSlots[0].Interface, Equals, "auto")
 	c.Check(candidateSlots[0].Name, Equals, "auto")
+	c.Assert(arities, HasLen, 1)
+	c.Check(arities[0].SlotsPerPlugAny(), Equals, true)
 
 	// Plugs candidates seen from the producer (for example if
 	// it's installed after) should be the same
 	candidatePlugs := repo.AutoConnectCandidatePlugs("producer", "auto", policyCheck)
 	c.Assert(candidatePlugs, HasLen, 2)
+}
+
+func (s *RepositorySuite) TestAutoConnectCandidateSlotsSideArity(c *C) {
+	repo := s.emptyRepo
+	// Add a "auto" interface
+	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "auto"})
+	c.Assert(err, IsNil)
+
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, SideArity, error) {
+		return slot.Interface() == "auto", &testSideArity{slot.Snap().InstanceName()}, nil
+	}
+
+	// Add two producer snaps for "auto"
+	producer1 := snaptest.MockInfo(c, `
+name: producer1
+version: 0
+slots:
+    auto:
+`, nil)
+	err = repo.AddSnap(producer1)
+	c.Assert(err, IsNil)
+
+	producer2 := snaptest.MockInfo(c, `
+name: producer2
+version: 0
+slots:
+    auto:
+`, nil)
+	err = repo.AddSnap(producer2)
+	c.Assert(err, IsNil)
+
+	// Add a consumer snap for "auto"
+	consumer := snaptest.MockInfo(c, `
+name: consumer
+version: 0
+plugs:
+    auto:
+`, nil)
+	err = repo.AddSnap(consumer)
+	c.Assert(err, IsNil)
+
+	// Both slots could auto-connect
+	seenProcucers := make(map[string]bool)
+	candidateSlots, arities := repo.AutoConnectCandidateSlots("consumer", "auto", policyCheck)
+	c.Assert(candidateSlots, HasLen, 2)
+	c.Assert(arities, HasLen, 2)
+	for i, candSlot := range candidateSlots {
+		c.Check(candSlot.Interface, Equals, "auto")
+		c.Check(candSlot.Name, Equals, "auto")
+		producerName := candSlot.Snap.InstanceName()
+		// SideArities match
+		switch producerName {
+		case "producer1":
+			c.Check(arities[i].SlotsPerPlugAny(), Equals, false)
+		case "producer2":
+			c.Check(arities[i].SlotsPerPlugAny(), Equals, true)
+		}
+		seenProcucers[producerName] = true
+	}
+	c.Check(seenProcucers, DeepEquals, map[string]bool{
+		"producer1": true,
+		"producer2": true,
+	})
 }
 
 // Tests for AddSnap and RemoveSnap
@@ -2064,8 +2142,8 @@ func (s *DisconnectSnapSuite) TestParallelInstances(c *C) {
 	c.Check(affected, testutil.Contains, "s2_instance")
 }
 
-func contentPolicyCheck(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
-	return plug.Snap().Publisher.ID == slot.Snap().Publisher.ID, nil
+func contentPolicyCheck(plug *ConnectedPlug, slot *ConnectedSlot) (bool, SideArity, error) {
+	return plug.Snap().Publisher.ID == slot.Snap().Publisher.ID, nil, nil
 }
 
 func contentAutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
@@ -2106,7 +2184,7 @@ slots:
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
 	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "mylib")
-	candidateSlots := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
+	candidateSlots, _ := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Name, Equals, "exported-content")
 	candidatePlugs := repo.AutoConnectCandidatePlugs("content-slot-snap", "exported-content", contentPolicyCheck)
@@ -2118,7 +2196,7 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) 
 	repo, _, slotSnap := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
 	slotSnap.SnapType = snap.TypeOS
 
-	candidateSlots := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
+	candidateSlots, _ := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
 	candidatePlugs := repo.AutoConnectCandidatePlugs("content-slot-snap", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)
@@ -2126,7 +2204,7 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) 
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingContent(c *C) {
 	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
-	candidateSlots := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
+	candidateSlots, _ := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
 	candidatePlugs := repo.AutoConnectCandidatePlugs("content-slot-snap", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)
@@ -2138,7 +2216,7 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingDeveloper(c *
 	plugSnap.Publisher.ID = "fooid"
 	slotSnap.Publisher.ID = "barid"
 
-	candidateSlots := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
+	candidateSlots, _ := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
 	candidatePlugs := repo.AutoConnectCandidatePlugs("content-slot-snap", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -465,7 +465,10 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		policyChecker = autochecker.check
+		policyChecker = func(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error) {
+			ok, _, err := autochecker.check(plug, slot)
+			return ok, err
+		}
 	} else {
 		policyCheck, err := newConnectChecker(st, deviceCtx)
 		if err != nil {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -486,7 +486,7 @@ func (c *autoConnectChecker) snapDeclaration(snapID string) (*asserts.SnapDeclar
 	return snapDecl, nil
 }
 
-func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error) {
+func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, interfaces.SideArity, error) {
 	modelAs := c.deviceCtx.Model()
 
 	var storeAs *asserts.Store
@@ -494,7 +494,7 @@ func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfa
 		var err error
 		storeAs, err = assertstate.Store(c.st, modelAs.Store())
 		if err != nil && !asserts.IsNotFound(err) {
-			return false, err
+			return false, nil, err
 		}
 	}
 
@@ -504,7 +504,7 @@ func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfa
 		plugDecl, err = c.snapDeclaration(plug.Snap().SnapID)
 		if err != nil {
 			logger.Noticef("error: cannot find snap declaration for %q: %v", plug.Snap().InstanceName(), err)
-			return false, nil
+			return false, nil, nil
 		}
 	}
 
@@ -514,7 +514,7 @@ func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfa
 		slotDecl, err = c.snapDeclaration(slot.Snap().SnapID)
 		if err != nil {
 			logger.Noticef("error: cannot find snap declaration for %q: %v", slot.Snap().InstanceName(), err)
-			return false, nil
+			return false, nil, nil
 		}
 	}
 
@@ -529,22 +529,29 @@ func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfa
 		Store:               storeAs,
 	}
 
-	return ic.CheckAutoConnect() == nil, nil
+	arity, err := ic.CheckAutoConnect()
+	if err == nil {
+		return true, arity, nil
+	}
+
+	return false, nil, nil
 }
 
 // filterUbuntuCoreSlots filters out any ubuntu-core slots,
 // if there are both ubuntu-core and core slots. This would occur
 // during a ubuntu-core -> core transition.
-func filterUbuntuCoreSlots(candidates []*snap.SlotInfo) []*snap.SlotInfo {
+func filterUbuntuCoreSlots(candidates []*snap.SlotInfo, arities []interfaces.SideArity) ([]*snap.SlotInfo, []interfaces.SideArity) {
 	hasCore := false
 	hasUbuntuCore := false
 	var withoutUbuntuCore []*snap.SlotInfo
+	var withoutUbuntuCoreArities []interfaces.SideArity
 	for i, candSlot := range candidates {
 		switch candSlot.Snap.InstanceName() {
 		case "ubuntu-core":
 			if !hasUbuntuCore {
 				hasUbuntuCore = true
 				withoutUbuntuCore = append(withoutUbuntuCore, candidates[:i]...)
+				withoutUbuntuCoreArities = append(withoutUbuntuCoreArities, arities[:i]...)
 			}
 		case "core":
 			hasCore = true
@@ -552,13 +559,15 @@ func filterUbuntuCoreSlots(candidates []*snap.SlotInfo) []*snap.SlotInfo {
 		default:
 			if hasUbuntuCore {
 				withoutUbuntuCore = append(withoutUbuntuCore, candSlot)
+				withoutUbuntuCoreArities = append(withoutUbuntuCoreArities, arities[i])
 			}
 		}
 	}
 	if hasCore && hasUbuntuCore {
 		candidates = withoutUbuntuCore
+		arities = withoutUbuntuCoreArities
 	}
-	return candidates
+	return candidates, arities
 }
 
 // addAutoConnections adds to newconns any applicable auto-connections
@@ -569,7 +578,7 @@ func filterUbuntuCoreSlots(candidates []*snap.SlotInfo) []*snap.SlotInfo {
 // to handle checkAutoconnectConflicts errors.
 func (c *autoConnectChecker) addAutoConnections(newconns map[string]*interfaces.ConnRef, plugs []*snap.PlugInfo, filter func([]*snap.SlotInfo) []*snap.SlotInfo, conns map[string]*connState, cannotAutoConnectLog func(plug *snap.PlugInfo, candRefs []string) string, conflictError func(*state.Retry, error) error) error {
 	for _, plug := range plugs {
-		candSlots := c.repo.AutoConnectCandidateSlots(plug.Snap.InstanceName(), plug.Name, c.check)
+		candSlots, arities := c.repo.AutoConnectCandidateSlots(plug.Snap.InstanceName(), plug.Name, c.check)
 
 		if len(candSlots) == 0 {
 			continue
@@ -580,12 +589,18 @@ func (c *autoConnectChecker) addAutoConnections(newconns map[string]*interfaces.
 		// providing the same interface. In that situation we
 		// want to ignore any candidates in ubuntu-core and
 		// simply go with those from the new core snap.
-		candSlots = filterUbuntuCoreSlots(candSlots)
+		candSlots, arities = filterUbuntuCoreSlots(candSlots, arities)
 
 		applicable := candSlots
 		// candidate arity check
-		if len(candSlots) != 1 {
-			applicable = nil
+		for _, arity := range arities {
+			if !arity.SlotsPerPlugAny() {
+				// ATM not any (*) => none or exactly one
+				if len(candSlots) != 1 {
+					applicable = nil
+				}
+				break
+			}
 		}
 
 		if filter != nil {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -7061,3 +7061,195 @@ func (s *interfaceManagerSuite) TestTransitionConnectionsCoreMigration(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(repoConns, HasLen, 0)
 }
+
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlugPlugSide(c *C) {
+	s.MockModel(c, nil)
+
+	// the producer snap
+	s.MockSnapDecl(c, "theme1", "one-publisher", nil)
+
+	// 2nd producer snap
+	s.MockSnapDecl(c, "theme2", "one-publisher", nil)
+
+	// the consumer
+	s.MockSnapDecl(c, "theme-consumer", "one-publisher", map[string]interface{}{
+		"format": "1",
+		"plugs": map[string]interface{}{
+			"content": map[string]interface{}{
+				"allow-auto-connection": map[string]interface{}{
+					"slots-per-plug": "*",
+				},
+			},
+		},
+	})
+
+	check := func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+		c.Check(repoConns, HasLen, 2)
+
+		c.Check(conns, DeepEquals, map[string]interface{}{
+			"theme-consumer:plug theme1:slot": map[string]interface{}{
+				"auto":        true,
+				"interface":   "content",
+				"plug-static": map[string]interface{}{"content": "themes"},
+				"slot-static": map[string]interface{}{"content": "themes"},
+			},
+			"theme-consumer:plug theme2:slot": map[string]interface{}{
+				"auto":        true,
+				"interface":   "content",
+				"plug-static": map[string]interface{}{"content": "themes"},
+				"slot-static": map[string]interface{}{"content": "themes"},
+			},
+		})
+	}
+
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c, check)
+}
+
+func (s *interfaceManagerSuite) testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c *C, check func(map[string]interface{}, []*interfaces.ConnRef)) {
+	const theme1Yaml = `
+name: theme1
+version: 1
+slots:
+  slot:
+    interface: content
+    content: themes
+`
+	s.mockSnap(c, theme1Yaml)
+	const theme2Yaml = `
+name: theme2
+version: 1
+slots:
+  slot:
+    interface: content
+    content: themes
+`
+	s.mockSnap(c, theme2Yaml)
+
+	mgr := s.manager(c)
+
+	const themeConsumerYaml = `
+name: theme-consumer
+version: 1
+plugs:
+  plug:
+    interface: content
+    content: themes
+`
+	snapInfo := s.mockSnap(c, themeConsumerYaml)
+
+	// Run the setup-snap-security task and let it finish.
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			SnapID:   snapInfo.SnapID,
+			Revision: snapInfo.Revision,
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	var conns map[string]interface{}
+	_ = s.state.Get("conns", &conns)
+
+	repo := mgr.Repository()
+	plug := repo.Plug("theme-consumer", "plug")
+	c.Assert(plug, Not(IsNil))
+
+	check(conns, repo.Interfaces().Connections)
+}
+
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlugSlotSide(c *C) {
+	s.MockModel(c, nil)
+
+	// the producer snap
+	s.MockSnapDecl(c, "theme1", "one-publisher", map[string]interface{}{
+		"format": "1",
+		"slots": map[string]interface{}{
+			"content": map[string]interface{}{
+				"allow-auto-connection": map[string]interface{}{
+					"slots-per-plug": "*",
+				},
+			},
+		},
+	})
+
+	// 2nd producer snap
+	s.MockSnapDecl(c, "theme2", "one-publisher", map[string]interface{}{
+		"format": "1",
+		"slots": map[string]interface{}{
+			"content": map[string]interface{}{
+				"allow-auto-connection": map[string]interface{}{
+					"slots-per-plug": "*",
+				},
+			},
+		},
+	})
+
+	// the consumer
+	s.MockSnapDecl(c, "theme-consumer", "one-publisher", nil)
+
+	check := func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+		c.Check(repoConns, HasLen, 2)
+
+		c.Check(conns, DeepEquals, map[string]interface{}{
+			"theme-consumer:plug theme1:slot": map[string]interface{}{
+				"auto":        true,
+				"interface":   "content",
+				"plug-static": map[string]interface{}{"content": "themes"},
+				"slot-static": map[string]interface{}{"content": "themes"},
+			},
+			"theme-consumer:plug theme2:slot": map[string]interface{}{
+				"auto":        true,
+				"interface":   "content",
+				"plug-static": map[string]interface{}{"content": "themes"},
+				"slot-static": map[string]interface{}{"content": "themes"},
+			},
+		})
+	}
+
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c, check)
+}
+
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlugAmbiguity(c *C) {
+	s.MockModel(c, nil)
+
+	// the producer snap
+	s.MockSnapDecl(c, "theme1", "one-publisher", map[string]interface{}{
+		"format": "1",
+		"slots": map[string]interface{}{
+			"content": map[string]interface{}{
+				"allow-auto-connection": map[string]interface{}{
+					"slots-per-plug": "*",
+				},
+			},
+		},
+	})
+
+	// 2nd producer snap
+	s.MockSnapDecl(c, "theme2", "one-publisher", map[string]interface{}{
+		"format": "1",
+		"slots": map[string]interface{}{
+			"content": map[string]interface{}{
+				"allow-auto-connection": map[string]interface{}{
+					"slots-per-plug": "1",
+				},
+			},
+		},
+	})
+
+	// the consumer
+	s.MockSnapDecl(c, "theme-consumer", "one-publisher", nil)
+
+	check := func(conns map[string]interface{}, repoConns []*interfaces.ConnRef) {
+		// slots-per-plug were ambigous, nothing was connected
+		c.Check(repoConns, HasLen, 0)
+		c.Check(conns, HasLen, 0)
+	}
+
+	s.testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c, check)
+}


### PR DESCRIPTION
Support for `slots-per-plug: *

See https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
