### PR TITLE
interfaces/gpg-keys: Enable access to system gpg_agent socket

### DIFF
--- a/interfaces/builtin/gpg_keys.go
+++ b/interfaces/builtin/gpg_keys.go
@@ -42,6 +42,13 @@ owner @{HOME}/.gnupg/{,**} r,
 # trustdb. For now, silence the denial since no other policy references this
 deny @{HOME}/.gnupg/trustdb.gpg w,
 
+# The intended use for this extra socket is to setup a Unix domain socket forwarding
+# from a remote snap to this socket on the local machine. A gpg running on the 
+# remote machine may then connect to the local gpg-agent and use its private keys. 
+# This enables decrypting or signing data on a remote machine without exposing the 
+# private keys to the remote machine. 
+owner /run/user/[0-9]*/gnupg/S.gpg-agent.extra r,
+
 # 'wk' is required for gpg encrypt and sign unless --no-random-seed-file is
 # used. Ideally we would not allow this access, but denying it causes gpg to
 # hang for all applications that don't specify --no-random-seed-file. Allow it

--- a/interfaces/builtin/gpg_keys.go
+++ b/interfaces/builtin/gpg_keys.go
@@ -42,12 +42,9 @@ owner @{HOME}/.gnupg/{,**} r,
 # trustdb. For now, silence the denial since no other policy references this
 deny @{HOME}/.gnupg/trustdb.gpg w,
 
-# The intended use for this extra socket is to setup a Unix domain socket forwarding
-# from a remote snap to this socket on the local machine. A gpg running on the 
-# remote machine may then connect to the local gpg-agent and use its private keys. 
-# This enables decrypting or signing data on a remote machine without exposing the 
-# private keys to the remote machine. 
-owner /run/user/[0-9]*/gnupg/S.gpg-agent.extra r,
+# This is needed to enable access to the gpg-agent running on the host.
+# With this, the snap can access private keys and decrypt files.
+owner /run/user/[0-9]*/gnupg/S.gpg-agent rw,
 
 # 'wk' is required for gpg encrypt and sign unless --no-random-seed-file is
 # used. Ideally we would not allow this access, but denying it causes gpg to


### PR DESCRIPTION
The main idea of this is to give read only access to the secret gpg key of the host.
This is potentially the solution to connecting to the agent and potentially decrypting encrypted files (or mail).

https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html#option-_002d_002dextra_002dsocket

To connect to this specific socket simply run gpg-connect-agent -S <socket>.

I still need to somewhat test this a little bit, it may be more appropriate in this case to allow access to the S.gpg-agent socket instead. In theory with some configuration in .gnupg it should connect to the extra socket and everything should just work.

I have signed the CLA and read the contributing.MD.

EDIT: Sorry for reopening but i just wanted to maybe adjust some things. I was thinking that it may be easier just to allow access to the gpg-agent socket rather than the extra socket. Although if it would be possible, it would be great to perhaps have access to the extra-socket as that would be able to limit how much potential damage a rogue snap could do with the private keys.

Looking at DMESG this file may be specifically asked for by gpg-agent and enigmail.

audit: type=1400 audit(1572395369.723:970): apparmor="DENIED" operation="connect" profile="snap.thunderbird.thunderbird" name="/run/user/1000/gnupg/S.gpg-agent" pid=14233 comm="gpg-connect-age" requested_mask="wr" denied_mask="wr" fsuid=1000 ouid=1000

audit: type=1400 audit(1572395349.623:967): apparmor="DENIED" operation="connect" profile="snap.thunderbird.thunderbird" name="/run/user/1000/gnupg/S.gpg-agent" pid=14228 comm="gpg-agent" requested_mask="wr" denied_mask="wr" fsuid=1000 ouid=1000
