### PR TITLE
tests: restart the snapd service in the snapd-failover test

### DIFF
--- a/tests/core18/snapd-failover/task.yaml
+++ b/tests/core18/snapd-failover/task.yaml
@@ -38,3 +38,7 @@ execute: |
 
     echo "Verify we got the expected error message"
     snap change --last=install|MATCH "there was a snapd rollback across the restart"
+
+    echo "restart snapd and ensure we can still talk to it"
+    systemctl restart snapd.socket snapd.service
+    snap list | MATCH "^snapd .* $current .*"


### PR DESCRIPTION
This commit adds an extra check to ensure that snapd restarts
cleanly and without issues after a failover. This was missing
in the test so far.
