### PR TITLE
packaging: tweak handling of usr.lib.snapd.snap-confine

### DIFF
--- a/packaging/ubuntu-14.04/snapd.maintscript
+++ b/packaging/ubuntu-14.04/snapd.maintscript
@@ -1,1 +1,5 @@
-../ubuntu-16.04/snapd.maintscript
+# we used to ship a custom grub config that is no longer needed
+rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
+rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
+# on trusty /etc/apparmor.d/usr.lib.snapd.snap-confine was never renamed
+# so we don't need to handle this file here (unlike in xenial+)

--- a/packaging/ubuntu-16.04/snap-confine.maintscript
+++ b/packaging/ubuntu-16.04/snap-confine.maintscript
@@ -1,1 +1,1 @@
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~

--- a/packaging/ubuntu-16.04/snap-confine.maintscript
+++ b/packaging/ubuntu-16.04/snap-confine.maintscript
@@ -1,1 +1,1 @@
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine

--- a/packaging/ubuntu-16.04/snapd.maintscript
+++ b/packaging/ubuntu-16.04/snapd.maintscript
@@ -3,3 +3,4 @@
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
 rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~ snap-confine
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine

--- a/packaging/ubuntu-16.04/snapd.maintscript
+++ b/packaging/ubuntu-16.04/snapd.maintscript
@@ -2,5 +2,4 @@
 # we used to ship a custom grub config that is no longer needed
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~ snap-confine
-rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~

--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -39,6 +39,16 @@ case "$1" in
             done
         fi
 
+        # In commit 0dce4704a5d (2017-03-28, snapd v2.23.6) we renamed
+        # /etc/apparmor.d/usr.lib.snap-confine to usr.lib.snap-confine.real
+        # to fix LP: #1673247 - however some people (developers?) still have
+        # the old usr.lib.snap-confine file. This seems to be loaded instead
+        # of the correct usr.lib.snap-confine.real profile. To fix this we
+        # use the rather blunt approach to rename the file forcefully.
+        if test -f /etc/apparmor.d/usr.lib.snapd.snap-confine && test -f /etc/apparmor.d/usr.lib.snapd.snap-confine.real; then
+            mv /etc/apparmor.d/usr.lib.snapd.snap-confine /etc/apparmor.d/usr.lib.snapd.snap-confine.dpkg-bak
+        fi
+
         # Ensure that the void directory has correct permissions.
         chmod 111 /var/lib/snapd/void
 esac

--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -39,16 +39,6 @@ case "$1" in
             done
         fi
 
-        # In commit 0dce4704a5d (2017-03-28, snapd v2.23.6) we renamed
-        # /etc/apparmor.d/usr.lib.snap-confine to usr.lib.snap-confine.real
-        # to fix LP: #1673247 - however some people (upgrades?) still have
-        # the old usr.lib.snap-confine file. This seems to be loaded instead
-        # of the correct usr.lib.snap-confine.real profile. To fix this we
-        # use the rather blunt approach to remove the file forcefully.
-        if test -f /etc/apparmor.d/usr.lib.snapd.snap-confine && test -f /etc/apparmor.d/usr.lib.snapd.snap-confine.real; then
-            rm -f /etc/apparmor.d/usr.lib.snapd.snap-confine
-        fi
-
         # Ensure that the void directory has correct permissions.
         chmod 111 /var/lib/snapd/void
 esac


### PR DESCRIPTION
This PR switches the code to use dpkg-maintscript-helper to deal
with usr.lib.snapd.snap-confine. Technically it's a dpkg conffile
(even though I think that is a mistake) so we should let the
dpkg tools handle it. This PR tweaks the call to try to remove it
regardless of version, it can cause quite a bit of harm to have
it, e.g. https://forum.snapcraft.io/t/13132

If it is acceptable to foundations I would like to unconditionally
rename it to ".dpkg-bak" but it's (technically) a violation of
the policy.

Note that this is tested in the tests/main/upgrade-from-2.15
spread test.