### PR TITLE
interfaces/content: workaround for renamed target

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -228,15 +228,16 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 				resolveSpecialVariable(w, slot.Snap()))
 			source, target := sourceTarget(plug, slot, w)
 			emit("  # Read-write content sharing %s -> %s (w#%d)\n", plug.Ref(), slot.Ref(), i)
-			emit("  mount options=(bind, rw) %s/ -> %s/,\n", source, target)
-			emit("  mount options=(rprivate) -> %s/,\n", target)
-			emit("  umount %s/,\n", target)
+			emit("  mount options=(bind, rw) %s/ -> %s{,-[0-9]*}/,\n", source, target)
+			emit("  mount options=(rprivate) -> %s{,-[0-9]*}/,\n", target)
+			emit("  umount %s{,-[0-9]*}/,\n", target)
 			// TODO: The assumed prefix depth could be optimized to be more
 			// precise since content sharing can only take place in a fixed
 			// list of places with well-known paths (well, constrained set of
 			// paths). This can be done when the prefix is actually consumed.
 			apparmor.GenWritableProfile(emit, source, 1)
 			apparmor.GenWritableProfile(emit, target, 1)
+			apparmor.GenWritableProfile(emit, fmt.Sprintf("%s-[0-9]*", target), 1)
 		}
 	}
 
@@ -253,13 +254,14 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 
 			source, target := sourceTarget(plug, slot, r)
 			emit("  # Read-only content sharing %s -> %s (r#%d)\n", plug.Ref(), slot.Ref(), i)
-			emit("  mount options=(bind) %s/ -> %s/,\n", source, target)
-			emit("  remount options=(bind, ro) %s/,\n", target)
-			emit("  mount options=(rprivate) -> %s/,\n", target)
-			emit("  umount %s/,\n", target)
+			emit("  mount options=(bind) %s/ -> %s{,-[0-9]*}/,\n", source, target)
+			emit("  remount options=(bind, ro) %s{,-[0-9]*}/,\n", target)
+			emit("  mount options=(rprivate) -> %s{,-[0-9]*}/,\n", target)
+			emit("  umount %s{,-[0-9]*}/,\n", target)
 			// Look at the TODO comment above.
 			apparmor.GenWritableProfile(emit, source, 1)
 			apparmor.GenWritableProfile(emit, target, 1)
+			apparmor.GenWritableProfile(emit, fmt.Sprintf("%s-[0-9]*", target), 1)
 		}
 	}
 

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -316,10 +316,10 @@ slots:
 
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-only content sharing consumer:content -> producer:content (r#0)
-  mount options=(bind) /snap/producer/5/export/ -> /snap/consumer/7/import/,
-  remount options=(bind, ro) /snap/consumer/7/import/,
-  mount options=(rprivate) -> /snap/consumer/7/import/,
-  umount /snap/consumer/7/import/,
+  mount options=(bind) /snap/producer/5/export/ -> /snap/consumer/7/import{,-[0-9]*}/,
+  remount options=(bind, ro) /snap/consumer/7/import{,-[0-9]*}/,
+  mount options=(rprivate) -> /snap/consumer/7/import{,-[0-9]*}/,
+  umount /snap/consumer/7/import{,-[0-9]*}/,
   # Writable mimic /snap/producer/5
   # .. permissions for traversing the prefix that is assumed to exist
   # .. variant with mimic at /
@@ -499,9 +499,9 @@ slots:
 
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-write content sharing consumer:content -> producer:content (w#0)
-  mount options=(bind, rw) /var/snap/producer/5/export/ -> /var/snap/consumer/7/import/,
-  mount options=(rprivate) -> /var/snap/consumer/7/import/,
-  umount /var/snap/consumer/7/import/,
+  mount options=(bind, rw) /var/snap/producer/5/export/ -> /var/snap/consumer/7/import{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/7/import{,-[0-9]*}/,
+  umount /var/snap/consumer/7/import{,-[0-9]*}/,
   # Writable directory /var/snap/producer/5/export
   /var/snap/producer/5/export/ rw,
   /var/snap/producer/5/ rw,
@@ -510,6 +510,8 @@ slots:
   /var/snap/consumer/7/import/ rw,
   /var/snap/consumer/7/ rw,
   /var/snap/consumer/ rw,
+  # Writable directory /var/snap/consumer/7/import-[0-9]*
+  /var/snap/consumer/7/import-[0-9]*/ rw,
 `
 	c.Assert(strings.Join(updateNS[:], ""), Equals, profile0)
 }
@@ -562,9 +564,9 @@ slots:
 
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-write content sharing consumer:content -> producer:content (w#0)
-  mount options=(bind, rw) /var/snap/producer/common/export/ -> /var/snap/consumer/common/import/,
-  mount options=(rprivate) -> /var/snap/consumer/common/import/,
-  umount /var/snap/consumer/common/import/,
+  mount options=(bind, rw) /var/snap/producer/common/export/ -> /var/snap/consumer/common/import{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import{,-[0-9]*}/,
+  umount /var/snap/consumer/common/import{,-[0-9]*}/,
   # Writable directory /var/snap/producer/common/export
   /var/snap/producer/common/export/ rw,
   /var/snap/producer/common/ rw,
@@ -573,6 +575,8 @@ slots:
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
+  # Writable directory /var/snap/consumer/common/import-[0-9]*
+  /var/snap/consumer/common/import-[0-9]*/ rw,
 `
 	c.Assert(strings.Join(updateNS[:], ""), Equals, profile0)
 }
@@ -660,9 +664,9 @@ slots:
 
 	updateNS := apparmorSpec.UpdateNS()
 	profile0 := `  # Read-write content sharing consumer:content -> producer:content (w#0)
-  mount options=(bind, rw) /var/snap/producer/common/write-common/ -> /var/snap/consumer/common/import/write-common/,
-  mount options=(rprivate) -> /var/snap/consumer/common/import/write-common/,
-  umount /var/snap/consumer/common/import/write-common/,
+  mount options=(bind, rw) /var/snap/producer/common/write-common/ -> /var/snap/consumer/common/import/write-common{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/write-common{,-[0-9]*}/,
+  umount /var/snap/consumer/common/import/write-common{,-[0-9]*}/,
   # Writable directory /var/snap/producer/common/write-common
   /var/snap/producer/common/write-common/ rw,
   /var/snap/producer/common/ rw,
@@ -672,6 +676,8 @@ slots:
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
+  # Writable directory /var/snap/consumer/common/import/write-common-[0-9]*
+  /var/snap/consumer/common/import/write-common-[0-9]*/ rw,
 `
 	// Find the slice that describes profile0 by looking for the first unique
 	// line of the next profile.
@@ -680,14 +686,16 @@ slots:
 	c.Assert(strings.Join(updateNS[start:end], ""), Equals, profile0)
 
 	profile1 := `  # Read-write content sharing consumer:content -> producer:content (w#1)
-  mount options=(bind, rw) /var/snap/producer/2/write-data/ -> /var/snap/consumer/common/import/write-data/,
-  mount options=(rprivate) -> /var/snap/consumer/common/import/write-data/,
-  umount /var/snap/consumer/common/import/write-data/,
+  mount options=(bind, rw) /var/snap/producer/2/write-data/ -> /var/snap/consumer/common/import/write-data{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/write-data{,-[0-9]*}/,
+  umount /var/snap/consumer/common/import/write-data{,-[0-9]*}/,
   # Writable directory /var/snap/producer/2/write-data
   /var/snap/producer/2/write-data/ rw,
   /var/snap/producer/2/ rw,
   # Writable directory /var/snap/consumer/common/import/write-data
   /var/snap/consumer/common/import/write-data/ rw,
+  # Writable directory /var/snap/consumer/common/import/write-data-[0-9]*
+  /var/snap/consumer/common/import/write-data-[0-9]*/ rw,
 `
 	// Find the slice that describes profile1 by looking for the first unique
 	// line of the next profile.
@@ -696,14 +704,16 @@ slots:
 	c.Assert(strings.Join(updateNS[start:end], ""), Equals, profile1)
 
 	profile2 := `  # Read-only content sharing consumer:content -> producer:content (r#0)
-  mount options=(bind) /var/snap/producer/common/read-common/ -> /var/snap/consumer/common/import/read-common/,
-  remount options=(bind, ro) /var/snap/consumer/common/import/read-common/,
-  mount options=(rprivate) -> /var/snap/consumer/common/import/read-common/,
-  umount /var/snap/consumer/common/import/read-common/,
+  mount options=(bind) /var/snap/producer/common/read-common/ -> /var/snap/consumer/common/import/read-common{,-[0-9]*}/,
+  remount options=(bind, ro) /var/snap/consumer/common/import/read-common{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/read-common{,-[0-9]*}/,
+  umount /var/snap/consumer/common/import/read-common{,-[0-9]*}/,
   # Writable directory /var/snap/producer/common/read-common
   /var/snap/producer/common/read-common/ rw,
   # Writable directory /var/snap/consumer/common/import/read-common
   /var/snap/consumer/common/import/read-common/ rw,
+  # Writable directory /var/snap/consumer/common/import/read-common-[0-9]*
+  /var/snap/consumer/common/import/read-common-[0-9]*/ rw,
 `
 	// Find the slice that describes profile2 by looking for the first unique
 	// line of the next profile.
@@ -712,14 +722,16 @@ slots:
 	c.Assert(strings.Join(updateNS[start:end], ""), Equals, profile2)
 
 	profile3 := `  # Read-only content sharing consumer:content -> producer:content (r#1)
-  mount options=(bind) /var/snap/producer/2/read-data/ -> /var/snap/consumer/common/import/read-data/,
-  remount options=(bind, ro) /var/snap/consumer/common/import/read-data/,
-  mount options=(rprivate) -> /var/snap/consumer/common/import/read-data/,
-  umount /var/snap/consumer/common/import/read-data/,
+  mount options=(bind) /var/snap/producer/2/read-data/ -> /var/snap/consumer/common/import/read-data{,-[0-9]*}/,
+  remount options=(bind, ro) /var/snap/consumer/common/import/read-data{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/read-data{,-[0-9]*}/,
+  umount /var/snap/consumer/common/import/read-data{,-[0-9]*}/,
   # Writable directory /var/snap/producer/2/read-data
   /var/snap/producer/2/read-data/ rw,
   # Writable directory /var/snap/consumer/common/import/read-data
   /var/snap/consumer/common/import/read-data/ rw,
+  # Writable directory /var/snap/consumer/common/import/read-data-[0-9]*
+  /var/snap/consumer/common/import/read-data-[0-9]*/ rw,
 `
 	// Find the slice that describes profile3 by looking for the first unique
 	// line of the next profile.
@@ -728,10 +740,10 @@ slots:
 	c.Assert(strings.Join(updateNS[start:end], ""), Equals, profile3)
 
 	profile4 := `  # Read-only content sharing consumer:content -> producer:content (r#2)
-  mount options=(bind) /snap/producer/2/read-snap/ -> /var/snap/consumer/common/import/read-snap/,
-  remount options=(bind, ro) /var/snap/consumer/common/import/read-snap/,
-  mount options=(rprivate) -> /var/snap/consumer/common/import/read-snap/,
-  umount /var/snap/consumer/common/import/read-snap/,
+  mount options=(bind) /snap/producer/2/read-snap/ -> /var/snap/consumer/common/import/read-snap{,-[0-9]*}/,
+  remount options=(bind, ro) /var/snap/consumer/common/import/read-snap{,-[0-9]*}/,
+  mount options=(rprivate) -> /var/snap/consumer/common/import/read-snap{,-[0-9]*}/,
+  umount /var/snap/consumer/common/import/read-snap{,-[0-9]*}/,
   # Writable mimic /snap/producer/2
   # .. permissions for traversing the prefix that is assumed to exist
   # .. variant with mimic at /
@@ -822,6 +834,8 @@ slots:
   umount /snap/producer/2/*/,
   # Writable directory /var/snap/consumer/common/import/read-snap
   /var/snap/consumer/common/import/read-snap/ rw,
+  # Writable directory /var/snap/consumer/common/import/read-snap-[0-9]*
+  /var/snap/consumer/common/import/read-snap-[0-9]*/ rw,
 `
 	// Find the slice that describes profile4 by looking till the end of the list.
 	start = end

--- a/tests/regression/lp-1849845/task.yaml
+++ b/tests/regression/lp-1849845/task.yaml
@@ -1,0 +1,47 @@
+summary: regression test for LP:#1849845
+details: |
+  This test verifies that apparmor permissions for de-conflicted overlapping
+  mount entries resulting from connecting two content slots to one plug in
+  direct mode (as opposed to spool mode) doesn't fail because of missing
+  permissions to create and mount the package-assets-2 directory.
+prepare: |
+  snap pack test-snapd-app
+  snap pack test-snapd-assets-foo
+  snap pack test-snapd-assets-bar
+
+  snap install --dangerous test-snapd-app_1_all.snap
+  snap install --dangerous test-snapd-assets-foo_1_all.snap
+  snap install --dangerous test-snapd-assets-bar_1_all.snap
+
+  snap connect test-snapd-app:package-assets test-snapd-assets-foo:package-assets
+  snap connect test-snapd-app:package-assets test-snapd-assets-bar:package-assets
+execute: |
+  # The directories are present
+  #shellcheck disable=SC2016
+  test-snapd-app.sh -c 'test -d $SNAP_DATA/package-assets'
+  #shellcheck disable=SC2016
+  test-snapd-app.sh -c 'test -d $SNAP_DATA/package-assets-2'
+  # The files are visible
+  #shellcheck disable=SC2016
+  test-snapd-app.sh -c 'test -f $SNAP_DATA/package-assets/asset.txt'
+  #shellcheck disable=SC2016
+  test-snapd-app.sh -c 'test -f $SNAP_DATA/package-assets-2/asset.txt'
+  # The content is as expected although we cannot rely on the order.
+  #shellcheck disable=SC2016
+  if [ "$(test-snapd-app.sh -c 'cat $SNAP_DATA/package-assets/asset.txt')" = A ]; then
+    #shellcheck disable=SC2016
+    test "$(test-snapd-app.sh -c 'cat $SNAP_DATA/package-assets-2/asset.txt')" = B
+  elif [ "$(test-snapd-app.sh -c 'cat $SNAP_DATA/package-assets/asset.txt')" = B ]; then
+    #shellcheck disable=SC2016
+    test "$(test-snapd-app.sh -c 'cat $SNAP_DATA/package-assets-2/asset.txt')" = A
+  else
+    false
+  fi
+restore: |
+  snap remove test-snapd-app
+  snap remove test-snapd-assets-foo
+  snap remove test-snapd-assets-bar
+
+  rm -f test-snapd-app_1_all.snap
+  rm -f test-snapd-assets-foo_1_all.snap
+  rm -f test-snapd-assets-bar_1_all.snap

--- a/tests/regression/lp-1849845/test-snapd-app/bin/sh
+++ b/tests/regression/lp-1849845/test-snapd-app/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/regression/lp-1849845/test-snapd-app/meta/snap.yaml
+++ b/tests/regression/lp-1849845/test-snapd-app/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-app
+version: 1
+architectures: [all]
+apps:
+  sh:
+    command: bin/sh
+plugs:
+  package-assets:
+    interface: content
+    target: $SNAP_DATA/package-assets

--- a/tests/regression/lp-1849845/test-snapd-assets-bar/meta/hooks/install
+++ b/tests/regression/lp-1849845/test-snapd-assets-bar/meta/hooks/install
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir "$SNAP_DATA/package-assets/"
+echo "B" > "$SNAP_DATA/package-assets/asset.txt"

--- a/tests/regression/lp-1849845/test-snapd-assets-bar/meta/snap.yaml
+++ b/tests/regression/lp-1849845/test-snapd-assets-bar/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-assets-bar
+version: 1
+architectures: [all]
+slots:
+  package-assets:
+    interface: content
+    read: [$SNAP_DATA/package-assets]

--- a/tests/regression/lp-1849845/test-snapd-assets-foo/meta/hooks/install
+++ b/tests/regression/lp-1849845/test-snapd-assets-foo/meta/hooks/install
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir "$SNAP_DATA/package-assets/"
+echo "A" > "$SNAP_DATA/package-assets/asset.txt"

--- a/tests/regression/lp-1849845/test-snapd-assets-foo/meta/snap.yaml
+++ b/tests/regression/lp-1849845/test-snapd-assets-foo/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-assets-foo
+version: 1
+architectures: [all]
+slots:
+  package-assets:
+    interface: content
+    read: [$SNAP_DATA/package-assets]


### PR DESCRIPTION
This patch works around a bug in misuse of the content interface in
direct mode when multiple slots are connected to one plug. For context
please follow the text below.

The content interface supports two fundamental modes: direct and spool.

The first mode, direct, is the oldest, where a directory is bind-mounted
from one place to another. This mode only works when the cardinality of
the set of mount sources over the mount target is equal to one. To use
this mode one has to define a pair of snaps with the following interface
declarations:

    interfaces:
	content:  # slot
	    read: $SNAP_DATA/source

    interfaces:
	content:  # plug
	    target: $SNAP_DATA/target

This fragment will correctly bind-mount source at target.

The second mode, spool, allows using multiple sources in one target. In
this mode the target (plug) becomes a spool directory and each source,
either read or write becomes a element in the spool directory. To use
this mode one has to define a slot with the "source" attribute as the
parent for either "read" or "write" attributes.

    interfaces:
	content:  # slot
	    source:
		read: [$SNAP_DATA/source]

This fragment will correctly bind mount source at target/source. Careful
reader might notice that this presents a new problem. What might happen
if multiple slots all want to provide a directory called "source". Such
declarations would over-write each other, defeating the purpose of
the new mode for app-with-plugins style of usage.

When the spool mode was introduced this problem was identified and the
mount backend was extended to automatically resolve such conflicts by
altering the name of the mount target from "target/source" to
"target/source-2" (for the second element that wishes to provide
"source" to "target").

The error reported as https://bugs.launchpad.net/snapd/+bug/1849845
arises when two or more slots are connected to one plug in direct mode.
The mount backend creates additional "target-2", "target-3" directories
but the apparmor backend is not matching that with appropriate
permissions.

Historically each security backend was entirely standalone and separate.
In practice, ever since the snap-update-ns apparmor profiles were
introduced, the apparmor and mount backends must agree on the
directories that need to be created and mounted. This is only done
implicitly for now.

The patch adjusts the apparmor specification for snap-update-ns so that
it can create and mount directories named "target{,-[0-9]*}/", in
anticipation of possibility of renaming.

This problem intersects with validation, connection cardinality and
upcoming work on greedy plugs and slots. Some improvements to usability
are possible once all are taken into account.

Fixes: https://bugs.launchpad.net/snapd/+bug/1849845
Fixes: https://bugs.launchpad.net/stuttgart/+bug/1849804

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
