### PR TITLE
overlord/patch: normalize tracking channel in state

### DIFF
--- a/overlord/patch/patch.go
+++ b/overlord/patch/patch.go
@@ -34,7 +34,7 @@ var Level = 6
 // Sublevel is the current implemented sublevel for the Level.
 // Sublevel 0 is the first patch for the new Level, rollback below x.0 is not possible.
 // Sublevel patches > 0 do not prevent rollbacks.
-var Sublevel = 2
+var Sublevel = 3
 
 type PatchFunc func(s *state.State) error
 

--- a/overlord/patch/patch6.go
+++ b/overlord/patch/patch6.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	patches[6] = []PatchFunc{patch6, patch6_1, patch6_2}
+	patches[6] = []PatchFunc{patch6, patch6_1, patch6_2, patch6_3}
 }
 
 type patch6Flags struct {

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -54,7 +54,7 @@ func patch6_3(st *state.State) error {
 		if err := json.Unmarshal([]byte(*raw), &snapst); err != nil {
 			return err
 		}
-		ch := snapst["channel"].(string)
+		ch, _ := snapst["channel"].(string)
 		if ch != "" {
 			normed := normChan(ch)
 			if normed != ch {
@@ -87,19 +87,23 @@ func patch6_3(st *state.State) error {
 			return fmt.Errorf("internal error: cannot get snap-setup of task %s: %s", task.ID(), err)
 		}
 		if err == nil {
-			ch := snapsup["channel"].(string)
-			normed := normChan(ch)
-			if normed != ch {
-				snapsup["channel"] = normed
-				task.Set("snap-setup", snapsup)
+			ch, _ := snapsup["channel"].(string)
+			if ch != "" {
+				normed := normChan(ch)
+				if normed != ch {
+					snapsup["channel"] = normed
+					task.Set("snap-setup", snapsup)
+				}
 			}
 		}
 		// check tasks "old-channel" data
 		var oldCh string
 		task.Get("old-channel", &oldCh)
-		normed := normChan(oldCh)
-		if normed != oldCh {
-			task.Set("old-channel", normed)
+		if oldCh != "" {
+			normed := normChan(oldCh)
+			if normed != oldCh {
+				task.Set("old-channel", normed)
+			}
 		}
 	}
 

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -1,0 +1,99 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func normChan(in string) string {
+	return strings.Join(strings.FieldsFunc(in, func(r rune) bool { return r == '/' }), "/")
+}
+
+// patch6_3:
+//  - ensure channel spec is valid
+func patch6_3(st *state.State) error {
+	var snaps map[string]*json.RawMessage
+	if err := st.Get("snaps", &snaps); err != nil && err != state.ErrNoState {
+		return fmt.Errorf("internal error: cannot get snaps: %s", err)
+	}
+
+	// Migrate snapstate
+	dirty := false
+	for name, raw := range snaps {
+		var snapst map[string]interface{}
+		if err := json.Unmarshal([]byte(*raw), &snapst); err != nil {
+			return err
+		}
+		ch := snapst["channel"].(string)
+		if ch != "" {
+			normed := normChan(ch)
+			if normed != ch {
+				snapst["channel"] = normed
+				data, err := json.Marshal(snapst)
+				if err != nil {
+					return err
+				}
+				newRaw := json.RawMessage(data)
+				snaps[name] = &newRaw
+				dirty = true
+			}
+		}
+	}
+	if dirty {
+		st.Set("snaps", snaps)
+	}
+
+	// migrate tasks' snap setup
+	for _, task := range st.Tasks() {
+		chg := task.Change()
+		if chg != nil && chg.Status().Ready() {
+			continue
+		}
+
+		// check task snap-setup
+		var snapsup map[string]interface{}
+		err := task.Get("snap-setup", &snapsup)
+		if err != nil && err != state.ErrNoState {
+			return fmt.Errorf("internal error: cannot get snap-setup of task %s: %s", task.ID(), err)
+		}
+		if err == nil {
+			ch := snapsup["channel"].(string)
+			normed := normChan(ch)
+			if normed != ch {
+				snapsup["channel"] = normed
+				task.Set("snap-setup", snapsup)
+			}
+		}
+		// check tasks "old-channel" data
+		var oldCh string
+		task.Get("old-channel", &oldCh)
+		normed := normChan(oldCh)
+		if normed != oldCh {
+			task.Set("old-channel", normed)
+		}
+	}
+
+	return nil
+}

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -22,7 +22,6 @@ package patch
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
@@ -32,17 +31,12 @@ import (
 // normChan will take a potentially unclean channel from the state
 // (with leading or trailing extra "/") and return a cleaned version.
 func normChan(in string) string {
-	// we need to do basic sanitation first or channel.Parse will fail
-	cleanIn := strings.Join(strings.FieldsFunc(in, func(r rune) bool { return r == '/' }), "/")
-
-	// now we clean the channel
-	ch, err := channel.Parse(cleanIn, "")
+	out, err := channel.Full(in)
 	if err != nil {
-		// now what?
-		logger.Noticef("cannot parse cleaned channel string %q", cleanIn)
+		logger.Noticef("cannot parse channel string %q: %v", in, err)
 		return in
 	}
-	return ch.Full()
+	return out
 }
 
 // patch6_3:

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -42,7 +42,7 @@ func normChan(in string) string {
 		logger.Noticef("cannot parse cleaned channel string %q", cleanIn)
 		return in
 	}
-	return ch.String()
+	return ch.Full()
 }
 
 // patch6_3:

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -24,11 +24,25 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/channel"
 )
 
+// normChan will take a potentially unclean channel from the state
+// (with leading or trailing extra "/") and return a cleaned version.
 func normChan(in string) string {
-	return strings.Join(strings.FieldsFunc(in, func(r rune) bool { return r == '/' }), "/")
+	// we need to do basic sanitation first or channel.Parse will fail
+	cleanIn := strings.Join(strings.FieldsFunc(in, func(r rune) bool { return r == '/' }), "/")
+
+	// now we clean the channel
+	ch, err := channel.Parse(cleanIn, "")
+	if err != nil {
+		// now what?
+		logger.Noticef("cannot parse cleaned channel string %q", cleanIn)
+		return in
+	}
+	return ch.String()
 }
 
 // patch6_3:

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -244,7 +244,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	c.Check(all, HasLen, 4)
 	c.Check(all["prefix-postfix-slashes"], NotNil)
 	// our patch changed this
-	c.Check(all["prefix-postfix-slashes"].Channel, Equals, "latest/edge")
+	c.Check(all["prefix-postfix-slashes"].TrackingChannel, Equals, "latest/edge")
 	// none of the other information has changed
 	c.Check(all["prefix-postfix-slashes"], DeepEquals, &snapstate.SnapState{
 		SnapType: "app",
@@ -263,17 +263,17 @@ func (s *patch63Suite) TestPatch63(c *C) {
 				EditedTitle: "some-title",
 			},
 		},
-		Active:  true,
-		Current: snap.R(32),
-		Channel: "latest/edge",
-		UserID:  1,
+		Active:          true,
+		Current:         snap.R(32),
+		TrackingChannel: "latest/edge",
+		UserID:          1,
 	})
 	// another transition
-	c.Check(all["one-prefix-slash"].Channel, Equals, "latest/stable")
+	c.Check(all["one-prefix-slash"].TrackingChannel, Equals, "latest/stable")
 	// full
-	c.Check(all["track-with-risk"].Channel, Equals, "latest/stable")
+	c.Check(all["track-with-risk"].TrackingChannel, Equals, "latest/stable")
 	// unchanged
-	c.Check(all["track-with-risk-branch"].Channel, Equals, "1.0/stable/branch")
+	c.Check(all["track-with-risk-branch"].TrackingChannel, Equals, "1.0/stable/branch")
 
 	// check tasks
 	task := st.Task("1")

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -1,0 +1,308 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package patch_test
+
+import (
+	"bytes"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/patch"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type patch63Suite struct{}
+
+var _ = Suite(&patch63Suite{})
+
+var statePatch6_3JSON = []byte(`
+{
+	"data": {
+		"patch-level": 6,
+		"snaps": {
+		  "prefix-postfix-slashes": {
+			"type": "app",
+			"sequence": [
+			  {
+				"name": "prefix-postfix-slashes",
+				"snap-id": "Hswp9oOzj3b4mw8gcC00XtxWnKH9QiCQ",
+				"revision": "30",
+                                "channel": "edge",
+                                "title": "some-title"
+			  },
+			  {
+				"name": "prefix-postfix-slashes",
+				"snap-id": "Hswp9oOzj3b4mw8gcC00XtxWnKH9QiCQ",
+				"revision": "32",
+                                "channel": "edge",
+                                "title": "some-title"
+			  }
+			],
+			"active": true,
+			"current": "32",
+			"channel": "//edge//",
+                        "user-id": 1
+		  },
+		  "one-prefix-slash": {
+			"type": "app",
+			"sequence": [
+			  {
+				"name": "white",
+				"snap-id": "one-prefix-slash-id",
+				"revision": "2"
+			  }
+			],
+			"active": true,
+			"current": "2",
+			"channel": "/stable"
+		  },
+		  "track-with-risk": {
+			"type": "app",
+			"sequence": [
+			  {
+				"name": "track-with-risk",
+				"snap-id": "track-with-snapid-id",
+				"revision": "3"
+			  }
+			],
+			"active": true,
+			"current": "3",
+			"channel": "latest/stable"
+		  },
+		  "track-with-risk-branch": {
+			"type": "app",
+			"sequence": [
+			  {
+				"name": "red",
+				"snap-id": "track-with-risk-branch-snapid-id",
+				"revision": "3"
+			  }
+			],
+			"active": true,
+			"current": "3",
+			"channel": "latest/stable/branch"
+		  }
+		}
+	  },
+         "changes": {
+                       "6": {
+                               "id": "6",
+                               "kind": "auto-refresh",
+                               "summary": "...",
+                               "status": 0,
+                               "clean": true,
+                               "task-ids": ["1", "8"]
+                       },
+                       "9": {
+                               "id": "9",
+                               "kind": "install",
+                               "summary": "...",
+                               "status": 4,
+                               "clean": true,
+                               "task-ids": ["10"]
+                       }
+                  
+         },
+         "tasks": {
+               "1": {
+                       "id": "1",
+                       "kind": "download-snap",
+                       "summary": "...",
+                       "status": 2,
+                       "clean": true,
+                       "data": {
+                         "snap-setup": {
+                               "channel": "/stable",
+                               "type": "app",
+                               "is-auto-refresh": true,
+                               "snap-path": "/path",
+                               "download-info": {
+                                 "download-url": "foo",
+                                 "size": 1234,
+                                 "sha3-384": "123456",
+                                 "deltas": [
+                                       {
+                                         "from-revision": 10934,
+                                         "to-revision": 10972,
+                                         "format": "xdelta3",
+                                         "download-url": "foo",
+                                         "size": 16431136,
+                                         "sha3-384": "1"
+                                       }
+                                 ]
+                               },
+                               "side-info": {
+                                 "name": "other-snap",
+                                 "snap-id": "other-snap-id",
+                                 "revision": "1",
+                                 "channel": "stable",
+                                 "title": "other-snap"
+                               },
+                               "media": [
+                                 {
+                                       "type": "icon",
+                                       "url": "a"
+                                 },
+                                 {
+                                       "type": "screenshot",
+                                       "url": "2"
+                                 },
+                                 {
+                                       "type": "screenshot",
+                                       "url": "3"
+                                 },
+                                 {
+                                       "type": "screenshot",
+                                       "url": "4"
+                                 },
+                                 {
+                                       "type": "video",
+                                       "url": "5"
+                                 }
+                               ]
+                         }
+                       },
+                       "change": "6"
+                 },
+                 "8": {
+                       "id": "8",
+                       "kind": "link-snap",
+                       "summary": "",
+                       "status": 2,
+                       "data": {
+                         "old-candidate-index": -1,
+                         "old-channel": "/18/edge//",
+                         "snap-setup-task": "1"
+                      },
+                      "change": "6"
+                 },
+                 "10": {
+                       "id": "10",
+                       "kind": "other",
+                       "summary": "",
+                       "status": 4,
+                       "data": {
+                         "old-channel": "/edge",
+                         "snap-setup": {
+                               "channel": "/stable",
+                               "type": "app",
+                                "snap-path": "/path",
+                                "side-info": {
+                                 "name": "some-snap",
+                                 "snap-id": "some-snap-id",
+                                 "revision": "1",
+                                 "channel": "stable",
+                                 "title": "snapd"
+                               }
+                          }
+                       },
+                       "change": "9"
+                 }
+        }
+}`)
+
+func (s *patch63Suite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	snap.MockSanitizePlugsSlots(func(*snap.Info) {})
+}
+
+func (s *patch63Suite) TestPatch63(c *C) {
+	restore1 := patch.MockLevel(6, 3)
+	defer restore1()
+
+	r := bytes.NewReader(statePatch6_3JSON)
+	st, err := state.ReadState(nil, r)
+	c.Assert(err, IsNil)
+
+	c.Assert(patch.Apply(st), IsNil)
+	st.Lock()
+	defer st.Unlock()
+
+	all, err := snapstate.All(st)
+	c.Assert(err, IsNil)
+	// our mocks are ok
+	c.Check(all, HasLen, 4)
+	c.Check(all["prefix-postfix-slashes"], NotNil)
+	// our patch changed this
+	c.Check(all["prefix-postfix-slashes"].Channel, Equals, "edge")
+	// none of the other information has changed
+	c.Check(all["prefix-postfix-slashes"], DeepEquals, &snapstate.SnapState{
+		SnapType: "app",
+		Sequence: []*snap.SideInfo{
+			{
+				RealName:    "prefix-postfix-slashes",
+				SnapID:      "Hswp9oOzj3b4mw8gcC00XtxWnKH9QiCQ",
+				Revision:    snap.R(30),
+				Channel:     "edge",
+				EditedTitle: "some-title",
+			}, {
+				RealName:    "prefix-postfix-slashes",
+				SnapID:      "Hswp9oOzj3b4mw8gcC00XtxWnKH9QiCQ",
+				Revision:    snap.R(32),
+				Channel:     "edge",
+				EditedTitle: "some-title",
+			},
+		},
+		Active:  true,
+		Current: snap.R(32),
+		Channel: "edge",
+		UserID:  1,
+	})
+	// another transition
+	c.Check(all["one-prefix-slash"].Channel, Equals, "stable")
+	// unchanged
+	c.Check(all["track-with-risk"].Channel, Equals, "latest/stable")
+	c.Check(all["track-with-risk-branch"].Channel, Equals, "latest/stable/branch")
+
+	// check tasks
+	task := st.Task("1")
+	c.Assert(task, NotNil)
+	// this was converted
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Check(snapsup.Channel, Equals, "stable")
+
+	// sanity check that old stuff is untouched
+	c.Check(snapsup.Flags.IsAutoRefresh, Equals, true)
+	c.Assert(snapsup.Media, HasLen, 5)
+	c.Check(snapsup.Media[0].URL, Equals, "a")
+	c.Assert(snapsup.DownloadInfo, NotNil)
+	c.Check(snapsup.DownloadInfo.DownloadURL, Equals, "foo")
+	c.Check(snapsup.DownloadInfo.Deltas, HasLen, 1)
+
+	// old-channel data got updated
+	task = st.Task("8")
+	c.Assert(task, NotNil)
+	var oldCh string
+	c.Assert(task.Get("old-channel", &oldCh), IsNil)
+	c.Check(oldCh, Equals, "18/edge")
+
+	// task 10 not updated because the change is ready
+	task = st.Task("10")
+	c.Assert(task, NotNil)
+	c.Assert(task.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.Channel, Equals, "/stable")
+	err = task.Get("old-channel", &oldCh)
+	c.Assert(err, IsNil)
+	c.Check(oldCh, Equals, "/edge")
+}

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -280,6 +280,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	// this was converted
 	var snapsup snapstate.SnapSetup
 	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
 	c.Check(snapsup.Channel, Equals, "stable")
 
 	// sanity check that old stuff is untouched

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -244,7 +244,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	c.Check(all, HasLen, 4)
 	c.Check(all["prefix-postfix-slashes"], NotNil)
 	// our patch changed this
-	c.Check(all["prefix-postfix-slashes"].Channel, Equals, "edge")
+	c.Check(all["prefix-postfix-slashes"].Channel, Equals, "latest/edge")
 	// none of the other information has changed
 	c.Check(all["prefix-postfix-slashes"], DeepEquals, &snapstate.SnapState{
 		SnapType: "app",
@@ -265,13 +265,13 @@ func (s *patch63Suite) TestPatch63(c *C) {
 		},
 		Active:  true,
 		Current: snap.R(32),
-		Channel: "edge",
+		Channel: "latest/edge",
 		UserID:  1,
 	})
 	// another transition
-	c.Check(all["one-prefix-slash"].Channel, Equals, "stable")
-	// normalized
-	c.Check(all["track-with-risk"].Channel, Equals, "stable")
+	c.Check(all["one-prefix-slash"].Channel, Equals, "latest/stable")
+	// full
+	c.Check(all["track-with-risk"].Channel, Equals, "latest/stable")
 	// unchanged
 	c.Check(all["track-with-risk-branch"].Channel, Equals, "1.0/stable/branch")
 
@@ -282,7 +282,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	var snapsup snapstate.SnapSetup
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
-	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapsup.Channel, Equals, "latest/stable")
 
 	// sanity check that old stuff is untouched
 	c.Check(snapsup.Flags.IsAutoRefresh, Equals, true)

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -40,6 +40,23 @@ var statePatch6_3JSON = []byte(`
 	"data": {
 		"patch-level": 6,
 		"snaps": {
+                  "local-install": {
+			"type": "app",
+			"sequence": [
+			  {
+				"name": "local-install",
+                                "snap-id": "",
+				"revision": "x1"
+			  },
+			  {
+				"name": "local-install",
+				"snap-id": "",
+				"revision": "x2"
+			  }
+			],
+			"active": true,
+			"current": "x2"
+                  },
 		  "prefix-postfix-slashes": {
 			"type": "app",
 			"sequence": [
@@ -120,8 +137,15 @@ var statePatch6_3JSON = []byte(`
                                "status": 4,
                                "clean": true,
                                "task-ids": ["10"]
+                       },
+                       "99": {
+                               "id": "99",
+                               "kind": "install",
+                               "summary": "...",
+                               "status": 0,
+                               "clean": true,
+                               "task-ids": ["99"]
                        }
-                  
          },
          "tasks": {
                "1": {
@@ -217,6 +241,24 @@ var statePatch6_3JSON = []byte(`
                           }
                        },
                        "change": "9"
+                 },
+                 "99": {
+                       "id": "99",
+                       "kind": "prepare-snap",
+                       "summary": "",
+                       "status": 0,
+                       "data": {
+                         "snap-setup": {
+                               "type": "app",
+                               "snap-path": "/path",
+                               "side-info": {
+                                 "name": "local-snap",
+                                 "snap-id": "",
+                                 "revision": "unset"
+                               }
+                          }
+                       },
+                       "change": "99"
                  }
         }
 }`)
@@ -241,7 +283,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	all, err := snapstate.All(st)
 	c.Assert(err, IsNil)
 	// our mocks are ok
-	c.Check(all, HasLen, 4)
+	c.Check(all, HasLen, 5)
 	c.Check(all["prefix-postfix-slashes"], NotNil)
 	// our patch changed this
 	c.Check(all["prefix-postfix-slashes"].TrackingChannel, Equals, "latest/edge")
@@ -274,6 +316,8 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	c.Check(all["track-with-risk"].TrackingChannel, Equals, "latest/stable")
 	// unchanged
 	c.Check(all["track-with-risk-branch"].TrackingChannel, Equals, "1.0/stable/branch")
+	// also unchanged
+	c.Check(all["local-install"].TrackingChannel, Equals, "")
 
 	// check tasks
 	task := st.Task("1")

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -100,7 +100,7 @@ var statePatch6_3JSON = []byte(`
 			],
 			"active": true,
 			"current": "3",
-			"channel": "latest/stable/branch"
+			"channel": "1.0/stable/branch"
 		  }
 		}
 	  },
@@ -270,9 +270,10 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	})
 	// another transition
 	c.Check(all["one-prefix-slash"].Channel, Equals, "stable")
+	// normalized
+	c.Check(all["track-with-risk"].Channel, Equals, "stable")
 	// unchanged
-	c.Check(all["track-with-risk"].Channel, Equals, "latest/stable")
-	c.Check(all["track-with-risk-branch"].Channel, Equals, "latest/stable/branch")
+	c.Check(all["track-with-risk-branch"].Channel, Equals, "1.0/stable/branch")
 
 	// check tasks
 	task := st.Task("1")


### PR DESCRIPTION
This PR adds a patch that will normalize the channel in the state.
Snapd was not normalizing the channel so it is possible that the
state contains channels like `/stable` or even `//edge//` without
perceivable ill effects. However with the upcoming change to
"default-tracks" that can be set store side the semantic of those
become less clear. To avoid any ambiguity we normalize the channels
so "/edge" -> "latest/edge".

I've built this on #7670, but it can easily be rebased on #7669 if that's the one we go for.

And yes, this is just an updating of #7377 (and a fix for a bug in it).