### PR TITLE
spread: disable secondary compression for deltas

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -468,7 +468,7 @@ repack: |
     else
         trap "rm -f delta-ref.tar current.delta" EXIT
         git archive -o delta-ref.tar --format=tar --prefix="$DELTA_PREFIX" "$DELTA_REF"
-        xdelta3 -s delta-ref.tar <&3 > current.delta
+        xdelta3 -S none -s delta-ref.tar <&3 > current.delta
         tar c current.delta >&4
     fi
 


### PR DESCRIPTION
With recent enough xdelta3 (eg. 3.1.0), and sufficiently old on the destination
host (eg. 3.0.7 on Amazon Linux 2), unpacking project deltas fails in the
following way:
```
  + xdelta3 -q -d -s delta-ref.tar current.delta
  xdelta3: unavailable secondary compressor: LZMA: XD3_INTERNAL
  tar: This does not look like a tar archive
  tar: Exiting with failure status due to previous errors
```
Spread already applies compression to the uploaded project content, so we can
disable the secondary compression used by xdelta.
