### PR TITLE
many: changes to testing in preparation of Core 20 seed consuming code

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -96,7 +96,6 @@ func (s *imageSuite) SetUpTest(c *C) {
 		"verification": "verified",
 	})
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
-	s.DB = s.StoreSigning.Database
 
 	s.model = s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name":   "my display name",
@@ -448,6 +447,10 @@ func (s *imageSuite) TestHappyDecodeModelAssertion(c *C) {
 	})
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.ModelType)
+}
+
+func (s *imageSuite) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string) {
+	s.SeedSnaps.MakeAssertedSnap(c, snapYaml, files, revision, developerID, s.StoreSigning.Database)
 }
 
 const stableChannel = "stable"

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -91,7 +91,7 @@ func (s *imageSuite) SetUpTest(c *C) {
 	s.tsto = image.MockToolingStore(s)
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
-	s.SetupAssertSigning("canonical", s)
+	s.SetupAssertSigning("canonical")
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -58,7 +58,7 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-type FirstBootTestSuite struct {
+type firstBoot16Suite struct {
 	testutil.BaseTest
 
 	systemctl *testutil.MockCmd
@@ -74,9 +74,9 @@ type FirstBootTestSuite struct {
 	perfTimings timings.Measurer
 }
 
-var _ = Suite(&FirstBootTestSuite{})
+var _ = Suite(&firstBoot16Suite{})
 
-func (s *FirstBootTestSuite) SetUpTest(c *C) {
+func (s *firstBoot16Suite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	tempdir := c.MkDir()
@@ -144,7 +144,7 @@ func checkTrivialSeeding(c *C, tsAll []*state.TaskSet) {
 	c.Check(tasks[0].Kind(), Equals, "mark-seeded")
 }
 
-func (s *FirstBootTestSuite) modelHeaders(modelStr string, reqSnaps ...string) map[string]interface{} {
+func (s *firstBoot16Suite) modelHeaders(modelStr string, reqSnaps ...string) map[string]interface{} {
 	headers := map[string]interface{}{
 		"architecture": "amd64",
 		"store":        "canonical",
@@ -165,11 +165,11 @@ func (s *FirstBootTestSuite) modelHeaders(modelStr string, reqSnaps ...string) m
 	return headers
 }
 
-func (s *FirstBootTestSuite) makeModelAssertionChain(c *C, modName string, extraHeaders map[string]interface{}, reqSnaps ...string) []asserts.Assertion {
+func (s *firstBoot16Suite) makeModelAssertionChain(c *C, modName string, extraHeaders map[string]interface{}, reqSnaps ...string) []asserts.Assertion {
 	return s.MakeModelAssertionChain("my-brand", modName, s.modelHeaders(modName, reqSnaps...), extraHeaders)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoop(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -203,7 +203,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	c.Check(ds.Model, Equals, "generic-classic")
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -231,7 +231,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	c.Check(ds.Model, Equals, "my-model-classic")
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicEmptySeedYaml(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicEmptySeedYaml(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -254,7 +254,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicEmptySeedYaml(c *C) {
 	c.Assert(err, ErrorMatches, "cannot proceed, no snaps to seed")
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudInstanceData(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudInstanceData(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -328,7 +328,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudIns
 	c.Check(cloud.AvailabilityZone, Equals, "us-east-2b")
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedErrorsOnState(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedErrorsOnState(c *C) {
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -338,7 +338,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedErrorsOnState(c *C) {
 	c.Assert(err, ErrorMatches, "cannot populate state: already seeded")
 }
 
-func (s *FirstBootTestSuite) makeCoreSnaps(c *C, extraGadgetYaml string) (coreFname, kernelFname, gadgetFname string) {
+func (s *firstBoot16Suite) makeCoreSnaps(c *C, extraGadgetYaml string) (coreFname, kernelFname, gadgetFname string) {
 	files := [][]string{}
 	if strings.Contains(extraGadgetYaml, "defaults:") {
 		files = [][]string{{"meta/hooks/configure", ""}}
@@ -416,7 +416,7 @@ func checkSeedTasks(c *C, tsAll []*state.TaskSet) {
 	c.Check(markSeededTask.WaitTasks(), DeepEquals, []*state.Task{gadgetConnectTask})
 }
 
-func (s *FirstBootTestSuite) makeSeedChange(c *C, st *state.State) *state.Change {
+func (s *firstBoot16Suite) makeSeedChange(c *C, st *state.State) *state.Change {
 	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
 
 	s.WriteAssertions("developer.account", s.devAcct)
@@ -486,7 +486,7 @@ snaps:
 	return chg
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedHappy(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -571,7 +571,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
 	c.Check(seedTime.IsZero(), Equals, false)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	st0 := s.overlord.State()
 	st0.Lock()
 	db := assertstate.DB(st0)
@@ -611,7 +611,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {
 	c.Assert(chg.Err(), ErrorMatches, `(?s).* cannot determine bootloader.*`)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedHappyMultiAssertsFiles(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedHappyMultiAssertsFiles(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -710,7 +710,7 @@ snaps:
 	c.Check(pubAcct.AccountID(), Equals, "developerid")
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedConfigureHappy(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedConfigureHappy(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -863,7 +863,7 @@ snaps:
 	c.Check(seeded, Equals, true)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedGadgetConnectHappy(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedGadgetConnectHappy(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -971,7 +971,7 @@ snaps:
 	c.Check(seeded, Equals, true)
 }
 
-func (s *FirstBootTestSuite) TestImportAssertionsFromSeedClassicModelMismatch(c *C) {
+func (s *firstBoot16Suite) TestImportAssertionsFromSeedClassicModelMismatch(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -994,7 +994,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedClassicModelMismatch(c 
 	c.Assert(err, ErrorMatches, "cannot seed a classic system with an all-snaps model")
 }
 
-func (s *FirstBootTestSuite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c *C) {
+func (s *firstBoot16Suite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c *C) {
 	ovld, err := overlord.New(nil)
 	c.Assert(err, IsNil)
 	st := ovld.State()
@@ -1014,7 +1014,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c
 	c.Assert(err, ErrorMatches, "cannot seed an all-snaps system with a classic model")
 }
 
-func (s *FirstBootTestSuite) TestImportAssertionsFromSeedHappy(c *C) {
+func (s *firstBoot16Suite) TestImportAssertionsFromSeedHappy(c *C) {
 	ovld, err := overlord.New(nil)
 	c.Assert(err, IsNil)
 	st := ovld.State()
@@ -1060,7 +1060,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedHappy(c *C) {
 	c.Check(model.Model(), Equals, "my-model")
 }
 
-func (s *FirstBootTestSuite) TestImportAssertionsFromSeedMissingSig(c *C) {
+func (s *firstBoot16Suite) TestImportAssertionsFromSeedMissingSig(c *C) {
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1083,7 +1083,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedMissingSig(c *C) {
 	c.Assert(err, ErrorMatches, "cannot resolve prerequisite assertion: account-key .*")
 }
 
-func (s *FirstBootTestSuite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
+func (s *firstBoot16Suite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1104,7 +1104,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
 	c.Assert(err, ErrorMatches, "cannot have multiple model assertions in seed")
 }
 
-func (s *FirstBootTestSuite) TestImportAssertionsFromSeedNoModelAsserts(c *C) {
+func (s *firstBoot16Suite) TestImportAssertionsFromSeedNoModelAsserts(c *C) {
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1130,7 +1130,7 @@ type core18SnapsOpts struct {
 	gadget  bool
 }
 
-func (s *FirstBootTestSuite) makeCore18Snaps(c *C, opts *core18SnapsOpts) (core18Fn, snapdFn, kernelFn, gadgetFn string) {
+func (s *firstBoot16Suite) makeCore18Snaps(c *C, opts *core18SnapsOpts) (core18Fn, snapdFn, kernelFn, gadgetFn string) {
 	if opts == nil {
 		opts = &core18SnapsOpts{}
 	}
@@ -1183,7 +1183,7 @@ base: core18
 	return core18Fname, snapdFname, kernelFname, gadgetFname
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedWithBaseHappy(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedWithBaseHappy(c *C) {
 	var sysdLog [][]string
 	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
@@ -1301,7 +1301,7 @@ snaps:
 	c.Check(seedTime.IsZero(), Equals, false)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOrdering(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOrdering(c *C) {
 	s.WriteAssertions("developer.account", s.devAcct)
 
 	// add a model assertion and its chain
@@ -1352,7 +1352,7 @@ snaps:
 	checkOrder(c, tsAll, "snapd", "pc-kernel", "core18", "pc", "other-base", "snap-req-other-base")
 }
 
-func (s *FirstBootTestSuite) TestFirstbootGadgetBaseModelBaseMismatch(c *C) {
+func (s *firstBoot16Suite) TestFirstbootGadgetBaseModelBaseMismatch(c *C) {
 	s.WriteAssertions("developer.account", s.devAcct)
 
 	// add a model assertion and its chain
@@ -1387,7 +1387,7 @@ snaps:
 	c.Assert(err, ErrorMatches, `cannot use gadget snap because its base "core" is different from model base "core18"`)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedWrongContentProviderOrder(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedWrongContentProviderOrder(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -1478,7 +1478,7 @@ snaps:
 	c.Check(conn.(map[string]interface{})["interface"], Equals, "content")
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBase(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedMissingBase(c *C) {
 	s.WriteAssertions("developer.account", s.devAcct)
 
 	// add a model assertion and its chain
@@ -1521,7 +1521,7 @@ snaps:
 	c.Assert(err, ErrorMatches, `cannot use snap "local": base "foo" is missing`)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicWithSnapdOnlyHappy(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicWithSnapdOnlyHappy(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -1629,7 +1629,7 @@ snaps:
 	c.Check(seedTime.IsZero(), Equals, false)
 }
 
-func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicWithSnapdOnlyAndGadgetHappy(c *C) {
+func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicWithSnapdOnlyAndGadgetHappy(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
@@ -102,7 +103,7 @@ func (s *firstBoot16Suite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
-	s.SetupAssertSigning("can0nical", s)
+	s.SetupAssertSigning("canonical")
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})
@@ -113,6 +114,7 @@ func (s *firstBoot16Suite) SetUpTest(c *C) {
 		"account-id": "developerid",
 	}, "")
 
+	s.AddCleanup(sysdb.InjectTrusted([]asserts.Assertion{s.StoreSigning.TrustedKey}))
 	s.AddCleanup(ifacestate.MockSecurityBackends(nil))
 
 	ovld, err := overlord.New(nil)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -63,9 +63,9 @@ type FirstBootTestSuite struct {
 
 	systemctl *testutil.MockCmd
 
-	// TestingSeed helps populating seeds (it provides
+	// TestingSeed16 helps populating seeds (it provides
 	// MakeAssertedSnap, WriteAssertions etc.) for tests.
-	*seedtest.TestingSeed
+	*seedtest.TestingSeed16
 
 	devAcct *asserts.Account
 
@@ -101,14 +101,13 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
 
-	s.TestingSeed = &seedtest.TestingSeed{}
+	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.SetupAssertSigning("can0nical", s)
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})
 
-	s.SnapsDir = filepath.Join(dirs.SnapSeedDir, "snaps")
-	s.AssertsDir = filepath.Join(dirs.SnapSeedDir, "assertions")
+	s.SeedDir = dirs.SnapSeedDir
 
 	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
 		"account-id": "developerid",

--- a/seed/helpers_test.go
+++ b/seed/helpers_test.go
@@ -51,7 +51,7 @@ func (s *helpersSuite) SetUpTest(c *C) {
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
-	s.SetupAssertSigning("canonical", s)
+	s.SetupAssertSigning("canonical")
 
 	dir := c.MkDir()
 	s.assertsDir = filepath.Join(dir, "assertions")

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -248,59 +248,7 @@ func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
 	c.Check(err, ErrorMatches, `cannot read seed yaml: invalid risk in channel name: track/not-a-risk`)
 }
 
-var snapYaml = map[string]string{
-	"core": `name: core
-type: os
-version: 1.0
-`,
-	"pc-kernel": `name: pc-kernel
-type: kernel
-version: 1.0
-`,
-	"pc": `name: pc
-type: gadget
-version: 1.0
-`,
-	"required": `name: required
-type: app
-version: 1.0
-`,
-	"snapd": `name: snapd
-type: snapd
-version: 1.0
-`,
-	"core18": `name: core18
-type: base
-version: 1.0
-`,
-	"pc-kernel=18": `name: pc-kernel
-type: kernel
-version: 1.0
-`,
-	"pc=18": `name: pc
-type: gadget
-base: core18
-version: 1.0
-`,
-	"required18": `name: required18
-type: app
-base: core18
-version: 1.0
-`,
-	"classic-snap": `name: classic-snap
-type: app
-confinement: classic
-version: 1.0
-`,
-	"classic-gadget": `name: classic-gadget
-type: gadget
-version: 1.0
-`,
-	"classic-gadget18": `name: classic-gadget18
-type: gadget
-base: core18
-version: 1.0
-`,
+var snapYaml = seedtest.MergeSampleSnapYaml(seedtest.SampleSnapYaml, map[string]string{
 	"private-snap": `name: private-snap
 base: core18
 version: 1.0
@@ -309,7 +257,7 @@ version: 1.0
 base: core18
 version: 1.0
 `,
-}
+})
 
 const pcGadgetYaml = `
 volumes:

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -44,7 +44,7 @@ func Test(t *testing.T) { TestingT(t) }
 type seed16Suite struct {
 	testutil.BaseTest
 
-	*seedtest.TestingSeed
+	*seedtest.TestingSeed16
 	devAcct *asserts.Account
 
 	seedDir string
@@ -66,23 +66,20 @@ func (s *seed16Suite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
-	s.TestingSeed = &seedtest.TestingSeed{}
+	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.SetupAssertSigning("canonical", s)
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})
 
-	s.seedDir = c.MkDir()
-
-	s.SnapsDir = filepath.Join(s.seedDir, "snaps")
-	s.AssertsDir = filepath.Join(s.seedDir, "assertions")
+	s.SeedDir = c.MkDir()
 
 	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
 		"account-id": "developerid",
 	}, "")
 	assertstest.AddMany(s.StoreSigning, s.devAcct)
 
-	seed16, err := seed.Open(s.seedDir)
+	seed16, err := seed.Open(s.SeedDir)
 	c.Assert(err, IsNil)
 	s.seed16 = seed16
 
@@ -105,14 +102,14 @@ func (s *seed16Suite) TestLoadAssertionsNoAssertions(c *C) {
 }
 
 func (s *seed16Suite) TestLoadAssertionsNoModelAssertion(c *C) {
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.LoadAssertions(s.db, s.commitTo), ErrorMatches, "seed must have a model assertion")
 }
 
 func (s *seed16Suite) TestLoadAssertionsTwoModelAssertionsError(c *C) {
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
@@ -129,7 +126,7 @@ func (s *seed16Suite) TestLoadAssertionsTwoModelAssertionsError(c *C) {
 }
 
 func (s *seed16Suite) TestLoadAssertionsConsistencyError(c *C) {
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	// write out only the model assertion
@@ -145,7 +142,7 @@ func (s *seed16Suite) TestLoadAssertionsConsistencyError(c *C) {
 }
 
 func (s *seed16Suite) TestLoadAssertionsModelHappy(c *C) {
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
@@ -175,7 +172,7 @@ func (s *seed16Suite) TestLoadAssertionsModelTempDBHappy(c *C) {
 	r := seed.MockTrusted(s.StoreSigning.Trusted)
 	defer r()
 
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
@@ -203,7 +200,7 @@ func (s *seed16Suite) TestSkippedLoadAssertion(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
@@ -222,7 +219,7 @@ func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {
 }
 
 func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
@@ -244,7 +241,7 @@ func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
 		}},
 	})
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.seedDir, "seed.yaml"), content, 0644)
+	err = ioutil.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.seed16.LoadMeta(s.perfTimings)
@@ -406,13 +403,13 @@ func (s *seed16Suite) makeSeed(c *C, modelHeaders map[string]interface{}, seedSn
 		coreHeaders["gadget"] = "pc"
 	}
 
-	err := os.Mkdir(s.AssertsDir, 0755)
+	err := os.Mkdir(s.AssertsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	modelChain := s.MakeModelAssertionChain("my-brand", "my-model", coreHeaders, modelHeaders)
 	s.WriteAssertions("model.asserts", modelChain...)
 
-	err = os.Mkdir(s.SnapsDir, 0755)
+	err = os.Mkdir(s.SnapsDir(), 0755)
 	c.Assert(err, IsNil)
 
 	var completeSeedSnaps []*seed.InternalSnap16
@@ -422,7 +419,7 @@ func (s *seed16Suite) makeSeed(c *C, modelHeaders map[string]interface{}, seedSn
 		if seedSnap.Unasserted {
 			mockSnapFile := snaptest.MakeTestSnapWithFiles(c, snapYaml[seedSnap.Name], snapFiles[seedSnap.Name])
 			snapFname = filepath.Base(mockSnapFile)
-			err := os.Rename(mockSnapFile, filepath.Join(s.seedDir, "snaps", snapFname))
+			err := os.Rename(mockSnapFile, filepath.Join(s.SeedDir, "snaps", snapFname))
 			c.Assert(err, IsNil)
 		} else {
 			publisher := snapPublishers[seedSnap.Name]
@@ -454,12 +451,12 @@ func (s *seed16Suite) writeSeed(c *C, seedSnaps []*seed.InternalSnap16) {
 		"snaps": seedSnaps,
 	})
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.seedDir, "seed.yaml"), content, 0644)
+	err = ioutil.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 }
 
 func (s *seed16Suite) expectedPath(snapName string) string {
-	return filepath.Join(s.seedDir, "snaps", filepath.Base(s.AssertedSnap(snapName)))
+	return filepath.Join(s.SeedDir, "snaps", filepath.Base(s.AssertedSnap(snapName)))
 }
 
 func (s *seed16Suite) TestLoadMetaCore16Minimal(c *C) {
@@ -950,7 +947,7 @@ func (s *seed16Suite) TestLoadMetaCore18Local(c *C) {
 
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
-			Path:     filepath.Join(s.seedDir, "snaps", "required18_1.0_all.snap"),
+			Path:     filepath.Join(s.SeedDir, "snaps", "required18_1.0_all.snap"),
 			SideInfo: &snap.SideInfo{RealName: "required18"},
 			Required: true,
 			DevMode:  true,
@@ -1070,7 +1067,7 @@ func (s *seed16Suite) TestLoadMetaBrokenSeed(c *C) {
 	otherSnapFile := snaptest.MakeTestSnapWithFiles(c, `name: other
 version: other`, nil)
 	otherFname := filepath.Base(otherSnapFile)
-	err := os.Rename(otherSnapFile, filepath.Join(s.seedDir, "snaps", otherFname))
+	err := os.Rename(otherSnapFile, filepath.Join(s.SeedDir, "snaps", otherFname))
 	c.Assert(err, IsNil)
 
 	const otherBaseGadget = `name: pc

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -67,7 +67,7 @@ func (s *seed16Suite) SetUpTest(c *C) {
 	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
-	s.SetupAssertSigning("canonical", s)
+	s.SetupAssertSigning("canonical")
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seedtest
+
+var SampleSnapYaml = map[string]string{
+	"core": `name: core
+type: os
+version: 1.0
+`,
+	"pc-kernel": `name: pc-kernel
+type: kernel
+version: 1.0
+`,
+	"pc": `name: pc
+type: gadget
+version: 1.0
+`,
+	"classic-gadget": `name: classic-gadget
+version: 1.0
+type: gadget
+`,
+	"required": `name: required
+type: app
+version: 1.0
+`,
+	"classic-snap": `name: classic-snap
+type: app
+confinement: classic
+version: 1.0
+`,
+	"snapd": `name: snapd
+type: snapd
+version: 1.0
+`,
+	"core18": `name: core18
+type: base
+version: 1.0
+`,
+	"pc-kernel=18": `name: pc-kernel
+type: kernel
+version: 1.0
+`,
+	"pc=18": `name: pc
+type: gadget
+base: core18
+version: 1.0
+`,
+	"classic-gadget18": `name: classic-gadget18
+version: 1.0
+base: core18
+type: gadget
+`,
+	"required18": `name: required18
+type: app
+base: core18
+version: 1.0
+`,
+	"core20": `name: core20
+type: base
+version: 1.0
+`,
+	"pc-kernel=20": `name: pc-kernel
+type: kernel
+version: 1.0
+`,
+	"pc=20": `name: pc
+type: gadget
+base: core20
+version: 1.0
+`,
+}
+
+func MergeSampleSnapYaml(snapYaml ...map[string]string) map[string]string {
+	if len(snapYaml) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(snapYaml[0]))
+	for _, m := range snapYaml {
+		for yamlKey, yaml := range m {
+			merged[yamlKey] = yaml
+		}
+	}
+	return merged
+}

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -44,6 +44,8 @@ type SeedSnaps struct {
 
 	snaps map[string]string
 	infos map[string]*snap.Info
+
+	snapRevs map[string]*asserts.SnapRevision
 }
 
 // SetupAssertSigning initializes StoreSigning for storeBrandID and Brands.
@@ -102,13 +104,17 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 	if ss.snaps == nil {
 		ss.snaps = make(map[string]string)
 		ss.infos = make(map[string]*snap.Info)
+		ss.snapRevs = make(map[string]*asserts.SnapRevision)
 	}
 
 	ss.snaps[snapName] = snapFile
 	info.SideInfo.RealName = snapName
 	ss.infos[snapName] = info
+	snapDecl := declA.(*asserts.SnapDeclaration)
+	snapRev := revA.(*asserts.SnapRevision)
+	ss.snapRevs[snapName] = snapRev
 
-	return declA.(*asserts.SnapDeclaration), revA.(*asserts.SnapRevision)
+	return snapDecl, snapRev
 }
 
 func (ss *SeedSnaps) AssertedSnap(snapName string) (snapFile string) {
@@ -117,6 +123,10 @@ func (ss *SeedSnaps) AssertedSnap(snapName string) (snapFile string) {
 
 func (ss *SeedSnaps) AssertedSnapInfo(snapName string) *snap.Info {
 	return ss.infos[snapName]
+}
+
+func (ss *SeedSnaps) AssertedSnapRevision(snapName string) *asserts.SnapRevision {
+	return ss.snapRevs[snapName]
 }
 
 // TestingSeed16 helps setting up a populated Core 16/18 testing seed.

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -126,28 +126,35 @@ func (ss *SeedSnaps) AssertedSnapInfo(snapName string) *snap.Info {
 	return ss.infos[snapName]
 }
 
-// TestingSeed helps setting up a populated testing seed.
-type TestingSeed struct {
+// TestingSeed16 helps setting up a populated Core 16/18 testing seed.
+type TestingSeed16 struct {
 	SeedSnaps
 
-	SnapsDir   string
-	AssertsDir string
+	SeedDir string
 }
 
-func (s *TestingSeed) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string) (snapFname string, snapDecl *asserts.SnapDeclaration, snapRev *asserts.SnapRevision) {
+func (s *TestingSeed16) SnapsDir() string {
+	return filepath.Join(s.SeedDir, "snaps")
+}
+
+func (s *TestingSeed16) AssertsDir() string {
+	return filepath.Join(s.SeedDir, "assertions")
+}
+
+func (s *TestingSeed16) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string) (snapFname string, snapDecl *asserts.SnapDeclaration, snapRev *asserts.SnapRevision) {
 	decl, rev := s.SeedSnaps.MakeAssertedSnap(c, snapYaml, files, revision, developerID)
 
 	snapFile := s.snaps[decl.SnapName()]
 
 	snapFname = filepath.Base(snapFile)
-	targetFile := filepath.Join(s.SnapsDir, snapFname)
+	targetFile := filepath.Join(s.SnapsDir(), snapFname)
 	err := os.Rename(snapFile, targetFile)
 	c.Assert(err, IsNil)
 
 	return snapFname, decl, rev
 }
 
-func (s *TestingSeed) MakeModelAssertionChain(brandID, model string, extras ...map[string]interface{}) []asserts.Assertion {
+func (s *TestingSeed16) MakeModelAssertionChain(brandID, model string, extras ...map[string]interface{}) []asserts.Assertion {
 	assertChain := []asserts.Assertion{}
 	modelA := s.Brands.Model(brandID, model, extras...)
 
@@ -160,8 +167,8 @@ func (s *TestingSeed) MakeModelAssertionChain(brandID, model string, extras ...m
 	return assertChain
 }
 
-func (s *TestingSeed) WriteAssertions(fn string, assertions ...asserts.Assertion) {
-	fn = filepath.Join(s.AssertsDir, fn)
+func (s *TestingSeed16) WriteAssertions(fn string, assertions ...asserts.Assertion) {
+	fn = filepath.Join(s.AssertsDir(), fn)
 	WriteAssertions(fn, assertions...)
 }
 

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
@@ -47,15 +46,9 @@ type SeedSnaps struct {
 	infos map[string]*snap.Info
 }
 
-type Cleaner interface {
-	AddCleanup(func())
-}
-
 // SetupAssertSigning initializes StoreSigning for storeBrandID and Brands.
-func (ss *SeedSnaps) SetupAssertSigning(storeBrandID string, cleaner Cleaner) {
+func (ss *SeedSnaps) SetupAssertSigning(storeBrandID string) {
 	ss.StoreSigning = assertstest.NewStoreStack(storeBrandID, nil)
-	cleaner.AddCleanup(sysdb.InjectTrusted(ss.StoreSigning.Trusted))
-
 	ss.Brands = assertstest.NewSigningAccounts(ss.StoreSigning)
 }
 

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -39,9 +39,6 @@ type SeedSnaps struct {
 	StoreSigning *assertstest.StoreStack
 	Brands       *assertstest.SigningAccounts
 
-	// DB will be populated with snap assertions if not nil
-	DB *asserts.Database
-
 	snaps map[string]string
 	infos map[string]*snap.Info
 
@@ -59,7 +56,7 @@ func (ss *SeedSnaps) AssertedSnapID(snapName string) string {
 	return (cleanedName + strings.Repeat("id", 16)[len(cleanedName):])
 }
 
-func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
+func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 	snapName := info.SnapName()
@@ -94,10 +91,10 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 		info.Revision = revision
 	}
 
-	if ss.DB != nil {
-		err := ss.DB.Add(declA)
+	for _, db := range dbs {
+		err := db.Add(declA)
 		c.Assert(err, IsNil)
-		err = ss.DB.Add(revA)
+		err = db.Add(revA)
 		c.Assert(err, IsNil)
 	}
 

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -161,8 +161,12 @@ func (s *TestingSeed) MakeModelAssertionChain(brandID, model string, extras ...m
 }
 
 func (s *TestingSeed) WriteAssertions(fn string, assertions ...asserts.Assertion) {
-	multifn := filepath.Join(s.AssertsDir, fn)
-	f, err := os.OpenFile(multifn, os.O_CREATE|os.O_WRONLY, 0644)
+	fn = filepath.Join(s.AssertsDir, fn)
+	WriteAssertions(fn, assertions...)
+}
+
+func WriteAssertions(fn string, assertions ...asserts.Assertion) {
+	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -83,7 +83,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 	}
 
 	s.SeedSnaps = &seedtest.SeedSnaps{}
-	s.SetupAssertSigning("canonical", s)
+	s.SetupAssertSigning("canonical")
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -123,46 +123,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 	s.aRefs = make(map[string][]*asserts.Ref)
 }
 
-// TODO: share this with seed over seedtest as Sample* ?
-var snapYaml = map[string]string{
-	"core": `name: core
-type: os
-version: 1.0
-`,
-	"pc-kernel": `name: pc-kernel
-type: kernel
-version: 1.0
-`,
-	"pc": `name: pc
-type: gadget
-version: 1.0
-`,
-	"required": `name: required
-type: app
-version: 1.0
-`,
-	"classic-snap": `name: classic-snap
-type: app
-confinement: classic
-version: 1.0
-`,
-	"snapd": `name: snapd
-type: snapd
-version: 1.0
-`,
-	"core18": `name: core18
-type: base
-version: 1.0
-`,
-	"pc-kernel=18": `name: pc-kernel
-type: kernel
-version: 1.0
-`,
-	"pc=18": `name: pc
-type: gadget
-base: core18
-version: 1.0
-`,
+var snapYaml = seedtest.MergeSampleSnapYaml(seedtest.SampleSnapYaml, map[string]string{
 	"cont-producer": `name: cont-producer
 type: app
 base: core18
@@ -181,39 +142,12 @@ plugs:
      content: cont
      default-provider: cont-producer
 `,
-	"classic-gadget": `name: classic-gadget
-version: 1.0
-type: gadget
-`,
-	"classic-gadget18": `name: classic-gadget18
-version: 1.0
-base: core18
-type: gadget
-`,
-	"required18": `name: required18
-type: app
-base: core18
-version: 1.0
-`,
 	"required-base-core16": `name: required-base-core16
 type: app
 base: core16
 version: 1.0
 `,
-	"core20": `name: core20
-type: base
-version: 1.0
-`,
-	"pc-kernel=20": `name: pc-kernel
-type: kernel
-version: 1.0
-`,
-	"pc=20": `name: pc
-type: gadget
-base: core20
-version: 1.0
-`,
-}
+})
 
 const pcGadgetYaml = `
 volumes:

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -86,7 +86,6 @@ func (s *writerSuite) SetUpTest(c *C) {
 	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
 		"verification": "verified",
 	})
-	s.DB = s.StoreSigning.Database
 	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
 
 	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
@@ -168,7 +167,7 @@ func (s *writerSuite) makeSnap(c *C, yamlKey, publisher string) {
 	if publisher == "" {
 		publisher = "canonical"
 	}
-	s.MakeAssertedSnap(c, snapYaml[yamlKey], snapFiles[yamlKey], snap.R(1), publisher)
+	s.MakeAssertedSnap(c, snapYaml[yamlKey], snapFiles[yamlKey], snap.R(1), publisher, s.StoreSigning.Database)
 }
 
 func (s *writerSuite) makeLocalSnap(c *C, yamlKey string) (fname string) {


### PR DESCRIPTION
Changes to the seedtest API,  and renaming of the first boot suite to firstBoot16Suite with an extracted firstBootBaseTest.
