### PR TITLE
cmd: fix the get command help message

### DIFF
--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -37,13 +37,12 @@ The get command prints configuration options for the provided snap.
     $ snap get snap-name username
     frank
 
-If multiple option names are provided, a document is returned:
+If multiple option names are provided, the corresponding values are returned:
 
     $ snap get snap-name username password
-    {
-        "username": "frank",
-        "password": "..."
-    }
+    Key       Value
+    username  frank
+    password  ...
 
 Nested values may be retrieved via a dotted path:
 


### PR DESCRIPTION
If multiple options are provided to snap get, a key-value list is
returned instead of a JSON document, as stated in the command
documentation. (Fixes LP: #1776466)

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>