### PR TITLE
snap-bootstrap: add go-flags cmdline parsing and tests

### DIFF
--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
+)
+
+var bootstrapRun = bootstrap.Run
+
+func init() {
+	const (
+		short = "Create missing partitions for the device"
+		long  = ""
+	)
+
+	if _, err := parser.AddCommand("create-partitions", short, long, &cmdCreatePartitions{}); err != nil {
+		panic(err)
+	}
+}
+
+type cmdCreatePartitions struct {
+	Positional struct {
+		GadgetRoot string `positional-arg-name:"<gadget-root>"`
+		Device     string `positional-arg-name:"<device>"`
+	} `positional-args:"yes"`
+}
+
+func (c *cmdCreatePartitions) Execute(args []string) error {
+	// XXX: add options
+	options := &bootstrap.Options{}
+
+	return bootstrapRun(c.Positional.GadgetRoot, c.Positional.Device, options)
+}

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
+)
+
+func (s *cmdSuite) TestCreatePartitionsHappy(c *C) {
+	n := 0
+	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts *bootstrap.Options) error {
+		c.Check(gadgetRoot, Equals, "gadget-dir")
+		c.Check(device, Equals, "device")
+		n++
+		return nil
+	})
+	defer restore()
+
+	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "gadget-dir", "device"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Assert(n, Equals, 1)
+}

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
+)
+
+var (
+	Parser = parser
+)
+
+func MockBootstrapRun(f func(string, string, *bootstrap.Options) error) (restore func()) {
+	oldBootstrapRun := bootstrapRun
+	bootstrapRun = f
+	return func() {
+		bootstrapRun = oldBootstrapRun
+	}
+}

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -22,9 +22,29 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
+	"github.com/jessevdk/go-flags"
+
 	"github.com/snapcore/snapd/osutil"
 )
+
+var (
+	shortHelp = "Bootstrap a Ubuntu Core system"
+	longHelp  = `
+snap-bootstrap is a tool to bootstrap a Ubuntu Core
+system in initramfs and from an ephemeral system.
+`
+
+	opts   struct{}
+	parser *flags.Parser = flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
+)
+
+func main() {
+	err := run(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}
 
 func run(args []string) error {
 	if !osutil.GetenvBool("SNAPPY_TESTING") {
@@ -33,22 +53,14 @@ func run(args []string) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("please run as root")
 	}
-	if len(os.Args) < 3 {
-		// XXX: slightly ugly to return usage as an error but ok for now
-		return fmt.Errorf("usage: %s <gadget root> <block device>\n", os.Args[0])
-	}
 
-	gadgetRoot := os.Args[1]
-	device := os.Args[2]
-	options := &bootstrap.Options{}
-
-	return bootstrap.Run(gadgetRoot, device, options)
+	return parseArgs(args)
 }
 
-func main() {
-	err := run(os.Args)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s\n", err)
-		os.Exit(1)
-	}
+func parseArgs(args []string) error {
+	parser.ShortDescription = shortHelp
+	parser.LongDescription = longHelp
+
+	_, err := parser.ParseArgs(args)
+	return err
 }

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -30,8 +30,8 @@ import (
 var (
 	shortHelp = "Bootstrap a Ubuntu Core system"
 	longHelp  = `
-snap-bootstrap is a tool to bootstrap a Ubuntu Core
-system in initramfs and from an ephemeral system.
+snap-bootstrap is a tool to bootstrap Ubuntu Core from ephemeral systems
+such as initramfs.
 `
 
 	opts   struct{}

--- a/cmd/snap-bootstrap/main_test.go
+++ b/cmd/snap-bootstrap/main_test.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type cmdSuite struct{}
+
+var _ = Suite(&cmdSuite{})
+
+func (s *cmdSuite) TestNoArgsErrors(c *C) {
+	_, err := main.Parser.ParseArgs(nil)
+	c.Assert(err, ErrorMatches, "Please specify .*")
+}

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -32,7 +32,7 @@ prepare: |
 execute: |
     LOOP="$(cat loop.txt)"
     echo "Run the snap-bootstrap tool"
-    /usr/lib/snapd/snap-bootstrap ./gadget-dir "$LOOP"
+    /usr/lib/snapd/snap-bootstrap create-partitions ./gadget-dir "$LOOP"
 
     echo "And check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '1M\s+BIOS boot'
@@ -69,7 +69,7 @@ execute: |
             filesystem-label: other-ext4
             size: 500M
     EOF
-    /usr/lib/snapd/snap-bootstrap ./gadget-dir "$LOOP"
+    /usr/lib/snapd/snap-bootstrap create-partitions ./gadget-dir "$LOOP"
     sfdisk -l "$LOOP" | MATCH '500M\s* Linux filesystem'
 
     echo "check that the filesystems are created"


### PR DESCRIPTION
This commit adds the go-flags commandline parser and tests. It
also moves the "create-partitions" functionality under a new
"create-partitions" sub-command.

This is needed so that we can extend snap-boostrap for more
options like "snap-bootstrap initramfs" in the future.

