### PR TITLE
tests/main/system-usernames: Amazon Linux 2 comes with libseccomp 2.4.1 now

### DIFF
--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -8,7 +8,7 @@ environment:
     # List of expected snap install failures due to libseccomp/golang-seccomp
     # being too old. This should only reduce with time since new systems should
     # have newer libseccomp and golang-seccomp
-    EXFAIL: "amazon-linux-2-64 centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 ubuntu-14"
+    EXFAIL: "centos-7-64 debian-9-64 fedora-29-64 fedora-30-64 opensuse-15\\.0-64 ubuntu-14"
 
 prepare: |
     echo "Install helper snaps with default confinement"


### PR DESCRIPTION
According to the test, the current images of AMZN2 have libseccomp 2.4.1 and support log action. It's likely that libseccomp 2.4.1 was recently moved to amzn2-core repository, before there was only 2.3.1 version avaialble. The `rpm -q --changelog` of libseccomp does not show anything interesting, but if the package     was indeed moved between repositories, this would not show up.
