### PR TITLE
tests/lib/state: snapshot and restore /var/snap during the tests

### DIFF
--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -47,6 +47,8 @@ save_snapd_state() {
         cp -rf /var/cache/snapd "$SNAPD_STATE_PATH"/snapd-cache
         cp -rf "$boot_path" "$SNAPD_STATE_PATH"/boot
         cp -f /etc/systemd/system/snap-*core*.mount "$SNAPD_STATE_PATH"/system-units
+        mkdir -p "$SNAPD_STATE_PATH"/var-snap
+        cp -a /var/snap/* "$SNAPD_STATE_PATH"/var-snap/
     else
         systemctl daemon-reload
         escaped_snap_mount_dir="$(systemd-escape --path "$SNAP_MOUNT_DIR")"
@@ -94,11 +96,14 @@ restore_snapd_state() {
         cp -rf "$SNAPD_STATE_PATH"/snapd-cache/*  /var/cache/snapd
         cp -rf "$SNAPD_STATE_PATH"/boot/* "$boot_path"
         cp -f "$SNAPD_STATE_PATH"/system-units/*  /etc/systemd/system
+        rm -rf /var/snap/*
+        cp -a "$SNAPD_STATE_PATH"/var-snap/* /var/snap/
     else
         # Purge all the systemd service units config
         rm -rf /etc/systemd/system/snapd.service.d
         rm -rf /etc/systemd/system/snapd.socket.d
 
+        # TODO: remove files created by the test
         tar -C/ -xf "$SNAPD_STATE_FILE"
     fi
 


### PR DESCRIPTION
The `/var/snap` directory was not properly restored after each test, thus data
that was created during the test would just leak from one test to another. In
this particular case, installation of a snap would create directories under
`/var/snap/<snap>/{rev,current}`, that would be left behind after restore
completed. Incidentally, this could break snap removal in subsequent tests if
the revisions that were installed before were not accounted for.

