### PR TITLE
tests: do not use lsblk in uc20-snap-recovery test

### DIFF
--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -36,11 +36,12 @@ execute: |
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '1M\s+BIOS boot'
     sfdisk -l "$LOOP" | MATCH '50M\s+EFI System'
-    # lsblk is unreliable here for some reason
+    # "lsblk --fs" is unrelaible here
     mkdir -p ./mnt
     mount "${LOOP}p2" ./mnt
     df -T "${LOOP}p2" | MATCH vfat
     umount ./mnt
+    file -s "${LOOP}p2" | MATCH 'label: "system-boot"'
 
     echo "now add a partition"
     cat >> gadget-dir/meta/gadget.yaml <<EOF
@@ -58,3 +59,4 @@ execute: |
     mount "${LOOP}p3" ./mnt
     df -T "${LOOP}p3" | MATCH ext4
     umount ./mnt
+    file -s "${LOOP}p2" | MATCH 'volume name "other-ext4"'

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -36,7 +36,7 @@ execute: |
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '1M\s+BIOS boot'
     sfdisk -l "$LOOP" | MATCH '50M\s+EFI System'
-    # "lsblk --fs" is unrelaible here
+    # we used "lsblk --fs" here but it was unreliable
     mkdir -p ./mnt
     mount "${LOOP}p2" ./mnt
     df -T "${LOOP}p2" | MATCH vfat
@@ -59,4 +59,4 @@ execute: |
     mount "${LOOP}p3" ./mnt
     df -T "${LOOP}p3" | MATCH ext4
     umount ./mnt
-    file -s "${LOOP}p2" | MATCH 'volume name "other-ext4"'
+    file -s "${LOOP}p3" | MATCH 'volume name "other-ext4"'

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -3,6 +3,9 @@ summary: Integration tests for the snap-recovery binary
 # one system is enough, its a very specialized test for now
 systems: [ubuntu-18.04-64]
 
+debug: |
+    cat /proc/partitions
+
 restore: |
     if [ -f loop.txt ]; then
         losetup -d "$(cat loop.txt)"
@@ -33,8 +36,11 @@ execute: |
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '1M\s+BIOS boot'
     sfdisk -l "$LOOP" | MATCH '50M\s+EFI System'
-    # add a very small delay here until udev(?) has caught up
-    retry-tool lsblk --fs "$LOOP" | MATCH 'vfat\s* system-boot'
+    # lsblk is unreliable here for some reason
+    mkdir -p ./mnt
+    mount "${LOOP}p2" ./mnt
+    df -T "${LOOP}p2" | MATCH vfat
+    umount ./mnt
 
     echo "now add a partition"
     cat >> gadget-dir/meta/gadget.yaml <<EOF
@@ -48,5 +54,7 @@ execute: |
     sfdisk -l "$LOOP" | MATCH '500M\s* Linux filesystem'
 
     echo "check that the filesystems are created"
-    # add a very small delay here until udev(?) has caught up
-    retry-tool lsblk --fs "$LOOP" | MATCH 'ext4\s* other-ext'
+    mkdir -p ./mnt
+    mount "${LOOP}p3" ./mnt
+    df -T "${LOOP}p3" | MATCH ext4
+    umount ./mnt


### PR DESCRIPTION
It seems like lsblk is not reliable in the tests. It's not entirely
clear why because AFAICT the filesystems are created correctly.

This PR changes the test to mount the filesystems directly instead
of using lsblk which hopefully fixes this unreliable test.
