### PR TITLE
tests: disable mount-ns test in release/2.42

### DIFF
--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -6,6 +6,12 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 # side-effects now. The test should be _eventually_ enabled on
 # ubuntu-core-16-64 and ubuntu-core-18-64.
 
+# set to manual in release/2.42 because core has changed and fixing
+# the tests would require larger changes, i.e.
+# https://github.com/snapcore/snapd/pull/7676 so it seems more expedient
+# disable this test here
+manual: true
+
 # The test is sensitive to backend type, which designates the used image.
 # Backends are enabled one-by-one along with the matching data set.
 backends: [google]


### PR DESCRIPTION
Set the mount-ns test to manual in release/2.42 because core has changed
and fixing the tests would require larger changes, i.e.
https://github.com/snapcore/snapd/pull/7676
so it seems more expedient disable this test here.

