### PR TITLE
builtin/browser_support.go: allow monitoring process memory utilizati…

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -230,6 +230,9 @@ owner /{dev,run}/shm/WK2SharedMemory.* mrw,
 
 # Chromium content api on (at least) later versions of Ubuntu just use this
 owner /{dev,run}/shm/shmfd-* mrw,
+
+# Allow monitoring process memory utilization (used by chromium)
+owner @{PROC}/@{pid}/clear_refs w,
 `
 
 const browserSupportConnectedPlugSecComp = `


### PR DESCRIPTION
…on (used by chromium)

Blockng this creates denials as chromium tries to write into it
continously. Allowing acces should be safe.

http://man7.org/linux/man-pages/man5/proc.5.html
