### PR TITLE
overlord: fix the get command help message

### DIFF
--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -55,13 +55,12 @@ The get command prints configuration options for the current snap.
     $ snapctl get username
     frank
 
-If multiple option names are provided, a document is returned:
+If multiple option names are provided, the corresponding values are returned:
 
     $ snapctl get username password
-    {
-        "username": "frank",
-        "password": "..."
-    }
+    Key       Value
+    username  frank
+    password  ...
 
 Nested values may be retrieved via a dotted path:
 


### PR DESCRIPTION
If multiple options are provided to snap get, a key-value list is
returned instead of a JSON document, as stated in the command
documentation. (Fixes LP: #1776466)

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>