### PR TITLE
interfaces: allow introspecting network-manager on core

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -294,7 +294,7 @@ dbus (receive, send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-const networkManagerSendIntrospectionSnippet = `
+const networkManagerConnectedPlugIntrospectionSnippet = `
 # Allow us to introspect the network-manager providing snap
 dbus (send)
     bus=system
@@ -303,7 +303,7 @@ dbus (send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-const networkManagerRecvIntrospectionSnippet = `
+const networkManagerConnectedSlotIntrospectionSnippet = `
 # Allow plugs to introspect us
 dbus (receive)
     bus=system
@@ -501,7 +501,7 @@ func (iface *networkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	spec.AddSnippet(snippet)
 	if !release.OnClassic {
 		// See https://bugs.launchpad.net/snapd/+bug/1849291 for details.
-		snippet := strings.Replace(networkManagerSendIntrospectionSnippet, old, new, -1)
+		snippet := strings.Replace(networkManagerConnectedPlugIntrospectionSnippet, old, new, -1)
 		spec.AddSnippet(snippet)
 	}
 	return nil
@@ -514,7 +514,7 @@ func (iface *networkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Speci
 	spec.AddSnippet(snippet)
 	if !release.OnClassic {
 		// See https://bugs.launchpad.net/snapd/+bug/1849291 for details.
-		snippet := strings.Replace(networkManagerRecvIntrospectionSnippet, old, new, -1)
+		snippet := strings.Replace(networkManagerConnectedSlotIntrospectionSnippet, old, new, -1)
 		spec.AddSnippet(snippet)
 	}
 	return nil

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -294,6 +294,24 @@ dbus (receive, send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
+const networkManagerSendIntrospectionSnippet = `
+# Allow us to introspect the network-manager providing snap
+dbus (send)
+    bus=system
+    interface="org.freedesktop.DBus.Introspectable"
+    member="Introspect"
+    peer=(label=###SLOT_SECURITY_TAGS###),
+`
+
+const networkManagerRecvIntrospectionSnippet = `
+# Allow plugs to introspect us
+dbus (receive)
+    bus=system
+    interface="org.freedesktop.DBus.Introspectable"
+    member="Introspect"
+    peer=(label=###PLUG_SECURITY_TAGS###),
+`
+
 const networkManagerConnectedPlugSecComp = `
 # Description: This is needed to talk to the network-manager service
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
@@ -481,6 +499,11 @@ func (iface *networkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	}
 	snippet := strings.Replace(networkManagerConnectedPlugAppArmor, old, new, -1)
 	spec.AddSnippet(snippet)
+	if !release.OnClassic {
+		// See https://bugs.launchpad.net/snapd/+bug/1849291 for details.
+		snippet := strings.Replace(networkManagerSendIntrospectionSnippet, old, new, -1)
+		spec.AddSnippet(snippet)
+	}
 	return nil
 }
 
@@ -489,6 +512,11 @@ func (iface *networkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Speci
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(networkManagerConnectedSlotAppArmor, old, new, -1)
 	spec.AddSnippet(snippet)
+	if !release.OnClassic {
+		// See https://bugs.launchpad.net/snapd/+bug/1849291 for details.
+		snippet := strings.Replace(networkManagerRecvIntrospectionSnippet, old, new, -1)
+		spec.AddSnippet(snippet)
+	}
 	return nil
 }
 

--- a/interfaces/builtin/network_manager_test.go
+++ b/interfaces/builtin/network_manager_test.go
@@ -158,6 +158,42 @@ func (s *NetworkManagerInterfaceSuite) TestConnectedPlugSnippedUsesUnconfinedLab
 	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), testutil.Contains, "peer=(label=unconfined),")
 }
 
+func (s *NetworkManagerInterfaceSuite) TestConnectedPlugIntrospectionOnCore(c *C) {
+	release.OnClassic = false
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager-client.nmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), testutil.Contains, "Allow us to introspect the network-manager providing snap")
+}
+
+func (s *NetworkManagerInterfaceSuite) TestConnectedSlotIntrospectionOnCore(c *C) {
+	release.OnClassic = false
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager.nm"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager.nm"), testutil.Contains, "# Allow plugs to introspect us")
+}
+
+func (s *NetworkManagerInterfaceSuite) TestConnectedPlugIntrospectionOnClassic(c *C) {
+	release.OnClassic = true
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager-client.nmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), Not(testutil.Contains), "Allow us to introspect the network-manager providing snap")
+}
+
+func (s *NetworkManagerInterfaceSuite) TestConnectedSlotIntrospectionOnClassic(c *C) {
+	release.OnClassic = true
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager.nm"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager.nm"), Not(testutil.Contains), "# Allow plugs to introspect us")
+}
+
 func (s *NetworkManagerInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.slot)


### PR DESCRIPTION
We were alerted about a program that fails to work on core systems, with
the network-manager plug connected, because said program used
introspection to discover the available DBus methods.

Introspection was not a part of the network manager interface before.
After discussion with security is is now conditionally added on core
systems only, where the peer is scoped to a snap.pkg.app label that
pinpoints a specific snap. On classic system that would be unavoidably
"unconfined" where it would apply to all the classic services.

Fixes: https://bugs.launchpad.net/snapd/+bug/1849291
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
