### PR TITLE
cmd/snap-confine: tracking processes with classic confinement

### DIFF
--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -5,11 +5,17 @@ details: |
 prepare: |
     # This feature depends on the release-app-awareness feature
     snap set core experimental.refresh-app-awareness=true
+    sed -e "s/@CONFINEMENT@/$CONFINEMENT/g" <test-snapd-refresh.v1/meta/snap.yaml.in >test-snapd-refresh.v1/meta/snap.yaml
+    sed -e "s/@CONFINEMENT@/$CONFINEMENT/g" <test-snapd-refresh.v2/meta/snap.yaml.in >test-snapd-refresh.v2/meta/snap.yaml
     snap pack test-snapd-refresh.v1
     snap pack test-snapd-refresh.v2
+environment:
+    CONFINEMENT/classic: classic
+    CONFINEMENT/strict: strict
 restore: |
     snap remove test-snapd-refresh
     rm -f test-snapd-refresh-{1,2}_all.snap
+    rm -f test-snapd-refresh.*/meta/snap.yaml
     rmdir /sys/fs/cgroup/pids/snap.test-snapd-refresh.sh || true
     rmdir /sys/fs/cgroup/pids/snap.test-snapd-refresh.version || true
     # TODO: There is currently no way to unset configuration options.
@@ -17,8 +23,19 @@ restore: |
     # snap unset core experimental.refresh-app-awareness
     rm -f install.log
 execute: |
+    if ! snap debug sandbox-features --required "confinement-options:$CONFINEMENT"; then
+        echo "SKIP: unsupported confinement variant"
+        exit 0
+    fi
     # Install v1 and see that it runs as expected.
-    snap install --dangerous test-snapd-refresh_1_all.snap
+    case "$CONFINEMENT" in
+        classic)
+            snap install --dangerous --classic test-snapd-refresh_1_all.snap
+            ;;
+        strict)
+            snap install --dangerous test-snapd-refresh_1_all.snap
+            ;;
+    esac
     test-snapd-refresh.version | MATCH v1
 
     # Run a sleeper app to keep the snap busy. The purpose of the stamp file is
@@ -30,14 +47,7 @@ execute: |
 
     # Ensure that snap-confine has finished its task and that the snap process
     # is active. Note that we don't want to wait forever either.
-    wait_for_stamp() {
-        for _ in $(seq 30); do
-            test -e "$1" && break
-            sleep 0.1
-        done
-    }
-
-    wait_for_stamp /var/snap/test-snapd-refresh/current/stamp
+    retry-tool -n 30 --wait 0.1 test -e /var/snap/test-snapd-refresh/current/stamp
 
     # Try to install v2, it should fail because v1 is running. Snapd is kind
     # enough to tell us what is preventing the install from working.
@@ -45,7 +55,14 @@ execute: |
     unwrap_msg() {
         tr '\n' ' ' | sed -e 's/ \+/ /g'
     }
-    not snap install --dangerous test-snapd-refresh_2_all.snap >install.log 2>&1
+    case "$CONFINEMENT" in
+        classic)
+            not snap install --dangerous --classic test-snapd-refresh_2_all.snap >install.log 2>&1
+            ;;
+        strict)
+            not snap install --dangerous test-snapd-refresh_2_all.snap >install.log 2>&1
+            ;;
+    esac
     unwrap_msg < install.log | MATCH 'error: cannot install snap file: snap "test-snapd-refresh" has running apps +\(sh\)'
     test-snapd-refresh.version | MATCH v1
 
@@ -53,5 +70,12 @@ execute: |
     kill "$pid"
     wait "$pid" || true  # wait returns the exit code and we kill the process
     # Try to install v2 again, it should now work.
-    snap install --dangerous test-snapd-refresh_2_all.snap
+    case "$CONFINEMENT" in
+        classic)
+            snap install --dangerous --classic test-snapd-refresh_2_all.snap
+            ;;
+        strict)
+            snap install --dangerous test-snapd-refresh_2_all.snap
+            ;;
+    esac
     test-snapd-refresh.version | MATCH v2

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v1/meta/snap.yaml.in
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v1/meta/snap.yaml.in
@@ -1,5 +1,6 @@
 name: test-snapd-refresh
 version: 1
+confinement: @CONFINEMENT@
 apps:
     sh:
         command: bin/sh

--- a/tests/main/refresh-app-awareness/test-snapd-refresh.v2/meta/snap.yaml.in
+++ b/tests/main/refresh-app-awareness/test-snapd-refresh.v2/meta/snap.yaml.in
@@ -1,5 +1,6 @@
 name: test-snapd-refresh
 version: 2
+confinement: @CONFINEMENT@
 apps:
     # NOTE: the v2 version of the application does not have the "sh"
     # application anymore. This is so that we are correctly looking at the


### PR DESCRIPTION
There are several cgroup operations being performed in snap confine now:

 - strictly confined snaps join the freezer controller
 - strictly confined snaps possibly join the pids controller
   (if refresh app awareness is enabled)

This patch changes this logic so that pids controller is joined
by both strictly and classically confined snaps. Note that the pids
controller will be soon replaced by the tracking hierarchy.

This change allows us to track all snap types equally.

The freezer can stay where it is because it is only meant to protect
strictly confined snaps from possibly interfering with concurrently
processed mount changes from a snap-update-ns process invoked by snapd.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
