### PR TITLE
overlord: mock device serial in gadget remodel unit tests

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4608,8 +4608,9 @@ volumes:
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "can0nical",
-		Model: "my-model",
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -4739,8 +4740,9 @@ volumes:
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "can0nical",
-		Model: "my-model",
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)
@@ -4864,8 +4866,9 @@ volumes:
 
 	// setup model assertion
 	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand: "can0nical",
-		Model: "my-model",
+		Brand:  "can0nical",
+		Model:  "my-model",
+		Serial: "serialserialserial",
 	})
 	err := assertstate.Add(st, model)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Device serial number was not mocked properly, what caused the request-serial
task to be injected in the gadget remodel unit tests. This in turn made affected
unit tests run much longer, as the task would timeout and fail. As a secondary
effect, the tasks might not have completed within the settle timeout.
