### PR TITLE
tests: opensuse tumbleweed has similar issue than arch linux with snap --strace

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -46,9 +46,10 @@ execute: |
     fi
     MATCH "Can't stat 'invalid': No such file or directory" < stderr
 
-    if [[ "$SPREAD_SYSTEM" == arch-linux-* ]]; then
-        # Arch runs the mainline kernel, strace (with event filter or not) *may*
-        # randomly get stuck on the kernel side, see:
+    if [[ "$SPREAD_SYSTEM" == arch-* || "$SPREAD_SYSTEM" == opensuse-tumbleweed-* ]] ; then
+        # Arch linux and Opensuse tumbleweed run the mainline kernel, strace
+        # (with event filter or not) *may* randomly get stuck on the kernel
+        # side, see:
         # - proposed patch: https://lore.kernel.org/patchwork/patch/719314/
         # - snap-exec & strace stuck: https://paste.ubuntu.com/p/8nVzj8Sqfq/
         echo "SKIP further tests due to know kernel/strace problems"


### PR DESCRIPTION
The idea of the change is to apply the same solution then the used for
arch but for Opensuse tumbleweed.

These are the kernels used by the reference platforms:
. opensuse-tumbleweed-64: Linux version 5.3.7-1-default
. arch-linux-64: Linux version 5.3.7-arch1-2-ARCH
. ubuntu 18.04-64: Linux version 5.0.0-32-generic
