### PR TITLE
tests: add 14.04 canonical-livepatch test

### DIFF
--- a/tests/main/canonical-livepatch-14.04/task.yaml
+++ b/tests/main/canonical-livepatch-14.04/task.yaml
@@ -9,6 +9,11 @@ description: |
 # livepatch works only on amd64 systems
 systems: [ubuntu-14.04-64]
 
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    distro_install_build_snapd
+
 execute: |
     echo "Keep a copy of the core snap with our latest snapd"
     cp /var/lib/snapd/snaps/core_*.snap .

--- a/tests/main/canonical-livepatch-14.04/task.yaml
+++ b/tests/main/canonical-livepatch-14.04/task.yaml
@@ -18,7 +18,7 @@ execute: |
     echo "Keep a copy of the core snap with our latest snapd"
     cp /var/lib/snapd/snaps/core_*.snap .
 
-    echo "And then install the snapd package from the trusty archvie"
+    echo "And then install the snapd package from the trusty archive"
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
     distro_purge_package snapd

--- a/tests/main/canonical-livepatch-14.04/task.yaml
+++ b/tests/main/canonical-livepatch-14.04/task.yaml
@@ -1,0 +1,36 @@
+summary: Ensure the canonical-livepatch snap works on 14.04
+
+description: |
+    This is a specific 14.04 test that ensure live-patch work
+    with a snapd that re-execs on 14.04. We don't regularly
+    update the deb on 14.04 anymore so we need to be sure that
+    re-exec is enough to run live-patch.
+
+# livepatch works only on amd64 systems
+systems: [ubuntu-14.04-64]
+
+execute: |
+    echo "Keep a copy of the core snap with our latest snapd"
+    cp /var/lib/snapd/snaps/core_*.snap .
+
+    echo "And then install the snapd package from the trusty archvie"
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    distro_purge_package snapd
+
+    echo "Install the snapd package from the trusty archive"
+    apt update
+    apt install snapd
+    snap install --dangerous ./core_*.snap
+
+    echo "Ensure snapd re-execs"
+    SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting into"
+    
+    echo "Ensure canonical-livepatch can be installed"
+    snap install canonical-livepatch
+
+    echo "Wait for it to respond"
+    retry-tool -n30 sh -c 'canonical-livepatch status 2>&1 | grep "Machine is not enabled"'
+
+    echo "And ensure we get the expected status"
+    canonical-livepatch status 2>&1 | MATCH "Machine is not enabled"

--- a/tests/main/canonical-livepatch/task.yaml
+++ b/tests/main/canonical-livepatch/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure canonical-livepatch snap works
 
-# livepatch works only on 16.04/18.04 amd64 systems
-systems: [ubuntu-16.04-64, ubuntu-18.04-64]
+# livepatch works only on LTS amd64 systems
+systems: [ubuntu-14.04-64, ubuntu-16.04-64, ubuntu-18.04-64]
 
 execute: |
     echo "Ensure canonical-livepatch can be installed"


### PR DESCRIPTION
This PR adds a new spread test that ensures that cannical-livepatch
works on 14.04 machines with re-exec and the snapd from the core
snap. We don't update the deb on 14.04 anymore but thanks to
re-exec 14.04 snapd is still fully up-to-date for people who
have the core snap installed. This PR ensures we don't break
this scenario.
