### PR TITLE
spread: enable bboozzoo/snapd-devel-deps COPR repo for getting golang-x-xerrors

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -505,6 +505,10 @@ prepare: |
         #
         # https://forum.snapcraft.io/t/issues-with-the-fedora-mirror-network/3489/
         sed -i -s -E -e 's@^#?baseurl=http://download.fedoraproject.org/@baseurl=http://dl.fedoraproject.org/@g' -e 's@^metalink=@#metalink@g' /etc/yum.repos.d/fedora*.repo
+
+        # TODO: disable once golang-x-xerrors is available in F30
+        dnf copr enable bboozzoo/snapd-devel-deps -y
+
         dnf --refresh -y makecache
 
         # enable audit daemon


### PR DESCRIPTION
The `golang-x-xerrors` package is available for Fedora 31 and later. While we have
filed a ticket https://bugzilla.redhat.com/show_bug.cgi?id=1764123 and reached
out the maintainers to get a build for Fedora 30 pushed to the repositories, it
may take a while for it to be resolved.

In the meantime, I've setup a COPR repo https://copr.fedorainfracloud.org/coprs/bboozzoo/snapd-devel-deps/ that contains the required dependency and could be used in future when similar issues appear.

cc @Conan-Kudo 

This will unblock #7645 and #7622 

