### PR TITLE
spread: do not explain errors

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -646,7 +646,7 @@ suites:
         debug: |
             if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
                 systemctl status snapd.socket || true
-                journalctl -xe
+                journalctl -e
             fi
     tests/core18/:
         summary: Subset of core18 specific tests


### PR DESCRIPTION
The output of `journalctl -xe` is super verbose, as each error log is has
additional 6-7 lines of text, which in the end is not very useful. Drop the
-x (--catalog) switch and keep -e (--pager-end).
