### PR TITLE
tests: enable degraded test on arch linux after latest image updates

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -1,9 +1,5 @@
 summary: Check that the system is not in "degraded" state
 
-# 20191115: arch has a broken google-cloud package and all services
-# fails to start there
-systems: [-arch-*]
-
 # run this early to ensure no test created failed units yet
 priority: 500
 


### PR DESCRIPTION
This can be enabled again because we have a new arch linux image with the new google compute engine packages built for python 3.8