### PR TITLE
tests/main/gadget-update-pc: cleanup per-revision directories

### DIFF
--- a/tests/main/gadget-update-pc/task.yaml
+++ b/tests/main/gadget-update-pc/task.yaml
@@ -91,6 +91,13 @@ restore: |
     # restore the original gadget snap
     snap install gadget.snap
 
+    # restoring the snapshot of / does not clean up /var/snap/pc/<rev>
+    # directories that were created during the test, given that the state is
+    # restored these directories will not be accounted for
+    for i in $(seq 0 2); do
+        rm -rf "/var/snap/pc/$((START_REVISION+i))"
+    done
+
 execute: |
     # external backends do not enable test keys
     if [ "$TRUST_TEST_KEYS" = "false" ]; then


### PR DESCRIPTION
The test installs a repacked snaps, with forged revisions 1000-1002. However,
when the snapshot of / is restored after the test, files and only overwritten,
but the entries created by the test will not be removed. Make sure to clean up
the created directories manually when restoring, otherwise this may break the
tests that run later.