### PR TITLE
gadget: add support for hybrid partitioning schemas

### DIFF
--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -732,12 +732,16 @@ func (s *gadgetYamlTestSuite) TestValidateStructureType(c *C) {
 		{"21686148-6449-6E6F-744E-656564454649", "", gadget.GPT},
 		// GPT UUID (lowercase)
 		{"21686148-6449-6e6f-744e-656564454649", "", gadget.GPT},
-		// hybrid ID
+		// hybrid ID with implicit GPT schema
 		{"EF,21686148-6449-6E6F-744E-656564454649", "", ""},
 		// hybrid ID (UUID lowercase)
 		{"EF,21686148-6449-6e6f-744e-656564454649", "", ""},
 		// hybrid, partially lowercase UUID
 		{"EF,aa686148-6449-6e6f-744E-656564454649", "", ""},
+		// hybrid ID with MBR schema
+		{"EF,21686148-6449-6e6f-744e-656564454649", "", gadget.MBR},
+		// hybrid ID with hybrid schema
+		{"EF,21686148-6449-6e6f-744e-656564454649", "", gadget.Hybrid},
 		// GPT UUID, partially lowercase
 		{"aa686148-6449-6e6f-744E-656564454649", "", ""},
 		// no type specified
@@ -763,6 +767,10 @@ func (s *gadgetYamlTestSuite) TestValidateStructureType(c *C) {
 		{"EF,AAAA686148-6449-6E6F-744E-656564454649", `invalid type "EF,AAAA686148-6449-6E6F-744E-656564454649": invalid format of hybrid type`, ""},
 		// GPT schema with non GPT type
 		{"EF,AAAA686148-6449-6E6F-744E-656564454649", `invalid type "EF,AAAA686148-6449-6E6F-744E-656564454649": invalid format of hybrid type`, gadget.GPT},
+		// solely GPT UUID with hybrid schema
+		{"21686148-6449-6E6F-744E-656564454649", `invalid type "21686148-6449-6E6F-744E-656564454649": non-hybrid type with a hybrid schema`, gadget.Hybrid},
+		// solely MBR type with a hybrid schema
+		{"0C", `invalid type "0C": non-hybrid type with a hybrid schema`, gadget.Hybrid},
 	} {
 		c.Logf("tc: %v %q", i, tc.s)
 
@@ -912,6 +920,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeSchema(c *C) {
 	}{
 		{gadget.GPT, ""},
 		{gadget.MBR, ""},
+		{gadget.Hybrid, ""},
 		// implicit GPT
 		{"", ""},
 		// invalid

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -165,7 +165,7 @@ func isLegacyMBRTransition(from *LaidOutStructure, to *LaidOutStructure) bool {
 }
 
 func canUpdateStructure(from *LaidOutStructure, to *LaidOutStructure, schema string) error {
-	if schema == GPT && from.Name != to.Name {
+	if (schema == GPT || schema == Hybrid) && from.Name != to.Name {
 		// partition names are only effective when GPT is used
 		return fmt.Errorf("cannot change structure name from %q to %q", from.Name, to.Name)
 	}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -518,6 +518,15 @@ func (u *updateTestSuite) TestCanUpdateName(c *C) {
 			},
 			err:    `cannot change structure name from "foo" to "gpt-unhappy"`,
 			schema: gadget.GPT,
+		}, {
+			from: gadget.LaidOutStructure{
+				VolumeStructure: &gadget.VolumeStructure{Name: "foo", Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			to: gadget.LaidOutStructure{
+				VolumeStructure: &gadget.VolumeStructure{Name: "gpt-unhappy", Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			},
+			err:    `cannot change structure name from "foo" to "gpt-unhappy"`,
+			schema: gadget.Hybrid,
 		},
 	}
 	u.testCanUpdate(c, cases)


### PR DESCRIPTION
The gadget spec lists mbr,gpt as an accepted identifier for a hybrid MBR/GPT
partitioning schema. Update the gadget validation code to accept such schemas.

At the same time the type validation rules are updated to accept schema specific
types or hybrid ones where appropriate to make current gadgets work. For
instance, the pc gadget snap uses the following bit in gadget.yaml:
```
volumes:
  pc:
    bootloader: grub
    structure:
      ...
      - name: BIOS Boot
        type: DA,21686148-6449-6E6F-744E-656564454649
        ...
      - name: EFI System
        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
        ...
```
What defaults to the GPT partitioning schema, but uses a hybrid type for
structures.
