### PR TITLE
gadget: skip fakeroot if not needed

### DIFF
--- a/gadget/mkfs.go
+++ b/gadget/mkfs.go
@@ -54,8 +54,15 @@ func MkfsExt4(img, label, contentsRootDir string) error {
 		mkfsArgs = append(mkfsArgs, "-L", label)
 	}
 	mkfsArgs = append(mkfsArgs, img)
-	// run through fakeroot so that files are owned by root
-	cmd := exec.Command("fakeroot", mkfsArgs...)
+
+	var cmd *exec.Cmd
+	if os.Geteuid() != 0 {
+		// run through fakeroot so that files are owned by root
+		cmd = exec.Command("fakeroot", mkfsArgs...)
+	} else {
+		// no need to fake it if we're already root
+		cmd = exec.Command(mkfsArgs[0], mkfsArgs[1:]...)
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)


### PR DESCRIPTION
If we're already running as root, don't fake it so filesystem creation
can be used during core bootstrap in an environment without fakeroot.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
