### PR TITLE
cmd/snap-confine: add sc_join_sub_group

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-support.c
+++ b/cmd/libsnap-confine-private/cgroup-support.c
@@ -97,3 +97,97 @@ bool sc_cgroup_is_v2() {
     }
     return false;
 }
+
+/**
+ * sc_find_unified_hierarchy produces the full /sys/fs/cgroup/ path of the v2
+ * hierarchy of the given process. The result is written to path buffer. If the
+ * location cannot be found or any other error occurs, the process dies.
+ **/
+static void sc_find_unified_hierarchy(pid_t pid, char *path, size_t path_size) {
+    /* Find the path of the unified hierarchy of the given process. */
+    char proc_pid_cgroup[PATH_MAX + 1] = {};
+    sc_must_snprintf(proc_pid_cgroup, sizeof proc_pid_cgroup, "/proc/%d/cgroup", (int)pid);
+    int fd = open(proc_pid_cgroup, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0) {
+        die("cannot open %s", proc_pid_cgroup);
+    }
+    /* The ownership of the descriptor is now passed to the stream. */
+    FILE *stream = fdopen(fd, "r");
+    if (stream == NULL) {
+        die("cannot open stream from %d", fd);
+    }
+    /* The format of the file is: set of lines representing records. Each
+     * record is a tuple (hierarchy-id,controller-list,cgroup-path) using
+     * colons as element separators. Controllers is in turn a list using commas
+     * as separators. See cgroups(7) for authoritative reference. */
+    char *line = NULL;
+    size_t size = 0;
+    bool found = false;
+    while (!found) {
+        /* Read the next line, chomp the trailing newline and parse it. */
+        errno = 0;
+        ssize_t len = getline(&line, &size, stream);
+        if (len < 0) {
+            if (errno != 0) {
+                die("cannot read subsequent line from %s", proc_pid_cgroup);
+            }
+            break;
+        }
+        if (len > 0 && line[len - 1] == '\n') {
+            line[len - 1] = '\0';
+            len--;
+        }
+        char *attr_id, *attr_ctrl_list, *attr_path, *tmp;
+
+        attr_id = line;
+
+        tmp = strchr(attr_id, ':');
+        if (tmp == NULL) {
+            die("cannot parse cgroup, expected hierarchy id: %s", line);
+        }
+        attr_ctrl_list = tmp + 1;
+
+        tmp = strchr(attr_ctrl_list, ':');
+        if (tmp == NULL) {
+            die("cannot parse cgroup, expected controller list: %s", line);
+        }
+        attr_path = tmp + 1;
+
+        tmp = strchr(attr_path, ':');
+        if (tmp != NULL) {
+            die("cannot parse cgroup, expected end of line: %s", line);
+        }
+        attr_ctrl_list[-1] = '\0';
+        attr_path[-1] = '\0';
+
+        debug("cgroup presence: id:%s, controllers:%s, path:%s", attr_id, attr_ctrl_list, attr_path);
+
+        /* Ignore all entires that describe v1 cgroup hierarchies. They have
+         * non-zero identifiers. Only v2 uses the id of zero. */
+        if (strcmp(attr_id, "0") != 0) {
+            continue;
+        }
+        if (attr_path[0] == '/') {
+            attr_path++;
+        }
+        /* TODO: parse mountinfo and find the mount point instead of assuming common sense. */
+        if (sc_cgroup_is_v2()) {
+            sc_must_snprintf(path, path_size, "/sys/fs/cgroup/%s", attr_path);
+        } else {
+            sc_must_snprintf(path, path_size, "/sys/fs/cgroup/unified/%s", attr_path);
+        }
+        found = true;
+        debug("unified/v2 cgroup path is %s", path);
+    }
+    free(line);
+    fclose(stream);
+    if (!found) {
+        die("cannot find cgroup v2 path");
+    }
+}
+
+void sc_join_sub_cgroup(const char *security_tag, pid_t pid) {
+    char current_hierarchy_path[PATH_MAX + 1] = {};
+    sc_find_unified_hierarchy(pid, current_hierarchy_path, sizeof current_hierarchy_path);
+    sc_cgroup_create_and_join(current_hierarchy_path, security_tag, pid);
+}

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -37,4 +37,13 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid);
  **/
 bool sc_cgroup_is_v2(void);
 
+/**
+ * sc_join_sub_cgroup() joins a leaf v2 hierarchy named after the security tag.
+ *
+ * The code scans /proc/[pid]/cgroup, finds the location in the unified
+ * hierarchy and moves the given process to a new leaf sub-hierarchy named
+ * like the security tag.
+ **/
+void sc_join_sub_cgroup(const char *security_tag, pid_t pid);
+
 #endif

--- a/cmd/libsnap-confine-private/cgroup-support.h
+++ b/cmd/libsnap-confine-private/cgroup-support.h
@@ -38,11 +38,11 @@ void sc_cgroup_create_and_join(const char *parent, const char *name, pid_t pid);
 bool sc_cgroup_is_v2(void);
 
 /**
- * sc_join_sub_cgroup() joins a leaf v2 hierarchy named after the security tag.
+ * sc_join_sub_cgroup() joins a leaf tracking cgroup named by the security tag.
  *
- * The code scans /proc/[pid]/cgroup, finds the location in the unified
- * hierarchy and moves the given process to a new leaf sub-hierarchy named
- * like the security tag.
+ * The code scans /proc/[pid]/cgroup, finds the location in either the unified
+ * hierarchy or the name=systemd hierarchy, and moves the given process to a
+ * new leaf sub-hierarchy named like the security tag.
  **/
 void sc_join_sub_cgroup(const char *security_tag, pid_t pid);
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -75,10 +75,10 @@
     /sys/fs/cgroup/pids/snap.*/ w,
     /sys/fs/cgroup/pids/snap.*/cgroup.procs w,
 
-    # cgroup: unified/v2
+    # cgroup: tracking via unified/v2 or name=systemd/v1
     @{PROC}/*/cgroup r,
-    /sys/fs/cgroup/{,unified/}**/snap.*/ w,
-    /sys/fs/cgroup/{,unified/}**/snap.*/cgroup.procs w,
+    /sys/fs/cgroup/{,unified/,name=systemd/}**/snap.*/ w,
+    /sys/fs/cgroup/{,unified/,name=systemd/}**/snap.*/cgroup.procs w,
 
     # querying udev
     /etc/udev/udev.conf r,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -75,6 +75,11 @@
     /sys/fs/cgroup/pids/snap.*/ w,
     /sys/fs/cgroup/pids/snap.*/cgroup.procs w,
 
+    # cgroup: unified/v2
+    @{PROC}/*/cgroup r,
+    /sys/fs/cgroup/{,unified/}**/snap.*/ w,
+    /sys/fs/cgroup/{,unified/}**/snap.*/cgroup.procs w,
+
     # querying udev
     /etc/udev/udev.conf r,
     /sys/**/uevent r,


### PR DESCRIPTION
This patch adds the logic for discovering the location in the unified
hierarchy and moving to a sub-directory of said hierarchy.

This allows all snaps, regardless of their type, "tag" their processes
in a way that is easy to detect. To detect presence of processes
belonging to a given snap one can lock the per-snap lock, iterate available
cgroups and look for all entries named snap.$SNAP_NAME.*.
Inside look at cgroup.procs and enumerate all processes.

This method works inside containers and across Ubuntu 14.04 all the way
to pure-cgroup v2 world Fedora 31. The method supports both v2 and,
as a fallback, v1 name=systemd cgroup.

This patch adds the code and permissions but does not make it effective
yet.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
