### PR TITLE
client,daemon: pass sha3-384 in /v2/download to the client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -43,16 +43,17 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type clientSuite struct {
-	cli     *client.Client
-	req     *http.Request
-	reqs    []*http.Request
-	rsp     string
-	rsps    []string
-	err     error
-	doCalls int
-	header  http.Header
-	status  int
-	restore func()
+	cli           *client.Client
+	req           *http.Request
+	reqs          []*http.Request
+	rsp           string
+	rsps          []string
+	err           error
+	doCalls       int
+	header        http.Header
+	status        int
+	contentLength int64
+	restore       func()
 }
 
 var _ = Suite(&clientSuite{})
@@ -70,6 +71,7 @@ func (cs *clientSuite) SetUpTest(c *C) {
 	cs.header = nil
 	cs.status = 200
 	cs.doCalls = 0
+	cs.contentLength = 0
 
 	dirs.SetRootDir(c.MkDir())
 
@@ -89,9 +91,10 @@ func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {
 		body = cs.rsps[cs.doCalls]
 	}
 	rsp := &http.Response{
-		Body:       ioutil.NopCloser(strings.NewReader(body)),
-		Header:     cs.header,
-		StatusCode: cs.status,
+		Body:          ioutil.NopCloser(strings.NewReader(body)),
+		Header:        cs.header,
+		StatusCode:    cs.status,
+		ContentLength: cs.contentLength,
 	}
 	cs.doCalls++
 	return rsp, cs.err

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -318,8 +318,14 @@ type downloadAction struct {
 	snapRevisionOptions
 }
 
+type DownloadInfo struct {
+	SuggestedFileName string
+	Size              int64
+	Sha3_384          string
+}
+
 // Download will stream the given snap to the client
-func (client *Client) Download(name string, options *SnapOptions) (suggestedFileName string, r io.ReadCloser, err error) {
+func (client *Client) Download(name string, options *SnapOptions) (dlInfo *DownloadInfo, r io.ReadCloser, err error) {
 	if options == nil {
 		options = &SnapOptions{}
 	}
@@ -333,7 +339,7 @@ func (client *Client) Download(name string, options *SnapOptions) (suggestedFile
 	}
 	data, err := json.Marshal(&action)
 	if err != nil {
-		return "", nil, fmt.Errorf("cannot marshal snap action: %s", err)
+		return nil, nil, fmt.Errorf("cannot marshal snap action: %s", err)
 	}
 	headers := map[string]string{
 		"Content-Type": "application/json",
@@ -343,21 +349,27 @@ func (client *Client) Download(name string, options *SnapOptions) (suggestedFile
 	ctx := context.Background()
 	rsp, err := client.raw(ctx, "POST", "/v2/download", nil, headers, bytes.NewBuffer(data))
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 
 	if rsp.StatusCode != 200 {
 		var r response
 		defer rsp.Body.Close()
 		if err := decodeInto(rsp.Body, &r); err != nil {
-			return "", nil, err
+			return nil, nil, err
 		}
-		return "", nil, r.err(client, rsp.StatusCode)
+		return nil, nil, r.err(client, rsp.StatusCode)
 	}
 	matches := contentDispositionMatcher(rsp.Header.Get("Content-Disposition"))
 	if matches == nil || matches[1] == "" {
-		return "", nil, fmt.Errorf("cannot determine filename")
+		return nil, nil, fmt.Errorf("cannot determine filename")
 	}
 
-	return matches[1], rsp.Body, nil
+	dlInfo = &DownloadInfo{
+		SuggestedFileName: matches[1],
+		Size:              rsp.ContentLength,
+		Sha3_384:          rsp.Header.Get("X-Sha3-384"),
+	}
+
+	return dlInfo, rsp.Body, nil
 }

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -368,7 +368,7 @@ func (client *Client) Download(name string, options *SnapOptions) (dlInfo *Downl
 	dlInfo = &DownloadInfo{
 		SuggestedFileName: matches[1],
 		Size:              rsp.ContentLength,
-		Sha3_384:          rsp.Header.Get("X-Sha3-384"),
+		Sha3_384:          rsp.Header.Get("Snap-Sha3-384"),
 	}
 
 	return dlInfo, rsp.Body, nil

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -443,16 +443,24 @@ func (cs *clientSuite) TestSnapOptionsSerialises(c *check.C) {
 
 func (cs *clientSuite) TestClientOpDownload(c *check.C) {
 	cs.status = 200
-	cs.header = http.Header{"Content-Disposition": {"attachment; filename=foo_2.snap"}}
+	cs.header = http.Header{
+		"Content-Disposition": {"attachment; filename=foo_2.snap"},
+		"X-Sha3-384":          {"sha3sha3sha3"},
+	}
+	cs.contentLength = 1234
 
 	cs.rsp = `lots-of-foo-data`
 
-	fname, rc, err := cs.cli.Download("foo", &client.SnapOptions{
+	dlInfo, rc, err := cs.cli.Download("foo", &client.SnapOptions{
 		Revision: "2",
 		Channel:  "edge",
 	})
 	c.Check(err, check.IsNil)
-	c.Check(fname, check.Equals, "foo_2.snap")
+	c.Check(dlInfo, check.DeepEquals, &client.DownloadInfo{
+		SuggestedFileName: "foo_2.snap",
+		Size:              1234,
+		Sha3_384:          "sha3sha3sha3",
+	})
 
 	// check we posted the right stuff
 	c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, "application/json")

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -445,7 +445,7 @@ func (cs *clientSuite) TestClientOpDownload(c *check.C) {
 	cs.status = 200
 	cs.header = http.Header{
 		"Content-Disposition": {"attachment; filename=foo_2.snap"},
-		"X-Sha3-384":          {"sha3sha3sha3"},
+		"Snap-Sha3-384":       {"sha3sha3sha3"},
 	}
 	cs.contentLength = 1234
 

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -76,6 +76,7 @@ var storeSnaps = map[string]*snap.Info{
 		DownloadInfo: snap.DownloadInfo{
 			Size:            int64(len(snapContent)),
 			AnonDownloadURL: "http://localhost/bar",
+			Sha3_384:        "sha3sha3sha3",
 		},
 	},
 	"edge-bar": {
@@ -88,6 +89,7 @@ var storeSnaps = map[string]*snap.Info{
 		DownloadInfo: snap.DownloadInfo{
 			Size:            int64(len(snapContent)),
 			AnonDownloadURL: "http://localhost/edge-bar",
+			Sha3_384:        "sha3sha3sha3",
 		},
 	},
 	"rev7-bar": {
@@ -99,12 +101,14 @@ var storeSnaps = map[string]*snap.Info{
 		DownloadInfo: snap.DownloadInfo{
 			Size:            int64(len(snapContent)),
 			AnonDownloadURL: "http://localhost/rev7-bar",
+			Sha3_384:        "sha3sha3sha3",
 		},
 	},
 	"download-error-trigger-snap": {
 		DownloadInfo: snap.DownloadInfo{
 			Size:            100,
 			AnonDownloadURL: "http://localhost/foo",
+			Sha3_384:        "sha3sha3sha3",
 		},
 	},
 }
@@ -238,6 +242,7 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 			c.Assert(w.Header().Get("Content-Length"), check.Equals, expectedLength)
 			c.Assert(w.Header().Get("Content-Type"), check.Equals, "application/octet-stream")
 			c.Assert(w.Header().Get("Content-Disposition"), check.Equals, fmt.Sprintf("attachment; filename=%s_%s.snap", s.snapName, info.Revision))
+			c.Assert(w.Header().Get("X-Sha3-384"), check.Equals, "sha3sha3sha3", check.Commentf("invalid sha3 for %v", s.snapName))
 			c.Assert(w.Body.String(), check.Equals, "SNAP")
 		}
 	}

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -242,7 +242,7 @@ func (s *snapDownloadSuite) TestStreamOneSnap(c *check.C) {
 			c.Assert(w.Header().Get("Content-Length"), check.Equals, expectedLength)
 			c.Assert(w.Header().Get("Content-Type"), check.Equals, "application/octet-stream")
 			c.Assert(w.Header().Get("Content-Disposition"), check.Equals, fmt.Sprintf("attachment; filename=%s_%s.snap", s.snapName, info.Revision))
-			c.Assert(w.Header().Get("X-Sha3-384"), check.Equals, "sha3sha3sha3", check.Commentf("invalid sha3 for %v", s.snapName))
+			c.Assert(w.Header().Get("Snap-Sha3-384"), check.Equals, "sha3sha3sha3", check.Commentf("invalid sha3 for %v", s.snapName))
 			c.Assert(w.Body.String(), check.Equals, "SNAP")
 		}
 	}

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -265,7 +265,7 @@ func (s fileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	size := fmt.Sprintf("%d", s.Info.Size)
 	hdr.Set("Content-Length", size)
-	hdr.Set("X-Sha3-384", s.Info.Sha3_384)
+	hdr.Set("Snap-Sha3-384", s.Info.Sha3_384)
 
 	defer s.stream.Close()
 	bytesCopied, err := io.Copy(w, s.stream)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -265,6 +265,7 @@ func (s fileStream) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	size := fmt.Sprintf("%d", s.Info.Size)
 	hdr.Set("Content-Length", size)
+	hdr.Set("X-Sha3-384", s.Info.Sha3_384)
 
 	defer s.stream.Close()
 	bytesCopied, err := io.Copy(w, s.stream)


### PR DESCRIPTION
This implements passing the expected size and the expected
sha3 for snap that is downloaded via the /v2/download API.

It also updates the client.Download() to use this information
and pass it to the user. This will be used so validate
the downloaded snap in a followup.
