### PR TITLE
spread, tests: openSUSE Tumbleweed to unstable systems, update system-usernames on Amazon Linux 2

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -95,8 +95,6 @@ backends:
                 manual: true
             - opensuse-15.1-64:
                 workers: 6
-            - opensuse-tumbleweed-64:
-                workers: 6
             - arch-linux-64:
                 workers: 6
 
@@ -113,6 +111,9 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
+            # zypper either segfaults or hangs installing snapd build dependencies
+            - opensuse-tumbleweed-64:
+                workers: 6
 
     google-sru:
         type: google

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -8,7 +8,7 @@ environment:
     # List of expected snap install failures due to libseccomp/golang-seccomp
     # being too old. This should only reduce with time since new systems should
     # have newer libseccomp and golang-seccomp
-    EXFAIL: "amazon-linux-2-64 centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 ubuntu-14"
+    EXFAIL: "centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 ubuntu-14"
 
 prepare: |
     echo "Install helper snaps with default confinement"


### PR DESCRIPTION
It was observed recently that zypper either gets a Segmentation fault or hangs
installing snapd build dependencies. While the issue is investigated, move it to
unstable systems so that PRs are not blocked.

Also merged #7736 with test fixes for Amazon Linux 2 into this branch
