### PR TITLE
overlord/state: panic in MarkEdge() if task is nil

### DIFF
--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -523,7 +523,7 @@ func (ts *TaskSet) AddTask(task *Task) {
 // edge mark will be overridden.
 func (ts *TaskSet) MarkEdge(task *Task, edge TaskSetEdge) {
 	if task == nil {
-		panic("cannot set edge %q with nil task")
+		panic(fmt.Sprintf("cannot set edge %q with nil task", edge))
 	}
 	if ts.edges == nil {
 		ts.edges = make(map[TaskSetEdge]*Task)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -522,6 +522,9 @@ func (ts *TaskSet) AddTask(task *Task) {
 // MarkEdge marks the given task as a specific edge. Any pre-existing
 // edge mark will be overridden.
 func (ts *TaskSet) MarkEdge(task *Task, edge TaskSetEdge) {
+	if task == nil {
+		panic("cannot set edge %q with nil task")
+	}
 	if ts.edges == nil {
 		ts.edges = make(map[TaskSetEdge]*Task)
 	}

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -562,6 +562,9 @@ func (cs *taskSuite) TestTaskSetEdge(c *C) {
 	edge1 := state.TaskSetEdge("on-edge")
 	edge2 := state.TaskSetEdge("eddie")
 
+	// nil task causes panic
+	c.Check(func() { ts.MarkEdge(nil, edge1) }, PanicMatches, `cannot set edge "on-edge" with nil task`)
+
 	// no edge marked yet
 	t, err := ts.Edge(edge1)
 	c.Assert(t, IsNil)


### PR DESCRIPTION
It was suggested by @pedronis in the other review that `MarkEdge` panics if task that we want to associate with an edge is `nil`. This PR does that.