### PR TITLE
tests: fix spread shellcheck and degraded tests to unbreak master

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -1,8 +1,8 @@
 summary: Check that the system is not in "degraded" state
 
-# autopkgtest images sometimes have failing services (cosmic/s390x)
-# in their images so this test is not useful there.
-backends: [-autopkgtest]
+# 20191115: arch has a broken google-cloud package and all services
+# fails to start there
+systems: [-arch-*]
 
 # run this early to ensure no test created failed units yet
 priority: 500

--- a/tests/unit/spread-shellcheck/task.yaml
+++ b/tests/unit/spread-shellcheck/task.yaml
@@ -7,7 +7,7 @@ prepare: |
     # need to install shellcheck in devmode, the tests are run by 'root', the
     # source code is under /home/gopath, all file accesses to the source code
     # will end up getting DENIED even though shellcheck uses home interface
-    snap install --edge --devmode shellcheck
+    snap install --beta --devmode shellcheck
 
 execute: |
     testdir=$PWD


### PR DESCRIPTION
Spread is currently breaking on two tests:
- shellcheck: the snap for shellcheck in edge is broken, switch to beta for now
- degraded: fails on arch because of the GCE arch package. Disable on arch until the package is fixed.