### PR TITLE
interfaces: simplify AddUpdateNS and emit

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -95,11 +95,9 @@ func (spec *Specification) AddUpdateNS(snippet string) {
 	spec.updateNS.Put(snippet)
 }
 
-// EmitUpdateNSFunc returns a function for emitting update-ns snippets.
-func (spec *Specification) EmitUpdateNSFunc() func(f string, args ...interface{}) {
-	return func(f string, args ...interface{}) {
-		spec.AddUpdateNS(fmt.Sprintf(f, args...))
-	}
+// AddUpdateNSf formats and adds a new apparmor snippet for the snap-update-ns program.
+func (spec *Specification) AddUpdateNSf(f string, args ...interface{}) {
+	spec.AddUpdateNS(fmt.Sprintf(f, args...))
 }
 
 // UpdateNSIndexOf returns the index of a previously added snippet.
@@ -158,7 +156,7 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 		sort.Strings(spec.snippets[tag])
 	}
 
-	emit := spec.EmitUpdateNSFunc()
+	emit := spec.AddUpdateNSf
 
 	// Append update-ns snippets that allow constructing the layout.
 	for _, path := range paths {

--- a/interfaces/builtin/appstream_metadata.go
+++ b/interfaces/builtin/appstream_metadata.go
@@ -75,7 +75,7 @@ func (iface *appstreamMetadataInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	spec.AddSnippet(appstreamMetadataConnectedPlugAppArmor)
 
 	// Generate rules to allow snap-update-ns to do its thing
-	emit := spec.EmitUpdateNSFunc()
+	emit := spec.AddUpdateNSf
 	for _, target := range appstreamMetadataDirs {
 		source := "/var/lib/snapd/hostfs" + target
 		emit("  # Read-only access to %s\n", target)

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -214,7 +214,7 @@ func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, 
 func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	contentSnippet := bytes.NewBuffer(nil)
 	writePaths := iface.path(slot, "write")
-	emit := spec.EmitUpdateNSFunc()
+	emit := spec.AddUpdateNSf
 	if len(writePaths) > 0 {
 		fmt.Fprintf(contentSnippet, `
 # In addition to the bind mount, add any AppArmor rules so that

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -231,7 +231,7 @@ func (iface *desktopInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 	spec.AddSnippet(desktopConnectedPlugAppArmor)
 
 	// Allow mounting document portal
-	emit := spec.EmitUpdateNSFunc()
+	emit := spec.AddUpdateNSf
 	emit("  # Mount the document portal\n")
 	emit("  mount options=(bind) /run/user/[0-9]*/doc/by-app/snap.%s/ -> /run/user/[0-9]*/doc/,\n", plug.Snap().InstanceName())
 	emit("  umount /run/user/[0-9]*/doc/,\n\n")


### PR DESCRIPTION
The emit function is like printf - taking a format string and argument
list. The AddUpdateNS function takes just a string. By adding
AddUpdateNSf we can remove glue code by matching the signatures.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
