### PR TITLE
tests: tweak wording in mount-ns test

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -127,8 +127,8 @@ prepare: |
     snap connect test-snapd-mountinfo-core16:mount-observe
     snap connect test-snapd-mountinfo-core18:mount-observe
 
-    echo "Collect mountinfo from the host before the test"
-    echo "but make sure that persistent mount namespaces don't clobber the output"
+    echo "Collect mountinfo from the host before running apps"
+    # "make sure that persistent mount namespaces don't clobber the output"
     if mountinfo-tool /run/snapd/ns; then
         umount /run/snapd/ns
     fi
@@ -148,8 +148,8 @@ prepare: |
     su root -c "snap run test-snapd-mountinfo-core18" >PER-SNAP-18.raw.txt
     su test -c "snap run test-snapd-mountinfo-core18" >PER-USER-18.raw.txt
 
-    echo "Collect mountinfo from the host after the test"
-    echo "but make sure that persistent mount namespaces don't clobber the output"
+    echo "Collect mountinfo from the host after running apps"
+    # "make sure that persistent mount namespaces don't clobber the output"
     snap-tool snap-discard-ns test-snapd-mountinfo-classic
     snap-tool snap-discard-ns test-snapd-mountinfo-core16
     snap-tool snap-discard-ns test-snapd-mountinfo-core18


### PR DESCRIPTION
Ian observed that the "before and after running the test" messages are a
little misleading since they are both used in the prepare section.  They
really meant to indicate before and after running application programs.
This is adjusted now.

In addition Maciej indicated that the extra line about persistent mount
namespace is not necessary as echo and can be demoted to a comment.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
