### PR TITLE
cmd/cmdutil: version helper

### DIFF
--- a/cmd/cmd_linux.go
+++ b/cmd/cmd_linux.go
@@ -77,8 +77,8 @@ func distroSupportsReExec() bool {
 // Ensure we do not use older version of snapd, look for info file and ignore
 // version of core that do not yet have it.
 func coreSupportsReExec(coreOrSnapdPath string) bool {
-	fullInfo := filepath.Join(coreOrSnapdPath, filepath.Join(dirs.CoreLibExecDir, "info"))
-	ver, err := cmdutil.SnapdVersionFromInfoFile(fullInfo)
+	infoPath := filepath.Join(coreOrSnapdPath, filepath.Join(dirs.CoreLibExecDir, "info"))
+	ver, err := cmdutil.SnapdVersionFromInfoFile(infoPath)
 	if err != nil {
 		logger.Noticef("%v", err)
 		return false

--- a/cmd/cmdutil/version.go
+++ b/cmd/cmdutil/version.go
@@ -22,16 +22,17 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
-
-	"github.com/snapcore/snapd/dirs"
 )
 
-func SnapdVersionFromInfoFile(rootDir string) (string, error) {
-	fullInfo := filepath.Join(rootDir, filepath.Join(dirs.CoreLibExecDir, "info"))
-	content, err := ioutil.ReadFile(fullInfo)
+// SnapdVersionFromInfoFile returns snapd version read for the
+// given info" file, pointed by infoPath.
+// The format of the "info" file is a single line with "VERSION=..."
+// in it. The file is produced by mkversion.sh and normally installed
+// along snapd binary in /usr/lib/snapd.
+func SnapdVersionFromInfoFile(infoPath string) (string, error) {
+	content, err := ioutil.ReadFile(infoPath)
 	if err != nil {
-		return "", fmt.Errorf("cannot open snapd info file %q: %s", fullInfo, err)
+		return "", fmt.Errorf("cannot open snapd info file %q: %s", infoPath, err)
 	}
 
 	if !bytes.HasPrefix(content, []byte("VERSION=")) {

--- a/cmd/cmdutil/version.go
+++ b/cmd/cmdutil/version.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package cmdutil
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+func SnapdVersionFromInfoFile(rootDir string) (string, error) {
+	fullInfo := filepath.Join(rootDir, filepath.Join(dirs.CoreLibExecDir, "info"))
+	content, err := ioutil.ReadFile(fullInfo)
+	if err != nil {
+		return "", fmt.Errorf("cannot open snapd info file %q: %s", fullInfo, err)
+	}
+
+	if !bytes.HasPrefix(content, []byte("VERSION=")) {
+		idx := bytes.Index(content, []byte("\nVERSION="))
+		if idx < 0 {
+			return "", fmt.Errorf("cannot find snapd version information in %q", content)
+		}
+		content = content[idx+1:]
+	}
+	content = content[8:]
+	idx := bytes.IndexByte(content, '\n')
+	if idx > -1 {
+		content = content[:idx]
+	}
+
+	return string(content), nil
+}

--- a/cmd/cmdutil/version_test.go
+++ b/cmd/cmdutil/version_test.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmdutil_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/cmdutil"
+)
+
+type versionSuite struct{}
+
+var _ = Suite(&versionSuite{})
+
+func (s *versionSuite) TestNoVersionFile(c *C) {
+	_, err := cmdutil.SnapdVersionFromInfoFile("/non-existing-file")
+	c.Assert(err, ErrorMatches, `cannot open snapd info file "/non-existing-file":.*`)
+}
+
+func (s *versionSuite) TestNoVersionData(c *C) {
+	top := c.MkDir()
+	infoFile := filepath.Join(top, "info")
+	c.Assert(ioutil.WriteFile(infoFile, []byte("foo"), 0644), IsNil)
+
+	_, err := cmdutil.SnapdVersionFromInfoFile(infoFile)
+	c.Assert(err, ErrorMatches, `cannot find snapd version information in "foo"`)
+}
+
+func (s *versionSuite) TestVersionHappy(c *C) {
+	top := c.MkDir()
+	infoFile := filepath.Join(top, "info")
+	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=1.2.3"), 0644), IsNil)
+
+	ver, err := cmdutil.SnapdVersionFromInfoFile(infoFile)
+	c.Assert(err, IsNil)
+	c.Check(ver, Equals, "1.2.3")
+}


### PR DESCRIPTION
Extract some of the code that reads VERSION info from coreSupportsReExec into a new helper function, the idea is to reuse this in version check in the pre-baking code.

Note: with this, there is a tiny change in error logging, it will now log any error related to reading version info - not sure if there was a good reason to log everything but os.IsNotExist.