### PR TITLE
overlord: add kernel remodel undo tests and fix undo

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1726,7 +1726,7 @@ type: kernel`
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 }
 
-func (s *mgrsSuite) TestInstallKernelSnapUndoUpdatesBootloader(c *C) {
+func (s *mgrsSuite) TestInstallKernelSnapUndoUpdatesBootloaderEnv(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -4151,7 +4151,7 @@ version: 1.0`
 	c.Assert(t.Status(), Equals, state.DoingStatus)
 
 	// simulate rollback of the kernel during reboot
-	ms.mockRollbackAccrossReboot(c, bloader)
+	ms.mockRollbackAcrossReboot(c, bloader)
 
 	// continue
 	st.Unlock()

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -219,4 +219,6 @@ func MockPidsCgroupDir(dir string) (restore func()) {
 // link, misc handlers
 var (
 	MissingDisabledServices = missingDisabledServices
+
+	MaybeUndoRemodelBootChanges = maybeUndoRemodelBootChanges
 )

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1291,6 +1291,8 @@ func maybeUndoRemodelBootChanges(t *state.Task, undoInfo *snap.Info) error {
 		return nil
 	}
 	newModel := deviceCtx.Model()
+	// XXX: this will also look at bases, see
+	// https://github.com/snapcore/snapd/pulls
 	if undoInfo.InstanceName() != newModel.Kernel() {
 		return nil
 	}
@@ -1306,6 +1308,7 @@ func maybeUndoRemodelBootChanges(t *state.Task, undoInfo *snap.Info) error {
 		return nil
 	}
 	// get info for old kernel/base/core and see if we need to reboot
+	// TODO: we may need something like infoForDeviceSnap here
 	var snapst SnapState
 	if err = Get(t.State(), snapName, &snapst); err != nil {
 		return err

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1295,6 +1295,9 @@ func maybeUndoRemodelBootChanges(t *state.Task) error {
 	// check type of the snap we are undoing, only kernel/base/core are
 	// relevant
 	snapsup, _, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
 	var newSnapName, snapName string
 	switch snapsup.Type {
 	case snap.TypeKernel:

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -849,7 +849,6 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// XXX: for undo we need the "old" model assertion
 	model, err := ModelFromTask(t)
 	if err != nil && err != state.ErrNoState {
 		return err


### PR DESCRIPTION
When we remodel to a new kernel we update the bootloader in the
"link-snap" task. If the remodel change needs to be undone this
change needs to be undone as well. Today we only undo bootloader
changes in the undo of the "unlink-current-snap". This was fine
in the past as any boot change would involve this task (e.g.
a refresh to a new kernel meant that the current kernel got the
"unlink-current-snap" task). However in a remodel add a new
kernel and never change the exiting one so no unlink-current-snap
is run (and hence no undo).

This PR fixes this by checking in the undoLinkSnap if we are
in a remodel and if so if the kernel is affected and if we
need to switch back.

It also adds a test for the regular kernel undo in the manager test.
No changes are required here but this was not tested at this level.

Based on https://github.com/snapcore/snapd/pull/7701