### PR TITLE
tests: don't depend on GNU time

### DIFF
--- a/tests/lib/bin/memory-tool
+++ b/tests/lib/bin/memory-tool
@@ -1,0 +1,84 @@
+#!/usr/bin/env any-python
+from __future__ import print_function, absolute_import, unicode_literals
+
+import os
+import argparse
+
+
+# Define MYPY as False and use it as a conditional for typing import. Despite
+# this declaration mypy will really treat MYPY as True when type-checking.
+# This is required so that we can import typing on Python 2.x without the
+# typing module installed. For more details see:
+# https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+MYPY = False
+if MYPY:
+    from typing import List, Tuple, Text
+
+
+def invoke(cmd):
+    # type: (List[Text]) -> Tuple[int, int]
+    """
+    invoke invokes command and returns the pair (result, max_rss)
+
+    For normal termination result is >= 0 and conveys the exit code.
+    For abnormal termination result is < 0 and conveys the signal number.
+    """
+    pid = os.fork()
+    if pid == 0:
+        # child
+        os.execvpe(cmd[0], cmd, os.environ)
+        os.exit(127)
+    else:
+        # parent
+        _, wait_status, rusage = os.wait4(pid, 0)
+        if os.WIFEXITED(wait_status):
+            exit_code = os.WEXITSTATUS(wait_status)
+            return exit_code, rusage.ru_maxrss
+        elif os.WIFSIGNALED(wait_status):
+            sig_num = os.WTERMSIG(wait_status)
+            return -sig_num, rusage.ru_maxrss
+        else:
+            raise OSError("unexpected wait status {}".format(wait_status))
+
+
+def _make_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser(
+        description="""
+Memory-tool executes COMMAND and stores the maximum size of RSS
+into the specified file. The exit status of COMMAND is preserved.
+"""
+    )
+    parser.add_argument(
+        "-o", dest="output",
+        metavar="RSS-FILE",
+        type=argparse.FileType(mode="w"),
+        help="write maximum RSS size to given file",
+    )
+    parser.add_argument(
+        "cmd", metavar="COMMAND", nargs="...", help="command to execute"
+    )
+    return parser
+
+
+def main():
+    # type: () -> None
+    parser = _make_parser()
+    ns = parser.parse_args()
+    # The command cannot be empty but it is difficult to express in argparse
+    # itself.
+    if len(ns.cmd) == 0:
+        parser.print_usage()
+        parser.exit(0)
+    try:
+        result, max_rss = invoke(ns.cmd)
+        if ns.output is not None:
+            ns.output.write("{}\n".format(max_rss))
+            ns.output.close()
+        raise SystemExit(result)
+    except OSError as exc:
+        raise SystemExit(exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression/lp-1848567/task.yaml
+++ b/tests/regression/lp-1848567/task.yaml
@@ -17,14 +17,13 @@ prepare: |
   snap connect test-snapd-app:icon-themes test-snapd-gtk-common-themes:icon-themes
   snap connect test-snapd-app:sound-themes test-snapd-gtk-common-themes:sound-themes
 execute: |
-  # TODO: expand this test to install GNU time or find a suitable replacement.
-  if snap debug sandbox-features --required apparmor:kernel:mount && [ "$(command -v time)" != time ]; then
+  if snap debug sandbox-features --required apparmor:kernel:mount; then
     # Re-compile the apparmor profile for snap-update-ns for the
     # test-snapd-app snap while ensuring that the profile is not loaded
-    # into kernel memory and that the compiler is not using any existing caches.
-    # Use time(1) to record the maximum resident memory usage and store it in a
-    # file.
-    command time -o memory-kb.txt -f "%M" apparmor_parser \
+    # into kernel memory and that the compiler is not using any existing
+    # caches. Use memory-tool(1) to record the maximum resident memory usage
+    # and store it in a file.
+    memory-tool -o memory-kb.txt apparmor_parser \
       --skip-read-cache --skip-cache --skip-kernel-load -Ono-expr-simplify \
       /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-app
     # Without de-duplicating mount rules the compiler would take about 1.5GB on a


### PR DESCRIPTION
This branch contains two small patches that let us easily measure the maximum
RSS size of a process with a python helper.

This way we no longer have to special-case systems that don't have GNU time
installed. The single existing user of "time" is ported to use memory-tool
instead.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>