### PR TITLE
snapstate,devicestate: make OldModel() available in DeviceContext

### DIFF
--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -60,6 +60,10 @@ func (dc modelDeviceContext) Model() *asserts.Model {
 	return dc.model
 }
 
+func (dc modelDeviceContext) OldModel() *asserts.Model {
+	return nil
+}
+
 func (dc modelDeviceContext) Store() snapstate.StoreService {
 	return nil
 }

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -29,6 +29,10 @@ import (
 type DeviceContext interface {
 	// Model returns the governing device model assertion for the context.
 	Model() *asserts.Model
+
+	// OldModel returns the old model assertion for the context. This will only return anything in a remodel context.
+	OldModel() *asserts.Model
+
 	// Store returns the store service to use under this context or nil if the snapstate store is appropriate.
 	Store() StoreService
 

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -30,7 +30,7 @@ type DeviceContext interface {
 	// Model returns the governing device model assertion for the context.
 	Model() *asserts.Model
 
-	// OldModel returns the old model assertion for the context. This will only return anything in a remodel context.
+	// OldModel returns the old model assertion for the device. This will only return something for a remodel context.
 	OldModel() *asserts.Model
 
 	// Store returns the store service to use under this context or nil if the snapstate store is appropriate.

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -27,9 +27,10 @@ import (
 )
 
 type TrivialDeviceContext struct {
-	DeviceModel *asserts.Model
-	Remodeling  bool
-	CtxStore    snapstate.StoreService
+	DeviceModel    *asserts.Model
+	OldDeviceModel *asserts.Model
+	Remodeling     bool
+	CtxStore       snapstate.StoreService
 }
 
 func (dc *TrivialDeviceContext) Model() *asserts.Model {
@@ -37,7 +38,7 @@ func (dc *TrivialDeviceContext) Model() *asserts.Model {
 }
 
 func (dc *TrivialDeviceContext) OldModel() *asserts.Model {
-	return nil
+	return dc.OldDeviceModel
 }
 
 func (dc *TrivialDeviceContext) Store() snapstate.StoreService {

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -36,6 +36,10 @@ func (dc *TrivialDeviceContext) Model() *asserts.Model {
 	return dc.DeviceModel
 }
 
+func (dc *TrivialDeviceContext) OldModel() *asserts.Model {
+	return nil
+}
+
 func (dc *TrivialDeviceContext) Store() snapstate.StoreService {
 	return dc.CtxStore
 }


### PR DESCRIPTION
This PR adds a new OldModel() accessor. This will be needed in
an undo for remodel operation.

This will be used in https://github.com/snapcore/snapd/pull/7682 (or a PR that is very similar to this one).