### PR TITLE
asserts: add "snapd" type to valid types in the model assertion

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -174,7 +174,7 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 }
 
 var (
-	validSnapTypes     = []string{"app", "base", "gadget", "kernel", "core"}
+	validSnapTypes     = []string{"app", "base", "gadget", "kernel", "core", "snapd"}
 	validSnapMode      = regexp.MustCompile("^[a-z][-a-z]+$")
 	validSnapPresences = []string{"required", "optional"}
 )
@@ -214,7 +214,7 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, 
 		typ = "app"
 	}
 	if !strutil.ListContains(validSnapTypes, typ) {
-		return nil, fmt.Errorf("type of snap %q must be one of app|base|gadget|kernel|core", name)
+		return nil, fmt.Errorf("type of snap %q must be one of app|base|gadget|kernel|core|snapd", name)
 	}
 
 	modes, err := checkStringListInMap(snap, "modes", fmt.Sprintf("%q %s", "modes", what), validSnapMode)

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -214,7 +214,7 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, 
 		typ = "app"
 	}
 	if !strutil.ListContains(validSnapTypes, typ) {
-		return nil, fmt.Errorf("type of snap %q must be one of app|base|gadget|kernel|core|snapd", name)
+		return nil, fmt.Errorf("type of snap %q must be one of %s", name, strings.Join(validSnapTypes, "|"))
 	}
 
 	modes, err := checkStringListInMap(snap, "modes", fmt.Sprintf("%q %s", "modes", what), validSnapMode)

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -749,7 +749,7 @@ func (mods *modelSuite) TestCore20DecodeInvalid(c *C) {
 		{"id: myappdididididididididididididid\n", "id: 2\n", `"id" of snap "myapp" contains invalid characters: "2"`},
 		{"    id: myappdididididididididididididid\n", "", `"id" of snap "myapp" is mandatory for stable model`},
 		{"type: gadget\n", "type:\n      - g\n", `"type" of snap "brand-gadget" must be a string`},
-		{"type: app\n", "type: thing\n", `"type" of snap "myappopt" must be one of must be one of app|base|gadget|kernel|core`},
+		{"type: app\n", "type: thing\n", `"type" of snap "myappopt" must be one of must be one of app|base|gadget|kernel|core|snapd`},
 		{"modes:\n      - run\n", "modes: run\n", `"modes" of snap "other-base" must be a list of strings`},
 		{"default-channel: 20\n", "default-channel: edge\n", `default channel for snap "baz-linux" must specify a track`},
 		{"default-channel: 2.0\n", "default-channel:\n      - x\n", `"default-channel" of snap "myapp" must be a string`},

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -686,6 +686,41 @@ func (mods *modelSuite) TestCore20ExplictBootBase(c *C) {
 	})
 }
 
+func (mods *modelSuite) TestCore20ExplictSnapd(c *C) {
+	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
+	encoded = strings.Replace(encoded, "OTHER", `  -
+    name: snapd
+    id: snapdidididididididididididididd
+    type: snapd
+    modes:
+      - run
+      - ephemeral
+    default-channel: latest/edge
+`, 1)
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.ModelType)
+	model := a.(*asserts.Model)
+	find := func(snapName string, haystack []*asserts.ModelSnap) *asserts.ModelSnap {
+		for _, s := range haystack {
+			if s.Name == snapName {
+				return s
+			}
+		}
+		return nil
+	}
+	snapdSnap := find("snapd", model.AllSnaps())
+	c.Assert(snapdSnap, NotNil)
+	c.Check(snapdSnap, DeepEquals, &asserts.ModelSnap{
+		Name:           "snapd",
+		SnapID:         "snapdidididididididididididididd",
+		SnapType:       "snapd",
+		Modes:          []string{"run", "ephemeral"},
+		DefaultChannel: "latest/edge",
+		Presence:       "required",
+	})
+}
+
 func (mods *modelSuite) TestCore20GradeOptionalDefaultSigned(c *C) {
 	encoded := strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1)
 	encoded = strings.Replace(encoded, "OTHER", "", 1)


### PR DESCRIPTION
This PR adds the "snapd" snap type to the valid types of the
model assertion.
