### PR TITLE
snap/snapenv: preserve XDG_RUNTIME_DIR for classic confinement

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -43,6 +43,8 @@ const (
 	PerUserMountNamespace
 	// RefreshAppAwareness controls refresh being aware of running applications.
 	RefreshAppAwareness
+	// ClassicPreservesXdgRuntimeDir controls $XDG_RUNTIME_DIR in snaps with classic confinement.
+	ClassicPreservesXdgRuntimeDir
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -65,6 +67,8 @@ var featureNames = map[SnapdFeature]string{
 	SnapdSnap:             "snapd-snap",
 	PerUserMountNamespace: "per-user-mount-namespace",
 	RefreshAppAwareness:   "refresh-app-awareness",
+
+	ClassicPreservesXdgRuntimeDir: "classic-preserves-xdg-runtime-dir",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
@@ -77,6 +81,8 @@ var featuresExported = map[SnapdFeature]bool{
 	PerUserMountNamespace: true,
 	RefreshAppAwareness:   true,
 	ParallelInstances:     true,
+
+	ClassicPreservesXdgRuntimeDir: true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -43,6 +43,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.SnapdSnap.String(), Equals, "snapd-snap")
 	c.Check(features.PerUserMountNamespace.String(), Equals, "per-user-mount-namespace")
 	c.Check(features.RefreshAppAwareness.String(), Equals, "refresh-app-awareness")
+	c.Check(features.ClassicPreservesXdgRuntimeDir.String(), Equals, "classic-preserves-xdg-runtime-dir")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 
@@ -63,6 +64,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.ParallelInstances.IsExported(), Equals, true)
 	c.Check(features.PerUserMountNamespace.IsExported(), Equals, true)
 	c.Check(features.RefreshAppAwareness.IsExported(), Equals, true)
+	c.Check(features.ClassicPreservesXdgRuntimeDir.IsExported(), Equals, true)
 }
 
 func (*featureSuite) TestIsEnabled(c *C) {
@@ -91,6 +93,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.SnapdSnap.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.PerUserMountNamespace.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.RefreshAppAwareness.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, false)
 }
 
 func (*featureSuite) TestControlFile(c *C) {

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -129,11 +129,11 @@ func userEnv(info *snap.Info, home string) map[string]string {
 	result := map[string]string{
 		"SNAP_USER_COMMON": info.UserCommonDataDir(home),
 		"SNAP_USER_DATA":   info.UserDataDir(home),
-		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(sys.Geteuid()),
 	}
 	// For non-classic snaps, we set HOME but on classic allow snaps to see real HOME
 	if !info.NeedsClassic() {
 		result["HOME"] = info.UserDataDir(home)
+		result["XDG_RUNTIME_DIR"] = info.UserXdgRuntimeDir(sys.Geteuid())
 	}
 	return result
 }

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/snap"
 )
@@ -130,8 +131,15 @@ func userEnv(info *snap.Info, home string) map[string]string {
 		"SNAP_USER_COMMON": info.UserCommonDataDir(home),
 		"SNAP_USER_DATA":   info.UserDataDir(home),
 	}
-	// For non-classic snaps, we set HOME but on classic allow snaps to see real HOME
-	if !info.NeedsClassic() {
+	if info.NeedsClassic() {
+		// Snaps using classic confinement don't have an override for
+		// HOME but may have an override for XDG_RUNTIME_DIR.
+		if !features.ClassicPreservesXdgRuntimeDir.IsEnabled() {
+			result["XDG_RUNTIME_DIR"] = info.UserXdgRuntimeDir(sys.Geteuid())
+		}
+	} else {
+		// Snaps using strict or devmode confinement get an override for both
+		// HOME and XDG_RUNTIME_DIR.
 		result["HOME"] = info.UserDataDir(home)
 		result["XDG_RUNTIME_DIR"] = info.UserXdgRuntimeDir(sys.Geteuid())
 	}

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -258,7 +258,7 @@ func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
 	c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0644), IsNil)
 	env = userEnv(&info, "/root")
 	c.Assert(env, DeepEquals, map[string]string{
-		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
+		// NOTE: Both HOME and XDG_RUNTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
 		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
 	})

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -130,7 +130,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 	c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0644), IsNil)
 	env = userEnv(mockClassicSnapInfo, "/root")
 	c.Assert(env, DeepEquals, map[string]string{
-		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
+		// NOTE: Both HOME and XDG_RUNTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 	})

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -118,7 +118,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 	// per-user environment contains an override for XDG_RUNTIME_DIR.
 	env := userEnv(mockClassicSnapInfo, "/root")
 	c.Assert(env, DeepEquals, map[string]string{
-		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
+		// NOTE: Both HOME and XDG_RUNTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf(dirs.GlobalRootDir+"/run/user/%d/snap.foo", sys.Geteuid()),

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -111,10 +111,9 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 	env := userEnv(mockClassicSnapInfo, "/root")
 
 	c.Assert(env, DeepEquals, map[string]string{
-		// NOTE HOME Is absent! we no longer override it
+		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", sys.Geteuid()),
 	})
 }
 
@@ -222,10 +221,8 @@ func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
 	env := userEnv(&info, "/root")
 
 	c.Assert(env, DeepEquals, map[string]string{
-		// NOTE HOME Is absent! we no longer override it
 		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
 		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
-		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo_bar", sys.Geteuid()),
 	})
 }
 

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -21,6 +21,7 @@ package snapenv
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"strings"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -108,13 +110,31 @@ func (ts *HTestSuite) TestUser(c *C) {
 }
 
 func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
-	env := userEnv(mockClassicSnapInfo, "/root")
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
 
+	// With the classic-preserves-xdg-runtime-dir feature disabled the snap
+	// per-user environment contains an override for XDG_RUNTIME_DIR.
+	env := userEnv(mockClassicSnapInfo, "/root")
+	c.Assert(env, DeepEquals, map[string]string{
+		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
+		"SNAP_USER_COMMON": "/root/snap/foo/common",
+		"SNAP_USER_DATA":   "/root/snap/foo/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf(dirs.GlobalRootDir+"/run/user/%d/snap.foo", sys.Geteuid()),
+	})
+
+	// With the classic-preserves-xdg-runtime-dir feature enabled the snap
+	// per-user environment contains no overrides for XDG_RUNTIME_DIR.
+	f := features.ClassicPreservesXdgRuntimeDir
+	c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0644), IsNil)
+	env = userEnv(mockClassicSnapInfo, "/root")
 	c.Assert(env, DeepEquals, map[string]string{
 		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 	})
+
 }
 
 func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
@@ -216,11 +236,29 @@ func (ts *HTestSuite) TestParallelInstallUser(c *C) {
 }
 
 func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
+
 	info := *mockClassicSnapInfo
 	info.InstanceKey = "bar"
-	env := userEnv(&info, "/root")
 
+	// With the classic-preserves-xdg-runtime-dir feature disabled the snap
+	// per-user environment contains an override for XDG_RUNTIME_DIR.
+	env := userEnv(&info, "/root")
 	c.Assert(env, DeepEquals, map[string]string{
+		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
+		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf(dirs.GlobalRootDir+"/run/user/%d/snap.foo_bar", sys.Geteuid()),
+	})
+
+	// With the classic-preserves-xdg-runtime-dir feature enabled the snap
+	// per-user environment contains no overrides for XDG_RUNTIME_DIR.
+	f := features.ClassicPreservesXdgRuntimeDir
+	c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0644), IsNil)
+	env = userEnv(&info, "/root")
+	c.Assert(env, DeepEquals, map[string]string{
+		// NOTE: Both HOME and XDG_RUMTIME_DIR are not defined here.
 		"SNAP_USER_COMMON": "/root/snap/foo_bar/common",
 		"SNAP_USER_DATA":   "/root/snap/foo_bar/17",
 	})


### PR DESCRIPTION
Snaps using classic confinement should not get a custom XDG_RUNTIME_DIR.
This breaks, for example, Wayland and High-DPI scaling support.

Forum: https://forum.snapcraft.io/t/classic-confinement-breaks-high-dpi-support/13868
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
