### PR TITLE
many: load/consume Core 20 seeds (aka recovery systems)

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -114,13 +114,16 @@ func DeriveSideInfo(snapPath string, db Finder) (*snap.SideInfo, error) {
 		return nil, err
 	}
 
-	name := snapDecl.SnapName()
+	return SideInfoFromSnapAssertions(snapDecl, snapRev), nil
+}
 
+// SideInfoFromSnapAssertions returns a *snap.SideInfo reflecting the given snap assertions.
+func SideInfoFromSnapAssertions(snapDecl *asserts.SnapDeclaration, snapRev *asserts.SnapRevision) *snap.SideInfo {
 	return &snap.SideInfo{
-		RealName: name,
-		SnapID:   snapID,
+		RealName: snapDecl.SnapName(),
+		SnapID:   snapDecl.SnapID(),
 		Revision: snap.R(snapRev.SnapRevision()),
-	}, nil
+	}
 }
 
 // FetchSnapAssertions fetches the assertions matching the snap file digest using the given fetcher.

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -514,7 +514,7 @@ func (s *imageSuite) setupSnaps(c *C, publishers map[string]string) {
 }
 
 func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runSnaps []*seed.Snap, roDB asserts.RODatabase) {
-	seed, err := seed.Open(seeddir)
+	seed, err := seed.Open(seeddir, "")
 	c.Assert(err, IsNil)
 
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -74,7 +74,7 @@ func populateStateFromSeedImpl(st *state.State, tm timings.Measurer) ([]*state.T
 
 	markSeeded := st.NewTask("mark-seeded", i18n.G("Mark system seeded"))
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "") // XXX label should be passed in?
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -990,7 +990,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedClassicModelMismatch(c *C
 	st.Lock()
 	defer st.Unlock()
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "")
 	c.Assert(err, IsNil)
 
 	_, err = devicestate.ImportAssertionsFromSeed(st, deviceSeed)
@@ -1010,7 +1010,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c *
 	st.Lock()
 	defer st.Unlock()
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "")
 	c.Assert(err, IsNil)
 
 	_, err = devicestate.ImportAssertionsFromSeed(st, deviceSeed)
@@ -1036,7 +1036,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedHappy(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "")
 	c.Assert(err, IsNil)
 
 	model, err := devicestate.ImportAssertionsFromSeed(st, deviceSeed)
@@ -1077,7 +1077,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedMissingSig(c *C) {
 		}
 	}
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "")
 	c.Assert(err, IsNil)
 
 	// try import and verify that its rejects because other assertions are
@@ -1098,7 +1098,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
 	model2 := s.Brands.Model("my-brand", "my-second-model", s.modelHeaders("my-second-model"))
 	s.WriteAssertions("model2", model2)
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "")
 	c.Assert(err, IsNil)
 
 	// try import and verify that its rejects because other assertions are
@@ -1119,7 +1119,7 @@ func (s *firstBoot16Suite) TestImportAssertionsFromSeedNoModelAsserts(c *C) {
 		}
 	}
 
-	deviceSeed, err := seed.Open(dirs.SnapSeedDir)
+	deviceSeed, err := seed.Open(dirs.SnapSeedDir, "")
 	c.Assert(err, IsNil)
 
 	// try import and verify that its rejects because other assertions are

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -22,6 +22,7 @@ package seed
 
 import (
 	"errors"
+	"path/filepath"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/snap"
@@ -92,7 +93,13 @@ type Seed interface {
 }
 
 // Open returns a Seed implementation for the seed at seedDir.
-// TODO: more parameters for the Core20 case
-func Open(seedDir string) (Seed, error) {
+// label if not empty is used to identify a Core 20 recovery system seed.
+func Open(seedDir, label string) (Seed, error) {
+	if label != "" {
+		return &seed20{systemDir: filepath.Join(seedDir, "systems", label)}, nil
+	}
+	// TODO: consider if systems is present to open the Core 20
+	// system if there is only one, or the lexicographically
+	// highest label one?
 	return &seed16{seedDir: seedDir}, nil
 }

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -79,7 +79,7 @@ func (s *seed16Suite) SetUpTest(c *C) {
 	}, "")
 	assertstest.AddMany(s.StoreSigning, s.devAcct)
 
-	seed16, err := seed.Open(s.SeedDir)
+	seed16, err := seed.Open(s.SeedDir, "")
 	c.Assert(err, IsNil)
 	s.seed16 = seed16
 

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -1,0 +1,348 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seed
+
+/* ATTN this should *not* use:
+
+* dirs package: it is passed an explicit directory to work on
+
+* release.OnClassic: it assumes classic based on the model classic
+  option; consistency between system and model can/must be enforced
+  elsewhere
+
+*/
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/seed/internal"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/timings"
+)
+
+type seed20 struct {
+	systemDir string
+
+	db asserts.RODatabase
+
+	model *asserts.Model
+
+	snapDeclsByID   map[string]*asserts.SnapDeclaration
+	snapDeclsByName map[string]*asserts.SnapDeclaration
+
+	snapRevsByID map[string]*asserts.SnapRevision
+
+	auxInfos map[string]*internal.AuxInfo20
+
+	snaps             []*Snap
+	essentialSnapsNum int
+}
+
+func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
+	if db == nil {
+		// a db was not provided, create an internal temporary one
+		var err error
+		db, commitTo, err = newMemAssertionsDB()
+		if err != nil {
+			return err
+		}
+	}
+
+	assertsDir := filepath.Join(s.systemDir, "assertions")
+	// collect assertions that are not the model
+	var declRefs []*asserts.Ref
+	var revRefs []*asserts.Ref
+	checkAssertion := func(ref *asserts.Ref) error {
+		switch ref.Type {
+		case asserts.ModelType:
+			return fmt.Errorf("system cannot have any model assertion but the one in the system model assertion file")
+		case asserts.SnapDeclarationType:
+			declRefs = append(declRefs, ref)
+		case asserts.SnapRevisionType:
+			revRefs = append(revRefs, ref)
+		}
+		return nil
+	}
+
+	batch, err := loadAssertions(assertsDir, checkAssertion)
+	if err != nil {
+		return err
+	}
+
+	refs, err := readAsserts(batch, filepath.Join(s.systemDir, "model"))
+	if err != nil {
+		return fmt.Errorf("cannot read model assertion: %v", err)
+	}
+	if len(refs) != 1 || refs[0].Type != asserts.ModelType {
+		return fmt.Errorf("system model assertion file must contain exactly the model assertion")
+	}
+	modelRef := refs[0]
+
+	// this also verifies the consistency of all of them
+	if err := commitTo(batch); err != nil {
+		return err
+	}
+
+	find := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		a, err := ref.Resolve(db.Find)
+		if err != nil {
+			return nil, fmt.Errorf("internal error: cannot find just accepted assertion %v: %v", ref, err)
+		}
+		return a, nil
+	}
+
+	a, err := find(modelRef)
+	if err != nil {
+		return err
+	}
+	modelAssertion := a.(*asserts.Model)
+
+	snapDeclsByName := make(map[string]*asserts.SnapDeclaration, len(declRefs))
+	snapDeclsByID := make(map[string]*asserts.SnapDeclaration, len(declRefs))
+
+	for _, declRef := range declRefs {
+		a, err := find(declRef)
+		if err != nil {
+			return err
+		}
+		snapDecl := a.(*asserts.SnapDeclaration)
+		snapDeclsByID[snapDecl.SnapID()] = snapDecl
+		if snapDecl1 := snapDeclsByName[snapDecl.SnapName()]; snapDecl1 != nil {
+			return fmt.Errorf("cannot have multiple snap-declarations for the same snap-name: %s", snapDecl.SnapName())
+		}
+		snapDeclsByName[snapDecl.SnapName()] = snapDecl
+	}
+
+	snapRevsByID := make(map[string]*asserts.SnapRevision, len(revRefs))
+
+	for _, revRef := range revRefs {
+		a, err := find(revRef)
+		if err != nil {
+			return err
+		}
+		snapRevision := a.(*asserts.SnapRevision)
+		snapRevision1 := snapRevsByID[snapRevision.SnapID()]
+		if snapRevision1 != nil {
+			if snapRevision1.SnapRevision() != snapRevision.SnapRevision() {
+				return fmt.Errorf("cannot have multiple snap-revisions for the same snap-id: %s", snapRevision1.SnapID())
+			}
+		} else {
+			snapRevsByID[snapRevision.SnapID()] = snapRevision
+		}
+	}
+
+	// remember db for later use
+	s.db = db
+	// remember
+	s.model = modelAssertion
+	s.snapDeclsByID = snapDeclsByID
+	s.snapDeclsByName = snapDeclsByName
+	s.snapRevsByID = snapRevsByID
+
+	return nil
+}
+
+func (s *seed20) Model() (*asserts.Model, error) {
+	if s.model == nil {
+		return nil, fmt.Errorf("internal error: model assertion unset")
+	}
+	return s.model, nil
+}
+
+func (s *seed20) UsesSnapdSnap() bool {
+	return true
+}
+
+func (s *seed20) loadAuxInfos() error {
+	auxInfoFn := filepath.Join(s.systemDir, "snaps", "aux-info.json")
+	if !osutil.FileExists(auxInfoFn) {
+		// missing
+		return nil
+	}
+
+	f, err := os.Open(auxInfoFn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	if err := dec.Decode(&s.auxInfos); err != nil {
+		return fmt.Errorf("cannot decode aux-info.json: %v", err)
+	}
+	return nil
+}
+
+func (s *seed20) lookupVerifiedRevision(snapRef naming.SnapRef) (snapPath string, snapRev *asserts.SnapRevision, snapDecl *asserts.SnapDeclaration, err error) {
+	snapID := snapRef.ID()
+	if snapID != "" {
+		snapDecl = s.snapDeclsByID[snapID]
+		if snapDecl == nil {
+			return "", nil, nil, fmt.Errorf("cannot find snap-declaration for snap-id: %s", snapID)
+		}
+	} else {
+		if s.model.Grade() != asserts.ModelDangerous && snapRef.SnapName() != "snapd" && snapRef.SnapName() != s.model.Base() /* TODO: use snap-id for snapd*/ {
+			return "", nil, nil, fmt.Errorf("all system snaps must be identified by snap-id, missing for %q", snapRef.SnapName())
+		}
+		snapName := snapRef.SnapName()
+		snapDecl = s.snapDeclsByName[snapName]
+		if snapDecl == nil {
+			return "", nil, nil, fmt.Errorf("cannot find snap-declaration for snap name: %s", snapName)
+		}
+		snapID = snapDecl.SnapID()
+	}
+
+	snapRev = s.snapRevsByID[snapID]
+	if snapRev == nil {
+		return "", nil, nil, fmt.Errorf("cannot find snap-revision for snap-id: %s", snapID)
+	}
+
+	snapName := snapDecl.SnapName()
+	snapPath = filepath.Join(s.systemDir, "../../snaps", fmt.Sprintf("%s_%d.snap", snapName, snapRev.SnapRevision()))
+
+	fi, err := os.Stat(snapPath)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("cannot stat snap %q: %v", snapPath, err)
+	}
+
+	if fi.Size() != int64(snapRev.SnapSize()) {
+		return "", nil, nil, fmt.Errorf("cannot validate snap %q for snap %q (snap-id %q), wrong size", snapPath, snapName, snapID)
+	}
+
+	snapSHA3_384, _, err := asserts.SnapFileSHA3_384(snapPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	if snapSHA3_384 != snapRev.SnapSHA3_384() {
+		return "", nil, nil, fmt.Errorf("cannot validate snap %q for snap %q (snap-id %q), hash mismatch with snap-revision", snapPath, snapName, snapID)
+
+	}
+
+	return snapPath, snapRev, snapDecl, nil
+}
+
+func (s *seed20) addModelSnap(modelSnap *asserts.ModelSnap, essential bool, tm timings.Measurer) (*Snap, error) {
+	// TODO|XXX: support optional snaps correctly
+	// XXX consider options.yaml for grade dangerous
+	// XXX unasserted case
+	var path string
+	var sideInfo *snap.SideInfo
+	var err error
+	timings.Run(tm, "derive-side-info", fmt.Sprintf("hash and derive side info for snap %q", modelSnap.SnapName()), func(nested timings.Measurer) {
+		var snapRev *asserts.SnapRevision
+		var snapDecl *asserts.SnapDeclaration
+		path, snapRev, snapDecl, err = s.lookupVerifiedRevision(modelSnap)
+		if err == nil {
+			sideInfo = snapasserts.SideInfoFromSnapAssertions(snapDecl, snapRev)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// complement with aux-info.json information
+	auxInfo := s.auxInfos[sideInfo.SnapID]
+	if auxInfo != nil {
+		sideInfo.Private = auxInfo.Private
+		sideInfo.Contact = auxInfo.Contact
+	}
+
+	seedSnap := &Snap{
+		Path: path,
+
+		SideInfo: sideInfo,
+
+		Essential: essential,
+		Required:  essential || modelSnap.Presence == "required",
+
+		Channel: modelSnap.DefaultChannel,
+	}
+
+	s.snaps = append(s.snaps, seedSnap)
+	if essential {
+		s.essentialSnapsNum++
+	}
+
+	return seedSnap, nil
+}
+
+func (s *seed20) LoadMeta(tm timings.Measurer) error {
+	model, err := s.Model()
+	if err != nil {
+		return err
+	}
+
+	if err := s.loadAuxInfos(); err != nil {
+		return err
+	}
+
+	snapdSnap := internal.MakeSystemSnap("snapd", "latest/stable", []string{"run", "ephemeral"})
+	if _, err := s.addModelSnap(snapdSnap, true, tm); err != nil {
+		return err
+	}
+
+	essential := true
+	for _, modelSnap := range model.AllSnaps() {
+		seedSnap, err := s.addModelSnap(modelSnap, essential, tm)
+		if err != nil {
+			return err
+		}
+		if modelSnap.SnapType == "gadget" {
+			// sanity
+			snapf, err := snap.Open(seedSnap.Path)
+			if err != nil {
+				return err
+			}
+			info, err := snap.ReadInfoFromSnapFile(snapf, seedSnap.SideInfo)
+			if err != nil {
+				return err
+			}
+			if info.Base != model.Base() {
+				return fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, model.Base())
+			}
+			// TODO: when we allow extend models for classic
+			// we need to add the gadget base here
+
+			// done with essential snaps
+			essential = false
+		}
+	}
+
+	return nil
+}
+
+func (s *seed20) EssentialSnaps() []*Snap {
+	return s.snaps[:s.essentialSnapsNum]
+}
+
+func (s *seed20) ModeSnaps(mode string) ([]*Snap, error) {
+	if mode != "run" {
+		// XXX
+		return nil, fmt.Errorf("internal error: only run mode supported atm")
+	}
+	return s.snaps[s.essentialSnapsNum:], nil
+}

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -1,0 +1,251 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seed_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/seed/seedtest"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
+)
+
+type seed20Suite struct {
+	testutil.BaseTest
+
+	*seedtest.TestingSeed20
+	devAcct *asserts.Account
+
+	db *asserts.Database
+
+	perfTimings timings.Measurer
+}
+
+var _ = Suite(&seed20Suite{})
+
+func (s *seed20Suite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
+	s.TestingSeed20 = &seedtest.TestingSeed20{}
+	s.SetupAssertSigning("canonical")
+	s.Brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+		"verification": "verified",
+	})
+	// needed by TestingSeed20.MakeSeed (to work with makeSnap)
+
+	s.devAcct = assertstest.NewAccount(s.StoreSigning, "developer", map[string]interface{}{
+		"account-id": "developerid",
+	}, "")
+	assertstest.AddMany(s.StoreSigning, s.devAcct)
+
+	s.SeedDir = c.MkDir()
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.StoreSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+	s.db = db
+
+	s.perfTimings = timings.New(nil)
+}
+
+func (s *seed20Suite) commitTo(b *asserts.Batch) error {
+	return b.CommitTo(s.db, nil)
+}
+
+func (s *seed20Suite) makeSnap(c *C, yamlKey, publisher string) {
+	if publisher == "" {
+		publisher = "canonical"
+	}
+	s.MakeAssertedSnap(c, snapYaml[yamlKey], nil, snap.R(1), publisher, s.StoreSigning.Database)
+}
+
+func (s *seed20Suite) expectedPath(snapName string) string {
+	return filepath.Join(s.SeedDir, "snaps", filepath.Base(s.AssertedSnapInfo(snapName).MountFile()))
+}
+
+func (s *seed20Suite) TestLoadMetaCore20Minimal(c *C) {
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+
+	sysLabel := "20101018"
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			}},
+	})
+
+	seed20, err := seed.Open(s.SeedDir, sysLabel)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadAssertions(s.db, s.commitTo)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadMeta(s.perfTimings)
+	c.Assert(err, IsNil)
+
+	c.Check(seed20.UsesSnapdSnap(), Equals, true)
+
+	essSnaps := seed20.EssentialSnaps()
+	c.Check(essSnaps, HasLen, 4)
+
+	c.Check(essSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:      s.expectedPath("snapd"),
+			SideInfo:  &s.AssertedSnapInfo("snapd").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "latest/stable",
+		}, {
+			Path:      s.expectedPath("pc-kernel"),
+			SideInfo:  &s.AssertedSnapInfo("pc-kernel").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "20",
+		}, {
+			Path:      s.expectedPath("core20"),
+			SideInfo:  &s.AssertedSnapInfo("core20").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "latest/stable",
+		}, {
+			Path:      s.expectedPath("pc"),
+			SideInfo:  &s.AssertedSnapInfo("pc").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "20",
+		},
+	})
+
+	runSnaps, err := seed20.ModeSnaps("run")
+	c.Assert(err, IsNil)
+	c.Check(runSnaps, HasLen, 0)
+}
+
+func (s *seed20Suite) TestLoadMetaCore20(c *C) {
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "required20", "developerid")
+
+	s.AssertedSnapInfo("required20").Contact = "author@example.com"
+
+	sysLabel := "20101018"
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+			}},
+	})
+
+	seed20, err := seed.Open(s.SeedDir, sysLabel)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadAssertions(s.db, s.commitTo)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadMeta(s.perfTimings)
+	c.Assert(err, IsNil)
+
+	c.Check(seed20.UsesSnapdSnap(), Equals, true)
+
+	essSnaps := seed20.EssentialSnaps()
+	c.Check(essSnaps, HasLen, 4)
+
+	c.Check(essSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:      s.expectedPath("snapd"),
+			SideInfo:  &s.AssertedSnapInfo("snapd").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "latest/stable",
+		}, {
+			Path:      s.expectedPath("pc-kernel"),
+			SideInfo:  &s.AssertedSnapInfo("pc-kernel").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "20",
+		}, {
+			Path:      s.expectedPath("core20"),
+			SideInfo:  &s.AssertedSnapInfo("core20").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "latest/stable",
+		}, {
+			Path:      s.expectedPath("pc"),
+			SideInfo:  &s.AssertedSnapInfo("pc").SideInfo,
+			Essential: true,
+			Required:  true,
+			Channel:   "20",
+		},
+	})
+
+	runSnaps, err := seed20.ModeSnaps("run")
+	c.Assert(err, IsNil)
+	c.Check(runSnaps, HasLen, 1)
+	c.Check(runSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:     s.expectedPath("required20"),
+			SideInfo: &s.AssertedSnapInfo("required20").SideInfo,
+			Required: true,
+			Channel:  "latest/stable",
+		},
+	})
+}

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -85,6 +85,11 @@ type: gadget
 base: core20
 version: 1.0
 `,
+	"required20": `name: required20
+type: app
+base: core20
+version: 1.0
+`,
 }
 
 func MergeSampleSnapYaml(snapYaml ...map[string]string) map[string]string {

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
@@ -185,4 +186,80 @@ func WriteAssertions(fn string, assertions ...asserts.Assertion) {
 			panic(err)
 		}
 	}
+}
+
+// TestingSeed20 helps setting up a populated Core 20 testing seed directory.
+type TestingSeed20 struct {
+	SeedSnaps
+
+	SeedDir string
+}
+
+func (s *TestingSeed20) MakeSeed(c *C, label, brandID, modelID string, modelHeaders map[string]interface{} /* XXX []OptionsSnap*/) {
+	model := s.Brands.Model(brandID, modelID, modelHeaders)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.StoreSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		return ref.Resolve(s.StoreSigning.Find)
+	}
+	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
+		save2 := func(a asserts.Assertion) error {
+			// for checking
+			err := db.Add(a)
+			if err != nil {
+				if _, ok := err.(*asserts.RevisionError); ok {
+					return nil
+				}
+				return err
+			}
+			return save(a)
+		}
+		return asserts.NewFetcher(db, retrieve, save2)
+	}
+	assertstest.AddMany(s.StoreSigning, s.Brands.AccountsAndKeys("my-brand")...)
+
+	opts := seedwriter.Options{
+		SeedDir: s.SeedDir,
+		Label:   label,
+	}
+	w, err := seedwriter.New(model, &opts)
+	c.Assert(err, IsNil)
+
+	rf, err := w.Start(db, newFetcher)
+	c.Assert(err, IsNil)
+
+	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
+
+	for _, sn := range snaps {
+		name := sn.SnapName()
+
+		info := s.AssertedSnapInfo(name)
+		c.Assert(info, NotNil, Commentf("%s", name))
+		err := w.SetInfo(sn, info)
+		c.Assert(err, IsNil)
+
+		prev := len(rf.Refs())
+		err = rf.Save(s.snapRevs[name])
+		c.Assert(err, IsNil)
+		sn.ARefs = rf.Refs()[prev:]
+
+		err = os.Rename(s.AssertedSnap(name), sn.Path)
+		c.Assert(err, IsNil)
+	}
+
+	complete, err := w.Downloaded()
+	c.Assert(err, IsNil)
+	c.Check(complete, Equals, true)
+
+	err = w.SeedSnaps(nil)
+	c.Assert(err, IsNil)
+
+	err = w.WriteMeta()
+	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Only non-dangerous features support so far.

This needs also more error path coverage, but that might need to come in follow ups, it's already quite large.

