### PR TITLE
tests/docker-smoke: add minimal docker smoke test

### DIFF
--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -1,0 +1,16 @@
+summary: Check that the the docker snap works basically
+
+# only run on ubuntus for now, the docker snap has issues on non-ubuntu ATM
+systems:
+  - ubuntu-*
+
+debug: |
+  journalctl -u snap.docker.dockerd
+
+execute: |
+  if ! snap install docker; then
+    echo "failed to install the docker snap!"
+    exit 1
+  fi
+
+  retry-tool -n 30 --wait 1 docker run hello-world | MATCH "installation appears to be working correctly"


### PR DESCRIPTION
This should help us catch potential issues with mount namespaces and cgroups and the like that may break the docker snap (and other similar container snaps).

Just running on Ubuntu for now since there are some known problems with the docker snap on other platforms.