### PR TITLE
cmd/snap: make completion skip commands (& opts) that ask for it

### DIFF
--- a/cmd/snap/cmd_booted.go
+++ b/cmd/snap/cmd_booted.go
@@ -29,7 +29,7 @@ type cmdBooted struct{}
 
 func init() {
 	cmd := addCommand("booted",
-		"Internal",
+		"Internal (hidden)",
 		"The booted command is only retained for backwards compatibility.",
 		func() flags.Commander {
 			return &cmdBooted{}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -49,6 +49,7 @@ var (
 	PrintDescr         = printDescr
 	WrapFlow           = wrapFlow
 	TrueishJSON        = trueishJSON
+	CompletionHandler  = completionHandler
 
 	CanUnicode           = canUnicode
 	ColorTable           = colorTable

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -31,9 +31,9 @@ import (
 	"strings"
 	"testing"
 
-	. "gopkg.in/check.v1"
-
+	"github.com/jessevdk/go-flags"
 	"golang.org/x/crypto/ssh/terminal"
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
@@ -422,4 +422,13 @@ func (s *SnapSuite) TestSetsUserAgent(c *C) {
 
 	_ = snap.RunMain()
 	c.Assert(testServerHit, Equals, true)
+}
+
+func (s *SnapSuite) TestCompletionHandlerSkipsHidden(c *C) {
+	snap.CompletionHandler([]flags.Completion{
+		{Item: "foo", Description: "foo yadda yadda"},
+		{Item: "bar", Description: "bar yadda yack (hidden)"},
+		{Item: "baz", Description: "bar yack yack yack"},
+	})
+	c.Check(s.Stdout(), Equals, "foo\nbaz\n")
 }


### PR DESCRIPTION
This also tags 'booted' to use this feature. More to follow.
