### PR TITLE
interfaces/lxd-support: Fix on core18

### DIFF
--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -40,7 +40,7 @@ const lxdSupportConnectedPlugAppArmor = `
 # giving access to all resources of the system so LXD may manage what to give
 # to its containers. This gives device ownership to connected snaps.
 @{PROC}/**/attr/current r,
-/usr/sbin/aa-exec ux,
+/{,usr/}{,s}bin/aa-exec ux,
 
 # Allow discovering the os-release of the host
 /var/lib/snapd/hostfs/{etc,usr/lib}/os-release r,

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -77,7 +77,7 @@ func (s *LxdSupportInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/sbin/aa-exec ux,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,usr/}{,s}bin/aa-exec ux,\n")
 }
 
 func (s *LxdSupportInterfaceSuite) TestSecCompSpec(c *C) {


### PR DESCRIPTION
The LXD interface effectively allows access to aa-exec.
This used to be in /usr/sbin/aa-exec on Ubuntu 16.04, on Ubuntu 18.04,
it's now in /usr/bin/aa-exec, making the interface unusable with core18.

This change allows aa-exec to be in any of:
 - /bin
 - /usr/bin
 - /sbin
 - /usr/sbin

Which should cover the location for core16, core18 and the upcoming core20.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>