### PR TITLE
tests: verify host is not affected by mount-ns tests

### DIFF
--- a/tests/main/mount-ns/google.ubuntu-core-16-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-16-64/HOST.expected.txt
@@ -63,7 +63,6 @@
 2:5 / /run rw,nosuid,noexec,relatime shared:57 - tmpfs tmpfs rw,mode=755
 2:11 / /run/cgmanager/fs rw,relatime shared:58 - tmpfs cgmfs rw,size=VARIABLE,mode=755
 2:12 / /run/lock rw,nosuid,nodev,noexec,relatime shared:59 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
 2:13 / /run/user/0 rw,nosuid,nodev,relatime shared:60 - tmpfs tmpfs rw,size=VARIABLE,mode=700
 1:1 /system-data/snap /snap rw,relatime shared:15 - ext4 /dev/sda3 rw,data=ordered
 0:2 / /snap/core/1 ro,nodev,relatime shared:61 - squashfs /dev/loop2 ro

--- a/tests/main/mount-ns/google.ubuntu-core-18-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-core-18-64/HOST.expected.txt
@@ -40,7 +40,6 @@
 2:10 / /run rw,nosuid,noexec,relatime shared:34 - tmpfs tmpfs rw,size=VARIABLE,mode=755
 2:5 / /run rw,nosuid,noexec,relatime shared:35 - tmpfs tmpfs rw,mode=755
 2:11 / /run/lock rw,nosuid,nodev,noexec,relatime shared:36 - tmpfs tmpfs rw,size=VARIABLE
-2:10 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=VARIABLE,mode=755
 2:12 / /run/user/0 rw,nosuid,nodev,relatime shared:37 - tmpfs tmpfs rw,size=VARIABLE,mode=700
 1:1 /system-data/snap /snap rw,relatime shared:13 - ext4 /dev/sda3 rw,data=ordered
 0:2 / /snap/core/1 ro,nodev,relatime shared:38 - squashfs /dev/loop2 ro

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -127,7 +127,11 @@ prepare: |
     snap connect test-snapd-mountinfo-core16:mount-observe
     snap connect test-snapd-mountinfo-core18:mount-observe
 
-    echo "Collect mountinfo from the host"
+    echo "Collect mountinfo from the host before the test"
+    echo "but make sure that persistent mount namespaces don't clobber the output"
+    if mountinfo-tool /run/snapd/ns; then
+        umount /run/snapd/ns
+    fi
     cat /proc/self/mountinfo >HOST.raw.txt
 
     if snap debug sandbox-features --required confinement-options:classic; then
@@ -144,6 +148,14 @@ prepare: |
     su root -c "snap run test-snapd-mountinfo-core18" >PER-SNAP-18.raw.txt
     su test -c "snap run test-snapd-mountinfo-core18" >PER-USER-18.raw.txt
 
+    echo "Collect mountinfo from the host after the test"
+    echo "but make sure that persistent mount namespaces don't clobber the output"
+    snap-tool snap-discard-ns test-snapd-mountinfo-classic
+    snap-tool snap-discard-ns test-snapd-mountinfo-core16
+    snap-tool snap-discard-ns test-snapd-mountinfo-core18
+    umount /run/snapd/ns
+    cat /proc/self/mountinfo >HOST-AFTER.raw.txt
+
     echo "Transform mountinfo tables to make them deterministic"
     deterministic-mountinfo-tool                                              -f HOST.raw.txt        >HOST.deterministic.txt
     deterministic-mountinfo-tool --ref HOST.raw.txt                           -f PER-SNAP-16.raw.txt >PER-SNAP-16.deterministic.txt
@@ -154,6 +166,7 @@ prepare: |
         deterministic-mountinfo-tool --ref HOST.raw.txt                           -f PER-SNAP-C7.raw.txt >PER-SNAP-C7.deterministic.txt
         deterministic-mountinfo-tool --ref HOST.raw.txt --ref PER-SNAP-C7.raw.txt -f PER-USER-C7.raw.txt >PER-USER-C7.deterministic.txt
     fi
+    deterministic-mountinfo-tool                                              -f HOST-AFTER.raw.txt  >HOST-AFTER.deterministic.txt
 
     if snap debug sandbox-features --required confinement-options:classic; then
         snap remove test-snapd-mountinfo-classic
@@ -165,6 +178,8 @@ execute: |
         exit 0
     fi
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/HOST.expected.txt" HOST.deterministic.txt
+    # The before and after host files should be identical.
+    diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/HOST.expected.txt" HOST-AFTER.deterministic.txt
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/PER-SNAP-16.expected.txt" PER-SNAP-16.deterministic.txt
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/PER-USER-16.expected.txt" PER-USER-16.deterministic.txt
     diff -u "$SPREAD_BACKEND.$SPREAD_SYSTEM/PER-SNAP-18.expected.txt" PER-SNAP-18.deterministic.txt


### PR DESCRIPTION
The mount-ns test performs a set of measurements to mount namespaces.
The test is structured so that the host is measured first, followed by a
number of per-snap and per-user mount namespaces.

What the test doesn't do though, is to check that the test has not
affected the host in any way. This patch closes that loophole.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
