### PR TITLE
snap: fix default-provider in seed validation

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -955,11 +955,15 @@ func ValidateSystemUsernames(info *Info) error {
 // neededDefaultProviders returns the names of all default-providers for
 // the content plugs that the given snap.Info needs.
 func NeededDefaultProviders(info *Info) (cps []string) {
+	// XXX: unify with the other places that parse default-providers
 	for _, plug := range info.Plugs {
 		if plug.Interface == "content" {
 			var dprovider string
 			if err := plug.Attr("default-provider", &dprovider); err == nil && dprovider != "" {
-				cps = append(cps, dprovider)
+				// usage can be "snap:slot" but we only check
+				// the snap here
+				name := strings.Split(dprovider, ":")[0]
+				cps = append(cps, name)
 			}
 		}
 	}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1592,6 +1592,23 @@ func (s *ValidateSuite) TestNeededDefaultProviders(c *C) {
 	c.Check(dps, DeepEquals, []string{"gtk-common-themes"})
 }
 
+const yamlNeedDfWithSlot = `name: need-df
+version: 1.0
+plugs:
+  gtk-3-themes:
+    interface: content
+    default-provider: gtk-common-themes2:with-slot
+`
+
+func (s *ValidateSuite) TestNeededDefaultProvidersLegacyColonSyntax(c *C) {
+	strk := NewScopedTracker()
+	info, err := InfoFromSnapYamlWithSideInfo([]byte(yamlNeedDfWithSlot), nil, strk)
+	c.Assert(err, IsNil)
+
+	dps := NeededDefaultProviders(info)
+	c.Check(dps, DeepEquals, []string{"gtk-common-themes2"})
+}
+
 func (s *validateSuite) TestValidateSnapMissingCore(c *C) {
 	const yaml = `name: some-snap
 version: 1.0`


### PR DESCRIPTION
The default-provider can have the form of: <snap>:<slot>. This is
currently not understood by the seed validation code. This PR
adds a minimal fix for this.

We need to get back to this and unify all the functions that parse
the default-provider string in a followup.
