### PR TITLE
po: sync translations from launchpad

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2019-10-29 16:30+0000\n"
+"Last-Translator: bernard stafford <Unknown>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,53 +24,54 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q oorgeskakel na die %q kanaal\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr ""
+msgstr "%s %s gemonteer vanaf %s\n"
 
 #, c-format
 msgid "%s (delta)"
-msgstr ""
+msgstr "%s (delta)"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr ""
+msgstr "%s (sien \"snap login --help\")"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr ""
+msgstr "%s (probeer -met sudo)"
 
 #, c-format
 msgid "%s already installed\n"
-msgstr ""
+msgstr "%s alreeds geïnstalleer\n"
 
 #, c-format
 msgid "%s disabled\n"
-msgstr ""
+msgstr "%s gestremde\n"
 
 #, c-format
 msgid "%s enabled\n"
-msgstr ""
+msgstr "%s geaktiveer is\n"
 
 #, c-format
 msgid "%s not installed\n"
-msgstr ""
+msgstr "%s nie geïnstalleer nie\n"
 
 #, c-format
 msgid "%s removed\n"
-msgstr ""
+msgstr "%s verwyder\n"
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr ""
+msgstr "%s reverted om %s\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
@@ -85,12 +86,12 @@ msgstr ""
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr ""
+msgstr "%s%s %s geïnstalleer\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr ""
+msgstr "%s%s %s verfris\n"
 
 msgid "--list does not take mode nor channel flags"
 msgstr ""
@@ -99,100 +100,104 @@ msgid "--time does not take mode nor channel flags"
 msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr ""
+msgstr "-r kan enigste wees gebruik met --haak"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr ""
+msgstr "<alias-or-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr ""
+msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr ""
+msgstr "<assertion lêer>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr ""
+msgstr "<assertion tipe>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr ""
+msgstr "<verandering-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr ""
+msgstr "<conf waarde>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr ""
+msgstr "<e-pos>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr ""
+msgstr "<lêernaam>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr ""
+msgstr "<kopskrif filter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr ""
+msgstr "<koppelvlak>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr ""
+msgstr "<sleutel-naam>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr ""
+msgstr "<sleutel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr ""
+msgstr "<model-assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr ""
+msgstr "<navraag>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr ""
+msgstr "<wortel-dir>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<diens>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr ""
+msgstr "<snap>:<prop>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr ""
+msgstr "<snap>:<gleuf of prop>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr ""
+msgstr "<snap>:<gleuf>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
+"N' diens spesifikasie, wat net 'n snap naam kan wees (vir alle dienste in "
+"die snap), of <snap>.<app> vir 'n enkele diens."
 
 msgid "Abort a pending change"
-msgstr ""
+msgstr "Staak 'n hangende verander"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr ""
+msgstr "Bygevoeg"
 
 msgid "Adds an assertion to the system"
 msgstr ""
@@ -200,133 +205,144 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr ""
+msgstr "Adviseer oor snaps dat verskaf die gegewe opdrag"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr ""
+msgstr "Alias vir --gevaarlike (VEROUDERD)"
 
 msgid "All snaps up to date."
-msgstr ""
+msgstr "Alle snaps op na datum."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Laat opning lêer?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
-msgstr ""
+msgstr "Toelaat verfris poging op snap onbekend na die winkel"
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Toelaat instellings verander?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Toelaat snap %q om te verander %q tot %q ?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Toelaat snap %q om lêer oop te maak %q?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr ""
+msgstr "Alternatief bevel om te hardloop"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr ""
+msgstr "Stuur altyd dokument terug, selfs met enkele sleutel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr ""
+msgstr "Altyd terugkeer lys, selfs met enkele sleutel"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr ""
+msgstr "'N E-pos van 'n gebruiker op login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
-msgstr ""
+msgstr "Sowel as begin die diens nou, reel dat dit wees begin op die boot."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
+"Sowel as stoping die diens nou, reël vir dit om nie meer wees nie begin is "
+"op boot."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr ""
+msgstr "Assertion lêer"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr ""
+msgstr "Assertion tik naam"
 
 msgid "Authenticates on snapd and the store"
 msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
-msgstr ""
+msgstr "Outo-verfris %d snaps"
 
 #, c-format
 msgid "Auto-refresh snap %q"
-msgstr ""
+msgstr "Outo-verfris snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Auto-refresh snaps %s"
-msgstr ""
+msgstr "Outo-verfris snaps %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
-msgstr ""
+msgstr "Outomaties konnekteer aanmerking kom proppe en slots van snap %q"
 
 msgid "Bad code. Try again: "
-msgstr ""
+msgstr "Slegte kode. Probeer weer: "
 
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "Verander ID"
 
 msgid "Changes configuration options"
-msgstr ""
+msgstr "Veranderinge konfigurasie opsies"
 
 msgid "Command\tAlias\tNotes"
-msgstr ""
+msgstr "Bevel\tAlias\tNotas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr ""
+msgstr "Bevestig wagwoordfrase: "
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
-msgstr ""
+msgstr "Konnekteer %s:%s tot %s:%s"
 
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr ""
+msgstr "Constrain lysing na 'n spesifieke snap of snap:naam"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr ""
+msgstr "Constrain lysing na spesifieke koppelvlakke"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr ""
+msgstr "Constrain lysing na diegene bypassende header=waarde"
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr ""
+msgstr "Kopieer snap %q data"
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
 
 msgid "Create cryptographic key pair"
-msgstr ""
+msgstr "Skep kriptografiese sleutel paar"
 
 msgid "Create snap build assertion"
 msgstr ""
@@ -338,22 +354,22 @@ msgid "Creates a local system user"
 msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr ""
+msgstr "Vee kriptografiese sleutel paar uit"
 
 msgid "Delete the local cryptographic key pair with the given name."
 msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr ""
+msgstr "Deaktiveer %q snap"
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr ""
+msgstr "Deaktiveer aliasse vir snap %q"
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr ""
+msgstr "Deaktiveer alle aliasse vir snap %q"
 
 msgid "Disables a snap in the system"
 msgstr ""
@@ -364,109 +380,128 @@ msgstr ""
 
 #, c-format
 msgid "Disconnect %s:%s from %s:%s"
-msgstr ""
+msgstr "Ontkoppel %s:%s van %s:%s"
 
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
+"Moenie wag vir die bewerking om afwerking maar net afdruk die verander id."
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr ""
+msgstr "Aflaai snap %q%s uit kanaal %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
+"Aflaai die gegee revision van 'n snap, om waartoe jy moet hê ontwikkelaar "
+"toegang"
 
 msgid "Downloads the given snap"
 msgstr ""
 
 msgid "Email address: "
-msgstr ""
+msgstr "E-pos adres: "
 
 #, c-format
 msgid "Enable %q snap"
-msgstr ""
+msgstr "Activeer %q snap"
 
 msgid "Enables a snap in the system"
 msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr ""
+msgstr "Verseker dat voorvereistes vir %q beskikbaar is"
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
 
 msgid "Export cryptographic public key"
-msgstr ""
+msgstr "Uitvoer kriptografiese openbare sleutel uit"
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
-msgstr ""
+msgstr "Fetch en kyk bewerings vir snap %q%s"
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr ""
+msgstr "Fetching assertions vir %q\n"
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr ""
+msgstr "Fetching snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr ""
+msgstr "Lêernaam van die snap wat jy wil assert 'n bou vir"
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
+"Dwing om die gebruiker by te voeg, selfs al is die toestel reeds bestuur"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr ""
+msgstr "Dwing invoer op klassieke stelsels"
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
+"Formateer openbare sleutel materiaal as 'n versoek vir 'n rekeningsleutel "
+"vir hierdie rekening-id"
 
 msgid "Generate device key"
-msgstr ""
+msgstr "Genereer toestel sleutel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr ""
+msgstr "Genereer die manpage"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
-msgstr ""
+msgstr "Graad state die bougehalte van die snap (standaard aan 'stable')"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr ""
+msgstr "Verleen toegang tot sudo aan die gebruiker wat geskep is"
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr ""
+msgstr "Haak om te hardloop"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "ID\tStatus\tKuit\tGereed\tOpsomming\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr ""
+msgstr "Identifiserier van die ondertekenaar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr ""
+msgstr "Identifiserier van die snap pakket geassosieer met die bou"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
+"Indien die diens het 'n herlaai bevel, gebruik dit inplaas van herbegin."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr ""
+msgstr "Ignoreer validering deur ander snaps die verfris blokkeer"
 
 #, c-format
 msgid ""
@@ -475,22 +510,27 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
+"Ten einde te koop %q, moet jy instem tot die nuutste bepalings en "
+"voorwaardes. Besoek asb https://my.ubuntu.com/payment/edit te doen hierdie.\n"
+"\n"
+"Sodra dit voltooi is, keer terug hierheen en hardloop 'snap buy %s' weer."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr ""
+msgstr "Sluit ongebruikte koppelvlakke in"
 
 msgid "Initialize device"
-msgstr ""
+msgstr "Inisialiseer toestel"
 
 msgid "Inspects devices for actionable information"
 msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr ""
+msgstr "Installeer %q snap"
 
 #, c-format
 msgid "Install %q snap from %q channel"
@@ -498,45 +538,59 @@ msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr ""
+msgstr "Installeer %q snap vanaf lêer"
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr ""
+msgstr "Installeer %q snap vanaf lêer %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr ""
+msgstr "Installeer vanaf die beta kanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr ""
+msgstr "Installeer vanaf die kandidaat kanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr ""
+msgstr "Installeer vanaf die rand kanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr ""
+msgstr "Installeer vanaf die stabiele kanaal"
 
 #, c-format
 msgid "Install snap %q"
-msgstr ""
+msgstr "Installeer snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr ""
+msgstr "Installeer snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
+"Installeer die gegewe revision van 'n snap, na watter jy moet he "
+"ontwikkelaar toegang"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
+"Installeer die gegewe snap-lêer selfs al is daar geen pre-erken het "
+"handtekeninge vir dit, wat beteken dat dit is nie geverifieer en kan "
+"gevaarlik wees (--devmode impliseer dit)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
+"Installering van die gegewe snap sonder in staat te stel sy outomatiese "
+"aliasse"
 
 #, c-format
 msgid ""
@@ -544,35 +598,38 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Installeer die snap met:\n"
+"   snap ack %s\n"
+"   snap installeer %s\n"
 
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr ""
+msgstr "Sleutel van belangstelling binne die konfigurasie"
 
 msgid "List a change's tasks"
-msgstr ""
+msgstr "lys 'n verander se take"
 
 msgid "List cryptographic keys"
-msgstr ""
+msgstr "Lys kriptografiese sleutels"
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
 
 msgid "List installed snaps"
-msgstr ""
+msgstr "Lys geïnstalleerde snaps"
 
 msgid "List system changes"
-msgstr ""
+msgstr "Lys stelsel veranderinge"
 
 msgid "Lists aliases in the system"
 msgstr ""
 
 msgid "Lists all repairs"
-msgstr ""
+msgstr "Lys alle herstelwerk"
 
 msgid "Lists interfaces in the system"
 msgstr ""
@@ -584,58 +641,63 @@ msgid "Log out of the store"
 msgstr ""
 
 msgid "Login successful"
-msgstr ""
+msgstr "Login suksesvol"
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr ""
+msgstr "Maak huidige revision vir snap %q onbeskikbaar"
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr ""
+msgstr "Maak snap %q (%s) beskikbaar na die stelsel"
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr ""
+msgstr "Maak snap %q (%s) ni beskikbaar nie na die stelsel"
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr ""
+msgstr "Maak snap %q ni beskikbaar nie na die stelsel"
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr ""
+msgstr "Maak snap %q%s beskibaar na die stelsel"
 
 msgid "Mark system seeded"
-msgstr ""
+msgstr "Merk stelsel gekeurdes"
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr ""
+msgstr "Berg snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr ""
+msgstr "Naam van sleutel om te skep; standaard na 'default'"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr ""
+msgstr "Naam van sleutel na skrap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr ""
+msgstr "Naam van sleutel na uitvoer"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
+"Naam van die GnuPG sleutel na gebruik (standaard na 'default' as sleutel "
+"naam)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
+"Naam van die sleutel om te gebruik, anders gebruik die standaard sleutel"
 
 msgid "Name\tSHA3-384"
-msgstr ""
+msgstr "Naam\tSHA3-384"
 
 msgid "Name\tSummary"
-msgstr ""
+msgstr "Naam\tOpsomming"
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
 msgstr ""
@@ -648,62 +710,67 @@ msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr ""
+msgstr "Geen aliasse is tans gedefinieer vir snap %q.\n"
 
 msgid "No aliases are currently defined."
-msgstr ""
+msgstr "Geen aliasse is tans gedefinieer nie."
 
 #, c-format
 msgid "No command %q found, did you mean:\n"
 msgstr ""
 
 msgid "No connections to disconnect"
-msgstr ""
+msgstr "Geen verbindings om te diskonnekteer nie"
 
 #. TRANSLATORS: the %q is the (quoted) name of the section the user entered
 #, c-format
 msgid "No matching section %q, use --section to list existing sections"
 msgstr ""
+"Geen passende afdeling nie &q, gebruik --afdeling om lys bestaande artikels"
 
 #. TRANSLATORS: the first %q is the (quoted) query, the
 #. second %q is the (quoted) name of the section the
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr ""
+msgstr "Geen ooreenstem nie snaps vir %q en afdeling %q\n"
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr ""
+msgstr "Geen ooreenstem nie snaps vir %q\n"
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
+"Geen soekterm gespesifiseer nie. Hier is paar interessante snaps:\n"
+"\n"
 
 msgid "No section specified. Available sections:\n"
-msgstr ""
+msgstr "Geen afdeling gespesifiseer nie. Beskikbare afdelings:\n"
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr ""
+msgstr "Uitset resultate in JSON formaat"
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
 
 #, c-format
 msgid "Packages matching %q:\n"
-msgstr ""
+msgstr "Pakkette bypassende %q:\n"
 
 msgid "Passphrase: "
-msgstr ""
+msgstr "Wagwoordfrase: "
 
 #, c-format
 msgid "Password of %q: "
-msgstr ""
+msgstr "Wagwoord van %q: "
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -711,34 +778,36 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
+"Voer u Ubuntu One-wagwoord weer in om te koop %q van %q\n"
+"vir %s. Druk ctrl-c om te kanselleer."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr ""
+msgstr "Verkies aliasse vir snap %q"
 
 msgid "Prefer aliases from a snap and disable conflicts"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr ""
+msgstr "Verkies aliasse van snap %q"
 
 msgid "Prepare a snappy image"
 msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr ""
+msgstr "Berei snap %q (%s)"
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr ""
+msgstr "Berei snap %q%s"
 
 msgid "Print the version and exit"
-msgstr ""
+msgstr "Afdruk die weergawe en uitgang"
 
 msgid "Prints configuration options"
 msgstr ""
@@ -754,48 +823,51 @@ msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr ""
+msgstr "Snoei outomatiese aliasse vir snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr ""
+msgstr "Sit snap in die klassieke modus en deaktiveer sekuriteit opsluiting"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr ""
+msgstr "Sit snap in ontwikkelings modus en deaktiveer sekuriteit opsluiting"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr ""
+msgstr "Sit snap in afgedwonge opsluiting-modus"
 
 msgid "Query the status of services"
-msgstr ""
+msgstr "Query die status van dienste"
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr ""
+msgstr "Verfris %q snap"
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr ""
+msgstr "Verfris %q snap vanaf %q kanaal"
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr ""
+msgstr "Verfris alises vir snap %q"
 
 msgid "Refresh all snaps: no updates"
-msgstr ""
+msgstr "Verfris alles snaps: geen opdaterings nie"
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr ""
+msgstr "Verfris smap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr ""
+msgstr "Verfris snaps %s"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr ""
+msgstr "Verfris snaps %s: geen opdaterings"
 
 msgid "Refresh to the given revision"
 msgstr ""
@@ -805,119 +877,125 @@ msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr ""
+msgstr "Verwyder %q snap"
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr ""
+msgstr "Verwyder aliasse vir snap %q"
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr ""
+msgstr "Verwyder data vir snap %q (%s)"
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr ""
+msgstr "Verwyder handleiding alias %q vir snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr ""
+msgstr "Verwyder enigste die gegewe revision"
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr ""
+msgstr "Verwyder sekuriteit profiel vir snap %q (%s)"
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr ""
+msgstr "Verwyder sekuriteit profiele van snap %q"
 
 #, c-format
 msgid "Remove snap %q"
-msgstr ""
+msgstr "Verwyder snap %q"
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr ""
+msgstr "Verwyder snap %q (%s) van die stelsel"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr ""
+msgstr "Verwyder snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr ""
+msgstr "Verwyder"
 
 msgid "Removes a snap from the system"
 msgstr ""
 
 msgid "Request device serial"
-msgstr ""
+msgstr "Versoek toestel reekse"
 
 msgid "Restart services"
-msgstr ""
+msgstr "Herbegin dienste"
 
 msgid "Restarted.\n"
-msgstr ""
+msgstr "Restarted.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr ""
+msgstr "Beperk die soektog na 'n gegewe afdeling"
 
 msgid "Retrieve logs of services"
 msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr ""
+msgstr "Revert %q snap"
 
 msgid "Reverts the given snap to the previous state"
-msgstr ""
+msgstr "Reverts die gegewe snap ann die viruge toestand"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr ""
+msgstr "Hardloop 'n omhulsel in plaas van die opdrag (nuttig vir ontfouting)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr ""
+msgstr "Hardloop as 'n timer-diens met 'n gegewe skedule"
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr ""
+msgstr "Hardloop konfigurasie haak van %q snap"
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr ""
+msgstr "Hardloop konfigurasie haak van %q snap indien teenwoordig"
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr ""
+msgstr "Hardloop haak %s van snap %q"
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr ""
+msgstr "Hardloop installeer haak van %q snap indien teenwoordig"
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Hardloop post-refresh haak van %q snap indien teenwoordig"
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Hardloop pre-refresh haak van %q snap indien teenwoordig"
 
 msgid "Run prepare-device hook"
-msgstr ""
+msgstr "Hardloop voorberei toestel haak"
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr ""
+msgstr "Hardloop verwyder haak van %q snap indien teenwoordig"
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
-msgstr ""
+msgstr "Hardloop die bevel met gdb"
 
 msgid "Run the given snap command"
-msgstr ""
+msgstr "Hardloop die gegewe snap opdrag"
 
 msgid "Run the given snap command with the right confinement and environment"
 msgstr ""
@@ -925,8 +1003,9 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr ""
+msgstr "Soek private snaps"
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
@@ -938,40 +1017,42 @@ msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr ""
+msgstr "Stel outomatiese aliasse vir snap %q"
 
 msgid "Sets up a manual alias"
 msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr ""
+msgstr "Stel alias op %q => %q vir snap %q"
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr ""
+msgstr "Stel handmatige alias op %q vir snap %q"
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr ""
+msgstr "Opstel van snap %q (%s) sekuriteit profiele"
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr ""
+msgstr "Opstel van snap %q aliasse"
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr ""
+msgstr "Opstel van snap %q%s sekuriteit profiele"
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
-msgstr ""
+msgstr "Wys alle revisions"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
-msgstr ""
+msgstr "Wys outo verfris inligting maar moenie uit te voer 'n verfris"
 
 msgid "Show available snaps for refresh but do not perform a refresh"
 msgstr ""
@@ -979,15 +1060,17 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
-msgstr ""
+msgstr "Wys besonderhede van 'n spesifieke koppelvlak"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
-msgstr ""
+msgstr "Wys koppelvlak attributen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
-msgstr ""
+msgstr "Wys net die gegewe aantal lyne, of 'all'."
 
 msgid "Shows known assertions of the provided type"
 msgstr ""
@@ -999,7 +1082,7 @@ msgid "Shows version details"
 msgstr ""
 
 msgid "Sign an assertion"
-msgstr ""
+msgstr "Teken 'n assertion"
 
 msgid ""
 "Sign an assertion using the specified key, using the input for headers from "
@@ -1008,66 +1091,70 @@ msgid ""
 msgstr ""
 
 msgid "Slot\tPlug"
-msgstr ""
+msgstr "Gleuf\tProp"
 
 #. TRANSLATORS: first %s is a snap name, following %s is a channel name
 #, c-format
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr ""
+msgstr "Snap naam"
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
 "your\n"
 "payment details at https://my.ubuntu.com/payment/edit and try again."
 msgstr ""
+"Jammer, jou betaalmetode is geweier deur die uitreiker. Hersien asseblief "
+"jou\n"
+"betaling besonderhede by https://my.ubuntu.com/payment/edit en probeer weer."
 
 msgid "Start services"
-msgstr ""
+msgstr "Begin dienste"
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr ""
+msgstr "Begin snap %q (%s) dienste"
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr ""
+msgstr "Begin snap %q%s dienste"
 
 msgid "Start snap services"
-msgstr ""
+msgstr "Begin snap dienste"
 
 msgid "Start the userd service"
-msgstr ""
+msgstr "Begin die gebruiker diens"
 
 msgid "Started.\n"
-msgstr ""
+msgstr "Begin is.\n"
 
 msgid "Status\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Status\tSpawn\tGereed\tOpsomming\n"
 
 msgid "Stop services"
-msgstr ""
+msgstr "Stop dienste"
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr ""
+msgstr "Stop snap %q (%s) dienste"
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr ""
+msgstr "Stop snap %q dienste"
 
 msgid "Stop snap services"
-msgstr ""
+msgstr "Stop snap dienste"
 
 msgid "Stopped.\n"
-msgstr ""
+msgstr "Gestop.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr ""
+msgstr "Streng tik met nulls en aangehaal snare"
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1082,10 +1169,11 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr ""
+msgstr "Skakelaars snap na 'n ander kanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
-msgstr ""
+msgstr "Tydelik mounteer toestel voor te inspekteer"
 
 msgid "Tests a snap in the system"
 msgstr ""
@@ -1096,20 +1184,24 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
+"Dankie vir die aankoop van %q. Jy kan nou installeer dit op enige van jou "
+"toestelle\n"
+"with 'snap install %s'."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
+"Die kry bevel-afdrukke-konfigurasie en koppelvlak verbinding instellings."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr ""
+msgstr "Die login.ubuntu.com e-pos om aan temeld as"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
-msgstr ""
+msgstr "Die model assertion naam"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,13 +1209,14 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr ""
+msgstr "Die snap om te konfigureer (e.g. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr ""
+msgstr "Die snap waarvan conf is synde gevraagde"
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1132,46 +1225,49 @@ msgid "This command logs the current user out of the store"
 msgstr ""
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
-msgstr ""
+msgstr "Hierdie dialoog sal outomaties sluit na 5 minute van onaktiwiteit."
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr ""
+msgstr "Wissel snap %q vlae"
 
 msgid "Tool to interact with snaps"
-msgstr ""
+msgstr "Instrument om te in wisselwerking met snaps"
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
-msgstr ""
+msgstr "Oorgang sekuriteits profiele vanaf %q na %q"
 
 msgid "Transition ubuntu-core to core"
-msgstr ""
+msgstr "Oorgang van ubuntu-kern na kern"
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr ""
+msgstr "Probeer %q snap vanaf %s"
 
 msgid "Try: snap install <selected snap>\n"
-msgstr ""
+msgstr "Probeer: snap installeer <gekeur snap>\n"
 
 msgid "Two-factor code: "
-msgstr ""
+msgstr "Twee-faktor kode: "
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr ""
+msgstr "Gebruik 'n spesifieke snap revision wanneer hardlooping haak"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
-msgstr ""
+msgstr "Gebruik bekende assertions vir gebruiker skepping"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
-msgstr ""
+msgstr "Gebruik hierdie kanaal in plaas van stabiel"
 
 msgid ""
 "WARNING: The output of \"snap get\" will become a list with columns - use -d "
@@ -1180,31 +1276,34 @@ msgstr ""
 
 #, c-format
 msgid "WARNING: failed to activate logging: %v\n"
-msgstr ""
+msgstr "WAARSKUWING: mislukte om te aktiveer logging: &v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
-msgstr ""
+msgstr "Wag vir nuwe lyns en afdruk hulle as hulle kom in."
 
 msgid "Waiting for server to restart"
-msgstr ""
+msgstr "Wag vir bediener om begin oor"
 
 msgid "Watch a change in progress"
-msgstr ""
+msgstr "Kyk na 'n verandering aan die gang"
 
 msgid "Wrong again. Once more: "
-msgstr ""
+msgstr "Verkeerd weer. Nog eenkeer: "
 
 #, c-format
 msgid "Xauthority file isn't owned by the current user %s"
-msgstr ""
+msgstr "Xgesag lêer is nie in besit van die huidige gebruiker %s"
 
 msgid "Yes, yes it does."
-msgstr ""
+msgstr "Ja, ja, dit doen."
 
 msgid ""
 "You need to be logged in to purchase software. Please run 'snap login' and "
 "try again."
 msgstr ""
+"Jy moet aangemeld wees om sagteware te koop. Hardloop asb 'snap login' en "
+"probeer weer."
 
 #, c-format
 msgid ""
@@ -1214,6 +1313,11 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
+"Jy moet 'n betaling metode te verband hou met jou rekening om ten einde koop "
+"'n snap, besoek gerus https://my.ubuntu.com/payment/edit een by te voeg.\n"
+"\n"
+"Sodra jy jou betaling besonderhede gevoeg het, jy net benodig na hardloop "
+"'snap buy %s' weer."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1235,11 +1339,16 @@ msgid ""
 "\n"
 "Provide a search term for more specific results.\n"
 msgstr ""
+"\n"
+"Verskaf 'n soekterm vir meer spesifieke resultate.\n"
 
 msgid ""
 "\n"
 "The abort command attempts to abort a change that still has pending tasks.\n"
 msgstr ""
+"\n"
+"Die abort bevel pogings om abort 'n verandering wat steeds hangende take "
+"het.\n"
 
 msgid ""
 "\n"
@@ -1301,6 +1410,8 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
+"\n"
+"Die koop bevel buys 'n snap vanaf die winkel.\n"
 
 msgid ""
 "\n"
@@ -1338,6 +1449,27 @@ msgid ""
 "matching\n"
 "the plug name.\n"
 msgstr ""
+"\n"
+"Die konnecteer bevel verbind 'n prop aan 'n gleuf.\n"
+"Dit kan genoem word op die volgende maniere:\n"
+"\n"
+"$ snap konnekteer <snap>:<prop> <snap>:<gleuf>\n"
+"\n"
+"Konnekteer die voorsien prop aan die gegewe gleuf.\n"
+"\n"
+"$ snap konnekteer <snap>:<prop> <snap>\n"
+"\n"
+"Verbind die spesifieke prop aan die enigste gleuf in die voorwaarde snap wat "
+"ooreenstem met\n"
+"die gekoppelde koppelvlak. As daar meer as een potensiële gleuf bestaan, die "
+"bevel\n"
+"versuim.\n"
+"\n"
+"$ snap konnekteer <snap>:<prop>\n"
+"\n"
+"Koppel die verskaf prop om die gleuf in die kern snap met 'n naam wat "
+"ooreenstem\n"
+"die prop naam.\n"
 
 msgid ""
 "\n"
@@ -1348,6 +1480,13 @@ msgid ""
 "\n"
 "An account can be setup at https://login.ubuntu.com.\n"
 msgstr ""
+"\n"
+"Die skep-gebruiker bevel-skep 'n plaaslike stelsel gebruiker met die "
+"gebruikers-naam en SSH\n"
+"sleutels geregistreer op die winkel rekening geïdentifiseer deur die "
+"voorsien e-pos adres.\n"
+"\n"
+"N' rekening kan opgestel word by https://login.ubuntu.com.\n"
 
 msgid ""
 "\n"
@@ -1356,6 +1495,13 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
+"\n"
+"Die debug bevel bevat 'n seleksie van addisionele sub-bevel.\n"
+"\n"
+"Debug bevel verwyder kan word sonder kennisgewing en mag nie aan werk nie "
+"op\n"
+"\n"
+"nie-ontwikkeling stelsels.\n"
 
 msgid ""
 "\n"
@@ -1378,6 +1524,18 @@ msgid ""
 "Disconnects everything from the provided plug or slot.\n"
 "The snap name may be omitted for the core snap.\n"
 msgstr ""
+"\n"
+"Die ontkoppel bevel ontkoppel 'n prop vanaf 'n gleuf.\n"
+"Dit kan genoem word op die volgende maniere:\n"
+"\n"
+"$ snap ontkoppel <snap>:<prop> <snap>:<gleuf>\n"
+"\n"
+"Ontkoppel die spesifieke prop vanaf die spesifieke gleuf.\n"
+"\n"
+"$ snap ontkoppel <snap>:<prop of gleuf>\n"
+"\n"
+"Ontkoppel alles van die meegaande prop of gleuf.\n"
+"Die snap naam kan weggelaat word vir die kern snap.\n"
 
 msgid ""
 "\n"
@@ -1390,6 +1548,9 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
+"\n"
+"Die in staat te stel bevel in staat stel om 'n snap daardie was voorheen "
+"gestremde.\n"
 
 msgid ""
 "\n"
@@ -1434,6 +1595,39 @@ msgid ""
 "This requests the \"usb-vendor\" setting from the slot that is connected to "
 "\"myplug\".\n"
 msgstr ""
+"\n"
+"Die kry bevel afdrukke konfigurasie opsies vir die huidige snap.\n"
+"\n"
+"    $ snapctl kry gebruikersnaam\n"
+"    frank\n"
+"\n"
+"As meerdere opsie name verskaf word, 'n dokument word teruggestuur:\n"
+"\n"
+"    $ snapctl kry gebruikersnaam wagwoord\n"
+"    {\n"
+"        \"gebruikersnaam\": \"frank\",\n"
+"        \"wagwoord\": \"...\"\n"
+"    }\n"
+"\n"
+"Geneste waardes mei wees retrieved via 'n gestippelde pad:\n"
+"\n"
+"    $ snapctl kry skrywer.naam\n"
+"    frank\n"
+"\n"
+"Waardes van koppelvlak verbinding instellings mei wees gedruk met:\n"
+"\n"
+"    $ snapctl kry :myprop usb-ondememer\n"
+"    $ snapctl kry :myslot pad\n"
+"\n"
+"Hierdie sal terugkeer die vernoem instelling vanaf die plaaslike koppelvlak "
+"endpunt, whether 'n prop\n"
+"of 'n slot. Terug na die instelling vanaf die gekonnekteer snap's endpunt is "
+"ook moontlik\n"
+"\n"
+"    $ snapctl kry :myprop --slot usb-ondememer\n"
+"\n"
+"Hierdie versoeke die \"usb-ondememer\" instelling van die slot daardie is "
+"gekonnekteer na \"myprop\".\n"
 
 msgid ""
 "\n"
@@ -1455,6 +1649,24 @@ msgid ""
 "    $ snap get snap-name author.name\n"
 "    frank\n"
 msgstr ""
+"\n"
+"Die kry bevel afdruks konfigurasie opsies vir die verskaf snap.\n"
+"\n"
+"    $ snap kry snap-naam gebruikersnaam\n"
+"    frank\n"
+"\n"
+"As veelvoudig opsie name word verskaf, 'n dokument word teruggestuur:\n"
+"\n"
+"    $ snap kry snap-naam gebruikersnaam wagwoord\n"
+"    {\n"
+"        \"gebruikersnaam\": \"frank\",\n"
+"        \"wagwoord\": \",,,\"\n"
+"    }\n"
+"\n"
+"Geneste waardes kan wees retrieved via 'n stip sti:\n"
+"\n"
+"    $ snap kry snap-name outeur.naam\n"
+"    frank\n"
 
 msgid ""
 "\n"
@@ -1479,6 +1691,13 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
+"\n"
+"Die koppelvlak bevel wys besonderhede van snap koppelvlakke.\n"
+"\n"
+"Indien geen naam koppelvlak word voorsien, 'n lys met koppelvlak name met "
+"ten minste\n"
+"een verbinding word getoon, of 'n lys van al koppelvlakke indien --alle is "
+"verskaf.\n"
 
 msgid ""
 "\n"
@@ -1507,6 +1726,13 @@ msgid ""
 "If header=value pairs are provided after the assertion type, the assertions\n"
 "shown must also have the specified headers matching the provided values.\n"
 msgstr ""
+"\n"
+"Die bekend bevel wys skoue bekend assertions van die met dien verstande "
+"tipe.\n"
+"Indien header=waarde pare word voorsien na die assertion tipe, die "
+"assertions\n"
+"getoon moet ook die gespesifiseerde hê headers wat oore met die met dien "
+"verstande waardes.\n"
 
 msgid ""
 "\n"
@@ -1537,6 +1763,9 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
+"\n"
+"Die bestuurde opdrag sal waar of vals afdruk met informing whether\n"
+"snapd het geregistreerde gebruikers.\n"
 
 msgid ""
 "\n"
@@ -1567,6 +1796,22 @@ msgid ""
 "if instead you want to install the snap forcing it into strict confinement\n"
 "repeat the command including --jailmode."
 msgstr ""
+"\n"
+"Die uitgewer van snap %q het aangedui dat hulle nie hierdie revision oorweeg "
+"nie\n"
+"om van produksie kwaliteit te wees en dit is slegs bedoel vir ontwikkeling "
+"of toetsing\n"
+"op hierdie punt. As 'n gevolge hierdie snap sal nie verfris outomaties nie "
+"en mag\n"
+"arbitrêre stelselveranderings uitvoer buite die sekuriteits sandkas snaps "
+"is\n"
+"in algemeen confined om, wat mag put jou stelsel in gevaar.\n"
+"\n"
+"As jy verstaan en wil om voort te gaan herhaal die opdrag insluitend --"
+"devmode;\n"
+"as in plaas daarvan jy wil die snap installeer dwing dit tot streng "
+"confinement\n"
+"herhaal die opdrag insluitend --jailmode."
 
 msgid ""
 "\n"
@@ -1588,11 +1833,16 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
+"\n"
+"Die herstel opdrag toon die besonderhede oor een of veelvuldige "
+"herstelwerk.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
+"\n"
+"Die herstelwerkopdrag bevat alle verwerkte herstelwerk vir hierdie toestel.\n"
 
 msgid ""
 "\n"
@@ -1600,6 +1850,10 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
+"\n"
+"Die herbegin bevel weerbegin die gegee dienste van die snap. Indien "
+"tereggestel uit die\n"
+"\"configure\" haak, die dienste sal begin word nadat die haak afwerkings."
 
 msgid ""
 "\n"
@@ -1618,6 +1872,15 @@ msgid ""
 "an exception, data which the snap explicitly chooses to share across\n"
 "revisions is not touched by the revert process.\n"
 msgstr ""
+"\n"
+"Die revert bevel reverts die gegee snap om sy staat vóór\n"
+"die nuutste verfris. Hierdie sal heraktiveer die vorige snap revision,\n"
+"en sal gebruik die oorspronklike data daardie was geassosieer met daardie "
+"revision,\n"
+"discarding enige data verander daardie was gedoen deur die jongste revision. "
+"As\n"
+"'n uitsondering, data watter die snap eksplisiet kies om deel regoor\n"
+"hersienings is nie aangeraak deur die revert proses.\n"
 
 msgid ""
 "\n"
@@ -1665,28 +1928,42 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
+"\n"
+"Die begin bevel begins die gegee dienste van die snap. As executed vanaf "
+"die\n"
+"\"configure\" haak, die dienste sal begin word nadat die haak klaar is."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
+"\n"
+"Die begin opdrag begin, en opsioneel in staat te stel, die gegewe dienste.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
+"\n"
+"Die stop bevel stop die gegewe dienste van die snap. As executed vanaf die\n"
+"\"configure\" haak, die dienste sal wees gestop nadat die haak afwerkings."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
+"\n"
+"Die stopopdrag stop, en deaktiveer opsioneel, die gegewe dienste.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
+"\n"
+"Die skakelaar bevel skakel die gegewe snap na 'n verskillende kanaal sonder\n"
+"doen 'n verfris.\n"
 
 msgid ""
 "\n"
@@ -1709,6 +1986,19 @@ msgid ""
 "be\n"
 "found relative to current working directory.\n"
 msgstr ""
+"\n"
+"Die probeer bevel installeer 'n uitgepak snap into die stelsel vir die toets "
+"doeleindes.\n"
+"Die uitgepak snap inhoud gaan voort om te gebruik selfs na die installasie, "
+"aldus\n"
+"nie-metadata veranderinge  daar gaan leef oombliklik. Metadata veranderinge "
+"sodanig as diegene\n"
+"uitgevoer in snap.yaml sal re-installasie vereis om gaan leef.\n"
+"\n"
+"Indien snap-dir argument word weggelaat, die probeer-opdrag sal sal poog om "
+"infer dit indien\n"
+"either snapcraft.yaml lêer en prime folder of meta/snap.yaml lêer kan wees\n"
+"gevind relatief tot die huidige working folder.\n"
 
 msgid ""
 "\n"
@@ -1721,6 +2011,9 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
+"\n"
+"Die weergawe bevel vertoon die weergawes van die hardloop kliënt, bediener,\n"
+"en bedryf stelsel.\n"
 
 msgid ""
 "\n"
@@ -1728,6 +2021,10 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
+"\n"
+"Die horlosie beveel wag vir die gegewe verandering-id om afwerking en wys "
+"vordering\n"
+"(Indien beskikbaar).\n"
 
 msgid ""
 "\n"
@@ -1746,6 +2043,15 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
+"\n"
+"Hierdie revision van snap %q was gepubliseer met behulp van klassieke "
+"opsluiting en thus mag\n"
+"arbitrêre stelsel veranderings uitvoer buitekant van die sekuriteit sandbox "
+"daardie snaps is\n"
+"gewoonlik opsluiting om, wat mag put jou stelsel by risiko.\n"
+"\n"
+"Indien jy verstaan en wil hê gaan voort, herhaal die beveel inbegrip --"
+"klassieke.\n"
 
 msgid ""
 "\n"
@@ -1753,203 +2059,212 @@ msgid ""
 msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
-msgstr ""
+msgstr "'n enkele naam is nodig om modus of kanaal te spesifiseer vlags"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr ""
+msgstr "'n engkele snap naam is nodig om die spesifiseer die revision"
 
 msgid "a single snap name must be specified when ignoring validation"
 msgstr ""
+"'n engkele snap naam moet gespesifiseer word wanneer ignoreer validering"
 
 msgid "active"
-msgstr ""
+msgstr "aktiewe"
 
 msgid "auto-refresh: all snaps are up-to-date"
-msgstr ""
+msgstr "outo-verfris: alle snaps is up-om-datum"
 
 msgid "bought"
-msgstr ""
+msgstr "gekoop"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr ""
+msgstr "gebroke"
 
 #, c-format
 msgid "cannot %s without a context"
-msgstr ""
+msgstr "kan nie %s sonder 'n konteks"
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr ""
+msgstr "kan nie koop snap: %v"
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr ""
+msgstr "kan nie koop snap: ongeldige karakters in naam"
 
 msgid "cannot buy snap: it has already been bought"
-msgstr ""
+msgstr "kan nie koop snap: dit is reeds gekoop"
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr ""
+msgstr "kan nie skep %q: %v"
 
 #, c-format
 msgid "cannot create assertions file: %v"
-msgstr ""
+msgstr "kan nie skep bewerings lêer: %v"
 
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr ""
+msgstr "kan nie uittreksel die snap-naam vanaf plaaslike lêer %q: %v"
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr ""
+msgstr "kan nie vind app %q in %q"
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr ""
+msgstr "kan nie vind haak %q in %q"
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr ""
+msgstr "kan nie kry data vir %q: %v"
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr ""
+msgstr "kan nie kry volle pad vir %q: %v"
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr ""
+msgstr "kan nie kry die huidige gebruiker: %s"
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr ""
+msgstr "kan nie kry die huidige gebruiker: %v"
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr ""
+msgstr "kan nie selflaai suksesvol merk nie: %s"
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr ""
+msgstr "kan nie die beweringsdatabasis oopmaak nie: %v"
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr ""
+msgstr "kan nie lees bewering insette: %v"
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr ""
+msgstr "cannot read symlink: %v"
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
-msgstr ""
+msgstr "kan nie oplos nie snap app %q: %v"
 
 #, c-format
 msgid "cannot sign assertion: %v"
-msgstr ""
+msgstr "kan nie assertion onderteken: %v"
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr ""
+msgstr "kan nie opdateer die 'current' symlink van %q: %v"
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr ""
+msgstr "kan nie gebruik %q sleutel: %v"
 
 msgid "cannot use change ID and type together"
-msgstr ""
+msgstr "kan nie gebruik verandering ID en tik saam"
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr ""
+msgstr "kan nie gebruik devmodus en tronk toe modus vlae saam"
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr ""
+msgstr "kan nie eienaar bekragtig van lêer %s"
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr ""
+msgstr "kan nie 'n nuwe Xoutoriteits lêer skryf by %s: %s"
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr ""
+msgstr "verandering klaar in status %q met geen fout boodskap"
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
+"klassieke opsluiting vereis snaps onder /snap of symlink vanaf/snap om %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr ""
+msgstr "geskep gebruiker %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr ""
+msgstr "d"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr ""
+msgstr "gestremde"
 
 msgid "email:"
-msgstr ""
+msgstr "e-pos:"
 
 msgid "enabled"
-msgstr ""
+msgstr "instaat gestel"
 
 #, c-format
 msgid "error: %v\n"
-msgstr ""
+msgstr "fout: %v\n"
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
 msgstr ""
+"fout: die `<snap-dir>` argument is nie voorsien nie en kon nie inferred word"
 
 msgid "get which option?"
-msgstr ""
+msgstr "kry watter opsie?"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr ""
+msgstr "h"
 
 msgid "ignore-validation"
-msgstr ""
+msgstr "ignoreer-validering"
 
 msgid "inactive"
-msgstr ""
+msgstr "onaktief"
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
 msgstr ""
+"koppelvlak attributen kan enigste wees lees tydens die -uitvoering van "
+"koppelvlak haak"
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
 msgstr ""
+"koppelvlak attributen kan enigste wees stel tydens die uitvoering van "
+"voorbereide hake ingestel is"
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr ""
+msgstr "internal error, please report: running %q failed: %v\n"
 
 msgid "internal error: cannot find attrs task"
-msgstr ""
+msgstr "Interne fout: kan attrs taak nie vind"
 
 msgid "internal error: cannot find plug or slot data in the appropriate task"
-msgstr ""
+msgstr "Interne fout: kan nie prop of gleuf data in die toepaslike taak vind"
 
 #, c-format
 msgid "internal error: cannot get %s from appropriate task"
-msgstr ""
+msgstr "Interne fout: kan nie kry %s vanaf toepaslike taak"
 
 msgid ""
 "invalid argument for flag ‘-n’: expected a non-negative integer argument, or "
 "“all”."
 msgstr ""
+"ongeldige argument vir vlag ‘-n’: het 'n nie-negatiewe heelgetal argument "
+"verwag, of “all”."
 
 #, c-format
 msgid "invalid attribute: %q (want key=value)"
@@ -1957,67 +2272,70 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr ""
+msgstr "ongeldig konfigurasie: %q (wil sleutel=waarde)"
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr ""
+msgstr "ongeldig kop filter: %q (wil sleutel=waarde)"
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr ""
+msgstr "ongeldige parameter: %q (wil sleutel=waarde)"
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr ""
+msgstr "ongeldige waarde: %q (wil snap:naam of snap)"
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
+"sleutel naam %q is nie geldig; enigste ASCII letters, syfers en koppeltekens "
+"word toegelaat"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
+"plaaslike snap %q is onbekend aan die winkel, gebruik --amend om voortgaan"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr ""
+msgstr "m"
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr ""
+msgstr "moet die aansoek om te hardloop as argument"
 
 msgid "no changes found"
-msgstr ""
+msgstr "geen veranderinge gevind"
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr ""
+msgstr "geen verandering van tipe %q gevind"
 
 msgid "no interfaces currently connected"
-msgstr ""
+msgstr "geen koppelvlakke tans gekoppel"
 
 msgid "no interfaces found"
-msgstr ""
+msgstr "geen koppelvlakke gevind"
 
 msgid "no matching snaps installed"
-msgstr ""
+msgstr "geen bypassende snaps geïnstalleer"
 
 msgid "no such interface"
-msgstr ""
+msgstr "geen sodanige koppelvlak"
 
 msgid "no valid snaps given"
-msgstr ""
+msgstr "geen sodanige koppelvlak"
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr ""
+msgstr "verskaf asseblief verandering ID of tipe met --last=<type>"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr ""
+msgstr "privaat"
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2025,19 +2343,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr ""
+msgstr "herstelwerk is nie op 'n klassieke stelsel beskikbaar"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #, c-format
 msgid "set failed: %v"
-msgstr ""
+msgstr "stel het misluk: %v"
 
 msgid "set which option?"
-msgstr ""
+msgstr "stel watter opsie in?"
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2051,7 +2369,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr ""
+msgstr "snap %q het geen updates beskikbaar"
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2059,30 +2377,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr ""
+msgstr "snap %q nie gevind"
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr ""
+msgstr "snap is gratis"
 
 msgid "too many arguments for command"
-msgstr ""
+msgstr "te veel argumente vir beveel"
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr ""
+msgstr "te veel argumente vir haak %q: %s"
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr ""
+msgstr "te veel argumente: %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "nie in staat is om snap winkel kontak"
 
 msgid "unavailable"
-msgstr ""
+msgstr "onbeskikbaar"
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2094,34 +2412,37 @@ msgstr ""
 
 #, c-format
 msgid "unknown plug or slot %q"
-msgstr ""
+msgstr "onbekende prop of gleuf %q"
 
 #, c-format
 msgid "unknown service: %q"
-msgstr ""
+msgstr "onbekende diens: %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr ""
+msgstr "waarskuwing: \t geen snap gevind vir %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr ""
+msgstr "y"
 
 msgid "Authenticate on snap daemon"
-msgstr ""
+msgstr "Outentiseer op snap daemon"
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr ""
+msgstr "Magtiging is nodig om te outentiseer op die snap daemon"
 
 msgid "Install, update, or remove packages"
-msgstr ""
+msgstr "Installeer, opdateer of verwyder pakkette"
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
+"Outentisering word vereis om pakkette te installeer, te opdateer of te "
+"verwyder"
 
 msgid "Connect, disconnect interfaces"
-msgstr ""
+msgstr "Koppel, ontkoppel koppelvlakke"
 
 msgid "Authentication is required to connect or disconnect interfaces"
 msgstr ""
+"Outentisering word vereis om koppelvlakke te koppel of te diskonnekteer"

--- a/po/am.po
+++ b/po/am.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<ሀሰት>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<ኢሜይል>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<የ ፋይል ስም>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<የ ራስጌ ማጣሪያ filter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<ቁልፍ-ስም>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<ቁልፍ>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<ጥያቄ>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "አማራጭ ትእዛዝ ለማስኬድ"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "ፋይል ማረጋገጫ"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "የ ማረጋገጫ ስም አይነት"
 
@@ -282,7 +293,7 @@ msgstr "መጥፎ ኮድ: እባክዎን እንደገና ይሞክሩ: "
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr "የ ማሰናጃ ምርጫ መቀየሪያ"
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr "መገናኛ %s:%s ወደ %s:%s"
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr "መለያያ %s:%s ከ %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr "የሚገጠሙ ጥቅሎች ተገኝተዋል"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "ማምጫ ማስገደጃ በ ዘመናዊ ስርአቶች ውስጥ"
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "የ አካል ቁልፍ ማመንጫ"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr "እርዳታ"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "የሚጠፋው የ ቁልፍ ስም"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "የሚላከው የ ቁልፍ ስም"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "የ ተሰጠውን ክለሳ ብቻ ማስወገጃ"
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "መፈለጊያውን በ ተሰጠው ክፍል መወሰኛ"
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -1,16 +1,16 @@
-# Swedish translation for snapd
-# Copyright (c) 2018 Rosetta Contributors and Canonical Ltd 2018
+# Bengali translation for snapd
+# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
 # This file is distributed under the same license as the snapd package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
+"PO-Revision-Date: 2019-01-07 16:37+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Swedish <sv@li.org>\n"
+"Language-Team: Bengali <bn@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,151 +23,148 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q innehåller inte ett uppackat snap-paket.\n"
-"\n"
-"Testa \"snapcraft prime\" i din projektmapp, sedan \"snap try\" igen."
 
 #. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr "%q bytte till kanalen %q\n"
+msgstr ""
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s monterades från %s\n"
+msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr "%s (delta)"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr "%s (se \"snap login --help\")"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr "%s (försök med sudo)"
+msgstr ""
 
 #, c-format
 msgid "%s already installed\n"
-msgstr "%s är redan installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s disabled\n"
-msgstr "%s inaktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s enabled\n"
-msgstr "%s aktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s not installed\n"
-msgstr "%s inte installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s removed\n"
-msgstr "%s borttagen\n"
+msgstr ""
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr "%s återställd till %s\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
 msgid "%s%s %s from '%s' installed\n"
-msgstr "%s%s %s från \"%s\" installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr "%s%s %s från \"%s\" uppdaterad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr "%s%s %s installerad\n"
+msgstr "%s%s %s ইন্সটল করা হয়েছে\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr "%s%s %s uppdaterad\n"
+msgstr ""
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "--time does not take mode nor channel flags"
-msgstr "--time tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr "-r kan bara användas med --hook"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr "<alias-eller-snap>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr "<alias>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<assert-fil>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<assert-typ>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<ändra-id>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr "<konf.värde>"
+msgstr ""
 
 #. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 #. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr "<epost>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr "<filnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr "<rubrikfilter>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr "<gränssnitt>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr "<nyckelnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr "<nyckel>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr "<modell-assert>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr "<fråga>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<root-kat>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
@@ -176,48 +173,46 @@ msgstr ""
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr "<snap>:<plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr "<snap>:<slot eller plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr "<snap>:<slot>"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
-"En tjänstespecifikation, som kan vara bara ett snappnamn (för alla tjänster "
-"i snappen), eller <snapp>.<app> för en enstaka tjänst."
 
 msgid "Abort a pending change"
-msgstr "Avbryt en väntande ändring"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr "Tillagd"
+msgstr "যোগ করা হয়েছে"
 
 msgid "Adds an assertion to the system"
-msgstr "Lägger till en assert i systemet"
+msgstr ""
 
 msgid "Advise on available snaps."
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr "Informera om snappar som tillhandahåller det givna kommandot"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr "Alias för --dangerous (FÖRÅLDRAD)"
+msgstr ""
 
 msgid "All snaps up to date."
-msgstr "Alla snap-paket uppdaterade."
+msgstr ""
 
 msgid "Allow opening file?"
 msgstr ""
@@ -231,27 +226,27 @@ msgstr ""
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr "Tillåt snapp %q att ändra %q till %q ?"
+msgstr ""
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr "Tillåt snapp %q att öppna filen %q?"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr "Alternativt kommando att köra"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr "Returnera alltid dokument, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr "Returnera alltid lista, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr "En e-postadress för en användare på login.ubuntu.com"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -266,14 +261,14 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr "Assert-fil"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr "Assert-typnamn"
+msgstr ""
 
 msgid "Authenticates on snapd and the store"
-msgstr "Autentiseras på snapd och butiken"
+msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
@@ -293,27 +288,27 @@ msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr "Felaktig kod. Försök igen: "
+msgstr ""
 
 msgid "Buys a snap"
-msgstr "Köper en snap"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr "Ändra ID"
+msgstr ""
 
 msgid "Changes configuration options"
-msgstr "Ändrar konfigurationsalternativ"
+msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr "Kommando\tAlias\tAnteckningar"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr "Konfigurationsvärde (nyckel=värde)"
+msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr "Bekräfta lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -324,57 +319,56 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr "Begränsa lista till en specifik snap eller snapp:namn"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr "Begränsa lista till specifika gränssnitt"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr "Begränsa lista till de som matchar rubrik=värde"
+msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr "Kopiera data från snapp %q"
+msgstr ""
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
-"Skapa ett kryptografiskt nyckelpar som kan användas för att signera asserts."
 
 msgid "Create cryptographic key pair"
-msgstr "Skapa kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Create snap build assertion"
-msgstr "Skapa snap-bygges-assert"
+msgstr ""
 
 msgid "Create snap-build assertion for the provided snap file."
-msgstr "Skapa snap-bygges-assert för den givna snap-filen."
+msgstr ""
 
 msgid "Creates a local system user"
-msgstr "Skapar en lokal systemanvändare"
+msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr "Radera kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Delete the local cryptographic key pair with the given name."
-msgstr "Radera det lokala kryptografiska nyckelparet med det givna namnet."
+msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr "Inaktivera %q-snap"
+msgstr ""
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr "Avaktivera alias för snapp %q"
+msgstr ""
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr "Avaktiverar alla alias för snap %q"
+msgstr ""
 
 msgid "Disables a snap in the system"
-msgstr "Avaktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
@@ -389,44 +383,41 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr "Vänta inte på att åtgärden ska slutföras, skriv bara ut ändrat ID."
+msgstr ""
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr "Ladda ned snapp %q%s från kanal %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
-"Hämta den givna revisionen av en snap, för vilket du behöver utvecklaråtkomst"
 
 msgid "Downloads the given snap"
-msgstr "Hämtar angiven snap"
+msgstr ""
 
 msgid "Email address: "
-msgstr "E-postadress: "
+msgstr ""
 
 #, c-format
 msgid "Enable %q snap"
-msgstr "Aktivera %q-snap"
+msgstr ""
 
 msgid "Enables a snap in the system"
-msgstr "Aktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr "Säkerställ att allt som %q kräver finns tillgängligt"
+msgstr ""
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
-"Exportera en öppen nyckel assert-nyttolast som kan importeras av andra "
-"system."
 
 msgid "Export cryptographic public key"
-msgstr "Exportera kryptografisk öppen nyckel"
+msgstr ""
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
@@ -434,40 +425,38 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr "Hämtar asserts för %q\n"
+msgstr ""
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr "Hämtar snap %q\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr "Filnamn för snap du vill försäkra ett bygge för"
+msgstr ""
 
 msgid "Finds packages to install"
-msgstr "Söker efter paket att installera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr "Tvinga tillägg av användare, även om enheten redan hanteras"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr "Tvinga import på klassiska system"
+msgstr ""
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
-"Formatera öppet nyckelmaterial som en begäran för en kontonyckel för detta "
-"konto-ID"
 
 msgid "Generate device key"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr "Generera manualsidan"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
@@ -475,25 +464,25 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr "Bevilja sudo-åtkomst för den skapade användaren"
+msgstr ""
 
 msgid "Help"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr "Krok att köra"
+msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr "Signerarens identifierare"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr "Identifierare för snap-paket associerat med bygge"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
@@ -501,7 +490,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr "Ignorera validering av andra snap-paket som blockerar uppdatering"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -510,73 +499,65 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
-"För att köpa %q, måste du godkänna de senaste villkoren. Gå till "
-"https://my.ubuntu.com/payment/edit för att göra detta.\n"
-"\n"
-"När du är färdig, kom tillbaka hit och kör \"snap buy %s\" igen."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
-"Inkludera en utförlig lista över ett snap-pakets anteckningar (annars "
-"sammanfattas anteckningar)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr "Inkludera gränssnitt som inte används"
+msgstr ""
 
 msgid "Initialize device"
 msgstr ""
 
 msgid "Inspects devices for actionable information"
-msgstr "Inspekterar enheter för användbar information"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installera snap-paketet %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr "Installera snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installera snap  %q från fil"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installera snap %q från fil %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installera från betakanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installera från kandidatkanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installera från spetskanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installera från stabila kanalen"
+msgstr ""
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installera snap %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installera snap-paket %s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installera den givna revisionen av en snap, för vilket du behöver ha "
-"utvecklaråtkomst"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -584,14 +565,10 @@ msgid ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installera den givna snap-filen även om det inte finns några tidigare kända "
-"signaturer för den, vilket innebär att den inte verifierades och kan vara "
-"farlig (--devmode antar detta)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installera det givna snap-paketet utan att aktivera dess automatiska alias"
 
 #, c-format
 msgid ""
@@ -599,118 +576,113 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
-"Installera snappen med:\n"
-"   snap ack %s\n"
-"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr "Installerar en snap i systemet"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr "Nyckel av intresse bland konfigurationen"
+msgstr ""
 
 msgid "List a change's tasks"
-msgstr "Lista en ändrings uppgifter"
+msgstr ""
 
 msgid "List cryptographic keys"
-msgstr "Lista kryptografiska nycklar"
+msgstr ""
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
-"Lista kryptografiska nycklar som kan användas för att signera försäkran."
 
 msgid "List installed snaps"
-msgstr "Lista installerade snap-paket"
+msgstr ""
 
 msgid "List system changes"
-msgstr "Lista systemändringar"
+msgstr ""
 
 msgid "Lists aliases in the system"
-msgstr "Lista alias i systemet"
+msgstr ""
 
 msgid "Lists all repairs"
-msgstr "Lista alla reparationer"
+msgstr ""
 
 msgid "Lists interfaces in the system"
-msgstr "Lista gränssnitt i systemet"
+msgstr ""
 
 msgid "Lists snap interfaces"
-msgstr "Lista snap-gränssnitt"
+msgstr ""
 
 msgid "Log out of the store"
-msgstr "Logga ut från butiken"
+msgstr ""
 
 msgid "Login successful"
-msgstr "Inloggning lyckades"
+msgstr ""
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr "Gör aktuell revision för snapp %q otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr "Gör snapp %q (%s) tillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr "Gör snapp %q (%s) otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr "Gör snapp %q otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr "Gör snapp %q%s tillgänglig för systemet"
+msgstr ""
 
 msgid "Mark system seeded"
 msgstr ""
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr "Montera snapp %q%s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr "Nyckelnamn att skapa; förval är \"default\""
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr "Nyckelnamn att radera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr "Nyckelnamn att exportera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
-"Namnet som GnuPG-nyckeln ska använda (förvalt nyckelnamn är \"default\")"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Nyckelnamn att använda, annars används förvald nyckel"
+msgstr ""
 
 msgid "Name\tSHA3-384"
-msgstr "Namn\tSHA3-384"
+msgstr ""
 
 msgid "Name\tSummary"
-msgstr "Namn\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr "Namn\tVersion\tUtvecklare\tAnteckningar\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr "Namn\tVersion\tRev\tUtvecklare\tAnteckningar"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr "Inga alias är definierade för snapp %q.\n"
+msgstr ""
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -732,31 +704,28 @@ msgstr ""
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr "Inga matchande snappar för %q i avsnitt %q\n"
+msgstr ""
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr "Inga matchande snappar för %q\n"
+msgstr ""
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
-"Ingen sökterm angiven. Här är några snappar att titta närmare på:\n"
-"\n"
 
 msgid "No section specified. Available sections:\n"
 msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
-"Inga snap-paket har installerats än. Testa \"snap install hello-world\"."
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr "Utdata resulterar i JSON-format"
+msgstr ""
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -766,11 +735,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr "Lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Password of %q: "
-msgstr "Lösenord för %q: "
+msgstr ""
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -778,212 +747,210 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
-"Ange ditt Ubuntu One-lösenord igen för att köpa %q från %q\n"
-"för %s. Tryck ctrl-C för att avbryta."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr "Föredra alias från en snap och inaktivera konflikter"
+msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prepare a snappy image"
-msgstr "Förbered en snappy-avbild"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr "Förbered snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr "Förbered snap %q%s"
+msgstr ""
 
 msgid "Print the version and exit"
-msgstr "Skriv ut version och avsluta"
+msgstr ""
 
 msgid "Prints configuration options"
-msgstr "Skriver ut konfigurationsalternativ"
+msgstr ""
 
 msgid "Prints the confinement mode the system operates in"
-msgstr "Skriver ut vilket inneslutningsläge systemet arbetar i"
+msgstr ""
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr "Skriver ut huruvida systemet är hanterat"
+msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr "Städa upp automatiska alias för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr "Sätt snap i klassiskt läge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr "Sätt snap i utvecklarläge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr "Sätt snap i bevakat inneslutningsläge"
+msgstr ""
 
 msgid "Query the status of services"
-msgstr "Undersök status för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr "Förnya snap %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr "Förnya snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr "Förnya alias för snap %q"
+msgstr ""
 
 msgid "Refresh all snaps: no updates"
-msgstr "Förnya alla snappar: inga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr "Förnya snapp %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr "Uppdatera snappar %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr "Förnya snappar %s: inga uppdateringar"
+msgstr ""
 
 msgid "Refresh to the given revision"
-msgstr "Uppdatera den givna revisionen"
+msgstr ""
 
 msgid "Refreshes a snap in the system"
-msgstr "Uppdaterar en snap i systemet"
+msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr "Ta bort alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr "Ta bort data för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr "Ta bort manuellt alias %q för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr "Ta endast bort den angivna revisionen"
+msgstr ""
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr "Ta bort säkerhetsprofil för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr "Ta bort säkerhetsprofiler för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr "Ta bort snap %q (%s) från systemet"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr "Ta bort snapp-paketen %s"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr "Borttagen"
+msgstr ""
 
 msgid "Removes a snap from the system"
-msgstr "Tar bort en snap från systemet"
+msgstr ""
 
 msgid "Request device serial"
-msgstr "Begär enhetens serienummer"
+msgstr ""
 
 msgid "Restart services"
-msgstr "Starta om tjänster"
+msgstr ""
 
 msgid "Restarted.\n"
-msgstr "Omstartad.\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr "Begränsa sökningen till ett givet avsnitt"
+msgstr ""
 
 msgid "Retrieve logs of services"
-msgstr "Hämta logg för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr "Rulla tillbaka snap %q"
+msgstr ""
 
 msgid "Reverts the given snap to the previous state"
-msgstr "Rulla tillbaka det givna snap-paketet till föregående tillstånd"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr "Kör ett skal istället för kommandot (hjälper vid felsökning)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr "Kör som en tidmätartjänst med ett givet schema"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr "Kör konfigureringskrok för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr "Kör konfigureringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr "Kör krok %s för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr "Kör installeringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr "Kör post-förnyelsekrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr "Kör förbered-enhets-krok"
+msgstr ""
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr "Kör borttagningskrok för snap %q om den finns"
+msgstr ""
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
@@ -995,54 +962,52 @@ msgid "Run the command with gdb"
 msgstr ""
 
 msgid "Run the given snap command"
-msgstr "Kör det givna snap-kommandot"
+msgstr ""
 
 msgid "Run the given snap command with the right confinement and environment"
-msgstr "Kör det givna snap-kommandot med korrekt inneslutning och miljö"
+msgstr ""
 
 msgid "Runs debug commands"
-msgstr "Kör felsökningskommandon"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr "Sök privata snap-paket"
+msgstr ""
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
-"Välj senaste ändring av given typ (installera, förnya, ta bort, testa, auto-"
-"förnya osv.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr "Ange automatiska alias för snap %q"
+msgstr ""
 
 msgid "Sets up a manual alias"
-msgstr "Anger ett manuellt alias"
+msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr "Ställ in alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr "Ställ in manuellt alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr "Ställ in säkerhetsprofiler för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr "Ställ in alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr "Ställ in säkerhetsprofiler för snapp %q%s"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
@@ -1103,7 +1068,7 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr "Snappnamn"
+msgstr ""
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
@@ -1116,14 +1081,14 @@ msgstr ""
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr "Starta tjänster från snapp %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr "Starta snapp %q%s-tjänster"
+msgstr ""
 
 msgid "Start snap services"
-msgstr "Starta snapptjänster"
+msgstr ""
 
 msgid "Start the userd service"
 msgstr ""
@@ -1139,21 +1104,21 @@ msgstr ""
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr "Stoppa snapp %q (%s)-tjänster"
+msgstr ""
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr "Stoppa snapp %q-tjänster"
+msgstr ""
 
 msgid "Stop snap services"
-msgstr "Stoppa snapptjänster"
+msgstr ""
 
 msgid "Stopped.\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr "Strikt inmatning med tomma och citerade strängar"
+msgstr ""
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1168,7 +1133,7 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr "Växlar snapp till en annan kanal"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
@@ -1183,8 +1148,6 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
-"Tack för att du köpte %q. Du kan nu installera det på valfri enhet med\n"
-"kommandot \"snap install %s\"."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
@@ -1192,7 +1155,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "E-postadress på login.ubuntu.com att logga in som"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
@@ -1209,11 +1172,11 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr "Snapp att konfigurera (t.ex. hello-world)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr "Snappen vars konf begärs"
+msgstr ""
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1226,10 +1189,10 @@ msgstr ""
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr "Växla snapp %q-flaggor"
+msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr "Verktyg för att interagera med snappar"
+msgstr ""
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
@@ -1240,20 +1203,20 @@ msgstr ""
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr "Testa snapp %q från %s"
+msgstr ""
 
 msgid "Try: snap install <selected snap>\n"
-msgstr "Testa: snap install <vald snapp>\n"
+msgstr ""
 
 msgid "Two-factor code: "
-msgstr "Två-faktor kod: "
+msgstr ""
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr "Använd en specifik snapprevision när krok körs"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
@@ -1308,11 +1271,6 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
-"Du måste ha en betalningsmetod associerad med ditt konto för att kunna köpa "
-"en snapp. Besök https://my.ubuntu.com/payment/edit för att lägga till en.\n"
-"\n"
-"När du har lagt till betalningsinformationen behöver du bara köra \"snap buy "
-"%s\" igen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1400,8 +1358,6 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
-"\n"
-"Kommandot buy köper en snapp från butiken.\n"
 
 msgid ""
 "\n"
@@ -1457,11 +1413,6 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
-"\n"
-"Kommandot debug innehåller ett urval av ytterligare delkommandon.\n"
-"\n"
-"Felsökningskommandon kan tas bort utan aviseringar och kanske inte\n"
-"fungerar på icke-utvecklarsystem.\n"
 
 msgid ""
 "\n"
@@ -1496,8 +1447,6 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
-"\n"
-"Kommandot enable aktiverar en snapp som tidigare avaktiverats.\n"
 
 msgid ""
 "\n"
@@ -1587,12 +1536,6 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
-"\n"
-"Kommandot interface visar detaljer om snappars gränssnitt.\n"
-"\n"
-"Om inget gränssnittsnamn anges kommer en lista över gränssnittsnamn\n"
-"med minst en anslutning att visas, eller en lista över alla gränssnitt om\n"
-"--all anges.\n"
 
 msgid ""
 "\n"
@@ -1651,9 +1594,6 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
-"\n"
-"Kommandot managed kommer att skriva ut true eller false, vilket visar\n"
-"huruvida snapd har registrerat användare.\n"
 
 msgid ""
 "\n"
@@ -1705,15 +1645,11 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
-"\n"
-"Kommandot repair visar detaljer om en eller flera reparationer.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
-"\n"
-"Kommandot repairs listar alla utförda reparationer för den här enheten.\n"
 
 msgid ""
 "\n"
@@ -1721,11 +1657,6 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot restart startar om de givna tjänsterna i snappen. Om det körs "
-"från\n"
-"kroken \"configure\" kommer tjänsterna att startas om efter att kroken "
-"slutförs."
 
 msgid ""
 "\n"
@@ -1764,18 +1695,6 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
-"\n"
-"Kommandot set ändrar de givna konfigurationsalternativen enligt begäran.\n"
-"\n"
-"    $ snap set snappnamn username=frank password=$PASSWORD\n"
-"\n"
-"Alla konfigurationsändringar är omedelbart bestående, och sparas endast "
-"efter\n"
-"att snappens konfigurationskrok slutförs med lyckat resultat.\n"
-"\n"
-"Nästlade värden kan ändras via en prickad sökväg:\n"
-"\n"
-"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1803,41 +1722,28 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot start startar de angivna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att startas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot start startar, och eventuellt aktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot stop stoppar de givna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att stoppas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot stop stoppar, och eventuellt avaktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
-"\n"
-"Kommandot switch växlar den givna snappen till en annan kanal utan att\n"
-"göra en förnyelse.\n"
 
 msgid ""
 "\n"
@@ -1872,9 +1778,6 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
-"\n"
-"Kommandot version visar versionerna för den aktiva klienten, servern,\n"
-"och operativsystemet.\n"
 
 msgid ""
 "\n"
@@ -1882,10 +1785,6 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
-"\n"
-"Kommandot watch väntar på att den givna ändrings-ID:n ska slutföras, och "
-"visar\n"
-"förloppet (om tillgängligt).\n"
 
 msgid ""
 "\n"
@@ -1904,14 +1803,6 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
-"\n"
-"Den här revisionen av snapp %q utgavs med klassisk inneslutning, och kan "
-"därför\n"
-"utföra godtyckliga systemändringar utanför den säkerhetssandlåda som "
-"snappar\n"
-"normalt avgränsas till, vilket kan utgöra en risk för ditt system.\n"
-"\n"
-"Om du förstår och vill fortsätta, upprepa kommandot med --classic.\n"
 
 msgid ""
 "\n"
@@ -1920,26 +1811,25 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
-"ett enstaka snappnamn behövs för att specificera läges- eller kanalflaggor"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr "ett enstaka snappnamn behövs för att specificera revision"
+msgstr ""
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr "ett enstaka snappnamn måste specificeras när validering ignoreras"
+msgstr ""
 
 msgid "active"
-msgstr "aktiv"
+msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr "köpt"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr "trasig"
+msgstr ""
 
 #, c-format
 msgid "cannot %s without a context"
@@ -1947,18 +1837,18 @@ msgstr ""
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr "kan inte köpa snapp: %v"
+msgstr ""
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr "kan inte köpa snapp: ogiltiga tecken i namnet"
+msgstr ""
 
 msgid "cannot buy snap: it has already been bought"
-msgstr "kan inte köpa snapp: den har redan köpts"
+msgstr ""
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr "kan inte skapa %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot create assertions file: %v"
@@ -1967,50 +1857,50 @@ msgstr ""
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr "kan inte extrahera snappnamn från lokal fil %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr "kan inte hitta program %q i %q"
+msgstr ""
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr "kan inte hitta krok %q i %q"
+msgstr ""
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr "kan inte hämta data för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr "kan inte hämta full sökväg för %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr "kan inte hämta aktuell användare: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr "kan inte hämta aktuell användare: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr "kan inte märka uppstart lyckad: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr "kan inte öppna försäkringsdatabasen: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr "kan inte läsa försäkransindata: %v"
+msgstr ""
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr "kan inte läsa symlänk: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
@@ -2022,87 +1912,86 @@ msgstr ""
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr "kan inte uppdatera \"aktuell\" symlänk för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr "kan inte använda nyckeln %q: %v"
+msgstr ""
 
 msgid "cannot use change ID and type together"
-msgstr "kan inte använda ändrings-ID och typ tillsammans"
+msgstr ""
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr "kan inte använda devmode- och jailmode-flaggorna tillsammans"
+msgstr ""
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr "kan inte validera ägare av filen %s"
+msgstr ""
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr "kan inte skriva ny Xauthority-fil på %s: %s"
+msgstr ""
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr "ändring slutförd i status %q utan felmeddelande"
+msgstr ""
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
-"klassisk inneslutning kräver snappar i /snap eller symlänk från /snap till %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr "skapade användare %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr "d"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr "avaktiverad"
+msgstr ""
 
 msgid "email:"
-msgstr "e-post:"
+msgstr ""
 
 msgid "enabled"
-msgstr "aktiverad"
+msgstr ""
 
 #, c-format
 msgid "error: %v\n"
-msgstr "fel: %v\n"
+msgstr ""
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr "fel: argumentet \"<snap-dir>\" angavs inte och kunde inte antydas"
+msgstr ""
 
 msgid "get which option?"
-msgstr "hämta vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr "t"
+msgstr ""
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr "inaktiv"
+msgstr ""
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr "gränssnittsattribut kan bara läsas när gränssnittskrokarna körs"
+msgstr ""
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
-msgstr "gränssnittsattribut kan bara sättas när förberedelsekrokarna körs"
+msgstr ""
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr "internt fel, var god rapportera: kunde inte köra %q: %v\n"
+msgstr ""
 
 msgid "internal error: cannot find attrs task"
 msgstr ""
@@ -2125,69 +2014,67 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr "ogiltig konfiguration: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr "ogiltigt huvudfilter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr "ogiltig parameter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr "ogiltigt värde: %q (vill ha snap:namn eller snapp)"
+msgstr ""
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
-"nyckelnamnet %q är ogiltigt; endast ASCII-tecken, siffror, och streck tillåts"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
-"lokal snapp %q är okänd för butiken; använd --amend för att fortsätta ändå"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr "m"
+msgstr ""
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr "kräver att programmet körs som argument"
+msgstr ""
 
 msgid "no changes found"
-msgstr "hittade inga ändringar"
+msgstr ""
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr "hittade inga ändringar av typen %q"
+msgstr ""
 
 msgid "no interfaces currently connected"
-msgstr "inga gränssnitt anslutna just nu"
+msgstr ""
 
 msgid "no interfaces found"
-msgstr "inga gränssnitt hittades"
+msgstr ""
 
 msgid "no matching snaps installed"
-msgstr "inga matchande snappar installerade"
+msgstr ""
 
 msgid "no such interface"
-msgstr "inget sådant gränssnitt"
+msgstr ""
 
 msgid "no valid snaps given"
-msgstr "inga giltiga snappar angivna"
+msgstr ""
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr "ange ändrings-ID eller typ med --last=<typ>"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr "privat"
+msgstr ""
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2195,19 +2082,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr "reparationer är inte tillgängliga på ett klassiskt system"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr "s"
+msgstr ""
 
 #, c-format
 msgid "set failed: %v"
-msgstr "set misslyckades: %v"
+msgstr ""
 
 msgid "set which option?"
-msgstr "sätt vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2221,7 +2108,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr "snapp %q har inga tillgängliga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2229,30 +2116,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr "snapp %q finns inte"
+msgstr ""
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr "snapp är gratis"
+msgstr ""
 
 msgid "too many arguments for command"
-msgstr "för många argument för kommandot"
+msgstr ""
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr "för många argument för krok %q: %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr "för många argument: %s"
+msgstr ""
 
 msgid "unable to contact snap store"
-msgstr "kan inte kontakta snap store"
+msgstr ""
 
 msgid "unavailable"
-msgstr "otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2268,31 +2155,30 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr "okänd tjänst: %q"
+msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr "varning:\tingen snapp hittades för %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr "å"
+msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr "Autentisera mot snapp-daemon"
+msgstr ""
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr "Identitskontroll krävs för att autentisera mot snapp-daemonen"
+msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr "Installera, uppdatera eller ta bort paket"
+msgstr ""
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
-"Autentisering krävs för att installera, uppdatera, eller ta bort paket"
 
 msgid "Connect, disconnect interfaces"
-msgstr "Anslut, koppla bort gränssnitt"
+msgstr ""
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr "Autentisering krävs för att ansluta eller koppla bort gränssnitt"
+msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Pokušajte \"snapcraft prime\" u direktoriju vašeg programa, zatim ponovo "
 "\"snap try\"."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q se pomjerio na kanal %q\n"
@@ -105,88 +106,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr "-r se može koristiti samo sa --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-or-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<filename>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<header filter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<interface>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<key-name>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<key>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<model-assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<query>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<root-dir>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<slot or plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Prekinuti promjenu na čekanju"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Dodano"
 
@@ -204,9 +207,11 @@ msgstr "Daje tvrdnju sistemu"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Pseudonim za --dangerous (OBUSTAVLJENO)"
 
@@ -216,6 +221,7 @@ msgstr "Svi snapovi su ažurirani."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +236,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Alternativna naredba za pokretanje"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Uvijek vrati dokument, čak i sa jednim ključem"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Uvijek vrati listu, čak i sa jednim ključem"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Email korisnika na login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Dokument tvrdnje"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Ime tipa tvrdnje"
 
@@ -286,7 +297,7 @@ msgstr "Pogrešan kod. Pokušajte ponovo: "
 msgid "Buys a snap"
 msgstr "Kupuje snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Promijeni ID"
 
@@ -296,7 +307,7 @@ msgstr "Mijenja opcije konfiguracija"
 msgid "Command\tAlias\tNotes"
 msgstr "Komanda\tPseudonim\tBilješke"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Vrijednost konfiguracije (key=value)"
 
@@ -310,14 +321,15 @@ msgstr "Spoji %s:%s sa %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Povezuje utikač sa utorom"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Ograniči spisak na posebne interfejse"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Ograniči spisak na poklapajuće header=value"
 
@@ -375,6 +387,7 @@ msgstr "Prekinuti vezu %s:%s sa %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Odspaja utikač iz utora"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr "Ne čekaj da se operacija završi nego samo odštampati promjenjeni id"
 
@@ -382,6 +395,7 @@ msgstr "Ne čekaj da se operacija završi nego samo odštampati promjenjeni id"
 msgid "Download snap %q%s from channel %q"
 msgstr "Preuzimanje snapa %q%s sa kanala %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -426,16 +440,18 @@ msgstr "Hvatanje tvrdnji za %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Hvatanje snapa %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Ime dadoteke snapa za koju želite potvrditi izgradnju"
 
 msgid "Finds packages to install"
 msgstr "Pronalazi paket za instalaciju"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr "Prisilno dodavanje korisnika, čak i ako se već upravlja uređajem"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Prisilno uvezi na klasične sisteme"
 
@@ -447,33 +463,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Stvoriti stranicu uputstva"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Dozvoli sudo pristup kreiranom korisniku"
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Identifikator potpisnika."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identifikator snap paketa koji je povezan sa izgradnjom."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Zanemari provjeru valjanosti snap-ova koji blokiraju osvježavanje"
 
@@ -492,6 +516,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Uključiti nekorištene interfejse"
 
@@ -517,15 +542,19 @@ msgstr "Instaliraj snap %q sa datoteke"
 msgid "Install %q snap from file %q"
 msgstr "Instaliraj snap %q sa datoteke %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Instaliraj sa beta kanala"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Instaliraj sa kandidatnog kanala"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Instaliraj sa krajnjeg kanala"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Instaliraj sa stabilnog kanala"
 
@@ -538,10 +567,12 @@ msgstr "Instaliraj snap %q"
 msgid "Install snaps %s"
 msgstr "Instaliraj snapove %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -550,6 +581,7 @@ msgstr ""
 "Instaliraj dati snap dokument čak i ako nema prethodno priznatih potpisa, "
 "što znači da nije provjereno i može biti opasno (--devmode implies this)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -563,8 +595,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Instalira snap na sistem"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Ključ interesa unutar konfiguracije"
 
@@ -629,21 +661,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -704,6 +738,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -772,12 +808,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -835,6 +874,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -859,6 +899,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr "Ukloni snapove %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -874,6 +915,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -887,9 +929,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -929,6 +973,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -941,6 +986,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -983,9 +1029,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -995,13 +1043,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1031,8 +1081,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1082,6 +1132,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1100,6 +1151,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1117,15 +1169,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1133,11 +1185,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1177,15 +1230,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1198,6 +1254,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q canviat al canal %q\n"
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr "-r només es pot utilitzar amb --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<correu>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<nom-de-fitxer>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<filtre-de-capçalera>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nom-de-la-clau>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<clau>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<consulta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<directori-arrel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Avorta un canvi pendent"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr "Afegeix una afirmació al sistema"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias de --dangerous"
 
@@ -212,6 +217,7 @@ msgstr "All snaps up to date."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Ordre alternativa que s'executarà"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Torna sempre el document, inclús amb una sola clau"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Un correu electrònic d'un usuari a login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Fitxer de definició"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Nom del tipus de definició"
 
@@ -282,7 +293,7 @@ msgstr "El codi és incorrecte. Torneu a provar: "
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Canvia l'identificador"
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,18 +24,19 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q přepnuto na kanál %q\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr ""
+msgstr "%s %s připojeno z %s\n"
 
 #, c-format
 msgid "%s (delta)"
-msgstr ""
+msgstr "%s (rozdíl)"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
@@ -45,32 +46,32 @@ msgstr ""
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr ""
+msgstr "%s (zkuste se sudo)"
 
 #, c-format
 msgid "%s already installed\n"
-msgstr ""
+msgstr "%s už je nainstalované\n"
 
 #, c-format
 msgid "%s disabled\n"
-msgstr ""
+msgstr "%s vypnuto\n"
 
 #, c-format
 msgid "%s enabled\n"
-msgstr ""
+msgstr "%s zapnuto\n"
 
 #, c-format
 msgid "%s not installed\n"
-msgstr ""
+msgstr "%s není nainstalováno\n"
 
 #, c-format
 msgid "%s removed\n"
-msgstr ""
+msgstr "%s odstraněno\n"
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr ""
+msgstr "%s vráceno na %s\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
@@ -85,12 +86,12 @@ msgstr ""
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr ""
+msgstr "%s%s %s nainstalováno\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr ""
+msgstr "%s%s %s aktualizováno\n"
 
 msgid "--list does not take mode nor channel flags"
 msgstr ""
@@ -99,100 +100,104 @@ msgid "--time does not take mode nor channel flags"
 msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr ""
+msgstr "-r je možné použít pouze ve spojení s --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr ""
+msgstr "<alias-nebo-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr ""
+msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr ""
+msgstr "<soubor tvrzení>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr ""
+msgstr "<typ tvrzení>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr ""
+msgstr "<identifikátor-změny>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr ""
+msgstr "<nastavovací hodnota>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr ""
+msgstr "<e-mail>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr ""
+msgstr "<nazev_souboru>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr ""
+msgstr "<filtr hlavičky>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr ""
+msgstr "<rozhrani>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr ""
+msgstr "<název-klíče>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr ""
+msgstr "<klíč>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr ""
+msgstr "<dotaz>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr ""
+msgstr "<kořenová_složka>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<služba>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr ""
+msgstr "<snap>:<slot nebo zástrčka>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
+"Určení služby, která může být pouze název snapu (pro všechny služby ve "
+"snapu), nebo <snap>.<app> pro jedinou službu."
 
 msgid "Abort a pending change"
-msgstr ""
+msgstr "Zrušit neprovedenou změnu"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr ""
+msgstr "Přidáno"
 
 msgid "Adds an assertion to the system"
 msgstr ""
@@ -200,133 +205,146 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr ""
+msgstr "Radit snapy které poskytují daný příkaz"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr ""
+msgstr "Alternativní název pro --dangerous (ZASTARALÉ)"
 
 msgid "All snaps up to date."
-msgstr ""
+msgstr "Všechny snapy jsou aktuální"
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Umožnit otevřít soubor?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
-msgstr ""
+msgstr "Umožnit pokus o aktualizaci snapu, který není obchodu znám"
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Umožnit změnu nastavení?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Umožnit snapu %q změnit %q na %q ?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Umožnit snapu %q otevřít soubor %q?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr ""
+msgstr "Který alternativní příkaz spustit"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr ""
+msgstr "Vždy vrátit dokument, i s jediným klíčem"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr ""
+msgstr "Vždy vrátit seznam, i pro jediný klíč"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr ""
+msgstr "E-mail uživatele na login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
+"Zároveň se spuštěním služby nyní, nastavit aby byla spouštěná při spouštění "
+"systému."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
+"Zároveň se zastavením služby nyní, nastavit aby už nebyla spouštěná při "
+"spouštění systému."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr ""
+msgstr "Soubor s tvrzením"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr ""
+msgstr "Název typu tvrzení"
 
 msgid "Authenticates on snapd and the store"
 msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
-msgstr ""
+msgstr "Automaticky aktualizovat %d snapy"
 
 #, c-format
 msgid "Auto-refresh snap %q"
-msgstr ""
+msgstr "Automaticky aktualizovat snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Auto-refresh snaps %s"
-msgstr ""
+msgstr "Automaticky aktualizovat snapy %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
-msgstr ""
+msgstr "Automaticky propojit oprávněné zástrčky a sloty snapu %q"
 
 msgid "Bad code. Try again: "
-msgstr ""
+msgstr "Chybný kód. Zkuste to znovu: "
 
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "Změnit identifikátor"
 
 msgid "Changes configuration options"
-msgstr ""
+msgstr "Změní volby nastavení"
 
 msgid "Command\tAlias\tNotes"
-msgstr ""
+msgstr "Příkaz\tAlternativní název\tPoznámky"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr ""
+msgstr "Potvrďte heslovou frázi: "
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
-msgstr ""
+msgstr "Připojit %s:%s k %s:%s"
 
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr ""
+msgstr "Omezit výpis na konkrétní snap nebo snap:name"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr ""
+msgstr "Omezit výpis na konkrétní rozhraní"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr ""
+msgstr "Omezit výpis na ty, odpovídající hlavička=hodnota"
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr ""
+msgstr "Zkopírovat data snapu %q"
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
 
 msgid "Create cryptographic key pair"
-msgstr ""
+msgstr "Vytvořit dvojici kryptografických klíčů"
 
 msgid "Create snap build assertion"
 msgstr ""
@@ -338,22 +356,22 @@ msgid "Creates a local system user"
 msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr ""
+msgstr "Smazat dvojici kryptografických klíčů"
 
 msgid "Delete the local cryptographic key pair with the given name."
 msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr ""
+msgstr "Zakázat snap %q"
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr ""
+msgstr "Vypnout alternativní názvy pro snap %q"
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr ""
+msgstr "Vypnout veškeré alternativní názvy pro snap %q"
 
 msgid "Disables a snap in the system"
 msgstr ""
@@ -364,109 +382,126 @@ msgstr ""
 
 #, c-format
 msgid "Disconnect %s:%s from %s:%s"
-msgstr ""
+msgstr "Odpojit %s:%s od %s:%s"
 
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr ""
+msgstr "Nečekat na dokončení operace, ale jen vypsat identifikátor změny."
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr ""
+msgstr "Stáhnout snap %q%s z kanálu %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
+"Stáhnout danou revizi snapu, ke které je třeba, abyste měli vývojářský "
+"přístup"
 
 msgid "Downloads the given snap"
 msgstr ""
 
 msgid "Email address: "
-msgstr ""
+msgstr "E-mailová adresa: "
 
 #, c-format
 msgid "Enable %q snap"
-msgstr ""
+msgstr "Povolit snap %q"
 
 msgid "Enables a snap in the system"
 msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr ""
+msgstr "Zajistit že přepoklady pro %q jsou k dispozici"
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
 
 msgid "Export cryptographic public key"
-msgstr ""
+msgstr "Exportovat kryptografický veřejný klíč"
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
-msgstr ""
+msgstr "Stáhnout a zkontrolovat tvrzení pro snap %q%s"
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr ""
+msgstr "Stahují se tvrzení pro %q\n"
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr ""
+msgstr "Stahování snap balíčku %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr ""
+msgstr "Název souboru se snapem, pro který chcete tvrdit sestavení"
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr ""
+msgstr "Vynutit přidání uživatele, i když je zařízení už spravováno"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr ""
+msgstr "Vynutit import na klasických systémech"
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
+"Formátovat materiál veřejného klíče jako požadavek pro account-key pro toto "
+"account-id"
 
 msgid "Generate device key"
-msgstr ""
+msgstr "Vytvořit klíč zařízení"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr ""
+msgstr "Vytvořit manuálovou stránku"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
-msgstr ""
+msgstr "Známka vyjadřuje kvalitu sestavení snapu (výchozí je „stable“)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr ""
+msgstr "Udělit vytvořenému uživateli sudo přístup"
 
 msgid "Help"
 msgstr "Nápověda"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr ""
+msgstr "Háček který spustit"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Identifikátor\tStav\tSpawn\tPřipraveno\tSouhrn\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr ""
+msgstr "Identifikátor podepisujícího"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr ""
+msgstr "Ideentifikátor snap balíčku související se sestavením"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
+"Pokud služba má příkaz reload (znovunačíst), použít ho namísto restartování."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr ""
+msgstr "Ignorovat ověření ostatními snapy blokujícími aktualizaci"
 
 #, c-format
 msgid ""
@@ -475,22 +510,27 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
+"Pro zakoupení %q, je třeba souhlasit s nejnovějšími všeobecnými podmínkami. "
+"To je možné na https://my.ubuntu.com/payment/edit.\n"
+"\n"
+"Po dokončení se  sem vraťte a spusťte „snap buy %s“ znovu."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr ""
+msgstr "Zahrnout nepoužívaná rozhraní"
 
 msgid "Initialize device"
-msgstr ""
+msgstr "Inicializovat zařízení"
 
 msgid "Inspects devices for actionable information"
 msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr ""
+msgstr "Nainstalovat snap %q"
 
 #, c-format
 msgid "Install %q snap from %q channel"
@@ -498,45 +538,56 @@ msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr ""
+msgstr "Instalovat snap %q ze souboru"
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr ""
+msgstr "Instalovat snap %q ze souboru %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr ""
+msgstr "Nainstalovat z kanálu testovacích verzí (beta)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr ""
+msgstr "Nainstalovat z kanálu verzí před vydáním (candidate)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr ""
+msgstr "Nainstalovat z kanálu vývojových verzí (edge)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr ""
+msgstr "Nainstalovat z kanálu stabilních verzí"
 
 #, c-format
 msgid "Install snap %q"
-msgstr ""
+msgstr "Nainstalovat snap balíček %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr ""
+msgstr "Nainstalovat snapy %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
+"Nainstalovat danou verzi snapu, ke které je třeba mít vývojářský přístup"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
+"Nainstalovat daný snap soubor i když zde nejsou žádné předem schválené "
+"podpisy pro něj, což znamená, že nebude ověřen a může být nebezpečný (--"
+"devmode toto zahrnuje)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
-msgstr ""
+msgstr "Instalovat daný snap bez povolení jeho automatických aliasů"
 
 #, c-format
 msgid ""
@@ -544,35 +595,38 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Nainstalovat snap pomocí:\n"
+"   snap ack %s\n"
+"   snap install %s\n"
 
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr ""
+msgstr "Klíče zájmu v nastavení"
 
 msgid "List a change's tasks"
-msgstr ""
+msgstr "Vypsat úkoly změny"
 
 msgid "List cryptographic keys"
-msgstr ""
+msgstr "Vypsat kryptografické klíče"
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
 
 msgid "List installed snaps"
-msgstr ""
+msgstr "Vypsat nainstalované snapy"
 
 msgid "List system changes"
-msgstr ""
+msgstr "Vypsat změny systému"
 
 msgid "Lists aliases in the system"
 msgstr ""
 
 msgid "Lists all repairs"
-msgstr ""
+msgstr "Vypsat všechny opravy"
 
 msgid "Lists interfaces in the system"
 msgstr ""
@@ -584,58 +638,62 @@ msgid "Log out of the store"
 msgstr ""
 
 msgid "Login successful"
-msgstr ""
+msgstr "Přihlášení úspěšné"
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr ""
+msgstr "Učinit stávající revizi pro snap %q nedostupnou"
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr ""
+msgstr "Zpřístupnit snap %q (%s) systému"
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr ""
+msgstr "Učinit snap %q (%s) nedostupný pro systém"
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr ""
+msgstr "Učinit snap %q nedostupný pro systém"
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr ""
+msgstr "Zpřístupnit snap %q%s systému"
 
 msgid "Mark system seeded"
-msgstr ""
+msgstr "Označit systém osazený"
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr ""
+msgstr "Připojit snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr ""
+msgstr "Název klíče, který vytvořit – výchozí je „default“"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr ""
+msgstr "Název klíče, který smazat"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr ""
+msgstr "Název klíče, který exportovat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
+"Název GnuPG klíče který použít (jinak bude použit výchozí název klíče "
+"„default“)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr ""
+msgstr "Název klíče, který použít – jinak použít výchozí klíč"
 
 msgid "Name\tSHA3-384"
-msgstr ""
+msgstr "Název\tSHA3-384"
 
 msgid "Name\tSummary"
-msgstr ""
+msgstr "Název\tSouhrn"
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
 msgstr ""
@@ -648,62 +706,67 @@ msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr ""
+msgstr "Pro snap %q nejsou momentálně definovány žádné aliasy\n"
 
 msgid "No aliases are currently defined."
-msgstr ""
+msgstr "V tuto chvíli nejsou definovány žádné alternativní názvy"
 
 #, c-format
 msgid "No command %q found, did you mean:\n"
 msgstr ""
 
 msgid "No connections to disconnect"
-msgstr ""
+msgstr "Žádná spojení k odpojení"
 
 #. TRANSLATORS: the %q is the (quoted) name of the section the user entered
 #, c-format
 msgid "No matching section %q, use --section to list existing sections"
 msgstr ""
+"Žádná odpovídající sekce %q, existující sekce si vypíšete pomocí --section"
 
 #. TRANSLATORS: the first %q is the (quoted) query, the
 #. second %q is the (quoted) name of the section the
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr ""
+msgstr "Žádné odpovídající snapy pro %q v sekci %q\n"
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr ""
+msgstr "%q neodpovídají žádné snapy\n"
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
+"Nezadán pojem k vyhledání. Tady je několik zajímavých snap balíčků:\n"
+"\n"
 
 msgid "No section specified. Available sections:\n"
-msgstr ""
+msgstr "Nezadána sekce. Sekce k dispozici:\n"
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr ""
+msgstr "Výsledky vracet ve formátu JSON"
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
 
 #, c-format
 msgid "Packages matching %q:\n"
-msgstr ""
+msgstr "Balíčky odpovídající %q:\n"
 
 msgid "Passphrase: "
-msgstr ""
+msgstr "Heslová fráze: "
 
 #, c-format
 msgid "Password of %q: "
-msgstr ""
+msgstr "Heslo %q: "
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -711,31 +774,33 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
+"Pro nákup %q od %q za %s prosím znovu zadejte své heslo do Ubuntu One.\n"
+"Pro zrušení stiskněte ctrl-c."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr ""
+msgstr "Upřednostňovat alternativní názvy pro snap %q"
 
 msgid "Prefer aliases from a snap and disable conflicts"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr ""
+msgstr "Upřednostňovat alternativní názvy snapu %q"
 
 msgid "Prepare a snappy image"
 msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr ""
+msgstr "Připravit snap %q (%s)"
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr ""
+msgstr "Připravit snap %q%s"
 
 msgid "Print the version and exit"
 msgstr "Vypsat informace o verzi a skončit"
@@ -754,48 +819,53 @@ msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr ""
+msgstr "Ořezat automatické alternativní názvy pro snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
+"Přepnout snap do klasického režimu a vypnout bezpečnostní ohraničování"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
+"Přepnout snap do vývojářského režimu a vypnout bezpečnostní ohraničení"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr ""
+msgstr "Přepnout snap do vynuceného režimu ohraničení"
 
 msgid "Query the status of services"
-msgstr ""
+msgstr "Dotázat na stav služby"
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr ""
+msgstr "Aktualizovat snap %q"
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr ""
+msgstr "Aktualizovat snap %q z kanálu %q"
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr ""
+msgstr "Aktualizovat alternativní názvy pro snap %q"
 
 msgid "Refresh all snaps: no updates"
-msgstr ""
+msgstr "Aktualizovat všechny snapy: žádné aktualizace"
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr ""
+msgstr "Aktualizovat snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr ""
+msgstr "Aktualizovat snapy %s"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr ""
+msgstr "Aktualizovat snapy %s: žádné aktualizace"
 
 msgid "Refresh to the given revision"
 msgstr ""
@@ -805,119 +875,125 @@ msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr ""
+msgstr "Odebrat snap %q"
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr ""
+msgstr "Odebrat alternativní názvy pro snap %q"
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr ""
+msgstr "Odebrat data pro snap %q (%s)"
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr ""
+msgstr "Odebrat ručně přidaný alternativní název %q pro snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr ""
+msgstr "Odebrat pouze danou revizi"
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr ""
+msgstr "Odebrat profil zabezpečení pro snap %q (%s)"
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr ""
+msgstr "Odebrat profily zabezpečení snap balíčku %q"
 
 #, c-format
 msgid "Remove snap %q"
-msgstr ""
+msgstr "Odstranit snap %q"
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr ""
+msgstr "Odstranit snap %q (%s) ze systému"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr ""
+msgstr "Odstranit snapy %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr ""
+msgstr "Odebráno"
 
 msgid "Removes a snap from the system"
 msgstr ""
 
 msgid "Request device serial"
-msgstr ""
+msgstr "Vyžádat sériové číslo zařízení"
 
 msgid "Restart services"
-msgstr ""
+msgstr "Restartovat služby"
 
 msgid "Restarted.\n"
-msgstr ""
+msgstr "Restartováno.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr ""
+msgstr "Omezit hledání na danou sekci"
 
 msgid "Retrieve logs of services"
 msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr ""
+msgstr "Vrátit zpět %q snap"
 
 msgid "Reverts the given snap to the previous state"
-msgstr ""
+msgstr "Vrátí daný snap balíček do předchozího stavu"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr ""
+msgstr "Spustit shell namísto příkazu (užitečné pro ladění)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr ""
+msgstr "Spustit jako službu časovače s daným plánem"
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr ""
+msgstr "Spustit háček nastavení snapu %q"
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr ""
+msgstr "Spustit háček nastavení snapu %q, pokud je přítomen"
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr ""
+msgstr "Spsutit háček %s snapu %q"
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr ""
+msgstr "Spustit instalační háček napu %q, pokud přítomen"
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Spustit poaktualizační háček snapu %s, pokud přítomen"
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Spustit předaktualizační háček snapu %q, pokud přítomen"
 
 msgid "Run prepare-device hook"
-msgstr ""
+msgstr "Spustit háček připravit zařízení"
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr ""
+msgstr "Spustit háček odebrat snapu %q, pokud přítomen"
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
-msgstr ""
+msgstr "Spustit příkaz s gdb"
 
 msgid "Run the given snap command"
-msgstr ""
+msgstr "Spsutit daný snap příkaz"
 
 msgid "Run the given snap command with the right confinement and environment"
 msgstr ""
@@ -925,8 +1001,9 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr ""
+msgstr "Hledat soukromé snapy"
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
@@ -938,40 +1015,42 @@ msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr ""
+msgstr "Nastavit automatické aliasy pro snap %q"
 
 msgid "Sets up a manual alias"
 msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr ""
+msgstr "Nastavit alias %q => %q pro snap %q"
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr ""
+msgstr "Nastavit ruční alias %q => %q pro snap %q"
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr ""
+msgstr "Nastavit profily zabezpečení pro snap %q (%s)"
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr ""
+msgstr "Nastavit alternativní názvy pro snap %q"
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr ""
+msgstr "Nastavit profily zabezpečení pro snap %q%s"
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
-msgstr ""
+msgstr "Ukázat všechny revize"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
-msgstr ""
+msgstr "Zobrazit informaci o automatické aktualizaci ale neprovádět ji"
 
 msgid "Show available snaps for refresh but do not perform a refresh"
 msgstr ""
@@ -979,15 +1058,17 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
-msgstr ""
+msgstr "Zobrazit podrobnosti o konkrétním rozhraní"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
-msgstr ""
+msgstr "Zobrazit atributy rozhraní"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
-msgstr ""
+msgstr "Zobrazit pouze daný počet řádků, nebo „vše“."
 
 msgid "Shows known assertions of the provided type"
 msgstr ""
@@ -999,7 +1080,7 @@ msgid "Shows version details"
 msgstr ""
 
 msgid "Sign an assertion"
-msgstr ""
+msgstr "Podepsat výrok"
 
 msgid ""
 "Sign an assertion using the specified key, using the input for headers from "
@@ -1008,66 +1089,71 @@ msgid ""
 msgstr ""
 
 msgid "Slot\tPlug"
-msgstr ""
+msgstr "Slot\tZástrčka"
 
 #. TRANSLATORS: first %s is a snap name, following %s is a channel name
 #, c-format
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr ""
+msgstr "Název snap balíčku"
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
 "your\n"
 "payment details at https://my.ubuntu.com/payment/edit and try again."
 msgstr ""
+"Je nám líto, ale vaše platební metoda byla vydavatelem odmítnuta. "
+"Zkontrolujte\n"
+"podrobnosti své platby na https://my.ubuntu.com/payment/edit a zkuste to "
+"znovu."
 
 msgid "Start services"
-msgstr ""
+msgstr "Spustit služby"
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr ""
+msgstr "Spustit služby snap balíčku %q (%s)"
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr ""
+msgstr "Spustit služby snap balíčku %q%s"
 
 msgid "Start snap services"
-msgstr ""
+msgstr "Spustit služby snap balíčku"
 
 msgid "Start the userd service"
-msgstr ""
+msgstr "Spustit službu userd"
 
 msgid "Started.\n"
-msgstr ""
+msgstr "Spuštěno.\n"
 
 msgid "Status\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Stav\tSpawn\tPřipraveno\tSouhrn\n"
 
 msgid "Stop services"
-msgstr ""
+msgstr "Zastavit služby"
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr ""
+msgstr "Zastavit služby snap balíčku %q (%s)"
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr ""
+msgstr "Zastavit služby snap balíčku %q"
 
 msgid "Stop snap services"
-msgstr ""
+msgstr "Zastavit služby snap balíčku"
 
 msgid "Stopped.\n"
-msgstr ""
+msgstr "Zastaveno.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr ""
+msgstr "Striktní typování s nulami a řetězci v uvozovkách"
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1082,10 +1168,11 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr ""
+msgstr "Přepíná snap balíčky na jiný kanál"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
-msgstr ""
+msgstr "Dočasně připojit zařízení před inspekcí"
 
 msgid "Tests a snap in the system"
 msgstr ""
@@ -1096,20 +1183,22 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
+"Děkujeme za zakoupení %q. Nyní ho můžete nainstalovat na jakémkoli ze svých\n"
+"zařízení pomocí „snap install %s“."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
-msgstr ""
+msgstr "Příkaz get vypíše nastavení a nastavení spojení rozhraní."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr ""
+msgstr "e-mail, kterým se přihlásit k login.ubuntu.com"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
-msgstr ""
+msgstr "Název tvrzení modelu"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,13 +1206,14 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr ""
+msgstr "Snap který nastavit (např. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr ""
+msgstr "Snap kterého nastavení je požadováno"
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1132,46 +1222,49 @@ msgid "This command logs the current user out of the store"
 msgstr ""
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
-msgstr ""
+msgstr "Tento dialog se sám zavře po pěti minutách nečinnosti."
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr ""
+msgstr "Přepnout příznaky snapu %q"
 
 msgid "Tool to interact with snaps"
-msgstr ""
+msgstr "Nástroj pro interakci se snapy"
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
-msgstr ""
+msgstr "Přejít s profilem zabezpečení z %q na %q"
 
 msgid "Transition ubuntu-core to core"
-msgstr ""
+msgstr "Přenést ubuntu-core na core"
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr ""
+msgstr "Vyzkoušet %q snap z %s"
 
 msgid "Try: snap install <selected snap>\n"
-msgstr ""
+msgstr "Zkuste: snap install <vybraný snap>\n"
 
 msgid "Two-factor code: "
-msgstr ""
+msgstr "Dvostupňový kód: "
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr ""
+msgstr "Při spouštění háčku použít konkrétní revizi snapu"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
-msgstr ""
+msgstr "Použít známá trvrzení pro vytvoření uživatele"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
-msgstr ""
+msgstr "Použít tento kanál namísto toho se stabilními vydáními"
 
 msgid ""
 "WARNING: The output of \"snap get\" will become a list with columns - use -d "
@@ -1180,31 +1273,34 @@ msgstr ""
 
 #, c-format
 msgid "WARNING: failed to activate logging: %v\n"
-msgstr ""
+msgstr "VAROVÁNÍ: nepodařilo se zapnout zaznamenávání událostí: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
-msgstr ""
+msgstr "Čekat na nové řádky a vypisovat je, jak přicházejí."
 
 msgid "Waiting for server to restart"
-msgstr ""
+msgstr "Čeká se na restart serveru"
 
 msgid "Watch a change in progress"
-msgstr ""
+msgstr "Sledovat probíhající změnu"
 
 msgid "Wrong again. Once more: "
-msgstr ""
+msgstr "Znovu nesprávně. Znovu: "
 
 #, c-format
 msgid "Xauthority file isn't owned by the current user %s"
-msgstr ""
+msgstr "soubor Xauthority není vlastněn stávajícím uživatelem %s"
 
 msgid "Yes, yes it does."
-msgstr ""
+msgstr "Ano, dělá."
 
 msgid ""
 "You need to be logged in to purchase software. Please run 'snap login' and "
 "try again."
 msgstr ""
+"Pro nakupování software je třeba, abyste byli přihlášeni. Spusťte „snap "
+"login“ a zkuste to znovu."
 
 #, c-format
 msgid ""
@@ -1214,6 +1310,11 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
+"Abyste si mohli zakoupit snap, je třeba mít ke svému účtu měli přiřazenou "
+"platební metodu –  navštivte https://my.ubuntu.com/payment/edit a přidejte "
+"nějakou.\n"
+"\n"
+"Jakmile přidáte své platební údaje, je třeba spustit „snap buy %s“ znovu."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1245,11 +1346,16 @@ msgid ""
 "\n"
 "Provide a search term for more specific results.\n"
 msgstr ""
+"\n"
+"Pro konkrétnější výsledky zadejte vyhledávaný pojem.\n"
 
 msgid ""
 "\n"
 "The abort command attempts to abort a change that still has pending tasks.\n"
 msgstr ""
+"\n"
+"Příkaz abort se pokusí přerušit změnu, u které úlohy ještě čekají na "
+"zpracování.\n"
 
 msgid ""
 "\n"
@@ -1311,6 +1417,8 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
+"\n"
+"Příkaz buy koupí snap z obchodu.\n"
 
 msgid ""
 "\n"
@@ -1358,6 +1466,13 @@ msgid ""
 "\n"
 "An account can be setup at https://login.ubuntu.com.\n"
 msgstr ""
+"\n"
+"Příkaz create-user vytvoří uživatele v místním systému s uživatelským jménem "
+"a SSH\n"
+"klíči zaregistrovanými na účtu v obchodu identifikovaný zadanou e-mailovou "
+"adresou.\n"
+"\n"
+"Účet je možné nastavit na https://login.ubuntu.com.\n"
 
 msgid ""
 "\n"
@@ -1366,6 +1481,11 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
+"\n"
+"Příkaz debug obsahuje výběr dalších dílčích příkazů.\n"
+"\n"
+"Příkaz debug může být odebrán bez upozornění a nemusí fungovat na\n"
+"nevývojářských systémech.\n"
 
 msgid ""
 "\n"
@@ -1388,6 +1508,18 @@ msgid ""
 "Disconnects everything from the provided plug or slot.\n"
 "The snap name may be omitted for the core snap.\n"
 msgstr ""
+"\n"
+"Příkaz disconnect odpojí zástrčku ze slotu.\n"
+"Je možné ho vyvolat následujícím způsoby:\n"
+"\n"
+"$ snap disconnect <snap>:<plug> <snap>:<slot>\n"
+"\n"
+"Odpojí zadanou zástrčku z konkrétního slotu.\n"
+"\n"
+"$ snap disconnect <snap>:<slot nebo zástrčka>\n"
+"\n"
+"Odpojí vše od zadané zástrčky nebo slotu.\n"
+"Název snapu je možné vynechat pro core snap.\n"
 
 msgid ""
 "\n"
@@ -1400,6 +1532,8 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
+"\n"
+"Příkaz enable zapne snap, který byl předtím vypnutý.\n"
 
 msgid ""
 "\n"
@@ -1444,6 +1578,40 @@ msgid ""
 "This requests the \"usb-vendor\" setting from the slot that is connected to "
 "\"myplug\".\n"
 msgstr ""
+"\n"
+"Příkaz get vypíše předvolby nastavení pro stávající snap.\n"
+"\n"
+"    $ snapctl get username\n"
+"    frantisek\n"
+"\n"
+"Pokud jsou zadány názvy vícero voleb, je vrácen dokument:\n"
+"\n"
+"    $ snapctl get username password\n"
+"    {\n"
+"        \"username\": \"frantisek\",\n"
+"        \"password\": \"...\"\n"
+"    }\n"
+"\n"
+"Vnořené hodnoty je možné získat pomocí tečkovaného popisu umístění:\n"
+"\n"
+"    $ snapctl get author.name\n"
+"    frantisek\n"
+"\n"
+"Hodnoty nastavení propojení rozhraní je možné si vypsat pomocí:\n"
+"\n"
+"    $ snapctl get :myplug usb-vendor\n"
+"    $ snapctl get :myslot path\n"
+"\n"
+"Toto vrátí vyjmenovaná nastavení z koncového bodu místního rozhraní, ať už "
+"zásuvky\n"
+"nebo slotu. Vrácení nastavení z připojeného koncového budu snapu je také "
+"možné\n"
+"výslovným vyžádáním prostřednictvím voleb příkazového řádku --plug a --"
+"slot:\n"
+"\n"
+"    $ snapctl get :myplug --slot usb-vendor\n"
+"\n"
+"Toto vyžádá nastavení „usb-vendor“ ze slotu nazvaného „myplug“.\n"
 
 msgid ""
 "\n"
@@ -1489,6 +1657,12 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
+"\n"
+"Příkaz interface zobrazí podrobnosti o snap rozhraních.\n"
+"\n"
+"Pokud není zadán název rozhraní, je zobrazen seznam názvů rozhraní\n"
+"s alespoň jedním připojením, nebo seznam všech rozhraní, pokud je\n"
+"zadáno --all.\n"
 
 msgid ""
 "\n"
@@ -1517,6 +1691,11 @@ msgid ""
 "If header=value pairs are provided after the assertion type, the assertions\n"
 "shown must also have the specified headers matching the provided values.\n"
 msgstr ""
+"\n"
+"Příkaz known zobrazí známá tvrzení zadaného typu.\n"
+"Pokud jsou ta typem tvrzení zadány dvojice hlavička=hodnota je třeba,\n"
+"aby zobrazená tvrzení měla také zadané hlavičky, odpovídající daným\n"
+"hodnotám.\n"
 
 msgid ""
 "\n"
@@ -1547,6 +1726,9 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
+"\n"
+"Příkaz managed vypíše true nebo false a informuje tak, zda\n"
+"snapd má registrované uživatele.\n"
 
 msgid ""
 "\n"
@@ -1598,11 +1780,15 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
+"\n"
+"Příkaz repair zobrazí podrobnosti o opravách.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
+"\n"
+"Příkaz repairs vypíše všechny zpracované opravy pro toto zařízení.\n"
 
 msgid ""
 "\n"
@@ -1610,6 +1796,9 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
+"\n"
+"Příkaz restart restartuje dané služby snapu. Pokud je vykonáno z háčku\n"
+"„configure“, služba bude po jeho dokončení restartována."
 
 msgid ""
 "\n"
@@ -1675,28 +1864,43 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
+"\n"
+"Příkaz start spustí dané služby snapu. Pokud je vykonáno z háčku "
+"„configure“\n"
+"služby budou spuštěny po jeho dokončení."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
+"\n"
+"Příkaz start spouští a volitelně povoluje danou službu.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
+"\n"
+"Příkaz stop zastaví dané služby snapu. Pokud je vykonáno z háčku "
+"„configure“\n"
+"služby budou zastaveny po jeho dokončení."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
+"\n"
+"Příkaz ztop zastavuje (a volitelně vypíná) dané služby.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
+"\n"
+"Příkaz switch přepíná daný snap na jiný kanál (aniž je provedena "
+"aktualizace).\n"
 
 msgid ""
 "\n"
@@ -1719,6 +1923,20 @@ msgid ""
 "be\n"
 "found relative to current working directory.\n"
 msgstr ""
+"\n"
+"Příkaz try (vyzkoušet) nainstaluje rozbalený snap na souborový systém pro "
+"účely testování.\n"
+"Obsah rozbaleného snapu bude nadále použit i po instalaci, takže změny "
+"netýkající se\n"
+"metadat zde okamžitě ožijí. Změny metadat jako ty provedené v snap.yaml "
+"vyžadují pro\n"
+"své uplatnění reinstalaci.\n"
+"\n"
+"Pokud je vynechán argument snap-dir, příkaz try se ho pokusí odvodit pokud "
+"je možné\n"
+"nalézt soubor. yaml a složku prime nebo meta/snap.yaml vztaženo ke složce, "
+"ve které se\n"
+"právě nacházíte.\n"
 
 msgid ""
 "\n"
@@ -1731,6 +1949,9 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
+"\n"
+"Příkaz version zobrazí verzi spuštěného klienta, serveru, a operačního "
+"systému.\n"
 
 msgid ""
 "\n"
@@ -1738,6 +1959,9 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
+"\n"
+"Příkaz watch čeká až dané change-id skončí a zobrazí průběh (pokud je k\n"
+"dispozici).\n"
 
 msgid ""
 "\n"
@@ -1756,6 +1980,12 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
+"\n"
+"Tato revize snapu %q byla vydána pomocí klasického ohraničení a proto může\n"
+"provádět libovolné změny v systému mimo ohraničené vyhrazené prostředí, ve\n"
+"které jsou snapy obvykle uzavřeny, což může váš systém ohrozit.\n"
+"\n"
+"Pokud rozumíte a chcete pokračovat, zopakujte příkaz včetně --classic.\n"
 
 msgid ""
 "\n"
@@ -1764,202 +1994,209 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
+"pro určení režimu nebo příznaků kanálu je třeba zadat právě jeden název snapu"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr ""
+msgstr "pro určení revize je třeba jediný název snap balíčku"
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr ""
+msgstr "při ignorování ověřování je třeba zadat název jediného snapu"
 
 msgid "active"
-msgstr ""
+msgstr "aktivní"
 
 msgid "auto-refresh: all snaps are up-to-date"
-msgstr ""
+msgstr "auto-refresh: všechny snapy jsou aktuální"
 
 msgid "bought"
-msgstr ""
+msgstr "zakoupeno"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr ""
+msgstr "poškozený"
 
 #, c-format
 msgid "cannot %s without a context"
-msgstr ""
+msgstr "není možné %s bez kontextu"
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr ""
+msgstr "není možné zakoupit snap: %v"
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr ""
+msgstr "není možné zakoupit snap: neplatné znaky v názvu"
 
 msgid "cannot buy snap: it has already been bought"
-msgstr ""
+msgstr "není možné zakoupit snap: už byl zakoupen"
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr ""
+msgstr "nepodařilo se vytvořit %q: %v"
 
 #, c-format
 msgid "cannot create assertions file: %v"
-msgstr ""
+msgstr "nedaří se vytvořit soubor s tvrzeními: %v"
 
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr ""
+msgstr "nedaří se vyzískat snap-name z místního soubour %q: %v"
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr ""
+msgstr "nedaří se nalézt aplikaci %q v %q"
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr ""
+msgstr "nedaří se nalézt háček %q v %q"
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr ""
+msgstr "nedaří se získat data pro %q: %v"
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr ""
+msgstr "nedaří se získat úplný popis umístění pro %q: %v"
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr ""
+msgstr "nedaří se najít stávajícího uživatele: %s"
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr ""
+msgstr "nedaří se získat stávajícího uživatele: %s"
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr ""
+msgstr "nedaří se označit zavedení úspěšné: %s"
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr ""
+msgstr "nedaří se otevřít databázi tvrzení: %v"
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr ""
+msgstr "nedaří se číst vstup tvrzení: %v"
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr ""
+msgstr "nedaří se číst symbolický odkaz: %v"
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
-msgstr ""
+msgstr "nedaří se přeložit snap app %q: %v"
 
 #, c-format
 msgid "cannot sign assertion: %v"
-msgstr ""
+msgstr "nedaří se podepsat tvrzení: %v"
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr ""
+msgstr "nedaří se aktualizovat symbolický odkaz „current“ pro %q: %v"
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr ""
+msgstr "není možné použít %q klíč: %v"
 
 msgid "cannot use change ID and type together"
-msgstr ""
+msgstr "není možné použít change ID a type dohromady"
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr ""
+msgstr "není možné použít příznaky devmode a jailmode naráz"
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr ""
+msgstr "není možné ověřit vlastníka souboru %s"
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr ""
+msgstr "nedaří se zapsat nový Xauthority soubor na %s:%s"
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr ""
+msgstr "změna dokončena ve stavu %q bez chybových hlášení"
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
+"klasické ohrazení vyžaduje snapy pod /snap nebo symbolické odkazy ze /snap "
+"do %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr ""
+msgstr "vytvořen uživatelský účet %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr ""
+msgstr "d"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr ""
+msgstr "vypnuto"
 
 msgid "email:"
-msgstr ""
+msgstr "e-mail:"
 
 msgid "enabled"
-msgstr ""
+msgstr "zapnuto"
 
 #, c-format
 msgid "error: %v\n"
-msgstr ""
+msgstr "chyba: %v\n"
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr ""
+msgstr "chyba: argument „<snap-dir>“ nebyl zadán a není možné ho inferred"
 
 msgid "get which option?"
-msgstr ""
+msgstr "jakou volbu získat?"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr ""
+msgstr "h"
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr ""
+msgstr "neaktivní"
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr ""
+msgstr "atributy rozhraní je možné číst pouze při vykonávání háčků rozhraní"
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
 msgstr ""
+"atributy rozhraní je možné nastavit pouze při vykonávání přípravných háčků"
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr ""
+msgstr "vnitřní chyba, nahlaste to: spouštění %q se nezdařilo: %v\n"
 
 msgid "internal error: cannot find attrs task"
-msgstr ""
+msgstr "vnitřní chyba: nedaří se nalézt úlohu attrs"
 
 msgid "internal error: cannot find plug or slot data in the appropriate task"
 msgstr ""
+"vnitřní chyba: v příslušné úloze se nedaří nalézt data zástrčky nebo slotu"
 
 #, c-format
 msgid "internal error: cannot get %s from appropriate task"
-msgstr ""
+msgstr "vnitřní chyba: nedaří se získat %s z příslušné úlohy"
 
 msgid ""
 "invalid argument for flag ‘-n’: expected a non-negative integer argument, or "
 "“all”."
 msgstr ""
+"neplatný argument pro příznak „-n“: očekáván nezáporný celočíselný argument, "
+"nebo „all“ (vše)."
 
 #, c-format
 msgid "invalid attribute: %q (want key=value)"
@@ -1967,67 +2204,70 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr ""
+msgstr "neplatné nastavení: %q (požaduje klíč=hodnota)"
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr ""
+msgstr "neplatný filtr hlavičky: %q (vyžaduje klíč=hodnota)"
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr ""
+msgstr "neplatný parametr: %q (požaduje klíč=hodnota)"
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr ""
+msgstr "neplatná hodnota: %q (požaduje klíč=hodnota)"
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
+"název klíče %q není platný – povolené jsou pouze písmena z ASCII, číslice a "
+"spojovníky"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
+"místní snap %q není obchodu znám – pro pokračování i tak použijte --amend"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr ""
+msgstr "m"
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr ""
+msgstr "jako argument vyžaduje aplikaci, kterou spustit"
 
 msgid "no changes found"
-msgstr ""
+msgstr "nenalezeny žádné změny"
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr ""
+msgstr "nenalezeny žádné změny typu %q"
 
 msgid "no interfaces currently connected"
-msgstr ""
+msgstr "momentálně nejsou připojena žádná rozhraní"
 
 msgid "no interfaces found"
-msgstr ""
+msgstr "nenalezena žádná rozhraní"
 
 msgid "no matching snaps installed"
-msgstr ""
+msgstr "nenainstalovány žádné odpovídající snapy"
 
 msgid "no such interface"
-msgstr ""
+msgstr "žádné takové rozhraní"
 
 msgid "no valid snaps given"
-msgstr ""
+msgstr "nezadány žádné platné snapy"
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr ""
+msgstr "zadejte identifikátor změny nebo napište s --last=<type>"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr ""
+msgstr "soukromé"
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2035,19 +2275,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr ""
+msgstr "opravy nejsou na klasickém systému k dispozici"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #, c-format
 msgid "set failed: %v"
-msgstr ""
+msgstr "nastavení se nezdařilo: %v"
 
 msgid "set which option?"
-msgstr ""
+msgstr "kterou volbu nastavit?"
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2061,7 +2301,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr ""
+msgstr "pro snap %q zatím nebyly vydány žádné nové aktualizace"
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2069,34 +2309,34 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr ""
+msgstr "snap %q nenalezen"
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr ""
+msgstr "snap je zdarma"
 
 msgid "too many arguments for command"
-msgstr ""
+msgstr "příliš mnoho argumentů pro příkaz"
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr ""
+msgstr "příliš mnoho argumentů pro háček %q: %s"
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr ""
+msgstr "příliš mnoho argumentů: %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "kontaktování snap store se nezdařilo"
 
 msgid "unavailable"
-msgstr ""
+msgstr "není k dispozici"
 
 #, c-format
 msgid "unknown attribute %q"
-msgstr ""
+msgstr "neznámý atribut %s"
 
 #, c-format
 msgid "unknown command %q, see \"snap --help\""
@@ -2104,19 +2344,19 @@ msgstr ""
 
 #, c-format
 msgid "unknown plug or slot %q"
-msgstr ""
+msgstr "neznámá zástrčka nebo slot %q"
 
 #, c-format
 msgid "unknown service: %q"
-msgstr ""
+msgstr "neznámá služba: %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr ""
+msgstr "varování:\tnenalezen žádný snap pro %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr ""
+msgstr "r"
 
 msgid "Authenticate on snap daemon"
 msgstr "Autentizace na snap démonu"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1192,7 +1192,7 @@ msgstr "Příkaz get vypíše nastavení a nastavení spojení rozhraní."
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "e-mail, kterým se přihlásit k login.ubuntu.com"
+msgstr "E-mail, kterým se přihlásit k login.ubuntu.com"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"

--- a/po/cy.po
+++ b/po/cy.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -27,6 +27,7 @@ msgstr ""
 "\n"
 "Prøv \"snapcraft prime\" i din projektmappe og \"snap try\" igen."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q skiftede til kanalen %q\n"
@@ -104,96 +105,100 @@ msgstr "--time tager hverken tilstands- eller kanalflag"
 msgid "-r can only be used with --hook"
 msgstr "-r kan kun bruges med --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-eller-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<assertionsfil>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<assertionstype>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<skift-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<konfigurationsværdi>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<e-mail>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<filnavn>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<headerfilter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<grænseflade>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nøglenavn>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<nøgle>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<modelassertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<forespørgsel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<rodmappe>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<tjeneste>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<slot eller plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
+"Angivelse af en tjeneste som bare kan være navnet på en snap (for alle "
+"tjenester i snappen) eller <snap>.<app> for en enkelt tjeneste."
 
 msgid "Abort a pending change"
 msgstr "Afbryd en ventende ændring"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Tilføjet"
 
@@ -203,9 +208,11 @@ msgstr "Tilføjer en assertion til systemet"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr ""
+msgstr "Rådgiv om snapper som giver den givne kommando"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias for --dangerous (FORÆLDET)"
 
@@ -213,49 +220,58 @@ msgid "All snaps up to date."
 msgstr "Alle snaps er opdateret."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Tillad at filen åbnes?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
-msgstr ""
+msgstr "Tillad forsøg på genopfriskning af snap, som er ukendt i butikken"
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Tillad ændring af indstillinger?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Tillad at snap %q ændrer %q til %q?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Tillad at snap %q åbner filen %q?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Alternativ kommando som skal køres"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Returnér altid dokumentet endda med enkelt nøgle"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Returnér altid listen selv med enkelt nøgle"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "En e-mail på en bruger på login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
+"Udover at starte tjenesten nu, sørg også for den starter ved opstart."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
+"Udover at stoppe tjenesten nu, sørg også for den ikke længere starter ved "
+"opstart."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Assertionsfil"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Navn på asssertionstype"
 
@@ -278,6 +294,7 @@ msgstr ""
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
+"Forbind automatisk berettigede plugger og slotter tilhørende snappen %q"
 
 msgid "Bad code. Try again: "
 msgstr "Ugyldig kode. Prøv igen: "
@@ -285,7 +302,7 @@ msgstr "Ugyldig kode. Prøv igen: "
 msgid "Buys a snap"
 msgstr "Køber en snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Skift id"
 
@@ -295,7 +312,7 @@ msgstr "Ændrer konfigurationsindstillinger"
 msgid "Command\tAlias\tNotes"
 msgstr "Kommando\tAlias\tNoter"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Konfigurationsværdi (nøgle=værdi)"
 
@@ -309,14 +326,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr "Forbinder en plug til en slot"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Begræns oversigt til en specifik snap eller snap:navn"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Begræns oversigt til specifikke grænseflader"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Begræns oversigt til dem som matcher header=værdi"
 
@@ -372,6 +390,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 "Vent ikke på at handlingen færdiggøres, men udskriv bare ændrings-id'et."
@@ -380,6 +399,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -422,17 +442,19 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr "Henter snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr "Finder pakker til installation"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 "Gennemtving tilføjelse af bruger også selvom enheden allerede håndteres"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Gennemtving import på klassiske systemer"
 
@@ -446,33 +468,43 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Generér man-side"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr "Karakteren angiver snap'ens buildkvalitet (som standard \"stable\")"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Giv sudo-adgang til den oprettede bruger"
 
 msgid "Help"
 msgstr "Hjælp"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Hook som skal køres"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "ID\tStatus\tKald\tKlar\tSammendrag\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Underskriverens identifikator"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identifikator for snap-pakken tilknyttet denne version"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
+"Brug en genindlæs-kommando, hvis tjenesten har den, i stedet for at "
+"genstarte."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Ignorér bekræftelse fra andre snap'er, som blokerer genopfriskningen"
 
@@ -493,6 +525,7 @@ msgstr ""
 "Inkludér en udførlig liste med en snaps noter (i modsat fald vises et "
 "sammendrag)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Inkludér ubrugte grænseflader"
 
@@ -518,15 +551,19 @@ msgstr "Installér snap'en %q fra en fil"
 msgid "Install %q snap from file %q"
 msgstr "Installér snap'en %q fra filen %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Installér fra betakanalen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Installér fra kandidatkanalen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Installér fra forkantskanalen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Installér fra kanalen stable"
 
@@ -539,12 +576,14 @@ msgstr "Installér snap'en %q"
 msgid "Install snaps %s"
 msgstr "Installér snap'erne %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Installér den angivne version af en snap, som du skal have adgang til som "
 "udvikler"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -554,6 +593,7 @@ msgstr ""
 "forhåndsgodkendte signaturer til den, hvilket betyder, den ikke kunne "
 "bekræftes og kan være farlig (--devmode antyder dette)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 "Installér den angivne snap uden at aktivere dens automatiske aliasser"
@@ -564,12 +604,15 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Installér snappen med:\n"
+"   snap ack %s\n"
+"   snap install %s\n"
 
 msgid "Installs a snap to the system"
 msgstr "Installerer en snap på systemet"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Interessant nøgle i konfigurationen"
 
@@ -634,23 +677,25 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Navn på nøglen som skal oprettes; som standard \"default\""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Navn på nøgle som skal slettes"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Navn på nøglen som skal eksporteres"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Navn på GnuPG-nøglen som skal bruges (nøglenavnet er som standard "
 "\"default\")"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Navn på nøglen som skal bruges. Ellers bruges standardnøglen"
 
@@ -671,48 +716,54 @@ msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr ""
+msgstr "Der er i øjeblikket ikke defineret nogen aliasser til snappen %q.\n"
 
 msgid "No aliases are currently defined."
-msgstr ""
+msgstr "Der er i øjeblikket ikke defineret nogen aliasser."
 
 #, c-format
 msgid "No command %q found, did you mean:\n"
 msgstr ""
 
 msgid "No connections to disconnect"
-msgstr ""
+msgstr "Ingen forbindelser at afbryde"
 
 #. TRANSLATORS: the %q is the (quoted) name of the section the user entered
 #, c-format
 msgid "No matching section %q, use --section to list existing sections"
 msgstr ""
+"Der er ingen sektion, som matcher %q. Brug --section for at få vist "
+"eksisterende sektioner"
 
 #. TRANSLATORS: the first %q is the (quoted) query, the
 #. second %q is the (quoted) name of the section the
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr ""
+msgstr "Ingen snapper matcher %q i sektionen %q\n"
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr ""
+msgstr "Ingen snapper matcher %q\n"
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
+"Ingen søgeterm angivet. Her er nogle interessante snapper:\n"
+"\n"
 
 msgid "No section specified. Available sections:\n"
-msgstr ""
+msgstr "Ingen sektioner angivet. Tilgængelige sektioner:\n"
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 "Der er endnu ikke installeret nogen snap'er. Prøv \"snap install hello-"
 "world\"."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Outputresultater i JSON-format"
 
@@ -721,7 +772,7 @@ msgstr ""
 
 #, c-format
 msgid "Packages matching %q:\n"
-msgstr ""
+msgstr "Pakker som matcher %q:\n"
 
 msgid "Passphrase: "
 msgstr "Adgangskode: "
@@ -783,12 +834,15 @@ msgstr "Udskriver, om systemet er håndteret"
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Sæt snap i klassisk tilstand og deaktivér sikkerhedsindeslutning"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr "Sæt snap i udviklingstilstand og deaktivér sikkerhedsindeslutning"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Sæt snap i gennemtvunget, indesluttet tilstand"
 
@@ -846,6 +900,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr "Fjern det manuelle alias %q for snap'en %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Fjern kun den angivne udgave"
 
@@ -870,6 +925,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr "Fjern snap'erne %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Fjernet"
 
@@ -885,6 +941,7 @@ msgstr "Genstart tjenester"
 msgid "Restarted.\n"
 msgstr "Genstartet.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Begræns søgningen til et angivent afsnit"
 
@@ -898,11 +955,13 @@ msgstr "Gendan snap'en %q"
 msgid "Reverts the given snap to the previous state"
 msgstr "Gendanner den angivne snap til sin forrige tilstand"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Kør en skal i stedet for kommandoen (nyttig til fejlsøgning)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr ""
+msgstr "Kør som en timertjeneste med given tidsplan"
 
 #, c-format
 msgid "Run configure hook of %q snap"
@@ -926,7 +985,7 @@ msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Kør præ-genopfriskningshook for snappen %q, hvis tilgængelig"
 
 msgid "Run prepare-device hook"
 msgstr ""
@@ -940,8 +999,9 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
-msgstr ""
+msgstr "Kør kommandoen med gdb"
 
 msgid "Run the given snap command"
 msgstr "Kør den angivne snap-kommando"
@@ -953,6 +1013,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Kører fejlsøgningskommandoer"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Søg private snap'er"
 
@@ -964,7 +1025,7 @@ msgstr ""
 "genopfrisk osv.)"
 
 msgid "Service\tStartup\tCurrent"
-msgstr ""
+msgstr "Tjeneste\tOpstart\tAktuelle"
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
@@ -997,9 +1058,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Vis alle udgaver"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Vis information om automatisk genopfriskning, men udfør ikke en "
@@ -1013,15 +1076,17 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Vis detaljer om en specifik grænseflade"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Vis grænsefladeattributer"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
-msgstr ""
+msgstr "Vis kun det givne antal linjer eller \"all\"."
 
 msgid "Shows known assertions of the provided type"
 msgstr "Viser kendte assertioner af den leverede type"
@@ -1049,8 +1114,8 @@ msgstr "Slot\tPlug"
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Snap-navn"
 
@@ -1103,6 +1168,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr "Stoppet.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Striks indtastning med null'er og strenge i anførselstegn"
 
@@ -1121,6 +1187,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr "Skifter snap'en til en anden kanal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Montér enheden midlertidigt før inspektion"
 
@@ -1140,15 +1207,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "E-mailen til login-ubuntu.com der skal logges ind med"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Modellens assertionsnavn"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Outputmappen"
 
@@ -1156,11 +1223,12 @@ msgstr "Outputmappen"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "Snap'en som skal konfigureres (f.eks. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "Snap'en hvis konfiguration der spørges om"
 
@@ -1171,11 +1239,11 @@ msgid "This command logs the current user out of the store"
 msgstr "Denne kommando logger den aktuelle bruger ud af butikken"
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
-msgstr ""
+msgstr "Denne dialog vil automatisk lukkes efter fem minutters inaktivitet."
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr ""
+msgstr "Vælg/fravælg flag for snappen %q"
 
 msgid "Tool to interact with snaps"
 msgstr "Værktøj til at interagere med snap'er"
@@ -1192,7 +1260,7 @@ msgid "Try %q snap from %s"
 msgstr "Prøv snap'en %q fra %s"
 
 msgid "Try: snap install <selected snap>\n"
-msgstr ""
+msgstr "Prøv \"snap install <valgte snap>\"\n"
 
 msgid "Two-factor code: "
 msgstr "To-faktorkode: "
@@ -1200,15 +1268,18 @@ msgstr "To-faktorkode: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr "Fjern alias fra et manualt alias eller en hel snap"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr "Brug en specifik udgave af snap'en, når hook køres"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Brug kendte assertioner til oprettelse af bruger"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Brug denne kanal i stedet for stable"
 
@@ -1223,8 +1294,9 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "ADVARSEL: Kunne ikke aktivere logning: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
-msgstr ""
+msgstr "Vent på nye linjer og udskriv dem efterhånden, som de kommer ind."
 
 msgid "Waiting for server to restart"
 msgstr "Venter på, at serveren genstarter"
@@ -1294,6 +1366,8 @@ msgid ""
 "\n"
 "Provide a search term for more specific results.\n"
 msgstr ""
+"\n"
+"Angiv en søgeterm for at få mere specifikke resultater.\n"
 
 msgid ""
 "\n"
@@ -1503,7 +1577,7 @@ msgstr ""
 "Kommandoen debug indeholder en samling underkommandoer.\n"
 "\n"
 "Debug-kommandoer kan blive fjernet uden forudgående besked og vil\n"
-"måske ikke virke på ikke-udviklingssystemer.\n"
+"måske ikke virke på ikkeudviklingssystemer.\n"
 
 msgid ""
 "\n"
@@ -1868,6 +1942,8 @@ msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
+"\n"
+"Kommandoen start starter, og aktiverer eventuelt, de angivne tjenester.\n"
 
 msgid ""
 "\n"
@@ -1879,6 +1955,8 @@ msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
+"\n"
+"Kommandoen stop stopper, og deaktiverer eventuelt, de angivne tjenester.\n"
 
 msgid ""
 "\n"
@@ -1907,6 +1985,20 @@ msgid ""
 "be\n"
 "found relative to current working directory.\n"
 msgstr ""
+"\n"
+"Kommandoen try installerer en snap, som ikke er pakket, til afprøvning på "
+"systemet.\n"
+"Indholdet af den ikkepakkede snap bruges selv efter installering, så "
+"ændringer, som\n"
+"ikke vedrører metadata, træder i kraft med det samme. Ændringer i metadata, "
+"som dem der\n"
+"f.eks. sker i snap.yaml, vil kræve geninstallation for at træde i kraft.\n"
+"\n"
+"Hvis argumentet til snap-dir udelades, vil kommandoen try forsøge at udlede "
+"det, hvis\n"
+"enten filen snapcraft.yaml og prime-mappen eller filen meta/snap.yaml kan "
+"findes\n"
+"relativt til den aktuelle arbejdsmappe.\n"
 
 msgid ""
 "\n"
@@ -1963,7 +2055,7 @@ msgid "active"
 msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
-msgstr ""
+msgstr "auto-genopfrisk: alle snapper er opdaterede"
 
 msgid "bought"
 msgstr ""
@@ -2089,7 +2181,7 @@ msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr ""
+msgstr "d"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
@@ -2114,10 +2206,10 @@ msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr ""
+msgstr "h"
 
 msgid "ignore-validation"
-msgstr ""
+msgstr "ignore-validation"
 
 msgid "inactive"
 msgstr ""
@@ -2148,6 +2240,8 @@ msgid ""
 "invalid argument for flag ‘-n’: expected a non-negative integer argument, or "
 "“all”."
 msgstr ""
+"ugyldigt argument for flaget \"-n\": forventede et ikkenegativt argument "
+"eller \"all\"."
 
 #, c-format
 msgid "invalid attribute: %q (want key=value)"
@@ -2177,10 +2271,12 @@ msgstr ""
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
+"den lokale snap %q kendes ikke i butikken. Brug --amend for alligevel at "
+"fortsætte"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr ""
+msgstr "m"
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
@@ -2228,7 +2324,7 @@ msgstr ""
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #, c-format
 msgid "set failed: %v"
@@ -2277,7 +2373,7 @@ msgid "too many arguments: %s"
 msgstr ""
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "kan ikke få forbindelse til Snapbutikken"
 
 msgid "unavailable"
 msgstr ""
@@ -2300,11 +2396,11 @@ msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr ""
+msgstr "advarsel:\tfandt ingen snap for %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr ""
+msgstr "å"
 
 msgid "Authenticate on snap daemon"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2019-09-13 12:55+0000\n"
+"Last-Translator: Tobias Bannert <tobannert@gmail.com>\n"
 "Language-Team: German <de@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -23,19 +23,20 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q enthält kein unkomprimiertes snap.\n"
+"%q enthält kein unkomprimiertes Snap.\n"
 "\n"
-"Versuchen Sie \"snapcraft prime\" in Ihrem Projektordner, dann \"snap try\" "
+"Versuchen Sie »snapcraft prime« in Ihrem Projektordner, danach »snap try« "
 "erneut."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q wechselte zum Kanal %q\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s zusammengebaut aus %s\n"
+msgstr "%s %s eingehängt in %s\n"
 
 #, c-format
 msgid "%s (delta)"
@@ -97,240 +98,256 @@ msgid "%s%s %s refreshed\n"
 msgstr "%s %s %s aufgefrischt\n"
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list nimmt weder Modus- noch Kanalflaggen an"
+msgstr "--list nimmt weder Modus- noch Kanalmarkierungen an"
 
 msgid "--time does not take mode nor channel flags"
-msgstr ""
+msgstr "--time nimmt keine Modus- oder Kanalmarkierungen an"
 
 msgid "-r can only be used with --hook"
 msgstr "-r kann nur mit --hook benutzt werden"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-oder-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<Alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<Behauptungsdatei>"
+msgstr "<Zusicherungsdatei>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<Behauptungstyp>"
+msgstr "<Zusicherungstyp>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<Änderungs-id>"
+msgstr "<Änderungs-ID>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<Konfigurationswert>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<E-Mail>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<Dateiname>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<Kopfzeilenfilter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<Schnittstelle>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<Schlüsselname>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<Schlüssel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr ""
+msgstr "<Modellzusicherung>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr ""
+msgstr "<Abfrage>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr ""
+msgstr "<Basisverzeichnis>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<Dienst>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr ""
+msgstr "<Snap>:<Plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr ""
+msgstr "<Snap>:<Slot oder Plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr ""
+msgstr "<Snap>:<Slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
+"Eine Dienstspezifikation, die nur ein Snap-Name (für alle Dienste im Snap) "
+"oder <Snap>.<App> für einen einzelnen Dienst sein kann."
 
 msgid "Abort a pending change"
-msgstr ""
+msgstr "Eine bevorstehende Änderung abbrechen"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr ""
+msgstr "Hinzugefügt"
 
 msgid "Adds an assertion to the system"
-msgstr ""
+msgstr "Fügt eine Zusicherung zum System hinzu"
 
 msgid "Advise on available snaps."
-msgstr ""
+msgstr "Ratschläge zu verfügbaren Snaps"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr ""
+msgstr "Snaps berücksichtigen, die den angegebenen Befehl bereitstellen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr ""
+msgstr "Alias für --dangerous (VERALTET)"
 
 msgid "All snaps up to date."
-msgstr "Alle Snaps sind aktuell"
+msgstr "Alle Snaps sind aktuell."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Öffnen der Datei erlauben?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
+"Den Auffrischversuch für den Snap erlauben, der dem Laden unbekannt ist"
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Einstellungsänderung erlauben?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Snap %q erlauben %q in %q zu ändern?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Snap %q erlauben, die Datei %q zu öffnen?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr ""
+msgstr "Alternativer Befehl zum Ausführen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr ""
+msgstr "Dokument immer zurückgeben, auch mit einem einzelnen Schlüssel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr ""
+msgstr "Liste immer zurückgeben, auch mit einem einzelnen Schlüssel"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr ""
+msgstr "Eine E-Mail des Nutzers auf login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
-msgstr ""
+msgstr "Den Dienst jetzt und automatisch beim Hochfahren starten."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
-msgstr ""
+msgstr "Den Dienst jetzt beenden und nicht mehr beim Hochfahren starten."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr ""
+msgstr "Zusicherungsdatei"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr ""
+msgstr "Zusicherungstypname"
 
 msgid "Authenticates on snapd and the store"
-msgstr ""
+msgstr "Authentifiziert in snapd und im Snap-Store"
 
 #, c-format
 msgid "Auto-refresh %d snaps"
-msgstr ""
+msgstr "Automatisch %d Snaps auffrischen"
 
 #, c-format
 msgid "Auto-refresh snap %q"
-msgstr ""
+msgstr "Automatisch Snap %q auffrischen"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Auto-refresh snaps %s"
-msgstr ""
+msgstr "Snaps automatisch auffrischen: %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
-msgstr ""
+msgstr "Automatisches Verbinden von geeigneten Plugs und Slots von Snap %q"
 
 msgid "Bad code. Try again: "
-msgstr ""
+msgstr "Falscher Code. Versuchen Sie es nochmal: "
 
 msgid "Buys a snap"
-msgstr ""
+msgstr "Snap wird gekauft"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "ID ändern"
 
 msgid "Changes configuration options"
-msgstr ""
+msgstr "Ändert die Konfigurationsoptionen"
 
 msgid "Command\tAlias\tNotes"
-msgstr ""
+msgstr "Befehl\tAlias\tAnmerkungen"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr ""
+msgstr "Konfigurationswert (key=value)"
 
 msgid "Confirm passphrase: "
-msgstr ""
+msgstr "Passwort bestätigen: "
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
-msgstr ""
+msgstr "%s:%s mit %s:%s verbinden"
 
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
+"Beschränken Sie die Auflistung auf einen bestimmten Snap oder Snap:Name"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr ""
+msgstr "Beschränken Sie die Auflistung auf bestimmte Schnittstellen"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
+"Beschränken Sie die Auflistung auf Übereinstimmungen mit header=value"
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr ""
+msgstr "Daten von Snap %q kopieren"
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
 
 msgid "Create cryptographic key pair"
-msgstr ""
+msgstr "Ein kryptografisches Schlüsselpaar erstellen"
 
 msgid "Create snap build assertion"
 msgstr ""
@@ -339,138 +356,163 @@ msgid "Create snap-build assertion for the provided snap file."
 msgstr ""
 
 msgid "Creates a local system user"
-msgstr ""
+msgstr "Erstelle einen lokalen Benutzer im System"
 
 msgid "Delete cryptographic key pair"
-msgstr ""
+msgstr "Ein kryptografisches Schlüsselpaar löschen"
 
 msgid "Delete the local cryptographic key pair with the given name."
 msgstr ""
+"Lösche das lokale kryptografische Schlüsselpaar mit dem angegebenen Namen."
 
 #, c-format
 msgid "Disable %q snap"
-msgstr ""
+msgstr "Snap %q deaktivieren"
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr ""
+msgstr "Aliasse für Snap %q deaktivieren"
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr ""
+msgstr "Alle Aliasse für Snap %q deaktivieren"
 
 msgid "Disables a snap in the system"
 msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
-msgstr ""
+msgstr "Die Schnittstellenverbindungen für Snap %q (%s) verwerfen"
 
 #, c-format
 msgid "Disconnect %s:%s from %s:%s"
-msgstr ""
+msgstr "%s:%s von %s:%s trennen"
 
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
+"Nicht warten, bis der Vorgang abgeschlossen ist, sondern nur die Änderungs-"
+"ID ausgeben."
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr ""
+msgstr "Snap %q%s von Kanal %q herunterladen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
+"Die gegebene Überarbeitung eines Snaps, zu dem Sie Entwicklerzugriff haben "
+"müssen, herunterladen."
 
 msgid "Downloads the given snap"
-msgstr ""
+msgstr "Lädt das angegebene Snap herunter"
 
 msgid "Email address: "
 msgstr "E-Mail-Adresse: "
 
 #, c-format
 msgid "Enable %q snap"
-msgstr ""
+msgstr "Snap %q aktivieren"
 
 msgid "Enables a snap in the system"
-msgstr ""
+msgstr "Aktiviert ein Snap im System"
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr ""
+msgstr "Sicherstellen, dass die Voraussetzungen für %q verfügbar sind"
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
 
 msgid "Export cryptographic public key"
-msgstr ""
+msgstr "Kryptografischen öffentlichen Schlüssel exportieren"
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
-msgstr ""
+msgstr "Zusicherungen für Snap %q%s abrufen und überprüfen"
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr ""
+msgstr "Zusicherungen für %q werden abgerufen\n"
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr ""
+msgstr "Snap %q holen\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr ""
+msgstr "Dateiname des Snap, für den ein Build erstellt werden soll"
 
 msgid "Finds packages to install"
-msgstr ""
+msgstr "Pakete zum Installieren finden"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
+"Hinzufügen des Benutzers erzwingen, auch wenn das Gerät bereits verwaltet "
+"wird"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr ""
+msgstr "Import auf klassischen Systemen erzwingen"
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
+"Formatiere Public-Key-Material als Anforderung für einen Konto-Schlüssel zu "
+"dieser Konto-ID"
 
 msgid "Generate device key"
-msgstr ""
+msgstr "Geräteschlüssel erstellen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr ""
+msgstr "Hilfeseite erstellen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
-msgstr ""
+msgstr "Note gibt die Build-Qualität des Snap an (standardmäßig »stabil«)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr ""
+msgstr "Dem erstellten Benutzer sudo-Zugriff gewähren"
 
 msgid "Help"
 msgstr "Hilfe"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr ""
+msgstr "Hook zum Ausführen"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "ID\tStatus\tSpawn\tBereit\tZusammenfassung\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr ""
+msgstr "Kennung des Unterzeichners"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr ""
+msgstr "Bezeichner des Snap-Pakets, das dem Build zugeordnet ist"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
+"Wenn der Dienst einen Befehl zum erneuten Laden hat, diesen verwenden statt "
+"neu zu starten."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
+"Validierung durch andere Snaps vernachlässigen, die das Auffrischen "
+"blockieren"
 
 #, c-format
 msgid ""
@@ -479,68 +521,89 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
+"Um %q zu kaufen, müssen Sie den aktuellen Nutzungsbedingungen zustimmen. "
+"Bitte besuchen Sie https://my.ubuntu.com/payment/edit, um dies zu tun.\n"
+"\n"
+"Nach Abschluss kehren Sie hierher zurück und führen \"snap buy %s\" erneut "
+"aus."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
+"Fügen Sie eine ausführliche Liste der Notizen eines Snaps hinzu (andernfalls "
+"Notizen zusammenfassen)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr ""
+msgstr "Nicht verwendete Schnittstellen einschließen"
 
 msgid "Initialize device"
-msgstr ""
+msgstr "Gerät initialisieren"
 
 msgid "Inspects devices for actionable information"
 msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr ""
+msgstr "Installiere %q Snap"
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr ""
+msgstr "Installiere %q Snap von %q Kanal"
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr ""
+msgstr "Installiere %q Snap von Datei"
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr ""
+msgstr "Installiere %q Snap von Datei %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr ""
+msgstr "Vom Beta-Kanal installieren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr ""
+msgstr "Vom Candidate-Kanal installieren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr ""
+msgstr "Vom Edge-Kanal installieren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr ""
+msgstr "Vom Stable-Kanal installieren"
 
 #, c-format
 msgid "Install snap %q"
-msgstr ""
+msgstr "Snap %q installieren"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr ""
+msgstr "Installiere Snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
+"Die angegebene Revision eines Snaps installieren, zu dem Sie "
+"Entwicklerzugriff haben müssen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
+"Die angegebene Snap-Datei installieren, auch wenn es keine vorbestätigte "
+"Signaturen dafür gibt, was bedeutet, dass sie nicht verifiziert wurde und "
+"gefährlich sein könnte (--devmode unterstellt dies)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
+"Angegebenen Snap installieren, ohne seine automatischen Aliase zu aktivieren"
 
 #, c-format
 msgid ""
@@ -548,20 +611,23 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Snap installieren mit:\n"
+"   snap ack %s\n"
+"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr ""
+msgstr "Ein Snap auf dem System installieren"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
 msgid "List a change's tasks"
-msgstr ""
+msgstr "Auflisten der Änderungsaufgaben"
 
 msgid "List cryptographic keys"
-msgstr ""
+msgstr "Kryptografische Schlüssel auflisten"
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
@@ -576,7 +642,7 @@ msgid "Lists aliases in the system"
 msgstr ""
 
 msgid "Lists all repairs"
-msgstr ""
+msgstr "Alle Reparaturen auflisten"
 
 msgid "Lists interfaces in the system"
 msgstr ""
@@ -592,122 +658,134 @@ msgstr "Anmeldung erfolgreich"
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr ""
+msgstr "Aktuelle Revision für Snap %q nicht verfügbar machen"
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr ""
+msgstr "Snap %q (%s) für das System verfügbar machen"
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr ""
+msgstr "Snap %q (%s) für das System nicht verfügbar machen"
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr ""
+msgstr "Snap %q für das System nicht verfügbar machen"
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr ""
+msgstr "Snap %q%s für das System verfügbar machen"
 
 msgid "Mark system seeded"
-msgstr ""
+msgstr "Markiere System gesetzt"
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr ""
+msgstr "Snap %q%s einbinden"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
+"Name des zu erstellenden Schlüssels; Standardeinstellung ist »Standard«"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr ""
+msgstr "Name des zu löschenden Schlüssels"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr ""
+msgstr "Name des zu exportierenden Schlüssels"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
+"Name des zu verwendenden GnuPG-Schlüssels (Standardwert ist »Standard« als "
+"Schlüsselname)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
+"Name des zu nutzenden Schlüssels, andernfalls den Standardschlüssel verwenden"
 
 msgid "Name\tSHA3-384"
-msgstr ""
+msgstr "Name\tSHA3-384"
 
 msgid "Name\tSummary"
-msgstr ""
+msgstr "Name\tZusammenfassung"
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr ""
+msgstr "Name\tVersion\tEntwickler\tAnmerkungen\tZusammenfassung"
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr ""
+msgstr "Name\tVersion\tRev\tEntwickler\tZusammenfassung"
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
-msgstr ""
+msgstr "Name\tVersion\tRev\tVerfolgung\tEntwickler\tZusammenfassung"
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr ""
+msgstr "Für den Snap %q sind derzeit keine Aliase definiert.\n"
 
 msgid "No aliases are currently defined."
-msgstr ""
+msgstr "Derzeit sind keine Aliase definiert."
 
 #, c-format
 msgid "No command %q found, did you mean:\n"
 msgstr ""
 
 msgid "No connections to disconnect"
-msgstr ""
+msgstr "Keine Verbindungen zum Trennen vorhanden"
 
 #. TRANSLATORS: the %q is the (quoted) name of the section the user entered
 #, c-format
 msgid "No matching section %q, use --section to list existing sections"
 msgstr ""
+"Kein passender Abschnitt %q, nutze --section,  um die existierenden "
+"Abschnitte aufzulisten"
 
 #. TRANSLATORS: the first %q is the (quoted) query, the
 #. second %q is the (quoted) name of the section the
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr ""
+msgstr "Keine passenden Snaps für %q im Abschnitt %q\n"
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr ""
+msgstr "Keine passenden Snaps für %q\n"
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
+"Kein Suchbegriff angegeben. Hier sind einige interessante Snaps:\n"
+"\n"
 
 msgid "No section specified. Available sections:\n"
-msgstr ""
+msgstr "Kein Abschnitt angegeben. Verfügbare Abschnitte:\n"
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr ""
+msgstr "Ergebnisausgabe erfolgt im JSON-Format"
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
 
 #, c-format
 msgid "Packages matching %q:\n"
-msgstr ""
+msgstr "Pakete stimmen überein mit %q:\n"
 
 msgid "Passphrase: "
-msgstr ""
+msgstr "Passphrase: "
 
 #, c-format
 msgid "Password of %q: "
-msgstr ""
+msgstr "Passwort von %q: "
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -715,91 +793,99 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
+"Bitte geben Sie Ihr Ubuntu-One-Passwort erneut ein, um %q von %q für %s zu "
+"kaufen.\n"
+"Drücken Sie Strg-c für Abbruch."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr ""
+msgstr "Bevorzuge Aliase für Snap %q"
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr ""
+msgstr "Aliase von einem Snap bevorzugen und Konflikte deaktivieren"
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr ""
+msgstr "Aliase von Snap %q bevorzugen"
 
 msgid "Prepare a snappy image"
 msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr ""
+msgstr "Snap %q (%s) vorbereiten"
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr ""
+msgstr "Snap %q%s vorbereiten"
 
 msgid "Print the version and exit"
-msgstr ""
+msgstr "Version anzeigen und  Programm beenden"
 
 msgid "Prints configuration options"
-msgstr ""
+msgstr "Gibt Konfigurationsoptionen aus"
 
 msgid "Prints the confinement mode the system operates in"
 msgstr ""
 
 msgid "Prints the email the user is logged in with"
-msgstr ""
+msgstr "Gibt die E-Mail-Adresse aus, mit der der Benutzer angemeldet ist"
 
 msgid "Prints whether system is managed"
 msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr ""
+msgstr "Automatische Aliase für Snap %q bereinigen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
+"Snap in klassischen Modus setzen und die Sicherheitsbeschränkung deaktivieren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
+"Snap in Entwickler-Modus setzen und die Sicherheitsbeschränkung deaktivieren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr ""
+msgstr "Snap in zwangsweise eingeschränkten Modus setzen"
 
 msgid "Query the status of services"
-msgstr ""
+msgstr "Status der Dienste abfragen"
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr ""
+msgstr "%q Snap auffrischen"
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr ""
+msgstr "%q Snap von %q Kanal auffrischen"
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr ""
+msgstr "Aliase für Snap %q aktualisieren"
 
 msgid "Refresh all snaps: no updates"
-msgstr ""
+msgstr "Alle Snaps auffrischen: keine Aktualisierungen"
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr ""
+msgstr "Snap %q aktualisieren"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr ""
+msgstr "Snaps %s aktualisieren"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr ""
+msgstr "Snaps auffrischen: %s: keine Aktualisierungen"
 
 msgid "Refresh to the given revision"
 msgstr ""
@@ -809,119 +895,125 @@ msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr ""
+msgstr "Entferne %q Snap"
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr ""
+msgstr "Aliase für Snap %q entfernen"
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr ""
+msgstr "Daten von Snap %q (%s) entfernen"
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr ""
+msgstr "Den manuellen Alias %q für Snap %q entfernen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr ""
+msgstr "Nur die angegebene Revision entfernen"
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr ""
+msgstr "Sicherheitsprofil für Snap %q (%s) entfernen"
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr ""
+msgstr "Sicherheitsprofile für Snap %q entfernen"
 
 #, c-format
 msgid "Remove snap %q"
-msgstr ""
+msgstr "Snap %q entfernen"
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr ""
+msgstr "Snap %q (%s) vom System entfernen"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr ""
+msgstr "Snaps %s entfernen"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr ""
+msgstr "Deinstalliert"
 
 msgid "Removes a snap from the system"
-msgstr ""
+msgstr "Entfernt ein Snap vom System"
 
 msgid "Request device serial"
-msgstr ""
+msgstr "Geräte-Seriennummer anfordern"
 
 msgid "Restart services"
-msgstr ""
+msgstr "Dienste neustarten"
 
 msgid "Restarted.\n"
-msgstr ""
+msgstr "Neugestartet.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr ""
+msgstr "Suche auf einen bestimmten Bereich beschränken"
 
 msgid "Retrieve logs of services"
-msgstr ""
+msgstr "Abrufen der Logs von Diensten"
 
 #, c-format
 msgid "Revert %q snap"
-msgstr ""
+msgstr "%q Snap wiederherstellen"
 
 msgid "Reverts the given snap to the previous state"
-msgstr ""
+msgstr "Stellt den angegebenen Snap mit vorherigen Zustand wieder her"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr ""
+msgstr "Führe eine Shell anstelle des Befehls aus (nützlich zum Debuggen)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr ""
+msgstr "Ausführen als Timer-Dienst mit einem bestimmten Zeitplan"
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr ""
+msgstr "Den Konfigurationshook von Snap %q ausführen"
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr ""
+msgstr "Den Konfigurationshook von Snap %q ausführen, falls vorhanden"
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr ""
+msgstr "Hook %s von Snap %q ausführen"
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr ""
+msgstr "Installationshook von Snap %q ausführen, falls vorhanden"
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Nachaktualisierungshook von Snap %q ausführen, falls vorhanden"
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Voraktualisierungshook von Snap %q ausführen, falls vorhanden"
 
 msgid "Run prepare-device hook"
-msgstr ""
+msgstr "Gerätevorbereitungshook ausführen"
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr ""
+msgstr "Entfernungshook von Snap %q ausführen, falls vorhanden"
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
-msgstr ""
+msgstr "Befehl mit gdb ausführen"
 
 msgid "Run the given snap command"
-msgstr ""
+msgstr "Den eingegebenen Snap Befehl ausführen"
 
 msgid "Run the given snap command with the right confinement and environment"
 msgstr ""
@@ -929,69 +1021,80 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr ""
+msgstr "Private Snaps durchsuchen"
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
+"Vorhergehende Änderung des angegebenen Typs auswählen (installieren, "
+"aktualisieren, entfernen, versuchen, automatisch aktualisieren usw.)"
 
 msgid "Service\tStartup\tCurrent"
-msgstr ""
+msgstr "Dienst\tStart\tAktuell"
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr ""
+msgstr "Automatisch Aliase für Snap %q setzen"
 
 msgid "Sets up a manual alias"
 msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr ""
+msgstr "Alias %q => %q für Snap %q einrichten"
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr ""
+msgstr "Manuellen Alias %q => %q für Snap %q setzen"
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr ""
+msgstr "Sicherheitsprofile für Snap %q (%s) setzen"
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr ""
+msgstr "Aliase für Snap %q setzen"
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr ""
+msgstr "Sicherheitsprofile für Snap %q%s setzen"
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr "Sicherheitsprofile für Snap %q%s einrichten (Phase 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
-msgstr ""
+msgstr "Alle Revisionen anzeigen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
+"Informationen zur automatisierten Aktualisierung anzeigen, aber keine "
+"durchführen"
 
 msgid "Show available snaps for refresh but do not perform a refresh"
 msgstr ""
+"Zeige verfügbare Snaps für die Aktualisierung an, aber keine Aktualisierung "
+"durchführen"
 
 msgid "Show detailed information about a snap"
-msgstr ""
+msgstr "Zeigt detaillierte Informationen über ein Snap an"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
-msgstr ""
+msgstr "Zeige Details einer bestimmten Schnittstelle an"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
-msgstr ""
+msgstr "Schnittstellenattribute anzeigen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
-msgstr ""
+msgstr "Nur die angegebene Anzahl von Zeilen anzeigen oder »alle«."
 
 msgid "Shows known assertions of the provided type"
 msgstr ""
@@ -1000,10 +1103,10 @@ msgid "Shows specific repairs"
 msgstr ""
 
 msgid "Shows version details"
-msgstr ""
+msgstr "Zeigt Versionsdetails an"
 
 msgid "Sign an assertion"
-msgstr ""
+msgstr "Eine Zusicherung unterschreiben"
 
 msgid ""
 "Sign an assertion using the specified key, using the input for headers from "
@@ -1012,84 +1115,90 @@ msgid ""
 msgstr ""
 
 msgid "Slot\tPlug"
-msgstr ""
+msgstr "Slot\tPlug"
 
 #. TRANSLATORS: first %s is a snap name, following %s is a channel name
 #, c-format
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr ""
+msgstr "Snap-Name"
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
 "your\n"
 "payment details at https://my.ubuntu.com/payment/edit and try again."
 msgstr ""
+"Entschuldigung, Ihre Zahlungsmethode wurde vom Aussteller abgelehnt. Bitte "
+"überprüfen Sie Ihre\n"
+"Zahlungsdetails unter https://my.ubuntu.com/payment/edit und versuchen Sie "
+"es erneut."
 
 msgid "Start services"
-msgstr ""
+msgstr "Dienste starten"
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr ""
+msgstr "Snap %q (%s) Dienste starten"
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr ""
+msgstr "Snap %q%s Dienste starten"
 
 msgid "Start snap services"
-msgstr ""
+msgstr "Snap-Dienste starten"
 
 msgid "Start the userd service"
-msgstr ""
+msgstr "Den Benutzerdienst starten"
 
 msgid "Started.\n"
-msgstr ""
+msgstr "Gestartet.\n"
 
 msgid "Status\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Status\tSpawn\tBereit\tZusammenfassung\n"
 
 msgid "Stop services"
-msgstr ""
+msgstr "Dienste anhalten"
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr ""
+msgstr "Snap %q (%s) Dienste anhalten"
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr ""
+msgstr "Snap %q Dienste anhalten"
 
 msgid "Stop snap services"
-msgstr ""
+msgstr "Snap-Dienste anhalten"
 
 msgid "Stopped.\n"
-msgstr ""
+msgstr "Angehalten.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr ""
+msgstr "Strikte Eingabe mit Nullen und Zeichenketten in Anführungszeichen"
 
 #, c-format
 msgid "Switch %q snap to %s"
-msgstr ""
+msgstr "%q Snap zu %s wechseln"
 
 #, c-format
 msgid "Switch snap %q from %s to %s"
-msgstr ""
+msgstr "Snap %q von %s zu %s wechseln"
 
 #, c-format
 msgid "Switch snap %q to %s"
-msgstr ""
+msgstr "Snap %q zu %s wechseln"
 
 msgid "Switches snap to a different channel"
-msgstr ""
+msgstr "Verschiebt Snap in einen anderen Kanal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
-msgstr ""
+msgstr "Gerät vor der Überprüfung vorübergehend einhängen"
 
 msgid "Tests a snap in the system"
 msgstr ""
@@ -1100,34 +1209,39 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
+"Danke für den Kauf von %q. Sie können es jetzt mit »snap install %s« \n"
+"auf jedem Ihrer Geräte installieren."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
+"Der Befehl 'get' zeigt Konfigurations- und "
+"Schnittstellenverbindungseinstellungen an."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr ""
+msgstr "Die login.ubuntu.com E-Mail-Adresse zum Einloggen als"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
-msgstr ""
+msgstr "Modelzusicherungsname"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
-msgstr ""
+msgstr "Ausgabeverzeichnis"
 
 #, c-format
 msgid "The program %q can be found in the following snaps:\n"
-msgstr ""
+msgstr "Das Programm %q kann in den folgenden Snaps gefunden werden:\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr ""
+msgstr "Den Snap konfigurieren (z.B. hallo-welt)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr ""
+msgstr "Der Snap, dessen Konfiguration angefordert wird"
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1137,45 +1251,50 @@ msgstr ""
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
 msgstr ""
+"Dieser Dialog wird nach 5 Minuten Inaktivität automatisch geschlossen."
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr ""
+msgstr "Snap %q-Markierungen umschalten"
 
 msgid "Tool to interact with snaps"
-msgstr ""
+msgstr "Werkzeug, um mit Snaps zu interagieren"
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
-msgstr ""
+msgstr "Sicherheitsprofile von %q zu %q übertragen"
 
 msgid "Transition ubuntu-core to core"
-msgstr ""
+msgstr "ubuntu-core zu core übertragen"
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr ""
+msgstr "Versuche %q Snap von %s"
 
 msgid "Try: snap install <selected snap>\n"
-msgstr ""
+msgstr "Versuchen Sie: snap install <ausgewähltes Snap>\n"
 
 msgid "Two-factor code: "
-msgstr ""
+msgstr "Zwei-Faktor-Code: "
 
 msgid "Unalias a manual alias or an entire snap"
-msgstr ""
+msgstr "Hebe einen manuellen Alias auf oder einen ganzen Snap"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
+"Verwenden Sie eine bestimmte Snap-Version, wenn Sie einen Hook ausführen"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
-msgstr ""
+msgstr "Bekannte Zusicherungen für die Benutzererstellung verwenden"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
-msgstr ""
+msgstr "Diesen Kanal anstelle von stabil verwenden"
 
 msgid ""
 "WARNING: The output of \"snap get\" will become a list with columns - use -d "
@@ -1184,23 +1303,24 @@ msgstr ""
 
 #, c-format
 msgid "WARNING: failed to activate logging: %v\n"
-msgstr ""
+msgstr "ACHTUNG: Aktivieren der Protokollierung fehlgeschlagen: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
-msgstr ""
+msgstr "Auf neue Zeilen warten und ausgeben, sobald sie eintreffen."
 
 msgid "Waiting for server to restart"
-msgstr ""
+msgstr "Auf Neustart des Servers wird gewartet"
 
 msgid "Watch a change in progress"
-msgstr ""
+msgstr "Eine Änderung verfolgen"
 
 msgid "Wrong again. Once more: "
-msgstr ""
+msgstr "Wieder falsch. Noch einmal: "
 
 #, c-format
 msgid "Xauthority file isn't owned by the current user %s"
-msgstr ""
+msgstr "Die Xauthority-Datei gehört nicht dem aktuellen Benutzer %s"
 
 msgid "Yes, yes it does."
 msgstr "Ja, ja, allerdings."
@@ -1209,6 +1329,8 @@ msgid ""
 "You need to be logged in to purchase software. Please run 'snap login' and "
 "try again."
 msgstr ""
+"Sie müssen eingeloggt sein, um Software zu kaufen. Bitte führen Sie »snap "
+"login« aus und versuchen es erneut."
 
 #, c-format
 msgid ""
@@ -1218,6 +1340,12 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
+"Sie benötigen eine mit Ihrem Konto verknüpfte Zahlungsmethode, um ein Snap "
+"zu kaufen. Besuchen Sie https://my.ubuntu.com/payment/edit, um eine "
+"hinzuzufügen.\n"
+"\n"
+"Nachdem Sie Ihre Zahlungsdetails hinzugefügt haben, müssen Sie »snap buy %s« "
+"erneut ausführen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1239,11 +1367,16 @@ msgid ""
 "\n"
 "Provide a search term for more specific results.\n"
 msgstr ""
+"\n"
+"Geben Sie einen Suchbegriff für genauere Ergebnisse ein.\n"
 
 msgid ""
 "\n"
 "The abort command attempts to abort a change that still has pending tasks.\n"
 msgstr ""
+"\n"
+"Der Abbruchbefehl versucht eine Änderung abzubrechen, die noch ausstehende "
+"Aufgaben hat.\n"
 
 msgid ""
 "\n"
@@ -1305,6 +1438,8 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
+"\n"
+"Der Befehl »buy« kauft einen Snap aus dem Store.\n"
 
 msgid ""
 "\n"
@@ -1342,6 +1477,26 @@ msgid ""
 "matching\n"
 "the plug name.\n"
 msgstr ""
+"\n"
+"Der Befehl »connect« verbindet einen Plug mit einem Slot.\n"
+"Er kann auf folgende Weise aufgerufen werden:\n"
+"\n"
+"$ snap connect <snap>:<plug> <snap>:<slot>\n"
+"\n"
+"verbindet den mitgelieferten Plug mit dem angegebenen Slot.\n"
+"\n"
+"$ snap connect <snap>:<plug> <snap>\n"
+"\n"
+"verbindet den bestimmten Plug mit dem einzigen Slot in dem bereitgestellten "
+"Snap, der mit der\n"
+"verbundenen Schnittstelle übereinstimmt. Wenn mehr als ein potenzieller Slot "
+"vorhanden ist,\n"
+" schlägt der Befehl fehl.\n"
+"\n"
+"$ snap connect <snap>:<plug>\n"
+"\n"
+"verbindet den bereitgestellten Plug mit dem Slot im Core-Snap mit einem dazu "
+"passenden Namen.\n"
 
 msgid ""
 "\n"
@@ -1352,6 +1507,13 @@ msgid ""
 "\n"
 "An account can be setup at https://login.ubuntu.com.\n"
 msgstr ""
+"\n"
+"Der Befehl »create-user« erstellt einen lokalen Systembenutzer mit dem "
+"Benutzernamen und den SSH-\n"
+"Schlüsseln, der auf dem Konto des Stores registriert und durch die "
+"angegebene E-Mail-Adresse identifiziert wird.\n"
+"\n"
+"Ein Konto kann unter https://login.ubuntu.com eingerichtet werden.\n"
 
 msgid ""
 "\n"
@@ -1360,6 +1522,12 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
+"\n"
+"Der Befehl »debug« enthält eine Auswahl zusätzlicher Unterbefehle.\n"
+"\n"
+"Debug-Befehle können ohne Vorankündigung entfernt werden und sind "
+"möglicherweise\n"
+"auf Nicht-Entwicklungssystemen nicht verfügbar.\n"
 
 msgid ""
 "\n"
@@ -1382,6 +1550,18 @@ msgid ""
 "Disconnects everything from the provided plug or slot.\n"
 "The snap name may be omitted for the core snap.\n"
 msgstr ""
+"\n"
+"Der Befehl »disconnect« trennt einen Plug von einem Slot.\n"
+"Es kann auf folgende Weise aufgerufen werden:\n"
+"\n"
+"$ snap disconnect <snap>:<plug> <snap>:<slot>\n"
+"\n"
+"trennt den angegebenen Plug vom angegebenen Slot.\n"
+"\n"
+"$ snap disconnect <snap>: <slot or plug>\n"
+"\n"
+"unterbricht alles vom mitgelieferten Plug oder Slot.\n"
+"Der Snap-Name kann für den Core-Snap weggelassen werden.\n"
 
 msgid ""
 "\n"
@@ -1394,6 +1574,8 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
+"\n"
+"Der Befehl »enable« aktiviert einen Snap, der zuvor deaktiviert wurde.\n"
 
 msgid ""
 "\n"
@@ -1438,6 +1620,44 @@ msgid ""
 "This requests the \"usb-vendor\" setting from the slot that is connected to "
 "\"myplug\".\n"
 msgstr ""
+"\n"
+"Der Befehl »get« gibt die Konfigurationsoptionen für den aktuellen Snap "
+"aus.\n"
+"\n"
+"    $ snapctl get username\n"
+"    frank\n"
+"\n"
+"Wenn mehrere Optionsnamen angegeben werden, wird ein Dokument "
+"zurückgegeben:\n"
+"\n"
+"    $ snapctl get username password\n"
+"    {\n"
+"        »Benutzername«: »frank«,\n"
+"        »Passwort«: »…«\n"
+"    }\n"
+"\n"
+"Verschachtelte Werte können über einen gepunkteten Pfad abgerufen werden:\n"
+"\n"
+"    $ snapctl get author.name\n"
+"    frank\n"
+"\n"
+"Werte der Einstellungen der Schnittstellenverbindung können ausgegeben "
+"werden:\n"
+"\n"
+"    $ snapctl get :myplug usb-vendor\n"
+"    $ snapctl get :myslot path\n"
+"\n"
+"Dadurch wird die benannte Einstellung vom lokalen Endpunkt der "
+"Schnittstellen zurückgegeben, unabhängig davon, ob es\n"
+"sich um einen Plug oder einen Slot handelt. Das Zurückgeben der Einstellung "
+"vom Endpunkt des verbundenen Snap ist ebenfalls\n"
+"möglich indem Sie dies explizit über die Befehlszeilenoptionen --plug und --"
+"slot anfordern:\n"
+"\n"
+"    $ snapctl get :myplug --slot usb-vendor\n"
+"\n"
+"Dies fordert die Einstellung »usb-vendor« von dem Slot an, der mit »myplug« "
+"verbunden ist.\n"
 
 msgid ""
 "\n"
@@ -1459,6 +1679,26 @@ msgid ""
 "    $ snap get snap-name author.name\n"
 "    frank\n"
 msgstr ""
+"\n"
+"Der Befehl »get« gibt die Konfigurationsoptionen für den angegebenen Snap "
+"aus.\n"
+"\n"
+"    $ snap get snap-name username\n"
+"    frank\n"
+"\n"
+"Wenn mehrere Optionsnamen angegeben werden, wird ein Dokument "
+"zurückgegeben:\n"
+"\n"
+"    $ snap get snap-name username password\n"
+"    {\n"
+"        »Benutzername«: »frank«,\n"
+"        »Passwort«: »…«\n"
+"    }\n"
+"\n"
+"Verschachtelte Werte können über eine gepunkteten Pfad abgerufen werden:\n"
+"\n"
+"    $ snap get snap-name author.name\n"
+"    frank\n"
 
 msgid ""
 "\n"
@@ -1483,6 +1723,12 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
+"\n"
+"Der interface-Befehl zeigt Details über Snap-Schnittstellen.\n"
+"\n"
+"Wenn kein Schnittstellenname angegeben ist, wird eine Liste mit "
+"Schnittstellennamen mit mindestens einer Verbindung gezeigt.\n"
+"Eine Liste aller Schnittstellen kann mit if --all angezeigt werden.\n"
 
 msgid ""
 "\n"
@@ -1511,6 +1757,11 @@ msgid ""
 "If header=value pairs are provided after the assertion type, the assertions\n"
 "shown must also have the specified headers matching the provided values.\n"
 msgstr ""
+"\n"
+"Der Befehl »known« zeigt bekannte Assertionen des angegebenen Typs.\n"
+"Wenn header=value-Paare nach dem Assertionstyp angegeben werden, müssen die "
+"Assertionen\n"
+"den angegebenen Headers mit den angegebenen Werten entsprechen.\n"
 
 msgid ""
 "\n"
@@ -1541,6 +1792,9 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
+"\n"
+"Der Befehl »managed« gibt true oder false aus und informiert darüber, ob\n"
+"Snapd registrierte Benutzer hat.\n"
 
 msgid ""
 "\n"
@@ -1571,6 +1825,20 @@ msgid ""
 "if instead you want to install the snap forcing it into strict confinement\n"
 "repeat the command including --jailmode."
 msgstr ""
+"\n"
+"Der Herausgebern von Snap %q  hat mitgeteilt, dass diese Revision \n"
+"nicht der Qualität für ein produktives Umfeld und diese Revision für \n"
+"Entwicklungen oder Tests zurzeit entspricht. Unter anderem aus diesen "
+"Gründen\n"
+"wird diese Snap sich nicht automatisch aktualisieren. Es kann vorkommen, "
+"dass\n"
+"unvermeidbare Änderungen am System außerhalb von Sandboxes auftreten,\n"
+"welche eigentlich Snap in einer sicherer Umgebung laufen lassen können.\n"
+"Ihr System kann also somit einem Risiko ausgesetzt sein.\n"
+"\n"
+"Wenn Sie dies verstanden haben, wiederholen Sie den Befehl mit der Option\n"
+"--devmode; möchten Sie eher in einer sicheren Umgebung fortfahren, \n"
+"verwenden Sie bitte die Option --jailmode."
 
 msgid ""
 "\n"
@@ -1592,11 +1860,16 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
+"\n"
+"Der repair-Befehl zeigt Details zu einer oder mehreren Reparaturen.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
+"\n"
+"Der repairs-Befehl listet alle durchgeführten Reparaturen für dieses Gerät "
+"auf.\n"
 
 msgid ""
 "\n"
@@ -1604,6 +1877,11 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
+"\n"
+"Der Befehl restart startet die angegebenen Dienste des Snaps neu. Bei "
+"Ausführung über den\n"
+"\"configure\"-Hook werden die Dienste nach Beendigung des Hooks neu "
+"gestartet."
 
 msgid ""
 "\n"
@@ -1622,6 +1900,16 @@ msgid ""
 "an exception, data which the snap explicitly chooses to share across\n"
 "revisions is not touched by the revert process.\n"
 msgstr ""
+"\n"
+"Der Befehl revert setzt den angegebenen Snap in den Zustand vor\n"
+"der neuesten Aktualisierung zurück. Dadurch wird die vorherige Snap-"
+"Revision\n"
+"sowie Originaldateien, die mit diesem Snap verbunden waren,\n"
+"wieder aktiviert, wobei Datenänderungen, die durch die letzte\n"
+"Revison vorgenommen wurden, verworfen werden. Als\n"
+"eine Ausnahme werden Daten, die der Snap explizit für die gemeinsame Nutzung "
+"neben\n"
+"Revisionen wählt, durch den Revert-Prozess nicht berührt.\n"
 
 msgid ""
 "\n"
@@ -1642,6 +1930,18 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
+"\n"
+"Der Befehl set ändert die verfügbaren Konfigurationsoptionen wie "
+"angefordert.\n"
+"\n"
+"    $ snap set snap-name username=frank password=$PASSWORD\n"
+"\n"
+"Alle Konfigurationsänderungen sind sofort wirksam, und erst nach einem\n"
+"Hook der Snapkonfiguration erfolgreich zurückgemeldet.\n"
+"\n"
+"Untergeordnete Werte können mittels Punkt festgelegt werden:\n"
+"\n"
+"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1662,6 +1962,25 @@ msgid ""
 "\n"
 "    $ snapctl set :myplug path=/dev/ttyS0\n"
 msgstr ""
+"\n"
+"Der Befehl set ändert die bereitgestellten Konfigurationsoptionen wie "
+"gewünscht.\n"
+"\n"
+"    $ snapctl set username=frank password=$PASSWORD\n"
+"\n"
+"Alle Konfigurationsänderungen bestehen sofort und nur nachdem der Hook "
+"erfolgreich \n"
+"zurückgegeben wurde.\n"
+"\n"
+"Verschachtelte Werte können über einen Punkt im Pfad geändert werden:\n"
+"\n"
+"    $ snapctl set author.name=frank\n"
+"\n"
+"Plug und Slot Attribute können über den betreffenden Prepare oder Connect-"
+"Hook durch \n"
+"Benennung des jeweiligen Plugs oder Slots geändert werden:\n"
+"\n"
+"    $ snapctl set :myplug path=/dev/ttyS0\n"
 
 msgid ""
 "\n"
@@ -1669,28 +1988,43 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
+"\n"
+"Der Befehl start startet die angegebenen Dienste des Snaps. Bei Ausführung "
+"über den\n"
+"\"configure\"-Hook werden die Dienste nach Beenden des Hooks gestartet."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
+"\n"
+"Der start-Befehl startet und aktiviert optional die angegebenen Dienste.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
+"\n"
+"Der Befehl stop stoppt die angegebenen Dienste des Snaps. Bei Ausführung "
+"über den\n"
+"\"configure\"-Hook werden die Dienste nach Beenden des Hooks gestoppt."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
+"\n"
+"Der stop-Befehl stoppt und deaktiviert optional die angegebenen Dienste.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
+"\n"
+"Der Befehl »switch« verschiebt den angegebenen Snap in einen anderen Kanal, "
+"ohne ein Auffrischen durchzuführen.\n"
 
 msgid ""
 "\n"
@@ -1713,6 +2047,21 @@ msgid ""
 "be\n"
 "found relative to current working directory.\n"
 msgstr ""
+"\n"
+"Der Befehl try installiert einen entpackten Snap zu Testzwecken in das "
+"System.\n"
+"Der entpackte Snap-Inhalt wird auch nach der Installation weiter verwendet, "
+"so\n"
+"dass Nicht-Metadatenänderungen dort sofort live gehen. Metadatenänderungen, "
+"wie die\n"
+"die in snap.yaml ausgeführt werden, erfordern eine Neuinstallation um live "
+"zu gehen.\n"
+"\n"
+"Wenn das snapdir-Argument weggelassen wird, versucht der try-Befehl es "
+"herzuleiten, wenn\n"
+"entweder die snapcraft.yaml-Datei und das Hauptverzeichnis, oder die "
+"meta/snap.yaml-Datei\n"
+"relativ zum aktuellen Arbeitsverzeichnis gefunden wurden.\n"
 
 msgid ""
 "\n"
@@ -1725,6 +2074,9 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
+"\n"
+"Der Befehl version liefert Version des laufenden Clients, Servers\n"
+"und des Betriebssystems.\n"
 
 msgid ""
 "\n"
@@ -1732,11 +2084,17 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
+"\n"
+"Der Befehl watch wartet zum Abschluss auf die vorgegebene Änderungs-ID und "
+"zeigt den Fortschritt an\n"
+"(wenn verfügbar).\n"
 
 msgid ""
 "\n"
 "The whoami command prints the email the user is logged in with.\n"
 msgstr ""
+"\n"
+"Der whoami-Befehl gibt die E-Mail aus, mit der der Benutzer angemeldet ist.\n"
 
 #, c-format
 msgid ""
@@ -1750,6 +2108,15 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
+"\n"
+"Diese Überarbeitung von Snap %q wurde unter Verwendung der klassischen "
+"Einschränkung veröffentlicht und kann\n"
+"daher möglicherweise beliebige Systemänderungen außerhalb der "
+"Sicherheitssandbox durchführen, in der die Snaps\n"
+"normalerweise eingeschlossen sind. Dies kann Ihr System gefährden.\n"
+"\n"
+"Wenn Sie dies verstehen und fortfahren wollen, wiederholen Sie den Befehl "
+"einschließlich --classic.\n"
 
 msgid ""
 "\n"
@@ -1758,154 +2125,162 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
+"ein einzelner Snap-Name wird benötigt, um Modus- oder Kanalmarkierungen "
+"festzulegen"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr ""
+msgstr "ein einzelner Snap-Name wird benötigt, um die Revision anzugeben"
 
 msgid "a single snap name must be specified when ignoring validation"
 msgstr ""
+"ein einzelner Snap-Name muss angegeben werden, wenn die Validierung "
+"ignoriert wird"
 
 msgid "active"
-msgstr ""
+msgstr "aktiv"
 
 msgid "auto-refresh: all snaps are up-to-date"
-msgstr ""
+msgstr "Automatische Aktualisierung: Alle Snaps sind aktuell"
 
 msgid "bought"
-msgstr ""
+msgstr "gekauft"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr ""
+msgstr "beschädigt"
 
 #, c-format
 msgid "cannot %s without a context"
-msgstr ""
+msgstr "kann %s nicht ohne Kontext"
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr ""
+msgstr "Kann Snap nicht kaufen: %v"
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr ""
+msgstr "Kann Snap nicht kaufen: ungültige Zeichen im Namen"
 
 msgid "cannot buy snap: it has already been bought"
-msgstr ""
+msgstr "Kann Snap nicht kaufen: Es wurde schon gekauft"
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr ""
+msgstr "Kann %q nicht erstellen: %v"
 
 #, c-format
 msgid "cannot create assertions file: %v"
-msgstr ""
+msgstr "Zusicherungsdatei kann nicht erstellt werden: %v"
 
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr ""
+msgstr "Kann snap-name nicht aus lokaler Datei %q extrahieren: %v"
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr ""
+msgstr "Kann Anwendung %q nicht in %q finden"
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr ""
+msgstr "kann Einhängepunkt %q in %q nicht finden"
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr ""
+msgstr "Kann Daten für %q nicht holen: %v"
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr ""
+msgstr "Kann vollständigen Pfad für %q nicht holen: %v"
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr ""
+msgstr "aktueller Benutzer kann nicht ermittelt werden: %s"
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr ""
+msgstr "aktueller Benutzer kann nicht ermittelt werden: %v"
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr ""
+msgstr "Kann Boot nicht erfolgreich markieren: %s"
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr ""
+msgstr "Zusicherungsdatenbank kann nicht geöffnet werden: %v"
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr ""
+msgstr "Zusicherungseingabe kann nicht gelesen werden: %v"
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr ""
+msgstr "symbolische Verknüpfung nicht lesbar: %v"
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
-msgstr ""
+msgstr "Kann Snap Anwendung %q nicht auflösen: %v"
 
 #, c-format
 msgid "cannot sign assertion: %v"
-msgstr ""
+msgstr "Aussage kann nicht unterschrieben werden: %v"
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
 msgstr ""
+"»aktuelle« symbolische Verknüpfung von %q kann nicht neu geladen werden: %v"
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr ""
+msgstr "Schlüssel %q kann nicht verwendet werden: %v"
 
 msgid "cannot use change ID and type together"
-msgstr ""
+msgstr "Kann Änderungs-ID und Typ nicht zusammen verwenden"
 
 msgid "cannot use devmode and jailmode flags together"
 msgstr ""
+"devmode- und jailmode-Markierung können nicht gleichzeitig verwendet werden"
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr ""
+msgstr "Besitzer der Datei %s kann nicht validiert werden"
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr ""
+msgstr "Neue Xauthority-Datei kann nicht nach %s geschrieben werden: %s"
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr ""
+msgstr "Änderung ohne Fehlermeldung im Status %q  abgeschlossen"
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
+"klassische Einschränkung erfordert Snaps unter /snap oder Symlink von /snap "
+"nach %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr ""
+msgstr "Benutzer %q erstellt\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr ""
+msgstr "t"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr ""
+msgstr "deaktiviert"
 
 msgid "email:"
-msgstr ""
+msgstr "E-Mail:"
 
 msgid "enabled"
-msgstr ""
+msgstr "aktiviert"
 
 #, c-format
 msgid "error: %v\n"
@@ -1914,110 +2289,125 @@ msgstr "Fehler: %v\n"
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
 msgstr ""
+"Fehler: Das »<snap-dir>« Argument wurde nicht angegeben und konnte nicht "
+"abgeleitet werden"
 
 msgid "get which option?"
-msgstr ""
+msgstr "Erhalte welche Option?"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr ""
+msgstr "h"
 
 msgid "ignore-validation"
-msgstr ""
+msgstr "Überprüfung ignorieren"
 
 msgid "inactive"
-msgstr ""
+msgstr "inaktiv"
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
 msgstr ""
+"Schnittstellen-Attribute können nur während der Ausführung von "
+"Schnittstellen-Hooks gelesen werden"
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
 msgstr ""
+"Interface-Attribute können nur während der Ausführung von prepare hooks "
+"gesetzt werden"
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
 msgstr ""
+"interner Fehler, bitte melden: Ausführung von %q fehlgeschlagen: %v\n"
 
 msgid "internal error: cannot find attrs task"
-msgstr ""
+msgstr "interner Fehler: kann attrs-Task nicht finden"
 
 msgid "internal error: cannot find plug or slot data in the appropriate task"
 msgstr ""
+"interner Fehler: Kann keine Plug- oder Slot-Daten im entsprechenden Task "
+"finden"
 
 #, c-format
 msgid "internal error: cannot get %s from appropriate task"
-msgstr ""
+msgstr "interner Fehler: kann %s von passendem Task nicht holen"
 
 msgid ""
 "invalid argument for flag ‘-n’: expected a non-negative integer argument, or "
 "“all”."
 msgstr ""
+"ungültiges Argument für Markierung »-n«: erwartet wird ein nicht negatives "
+"Integer-Argument oder »all«"
 
 #, c-format
 msgid "invalid attribute: %q (want key=value)"
-msgstr ""
+msgstr "ungültiges Attribut: %q (benötigt Schlüssel=Wert)"
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr ""
+msgstr "ungültige Konfiguration: %q (benötigt Schlüssel=Wert)"
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr ""
+msgstr "ungültiger Header-Filter: %q (want key=Wert)"
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr ""
+msgstr "ungültiger Parameter: %q (benötigt Schlüssel=Wert)"
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr ""
+msgstr "ungültiger Wert: %q (benötigt Snap:Name oder Snap)"
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
+"Schlüsselname %q ist ungültig; nur ASCII-Buchstaben, Zahlen und Bindestriche "
+"sind erlaubt"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
+"Lokales Snap %q ist dem Speicher unbekannt, verwenden Sie --amend, um "
+"dennoch fortzufahren"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr ""
+msgstr "m"
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr ""
+msgstr "benötigt die Applikation, um als Argument ausgeführt zu werden"
 
 msgid "no changes found"
 msgstr "keine Änderungen gefunden"
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr ""
+msgstr "keine Änderungen des Typs %q gefunden"
 
 msgid "no interfaces currently connected"
-msgstr ""
+msgstr "aktuell sind keine Schnittstellen verbunden"
 
 msgid "no interfaces found"
-msgstr ""
+msgstr "keine Schnittstellen gefunden"
 
 msgid "no matching snaps installed"
 msgstr "keine passenden Snaps installiert"
 
 msgid "no such interface"
-msgstr ""
+msgstr "Schnittstelle nicht vorhanden"
 
 msgid "no valid snaps given"
 msgstr "keine gültigen Snaps angegeben"
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr ""
+msgstr "Bitte geben Sie die Änderungs-ID oder den Typ mit --last=<type> an"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
@@ -2029,19 +2419,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr ""
+msgstr "Reparaturen sind auf einem klassischen System nicht verfügbar"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #, c-format
 msgid "set failed: %v"
-msgstr ""
+msgstr "als fehlgeschlagen festlegen: %v"
 
 msgid "set which option?"
-msgstr ""
+msgstr "Welche Option soll festgelegt werden?"
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2055,7 +2445,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr ""
+msgstr "für Snap %q sind keine Aktualisierungen verfügbar"
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2063,34 +2453,34 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr ""
+msgstr "Snap %q nicht gefunden"
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
 msgstr "Snap ist kostenlos"
 
 msgid "too many arguments for command"
-msgstr ""
+msgstr "zu viele Argumente für diesen Befehl"
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr ""
+msgstr "zu viele Argumente für hook %q: %s"
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr ""
+msgstr "zu viele Argumente: %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "Mit dem snap-Store konnte keine Verbindung hergestellt werden"
 
 msgid "unavailable"
 msgstr "nicht verfügbar"
 
 #, c-format
 msgid "unknown attribute %q"
-msgstr ""
+msgstr "unbekanntes Attribut %q"
 
 #, c-format
 msgid "unknown command %q, see \"snap --help\""
@@ -2098,34 +2488,39 @@ msgstr "unbekannter Befehl %q, siehe »snap --help«"
 
 #, c-format
 msgid "unknown plug or slot %q"
-msgstr ""
+msgstr "unbekannter Plug oder Slot %q"
 
 #, c-format
 msgid "unknown service: %q"
-msgstr ""
+msgstr "unbekannter Dienst %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr ""
+msgstr "Achtung:\tkein Snap für %q gefunden\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr ""
+msgstr "j"
 
 msgid "Authenticate on snap daemon"
-msgstr ""
+msgstr "Beim Snap-Dienst legitimeren"
 
 msgid "Authorization is required to authenticate on the snap daemon"
 msgstr ""
+"Legitimierung ist erforderlich, um sich beim Snap-Dienst zu legitimieren"
 
 msgid "Install, update, or remove packages"
-msgstr ""
+msgstr "Pakete installieren, aktualisieren oder entfernen"
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
+"Legitimierung ist erforderlich, um Pakete zu installieren, aktualisieren "
+"oder zu entfernen"
 
 msgid "Connect, disconnect interfaces"
-msgstr ""
+msgstr "Schnittstellen verbinden oder trennen"
 
 msgid "Authentication is required to connect or disconnect interfaces"
 msgstr ""
+"Legitimierung ist erforderlich, um Schnittstellen zu verbinden oder zu "
+"trennen"

--- a/po/el.po
+++ b/po/el.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Δοκιμάστε με «snapcraft prime» μέσα στον κατάλογο του έργου, και μετά «snap "
 "try» ξανά."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "Το %q άλλαξε προς στο κανάλι %q\n"
@@ -105,88 +106,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr "το -r μπορεί να χρησιμοποιηθεί μόνο με --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<ψευδώνυμο-ή-πακέτο-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<ψευδώνυμο>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<ηλεκ. διεύθυνση>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<όνομα αρχείου>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<φίλτρο κεφαλίδας>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<διεπαφή>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<κλειδί-όνομα>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<κλειδί>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<λεκτικό αναζήτησης>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<γονικός-κατάλογος>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Εγκατάλειψη εκκρεμούς αλλαγής"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Προστέθηκε"
 
@@ -204,9 +207,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Ψευδώνυμο για --dangerous (ΠΑΡΩΧΗΜΕΝΟ)"
 
@@ -216,6 +221,7 @@ msgstr "Όλα τα πακέτα snap είναι ενημερωμένα."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +236,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Εναλλακτική εντολή για εκτέλεση"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Πάντα επιστροφή εγγράφου, ακόμα και με μονό κλειδί"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Πάντα επιστροφή λίστας, ακόμα και με μονό κλειδί"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Μια ηλεκτρονική διεύθυνση χρήστη στο login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -286,7 +297,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr "Αγορά πακέτου snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Αλλαγή αναγνωριστικού"
 
@@ -296,7 +307,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr "Εντολή\tΨευδώνυμο\tΣημειώσεις"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -310,14 +321,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Περιορισμός λίστας σε συγκεκριμένο snap ή snap:όνομα"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Περιορισμός λίστας σε συγκεκριμένη διεπαφή"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -374,6 +386,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -381,6 +394,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -422,16 +436,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr "Ανάκτηση snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr "Αναζήτηση πακέτων προς εγκατάσταση"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -443,33 +459,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Δημιουργία κλειδιού συσκευής"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr "Βοήθεια"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "Ταυτότητα\tΚατάσταση\tΣτιγμή εκκίνησης\tΣε λειτουργία\tΠερίληψη\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -484,6 +508,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -509,15 +534,19 @@ msgstr "Εγκατάσταση snap %q από αρχείο"
 msgid "Install %q snap from file %q"
 msgstr "Εγκατάσταση snap %q από το αρχείο %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Εγκατάσταση από το κανάλι beta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Εγκατάσταση από το κανάλι candidate"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Εγκατάσταση από το κανάλι edge"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Εγκατάσταση από το κανάλι stable"
 
@@ -530,16 +559,19 @@ msgstr "Εγκατάσταση snap %q"
 msgid "Install snaps %s"
 msgstr "Εγκατάσταση snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -553,8 +585,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Εγκατάσταση snap στο σύστημα"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -618,21 +650,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Όνομα κλειδιού προς διαγραφή"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Όνομα κλειδιού προς εξαγωγή"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -695,6 +729,8 @@ msgstr ""
 "Κανένα span δεν έχει εγκατασταθεί ακόμα. Δοκιμάστε «snap install hello-"
 "world»."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Η έξοδος καταλήγει σε μορφή JSON"
 
@@ -763,12 +799,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -826,6 +865,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr "Αφαίρεση χειροκίνητου ψευδώνυμου %q για το snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Αφαίρεση μόνο της συγκεκριμένης αναθεώρησης"
 
@@ -850,6 +890,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr "Αφαίρεση snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Αφαιρέθηκε"
 
@@ -865,6 +906,7 @@ msgstr "Επανεκκίνηση υπηρεσιών"
 msgid "Restarted.\n"
 msgstr "Επανεκκινήθηκε.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -878,9 +920,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Εκτέλεση ενός φλοιού αντί μιας εντολής (χρήσιμο στην εκσφαλμάτωση)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -920,6 +964,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -932,6 +977,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Εκτέλεση εντολών αποσφαλμάτωσης"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Αναζήτηση ιδιωτικών snaps"
 
@@ -974,9 +1020,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Εμφάνιση όλων των αναθεωρήσεων"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -987,13 +1035,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Εμφάνιση λεπτομερειών συγκεκριμένης διεπαφής"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Εμφάνιση ιδιοτήτων διεπαφής"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1023,8 +1073,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Όνομα snap"
 
@@ -1074,6 +1124,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1092,6 +1143,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr "Αλλάζει το κανάλι σε ένα πακέτο snap"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1109,15 +1161,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Κατάλογος εξόδου"
 
@@ -1125,11 +1177,12 @@ msgstr "Κατάλογος εξόδου"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "Snap προς ρύθμιση (π.χ. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1169,15 +1222,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Να χρησιμοποιηθεί αυτό το κανάλι αντί του stable"
 
@@ -1190,6 +1246,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2019-01-18 18:39+0000\n"
+"Last-Translator: Stephan Woidowski <swoidowski@t-online.de>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -27,6 +27,7 @@ msgstr ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q switched to the %q channel\n"
@@ -104,96 +105,100 @@ msgstr "--time does not take mode nor channel flags"
 msgid "-r can only be used with --hook"
 msgstr "-r can only be used with --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-or-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<assertion file>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<assertion type>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<change-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<conf value>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<email>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<filename>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<header filter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<interface>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<key-name>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<key>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<model-assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<query>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<root-dir>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<service>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<slot or plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
+"A service specification, which can be just a snap name (for all services in "
+"the snap), or <snap>.<app> for a single service."
 
 msgid "Abort a pending change"
 msgstr "Abort a pending change"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Added"
 
@@ -201,11 +206,13 @@ msgid "Adds an assertion to the system"
 msgstr "Adds an assertion to the system"
 
 msgid "Advise on available snaps."
-msgstr ""
+msgstr "Advise on available snaps."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr ""
+msgstr "Advise on snaps that provide the given command"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias for --dangerous (DEPRECATED)"
 
@@ -213,49 +220,58 @@ msgid "All snaps up to date."
 msgstr "All snaps up to date."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Allow opening file?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
-msgstr ""
+msgstr "Allow refresh attempt on snap unknown to the store"
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Allow settings change?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Allow snap %q to change %q to %q ?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Allow snap %q to open file %q?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Alternative command to run"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Always return document, even with single key"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Always return list, even with single key"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "An e-mail of a user on login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
+"As well as starting the service now, arrange for it to be started on boot."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
+"As well as stopping the service now, arrange for it to no longer be started "
+"on boot."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Assertion file"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Assertion type name"
 
@@ -277,7 +293,7 @@ msgstr "Auto-refresh snaps %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
-msgstr ""
+msgstr "Automatically connect eligible plugs and slots of snap %q"
 
 msgid "Bad code. Try again: "
 msgstr "Bad code. Try again: "
@@ -285,7 +301,7 @@ msgstr "Bad code. Try again: "
 msgid "Buys a snap"
 msgstr "Buys a snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Change ID"
 
@@ -295,7 +311,7 @@ msgstr "Changes configuration options"
 msgid "Command\tAlias\tNotes"
 msgstr "Command\tAlias\tNotes"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Configuration value (key=value)"
 
@@ -309,14 +325,15 @@ msgstr "Connect %s:%s to %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Connects a plug to a slot"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Constrain listing to a specific snap or snap:name"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Constrain listing to specific interfaces"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Constrain listing to those matching header=value"
 
@@ -373,6 +390,7 @@ msgstr "Disconnect %s:%s from %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Disconnects a plug from a slot"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 "Do not wait for the operation to finish but just print the change id."
@@ -381,6 +399,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr "Download snap %q%s from channel %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -425,16 +444,18 @@ msgstr "Fetching assertions for %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Fetching snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Filename of the snap you want to assert a build for"
 
 msgid "Finds packages to install"
 msgstr "Finds packages to install"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr "Force adding the user, even if the device is already managed"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Force import on classic systems"
 
@@ -448,33 +469,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Generate device key"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Generate the manpage"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr "Grade states the build quality of the snap (defaults to 'stable')"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Grant sudo access to the created user"
 
 msgid "Help"
 msgstr "Help"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Hook to run"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "ID\tStatus\tSpawn\tReady\tSummary\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Identifier of the signer"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identifier of the snap package associated with the build"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
-msgstr ""
+msgstr "If the service has a reload command, use it instead of restarting."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Ignore validation by other snaps blocking the refresh"
 
@@ -494,6 +523,7 @@ msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Include unused interfaces"
 
@@ -519,15 +549,19 @@ msgstr "Install %q snap from file"
 msgid "Install %q snap from file %q"
 msgstr "Install %q snap from file %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Install from the beta channel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Install from the candidate channel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Install from the edge channel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Install from the stable channel"
 
@@ -540,11 +574,13 @@ msgstr "Install snap %q"
 msgid "Install snaps %s"
 msgstr "Install snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Install the given revision of a snap, to which you must have developer access"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -554,6 +590,7 @@ msgstr ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr "Install the given snap without enabling its automatic aliases"
 
@@ -563,12 +600,15 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Install the snap with:\n"
+"   snap ack %s\n"
+"   snap install %s\n"
 
 msgid "Installs a snap to the system"
 msgstr "Installs a snap to the system"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Key of interest within the configuration"
 
@@ -632,21 +672,23 @@ msgstr "Mark system seeded"
 msgid "Mount snap %q%s"
 msgstr "Mount snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Name of key to create; defaults to 'default'"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Name of key to be deleted"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Name of key to export"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr "Name of the GnuPG key to use (defaults to 'default' as key name)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Name of the key to use, otherwise use the default key"
 
@@ -663,59 +705,63 @@ msgid "Name\tVersion\tRev\tDeveloper\tNotes"
 msgstr "Name\tVersion\tRev\tDeveloper\tNotes"
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
-msgstr ""
+msgstr "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr ""
+msgstr "No aliases are currently defined for snap %q.\n"
 
 msgid "No aliases are currently defined."
-msgstr ""
+msgstr "No aliases are currently defined."
 
 #, c-format
 msgid "No command %q found, did you mean:\n"
-msgstr ""
+msgstr "No command %q found, did you mean:\n"
 
 msgid "No connections to disconnect"
-msgstr ""
+msgstr "No connections to disconnect"
 
 #. TRANSLATORS: the %q is the (quoted) name of the section the user entered
 #, c-format
 msgid "No matching section %q, use --section to list existing sections"
-msgstr ""
+msgstr "No matching section %q, use --section to list existing sections"
 
 #. TRANSLATORS: the first %q is the (quoted) query, the
 #. second %q is the (quoted) name of the section the
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr ""
+msgstr "No matching snaps for %q in section %q\n"
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr ""
+msgstr "No matching snaps for %q\n"
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
+"No search term specified. Here are some interesting snaps:\n"
+"\n"
 
 msgid "No section specified. Available sections:\n"
-msgstr ""
+msgstr "No section specified. Available sections:\n"
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr "No snaps are installed yet. Try \"snap install hello-world\"."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Output results in JSON format"
 
 msgid "Pack the given target dir as a snap"
-msgstr ""
+msgstr "Pack the given target dir as a snap"
 
 #, c-format
 msgid "Packages matching %q:\n"
-msgstr ""
+msgstr "Packages matching %q:\n"
 
 msgid "Passphrase: "
 msgstr "Passphrase: "
@@ -734,7 +780,7 @@ msgstr ""
 "for %s. Press ctrl-c to cancel."
 
 msgid "Please try: snap find --section=<selected section>\n"
-msgstr ""
+msgstr "Please try: snap find --section=<selected section>\n"
 
 #, c-format
 msgid "Prefer aliases for snap %q"
@@ -768,7 +814,7 @@ msgid "Prints the confinement mode the system operates in"
 msgstr "Prints the confinement mode the system operates in"
 
 msgid "Prints the email the user is logged in with"
-msgstr ""
+msgstr "Prints the email the user is logged in with"
 
 msgid "Prints whether system is managed"
 msgstr "Prints whether system is managed"
@@ -777,12 +823,15 @@ msgstr "Prints whether system is managed"
 msgid "Prune automatic aliases for snap %q"
 msgstr "Prune automatic aliases for snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Put snap in classic mode and disable security confinement"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr "Put snap in development mode and disable security confinement"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Put snap in enforced confinement mode"
 
@@ -840,6 +889,7 @@ msgstr "Remove data for snap %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr "Remove manual alias %q for snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Remove only the given revision"
 
@@ -864,6 +914,7 @@ msgstr "Remove snap %q (%s) from the system"
 msgid "Remove snaps %s"
 msgstr "Remove snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Removed"
 
@@ -879,6 +930,7 @@ msgstr "Restart services"
 msgid "Restarted.\n"
 msgstr "Restarted.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Restrict the search to a given section"
 
@@ -892,11 +944,13 @@ msgstr "Revert %q snap"
 msgid "Reverts the given snap to the previous state"
 msgstr "Reverts the given snap to the previous state"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Run a shell instead of the command (useful for debugging)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr ""
+msgstr "Run as a timer service with given schedule"
 
 #, c-format
 msgid "Run configure hook of %q snap"
@@ -920,7 +974,7 @@ msgstr "Run post-refresh hook of %q snap if present"
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
-msgstr ""
+msgstr "Run pre-refresh hook of %q snap if present"
 
 msgid "Run prepare-device hook"
 msgstr "Run prepare-device hook"
@@ -933,9 +987,12 @@ msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
 "can be specified as well here."
 msgstr ""
+"Run the command under strace (useful for debugging). Extra strace options "
+"can be specified as well here."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
-msgstr ""
+msgstr "Run the command with gdb"
 
 msgid "Run the given snap command"
 msgstr "Run the given snap command"
@@ -947,6 +1004,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Runs debug commands"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Search private snaps"
 
@@ -958,7 +1016,7 @@ msgstr ""
 "refresh etc.)"
 
 msgid "Service\tStartup\tCurrent"
-msgstr ""
+msgstr "Service\tStartup\tCurrent"
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
@@ -991,9 +1049,11 @@ msgstr "Setup snap %q%s security profiles"
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr "Setup snap %q%s security profiles (phase 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Show all revisions"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr "Show auto refresh information but do not perform a refresh"
 
@@ -1001,17 +1061,19 @@ msgid "Show available snaps for refresh but do not perform a refresh"
 msgstr "Show available snaps for refresh but do not perform a refresh"
 
 msgid "Show detailed information about a snap"
-msgstr ""
+msgstr "Show detailed information about a snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Show details of a specific interface"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Show interface attributes"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
-msgstr ""
+msgstr "Show only the given number of lines, or 'all'."
 
 msgid "Shows known assertions of the provided type"
 msgstr "Shows known assertions of the provided type"
@@ -1040,10 +1102,10 @@ msgstr "Slot\tPlug"
 #. TRANSLATORS: first %s is a snap name, following %s is a channel name
 #, c-format
 msgid "Snap %s is no longer tracking %s.\n"
-msgstr ""
+msgstr "Snap %s is no longer tracking %s.\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Snap name"
 
@@ -1096,6 +1158,7 @@ msgstr "Stop snap services"
 msgid "Stopped.\n"
 msgstr "Stopped.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Strict typing with nulls and quoted strings"
 
@@ -1114,6 +1177,7 @@ msgstr "Switch snap %q to %s"
 msgid "Switches snap to a different channel"
 msgstr "Switches snap to a different channel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Temporarily mount device before inspecting"
 
@@ -1134,27 +1198,28 @@ msgid ""
 msgstr ""
 "The get command prints configuration and interface connection settings."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "The login.ubuntu.com e-mail to login as"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "The model assertion name"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "The output directory"
 
 #, c-format
 msgid "The program %q can be found in the following snaps:\n"
-msgstr ""
+msgstr "The program %q can be found in the following snaps:\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "The snap to configure (e.g. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "The snap whose conf is being requested"
 
@@ -1166,10 +1231,11 @@ msgstr "This command logs the current user out of the store"
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
 msgstr ""
+"This dialogue will close automatically after 5 minutes of inactivity."
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr ""
+msgstr "Toggle snap %q flags"
 
 msgid "Tool to interact with snaps"
 msgstr "Tool to interact with snaps"
@@ -1186,7 +1252,7 @@ msgid "Try %q snap from %s"
 msgstr "Try %q snap from %s"
 
 msgid "Try: snap install <selected snap>\n"
-msgstr ""
+msgstr "Try: snap install <selected snap>\n"
 
 msgid "Two-factor code: "
 msgstr "Two-factor code: "
@@ -1194,15 +1260,18 @@ msgstr "Two-factor code: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr "Unalias a manual alias or an entire snap"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr "Use a specific snap revision when running hook"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Use known assertions for user creation"
 
 msgid "Use the given output format (pretty or json)"
-msgstr ""
+msgstr "Use the given output format (pretty or json)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Use this channel instead of stable"
 
@@ -1217,8 +1286,9 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "WARNING: failed to activate logging: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
-msgstr ""
+msgstr "Wait for new lines and print them as they come in."
 
 msgid "Waiting for server to restart"
 msgstr "Waiting for server to restart"
@@ -1285,6 +1355,8 @@ msgid ""
 "\n"
 "Provide a search term for more specific results.\n"
 msgstr ""
+"\n"
+"Provide a search term for more specific results.\n"
 
 msgid ""
 "\n"
@@ -1322,6 +1394,9 @@ msgid ""
 "The advise-snap command shows what snaps with the given command are\n"
 "available.\n"
 msgstr ""
+"\n"
+"The advise-snap command shows what snaps with the given command are\n"
+"available.\n"
 
 msgid ""
 "\n"
@@ -1788,6 +1863,9 @@ msgid ""
 "The logs command fetches logs of the given services and displays them in "
 "chronological order.\n"
 msgstr ""
+"\n"
+"The logs command fetches logs of the given services and displays them in "
+"chronological order.\n"
 
 msgid ""
 "\n"
@@ -1907,6 +1985,11 @@ msgid ""
 "If the --reload option is given, for each service whose app has a reload "
 "command, a reload is performed instead of a restart.\n"
 msgstr ""
+"\n"
+"The restart command restarts the given services.\n"
+"\n"
+"If the --reload option is given, for each service whose app has a reload "
+"command, a reload is performed instead of a restart.\n"
 
 msgid ""
 "\n"
@@ -1930,6 +2013,9 @@ msgid ""
 "The services command lists information about the services specified, or "
 "about the services in all currently installed snaps.\n"
 msgstr ""
+"\n"
+"The services command lists information about the services specified, or "
+"about the services in all currently installed snaps.\n"
 
 msgid ""
 "\n"
@@ -2008,6 +2094,8 @@ msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
+"\n"
+"The start command starts, and optionally enables, the given services.\n"
 
 msgid ""
 "\n"
@@ -2022,6 +2110,8 @@ msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
+"\n"
+"The stop command stops, and optionally disables, the given services.\n"
 
 msgid ""
 "\n"
@@ -2133,6 +2223,8 @@ msgid ""
 "\n"
 "Use snap alias --help to learn how to create aliases manually."
 msgstr ""
+"\n"
+"Use snap alias --help to learn how to create aliases manually."
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr "a single snap name is needed to specify mode or channel flags"
@@ -2147,7 +2239,7 @@ msgid "active"
 msgstr "active"
 
 msgid "auto-refresh: all snaps are up-to-date"
-msgstr ""
+msgstr "auto-refresh: all snaps are up-to-date"
 
 msgid "bought"
 msgstr "bought"
@@ -2274,7 +2366,7 @@ msgstr "created user %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr ""
+msgstr "d"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
@@ -2300,10 +2392,10 @@ msgstr "get which option?"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr ""
+msgstr "h"
 
 msgid "ignore-validation"
-msgstr ""
+msgstr "ignore-validation"
 
 msgid "inactive"
 msgstr "inactive"
@@ -2368,11 +2460,11 @@ msgstr ""
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
-msgstr ""
+msgstr "local snap %q is unknown to the store, use --amend to proceed anyway"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr ""
+msgstr "m"
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr "missing snap-confine: try updating your snapd package"
@@ -2422,7 +2514,7 @@ msgstr "repairs are not available on a classic system"
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #, c-format
 msgid "set failed: %v"
@@ -2471,7 +2563,7 @@ msgid "too many arguments: %s"
 msgstr "too many arguments: %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "unable to contact snap store"
 
 msgid "unavailable"
 msgstr "unavailable"
@@ -2494,11 +2586,11 @@ msgstr "unknown service: %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr ""
+msgstr "warning:\tno snap found for %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr ""
+msgstr "y"
 
 msgid "Authenticate on snap daemon"
 msgstr "Authenticate on snap daemon"

--- a/po/eo.po
+++ b/po/eo.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Intente «snapcraft prime» en su directorio de proyecto y luego intente «snap "
 "try» nuevamente."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q cambiado al canal %q\n"
@@ -105,88 +106,89 @@ msgstr "--time no recibe modos o indicadores de canal"
 msgid "-r can only be used with --hook"
 msgstr "-r solo se puede usar con --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-o-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<archivo de afirmación>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<tipo de afirmación>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<cambiar-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<valor conf>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<email>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<nombredearchivo>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<filtro cabecera>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<interfaz>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nombre-clave>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<clave>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<afirmación-modelo>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<consulta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<dir-raíz>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<enchufe>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<ranura o enchufe>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Abortar un cambio pendiente"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Añadido"
 
@@ -204,9 +207,11 @@ msgstr "Añadir una aserción al sistema"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias para --dangerous (OBSOLETO)"
 
@@ -216,6 +221,7 @@ msgstr "Todos los snaps están actualizados."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +236,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Orden alternativa a ejecutar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Devolver siempre un documento, incluso con clave única"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Siempre devolver la lista, incluso con una sola clave"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Una dirección de correo de un usuario en login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Nombre del tipo de aserción"
 
@@ -286,9 +297,9 @@ msgstr "Código incorrecto. Inténtelo de nuevo: "
 msgid "Buys a snap"
 msgstr "Compra un snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "Cambiar ID"
 
 msgid "Changes configuration options"
 msgstr "Opciones de configuración de cambios"
@@ -296,7 +307,7 @@ msgstr "Opciones de configuración de cambios"
 msgid "Command\tAlias\tNotes"
 msgstr "Orden\tAlias\tNotas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Valor de configuración (clave=valor)"
 
@@ -310,14 +321,15 @@ msgstr "Conectar %s:%s a %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Conectar un enchufe al zócalo"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Restringir el listado a una snap específica o snap:nombre"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Restringir el listado a interfaces específicas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Restringir el listado a aquellos que coincidan en encabezado=valor"
 
@@ -375,6 +387,7 @@ msgstr "Desconectar %s:%s de %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Desconectar un enchufe del zócalo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 "En vez de esperar a que finalice la operación, imprimir el id de cambio."
@@ -383,6 +396,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr "Descargar snap %q%s del canal %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -428,17 +442,19 @@ msgstr "Buscando afirmaciones para %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Traer snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Nombre del archivo snap para el que desea afirmar su construcción"
 
 msgid "Finds packages to install"
 msgstr "Buscar paquetes para instalar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 "Forzar a añadir el usuario, incluso si el dispositivo ya está administrado"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Forzar importación en sistemas clásicos"
 
@@ -452,35 +468,43 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Generar clave de dispositivo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Generar la página de manual"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 "Califica por estados la calidad de construcción del snap (por defecto es "
 "«stable»)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Garantizar acceso de sudo al usuario creado"
 
 msgid "Help"
 msgstr "Ayuda"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Enganchar para ejecutar"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "ID\tEstado\tGenerado\tListo\tResumen\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Identificador del firmante"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identificador del paquete de snap asociado con la construcción"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Ignorar la validación por otras snaps bloqueando el refresco"
 
@@ -500,6 +524,7 @@ msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 "Incluir una lista amplia de notas de snap (de otra forma, resumir las notas)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Incluir interfaces sin usar"
 
@@ -525,15 +550,19 @@ msgstr "Instalar snap %q desde un archivo"
 msgid "Install %q snap from file %q"
 msgstr "Instalar snap %q desde el archivo %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Instalar desde el canal beta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Instalar desde el canal candidato"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Instalar desde el canal vanguardia"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Instalar desde el canal estable"
 
@@ -546,12 +575,14 @@ msgstr "Instalar snap %q"
 msgid "Install snaps %s"
 msgstr "Instalar snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Instalar la revisión dada de un snap, para lo cual debe tener acceso de "
 "desarrollador"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -561,6 +592,7 @@ msgstr ""
 "lo cual significa que no se verificó y podría ser peligroso (--devmode "
 "implica esto)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr "Instalar el snap dado sin activar sus aliases automáticos"
 
@@ -574,8 +606,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Instalar un snap en el sistema"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Clave de interés en la configuración"
 
@@ -640,23 +672,25 @@ msgstr "Marcar el sistema como sembrado"
 msgid "Mount snap %q%s"
 msgstr "Montar snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Nombre de la clave a crear; el predeterminado es «default»"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Nombre de la clave a eliminar"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Nombre de la clave a exportar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Nombre de la clave GnuPG a usar (el predeterminado es «default» para el "
 "nombre de clave)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 "Nombre de la clave a utilizar, de otro modo usar la clave predeterminada"
@@ -719,6 +753,8 @@ msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 "Aun no se han instalado snaps. Pruebe con «snap install hello-world»."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Resultados de salida en formato JSON"
 
@@ -789,14 +825,17 @@ msgstr "Imprime si el sistema está administrado"
 msgid "Prune automatic aliases for snap %q"
 msgstr "Quitar los aliases automáticos del snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 "Poner snap en modo clásico y desactivar el confinamiento de seguridad"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 "Poner snap en modo de desarrollo y desactivar el confinamiento de seguridad"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Poner snap en modo de confinamiento forzado"
 
@@ -854,6 +893,7 @@ msgstr "Eliminar datos para el snap %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr "Eliminar alias manual %q para el snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Eliminar solo la revisión dada"
 
@@ -878,6 +918,7 @@ msgstr "Eliminar el snap %q (%s) del sistema"
 msgid "Remove snaps %s"
 msgstr "Eliminar snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Eliminado"
 
@@ -893,6 +934,7 @@ msgstr "Reiniciar servicios"
 msgid "Restarted.\n"
 msgstr "Reiniciado.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Restringir la búsqueda a una sección dada"
 
@@ -906,10 +948,12 @@ msgstr "Revertir snap %q"
 msgid "Reverts the given snap to the previous state"
 msgstr "Revierte el snap dado a su estado previo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 "Ejecutar un intérprete de ordenes en vez de la orden (útil para depurar)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -949,6 +993,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -961,6 +1006,7 @@ msgstr "Ejecutar la orden snap dada con el confinamiento y entorno apropiado"
 msgid "Runs debug commands"
 msgstr "Ejecuta ordenes de depurado"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Buscar snaps privados"
 
@@ -1005,9 +1051,11 @@ msgstr "Configurar los perfiles de seguridad del snap %q%s"
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr "Configurar los perfiles de seguridad del snap %q%s (fase 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Mostrar todas las revisiones"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr "Mostrar la información de auto refresco sin realizar un refresco"
 
@@ -1017,13 +1065,15 @@ msgstr "Mostrar snaps disponibles para refresco sin realizar un refresco"
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Mostrar detalles de una interfaz específica"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Mostrar atributos de la interfaz"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1057,8 +1107,8 @@ msgstr "Ranura\tEnchufe"
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Nombre de snap"
 
@@ -1111,6 +1161,7 @@ msgstr "Parar los servicios de snap"
 msgid "Stopped.\n"
 msgstr "Detenido.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Escritura estricta con cadenas nulas y citadas"
 
@@ -1129,6 +1180,7 @@ msgstr "Cambiar el snap %q a %s"
 msgid "Switches snap to a different channel"
 msgstr "Cambia el snap a un canal diferente"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Montar el dispositivo temporalmente antes de inspeccionar"
 
@@ -1149,15 +1201,15 @@ msgid ""
 msgstr ""
 "La orden get imprime los ajustes de configuración e interfaz de conexión."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "El email con el que acceder a login.ubuntu.com"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "El nombre de afirmación del modelo"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "DIrectorio de salida"
 
@@ -1165,11 +1217,12 @@ msgstr "DIrectorio de salida"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "El snap a configurar (p.ej.: hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "El snap para el que se solicita su conf"
 
@@ -1209,15 +1262,18 @@ msgstr "Código de dos factores: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr "Desactivar un alias manual o un snap completo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr "Usar una revisión específica de un snap al ejecutar un enganche"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Usar afirmaciones conocidas para crear el usuario"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Usar este canal en lugar del estable"
 
@@ -1232,6 +1288,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "AVISO: no se ha podido activar el registro: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 
@@ -2503,7 +2560,7 @@ msgid "too many arguments: %s"
 msgstr "demasiados argumentos: %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "no se puede contactar con la Snap Store"
 
 msgid "unavailable"
 msgstr "no disponible"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1,16 +1,16 @@
-# Swedish translation for snapd
-# Copyright (c) 2018 Rosetta Contributors and Canonical Ltd 2018
+# Persian translation for snapd
+# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
 # This file is distributed under the same license as the snapd package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
+"PO-Revision-Date: 2019-01-22 10:51+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Swedish <sv@li.org>\n"
+"Language-Team: Persian <fa@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,151 +23,148 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q innehåller inte ett uppackat snap-paket.\n"
-"\n"
-"Testa \"snapcraft prime\" i din projektmapp, sedan \"snap try\" igen."
 
 #. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr "%q bytte till kanalen %q\n"
+msgstr ""
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s monterades från %s\n"
+msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr "%s (delta)"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr "%s (se \"snap login --help\")"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr "%s (försök med sudo)"
+msgstr ""
 
 #, c-format
 msgid "%s already installed\n"
-msgstr "%s är redan installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s disabled\n"
-msgstr "%s inaktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s enabled\n"
-msgstr "%s aktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s not installed\n"
-msgstr "%s inte installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s removed\n"
-msgstr "%s borttagen\n"
+msgstr ""
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr "%s återställd till %s\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
 msgid "%s%s %s from '%s' installed\n"
-msgstr "%s%s %s från \"%s\" installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr "%s%s %s från \"%s\" uppdaterad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr "%s%s %s installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr "%s%s %s uppdaterad\n"
+msgstr ""
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "--time does not take mode nor channel flags"
-msgstr "--time tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr "-r kan bara användas med --hook"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr "<alias-eller-snap>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr "<alias>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<assert-fil>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<assert-typ>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<ändra-id>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr "<konf.värde>"
+msgstr ""
 
 #. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 #. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr "<epost>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr "<filnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr "<rubrikfilter>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr "<gränssnitt>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr "<nyckelnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr "<nyckel>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr "<modell-assert>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr "<fråga>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<root-kat>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
@@ -176,48 +173,46 @@ msgstr ""
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr "<snap>:<plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr "<snap>:<slot eller plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr "<snap>:<slot>"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
-"En tjänstespecifikation, som kan vara bara ett snappnamn (för alla tjänster "
-"i snappen), eller <snapp>.<app> för en enstaka tjänst."
 
 msgid "Abort a pending change"
-msgstr "Avbryt en väntande ändring"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr "Tillagd"
+msgstr ""
 
 msgid "Adds an assertion to the system"
-msgstr "Lägger till en assert i systemet"
+msgstr ""
 
 msgid "Advise on available snaps."
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr "Informera om snappar som tillhandahåller det givna kommandot"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr "Alias för --dangerous (FÖRÅLDRAD)"
+msgstr ""
 
 msgid "All snaps up to date."
-msgstr "Alla snap-paket uppdaterade."
+msgstr ""
 
 msgid "Allow opening file?"
 msgstr ""
@@ -231,27 +226,27 @@ msgstr ""
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr "Tillåt snapp %q att ändra %q till %q ?"
+msgstr ""
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr "Tillåt snapp %q att öppna filen %q?"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr "Alternativt kommando att köra"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr "Returnera alltid dokument, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr "Returnera alltid lista, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr "En e-postadress för en användare på login.ubuntu.com"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -266,14 +261,14 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr "Assert-fil"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr "Assert-typnamn"
+msgstr ""
 
 msgid "Authenticates on snapd and the store"
-msgstr "Autentiseras på snapd och butiken"
+msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
@@ -293,27 +288,27 @@ msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr "Felaktig kod. Försök igen: "
+msgstr ""
 
 msgid "Buys a snap"
-msgstr "Köper en snap"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr "Ändra ID"
+msgstr ""
 
 msgid "Changes configuration options"
-msgstr "Ändrar konfigurationsalternativ"
+msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr "Kommando\tAlias\tAnteckningar"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr "Konfigurationsvärde (nyckel=värde)"
+msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr "Bekräfta lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -324,57 +319,56 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr "Begränsa lista till en specifik snap eller snapp:namn"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr "Begränsa lista till specifika gränssnitt"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr "Begränsa lista till de som matchar rubrik=värde"
+msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr "Kopiera data från snapp %q"
+msgstr ""
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
-"Skapa ett kryptografiskt nyckelpar som kan användas för att signera asserts."
 
 msgid "Create cryptographic key pair"
-msgstr "Skapa kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Create snap build assertion"
-msgstr "Skapa snap-bygges-assert"
+msgstr ""
 
 msgid "Create snap-build assertion for the provided snap file."
-msgstr "Skapa snap-bygges-assert för den givna snap-filen."
+msgstr ""
 
 msgid "Creates a local system user"
-msgstr "Skapar en lokal systemanvändare"
+msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr "Radera kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Delete the local cryptographic key pair with the given name."
-msgstr "Radera det lokala kryptografiska nyckelparet med det givna namnet."
+msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr "Inaktivera %q-snap"
+msgstr ""
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr "Avaktivera alias för snapp %q"
+msgstr ""
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr "Avaktiverar alla alias för snap %q"
+msgstr ""
 
 msgid "Disables a snap in the system"
-msgstr "Avaktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
@@ -389,44 +383,41 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr "Vänta inte på att åtgärden ska slutföras, skriv bara ut ändrat ID."
+msgstr ""
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr "Ladda ned snapp %q%s från kanal %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
-"Hämta den givna revisionen av en snap, för vilket du behöver utvecklaråtkomst"
 
 msgid "Downloads the given snap"
-msgstr "Hämtar angiven snap"
+msgstr ""
 
 msgid "Email address: "
-msgstr "E-postadress: "
+msgstr ""
 
 #, c-format
 msgid "Enable %q snap"
-msgstr "Aktivera %q-snap"
+msgstr ""
 
 msgid "Enables a snap in the system"
-msgstr "Aktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr "Säkerställ att allt som %q kräver finns tillgängligt"
+msgstr ""
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
-"Exportera en öppen nyckel assert-nyttolast som kan importeras av andra "
-"system."
 
 msgid "Export cryptographic public key"
-msgstr "Exportera kryptografisk öppen nyckel"
+msgstr ""
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
@@ -434,40 +425,38 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr "Hämtar asserts för %q\n"
+msgstr ""
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr "Hämtar snap %q\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr "Filnamn för snap du vill försäkra ett bygge för"
+msgstr ""
 
 msgid "Finds packages to install"
-msgstr "Söker efter paket att installera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr "Tvinga tillägg av användare, även om enheten redan hanteras"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr "Tvinga import på klassiska system"
+msgstr ""
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
-"Formatera öppet nyckelmaterial som en begäran för en kontonyckel för detta "
-"konto-ID"
 
 msgid "Generate device key"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr "Generera manualsidan"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
@@ -475,25 +464,25 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr "Bevilja sudo-åtkomst för den skapade användaren"
+msgstr ""
 
 msgid "Help"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr "Krok att köra"
+msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr "Signerarens identifierare"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr "Identifierare för snap-paket associerat med bygge"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
@@ -501,7 +490,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr "Ignorera validering av andra snap-paket som blockerar uppdatering"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -510,73 +499,65 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
-"För att köpa %q, måste du godkänna de senaste villkoren. Gå till "
-"https://my.ubuntu.com/payment/edit för att göra detta.\n"
-"\n"
-"När du är färdig, kom tillbaka hit och kör \"snap buy %s\" igen."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
-"Inkludera en utförlig lista över ett snap-pakets anteckningar (annars "
-"sammanfattas anteckningar)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr "Inkludera gränssnitt som inte används"
+msgstr ""
 
 msgid "Initialize device"
 msgstr ""
 
 msgid "Inspects devices for actionable information"
-msgstr "Inspekterar enheter för användbar information"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installera snap-paketet %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr "Installera snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installera snap  %q från fil"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installera snap %q från fil %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installera från betakanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installera från kandidatkanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installera från spetskanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installera från stabila kanalen"
+msgstr ""
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installera snap %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installera snap-paket %s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installera den givna revisionen av en snap, för vilket du behöver ha "
-"utvecklaråtkomst"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -584,14 +565,10 @@ msgid ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installera den givna snap-filen även om det inte finns några tidigare kända "
-"signaturer för den, vilket innebär att den inte verifierades och kan vara "
-"farlig (--devmode antar detta)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installera det givna snap-paketet utan att aktivera dess automatiska alias"
 
 #, c-format
 msgid ""
@@ -599,118 +576,113 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
-"Installera snappen med:\n"
-"   snap ack %s\n"
-"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr "Installerar en snap i systemet"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr "Nyckel av intresse bland konfigurationen"
+msgstr ""
 
 msgid "List a change's tasks"
-msgstr "Lista en ändrings uppgifter"
+msgstr ""
 
 msgid "List cryptographic keys"
-msgstr "Lista kryptografiska nycklar"
+msgstr ""
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
-"Lista kryptografiska nycklar som kan användas för att signera försäkran."
 
 msgid "List installed snaps"
-msgstr "Lista installerade snap-paket"
+msgstr ""
 
 msgid "List system changes"
-msgstr "Lista systemändringar"
+msgstr ""
 
 msgid "Lists aliases in the system"
-msgstr "Lista alias i systemet"
+msgstr ""
 
 msgid "Lists all repairs"
-msgstr "Lista alla reparationer"
+msgstr ""
 
 msgid "Lists interfaces in the system"
-msgstr "Lista gränssnitt i systemet"
+msgstr ""
 
 msgid "Lists snap interfaces"
-msgstr "Lista snap-gränssnitt"
+msgstr ""
 
 msgid "Log out of the store"
-msgstr "Logga ut från butiken"
+msgstr ""
 
 msgid "Login successful"
-msgstr "Inloggning lyckades"
+msgstr ""
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr "Gör aktuell revision för snapp %q otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr "Gör snapp %q (%s) tillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr "Gör snapp %q (%s) otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr "Gör snapp %q otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr "Gör snapp %q%s tillgänglig för systemet"
+msgstr ""
 
 msgid "Mark system seeded"
 msgstr ""
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr "Montera snapp %q%s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr "Nyckelnamn att skapa; förval är \"default\""
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr "Nyckelnamn att radera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr "Nyckelnamn att exportera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
-"Namnet som GnuPG-nyckeln ska använda (förvalt nyckelnamn är \"default\")"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Nyckelnamn att använda, annars används förvald nyckel"
+msgstr ""
 
 msgid "Name\tSHA3-384"
-msgstr "Namn\tSHA3-384"
+msgstr ""
 
 msgid "Name\tSummary"
-msgstr "Namn\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr "Namn\tVersion\tUtvecklare\tAnteckningar\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr "Namn\tVersion\tRev\tUtvecklare\tAnteckningar"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr "Inga alias är definierade för snapp %q.\n"
+msgstr ""
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -732,31 +704,28 @@ msgstr ""
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr "Inga matchande snappar för %q i avsnitt %q\n"
+msgstr ""
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr "Inga matchande snappar för %q\n"
+msgstr ""
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
-"Ingen sökterm angiven. Här är några snappar att titta närmare på:\n"
-"\n"
 
 msgid "No section specified. Available sections:\n"
 msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
-"Inga snap-paket har installerats än. Testa \"snap install hello-world\"."
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr "Utdata resulterar i JSON-format"
+msgstr ""
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -766,11 +735,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr "Lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Password of %q: "
-msgstr "Lösenord för %q: "
+msgstr ""
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -778,212 +747,210 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
-"Ange ditt Ubuntu One-lösenord igen för att köpa %q från %q\n"
-"för %s. Tryck ctrl-C för att avbryta."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr "Föredra alias från en snap och inaktivera konflikter"
+msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prepare a snappy image"
-msgstr "Förbered en snappy-avbild"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr "Förbered snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr "Förbered snap %q%s"
+msgstr ""
 
 msgid "Print the version and exit"
-msgstr "Skriv ut version och avsluta"
+msgstr ""
 
 msgid "Prints configuration options"
-msgstr "Skriver ut konfigurationsalternativ"
+msgstr ""
 
 msgid "Prints the confinement mode the system operates in"
-msgstr "Skriver ut vilket inneslutningsläge systemet arbetar i"
+msgstr ""
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr "Skriver ut huruvida systemet är hanterat"
+msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr "Städa upp automatiska alias för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr "Sätt snap i klassiskt läge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr "Sätt snap i utvecklarläge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr "Sätt snap i bevakat inneslutningsläge"
+msgstr ""
 
 msgid "Query the status of services"
-msgstr "Undersök status för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr "Förnya snap %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr "Förnya snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr "Förnya alias för snap %q"
+msgstr ""
 
 msgid "Refresh all snaps: no updates"
-msgstr "Förnya alla snappar: inga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr "Förnya snapp %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr "Uppdatera snappar %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr "Förnya snappar %s: inga uppdateringar"
+msgstr ""
 
 msgid "Refresh to the given revision"
-msgstr "Uppdatera den givna revisionen"
+msgstr ""
 
 msgid "Refreshes a snap in the system"
-msgstr "Uppdaterar en snap i systemet"
+msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr "Ta bort alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr "Ta bort data för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr "Ta bort manuellt alias %q för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr "Ta endast bort den angivna revisionen"
+msgstr ""
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr "Ta bort säkerhetsprofil för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr "Ta bort säkerhetsprofiler för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr "Ta bort snap %q (%s) från systemet"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr "Ta bort snapp-paketen %s"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr "Borttagen"
+msgstr ""
 
 msgid "Removes a snap from the system"
-msgstr "Tar bort en snap från systemet"
+msgstr ""
 
 msgid "Request device serial"
-msgstr "Begär enhetens serienummer"
+msgstr ""
 
 msgid "Restart services"
-msgstr "Starta om tjänster"
+msgstr ""
 
 msgid "Restarted.\n"
-msgstr "Omstartad.\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr "Begränsa sökningen till ett givet avsnitt"
+msgstr ""
 
 msgid "Retrieve logs of services"
-msgstr "Hämta logg för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr "Rulla tillbaka snap %q"
+msgstr ""
 
 msgid "Reverts the given snap to the previous state"
-msgstr "Rulla tillbaka det givna snap-paketet till föregående tillstånd"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr "Kör ett skal istället för kommandot (hjälper vid felsökning)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr "Kör som en tidmätartjänst med ett givet schema"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr "Kör konfigureringskrok för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr "Kör konfigureringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr "Kör krok %s för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr "Kör installeringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr "Kör post-förnyelsekrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr "Kör förbered-enhets-krok"
+msgstr ""
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr "Kör borttagningskrok för snap %q om den finns"
+msgstr ""
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
@@ -995,54 +962,52 @@ msgid "Run the command with gdb"
 msgstr ""
 
 msgid "Run the given snap command"
-msgstr "Kör det givna snap-kommandot"
+msgstr ""
 
 msgid "Run the given snap command with the right confinement and environment"
-msgstr "Kör det givna snap-kommandot med korrekt inneslutning och miljö"
+msgstr ""
 
 msgid "Runs debug commands"
-msgstr "Kör felsökningskommandon"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr "Sök privata snap-paket"
+msgstr ""
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
-"Välj senaste ändring av given typ (installera, förnya, ta bort, testa, auto-"
-"förnya osv.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr "Ange automatiska alias för snap %q"
+msgstr ""
 
 msgid "Sets up a manual alias"
-msgstr "Anger ett manuellt alias"
+msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr "Ställ in alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr "Ställ in manuellt alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr "Ställ in säkerhetsprofiler för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr "Ställ in alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr "Ställ in säkerhetsprofiler för snapp %q%s"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
@@ -1103,7 +1068,7 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr "Snappnamn"
+msgstr ""
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
@@ -1116,14 +1081,14 @@ msgstr ""
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr "Starta tjänster från snapp %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr "Starta snapp %q%s-tjänster"
+msgstr ""
 
 msgid "Start snap services"
-msgstr "Starta snapptjänster"
+msgstr ""
 
 msgid "Start the userd service"
 msgstr ""
@@ -1139,21 +1104,21 @@ msgstr ""
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr "Stoppa snapp %q (%s)-tjänster"
+msgstr ""
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr "Stoppa snapp %q-tjänster"
+msgstr ""
 
 msgid "Stop snap services"
-msgstr "Stoppa snapptjänster"
+msgstr ""
 
 msgid "Stopped.\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr "Strikt inmatning med tomma och citerade strängar"
+msgstr ""
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1168,7 +1133,7 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr "Växlar snapp till en annan kanal"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
@@ -1183,8 +1148,6 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
-"Tack för att du köpte %q. Du kan nu installera det på valfri enhet med\n"
-"kommandot \"snap install %s\"."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
@@ -1192,7 +1155,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "E-postadress på login.ubuntu.com att logga in som"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
@@ -1209,11 +1172,11 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr "Snapp att konfigurera (t.ex. hello-world)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr "Snappen vars konf begärs"
+msgstr ""
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1226,10 +1189,10 @@ msgstr ""
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr "Växla snapp %q-flaggor"
+msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr "Verktyg för att interagera med snappar"
+msgstr ""
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
@@ -1240,20 +1203,20 @@ msgstr ""
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr "Testa snapp %q från %s"
+msgstr ""
 
 msgid "Try: snap install <selected snap>\n"
-msgstr "Testa: snap install <vald snapp>\n"
+msgstr ""
 
 msgid "Two-factor code: "
-msgstr "Två-faktor kod: "
+msgstr ""
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr "Använd en specifik snapprevision när krok körs"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
@@ -1308,11 +1271,6 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
-"Du måste ha en betalningsmetod associerad med ditt konto för att kunna köpa "
-"en snapp. Besök https://my.ubuntu.com/payment/edit för att lägga till en.\n"
-"\n"
-"När du har lagt till betalningsinformationen behöver du bara köra \"snap buy "
-"%s\" igen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1400,8 +1358,6 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
-"\n"
-"Kommandot buy köper en snapp från butiken.\n"
 
 msgid ""
 "\n"
@@ -1457,11 +1413,6 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
-"\n"
-"Kommandot debug innehåller ett urval av ytterligare delkommandon.\n"
-"\n"
-"Felsökningskommandon kan tas bort utan aviseringar och kanske inte\n"
-"fungerar på icke-utvecklarsystem.\n"
 
 msgid ""
 "\n"
@@ -1496,8 +1447,6 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
-"\n"
-"Kommandot enable aktiverar en snapp som tidigare avaktiverats.\n"
 
 msgid ""
 "\n"
@@ -1587,12 +1536,6 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
-"\n"
-"Kommandot interface visar detaljer om snappars gränssnitt.\n"
-"\n"
-"Om inget gränssnittsnamn anges kommer en lista över gränssnittsnamn\n"
-"med minst en anslutning att visas, eller en lista över alla gränssnitt om\n"
-"--all anges.\n"
 
 msgid ""
 "\n"
@@ -1651,9 +1594,6 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
-"\n"
-"Kommandot managed kommer att skriva ut true eller false, vilket visar\n"
-"huruvida snapd har registrerat användare.\n"
 
 msgid ""
 "\n"
@@ -1705,15 +1645,11 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
-"\n"
-"Kommandot repair visar detaljer om en eller flera reparationer.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
-"\n"
-"Kommandot repairs listar alla utförda reparationer för den här enheten.\n"
 
 msgid ""
 "\n"
@@ -1721,11 +1657,6 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot restart startar om de givna tjänsterna i snappen. Om det körs "
-"från\n"
-"kroken \"configure\" kommer tjänsterna att startas om efter att kroken "
-"slutförs."
 
 msgid ""
 "\n"
@@ -1764,18 +1695,6 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
-"\n"
-"Kommandot set ändrar de givna konfigurationsalternativen enligt begäran.\n"
-"\n"
-"    $ snap set snappnamn username=frank password=$PASSWORD\n"
-"\n"
-"Alla konfigurationsändringar är omedelbart bestående, och sparas endast "
-"efter\n"
-"att snappens konfigurationskrok slutförs med lyckat resultat.\n"
-"\n"
-"Nästlade värden kan ändras via en prickad sökväg:\n"
-"\n"
-"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1803,41 +1722,28 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot start startar de angivna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att startas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot start startar, och eventuellt aktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot stop stoppar de givna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att stoppas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot stop stoppar, och eventuellt avaktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
-"\n"
-"Kommandot switch växlar den givna snappen till en annan kanal utan att\n"
-"göra en förnyelse.\n"
 
 msgid ""
 "\n"
@@ -1872,9 +1778,6 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
-"\n"
-"Kommandot version visar versionerna för den aktiva klienten, servern,\n"
-"och operativsystemet.\n"
 
 msgid ""
 "\n"
@@ -1882,10 +1785,6 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
-"\n"
-"Kommandot watch väntar på att den givna ändrings-ID:n ska slutföras, och "
-"visar\n"
-"förloppet (om tillgängligt).\n"
 
 msgid ""
 "\n"
@@ -1904,14 +1803,6 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
-"\n"
-"Den här revisionen av snapp %q utgavs med klassisk inneslutning, och kan "
-"därför\n"
-"utföra godtyckliga systemändringar utanför den säkerhetssandlåda som "
-"snappar\n"
-"normalt avgränsas till, vilket kan utgöra en risk för ditt system.\n"
-"\n"
-"Om du förstår och vill fortsätta, upprepa kommandot med --classic.\n"
 
 msgid ""
 "\n"
@@ -1920,26 +1811,25 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
-"ett enstaka snappnamn behövs för att specificera läges- eller kanalflaggor"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr "ett enstaka snappnamn behövs för att specificera revision"
+msgstr ""
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr "ett enstaka snappnamn måste specificeras när validering ignoreras"
+msgstr ""
 
 msgid "active"
-msgstr "aktiv"
+msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr "köpt"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr "trasig"
+msgstr ""
 
 #, c-format
 msgid "cannot %s without a context"
@@ -1947,18 +1837,18 @@ msgstr ""
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr "kan inte köpa snapp: %v"
+msgstr ""
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr "kan inte köpa snapp: ogiltiga tecken i namnet"
+msgstr ""
 
 msgid "cannot buy snap: it has already been bought"
-msgstr "kan inte köpa snapp: den har redan köpts"
+msgstr ""
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr "kan inte skapa %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot create assertions file: %v"
@@ -1967,50 +1857,50 @@ msgstr ""
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr "kan inte extrahera snappnamn från lokal fil %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr "kan inte hitta program %q i %q"
+msgstr ""
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr "kan inte hitta krok %q i %q"
+msgstr ""
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr "kan inte hämta data för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr "kan inte hämta full sökväg för %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr "kan inte hämta aktuell användare: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr "kan inte hämta aktuell användare: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr "kan inte märka uppstart lyckad: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr "kan inte öppna försäkringsdatabasen: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr "kan inte läsa försäkransindata: %v"
+msgstr ""
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr "kan inte läsa symlänk: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
@@ -2022,87 +1912,86 @@ msgstr ""
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr "kan inte uppdatera \"aktuell\" symlänk för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr "kan inte använda nyckeln %q: %v"
+msgstr ""
 
 msgid "cannot use change ID and type together"
-msgstr "kan inte använda ändrings-ID och typ tillsammans"
+msgstr ""
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr "kan inte använda devmode- och jailmode-flaggorna tillsammans"
+msgstr ""
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr "kan inte validera ägare av filen %s"
+msgstr ""
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr "kan inte skriva ny Xauthority-fil på %s: %s"
+msgstr ""
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr "ändring slutförd i status %q utan felmeddelande"
+msgstr ""
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
-"klassisk inneslutning kräver snappar i /snap eller symlänk från /snap till %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr "skapade användare %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr "d"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr "avaktiverad"
+msgstr ""
 
 msgid "email:"
-msgstr "e-post:"
+msgstr ""
 
 msgid "enabled"
-msgstr "aktiverad"
+msgstr ""
 
 #, c-format
 msgid "error: %v\n"
-msgstr "fel: %v\n"
+msgstr ""
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr "fel: argumentet \"<snap-dir>\" angavs inte och kunde inte antydas"
+msgstr ""
 
 msgid "get which option?"
-msgstr "hämta vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr "t"
+msgstr ""
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr "inaktiv"
+msgstr ""
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr "gränssnittsattribut kan bara läsas när gränssnittskrokarna körs"
+msgstr ""
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
-msgstr "gränssnittsattribut kan bara sättas när förberedelsekrokarna körs"
+msgstr ""
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr "internt fel, var god rapportera: kunde inte köra %q: %v\n"
+msgstr ""
 
 msgid "internal error: cannot find attrs task"
 msgstr ""
@@ -2125,69 +2014,67 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr "ogiltig konfiguration: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr "ogiltigt huvudfilter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr "ogiltig parameter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr "ogiltigt värde: %q (vill ha snap:namn eller snapp)"
+msgstr ""
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
-"nyckelnamnet %q är ogiltigt; endast ASCII-tecken, siffror, och streck tillåts"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
-"lokal snapp %q är okänd för butiken; använd --amend för att fortsätta ändå"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr "m"
+msgstr ""
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr "kräver att programmet körs som argument"
+msgstr ""
 
 msgid "no changes found"
-msgstr "hittade inga ändringar"
+msgstr ""
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr "hittade inga ändringar av typen %q"
+msgstr ""
 
 msgid "no interfaces currently connected"
-msgstr "inga gränssnitt anslutna just nu"
+msgstr ""
 
 msgid "no interfaces found"
-msgstr "inga gränssnitt hittades"
+msgstr ""
 
 msgid "no matching snaps installed"
-msgstr "inga matchande snappar installerade"
+msgstr ""
 
 msgid "no such interface"
-msgstr "inget sådant gränssnitt"
+msgstr ""
 
 msgid "no valid snaps given"
-msgstr "inga giltiga snappar angivna"
+msgstr ""
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr "ange ändrings-ID eller typ med --last=<typ>"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr "privat"
+msgstr ""
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2195,19 +2082,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr "reparationer är inte tillgängliga på ett klassiskt system"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr "s"
+msgstr ""
 
 #, c-format
 msgid "set failed: %v"
-msgstr "set misslyckades: %v"
+msgstr ""
 
 msgid "set which option?"
-msgstr "sätt vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2221,7 +2108,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr "snapp %q har inga tillgängliga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2229,30 +2116,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr "snapp %q finns inte"
+msgstr ""
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr "snapp är gratis"
+msgstr ""
 
 msgid "too many arguments for command"
-msgstr "för många argument för kommandot"
+msgstr ""
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr "för många argument för krok %q: %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr "för många argument: %s"
+msgstr ""
 
 msgid "unable to contact snap store"
-msgstr "kan inte kontakta snap store"
+msgstr ""
 
 msgid "unavailable"
-msgstr "otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2268,31 +2155,30 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr "okänd tjänst: %q"
+msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr "varning:\tingen snapp hittades för %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr "å"
+msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr "Autentisera mot snapp-daemon"
+msgstr ""
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr "Identitskontroll krävs för att autentisera mot snapp-daemonen"
+msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr "Installera, uppdatera eller ta bort paket"
+msgstr ""
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
-"Autentisering krävs för att installera, uppdatera, eller ta bort paket"
 
 msgid "Connect, disconnect interfaces"
-msgstr "Anslut, koppla bort gränssnitt"
+msgstr ""
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr "Autentisering krävs för att ansluta eller koppla bort gränssnitt"
+msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,9 +24,10 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q vaihdettiin %q -kanavalle\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
@@ -70,7 +71,7 @@ msgstr "%s poistettu\n"
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr ""
+msgstr "%s palautettiin %s\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
@@ -90,7 +91,7 @@ msgstr "%s%s %s asennettu\n"
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr ""
+msgstr "%s%s versio %s päivitettiin\n"
 
 msgid "--list does not take mode nor channel flags"
 msgstr ""
@@ -99,98 +100,100 @@ msgid "--time does not take mode nor channel flags"
 msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr ""
+msgstr "-r voidaan käyttää vain valinnan --hook kanssa"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr ""
+msgstr "<alias-tai-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr ""
+msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr ""
+msgstr "<julistustiedosto>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr ""
+msgstr "<julistuksen tyyppi>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr ""
+msgstr "<vaihto-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr ""
+msgstr "<konfiguraation arvo>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr ""
+msgstr "<sähköposti>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr ""
+msgstr "<tiedostonimi>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr ""
+msgstr "<otsikkosuodatin>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr ""
+msgstr "<rajapinta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr ""
+msgstr "<avaimen-nimi>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr ""
+msgstr "<avain>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr ""
+msgstr "<pyyntö>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr ""
+msgstr "<juurihakemisto>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<palvelu>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr ""
+msgstr "<snap>:<liitäntä>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
 
 msgid "Abort a pending change"
-msgstr ""
+msgstr "Peruuta odottavat muutokset"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Lisätty"
 
@@ -200,59 +203,67 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr ""
+msgstr "Alias argumentille --dangerous (VANHENTUNUT)"
 
 msgid "All snaps up to date."
 msgstr "Kaikki snapit ovat ajan tasalla."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Hyväksy tiedoston avaaminen?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Hyväksy asetusten muuttaminen?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Sallitko sen, että snap %q vaihtaa %q muotoon %q ?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Sallitko sen, että snap %q avaa tiedoston %q?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr ""
+msgstr "Vaihtoehtoinen komento suoritettavaksi"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -261,16 +272,16 @@ msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
-msgstr ""
+msgstr "Automaattisesti päivitä %d snappia"
 
 #, c-format
 msgid "Auto-refresh snap %q"
-msgstr ""
+msgstr "Automaattisesti päivitä snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Auto-refresh snaps %s"
-msgstr ""
+msgstr "Automaattisesti päivitä snapit %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -290,14 +301,14 @@ msgid "Changes configuration options"
 msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr ""
+msgstr "Komento\tAlias\tHuomiot"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr ""
+msgstr "Varmista salalause: "
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -306,20 +317,21 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr ""
+msgstr "Kopioi snapin %q data"
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
@@ -345,15 +357,15 @@ msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr ""
+msgstr "Poista käytöstä snap %q"
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr ""
+msgstr "Poista käytöstä aliasit snapilta %q"
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr ""
+msgstr "Poista käytöstä kaikki aliasit snapilta %q"
 
 msgid "Disables a snap in the system"
 msgstr ""
@@ -364,11 +376,12 @@ msgstr ""
 
 #, c-format
 msgid "Disconnect %s:%s from %s:%s"
-msgstr ""
+msgstr "Katkaise yhteys %s:%s kohteesta %s:%s"
 
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -389,7 +403,7 @@ msgstr "Sähköpostiosoite: "
 
 #, c-format
 msgid "Enable %q snap"
-msgstr ""
+msgstr "Ota käyttöön snap %q"
 
 msgid "Enables a snap in the system"
 msgstr ""
@@ -411,22 +425,24 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr ""
+msgstr "Haetaan julistukset kohteelle %q\n"
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr ""
+msgstr "Haetaan snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -436,35 +452,43 @@ msgid ""
 msgstr ""
 
 msgid "Generate device key"
-msgstr ""
+msgstr "Luo laiteavain"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Luo man-sivu"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr ""
+msgstr "Anna sudo-oikeudet luodulle käyttäjälle"
 
 msgid "Help"
 msgstr "Ohje"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Tunniste\tTila\tMuodostettu\tValmis\tYhteenveto\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Asenna betakanavalta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Asenna ehdokaskanavalta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Asenna edge-kanavalta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Asenna vakaalta kanavalta"
 
@@ -525,16 +554,19 @@ msgstr "Asenna snap %q"
 msgid "Install snaps %s"
 msgstr "Asenna snapit %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Poistettavan avaimen nimi"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Vietävän avaimen nimi"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr "Snapeja ei ole vielä asennettu. Yritä \"snap install hello-world\"."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr "Poista snapit %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Poistettu"
 
@@ -858,6 +899,7 @@ msgstr "Käynnistä uudelleen palvelut"
 msgid "Restarted.\n"
 msgstr "Käynnistetty uudelleen.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Snapin nimi"
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr "Pysäytetty.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr "Vaihtaa snapin eri kanavaan"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1103,15 +1155,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1119,11 +1171,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1163,15 +1216,18 @@ msgstr "Kaksivaiheinen koodi: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Käytä tätä kanavaa vakaan kanavan sijaan"
 
@@ -1184,6 +1240,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 
@@ -2075,7 +2132,7 @@ msgid "snap is free"
 msgstr "snap on ilmainen"
 
 msgid "too many arguments for command"
-msgstr ""
+msgstr "liian monta argumenttia komennolle"
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
@@ -2085,13 +2142,13 @@ msgstr ""
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr ""
+msgstr "liian monta argumenttia: %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "snap-varastoon yhdistäminen epäonnistui"
 
 msgid "unavailable"
-msgstr ""
+msgstr "ei saatavilla"
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2118,7 +2175,7 @@ msgid "y"
 msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr ""
+msgstr "Autentikoi snap-taustaprosessissa"
 
 msgid "Authorization is required to authenticate on the snap daemon"
 msgstr ""
@@ -2131,7 +2188,7 @@ msgstr ""
 "Pakettien asentaminen, päivittäminen tai poistaminen vaatii tunnistautumisen"
 
 msgid "Connect, disconnect interfaces"
-msgstr ""
+msgstr "Yhdistä, katkaise yhteys liitännöistä"
 
 msgid "Authentication is required to connect or disconnect interfaces"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Essayez « snapcraft prime » dans votre répertoire de projet, puis à nouveau "
 "« snap try »."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q commuté sur le canal %q\n"
@@ -105,96 +106,100 @@ msgstr "--time n'accepte pas les options mode et/ou canal"
 msgid "-r can only be used with --hook"
 msgstr "-r ne peut être utilisé qu'avec --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias ou paquet Snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<fichier d'assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<type d'assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<identifiant de changement>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<valeur de configuration>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<courriel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<nom du fichier>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<filtre d'en-tête>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<interface>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nom de la clé>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<clé>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<modèle d'assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<requête>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<répertoire racine>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<connecteur>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<prise ou connecteur>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<prise>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
+"Une spécification de service, pouvant être juste un nom de snap (pour tous "
+"les services dans le snap), ou <snap>.<app> pour un service unique."
 
 msgid "Abort a pending change"
 msgstr "Annuler un changement en attente"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Ajouté"
 
@@ -204,9 +209,11 @@ msgstr "Ajoute une assertion au système"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias pour --dangerous (OBSOLÈTE)"
 
@@ -216,6 +223,7 @@ msgstr "Tous les paquets Snaps sont à jour."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +238,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Commande alternative à « run »"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Toujours retourner un document, même avec une clé unique"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Toujours retourner la liste, même avec une clé unique"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Fichier d'assertion"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Nom du type d'assertion"
 
@@ -286,7 +299,7 @@ msgstr "Code faux. Réessayez : "
 msgid "Buys a snap"
 msgstr "Achète un paquet Snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Changer l'identifiant"
 
@@ -296,7 +309,7 @@ msgstr "Modifie les options de configuration"
 msgid "Command\tAlias\tNotes"
 msgstr "Commande\tAlias\tNotes"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Valeur de configuration (clé=valeur)"
 
@@ -310,14 +323,15 @@ msgstr "Connecter %s:%s à %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Connecte un connecteur à une prise"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Limite la liste à un paquet Snap spécifique ou snap:nom"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Limite la liste à des interfaces spécifiques"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Limite la liste aux éléments correspondant à en-tête=valeur"
 
@@ -378,6 +392,7 @@ msgstr "Déconnecter %s:%s de %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Déconnecte un connecteur d'une prise"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 "Ne pas attendre la fin de l'opération, mais afficher simplement "
@@ -387,6 +402,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr "Télécharger un paquet Snap %q%s à partir du canal %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -432,7 +448,7 @@ msgstr "Récupération des assertions pour %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Récupération du paquet Snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 "Le nom du fichier du paquet Snap pour lequel vous voulez définir une version"
@@ -440,10 +456,12 @@ msgstr ""
 msgid "Finds packages to install"
 msgstr "Trouve les paquets à installer"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 "Forcer l'ajout de l'utilisateur, même si l'appareil est déjà administré"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Forcer l'importation dans les systèmes classiques"
 
@@ -457,34 +475,42 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Générer la clé du périphérique"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Générer les page de manuel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 "Le grade indique la qualité de version du paquet Snap (« stable » par défaut)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Accorder les accès administrateur à l'utilisateur créé"
 
 msgid "Help"
 msgstr "Aide"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Point d'accroche à exécuter"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "Identifiant\tÉtat\tDescendance\tPrêt\tRésumé\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Identifiant du signataire"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identifiant du paquet Snap associé à la version"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 "Ignorer la validation par d'autres paquets Snap bloquant l'actualisation"
@@ -506,6 +532,7 @@ msgstr ""
 "Inclure une liste détaillée des notes d'un paquet Snap (résume les notes "
 "dans le cas contraire)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Inclure les interfaces inutilisées"
 
@@ -531,15 +558,19 @@ msgstr "Installer le paquet Snap %q à partir du fichier"
 msgid "Install %q snap from file %q"
 msgstr "Installer le paquet Snap %q à partir du fichier %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Installer à partir du canal bêta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Installer à partir du canal candidat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Installer à partir du canal avancé"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Installer à partir du canal stable"
 
@@ -552,12 +583,14 @@ msgstr "Installer le paquet Snap %q"
 msgid "Install snaps %s"
 msgstr "Installer les paquets Snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Installer la révision donnée d'un paquet Snap, auquel vous devez avoir les "
 "accès développeur"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -567,6 +600,7 @@ msgstr ""
 "préalablement pour celui-ci, ce qui signifie qu'il n'a pas été vérifié et "
 "pourrait être dangereux (--devmode implique cela)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr "Installer le snap donné sans activer ses alias automatiques"
 
@@ -580,8 +614,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Installe un paquet Snap sur le système"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Clef d'intérêt dans le cadre de la configuration"
 
@@ -647,21 +681,23 @@ msgstr "Marquer le système comme préparé"
 msgid "Mount snap %q%s"
 msgstr "Monter le paquet Snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Nom de la clé à créer ; « default » par défaut"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Nom de la clé à supprimer"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Nom de la clé à exporter"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr "Nom de la clé GnuPG à utiliser (nom de clé « default » par défaut)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Nom de la clé à utiliser, utilisation de la clé par défaut autrement"
 
@@ -685,7 +721,7 @@ msgid "No aliases are currently defined for snap %q.\n"
 msgstr ""
 
 msgid "No aliases are currently defined."
-msgstr ""
+msgstr "Aucun alias n'est actuellement défini."
 
 #, c-format
 msgid "No command %q found, did you mean:\n"
@@ -698,32 +734,39 @@ msgstr ""
 #, c-format
 msgid "No matching section %q, use --section to list existing sections"
 msgstr ""
+"Aucune section %q correspondante, utilisez --section pour lister les "
+"sections existantes"
 
 #. TRANSLATORS: the first %q is the (quoted) query, the
 #. second %q is the (quoted) name of the section the
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr ""
+msgstr "Aucun snap correspondant à %q dans la section %q\n"
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr ""
+msgstr "Aucun snap correspondant à %q\n"
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
+"Aucun terme de recherche n'a été spécifié. Voici quelques snaps "
+"intéressants :\n"
+"\n"
 
 msgid "No section specified. Available sections:\n"
-msgstr ""
+msgstr "Aucune section spécifiée. Sections disponibles :\n"
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 "Aucun paquet Snap n'est encore installé. Essayez « snap install hello-"
 "world »."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Résultats de sortie en format JSON"
 
@@ -732,7 +775,7 @@ msgstr ""
 
 #, c-format
 msgid "Packages matching %q:\n"
-msgstr ""
+msgstr "Paquets en concordance avec %q :\n"
 
 msgid "Passphrase: "
 msgstr "Phrase de passe : "
@@ -794,16 +837,19 @@ msgstr "Indique si le système est géré"
 msgid "Prune automatic aliases for snap %q"
 msgstr "Enlever les alias automatiques pour le paquet Snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 "Placer le paquet Snap en mode classique et désactiver le confinement de "
 "sécurité"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 "Placer le paquet Snap en mode développement et désactiver le confinement de "
 "sécurité"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Placer le paquet Snap en mode de confinement forcé"
 
@@ -861,6 +907,7 @@ msgstr "Supprimer les données du paquet Snap %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr "Supprime l'alias manuel %q pour le paquet Snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Supprimer uniquement la révision donnée"
 
@@ -885,6 +932,7 @@ msgstr "Supprimer le paquet Snap %q (%s) du système"
 msgid "Remove snaps %s"
 msgstr "Supprimer les paquets Snap %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Supprimé"
 
@@ -900,6 +948,7 @@ msgstr "Redémarrer les services"
 msgid "Restarted.\n"
 msgstr "Redémarré.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Restreindre la recherche à une section donnée"
 
@@ -913,9 +962,11 @@ msgstr "Rétablir le paquet Snap %q"
 msgid "Reverts the given snap to the previous state"
 msgstr "Rétablit le paquet Snap donné à son précédent état"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Exécuter un shell plutôt que la commande (utile pour le débogage)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -958,6 +1009,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -972,6 +1024,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Exécute les commandes de débogage"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Rechercher des paquets Snap privés"
 
@@ -1016,9 +1069,11 @@ msgstr "Définir les profils de sécurité du paquet Snap %q%s"
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr "Configurer les profils de sécurité du paquet Snap %q%s (phase 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Afficher toutes les révisions"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Affiche les informations de rafraîchissement automatique sans actualiser"
@@ -1031,13 +1086,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Afficher les détails d'une interface spécifique"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Afficher les attributs de l'interface"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1070,8 +1127,8 @@ msgstr "Prise\tConnecteur"
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Nom du paquet Snap"
 
@@ -1123,6 +1180,7 @@ msgstr "Arrêter les services du paquet Snap"
 msgid "Stopped.\n"
 msgstr "Stoppé.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Frappe exacte avec chaînes vides et entre guillemets"
 
@@ -1141,6 +1199,7 @@ msgstr "Basculer le snap %q sur %s"
 msgid "Switches snap to a different channel"
 msgstr "Bascule le snap sur un autre canal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Monter le périphérique temporairement avant inspection"
 
@@ -1163,15 +1222,15 @@ msgstr ""
 "La commande « get » affiche les paramètres de configuration et de "
 "l'interface de connexion."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "L'adresse électronique login.ubuntu.com avec laquelle se connecter"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Le nom du modèle d'assertion"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Le répertoire de sortie"
 
@@ -1179,11 +1238,12 @@ msgstr "Le répertoire de sortie"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "Le paquet Snap à configurer (par exemple, hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "Le paquet Snap dont la configuration est demandée"
 
@@ -1196,6 +1256,8 @@ msgstr "Cette commande déconnecte l'utilisateur actuel de la logithèque"
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
 msgstr ""
+"Cette boîte de dialogue se fermera automatiquement après 5 minutes "
+"d'inactivité."
 
 #, c-format
 msgid "Toggle snap %q flags"
@@ -1224,17 +1286,20 @@ msgstr "Code à deux facteurs : "
 msgid "Unalias a manual alias or an entire snap"
 msgstr "Supprime un alias manuel ou un paquet Snap entier"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 "Utiliser une version spécifique du paquet Snap lors de l'exécution du point "
 "d'accroche"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Utiliser les assertions connues pour la création d'utilisateur"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Utiliser ce canal plutôt que le canal stable"
 
@@ -1249,8 +1314,9 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "ATTENTION : échec de l'activation de la connexion : %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
-msgstr ""
+msgstr "Attendre de nouvelles lignes et les afficher au fur et à mesure."
 
 msgid "Waiting for server to restart"
 msgstr "En attente du redémarrage du serveur"
@@ -2240,7 +2306,7 @@ msgid "active"
 msgstr "actif"
 
 msgid "auto-refresh: all snaps are up-to-date"
-msgstr ""
+msgstr "auto-refresh : tous les snaps sont mis à jour"
 
 msgid "bought"
 msgstr "acheté"
@@ -2573,7 +2639,7 @@ msgid "too many arguments: %s"
 msgstr "trop d'arguments : %s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "impossible de contacter la logithèque de paquets Snap"
 
 msgid "unavailable"
 msgstr "indisponible"
@@ -2596,7 +2662,7 @@ msgstr "service inconnu : %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr ""
+msgstr "avertissement :\taucun snap trouvé pour %q\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"

--- a/po/gl.po
+++ b/po/gl.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -27,6 +27,7 @@ msgstr ""
 "\n"
 "Probe «snapcraft prime» no cartafol do proxecto, despois «snap try» de novo."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q cambiou á canle %q\n"
@@ -104,88 +105,89 @@ msgstr "--time non acepta sinaladores de modo nin de canle"
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-ou-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<ficheiro de aserción>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<tipo de aserción>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<cambiar-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<valor de configuración>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<correo electrónico>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<nome de ficheiro>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<filtro de cabeceira>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<interface>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<modelo-aserción>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<consulta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<directorio raíz>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<conector>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<rañura ou conector>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<rañura>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -194,6 +196,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Cancelar un cambio pendente"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Engadido"
 
@@ -203,9 +206,11 @@ msgstr "Engade unha aserción ao sistema"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias para --dangerous (DESFASADO)"
 
@@ -215,6 +220,7 @@ msgstr "Todos os snaps está actualizados."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -229,33 +235,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Orde alternativa a executar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Devolver sempre un documento, incluso cunha soa chave"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Devolver sempre unha lista, incluso cunha soa chave"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Correo electrónico dun usuario en login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Ficheiro de aserción"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Nome do tipo de aserción"
 
@@ -285,7 +296,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr "Compra unha snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -295,7 +306,7 @@ msgstr "Cambia as opcións de configuración"
 msgid "Command\tAlias\tNotes"
 msgstr "Orde\tAlias\tNotas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Valor da configuración (chave=valor)"
 
@@ -309,14 +320,15 @@ msgstr "Conectar %s:%s a %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Conecta o conector nunha rañura"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Restrinxir a lista a un snap específico ou snap:nome"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Restrinxir a lista a interfaces específicas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Restrinxir a lista ás coincidencias cabeceira=valor"
 
@@ -374,6 +386,7 @@ msgstr "Desconectar %s:%s de %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Desconecta un conector dunha rañura"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 "Non agardar a que a operación remate, simplemente imprimir o identificador "
@@ -383,6 +396,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr "Descargar o snap %q%s da canle %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -428,7 +442,7 @@ msgstr "Obtendo asercións para %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Obtendo o snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 "Nome do ficheiro do paquete snap para o que desexa definir unha versión"
@@ -436,10 +450,12 @@ msgstr ""
 msgid "Finds packages to install"
 msgstr "Busca paquetes para instalar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 "Forzar a adición do usuario incluso se o dispositivo xa está administrado"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Forzar importación en sistemas clásicos"
 
@@ -453,34 +469,42 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Xerar chave do dispositivo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Xerar o manual"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 "O grao indica a calidade da versión do snap («estábel» como predeterminada)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Conceder acceso sudo ao usuario creado"
 
 msgid "Help"
 msgstr "Axuda"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "«Hook» a executar"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "Identificador\tEstado\tDescendencia\tListo\tResumo\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Identificador do asinante"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identificador do paquete snap asociado á versión"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Ignorar a validación por outros snaps que bloquean a actualización"
 
@@ -500,6 +524,7 @@ msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 "Incluír unha lista detallada de notas dos snaps (do contrario, resumir notas)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Incluír interfaces non usadas"
 
@@ -525,15 +550,19 @@ msgstr "Instalar o snap %q desde ficheiro"
 msgid "Install %q snap from file %q"
 msgstr "Instalar o snap %q desde o ficheiro %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Instalar da canle beta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Instalar da canle candidata"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Instalar da canle avanzada"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Instalar da canle estábel"
 
@@ -546,12 +575,14 @@ msgstr "Instalar snap %q"
 msgid "Install snaps %s"
 msgstr "Instalar snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Instalar a revisión indicada dun snap, para o cal debe ter acceso de "
 "desenvolvedor"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -561,6 +592,7 @@ msgstr ""
 "el, o cal significa que non foi comprobado e podería ser perigoso (--devmode "
 "implica isto)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr "Instalar o snap indicado sen activar os seus alias automáticos"
 
@@ -574,8 +606,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Instala un snap no sistema"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Chave de interese na configuración"
 
@@ -639,22 +671,24 @@ msgstr "Marcar o sistema como propagado"
 msgid "Mount snap %q%s"
 msgstr "Montar o snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Nome da chave a crear; a predeteminación é «predeterminada»"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Nome da chave a eliminar"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Nome da chave a exportar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Nome da chave GnuPG a usar (nome da chave «predeterminada» por omisión)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Nome da chave a usar, do contrario usar a chave predeterminada"
 
@@ -715,6 +749,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr "Aínda non hai snaps instalados. Probe «snap install hello-world»."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Saída de resultados en formato JSON"
 
@@ -785,13 +821,16 @@ msgstr "Imprime se o sistema está administrado"
 msgid "Prune automatic aliases for snap %q"
 msgstr "Purgar os alias automáticos do snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Poñer snap no  modo clásico e desactivar o confinamento de seguranza"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 "Poñer snap en modo desenvolvemento e desactivar o confinamento de seguranza"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Poñer snap en modo confinamento forzado"
 
@@ -849,6 +888,7 @@ msgstr "Eliminar datos do snap %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr "Retirar o alias manual %q do snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Retirar só a revisión indicada"
 
@@ -873,6 +913,7 @@ msgstr "Eliminar o snap %q (%s) do sistema"
 msgid "Remove snaps %s"
 msgstr "Eliminar snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Retirado"
 
@@ -888,6 +929,7 @@ msgstr "Reiniciar servizos"
 msgid "Restarted.\n"
 msgstr "Reiniciado.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Restrinxir a busca a unha sección dada"
 
@@ -901,10 +943,12 @@ msgstr "Reverter %q snap"
 msgid "Reverts the given snap to the previous state"
 msgstr "Reverte o snap indicado ao estado anterior"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 "Executar un intérprete de ordes no canto da orde (útil para depuración)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -944,6 +988,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -957,6 +1002,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Executa ordes do modo depuración"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Buscar snaps privados"
 
@@ -1001,9 +1047,11 @@ msgstr "Configurar os perfís de seguranza do snap %q%s"
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr "Configurar os perfís de seguranza do snap %q%s (fase 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Mostrar todas as opinións"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Mostrar a información da actualización automática pero non realizar ningunha "
@@ -1017,13 +1065,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Mostrar os detalles dunha interface específica"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Mostrar atributos da interface"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1056,8 +1106,8 @@ msgstr "Rañura\tConector"
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Nome do snap"
 
@@ -1111,6 +1161,7 @@ msgstr "Parar os servizos do snap"
 msgid "Stopped.\n"
 msgstr "Parado.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Escritura estrita con cadeas baleiras e entre comiñas"
 
@@ -1129,6 +1180,7 @@ msgstr "Cambiar o snap %q a %s"
 msgid "Switches snap to a different channel"
 msgstr "Cambia o snap a unha canle diferente"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Montar temporalmente o dispositivo antes de inspeccionalo"
 
@@ -1149,15 +1201,15 @@ msgid ""
 msgstr ""
 "A orde «get» imprime a configuración e os axustes de conexión da interface."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "Correo electrónico de login.ubuntu.com para iniciar sesión"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Nome da aserción do modelo"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "O cartafol de saída"
 
@@ -1165,11 +1217,12 @@ msgstr "O cartafol de saída"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "O snap a configurar (p.e.: hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "O snap da configuración que está sendo solicitada"
 
@@ -1209,15 +1262,18 @@ msgstr "Código de dous factores: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr "Eliminar un alias manual ou un snap completo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr "Usar unha revisión específica do snap cando se execute o «hook»."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Usar asercións coñecidas para a creación do usuario"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Usar esta canle no canto da estábel"
 
@@ -1232,6 +1288,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "AVISO: produciuse un fallo na activación do rexistro %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Pokušajte \"snapcraft prime\" u vašem direktoriju projekta, zatim ponovno "
 "\"snap try\"."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q prebačen na %q kanal\n"
@@ -105,88 +106,89 @@ msgstr "--time ne uzima način ni oznake kanala"
 msgid "-r can only be used with --hook"
 msgstr "-r se može samo koristiti s --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<pseudonim-ili-snap paket>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<pseudonim>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<datoteka potvrde>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<naziv potvrde>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<id-promjene>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<vrijednost podešavanja>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<e-pošta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<naziv datoteke>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<filter zaglavlja>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<sučelje>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<naziv-ključa>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<ključ>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<potvrda-modela>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<zahtjev>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<korijenski-dir>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<priključak>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<priključnica ili priključak>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<priključnica>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Prekini očekivanu promjenu"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Dodano"
 
@@ -204,9 +207,11 @@ msgstr "Dodaj potvrde u sustav"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Pseudonim za --dangerous (DEPRECATED)"
 
@@ -216,6 +221,7 @@ msgstr "Svi snap paketi su nadopunjeni."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,35 +236,40 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Zamjenska naredba za pokretanje"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Uvijek vrati dokument, čak i s jednim ključem"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Uvijek vrati popis, čak i s jednim ključem"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 "Adresa e-pošte korisnika na login.ubuntu.com može sadržvati više adresa e-"
 "pošte"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Datoteka potvrde"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Naziv vrste potvrde"
 
@@ -288,7 +299,7 @@ msgstr "Netočan kôd. Pokušajte ponovno: "
 msgid "Buys a snap"
 msgstr "Kupovanje snap paketa"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "ID promjene"
 
@@ -298,7 +309,7 @@ msgstr "Promjene mogućnosti podešavanja"
 msgid "Command\tAlias\tNotes"
 msgstr "Naredba\tPseudonim\tBilješke"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Vrijednost podešavanja (ključ=vrijednost)"
 
@@ -312,14 +323,15 @@ msgstr "Povezivanje %s:%s s %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Povezuje priključak u priključnicu"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Ograniči prikazivanje na određeni snap paket ili snap:naziv"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Ograniči prikazivanje na određeno sučelje"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Ograniči prikazivanje onima koji odgovaraju zaglavlje=vrijednost"
 
@@ -377,6 +389,7 @@ msgstr "Prekidanje povezivanja %s:%s sa %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Prekidanje povezivanja priključka s priključnice"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr "Ne čekaj da radnja završi samo prikaži id promjene."
 
@@ -384,6 +397,7 @@ msgstr "Ne čekaj da radnja završi samo prikaži id promjene."
 msgid "Download snap %q%s from channel %q"
 msgstr "Preuzimam snap paket %q%s s kanala %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -429,16 +443,18 @@ msgstr "Preuzimanje potvrde za %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Preuzimanje snap paketa %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Naziv datoteke snap paketa za koji želite potvrditi izgradnju"
 
 msgid "Finds packages to install"
 msgstr "Traži pakete za instalaciju"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr "Prisilno dodavanje korisnika, čak i ako se uređajem već upravlja"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Prisili uvoz na klasičnim sustavima"
 
@@ -452,33 +468,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Generiraj ključ uređaja"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Generieaj man stranice"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr "Ocjeni stanje kvalitete izgradnje snap paketa (zadano je 'stable')"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Dopusti sudo pristup stvorenom korisniku"
 
 msgid "Help"
 msgstr "Pomoć"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Identifikator potpisnika"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identifikator snap paketa pridružen u izgradnji"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Zanemari provjeru od blokiranja osvježvanja drugih snap paketa"
 
@@ -499,6 +523,7 @@ msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 "Uključi opširan popis bilješki snap paketa (u suprotnome, sažmi bilješke)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Uključi nekorištena sučelja"
 
@@ -524,15 +549,19 @@ msgstr "Instaliraj %q snap paket iz datoteke"
 msgid "Install %q snap from file %q"
 msgstr "Instaliraj %q snap paket iz datoteke %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Instaliraj iz beta kanala"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Instaliraj iz candidate kanala"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Instaliraj iz edge kanala"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Instaliraj iz stable kanala"
 
@@ -545,12 +574,14 @@ msgstr "Instal snap paket %q"
 msgid "Install snaps %s"
 msgstr "Instaliraj snap pakete %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Instalirajte zadanu reviziju snap paketa, za koju morate imati "
 "razvijateljski pristup"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -560,6 +591,7 @@ msgstr ""
 "za nju, to znači da nije provjerena i može biti opasna (--devmode to "
 "podrazumijeva)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 "Instaliraj zadan snap paket bez omogućavanja njegovih automatskih pseudonima"
@@ -574,8 +606,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Instalira snap paket na sustav"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Ključ interesa s podešavanjem"
 
@@ -640,22 +672,24 @@ msgstr "Označi sustav zasijanim"
 msgid "Mount snap %q%s"
 msgstr "Montiram snap paket %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Naziv ključa za stvaranje; zadano je 'default'"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Naziv ključa za brisanje"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Naziv ključa za izvoz"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Naziv GnuPG ključa za korištenje (zadano je 'default' kao naziv ključa)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Naziv ključa za korištenje, u suprotnome koristi zadani ključ"
 
@@ -717,6 +751,8 @@ msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 "Još nema instaliranih snap paketa. Pokušajte \"snap install hello-world\"."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Izlazni rezultati u JSON formatu"
 
@@ -787,12 +823,15 @@ msgstr "Prikaži kako se upravlja sustavom"
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Postavi snap u klasičan način i onemogući sigurnosno ograničenje"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr "Postavi snap u razvojni način i onemogući sigurnosno ograničenje"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Postavi snap u način prisilne izolacije"
 
@@ -850,6 +889,7 @@ msgstr "Uklanjam podatke za snap paket %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr "Ukloni ručno pseudonim %q za snap paket %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Uklanjam samo zadanu reviziju"
 
@@ -874,6 +914,7 @@ msgstr "Uklanjam snap paket %q (%s) iz sustava"
 msgid "Remove snaps %s"
 msgstr "Uklanjam snap pakete %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Uklonjeno"
 
@@ -889,6 +930,7 @@ msgstr "Ponovno pokreni usluge"
 msgid "Restarted.\n"
 msgstr "Ponovno pokrenuto.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Ograniči pretragu u zadanom odjeljku"
 
@@ -902,9 +944,11 @@ msgstr "Vrati %q snap paket"
 msgid "Reverts the given snap to the previous state"
 msgstr "Vraća zadani snap paket na prijašnje stanje"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Pokreni ljusku umjesto naredbe (korisno za otklanjanje grešaka)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -945,6 +989,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -958,6 +1003,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Pokreće naredbe otklanjanja grešaka"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Pretraga privatnih snap paketa"
 
@@ -1002,9 +1048,11 @@ msgstr "Postavljam snap paket %q%s sigurnosne profile"
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr "Postavljam snap paket %q%s sigurnosne profile (faza 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Prikaži sve revizije"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Prikaži informacije automatskog osvježavanja ali ne pokreći osvježavanje"
@@ -1016,13 +1064,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Prikaži pojedinosti određenog sučelja"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Prikaži svojstva sučelja"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1055,8 +1105,8 @@ msgstr "Priključak\tPriključnica"
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Naziv snap paketa"
 
@@ -1109,6 +1159,7 @@ msgstr "Zaustavljam snap usluge"
 msgid "Stopped.\n"
 msgstr "Zaustavljeno.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Ograniči upisivanje nula i znakova navoda"
 
@@ -1127,6 +1178,7 @@ msgstr "Prebaci snap paket %q na %s"
 msgid "Switches snap to a different channel"
 msgstr "Prebaci snap paket na drugi kanal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Privremeno montiram uređaj prije provjere"
 
@@ -1148,15 +1200,15 @@ msgid ""
 msgstr ""
 "Za dobivanje podešavanje naredbi prikaza i postavki sučelja povezivanja."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "Adresa e-pošte pri login.ubuntu.com"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Naziv modela potvrđivanja"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Izlazni direktorij"
 
@@ -1164,11 +1216,12 @@ msgstr "Izlazni direktorij"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "Snap paket za podešavanje (npr. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "Snap paket čije je podešavanje zatraženo"
 
@@ -1208,15 +1261,18 @@ msgstr "Dvofaktorni kôd: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr "Ukloni ručni pseudonim ili cjelokupan snap paket"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr "Koristi određenu snap reviziju pri pokretanju kvačenja"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Koristi poznate potvrde za stvaranje korisnika"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Koristi ovaj kanal umjesto stabilnog"
 
@@ -1231,6 +1287,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "UPOZORENJE: neuspješno aktiviranje zapisivanje: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ia.po
+++ b/po/ia.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,18 +24,19 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q telah berpindah ke kanal %q\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr ""
+msgstr "%s %s dikait dari %s\n"
 
 #, c-format
 msgid "%s (delta)"
-msgstr ""
+msgstr "%s (delta)"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,14 +24,15 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q è passato al canale %q\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr ""
+msgstr "%s %s montato da %s\n"
 
 #, c-format
 msgid "%s (delta)"
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-o-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<id-modifica>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<valore conf>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<email>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<nomefile>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<interfaccia>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nome-chiave>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<chiave>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<dir-root->"
+msgstr "<dir-root>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Annulla una modifica in corso"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Aggiunta"
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr "Tutte le snap aggiornate."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Comando alternativo da eseguire"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr "Codice errato, riprovare: "
 msgid "Buys a snap"
 msgstr "Acquista una snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Id modifica"
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr "Comando\tAlias\tNote"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr "Installa snap %q da file"
 msgid "Install %q snap from file %q"
 msgstr "Installa snap %q dal file %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr "Installa snap %q"
 msgid "Install snaps %s"
 msgstr "Installa snap %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/km.po
+++ b/po/km.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,8 +193,9 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr ""
+msgstr "추가되었습니다"
 
 msgid "Adds an assertion to the system"
 msgstr ""
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -210,8 +215,9 @@ msgid "All snaps up to date."
 msgstr ""
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "파일을 여시겠습니까?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 
@@ -2066,7 +2123,7 @@ msgid "snap is free"
 msgstr ""
 
 msgid "too many arguments for command"
-msgstr ""
+msgstr "명령어에 대한 인자가 너무 많습니다"
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
@@ -2076,17 +2133,17 @@ msgstr ""
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr ""
+msgstr "인자가 너무 많습니다:%s"
 
 msgid "unable to contact snap store"
-msgstr ""
+msgstr "snap store에 연결 할 수 없습니다"
 
 msgid "unavailable"
 msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
-msgstr ""
+msgstr "알수 없는 속성 %q"
 
 #, c-format
 msgid "unknown command %q, see \"snap --help\""
@@ -2098,7 +2155,7 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr ""
+msgstr "알 수 없는 서비스:%q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
@@ -2115,13 +2172,13 @@ msgid "Authorization is required to authenticate on the snap daemon"
 msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr ""
+msgstr "패키지를 설치, 업데이트, 또는 삭제하시오"
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
 
 msgid "Connect, disconnect interfaces"
-msgstr ""
+msgstr "인터페이스를 연결, 연결 해제 하시오"
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr ""
+msgstr "인터페이스 연결 또는 연결 해제를 위해선 인증이 필요합니다."

--- a/po/lt.po
+++ b/po/lt.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<raktas>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Nutraukti laukiamą pakeitimą"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -1,16 +1,16 @@
-# Swedish translation for snapd
-# Copyright (c) 2018 Rosetta Contributors and Canonical Ltd 2018
+# Latvian translation for snapd
+# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
 # This file is distributed under the same license as the snapd package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
+"PO-Revision-Date: 2019-01-04 21:36+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Swedish <sv@li.org>\n"
+"Language-Team: Latvian <lv@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,151 +23,148 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q innehåller inte ett uppackat snap-paket.\n"
-"\n"
-"Testa \"snapcraft prime\" i din projektmapp, sedan \"snap try\" igen."
 
 #. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr "%q bytte till kanalen %q\n"
+msgstr ""
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s monterades från %s\n"
+msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr "%s (delta)"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr "%s (se \"snap login --help\")"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr "%s (försök med sudo)"
+msgstr ""
 
 #, c-format
 msgid "%s already installed\n"
-msgstr "%s är redan installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s disabled\n"
-msgstr "%s inaktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s enabled\n"
-msgstr "%s aktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s not installed\n"
-msgstr "%s inte installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s removed\n"
-msgstr "%s borttagen\n"
+msgstr ""
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr "%s återställd till %s\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
 msgid "%s%s %s from '%s' installed\n"
-msgstr "%s%s %s från \"%s\" installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr "%s%s %s från \"%s\" uppdaterad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr "%s%s %s installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr "%s%s %s uppdaterad\n"
+msgstr ""
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "--time does not take mode nor channel flags"
-msgstr "--time tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr "-r kan bara användas med --hook"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr "<alias-eller-snap>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr "<alias>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<assert-fil>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<assert-typ>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<ändra-id>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr "<konf.värde>"
+msgstr ""
 
 #. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 #. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr "<epost>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr "<filnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr "<rubrikfilter>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr "<gränssnitt>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr "<nyckelnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr "<nyckel>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr "<modell-assert>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr "<fråga>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<root-kat>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
@@ -176,48 +173,46 @@ msgstr ""
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr "<snap>:<plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr "<snap>:<slot eller plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr "<snap>:<slot>"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
-"En tjänstespecifikation, som kan vara bara ett snappnamn (för alla tjänster "
-"i snappen), eller <snapp>.<app> för en enstaka tjänst."
 
 msgid "Abort a pending change"
-msgstr "Avbryt en väntande ändring"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr "Tillagd"
+msgstr ""
 
 msgid "Adds an assertion to the system"
-msgstr "Lägger till en assert i systemet"
+msgstr ""
 
 msgid "Advise on available snaps."
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr "Informera om snappar som tillhandahåller det givna kommandot"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr "Alias för --dangerous (FÖRÅLDRAD)"
+msgstr ""
 
 msgid "All snaps up to date."
-msgstr "Alla snap-paket uppdaterade."
+msgstr ""
 
 msgid "Allow opening file?"
 msgstr ""
@@ -231,27 +226,27 @@ msgstr ""
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr "Tillåt snapp %q att ändra %q till %q ?"
+msgstr ""
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr "Tillåt snapp %q att öppna filen %q?"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr "Alternativt kommando att köra"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr "Returnera alltid dokument, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr "Returnera alltid lista, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr "En e-postadress för en användare på login.ubuntu.com"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -266,14 +261,14 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr "Assert-fil"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr "Assert-typnamn"
+msgstr ""
 
 msgid "Authenticates on snapd and the store"
-msgstr "Autentiseras på snapd och butiken"
+msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
@@ -293,27 +288,27 @@ msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr "Felaktig kod. Försök igen: "
+msgstr ""
 
 msgid "Buys a snap"
-msgstr "Köper en snap"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr "Ändra ID"
+msgstr ""
 
 msgid "Changes configuration options"
-msgstr "Ändrar konfigurationsalternativ"
+msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr "Kommando\tAlias\tAnteckningar"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr "Konfigurationsvärde (nyckel=värde)"
+msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr "Bekräfta lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -324,57 +319,56 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr "Begränsa lista till en specifik snap eller snapp:namn"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr "Begränsa lista till specifika gränssnitt"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr "Begränsa lista till de som matchar rubrik=värde"
+msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr "Kopiera data från snapp %q"
+msgstr ""
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
-"Skapa ett kryptografiskt nyckelpar som kan användas för att signera asserts."
 
 msgid "Create cryptographic key pair"
-msgstr "Skapa kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Create snap build assertion"
-msgstr "Skapa snap-bygges-assert"
+msgstr ""
 
 msgid "Create snap-build assertion for the provided snap file."
-msgstr "Skapa snap-bygges-assert för den givna snap-filen."
+msgstr ""
 
 msgid "Creates a local system user"
-msgstr "Skapar en lokal systemanvändare"
+msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr "Radera kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Delete the local cryptographic key pair with the given name."
-msgstr "Radera det lokala kryptografiska nyckelparet med det givna namnet."
+msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr "Inaktivera %q-snap"
+msgstr ""
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr "Avaktivera alias för snapp %q"
+msgstr ""
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr "Avaktiverar alla alias för snap %q"
+msgstr ""
 
 msgid "Disables a snap in the system"
-msgstr "Avaktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
@@ -389,44 +383,41 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr "Vänta inte på att åtgärden ska slutföras, skriv bara ut ändrat ID."
+msgstr ""
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr "Ladda ned snapp %q%s från kanal %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
-"Hämta den givna revisionen av en snap, för vilket du behöver utvecklaråtkomst"
 
 msgid "Downloads the given snap"
-msgstr "Hämtar angiven snap"
+msgstr ""
 
 msgid "Email address: "
-msgstr "E-postadress: "
+msgstr ""
 
 #, c-format
 msgid "Enable %q snap"
-msgstr "Aktivera %q-snap"
+msgstr ""
 
 msgid "Enables a snap in the system"
-msgstr "Aktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr "Säkerställ att allt som %q kräver finns tillgängligt"
+msgstr ""
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
-"Exportera en öppen nyckel assert-nyttolast som kan importeras av andra "
-"system."
 
 msgid "Export cryptographic public key"
-msgstr "Exportera kryptografisk öppen nyckel"
+msgstr ""
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
@@ -434,40 +425,38 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr "Hämtar asserts för %q\n"
+msgstr ""
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr "Hämtar snap %q\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr "Filnamn för snap du vill försäkra ett bygge för"
+msgstr ""
 
 msgid "Finds packages to install"
-msgstr "Söker efter paket att installera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr "Tvinga tillägg av användare, även om enheten redan hanteras"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr "Tvinga import på klassiska system"
+msgstr ""
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
-"Formatera öppet nyckelmaterial som en begäran för en kontonyckel för detta "
-"konto-ID"
 
 msgid "Generate device key"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr "Generera manualsidan"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
@@ -475,25 +464,25 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr "Bevilja sudo-åtkomst för den skapade användaren"
+msgstr ""
 
 msgid "Help"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr "Krok att köra"
+msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr "Signerarens identifierare"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr "Identifierare för snap-paket associerat med bygge"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
@@ -501,7 +490,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr "Ignorera validering av andra snap-paket som blockerar uppdatering"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -510,73 +499,65 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
-"För att köpa %q, måste du godkänna de senaste villkoren. Gå till "
-"https://my.ubuntu.com/payment/edit för att göra detta.\n"
-"\n"
-"När du är färdig, kom tillbaka hit och kör \"snap buy %s\" igen."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
-"Inkludera en utförlig lista över ett snap-pakets anteckningar (annars "
-"sammanfattas anteckningar)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr "Inkludera gränssnitt som inte används"
+msgstr ""
 
 msgid "Initialize device"
 msgstr ""
 
 msgid "Inspects devices for actionable information"
-msgstr "Inspekterar enheter för användbar information"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installera snap-paketet %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr "Installera snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installera snap  %q från fil"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installera snap %q från fil %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installera från betakanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installera från kandidatkanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installera från spetskanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installera från stabila kanalen"
+msgstr ""
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installera snap %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installera snap-paket %s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installera den givna revisionen av en snap, för vilket du behöver ha "
-"utvecklaråtkomst"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -584,14 +565,10 @@ msgid ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installera den givna snap-filen även om det inte finns några tidigare kända "
-"signaturer för den, vilket innebär att den inte verifierades och kan vara "
-"farlig (--devmode antar detta)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installera det givna snap-paketet utan att aktivera dess automatiska alias"
 
 #, c-format
 msgid ""
@@ -599,118 +576,113 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
-"Installera snappen med:\n"
-"   snap ack %s\n"
-"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr "Installerar en snap i systemet"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr "Nyckel av intresse bland konfigurationen"
+msgstr ""
 
 msgid "List a change's tasks"
-msgstr "Lista en ändrings uppgifter"
+msgstr ""
 
 msgid "List cryptographic keys"
-msgstr "Lista kryptografiska nycklar"
+msgstr ""
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
-"Lista kryptografiska nycklar som kan användas för att signera försäkran."
 
 msgid "List installed snaps"
-msgstr "Lista installerade snap-paket"
+msgstr ""
 
 msgid "List system changes"
-msgstr "Lista systemändringar"
+msgstr ""
 
 msgid "Lists aliases in the system"
-msgstr "Lista alias i systemet"
+msgstr ""
 
 msgid "Lists all repairs"
-msgstr "Lista alla reparationer"
+msgstr ""
 
 msgid "Lists interfaces in the system"
-msgstr "Lista gränssnitt i systemet"
+msgstr ""
 
 msgid "Lists snap interfaces"
-msgstr "Lista snap-gränssnitt"
+msgstr ""
 
 msgid "Log out of the store"
-msgstr "Logga ut från butiken"
+msgstr ""
 
 msgid "Login successful"
-msgstr "Inloggning lyckades"
+msgstr ""
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr "Gör aktuell revision för snapp %q otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr "Gör snapp %q (%s) tillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr "Gör snapp %q (%s) otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr "Gör snapp %q otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr "Gör snapp %q%s tillgänglig för systemet"
+msgstr ""
 
 msgid "Mark system seeded"
 msgstr ""
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr "Montera snapp %q%s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr "Nyckelnamn att skapa; förval är \"default\""
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr "Nyckelnamn att radera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr "Nyckelnamn att exportera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
-"Namnet som GnuPG-nyckeln ska använda (förvalt nyckelnamn är \"default\")"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Nyckelnamn att använda, annars används förvald nyckel"
+msgstr ""
 
 msgid "Name\tSHA3-384"
-msgstr "Namn\tSHA3-384"
+msgstr ""
 
 msgid "Name\tSummary"
-msgstr "Namn\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr "Namn\tVersion\tUtvecklare\tAnteckningar\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr "Namn\tVersion\tRev\tUtvecklare\tAnteckningar"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr "Inga alias är definierade för snapp %q.\n"
+msgstr ""
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -732,31 +704,28 @@ msgstr ""
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr "Inga matchande snappar för %q i avsnitt %q\n"
+msgstr ""
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr "Inga matchande snappar för %q\n"
+msgstr ""
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
-"Ingen sökterm angiven. Här är några snappar att titta närmare på:\n"
-"\n"
 
 msgid "No section specified. Available sections:\n"
 msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
-"Inga snap-paket har installerats än. Testa \"snap install hello-world\"."
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr "Utdata resulterar i JSON-format"
+msgstr ""
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -766,11 +735,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr "Lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Password of %q: "
-msgstr "Lösenord för %q: "
+msgstr ""
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -778,212 +747,210 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
-"Ange ditt Ubuntu One-lösenord igen för att köpa %q från %q\n"
-"för %s. Tryck ctrl-C för att avbryta."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr "Föredra alias från en snap och inaktivera konflikter"
+msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prepare a snappy image"
-msgstr "Förbered en snappy-avbild"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr "Förbered snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr "Förbered snap %q%s"
+msgstr ""
 
 msgid "Print the version and exit"
-msgstr "Skriv ut version och avsluta"
+msgstr ""
 
 msgid "Prints configuration options"
-msgstr "Skriver ut konfigurationsalternativ"
+msgstr ""
 
 msgid "Prints the confinement mode the system operates in"
-msgstr "Skriver ut vilket inneslutningsläge systemet arbetar i"
+msgstr ""
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr "Skriver ut huruvida systemet är hanterat"
+msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr "Städa upp automatiska alias för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr "Sätt snap i klassiskt läge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr "Sätt snap i utvecklarläge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr "Sätt snap i bevakat inneslutningsläge"
+msgstr ""
 
 msgid "Query the status of services"
-msgstr "Undersök status för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr "Förnya snap %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr "Förnya snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr "Förnya alias för snap %q"
+msgstr ""
 
 msgid "Refresh all snaps: no updates"
-msgstr "Förnya alla snappar: inga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr "Förnya snapp %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr "Uppdatera snappar %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr "Förnya snappar %s: inga uppdateringar"
+msgstr ""
 
 msgid "Refresh to the given revision"
-msgstr "Uppdatera den givna revisionen"
+msgstr ""
 
 msgid "Refreshes a snap in the system"
-msgstr "Uppdaterar en snap i systemet"
+msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr "Ta bort alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr "Ta bort data för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr "Ta bort manuellt alias %q för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr "Ta endast bort den angivna revisionen"
+msgstr ""
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr "Ta bort säkerhetsprofil för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr "Ta bort säkerhetsprofiler för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr "Ta bort snap %q (%s) från systemet"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr "Ta bort snapp-paketen %s"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr "Borttagen"
+msgstr ""
 
 msgid "Removes a snap from the system"
-msgstr "Tar bort en snap från systemet"
+msgstr ""
 
 msgid "Request device serial"
-msgstr "Begär enhetens serienummer"
+msgstr ""
 
 msgid "Restart services"
-msgstr "Starta om tjänster"
+msgstr ""
 
 msgid "Restarted.\n"
-msgstr "Omstartad.\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr "Begränsa sökningen till ett givet avsnitt"
+msgstr ""
 
 msgid "Retrieve logs of services"
-msgstr "Hämta logg för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr "Rulla tillbaka snap %q"
+msgstr ""
 
 msgid "Reverts the given snap to the previous state"
-msgstr "Rulla tillbaka det givna snap-paketet till föregående tillstånd"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr "Kör ett skal istället för kommandot (hjälper vid felsökning)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr "Kör som en tidmätartjänst med ett givet schema"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr "Kör konfigureringskrok för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr "Kör konfigureringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr "Kör krok %s för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr "Kör installeringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr "Kör post-förnyelsekrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr "Kör förbered-enhets-krok"
+msgstr ""
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr "Kör borttagningskrok för snap %q om den finns"
+msgstr ""
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
@@ -995,54 +962,52 @@ msgid "Run the command with gdb"
 msgstr ""
 
 msgid "Run the given snap command"
-msgstr "Kör det givna snap-kommandot"
+msgstr ""
 
 msgid "Run the given snap command with the right confinement and environment"
-msgstr "Kör det givna snap-kommandot med korrekt inneslutning och miljö"
+msgstr ""
 
 msgid "Runs debug commands"
-msgstr "Kör felsökningskommandon"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr "Sök privata snap-paket"
+msgstr ""
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
-"Välj senaste ändring av given typ (installera, förnya, ta bort, testa, auto-"
-"förnya osv.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr "Ange automatiska alias för snap %q"
+msgstr ""
 
 msgid "Sets up a manual alias"
-msgstr "Anger ett manuellt alias"
+msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr "Ställ in alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr "Ställ in manuellt alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr "Ställ in säkerhetsprofiler för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr "Ställ in alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr "Ställ in säkerhetsprofiler för snapp %q%s"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
@@ -1103,7 +1068,7 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr "Snappnamn"
+msgstr ""
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
@@ -1116,14 +1081,14 @@ msgstr ""
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr "Starta tjänster från snapp %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr "Starta snapp %q%s-tjänster"
+msgstr ""
 
 msgid "Start snap services"
-msgstr "Starta snapptjänster"
+msgstr ""
 
 msgid "Start the userd service"
 msgstr ""
@@ -1139,21 +1104,21 @@ msgstr ""
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr "Stoppa snapp %q (%s)-tjänster"
+msgstr ""
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr "Stoppa snapp %q-tjänster"
+msgstr ""
 
 msgid "Stop snap services"
-msgstr "Stoppa snapptjänster"
+msgstr ""
 
 msgid "Stopped.\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr "Strikt inmatning med tomma och citerade strängar"
+msgstr ""
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1168,7 +1133,7 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr "Växlar snapp till en annan kanal"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
@@ -1183,8 +1148,6 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
-"Tack för att du köpte %q. Du kan nu installera det på valfri enhet med\n"
-"kommandot \"snap install %s\"."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
@@ -1192,7 +1155,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "E-postadress på login.ubuntu.com att logga in som"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
@@ -1209,11 +1172,11 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr "Snapp att konfigurera (t.ex. hello-world)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr "Snappen vars konf begärs"
+msgstr ""
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1226,10 +1189,10 @@ msgstr ""
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr "Växla snapp %q-flaggor"
+msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr "Verktyg för att interagera med snappar"
+msgstr ""
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
@@ -1240,20 +1203,20 @@ msgstr ""
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr "Testa snapp %q från %s"
+msgstr ""
 
 msgid "Try: snap install <selected snap>\n"
-msgstr "Testa: snap install <vald snapp>\n"
+msgstr ""
 
 msgid "Two-factor code: "
-msgstr "Två-faktor kod: "
+msgstr ""
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr "Använd en specifik snapprevision när krok körs"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
@@ -1308,11 +1271,6 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
-"Du måste ha en betalningsmetod associerad med ditt konto för att kunna köpa "
-"en snapp. Besök https://my.ubuntu.com/payment/edit för att lägga till en.\n"
-"\n"
-"När du har lagt till betalningsinformationen behöver du bara köra \"snap buy "
-"%s\" igen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1400,8 +1358,6 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
-"\n"
-"Kommandot buy köper en snapp från butiken.\n"
 
 msgid ""
 "\n"
@@ -1457,11 +1413,6 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
-"\n"
-"Kommandot debug innehåller ett urval av ytterligare delkommandon.\n"
-"\n"
-"Felsökningskommandon kan tas bort utan aviseringar och kanske inte\n"
-"fungerar på icke-utvecklarsystem.\n"
 
 msgid ""
 "\n"
@@ -1496,8 +1447,6 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
-"\n"
-"Kommandot enable aktiverar en snapp som tidigare avaktiverats.\n"
 
 msgid ""
 "\n"
@@ -1587,12 +1536,6 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
-"\n"
-"Kommandot interface visar detaljer om snappars gränssnitt.\n"
-"\n"
-"Om inget gränssnittsnamn anges kommer en lista över gränssnittsnamn\n"
-"med minst en anslutning att visas, eller en lista över alla gränssnitt om\n"
-"--all anges.\n"
 
 msgid ""
 "\n"
@@ -1651,9 +1594,6 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
-"\n"
-"Kommandot managed kommer att skriva ut true eller false, vilket visar\n"
-"huruvida snapd har registrerat användare.\n"
 
 msgid ""
 "\n"
@@ -1705,15 +1645,11 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
-"\n"
-"Kommandot repair visar detaljer om en eller flera reparationer.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
-"\n"
-"Kommandot repairs listar alla utförda reparationer för den här enheten.\n"
 
 msgid ""
 "\n"
@@ -1721,11 +1657,6 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot restart startar om de givna tjänsterna i snappen. Om det körs "
-"från\n"
-"kroken \"configure\" kommer tjänsterna att startas om efter att kroken "
-"slutförs."
 
 msgid ""
 "\n"
@@ -1764,18 +1695,6 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
-"\n"
-"Kommandot set ändrar de givna konfigurationsalternativen enligt begäran.\n"
-"\n"
-"    $ snap set snappnamn username=frank password=$PASSWORD\n"
-"\n"
-"Alla konfigurationsändringar är omedelbart bestående, och sparas endast "
-"efter\n"
-"att snappens konfigurationskrok slutförs med lyckat resultat.\n"
-"\n"
-"Nästlade värden kan ändras via en prickad sökväg:\n"
-"\n"
-"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1803,41 +1722,28 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot start startar de angivna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att startas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot start startar, och eventuellt aktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot stop stoppar de givna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att stoppas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot stop stoppar, och eventuellt avaktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
-"\n"
-"Kommandot switch växlar den givna snappen till en annan kanal utan att\n"
-"göra en förnyelse.\n"
 
 msgid ""
 "\n"
@@ -1872,9 +1778,6 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
-"\n"
-"Kommandot version visar versionerna för den aktiva klienten, servern,\n"
-"och operativsystemet.\n"
 
 msgid ""
 "\n"
@@ -1882,10 +1785,6 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
-"\n"
-"Kommandot watch väntar på att den givna ändrings-ID:n ska slutföras, och "
-"visar\n"
-"förloppet (om tillgängligt).\n"
 
 msgid ""
 "\n"
@@ -1904,14 +1803,6 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
-"\n"
-"Den här revisionen av snapp %q utgavs med klassisk inneslutning, och kan "
-"därför\n"
-"utföra godtyckliga systemändringar utanför den säkerhetssandlåda som "
-"snappar\n"
-"normalt avgränsas till, vilket kan utgöra en risk för ditt system.\n"
-"\n"
-"Om du förstår och vill fortsätta, upprepa kommandot med --classic.\n"
 
 msgid ""
 "\n"
@@ -1920,26 +1811,25 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
-"ett enstaka snappnamn behövs för att specificera läges- eller kanalflaggor"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr "ett enstaka snappnamn behövs för att specificera revision"
+msgstr ""
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr "ett enstaka snappnamn måste specificeras när validering ignoreras"
+msgstr ""
 
 msgid "active"
-msgstr "aktiv"
+msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr "köpt"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr "trasig"
+msgstr ""
 
 #, c-format
 msgid "cannot %s without a context"
@@ -1947,18 +1837,18 @@ msgstr ""
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr "kan inte köpa snapp: %v"
+msgstr ""
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr "kan inte köpa snapp: ogiltiga tecken i namnet"
+msgstr ""
 
 msgid "cannot buy snap: it has already been bought"
-msgstr "kan inte köpa snapp: den har redan köpts"
+msgstr ""
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr "kan inte skapa %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot create assertions file: %v"
@@ -1967,50 +1857,50 @@ msgstr ""
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr "kan inte extrahera snappnamn från lokal fil %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr "kan inte hitta program %q i %q"
+msgstr ""
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr "kan inte hitta krok %q i %q"
+msgstr ""
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr "kan inte hämta data för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr "kan inte hämta full sökväg för %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr "kan inte hämta aktuell användare: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr "kan inte hämta aktuell användare: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr "kan inte märka uppstart lyckad: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr "kan inte öppna försäkringsdatabasen: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr "kan inte läsa försäkransindata: %v"
+msgstr ""
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr "kan inte läsa symlänk: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
@@ -2022,87 +1912,86 @@ msgstr ""
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr "kan inte uppdatera \"aktuell\" symlänk för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr "kan inte använda nyckeln %q: %v"
+msgstr ""
 
 msgid "cannot use change ID and type together"
-msgstr "kan inte använda ändrings-ID och typ tillsammans"
+msgstr ""
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr "kan inte använda devmode- och jailmode-flaggorna tillsammans"
+msgstr ""
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr "kan inte validera ägare av filen %s"
+msgstr ""
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr "kan inte skriva ny Xauthority-fil på %s: %s"
+msgstr ""
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr "ändring slutförd i status %q utan felmeddelande"
+msgstr ""
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
-"klassisk inneslutning kräver snappar i /snap eller symlänk från /snap till %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr "skapade användare %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr "d"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr "avaktiverad"
+msgstr ""
 
 msgid "email:"
-msgstr "e-post:"
+msgstr ""
 
 msgid "enabled"
-msgstr "aktiverad"
+msgstr ""
 
 #, c-format
 msgid "error: %v\n"
-msgstr "fel: %v\n"
+msgstr ""
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr "fel: argumentet \"<snap-dir>\" angavs inte och kunde inte antydas"
+msgstr ""
 
 msgid "get which option?"
-msgstr "hämta vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr "t"
+msgstr ""
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr "inaktiv"
+msgstr ""
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr "gränssnittsattribut kan bara läsas när gränssnittskrokarna körs"
+msgstr ""
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
-msgstr "gränssnittsattribut kan bara sättas när förberedelsekrokarna körs"
+msgstr ""
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr "internt fel, var god rapportera: kunde inte köra %q: %v\n"
+msgstr ""
 
 msgid "internal error: cannot find attrs task"
 msgstr ""
@@ -2125,69 +2014,67 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr "ogiltig konfiguration: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr "ogiltigt huvudfilter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr "ogiltig parameter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr "ogiltigt värde: %q (vill ha snap:namn eller snapp)"
+msgstr ""
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
-"nyckelnamnet %q är ogiltigt; endast ASCII-tecken, siffror, och streck tillåts"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
-"lokal snapp %q är okänd för butiken; använd --amend för att fortsätta ändå"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr "m"
+msgstr ""
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr "kräver att programmet körs som argument"
+msgstr ""
 
 msgid "no changes found"
-msgstr "hittade inga ändringar"
+msgstr ""
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr "hittade inga ändringar av typen %q"
+msgstr ""
 
 msgid "no interfaces currently connected"
-msgstr "inga gränssnitt anslutna just nu"
+msgstr ""
 
 msgid "no interfaces found"
-msgstr "inga gränssnitt hittades"
+msgstr ""
 
 msgid "no matching snaps installed"
-msgstr "inga matchande snappar installerade"
+msgstr ""
 
 msgid "no such interface"
-msgstr "inget sådant gränssnitt"
+msgstr ""
 
 msgid "no valid snaps given"
-msgstr "inga giltiga snappar angivna"
+msgstr ""
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr "ange ändrings-ID eller typ med --last=<typ>"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr "privat"
+msgstr ""
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2195,19 +2082,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr "reparationer är inte tillgängliga på ett klassiskt system"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr "s"
+msgstr ""
 
 #, c-format
 msgid "set failed: %v"
-msgstr "set misslyckades: %v"
+msgstr ""
 
 msgid "set which option?"
-msgstr "sätt vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2221,7 +2108,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr "snapp %q har inga tillgängliga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2229,30 +2116,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr "snapp %q finns inte"
+msgstr ""
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr "snapp är gratis"
+msgstr ""
 
 msgid "too many arguments for command"
-msgstr "för många argument för kommandot"
+msgstr ""
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr "för många argument för krok %q: %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr "för många argument: %s"
+msgstr ""
 
 msgid "unable to contact snap store"
-msgstr "kan inte kontakta snap store"
+msgstr ""
 
 msgid "unavailable"
-msgstr "otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2268,31 +2155,30 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr "okänd tjänst: %q"
+msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr "varning:\tingen snapp hittades för %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr "å"
+msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr "Autentisera mot snapp-daemon"
+msgstr ""
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr "Identitskontroll krävs för att autentisera mot snapp-daemonen"
+msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr "Installera, uppdatera eller ta bort paket"
+msgstr ""
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
-"Autentisering krävs för att installera, uppdatera, eller ta bort paket"
 
 msgid "Connect, disconnect interfaces"
-msgstr "Anslut, koppla bort gränssnitt"
+msgstr ""
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr "Autentisering krävs för att ansluta eller koppla bort gränssnitt"
+msgstr ""

--- a/po/mnw.po
+++ b/po/mnw.po
@@ -1,16 +1,16 @@
-# Swedish translation for snapd
-# Copyright (c) 2018 Rosetta Contributors and Canonical Ltd 2018
+# Mon translation for snapd
+# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
 # This file is distributed under the same license as the snapd package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
+"PO-Revision-Date: 2019-11-06 00:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Swedish <sv@li.org>\n"
+"Language-Team: Mon <mnw@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,155 +23,152 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q innehåller inte ett uppackat snap-paket.\n"
-"\n"
-"Testa \"snapcraft prime\" i din projektmapp, sedan \"snap try\" igen."
 
 #. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr "%q bytte till kanalen %q\n"
+msgstr ""
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s monterades från %s\n"
+msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr "%s (delta)"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr "%s (se \"snap login --help\")"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr "%s (försök med sudo)"
+msgstr "%s (ဂစာန် ကေုာံ သူဒို)"
 
 #, c-format
 msgid "%s already installed\n"
-msgstr "%s är redan installerad\n"
+msgstr "%s စုတ် လဝ်တုဲတုဲ\n"
 
 #, c-format
 msgid "%s disabled\n"
-msgstr "%s inaktiverad\n"
+msgstr "%s ဒှ်ဟွံမာန်\n"
 
 #, c-format
 msgid "%s enabled\n"
-msgstr "%s aktiverad\n"
+msgstr "%s ဒှ်မာန်\n"
 
 #, c-format
 msgid "%s not installed\n"
-msgstr "%s inte installerad\n"
+msgstr "%s ဟွံ စုတ်လဝ်\n"
 
 #, c-format
 msgid "%s removed\n"
-msgstr "%s borttagen\n"
+msgstr "%s ပဲါလဝ်\n"
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr "%s återställd till %s\n"
+msgstr "%s ကလေၚ်စွံလဝ် အတိုၚ်ပကတိ ကဵု  %s\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
 msgid "%s%s %s from '%s' installed\n"
-msgstr "%s%s %s från \"%s\" installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr "%s%s %s från \"%s\" uppdaterad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr "%s%s %s installerad\n"
+msgstr "%s%s %s စုတ်လဝ်\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr "%s%s %s uppdaterad\n"
+msgstr "%s%s %s ပသောၚ်လဝ်\n"
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "--time does not take mode nor channel flags"
-msgstr "--time tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr "-r kan bara användas med --hook"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr "<alias-eller-snap>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr "<alias>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<assert-fil>"
+msgstr "<ဝှာၚ် ခိုၚ်ၚ်ကၠိုက်က်>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<assert-typ>"
+msgstr "<ဂကူ ခိုၚ်ၚ်ကၠိုက်က်>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<ändra-id>"
+msgstr "<သၠာဲ-id>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr "<konf.värde>"
+msgstr "<ၚုဟ်မး conf>"
 
 #. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 #. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr "<epost>"
+msgstr "<အဳမေလ်>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr "<filnamn>"
+msgstr "<ယၟုဝှာၚ်>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr "<rubrikfilter>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr "<gränssnitt>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr "<nyckelnamn>"
+msgstr "<ယၟု-ကဳ>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr "<nyckel>"
+msgstr "<ကဳ>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr "<modell-assert>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr "<fråga>"
+msgstr "<ဂၠာဲလ္ၚတ်>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<root-kat>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<ရေၚ်တၠုၚ်>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
@@ -180,78 +177,76 @@ msgstr "<snap>:<plug>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr "<snap>:<slot eller plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr "<snap>:<slot>"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
-"En tjänstespecifikation, som kan vara bara ett snappnamn (för alla tjänster "
-"i snappen), eller <snapp>.<app> för en enstaka tjänst."
 
 msgid "Abort a pending change"
-msgstr "Avbryt en väntande ändring"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr "Tillagd"
+msgstr "ထပ်လဝ်"
 
 msgid "Adds an assertion to the system"
-msgstr "Lägger till en assert i systemet"
+msgstr ""
 
 msgid "Advise on available snaps."
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr "Informera om snappar som tillhandahåller det givna kommandot"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr "Alias för --dangerous (FÖRÅLDRAD)"
+msgstr ""
 
 msgid "All snaps up to date."
-msgstr "Alla snap-paket uppdaterade."
+msgstr ""
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "ကဵုအခေါၚ် ပံက်ဒၟံၚ် ဝှာၚ်?"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "ကဵုအခေါၚ် ပြံၚ်လှာဲ မဆိၚ်ဒၟံၚ်"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr "Tillåt snapp %q att ändra %q till %q ?"
+msgstr ""
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr "Tillåt snapp %q att öppna filen %q?"
+msgstr "ကဵုအခေါၚ် snap %q သ္ဂောံ ပံက် ဝှာၚ် %q?"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr "Alternativt kommando att köra"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr "Returnera alltid dokument, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr "Returnera alltid lista, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr "En e-postadress för en användare på login.ubuntu.com"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -266,14 +261,14 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr "Assert-fil"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr "Assert-typnamn"
+msgstr ""
 
 msgid "Authenticates on snapd and the store"
-msgstr "Autentiseras på snapd och butiken"
+msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
@@ -293,27 +288,27 @@ msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr "Felaktig kod. Försök igen: "
+msgstr ""
 
 msgid "Buys a snap"
-msgstr "Köper en snap"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr "Ändra ID"
+msgstr ""
 
 msgid "Changes configuration options"
-msgstr "Ändrar konfigurationsalternativ"
+msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr "Kommando\tAlias\tAnteckningar"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr "Konfigurationsvärde (nyckel=värde)"
+msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr "Bekräfta lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -324,57 +319,56 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr "Begränsa lista till en specifik snap eller snapp:namn"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr "Begränsa lista till specifika gränssnitt"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr "Begränsa lista till de som matchar rubrik=värde"
+msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr "Kopiera data från snapp %q"
+msgstr ""
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
-"Skapa ett kryptografiskt nyckelpar som kan användas för att signera asserts."
 
 msgid "Create cryptographic key pair"
-msgstr "Skapa kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Create snap build assertion"
-msgstr "Skapa snap-bygges-assert"
+msgstr ""
 
 msgid "Create snap-build assertion for the provided snap file."
-msgstr "Skapa snap-bygges-assert för den givna snap-filen."
+msgstr ""
 
 msgid "Creates a local system user"
-msgstr "Skapar en lokal systemanvändare"
+msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr "Radera kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Delete the local cryptographic key pair with the given name."
-msgstr "Radera det lokala kryptografiska nyckelparet med det givna namnet."
+msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr "Inaktivera %q-snap"
+msgstr ""
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr "Avaktivera alias för snapp %q"
+msgstr ""
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr "Avaktiverar alla alias för snap %q"
+msgstr ""
 
 msgid "Disables a snap in the system"
-msgstr "Avaktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
@@ -389,44 +383,41 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr "Vänta inte på att åtgärden ska slutföras, skriv bara ut ändrat ID."
+msgstr ""
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr "Ladda ned snapp %q%s från kanal %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
-"Hämta den givna revisionen av en snap, för vilket du behöver utvecklaråtkomst"
 
 msgid "Downloads the given snap"
-msgstr "Hämtar angiven snap"
+msgstr ""
 
 msgid "Email address: "
-msgstr "E-postadress: "
+msgstr ""
 
 #, c-format
 msgid "Enable %q snap"
-msgstr "Aktivera %q-snap"
+msgstr ""
 
 msgid "Enables a snap in the system"
-msgstr "Aktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr "Säkerställ att allt som %q kräver finns tillgängligt"
+msgstr ""
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
-"Exportera en öppen nyckel assert-nyttolast som kan importeras av andra "
-"system."
 
 msgid "Export cryptographic public key"
-msgstr "Exportera kryptografisk öppen nyckel"
+msgstr ""
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
@@ -434,40 +425,38 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr "Hämtar asserts för %q\n"
+msgstr ""
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr "Hämtar snap %q\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr "Filnamn för snap du vill försäkra ett bygge för"
+msgstr ""
 
 msgid "Finds packages to install"
-msgstr "Söker efter paket att installera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr "Tvinga tillägg av användare, även om enheten redan hanteras"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr "Tvinga import på klassiska system"
+msgstr ""
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
-"Formatera öppet nyckelmaterial som en begäran för en kontonyckel för detta "
-"konto-ID"
 
 msgid "Generate device key"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr "Generera manualsidan"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
@@ -475,25 +464,25 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr "Bevilja sudo-åtkomst för den skapade användaren"
+msgstr ""
 
 msgid "Help"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr "Krok att köra"
+msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr "Signerarens identifierare"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr "Identifierare för snap-paket associerat med bygge"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
@@ -501,7 +490,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr "Ignorera validering av andra snap-paket som blockerar uppdatering"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -510,73 +499,65 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
-"För att köpa %q, måste du godkänna de senaste villkoren. Gå till "
-"https://my.ubuntu.com/payment/edit för att göra detta.\n"
-"\n"
-"När du är färdig, kom tillbaka hit och kör \"snap buy %s\" igen."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
-"Inkludera en utförlig lista över ett snap-pakets anteckningar (annars "
-"sammanfattas anteckningar)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr "Inkludera gränssnitt som inte används"
+msgstr ""
 
 msgid "Initialize device"
 msgstr ""
 
 msgid "Inspects devices for actionable information"
-msgstr "Inspekterar enheter för användbar information"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installera snap-paketet %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr "Installera snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installera snap  %q från fil"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installera snap %q från fil %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installera från betakanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installera från kandidatkanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installera från spetskanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installera från stabila kanalen"
+msgstr ""
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installera snap %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installera snap-paket %s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installera den givna revisionen av en snap, för vilket du behöver ha "
-"utvecklaråtkomst"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -584,14 +565,10 @@ msgid ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installera den givna snap-filen även om det inte finns några tidigare kända "
-"signaturer för den, vilket innebär att den inte verifierades och kan vara "
-"farlig (--devmode antar detta)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installera det givna snap-paketet utan att aktivera dess automatiska alias"
 
 #, c-format
 msgid ""
@@ -599,118 +576,113 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
-"Installera snappen med:\n"
-"   snap ack %s\n"
-"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr "Installerar en snap i systemet"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr "Nyckel av intresse bland konfigurationen"
+msgstr ""
 
 msgid "List a change's tasks"
-msgstr "Lista en ändrings uppgifter"
+msgstr ""
 
 msgid "List cryptographic keys"
-msgstr "Lista kryptografiska nycklar"
+msgstr ""
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
-"Lista kryptografiska nycklar som kan användas för att signera försäkran."
 
 msgid "List installed snaps"
-msgstr "Lista installerade snap-paket"
+msgstr ""
 
 msgid "List system changes"
-msgstr "Lista systemändringar"
+msgstr ""
 
 msgid "Lists aliases in the system"
-msgstr "Lista alias i systemet"
+msgstr ""
 
 msgid "Lists all repairs"
-msgstr "Lista alla reparationer"
+msgstr ""
 
 msgid "Lists interfaces in the system"
-msgstr "Lista gränssnitt i systemet"
+msgstr ""
 
 msgid "Lists snap interfaces"
-msgstr "Lista snap-gränssnitt"
+msgstr ""
 
 msgid "Log out of the store"
-msgstr "Logga ut från butiken"
+msgstr ""
 
 msgid "Login successful"
-msgstr "Inloggning lyckades"
+msgstr ""
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr "Gör aktuell revision för snapp %q otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr "Gör snapp %q (%s) tillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr "Gör snapp %q (%s) otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr "Gör snapp %q otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr "Gör snapp %q%s tillgänglig för systemet"
+msgstr ""
 
 msgid "Mark system seeded"
 msgstr ""
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr "Montera snapp %q%s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr "Nyckelnamn att skapa; förval är \"default\""
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr "Nyckelnamn att radera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr "Nyckelnamn att exportera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
-"Namnet som GnuPG-nyckeln ska använda (förvalt nyckelnamn är \"default\")"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Nyckelnamn att använda, annars används förvald nyckel"
+msgstr ""
 
 msgid "Name\tSHA3-384"
-msgstr "Namn\tSHA3-384"
+msgstr ""
 
 msgid "Name\tSummary"
-msgstr "Namn\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr "Namn\tVersion\tUtvecklare\tAnteckningar\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr "Namn\tVersion\tRev\tUtvecklare\tAnteckningar"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr "Inga alias är definierade för snapp %q.\n"
+msgstr ""
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -732,31 +704,28 @@ msgstr ""
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr "Inga matchande snappar för %q i avsnitt %q\n"
+msgstr ""
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr "Inga matchande snappar för %q\n"
+msgstr ""
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
-"Ingen sökterm angiven. Här är några snappar att titta närmare på:\n"
-"\n"
 
 msgid "No section specified. Available sections:\n"
 msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
-"Inga snap-paket har installerats än. Testa \"snap install hello-world\"."
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr "Utdata resulterar i JSON-format"
+msgstr ""
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -766,11 +735,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr "Lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Password of %q: "
-msgstr "Lösenord för %q: "
+msgstr ""
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -778,212 +747,210 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
-"Ange ditt Ubuntu One-lösenord igen för att köpa %q från %q\n"
-"för %s. Tryck ctrl-C för att avbryta."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr "Föredra alias från en snap och inaktivera konflikter"
+msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prepare a snappy image"
-msgstr "Förbered en snappy-avbild"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr "Förbered snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr "Förbered snap %q%s"
+msgstr ""
 
 msgid "Print the version and exit"
-msgstr "Skriv ut version och avsluta"
+msgstr ""
 
 msgid "Prints configuration options"
-msgstr "Skriver ut konfigurationsalternativ"
+msgstr ""
 
 msgid "Prints the confinement mode the system operates in"
-msgstr "Skriver ut vilket inneslutningsläge systemet arbetar i"
+msgstr ""
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr "Skriver ut huruvida systemet är hanterat"
+msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr "Städa upp automatiska alias för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr "Sätt snap i klassiskt läge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr "Sätt snap i utvecklarläge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr "Sätt snap i bevakat inneslutningsläge"
+msgstr ""
 
 msgid "Query the status of services"
-msgstr "Undersök status för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr "Förnya snap %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr "Förnya snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr "Förnya alias för snap %q"
+msgstr ""
 
 msgid "Refresh all snaps: no updates"
-msgstr "Förnya alla snappar: inga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr "Förnya snapp %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr "Uppdatera snappar %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr "Förnya snappar %s: inga uppdateringar"
+msgstr ""
 
 msgid "Refresh to the given revision"
-msgstr "Uppdatera den givna revisionen"
+msgstr ""
 
 msgid "Refreshes a snap in the system"
-msgstr "Uppdaterar en snap i systemet"
+msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr "Ta bort alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr "Ta bort data för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr "Ta bort manuellt alias %q för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr "Ta endast bort den angivna revisionen"
+msgstr ""
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr "Ta bort säkerhetsprofil för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr "Ta bort säkerhetsprofiler för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr "Ta bort snap %q (%s) från systemet"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr "Ta bort snapp-paketen %s"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr "Borttagen"
+msgstr ""
 
 msgid "Removes a snap from the system"
-msgstr "Tar bort en snap från systemet"
+msgstr ""
 
 msgid "Request device serial"
-msgstr "Begär enhetens serienummer"
+msgstr ""
 
 msgid "Restart services"
-msgstr "Starta om tjänster"
+msgstr ""
 
 msgid "Restarted.\n"
-msgstr "Omstartad.\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr "Begränsa sökningen till ett givet avsnitt"
+msgstr ""
 
 msgid "Retrieve logs of services"
-msgstr "Hämta logg för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr "Rulla tillbaka snap %q"
+msgstr ""
 
 msgid "Reverts the given snap to the previous state"
-msgstr "Rulla tillbaka det givna snap-paketet till föregående tillstånd"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr "Kör ett skal istället för kommandot (hjälper vid felsökning)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr "Kör som en tidmätartjänst med ett givet schema"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr "Kör konfigureringskrok för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr "Kör konfigureringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr "Kör krok %s för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr "Kör installeringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr "Kör post-förnyelsekrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr "Kör förbered-enhets-krok"
+msgstr ""
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr "Kör borttagningskrok för snap %q om den finns"
+msgstr ""
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
@@ -995,54 +962,52 @@ msgid "Run the command with gdb"
 msgstr ""
 
 msgid "Run the given snap command"
-msgstr "Kör det givna snap-kommandot"
+msgstr ""
 
 msgid "Run the given snap command with the right confinement and environment"
-msgstr "Kör det givna snap-kommandot med korrekt inneslutning och miljö"
+msgstr ""
 
 msgid "Runs debug commands"
-msgstr "Kör felsökningskommandon"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr "Sök privata snap-paket"
+msgstr ""
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
-"Välj senaste ändring av given typ (installera, förnya, ta bort, testa, auto-"
-"förnya osv.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr "Ange automatiska alias för snap %q"
+msgstr ""
 
 msgid "Sets up a manual alias"
-msgstr "Anger ett manuellt alias"
+msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr "Ställ in alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr "Ställ in manuellt alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr "Ställ in säkerhetsprofiler för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr "Ställ in alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr "Ställ in säkerhetsprofiler för snapp %q%s"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
@@ -1103,7 +1068,7 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr "Snappnamn"
+msgstr ""
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
@@ -1116,14 +1081,14 @@ msgstr ""
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr "Starta tjänster från snapp %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr "Starta snapp %q%s-tjänster"
+msgstr ""
 
 msgid "Start snap services"
-msgstr "Starta snapptjänster"
+msgstr ""
 
 msgid "Start the userd service"
 msgstr ""
@@ -1139,21 +1104,21 @@ msgstr ""
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr "Stoppa snapp %q (%s)-tjänster"
+msgstr ""
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr "Stoppa snapp %q-tjänster"
+msgstr ""
 
 msgid "Stop snap services"
-msgstr "Stoppa snapptjänster"
+msgstr ""
 
 msgid "Stopped.\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr "Strikt inmatning med tomma och citerade strängar"
+msgstr ""
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1168,7 +1133,7 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr "Växlar snapp till en annan kanal"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
@@ -1183,8 +1148,6 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
-"Tack för att du köpte %q. Du kan nu installera det på valfri enhet med\n"
-"kommandot \"snap install %s\"."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
@@ -1192,7 +1155,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "E-postadress på login.ubuntu.com att logga in som"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
@@ -1209,11 +1172,11 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr "Snapp att konfigurera (t.ex. hello-world)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr "Snappen vars konf begärs"
+msgstr ""
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1226,10 +1189,10 @@ msgstr ""
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr "Växla snapp %q-flaggor"
+msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr "Verktyg för att interagera med snappar"
+msgstr ""
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
@@ -1240,20 +1203,20 @@ msgstr ""
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr "Testa snapp %q från %s"
+msgstr ""
 
 msgid "Try: snap install <selected snap>\n"
-msgstr "Testa: snap install <vald snapp>\n"
+msgstr ""
 
 msgid "Two-factor code: "
-msgstr "Två-faktor kod: "
+msgstr ""
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr "Använd en specifik snapprevision när krok körs"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
@@ -1308,11 +1271,6 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
-"Du måste ha en betalningsmetod associerad med ditt konto för att kunna köpa "
-"en snapp. Besök https://my.ubuntu.com/payment/edit för att lägga till en.\n"
-"\n"
-"När du har lagt till betalningsinformationen behöver du bara köra \"snap buy "
-"%s\" igen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1400,8 +1358,6 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
-"\n"
-"Kommandot buy köper en snapp från butiken.\n"
 
 msgid ""
 "\n"
@@ -1457,11 +1413,6 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
-"\n"
-"Kommandot debug innehåller ett urval av ytterligare delkommandon.\n"
-"\n"
-"Felsökningskommandon kan tas bort utan aviseringar och kanske inte\n"
-"fungerar på icke-utvecklarsystem.\n"
 
 msgid ""
 "\n"
@@ -1496,8 +1447,6 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
-"\n"
-"Kommandot enable aktiverar en snapp som tidigare avaktiverats.\n"
 
 msgid ""
 "\n"
@@ -1587,12 +1536,6 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
-"\n"
-"Kommandot interface visar detaljer om snappars gränssnitt.\n"
-"\n"
-"Om inget gränssnittsnamn anges kommer en lista över gränssnittsnamn\n"
-"med minst en anslutning att visas, eller en lista över alla gränssnitt om\n"
-"--all anges.\n"
 
 msgid ""
 "\n"
@@ -1651,9 +1594,6 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
-"\n"
-"Kommandot managed kommer att skriva ut true eller false, vilket visar\n"
-"huruvida snapd har registrerat användare.\n"
 
 msgid ""
 "\n"
@@ -1705,15 +1645,11 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
-"\n"
-"Kommandot repair visar detaljer om en eller flera reparationer.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
-"\n"
-"Kommandot repairs listar alla utförda reparationer för den här enheten.\n"
 
 msgid ""
 "\n"
@@ -1721,11 +1657,6 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot restart startar om de givna tjänsterna i snappen. Om det körs "
-"från\n"
-"kroken \"configure\" kommer tjänsterna att startas om efter att kroken "
-"slutförs."
 
 msgid ""
 "\n"
@@ -1764,18 +1695,6 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
-"\n"
-"Kommandot set ändrar de givna konfigurationsalternativen enligt begäran.\n"
-"\n"
-"    $ snap set snappnamn username=frank password=$PASSWORD\n"
-"\n"
-"Alla konfigurationsändringar är omedelbart bestående, och sparas endast "
-"efter\n"
-"att snappens konfigurationskrok slutförs med lyckat resultat.\n"
-"\n"
-"Nästlade värden kan ändras via en prickad sökväg:\n"
-"\n"
-"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1803,41 +1722,28 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot start startar de angivna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att startas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot start startar, och eventuellt aktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot stop stoppar de givna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att stoppas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot stop stoppar, och eventuellt avaktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
-"\n"
-"Kommandot switch växlar den givna snappen till en annan kanal utan att\n"
-"göra en förnyelse.\n"
 
 msgid ""
 "\n"
@@ -1872,9 +1778,6 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
-"\n"
-"Kommandot version visar versionerna för den aktiva klienten, servern,\n"
-"och operativsystemet.\n"
 
 msgid ""
 "\n"
@@ -1882,10 +1785,6 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
-"\n"
-"Kommandot watch väntar på att den givna ändrings-ID:n ska slutföras, och "
-"visar\n"
-"förloppet (om tillgängligt).\n"
 
 msgid ""
 "\n"
@@ -1904,14 +1803,6 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
-"\n"
-"Den här revisionen av snapp %q utgavs med klassisk inneslutning, och kan "
-"därför\n"
-"utföra godtyckliga systemändringar utanför den säkerhetssandlåda som "
-"snappar\n"
-"normalt avgränsas till, vilket kan utgöra en risk för ditt system.\n"
-"\n"
-"Om du förstår och vill fortsätta, upprepa kommandot med --classic.\n"
 
 msgid ""
 "\n"
@@ -1920,26 +1811,25 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
-"ett enstaka snappnamn behövs för att specificera läges- eller kanalflaggor"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr "ett enstaka snappnamn behövs för att specificera revision"
+msgstr ""
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr "ett enstaka snappnamn måste specificeras när validering ignoreras"
+msgstr ""
 
 msgid "active"
-msgstr "aktiv"
+msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr "köpt"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr "trasig"
+msgstr ""
 
 #, c-format
 msgid "cannot %s without a context"
@@ -1947,18 +1837,18 @@ msgstr ""
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr "kan inte köpa snapp: %v"
+msgstr ""
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr "kan inte köpa snapp: ogiltiga tecken i namnet"
+msgstr ""
 
 msgid "cannot buy snap: it has already been bought"
-msgstr "kan inte köpa snapp: den har redan köpts"
+msgstr ""
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr "kan inte skapa %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot create assertions file: %v"
@@ -1967,50 +1857,50 @@ msgstr ""
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr "kan inte extrahera snappnamn från lokal fil %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr "kan inte hitta program %q i %q"
+msgstr ""
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr "kan inte hitta krok %q i %q"
+msgstr ""
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr "kan inte hämta data för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr "kan inte hämta full sökväg för %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr "kan inte hämta aktuell användare: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr "kan inte hämta aktuell användare: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr "kan inte märka uppstart lyckad: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr "kan inte öppna försäkringsdatabasen: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr "kan inte läsa försäkransindata: %v"
+msgstr ""
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr "kan inte läsa symlänk: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
@@ -2022,87 +1912,86 @@ msgstr ""
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr "kan inte uppdatera \"aktuell\" symlänk för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr "kan inte använda nyckeln %q: %v"
+msgstr ""
 
 msgid "cannot use change ID and type together"
-msgstr "kan inte använda ändrings-ID och typ tillsammans"
+msgstr ""
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr "kan inte använda devmode- och jailmode-flaggorna tillsammans"
+msgstr ""
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr "kan inte validera ägare av filen %s"
+msgstr ""
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr "kan inte skriva ny Xauthority-fil på %s: %s"
+msgstr ""
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr "ändring slutförd i status %q utan felmeddelande"
+msgstr ""
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
-"klassisk inneslutning kräver snappar i /snap eller symlänk från /snap till %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr "skapade användare %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr "d"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr "avaktiverad"
+msgstr ""
 
 msgid "email:"
-msgstr "e-post:"
+msgstr ""
 
 msgid "enabled"
-msgstr "aktiverad"
+msgstr ""
 
 #, c-format
 msgid "error: %v\n"
-msgstr "fel: %v\n"
+msgstr ""
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr "fel: argumentet \"<snap-dir>\" angavs inte och kunde inte antydas"
+msgstr ""
 
 msgid "get which option?"
-msgstr "hämta vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr "t"
+msgstr ""
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr "inaktiv"
+msgstr ""
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr "gränssnittsattribut kan bara läsas när gränssnittskrokarna körs"
+msgstr ""
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
-msgstr "gränssnittsattribut kan bara sättas när förberedelsekrokarna körs"
+msgstr ""
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr "internt fel, var god rapportera: kunde inte köra %q: %v\n"
+msgstr ""
 
 msgid "internal error: cannot find attrs task"
 msgstr ""
@@ -2125,69 +2014,67 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr "ogiltig konfiguration: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr "ogiltigt huvudfilter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr "ogiltig parameter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr "ogiltigt värde: %q (vill ha snap:namn eller snapp)"
+msgstr ""
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
-"nyckelnamnet %q är ogiltigt; endast ASCII-tecken, siffror, och streck tillåts"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
-"lokal snapp %q är okänd för butiken; använd --amend för att fortsätta ändå"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr "m"
+msgstr ""
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr "kräver att programmet körs som argument"
+msgstr ""
 
 msgid "no changes found"
-msgstr "hittade inga ändringar"
+msgstr ""
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr "hittade inga ändringar av typen %q"
+msgstr ""
 
 msgid "no interfaces currently connected"
-msgstr "inga gränssnitt anslutna just nu"
+msgstr ""
 
 msgid "no interfaces found"
-msgstr "inga gränssnitt hittades"
+msgstr ""
 
 msgid "no matching snaps installed"
-msgstr "inga matchande snappar installerade"
+msgstr ""
 
 msgid "no such interface"
-msgstr "inget sådant gränssnitt"
+msgstr ""
 
 msgid "no valid snaps given"
-msgstr "inga giltiga snappar angivna"
+msgstr ""
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr "ange ändrings-ID eller typ med --last=<typ>"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr "privat"
+msgstr ""
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2195,19 +2082,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr "reparationer är inte tillgängliga på ett klassiskt system"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr "s"
+msgstr ""
 
 #, c-format
 msgid "set failed: %v"
-msgstr "set misslyckades: %v"
+msgstr ""
 
 msgid "set which option?"
-msgstr "sätt vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2221,7 +2108,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr "snapp %q har inga tillgängliga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2229,30 +2116,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr "snapp %q finns inte"
+msgstr ""
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr "snapp är gratis"
+msgstr ""
 
 msgid "too many arguments for command"
-msgstr "för många argument för kommandot"
+msgstr ""
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr "för många argument för krok %q: %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr "för många argument: %s"
+msgstr ""
 
 msgid "unable to contact snap store"
-msgstr "kan inte kontakta snap store"
+msgstr ""
 
 msgid "unavailable"
-msgstr "otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2268,31 +2155,30 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr "okänd tjänst: %q"
+msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr "varning:\tingen snapp hittades för %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr "å"
+msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr "Autentisera mot snapp-daemon"
+msgstr ""
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr "Identitskontroll krävs för att autentisera mot snapp-daemonen"
+msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr "Installera, uppdatera eller ta bort paket"
+msgstr ""
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
-"Autentisering krävs för att installera, uppdatera, eller ta bort paket"
 
 msgid "Connect, disconnect interfaces"
-msgstr "Anslut, koppla bort gränssnitt"
+msgstr ""
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr "Autentisering krävs för att ansluta eller koppla bort gränssnitt"
+msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -112,7 +112,7 @@ msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "forutsetningsfil>"
+msgstr "<forutsetningsfil>"
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"

--- a/po/nb.po
+++ b/po/nb.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr "«-r» kan bare brukes sammen med «--hook»"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<forutsetningsfil>"
+msgstr "forutsetningsfil>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<forutsetningstype>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<endrings-ID>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<oppsettsverdi>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<e-post>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<filnavn>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<hodefilter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nøkkelnavn>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<nøkkel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<modellforutsetning>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<spørring>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<rotmappe>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plugg>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<spor eller or plugg>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<spor>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Avbryt pågående endring"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr "Legger til en forutsetning i systemet"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias for «--dangerous» (UTGÅTT)"
 
@@ -212,6 +217,7 @@ msgstr "Alle snap-pakker er oppdatert."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Alternativ kommando som skal kjøres"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Vis alltid dokument, selv med enkeltknapp"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "E-postadresse til en bruker på login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Forutsetningsfil"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Forutsetningstypenavn"
 
@@ -282,7 +293,7 @@ msgstr "Ugyldig kode. Prøv igjen: "
 msgid "Buys a snap"
 msgstr "Kjøper en snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Oppsettsverdi (nøkkel=verdi)"
 
@@ -306,14 +317,15 @@ msgstr "Koble %s:%s til %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Kobler en plugg til et spor"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Begrens visning til bestemt snap eller snap:navn"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Begrens visning til bestemt grensesnitt"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Begrens visning til elementer som samsvarer med hode=verdi"
 
@@ -370,6 +382,7 @@ msgstr "Koble %s:%s fra %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Kobler en plugg fra et spor"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -377,6 +390,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr "Last ned snap %q%s fra kanal %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -420,16 +434,18 @@ msgstr "Henter forutsetninger for %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Henter snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Filnavn på snap som du vil bygge for"
 
 msgid "Finds packages to install"
 msgstr "Finner pakker som skal installeres"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -443,33 +459,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Lag enhetsnøkkel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Lag bruksanvisning («manpage»)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr "Grad viser snap-ens byggekvalitet (standard er «stable» - stabil)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Gi sudo-tilgang til opprettet bruker"
 
 msgid "Help"
 msgstr "Hjelp"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Krok som skal kjøres"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr "ID\tStatus\tFramtoning\tKlar\tSammendrag\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Signatur-identifisering"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Identifisering av snap-pakke som er knyttet til bygget"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -484,6 +508,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -509,15 +534,19 @@ msgstr "Installer %q snap fra fil"
 msgid "Install %q snap from file %q"
 msgstr "Installer %q snap fra fil %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Installer fra beta-kanal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Installer fra kandidat-kanal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Installer fra edge-kanal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Installer fra stable-kanal"
 
@@ -530,10 +559,12 @@ msgstr "Installer snap %q"
 msgid "Install snaps %s"
 msgstr "Installer %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr "Installer valgt revisjon av en snap som du må ha utviklertilgang til"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
@@ -543,6 +574,7 @@ msgstr ""
 "signaturer for den. Dette betyr at snap-en ikke er bekreftet, og at den kan "
 "være farlig (dette er vanlig ved bruk av «--devmode»)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -556,8 +588,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Installerer en snap på systemet"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr "Interessenøkkel i oppsettet"
 
@@ -622,22 +654,24 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr "Monter snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Navn på nøkkel som skal lages (standard er «default»)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Navn på nøkkel du vil slette"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Navn på nøkkel du vil eksportere"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Navn på GnuPG-nøkkel du vil bruke (bruker navnet «default» som standard)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Navn på nøkkelen du vil bruke (hvis annet enn standardnøkkel)"
 
@@ -698,6 +732,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr "Ingen snap-er er installert enda. Prøv «snap install hello-world»."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Skriv ut treff i JSON-format"
 
@@ -766,12 +802,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -829,6 +868,7 @@ msgstr "Fjern snap-data %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Bare fjern valgt revisjon"
 
@@ -853,6 +893,7 @@ msgstr "Fjern snap %q (%s) fra systemet"
 msgid "Remove snaps %s"
 msgstr "Fjern snap-er %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -868,6 +909,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -881,9 +923,11 @@ msgstr "Tilbakestill %q snap"
 msgid "Reverts the given snap to the previous state"
 msgstr "Tilbakestiller valgt snap til tidligere tilstand"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Kjør skall i stedet for kommando (nyttig ved feilsøking)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -923,6 +967,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -935,6 +980,7 @@ msgstr "Kjør valgt snap-kommando med korrekt begrensning og miljø"
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Søk etter private snap-er"
 
@@ -977,9 +1023,11 @@ msgstr "Sett opp sikkerhetsprofiler for snap %q%s"
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -989,13 +1037,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1028,8 +1078,8 @@ msgstr "Spor\tPlugg"
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Snapnavn"
 
@@ -1079,6 +1129,7 @@ msgstr "Stopp snap-tjenester"
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1097,6 +1148,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1114,16 +1166,16 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 "Brukernavn/e-postadresse (login.ubuntu.com) som skal brukes til innlogging"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Modell-forutsetningsnavn"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Utdata-mappe"
 
@@ -1131,11 +1183,12 @@ msgstr "Utdata-mappe"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "Snap som skal settes opp (f.eks. «hello-world»)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "Snap som oppsett blir forespurt for"
 
@@ -1175,15 +1228,18 @@ msgstr "Toveis-autentiseringskode: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr "Bruk bestemt snap-revisjon ved kjørng av krok"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Bruk denne kanalen i stedet for «stable» (stabil)"
 
@@ -1196,6 +1252,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "ADVARSEL: klarte ikke å slå på loggføring: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Probeer 'snapcraft prime' in uw projectmap en probeer daarna opnieuw 'snap "
 "try'."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q overgeschakeld naar het kanaal %q\n"
@@ -105,88 +106,89 @@ msgstr "--list kent geen modus of kanaalvlaggen"
 msgid "-r can only be used with --hook"
 msgstr "-r kan alleen worden gebruikt met --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<alias-of-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<bevestigingsbestand>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<bevestigingstype>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<change-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<conf value>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<email>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<bestandsnaam>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<kopfilter>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<apparaat>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<key-name>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<sleutel>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<model-assertion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<zoekopdracht>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<root-dir>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<slot or plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Breek een wachtende verandering af"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Toegevoegd"
 
@@ -204,9 +207,11 @@ msgstr "Voegt een bevestiging toe aan het systeem"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Alias voor --dangerous (VEROUDERD)"
 
@@ -216,6 +221,7 @@ msgstr "Alle snaps zijn bijgewerkt."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +236,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Alternatieve opdracht om uit te voeren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Toon altijd het document, zelfs met een enkele toets"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Toon altijd de lijst, zelfs met een enkele toets"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Een e-mail van een gebruiker op login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Bevestigingsbestand"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Naam van bevestigingstype"
 
@@ -286,7 +297,7 @@ msgstr "Slechte code. Probeer opnieuw: "
 msgid "Buys a snap"
 msgstr "Koopt een snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "ID veranderen"
 
@@ -296,7 +307,7 @@ msgstr "Verandert instellingsopties"
 msgid "Command\tAlias\tNotes"
 msgstr "Opdracht\tAlias\tNotities"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Instellingswaarde (key=value)"
 
@@ -310,14 +321,15 @@ msgstr "Aansluiten van %s: %s aan %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Verbindt een stekker met een contact"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Beperk lijstweergave tot een specifieke snap of snap:naam"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Beperk lijstweergave tot specifieke apparaten"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -375,6 +387,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr "Trekt een stekker uit een contact"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 "Wacht niet totdat de bewerking is voltooid maar druk gewoon de wijzigings-ID "
@@ -384,6 +397,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -427,18 +441,20 @@ msgstr "Bevestigingen aan het ophalen voor %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Snap %q aan het ophalen\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Bestandsnaam van de snap waar u een bouwsel voor wilt bevestigen"
 
 msgid "Finds packages to install"
 msgstr "Zoekt pakketten om te installeren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 "Dwing toevoegen van de gebruiker af, zelfs indien het apparaat reeds wordt "
 "beheerd"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Dwing invoeren af op klassieke systemen"
 
@@ -450,33 +466,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Maak de hulppagina aan"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr "Graad vermeldt de bouwkwaliteit van de snap (standaard is 'stabiel')"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Verleen sudo-toegang aan de aangemaakte gebruiker"
 
 msgid "Help"
 msgstr "Hulp"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr "Negeer validatie door andere snaps die de verversing blokkeren"
 
@@ -499,6 +523,7 @@ msgstr ""
 "Neem een uitgebreide lijst op van de aantekeningen van een snap (zo niet: "
 "vat de aantekeningen samen)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Neem ongebruikte apparaten op"
 
@@ -510,7 +535,7 @@ msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installeer %q snap"
+msgstr "Snap %q installeren"
 
 #, c-format
 msgid "Install %q snap from %q channel"
@@ -518,51 +543,58 @@ msgstr "Installeer %q snap vanuit %q kanaal"
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installeer %q snap vanuit bestand"
+msgstr "Snap %q vanuit bestand installeren"
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installeer %q snap vanuit bestand %q"
+msgstr "Snap %q vanuit bestand %q installeren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installeer vanuit het bètakanaal"
+msgstr "Installeren vanuit het bètakanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installeer vanuit het kandidatenkanaal"
+msgstr "Installeren vanuit het kandidatenkanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installeer vanuit het onstabiele kanaal"
+msgstr "Installeren vanuit het onstabiele kanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installeer vanuit het stabiele kanaal"
+msgstr "Installeren vanuit het stabiele kanaal"
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installeer snap %q"
+msgstr "Snap %q installeren"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installeer snaps %s"
+msgstr "Snaps %s installeren"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installeer de opgegeven revisie van een snap waarvoor u ontwikkelaarstoegang "
-"nodig hebt"
+"Installeren van de opgegeven revisie van een snap waarvoor u "
+"ontwikkelaarstoegang nodig heeft"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installeer het opgegeven snapbestand zelfs indien er geen vooraf erkende "
+"Het opgegeven snapbestand installeren, zelfs wanneer er geen vooraf erkende "
 "handtekeningen voor zijn, hetgeen betekent dat het niet werd geverifieerd en "
 "dus gevaarlijk zou kunnen zijn (--devmode impliceert dit)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installeer de opgegeven snap zonder zijn automatische aliassen in te "
+"De opgegeven snap installeren zonder zijn automatische aliassen in te "
 "schakelen"
 
 #, c-format
@@ -571,20 +603,23 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Installeer de snap met:\n"
+"   snap ack %s\n"
+"   snap install %s\n"
 
 msgid "Installs a snap to the system"
 msgstr "Installeert een snap in uw systeem"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr ""
+msgstr "Sleutel die van belang is binnen de configuratie"
 
 msgid "List a change's tasks"
-msgstr "Maak een lijst van de taken van een verandering"
+msgstr "Een lijst maken van de taken van een wijziging"
 
 msgid "List cryptographic keys"
-msgstr "Maak een lijst van cryptografische sleutels"
+msgstr "Een lijst maken van cryptografische sleutels"
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
@@ -642,25 +677,27 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Naam van te maken sleutel; valt standaard terug op 'default'"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Naam van te wissen sleutel"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Naam van te exporteren sleutel"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Naam van de te gebruiken sleutel voor GnuPG (valt standaard terug op "
 "'default' als sleutelnaam)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Naam van de te gebruiken sleutel, gebruik anders de standaardsleutel"
+msgstr "naam van de te gebruiken sleutel, gebruik anders de standaardsleutel"
 
 msgid "Name\tSHA3-384"
 msgstr "Naam\tSHA3-384"
@@ -721,6 +758,8 @@ msgstr ""
 "Thans zijn er nog geen snaps geïnstalleerd. Probeer 'snap install hello-"
 "world'."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Gefe resulaten weer in JSON-opmaak"
 
@@ -791,12 +830,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Zet snap in klassieke modus en schakel veiligheidsbeperking uit"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr "Zet snap in ontwikkelingsmodus en schakel veiligheidsbeperking uit"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Zet snap in afgedwongen beperkte modus"
 
@@ -854,6 +896,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr "Verwijder handmatige alias %q voor snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Verwijder alleen de opgegeven revisie"
 
@@ -878,6 +921,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr "Verwijder snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Verwijderd"
 
@@ -893,6 +937,7 @@ msgstr "Herstart diensten"
 msgid "Restarted.\n"
 msgstr "Herstart.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Beperk de zoekopdracht tot een opgegeven sectie"
 
@@ -906,9 +951,11 @@ msgstr "Draai %q snap terug"
 msgid "Reverts the given snap to the previous state"
 msgstr "Draait de opgegeven snap terug naar de vorige toestand"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -948,6 +995,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -960,6 +1008,7 @@ msgstr "Draai de opgegeven snapopdracht met de juiste beperking en omgeving"
 msgid "Runs debug commands"
 msgstr "Draait foutopsporingsopdrachten"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Doorzoek private snaps"
 
@@ -1004,9 +1053,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Toon alle revisies"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Toon automatische verversingsinformatie maar voer geen verversing uit"
@@ -1017,13 +1068,15 @@ msgstr "Toon beschikbare snaps voor verversen maar voer geen verversing uit"
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Toon bijzonderheden van een specifiek apparaat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Toon attributen van apparaten"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1053,8 +1106,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Naam van snap"
 
@@ -1107,6 +1160,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr "Stilgezet.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Strict intikken met nullen en tekenreeksen tussen aanhalingstekens"
 
@@ -1125,6 +1179,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr "Schakelt snap om naar een ander kanaal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Koppel het apparaat tijdelijk aan alvorens het te inspecteren"
 
@@ -1144,15 +1199,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "Het e-mailadres voor login.ubuntu.com om mee aan te melden"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "De uitvoermap"
 
@@ -1160,11 +1215,12 @@ msgstr "De uitvoermap"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "De in te stellen snap (bijv. hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "De snap waarvan de instellingen worden opgevraagd"
 
@@ -1204,15 +1260,18 @@ msgstr "Twee-factorcode: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Gebruik bekende bevestigingen voor het aanmaken van een gebruiker"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Gebruik dit kanaal in plaats van stabiel"
 
@@ -1225,6 +1284,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "Waarschuwing: kon logboek niet activeren: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -697,7 +697,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "naam van de te gebruiken sleutel, gebruik anders de standaardsleutel"
+msgstr "Naam van de te gebruiken sleutel, gebruik anders de standaardsleutel"
 
 msgid "Name\tSHA3-384"
 msgstr "Naam\tSHA3-384"

--- a/po/oc.po
+++ b/po/oc.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -23,10 +23,15 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
+"%q ne contient aucun paquet Snap décompressé.\n"
+"\n"
+"Ensajatz « snapcraft prime » dins votre repertòri de projet, puis a nouveau "
+"« snap try »."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q comutat sul canal %q\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
@@ -35,7 +40,7 @@ msgstr "%s %s montat dempuèi %s\n"
 
 #, c-format
 msgid "%s (delta)"
-msgstr ""
+msgstr "%s (dèlta)"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
@@ -45,11 +50,11 @@ msgstr "%s (veire « snap login --help »)"
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr ""
+msgstr "%s (ensajatz amb sudo)"
 
 #, c-format
 msgid "%s already installed\n"
-msgstr ""
+msgstr "%s es ja installat\n"
 
 #, c-format
 msgid "%s disabled\n"
@@ -61,7 +66,7 @@ msgstr "%s activat\n"
 
 #, c-format
 msgid "%s not installed\n"
-msgstr ""
+msgstr "%s es pas installat\n"
 
 #, c-format
 msgid "%s removed\n"
@@ -70,7 +75,7 @@ msgstr "%s suprimit\n"
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr ""
+msgstr "%s tornat a %s\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
@@ -80,7 +85,7 @@ msgstr "%s%s %s de « %s » installat\n"
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr ""
+msgstr "%s%s %s de « %s » actualizat\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
@@ -90,383 +95,427 @@ msgstr "%s%s %s installat\n"
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr ""
+msgstr "%s%s %s actualizat\n"
 
 msgid "--list does not take mode nor channel flags"
 msgstr ""
+"--list accèpta pas ni los marcadors de mòde ni los marcadors de canal"
 
 msgid "--time does not take mode nor channel flags"
-msgstr ""
+msgstr "--time accèpta pas las opcions mòde e/o canal"
 
 msgid "-r can only be used with --hook"
-msgstr ""
+msgstr "-r pòt pas èsser utilizat qu'amb --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr ""
+msgstr "<aliàs o paquet Snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr ""
+msgstr "<aliàs>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr ""
+msgstr "<fichièr d'assercion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr ""
+msgstr "<tipe d'assercion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr ""
+msgstr "<identificant de cambiament>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr ""
+msgstr "<Valor de configuracion>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr ""
+msgstr "<corrièl>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr ""
+msgstr "<nom del fichièr>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr ""
+msgstr "<filtre d'entèsta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr ""
+msgstr "<interfàcia>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr ""
+msgstr "<nom de la clau>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr ""
+msgstr "<modèl d'assercion>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr ""
+msgstr "<requèsta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr ""
+msgstr "<repertòri raiç>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<servici>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr ""
+msgstr "<snap>:<connector>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr ""
+msgstr "<snap>:<presa o connector>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr ""
+msgstr "<snap>:<presa>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
 
 msgid "Abort a pending change"
-msgstr ""
+msgstr "Anullar un cambiament en espèra"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
 msgid "Adds an assertion to the system"
-msgstr ""
+msgstr "Ajoute una assertion au sistèma"
 
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr ""
+msgstr "Aliàs per --dangerous (OBSOLÈT)"
 
 msgid "All snaps up to date."
-msgstr ""
+msgstr "Totes los paquets Snaps son a jorn."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Autorizar la dobertura del fichièr ?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Autorizar la modificacion de las preferéncias ?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Autorizar lo paquet Snap %q a cambiar %q en %q ?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Autorizar lo paquet Snap %q a dobrir lo fichièr %q ?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr ""
+msgstr "Comanda alternativa a « run »"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr ""
+msgstr "Totjorn tornar un document, quitament amb una clau unica"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr ""
+msgstr "Totjorn tornar la lista, quitament amb una clau unica"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr ""
+msgstr "Una adreça electronica d'un utilizaire sus login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
+"Amai d'aviar lo servici ara, lo configurar per que s'avie a l'aviada."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
+"Amai d'arrestar lo servici ara, lo configurar per que s'avie pas mai plus a "
+"l'aviada."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr ""
+msgstr "Fichièr d'assercion"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr ""
+msgstr "Nom del tipe d'assercion"
 
 msgid "Authenticates on snapd and the store"
-msgstr ""
+msgstr "Authentifie sus Snapd e sus la logithèque"
 
 #, c-format
 msgid "Auto-refresh %d snaps"
-msgstr ""
+msgstr "Actualizar automaticament %d paquets Snap"
 
 #, c-format
 msgid "Auto-refresh snap %q"
-msgstr ""
+msgstr "Actualizar automaticament lo paquet Snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Auto-refresh snaps %s"
-msgstr ""
+msgstr "Actualizar automaticament los paquets Snap %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr ""
+msgstr "Còde fals. Reensajatz : "
 
 msgid "Buys a snap"
-msgstr ""
+msgstr "Achète un paquet Snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "Cambiar l'identificant"
 
 msgid "Changes configuration options"
-msgstr ""
+msgstr "Modifica las opcions de configuracion"
 
 msgid "Command\tAlias\tNotes"
-msgstr ""
+msgstr "Comanda\tAliàs\tNòtas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr ""
+msgstr "Valor de configuracion (clau=valor)"
 
 msgid "Confirm passphrase: "
-msgstr ""
+msgstr "Confirmatz la frasa secreta : "
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
-msgstr ""
+msgstr "Connectar %s:%s a %s:%s"
 
 msgid "Connects a plug to a slot"
-msgstr ""
+msgstr "Connecte un connecteur a una prise"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr ""
+msgstr "Limita la lista a un paquet Snap especific o snap:nom"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr ""
+msgstr "Limita la lista a d'interfàcias especificas"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr ""
+msgstr "Limita la lista als elements que correspondon a entèsta=Valor"
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr ""
+msgstr "Copiar las donadas del paquet Snap %q"
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
+"Crear una paire de claus chiffrées qui pòt èsser utilizada per la signature "
+"des assertions."
 
 msgid "Create cryptographic key pair"
-msgstr ""
+msgstr "Crear una para de claus chifradas"
 
 msgid "Create snap build assertion"
-msgstr ""
+msgstr "Crear una assertion de construction del paquet Snap"
 
 msgid "Create snap-build assertion for the provided snap file."
 msgstr ""
+"Crear una assertion de construction del paquet Snap per lo fichièr Snap "
+"fourni."
 
 msgid "Creates a local system user"
-msgstr ""
+msgstr "Crée un utilizaire local del sistèma"
 
 msgid "Delete cryptographic key pair"
-msgstr ""
+msgstr "Suprimir una para de claus chifradas"
 
 msgid "Delete the local cryptographic key pair with the given name."
 msgstr ""
+"Suprimir la paire de claus locales chiffrées possédant lo nom indiqué."
 
 #, c-format
 msgid "Disable %q snap"
-msgstr ""
+msgstr "Paquet Snap %q desactivat"
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr ""
+msgstr "Desactivar los aliasses pel paquet Snap %q"
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr ""
+msgstr "Desactiva totes los aliasses pel paquet Snap %q"
 
 msgid "Disables a snap in the system"
-msgstr ""
+msgstr "Desactiva un paquet Snap dins lo sistèma"
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
-msgstr ""
+msgstr "Escafar las connexions entre interfàcias pel paquet Snap %q (%s)"
 
 #, c-format
 msgid "Disconnect %s:%s from %s:%s"
-msgstr ""
+msgstr "Desconnectar %s:%s de %s:%s"
 
 msgid "Disconnects a plug from a slot"
-msgstr ""
+msgstr "Déconnecte un connecteur d'una prise"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
+"Esperar pas la fin de l'operacion, mas afichar simplament l'identificant de "
+"modificacion."
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr ""
+msgstr "Telecargar un paquet Snap %q%s a partir del canal %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
+"Telecargar la revision donada d'un paquet Snap, cap a la quala vos cal aver "
+"d'accèsses desvolopaire"
 
 msgid "Downloads the given snap"
-msgstr ""
+msgstr "Télécharge lo paquet Snap en question"
 
 msgid "Email address: "
-msgstr ""
+msgstr "Adreça electronica : "
 
 #, c-format
 msgid "Enable %q snap"
-msgstr ""
+msgstr "Activar lo paquet Snap %q"
 
 msgid "Enables a snap in the system"
-msgstr ""
+msgstr "Active un paquet Snap dins lo sistèma"
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr ""
+msgstr "Asseguratz-vos que los prerequesits per %q son disponibles"
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
+"Exportar un corps d'assercion de clau publique qui puisse être importé per "
+"d'autres sistèmas."
 
 msgid "Export cryptographic public key"
-msgstr ""
+msgstr "Exportar una clau de chiframent publica"
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
-msgstr ""
+msgstr "Recuperar e verificar las assercions pel paquet Snap %q%s"
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr ""
+msgstr "Recuperacion de las assercions per %q\n"
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr ""
+msgstr "Recuperacion del paquet Snap %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
+"Lo nom del fichièr del paquet Snap pel qual volètz definir una version"
 
 msgid "Finds packages to install"
-msgstr ""
+msgstr "Trouve los paquets a installar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
+"Forçar l'apondon de l'utilizaire, quitament se l'aparelh es ja administrat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr ""
+msgstr "Forçar l'importacion dins los sistèmas classics"
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
+"Formatar lo material de clau publica coma una demanda de clau de compte per "
+"aqueste identificant de compte"
 
 msgid "Generate device key"
-msgstr ""
+msgstr "Generar la clau del periferic"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr ""
+msgstr "Generar las paginas de manual"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
+"Lo grad indica la qualitat de version del paquet Snap (« stable » per defaut)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr ""
+msgstr "Acordar los accèsses administrator a l'utilizaire creat"
 
 msgid "Help"
-msgstr ""
+msgstr "Aide"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr ""
+msgstr "Punt d'acròcha a executar"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Identificant\tEstat\tDescendéncia\tPrèst\tResumit\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr ""
+msgstr "Identificant del signatari"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr ""
+msgstr "Identificant del paquet Snap associat a la version"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
+"Ignorar la validacion per d'autres paquets Snap que blòcan l'actualizacion"
 
 #, c-format
 msgid ""
@@ -475,68 +524,87 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
+"Per crompar %q, vos cal acceptar la darrièra version de las condicions "
+"generalas. Per aquò, anatz sus https://my.ubuntu.com/payment/edit.\n"
+"\n"
+"Puèi, tornatz aicí e executatz tornamai « snap buy %s »."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
+"Inclure una liste detalhada des notes d'un paquet Snap (résume les notes "
+"dans lo cas contraire)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr ""
+msgstr "Inclure las interfàcias inutilizadas"
 
 msgid "Initialize device"
-msgstr ""
+msgstr "Inicializar l'aparelh"
 
 msgid "Inspects devices for actionable information"
-msgstr ""
+msgstr "Cherche las informacions actionnables sus les aparelhs"
 
 #, c-format
 msgid "Install %q snap"
-msgstr ""
+msgstr "Installar lo paquet Snap %q"
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr ""
+msgstr "Installar lo paquet Snap %q que proven del canal %q"
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr ""
+msgstr "Installar lo paquet Snap %q a partir del fichièr"
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr ""
+msgstr "Installar lo paquet Snap %q a partir del fichièr %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr ""
+msgstr "Installar a partir del canal bèta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr ""
+msgstr "Installar a partir del canal candidat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr ""
+msgstr "Installar a partir del canal avançat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr ""
+msgstr "Installar a partir del canal estable"
 
 #, c-format
 msgid "Install snap %q"
-msgstr ""
+msgstr "Installar lo paquet Snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr ""
+msgstr "Installar los paquets Snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
+"Installar la revision donada d'un paquet Snap, al qual vos cal aver los "
+"accèsses desvolopaire"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
+"Installar lo paquet Snap donat quitament se i a pas de signaturas "
+"reconegudas prealablament per aqueste, aquò significa qu'es pas estat "
+"verificat e poiriá èsser dangierós (--devmode implica aquò)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
-msgstr ""
+msgstr "Installar lo snap donat sens activar sos aliasses automatics"
 
 #, c-format
 msgid ""
@@ -544,111 +612,119 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
+"Installar lo paquet Snap amb :\n"
+"   snap ack %s\n"
+"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr ""
+msgstr "Installe un paquet Snap sus lo sistèma"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr ""
+msgstr "Clau d'interès dins lo quadre de la configuracion"
 
 msgid "List a change's tasks"
-msgstr ""
+msgstr "Listar los prètzfaitss d'una modificacion"
 
 msgid "List cryptographic keys"
-msgstr ""
+msgstr "Listar las claus de chiframent"
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
+"Listar las claus de chiframent qui pòdon èsser utilizadas per la signature "
+"des assertions."
 
 msgid "List installed snaps"
-msgstr ""
+msgstr "Listar los paquets Snap installats"
 
 msgid "List system changes"
-msgstr ""
+msgstr "Listar los cambiaments del sistèma"
 
 msgid "Lists aliases in the system"
-msgstr ""
+msgstr "Afichar la liste des alias dins lo sistèma"
 
 msgid "Lists all repairs"
-msgstr ""
+msgstr "Liste totas las reparacions"
 
 msgid "Lists interfaces in the system"
-msgstr ""
+msgstr "Liste las interfàcias dins lo sistèma"
 
 msgid "Lists snap interfaces"
-msgstr ""
+msgstr "Liste las interfàcias snap"
 
 msgid "Log out of the store"
-msgstr ""
+msgstr "Se desconnectar de la logithèque"
 
 msgid "Login successful"
-msgstr ""
+msgstr "Connexion capitada"
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr ""
+msgstr "Rendre indisponibla la revision actuala del paquet Snap %q"
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr ""
+msgstr "Rendre disponible lo paquet Snap %q (%s) pel sistèma"
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr ""
+msgstr "Rendre indisponible lo paquet Snap %q (%s)  pel sistèma"
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr ""
+msgstr "Rendre indisponible lo paquet Snap %q pel sistèma"
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr ""
+msgstr "Rendre disponible lo paquet Snap %q%s pel sistèma"
 
 msgid "Mark system seeded"
-msgstr ""
+msgstr "Marcar lo sistèma coma preparat"
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr ""
+msgstr "Montar lo paquet Snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr ""
+msgstr "Nom de la clau de crear ; « default » per defaut"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr ""
+msgstr "Nom de la clau de suprimir"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr ""
+msgstr "Nom de la clau d'exportar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
-msgstr ""
+msgstr "Nom de la clau GnuPG d'utilizar (nom de clau « default » per defaut)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
+"Nom de la clau d'utilizar, utilizacion de la clau per defaut autrament"
 
 msgid "Name\tSHA3-384"
-msgstr ""
+msgstr "Nom\tSHA3-384"
 
 msgid "Name\tSummary"
-msgstr ""
+msgstr "Nom\tResumit"
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr ""
+msgstr "Nom\tVersion\tDesvolopaire\tNotes\tRésumé"
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr ""
+msgstr "Nom\tVersion\tRevision\tDesvolopaire\tNotes"
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr ""
+msgstr "Cap d'aliàs es pas definit pel paquet Snap %q.\n"
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -658,7 +734,7 @@ msgid "No command %q found, did you mean:\n"
 msgstr ""
 
 msgid "No connections to disconnect"
-msgstr ""
+msgstr "Pas cap de connexion de desconnectar"
 
 #. TRANSLATORS: the %q is the (quoted) name of the section the user entered
 #, c-format
@@ -687,9 +763,13 @@ msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
+"Aucun paquet Snap n'est encore installat. Ensajatz « snap install hello-"
+"world »."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr ""
+msgstr "Resultats de sortida en format JSON"
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -699,11 +779,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr ""
+msgstr "Frasa secreta : "
 
 #, c-format
 msgid "Password of %q: "
-msgstr ""
+msgstr "Senhal de %q : amp> "
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -711,384 +791,419 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
+"Picatz tornamai vòstre senhal Ubuntu One per \n"
+"crompar %q de %q per %s. Quichatz sus Ctrl-C per anullar."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr ""
+msgstr "Preferís los aliasses pel paquet Snap %q"
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr ""
+msgstr "Preferís los aliasses d'un paquet Snap e desactiva los conflictes"
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr ""
+msgstr "Preferís los aliasses del paquet Snap %q"
 
 msgid "Prepare a snappy image"
-msgstr ""
+msgstr "Preparar una image Snappy"
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr ""
+msgstr "Preparar lo paquet Snap %q (%s)"
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr ""
+msgstr "Preparar lo paquet Snap %q%s"
 
 msgid "Print the version and exit"
-msgstr ""
+msgstr "Imprimir la version e quitar"
 
 msgid "Prints configuration options"
-msgstr ""
+msgstr "Aficha las opcions de configuracion"
 
 msgid "Prints the confinement mode the system operates in"
-msgstr ""
+msgstr "Imprime lo mode de confinement dins lequel lo sistèma fonctionne"
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr ""
+msgstr "Indique si lo sistèma es géré"
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
+"Plaçar lo paquet Snap en mòde classic e desactivar lo confinament de "
+"seguretat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
+"Plaçar lo paquet Snap en mòde desvolopament e desactivar lo confinament de "
+"seguretat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr ""
+msgstr "Plaçar lo paquet Snap en mòde de confinament forçat"
 
 msgid "Query the status of services"
-msgstr ""
+msgstr "Interrogar l'estat dels servicis"
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr ""
+msgstr "Actualizar lo paquet Snap %q"
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr ""
+msgstr "Actualizar lo paquet Snap %q del canal %q"
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr ""
+msgstr "Actualiza los aliasses pel paquet Snap %q"
 
 msgid "Refresh all snaps: no updates"
-msgstr ""
+msgstr "Actualizar totes los paquets Snap : pas de mesa a jorn"
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr ""
+msgstr "Actualizar lo paquet Snap %q"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr ""
+msgstr "Actualizar los paquets Snap %s"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr ""
+msgstr "Actualizar automaticament los paquets Snap %s : pas de mesa a jorn"
 
 msgid "Refresh to the given revision"
-msgstr ""
+msgstr "Actualizar la revision donada"
 
 msgid "Refreshes a snap in the system"
-msgstr ""
+msgstr "Actualise un paquet Snap del sistèma"
 
 #, c-format
 msgid "Remove %q snap"
-msgstr ""
+msgstr "Suprimir lo paquet Snap %q"
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr ""
+msgstr "Suprimir los aliasses pel paquet Snap %q"
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr ""
+msgstr "Suprimir las donadas del paquet Snap %q (%s)"
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr ""
+msgstr "Suprimís l'aliàs manual %q pel paquet Snap %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr ""
+msgstr "Suprimir unicament la revision donada"
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr ""
+msgstr "Suprimir lo perfil de seguretat del paquet Snap %q (%s)"
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr ""
+msgstr "Suprimir lo perfil de seguretat del paquet Snap %q"
 
 #, c-format
 msgid "Remove snap %q"
-msgstr ""
+msgstr "Suprimir lo paquet Snap %q"
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr ""
+msgstr "Suprimir lo paquet Snap %q (%s) del sistèma"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr ""
+msgstr "Suprimir los paquets Snap %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr ""
+msgstr "Suprimit"
 
 msgid "Removes a snap from the system"
-msgstr ""
+msgstr "Supprime un paquet Snap del sistèma"
 
 msgid "Request device serial"
-msgstr ""
+msgstr "Demandar lo numèro de seria de l'aparelh"
 
 msgid "Restart services"
-msgstr ""
+msgstr "Reaviar los servicis"
 
 msgid "Restarted.\n"
-msgstr ""
+msgstr "Reaviat.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr ""
+msgstr "Restrénher la recèrca a una seccion donada"
 
 msgid "Retrieve logs of services"
-msgstr ""
+msgstr "Recuperar los jornals de servicis"
 
 #, c-format
 msgid "Revert %q snap"
-msgstr ""
+msgstr "Restablir lo paquet Snap %q"
 
 msgid "Reverts the given snap to the previous state"
-msgstr ""
+msgstr "Retablís lo paquet Snap donat a son precedent estat"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr ""
+msgstr "Executar un shell puslèu que la comanda (utile pel desbugatge)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr ""
+msgstr "Executar la configuracion del punt d'acròcha del paquet Snap %q"
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
 msgstr ""
+"Executar la configuracion del punt d'acròcha del paquet Snap %q s'es present"
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr ""
+msgstr "Executar lo punt d'acròcha %s del paquet Snap %q"
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr ""
+msgstr "Aviar l'installacion del punt d'acròcha del snap %q se existent"
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
 msgstr ""
+"Aviar lo post-refrescament del punt d'acròcha del snap %q se existent"
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr ""
+msgstr "Executar lo punt d'acròcha prepare-device"
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr ""
+msgstr "Aviar la supression del punt d'acròcha del snap %q se existent"
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
-msgstr ""
+msgstr "Executar la comanda amb gdb"
 
 msgid "Run the given snap command"
-msgstr ""
+msgstr "Executar la comanda Snap donada"
 
 msgid "Run the given snap command with the right confinement and environment"
 msgstr ""
+"Executar la comanda Snap donada amb lo confinement e l'environnement corrects"
 
 msgid "Runs debug commands"
-msgstr ""
+msgstr "Exécute les commandes de desbugatge"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr ""
+msgstr "Recercar de paquets Snap privats"
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
+"Sélectionnez lo dernier cambiament de type donat (installar, actualizar, "
+"suprimir, ensajar, actualizar automaticament, etc.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr ""
+msgstr "Definir los aliasses automatics pel paquet Snap %q"
 
 msgid "Sets up a manual alias"
-msgstr ""
+msgstr "Definís un aliàs manuel"
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr ""
+msgstr "Definís l'aliàs %q => %q pel paquet Snap %q"
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr ""
+msgstr "Definís l'aliàs manual %q => %q pel paquet Snap %q"
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr ""
+msgstr "Configurar los perfils de seguretat del paquet Snap %q (%s)"
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr ""
+msgstr "Configurar los aliasses del paquet Snap %q"
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr ""
+msgstr "Definir los perfils de seguretat del paquet Snap %q%s"
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
-msgstr ""
+msgstr "Configurer los perfils de seguretat del paquet Snap %q%s (phase 2)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
-msgstr ""
+msgstr "Afichar totas las revisions"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
-msgstr ""
+msgstr "Aficha las informacions de refrescament automatic sens actualizar"
 
 msgid "Show available snaps for refresh but do not perform a refresh"
 msgstr ""
+"Aficha los paquets Snap disponibles per un refrescament sens efectuar "
+"d'actualizacion"
 
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
-msgstr ""
+msgstr "Afichar los detalhs d'una interfàcia especifica"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
-msgstr ""
+msgstr "Afichar los atributs de l'interfàcia"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
 msgid "Shows known assertions of the provided type"
-msgstr ""
+msgstr "Aficha las assercions connues del type fourni"
 
 msgid "Shows specific repairs"
-msgstr ""
+msgstr "Aficha les réparations spécifiques"
 
 msgid "Shows version details"
-msgstr ""
+msgstr "Afichar los detalhs de la version"
 
 msgid "Sign an assertion"
-msgstr ""
+msgstr "Signar una assercion"
 
 msgid ""
 "Sign an assertion using the specified key, using the input for headers from "
 "a JSON mapping provided through stdin, the body of the assertion can be "
 "specified through a \"body\" pseudo-header.\n"
 msgstr ""
+"Signer una assertion amb la clau spécifiée, en utilisant coma entrée per les "
+"entèstas un modèl JSON fourni via stdin. Lo corps de l'assercion peut être "
+"spécifié via un pseudo-entèsta « body ».\n"
 
 msgid "Slot\tPlug"
-msgstr ""
+msgstr "Presa\tConnector"
 
 #. TRANSLATORS: first %s is a snap name, following %s is a channel name
 #, c-format
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr ""
+msgstr "Nom del paquet Snap"
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
 "your\n"
 "payment details at https://my.ubuntu.com/payment/edit and try again."
 msgstr ""
+"O planhèm, vòstre mòde de pagament es refusat per l'emeteire. Consultatz "
+"vòstres\n"
+"detalhs de pagament sus https://my.ubuntu.com/payment/edit e reensajatz."
 
 msgid "Start services"
-msgstr ""
+msgstr "Aviar los servicis"
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr ""
+msgstr "Aviar los servicis del paquet Snap %q (%s)"
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr ""
+msgstr "Aviar los servicis del paquet Snap %q%s"
 
 msgid "Start snap services"
-msgstr ""
+msgstr "Aviar los servicis del paquet Snap"
 
 msgid "Start the userd service"
-msgstr ""
+msgstr "Aviar lo servici userd"
 
 msgid "Started.\n"
-msgstr ""
+msgstr "Aviat.\n"
 
 msgid "Status\tSpawn\tReady\tSummary\n"
-msgstr ""
+msgstr "Estat\tDescendéncia\tPrèst\tResumit\n"
 
 msgid "Stop services"
-msgstr ""
+msgstr "Arrestar los servicis"
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr ""
+msgstr "Arrestar los servicis del paquet Snap %q (%s)"
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr ""
+msgstr "Arrestar los servicis del paquet Snap %q"
 
 msgid "Stop snap services"
-msgstr ""
+msgstr "Arrestar los servicis del paquet Snap"
 
 msgid "Stopped.\n"
-msgstr ""
+msgstr "Arrestat.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr ""
+msgstr "Picada exacta amb cadenas voidas e entre verguetas"
 
 #, c-format
 msgid "Switch %q snap to %s"
-msgstr ""
+msgstr "Bascular lo snap %q cap a %s"
 
 #, c-format
 msgid "Switch snap %q from %s to %s"
-msgstr ""
+msgstr "Passar lo paquet Snap %q de %s a %s"
 
 #, c-format
 msgid "Switch snap %q to %s"
-msgstr ""
+msgstr "Bascular lo snap %q sus %s"
 
 msgid "Switches snap to a different channel"
-msgstr ""
+msgstr "Bascula lo snap sus un autre canal"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
-msgstr ""
+msgstr "Montar lo periferic temporàriament abans inspeccion"
 
 msgid "Tests a snap in the system"
-msgstr ""
+msgstr "Teste un paquet Snap dins lo sistèma"
 
 #. TRANSLATORS: %q and %s are the same snap name. Please wrap the translation at 80 characters.
 #, c-format
@@ -1096,40 +1211,45 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
+"Mercé d'aver crompat %q. Ara, lo podètz installar sus vòstres aparelhs\n"
+"via un « snap install %s »."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
+"La comanda « get » aficha los paramètres de configuracion e de l'interfàcia "
+"de connexion."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr ""
+msgstr "L'adreça electronica login.ubuntu.com amb la quala se cal connectar"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
-msgstr ""
+msgstr "Lo nom del modèl d'assercion"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
-msgstr ""
+msgstr "Lo repertòri de sortida"
 
 #, c-format
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr ""
+msgstr "Lo paquet Snap de configurar (per exemple, hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr ""
+msgstr "Lo paquet Snap que la configuracion n'es demandada"
 
 msgid "The userd command starts the snap user session service."
-msgstr ""
+msgstr "La comanda userd démarre lo servici de session d'utilizaire de snap"
 
 msgid "This command logs the current user out of the store"
-msgstr ""
+msgstr "Cette comanda déconnecte l'utilizaire actuel de la logithèque"
 
 msgid "This dialog will close automatically after 5 minutes of inactivity."
 msgstr ""
@@ -1139,72 +1259,82 @@ msgid "Toggle snap %q flags"
 msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr ""
+msgstr "Aisina per interagir amb los paquets Snap"
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
-msgstr ""
+msgstr "Transferiment dels perfils de seguretat de %q cap a %q"
 
 msgid "Transition ubuntu-core to core"
-msgstr ""
+msgstr "Transferiment d'ubuntu-core cap a core"
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr ""
+msgstr "Ensajar lo paquet Snap %q de %s"
 
 msgid "Try: snap install <selected snap>\n"
 msgstr ""
 
 msgid "Two-factor code: "
-msgstr ""
+msgstr "Còdi de dos factors : "
 
 msgid "Unalias a manual alias or an entire snap"
-msgstr ""
+msgstr "Suprimís un aliàs manual o un paquet Snap entièr"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
+"Utilizar una version especifica del paquet Snap al moment de l'execucion del "
+"punt d'acròcha"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
-msgstr ""
+msgstr "Utilizar las assercions conegudas per la creacion d'utilizaire"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
-msgstr ""
+msgstr "Utilizar aqueste canal puslèu que lo canal estable"
 
 msgid ""
 "WARNING: The output of \"snap get\" will become a list with columns - use -d "
 "or -l to force the output format.\n"
 msgstr ""
+"AVERTISSEMENT : La sortida de « snap get » deviendra una liste amb des "
+"colonnes, utilisez -d o -l per forcer lo format de sortida.\n"
 
 #, c-format
 msgid "WARNING: failed to activate logging: %v\n"
-msgstr ""
+msgstr "ATENCION : fracàs de l'activacion de la connexion : %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 
 msgid "Waiting for server to restart"
-msgstr ""
+msgstr "En espèra de la reaviada del servidor"
 
 msgid "Watch a change in progress"
-msgstr ""
+msgstr "Susvelhar un cambiament en cors"
 
 msgid "Wrong again. Once more: "
-msgstr ""
+msgstr "Tornamai incorrècte. Encara un còp : "
 
 #, c-format
 msgid "Xauthority file isn't owned by the current user %s"
-msgstr ""
+msgstr "Lo fichièr Xauthority aparten pas a l'utilizaire actual %s"
 
 msgid "Yes, yes it does."
-msgstr ""
+msgstr "Òc, òc es lo cas."
 
 msgid ""
 "You need to be logged in to purchase software. Please run 'snap login' and "
 "try again."
 msgstr ""
+"Vos cal èsser connectat per crompar de logicials. Executatz « snap login » e "
+"réensajar."
 
 #, c-format
 msgid ""
@@ -1214,11 +1344,17 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
+"Un mòde de pagament deu èsser associat a vòstre compte per poder crompar un "
+"paquet Snap. Anatz sus https://my.ubuntu.com/payment/edit per n'apondre un.\n"
+"\n"
+"Puèi, sufís d'executar tornamai « snap buy %s »."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
 msgid "\"snap changes\" command expects a snap name, try: \"snap tasks %s\""
 msgstr ""
+"La comanda « snap changes » attend un nom de paquet Snap, ensajatz : « snap "
+"tasks %s »"
 
 msgid ""
 "\n"
@@ -1230,6 +1366,19 @@ msgid ""
 "This is the CLI for snapd, a background service that takes care of\n"
 "snaps on the system. Start with 'snap list' to see installed snaps.\n"
 msgstr ""
+"\n"
+"Installar, configurer, actualizar e suprimir des paquets Snap. Ceux-ci sont "
+"des\n"
+"« paquets universels » qui fonctionnent sus de nombreux sistèmas Linux "
+"différents,\n"
+"permettant la distribution sécurisée des dernières applications e des "
+"derniers utilitaires pour\n"
+"le nuage, les servidors, les ordinateurs de bureau e l'internet des objets.\n"
+"\n"
+"Aquò es l'interfàcia en ligne de comanda per Snapd, un service en arrière-"
+"plan qui prend en charge les\n"
+"paquets Snap sus lo sistèma. Commencez amb « snap list » per voir les "
+"paquets Snap installats.\n"
 
 msgid ""
 "\n"
@@ -1240,6 +1389,9 @@ msgid ""
 "\n"
 "The abort command attempts to abort a change that still has pending tasks.\n"
 msgstr ""
+"\n"
+"La comanda « abort » ensaja d'interrompre un cambiament qu'a encara de "
+"prètzfaits en cors.\n"
 
 msgid ""
 "\n"
@@ -1253,6 +1405,17 @@ msgid ""
 "public key and the assertion consistent with and its prerequisite in the\n"
 "database.\n"
 msgstr ""
+"\n"
+"La comanda « ack » essaye d'ajouter una assertion a la basa de donadas "
+"d'assercions del sistèma.\n"
+"\n"
+"L'assercion peut également être una nouvelle revision d'una assertion "
+"préexistante qu'elle remplacera.\n"
+"\n"
+"Pour réussir, l'assercion doit être valide, sa signature vérifiée amb una "
+"clé publique connue e per \n"
+"laquelle l'assercion es consistante e sa condition préalable dins la base de "
+"donadas.\n"
 
 msgid ""
 "\n"
@@ -1267,6 +1430,11 @@ msgid ""
 "Once this manual alias is setup the respective application command can be "
 "invoked just using the alias.\n"
 msgstr ""
+"\n"
+"La comanda « alias » associe lo paquet Snap donat a l'aliàs donat.\n"
+"\n"
+"Una fois que cet alias manuel es défini, la comanda de l'aplicacion "
+"correspondante pòt èsser invoquée en utilisant simplement l'aliàs.\n"
 
 msgid ""
 "\n"
@@ -1282,6 +1450,19 @@ msgid ""
 "not defined in the current revision of the snap; possibly temporarely (e.g\n"
 "because of a revert), if not this can be cleared with snap alias --reset.\n"
 msgstr ""
+"\n"
+"La comanda « alisases » aficha la liste de Totes los alias disponibles dins "
+"le sistèma e leur état.\n"
+"\n"
+"$ snap aliases <snap>\n"
+"\n"
+"Aficha uniquement los aliasses définis pel paquet Snap spécifié.\n"
+"\n"
+"Un alias es indiqué coma indéfini s'il a été explicitement activé o "
+"désactivé mais \n"
+"qu'il es pas défini dins la version del paquet Snap en cors d'utilisation ;\n"
+"éventuellement temporairement (par exemple a cause d'un retour en arrière),\n"
+"sinon ceci pòt èsser résolu amb snap alias --reset.\n"
 
 msgid ""
 "\n"
@@ -1296,17 +1477,35 @@ msgid ""
 "Imported assertions must be made available in the auto-import.assert file\n"
 "in the root of the filesystem.\n"
 msgstr ""
+"\n"
+"La comanda « auto-import » recèrca las assercions signées per des\n"
+"autorités de confiance sus les aparelhs montés disponibles et, lo cas "
+"échéant, \n"
+"exécute des modifications del sistèma sus cette base.\n"
+"\n"
+"Si un o plusieurs aparelhs sont disponibles via --mount, ils sont montés \n"
+"temporairement per être inspectés eux aussi. Même dins ce cas, la commande\n"
+"prendra totjorn en compte Totes los aparelhs montés.\n"
+"\n"
+"Les assertions importées doivent être disponibles dins lo fichièr auto-"
+"import.assert \n"
+"à la racine del sistèma de fichièr.\n"
 
 msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
+"\n"
+"La comanda « buy » crompa un paquet Snap dins la logitèca.\n"
 
 msgid ""
 "\n"
 "The changes command displays a summary of the recent system changes "
 "performed."
 msgstr ""
+"\n"
+"La comanda « changes » aficha un résumé des cambiaments récents effectués "
+"sur lo sistèma."
 
 msgid ""
 "\n"
@@ -1314,6 +1513,10 @@ msgid ""
 "none)\n"
 "the system operates in.\n"
 msgstr ""
+"\n"
+"La comanda de confinement imprimira lo mode de confinement (strict, partiel "
+"ou aucun)\n"
+"dans lequel lo sistèma fonctionne.\n"
 
 msgid ""
 "\n"
@@ -1338,6 +1541,26 @@ msgid ""
 "matching\n"
 "the plug name.\n"
 msgstr ""
+"\n"
+"La comanda « connect » religa un connector a una presa.\n"
+"Pòt èsser apelada de doas manièras :\n"
+"\n"
+"$ snap connect <snap>:<connector> <snap>:<presa>\n"
+"\n"
+"Religa lo connector indicat a la presa especificada.\n"
+"\n"
+"$ snap connect <snap>:<connector> <snap>\n"
+"\n"
+"Religa lo connector especificat a la sola presa del paquet Snap que "
+"correspond\n"
+"a l'interfàcia connectada. S'existís mai d'una presa potenciala, la comanda\n"
+"fracassa.\n"
+"\n"
+"$ snap connect <snap>:<connector>\n"
+"\n"
+"Connècta lo connector indicat dins la presa del paquet Snap principal amb un "
+"nom que correspond\n"
+"al nom del connector.\n"
 
 msgid ""
 "\n"
@@ -1348,6 +1571,13 @@ msgid ""
 "\n"
 "An account can be setup at https://login.ubuntu.com.\n"
 msgstr ""
+"\n"
+"La comanda « create-user » crèa un utilizaire local del sistèma amb lo nom "
+"d'utilizaire\n"
+"e las claus SSH enregistradas sul compte de la logitèca identificat via "
+"l'adreça electronica provesida.\n"
+"\n"
+"Un compte pòt èsser configurat sus https://login.ubuntu.com.\n"
 
 msgid ""
 "\n"
@@ -1356,6 +1586,11 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
+"\n"
+"La comanda « debug » compòrta mantuna soscomanda supplémentaires.\n"
+"\n"
+"La comanda debug pòt èsser suprimida sens preavís e es possible que\n"
+"foncione pas dins los sistèmas autres que de desvolopament.\n"
 
 msgid ""
 "\n"
@@ -1363,6 +1598,12 @@ msgid ""
 "snap will no longer be available. But all the data is still available\n"
 "and the snap can easily be enabled again.\n"
 msgstr ""
+"\n"
+"La comanda « disable » desactiva un paquet Snap. Les binaires e les services "
+"del paquet\n"
+"Snap ne seront plus disponibles. Mais totas las donadas seront totjorn "
+"disponibles e lo paquet\n"
+"Snap peut facilement être de nouveau activé.\n"
 
 msgid ""
 "\n"
@@ -1378,6 +1619,19 @@ msgid ""
 "Disconnects everything from the provided plug or slot.\n"
 "The snap name may be omitted for the core snap.\n"
 msgstr ""
+"\n"
+"La comanda « disconnect » desconnècta un connector d'una presa.\n"
+"Pòt èsser apelada de doas manièras :\n"
+"\n"
+"$ snap disconnect <snap>:<connector> <snap>:<presa>\n"
+"\n"
+"Desconnècta lo connector indicat de la presa especificada.\n"
+"\n"
+"$ snap disconnect <snap>:<presa o connector>\n"
+"\n"
+"Desconnècta tot çò qu'es religat al connector indicat o a la presa "
+"especificada.\n"
+"Lo nom del paquet Snap pòt èsser omés pel paquet Snap principal.\n"
 
 msgid ""
 "\n"
@@ -1385,17 +1639,28 @@ msgid ""
 "to the current directory under .snap and .assert file extensions, "
 "respectively.\n"
 msgstr ""
+"\n"
+"La comanda « download » télécharge lo paquet Snap indiqué e las assercions \n"
+"qui lui sont nécessaires dins lo repertòri en cors d'utilisation, dins des "
+"fichièrs\n"
+"portant respectivement les extensions .snap e .assert.\n"
 
 msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
+"\n"
+"La comanda « enable » activa un paquet Snap qu'es estat desactivat "
+"precedentament.\n"
 
 msgid ""
 "\n"
 "The find command queries the store for available packages in the stable "
 "channel.\n"
 msgstr ""
+"\n"
+"La comanda find interroge lo magasin per los paquets disponibles dins lo "
+"canal stable.\n"
 
 msgid ""
 "\n"
@@ -1434,6 +1699,46 @@ msgid ""
 "This requests the \"usb-vendor\" setting from the slot that is connected to "
 "\"myplug\".\n"
 msgstr ""
+"\n"
+"La comanda « get » aficha las opcions de configuracion pel paquet Snap en "
+"cours d'utilizacion.\n"
+"\n"
+"    $ snapctl get username\n"
+"    frank\n"
+"\n"
+"Se mantun nom d'opcions son provesits, la comanda renvia un document :\n"
+"\n"
+"    $ snapctl get username password\n"
+"    {\n"
+"        \"username\": \"frank\",\n"
+"        \"password\": \"...\"\n"
+"    }\n"
+"\n"
+"Las valors imbricadas pòdon èsser recuperadas en utilizant un camin separat "
+"per de \n"
+"punts :\n"
+"\n"
+"    $ snapctl get author.name\n"
+"    frank\n"
+"\n"
+"Las valors dels paramètres de connexion a l'interfàcia pòdon èsser afichats "
+"amb :\n"
+"\n"
+"    $ snapctl get :monconnector usb-vendor\n"
+"    $ snapctl get :mapresa path\n"
+"\n"
+"Aquò renvia los paramètres donats a partir de l'extremitat de l'interfàcia "
+"locala, que s'agisca \n"
+"d'una presa o d'un connector. Es tanben possible de recuperar lo paramètre "
+"de \n"
+"l'extremitat del paquet Snap connectat en lo demandant explicitament amb "
+"l'ajuda de las opcions \n"
+"« --plug » e « --slot » :\n"
+"\n"
+"    $ snapctl get :monconnector --slot usb-vendor\n"
+"\n"
+"Aquò recèrca lo paramètre « usb-vendor » de la presa qu'es connectada a "
+"« monconnector ».\n"
 
 msgid ""
 "\n"
@@ -1455,22 +1760,51 @@ msgid ""
 "    $ snap get snap-name author.name\n"
 "    frank\n"
 msgstr ""
+"\n"
+"La comanda « get » aficha las opcions de configuracion del paquet Snap\n"
+"mencionat.\n"
+"\n"
+"    $ snap get nom-du-snap username\n"
+"    frank\n"
+"\n"
+"Se los noms de mantuna opcion son demandats, la comanda renvia\n"
+"un document :\n"
+"\n"
+"    $ snap get nom-du-snap username password\n"
+"    {\n"
+"        \"username\": \"frank\",\n"
+"        \"password\": \"...\"\n"
+"    }\n"
+"\n"
+"Las valors imbricadas pòdon èsser obtengudas en indicant \n"
+"lo camin amb de punts :\n"
+"\n"
+"    $ snap get nom-du-snap author.name\n"
+"    frank\n"
 
 msgid ""
 "\n"
 "The help command shows helpful information. Unlike this. ;-)\n"
 msgstr ""
+"\n"
+"La comanda « help » aficha des informations utiles - plus utiles que celle-"
+"ci ;)\n"
 
 msgid ""
 "\n"
 "The info command shows detailed information about a snap, be it by name or "
 "by path."
 msgstr ""
+"\n"
+"La comanda « info » aficha des informations detalhadas a propos d'un paquet "
+"Snap, que ce soit per nom o per camin."
 
 msgid ""
 "\n"
 "The install command installs the named snap in the system.\n"
 msgstr ""
+"\n"
+"La comanda « install » installe sus lo sistèma lo paquet Snap cité.\n"
 
 msgid ""
 "\n"
@@ -1479,6 +1813,13 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
+"\n"
+"La comanda interface aficha los detalhs de las interfàcias snap.\n"
+"\n"
+"Quand cap de nom d'interfàcia es pas provesit, una lista de noms "
+"d'interfàcia amb al mens \n"
+"Una connexion es afichada, o la lista de totas las interfàcias quand --all "
+"es especificat.\n"
 
 msgid ""
 "\n"
@@ -1500,6 +1841,26 @@ msgid ""
 "Filters the complete output so only plugs and/or slots matching the provided "
 "details are listed.\n"
 msgstr ""
+"\n"
+"La comanda « interfaces » liste las interfàcias disponibles dins lo "
+"sistèma.\n"
+"\n"
+"Par defaut, totas las prises e Totes los connecteurs, utilizats e offerts "
+"par Totes los paquets Snap, sont afichats.\n"
+" \n"
+"$ snap interfaces <snap>:<prise o connecteur>\n"
+"\n"
+"Liste uniquement les prises o les connecteurs spécifiés.\n"
+"\n"
+"$ snap interfaces <snap>\n"
+"\n"
+"Liste les prises offertes e les connecteurs utilizats pel paquet Snap "
+"spécifié.\n"
+"\n"
+"$ snap interfaces -i=<interface> [<snap>]\n"
+"\n"
+"Filtre toute la sortida de manière a ce que seuls les connecteurs et/ou les "
+"prises correspondants als détails fournis soient listés.\n"
 
 msgid ""
 "\n"
@@ -1507,11 +1868,20 @@ msgid ""
 "If header=value pairs are provided after the assertion type, the assertions\n"
 "shown must also have the specified headers matching the provided values.\n"
 msgstr ""
+"\n"
+"La comanda « known » aficha las assercions conegudas del tipe provesit.\n"
+"Se las paras entèsta=Valor son provesidas aprèp lo tipe d'assercion, las "
+"assercions\n"
+"afichadas devon alara aver lors entèstas que correspondon a las valors "
+"provesidas.\n"
 
 msgid ""
 "\n"
 "The list command displays a summary of snaps installed in the current system."
 msgstr ""
+"\n"
+"La comanda « list » aficha un résumé des paquets Snap installats sus lo "
+"sistèma actuel."
 
 msgid ""
 "\n"
@@ -1525,6 +1895,17 @@ msgid ""
 "\n"
 "An account can be setup at https://login.ubuntu.com\n"
 msgstr ""
+"\n"
+"La comanda « login » authentifie vis-à-vis de Snapd e de la logithèque e "
+"enregistre les\n"
+"identificants dins lo fichièr ~/.snap/auth.json. Les communications a venir "
+"seront alors effectuées en\n"
+"utilisant ces identificants.\n"
+"\n"
+"La connexion marche uniquement per des utilizaires locaux des groupes sudo, "
+"admin o wheel.\n"
+"\n"
+"Un compte pòt èsser configuré sus https://login.ubuntu.com\n"
 
 msgid ""
 "\n"
@@ -1537,11 +1918,16 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
+"\n"
+"La comanda « managed » aficha verai o fals, segon\n"
+"que Snapd aja d'utilizaires enregistrats o pas.\n"
 
 msgid ""
 "\n"
 "The pack command packs the given snap-dir as a snap."
 msgstr ""
+"\n"
+"La comanda pack prépare lo repertòri snap coma un snap."
 
 msgid ""
 "\n"
@@ -1549,6 +1935,10 @@ msgid ""
 "to conflicting aliases of other snaps whose aliases will be disabled\n"
 "(removed for manual ones).\n"
 msgstr ""
+"\n"
+"La comanda « prefer » active Totes los alias del paquet Snap donat \n"
+"et desactiva Totes los alias des paquets Snap qui entrent en conflit amb \n"
+"ceux-ci (ou les supprime, dins lo cas des alias manuels).\n"
 
 #, c-format
 msgid ""
@@ -1567,11 +1957,30 @@ msgid ""
 "if instead you want to install the snap forcing it into strict confinement\n"
 "repeat the command including --jailmode."
 msgstr ""
+"\n"
+"Los editors del snap %q an indicat que la qualitat d'aquesta version es "
+"inferiora\n"
+"a la de produccion e qu'es pas, uèi, destinada qu'a de fins de desvolopament "
+"\n"
+"o de tèst. Per consequéncia, aqueste snap se met pas a jorn automaticament e "
+"poiriá\n"
+"entrainar de modificacions arbitràrias del sistèma en defòra del nauc de "
+"sabla de seguretat ont \n"
+"los snaps son de costuma confinats, e pòdon far córrer una risca a vòstre "
+"sistèma.\n"
+"\n"
+"Se comprenètz e que volètz contunhar, repetissètz la comanda en apondent --"
+"devmode ;\n"
+"siquenon, se volètz installar lo snap en lo constrenhent dins un confinament "
+"estrict,\n"
+"repetissètz la comanda en apondent --jailmode."
 
 msgid ""
 "\n"
 "The refresh command refreshes (updates) the named snap.\n"
 msgstr ""
+"\n"
+"La comanda « refresh » actualise (met a jour) lo paquet Snap cité.\n"
 
 msgid ""
 "\n"
@@ -1583,16 +1992,29 @@ msgid ""
 "revision is\n"
 "removed.\n"
 msgstr ""
+"\n"
+"La comanda « remove » supprime del sistèma lo paquet Snap indiqué.\n"
+"\n"
+"Par defaut, totas las versions del paquet Snap sont suprimidas, y compris "
+"leurs donadas e \n"
+"le repertòri commun de donadas. Quand una option « --revision » es provesida "
+"en argument, seule la\n"
+"version spécifiée es suprimida.\n"
 
 msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
+"\n"
+"La comanda repair aficha los detalhs d'una o de mantuna reparacions.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
+"\n"
+"La comanda repair repertòria totas las reparacions tractadas per aqueste "
+"periferic.\n"
 
 msgid ""
 "\n"
@@ -1600,6 +2022,11 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
+"\n"
+"La comanda restart reavia los servicis donats del snap. Quand es executada "
+"dempuèi\n"
+"lo punt d'acròcha « configuration », los servicis seràn reaviats a la fin "
+"del punt d'acròcha."
 
 msgid ""
 "\n"
@@ -1618,6 +2045,16 @@ msgid ""
 "an exception, data which the snap explicitly chooses to share across\n"
 "revisions is not touched by the revert process.\n"
 msgstr ""
+"\n"
+"La comanda « revert » restablís lo paquet Snap donat cap a son estat abans\n"
+"la darrièra actualizacion. Aquò reactivarà la precedenta revision del paquet "
+"Snap e\n"
+"utilizarà las donadas d'origina qu'èran associadas a aquesta revision,\n"
+"eliminant tot cambiament dins las donadas que seriá estat efectuat per la "
+"darrièra revision.\n"
+"En tant qu'excepcion, las donadas que lo paquet Snap causís explicitament de "
+"partejar entre\n"
+"las revisions son pas tocadas pel processus de restabliment.\n"
 
 msgid ""
 "\n"
@@ -1638,6 +2075,20 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
+"\n"
+"La comanda « set » càmbia las opcions de configuracions provesidas coma "
+"demandat.\n"
+"\n"
+"    $ snap set snap-name username=frank password=$SENHAL\n"
+"\n"
+"Totes los cambiaments de configuracion son conservats en un sol còp, e \n"
+"solament aprèp que lo punt d'acròcha de configuracion del paquet Snap\n"
+"siá estat executat corrèctament.\n"
+"\n"
+"Las valors imbricadas pòdon èsser modificadas via l'indicacion d'un camin \n"
+"separat per de punts :\n"
+"\n"
+"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1658,6 +2109,27 @@ msgid ""
 "\n"
 "    $ snapctl set :myplug path=/dev/ttyS0\n"
 msgstr ""
+"\n"
+"La comanda « set » modifica las opcions de configuracion provesidas coma "
+"demandat.\n"
+"\n"
+"    $ snapctl set username=frank password=$SENHAL\n"
+"\n"
+"Totes los cambiaments de configuracion son conservats en un sol còp e \n"
+"solament aprèp que lo punt d'acròcha de configuracion del paquet Snap\n"
+"siá estat executat corrèctament.\n"
+"\n"
+"Las valors imbricadas pòdon èsser modificadas via l'indication d'un camin \n"
+"separat per de punts :\n"
+"\n"
+"    $ snapctl set author.name=frank\n"
+"\n"
+"Los atributs de las presas e dels connectors pòdon èsser definits dins los "
+"punts d'acròcha\n"
+"« prepare » e « connect » respectius en indicant lo connector o la presa "
+"volgut(-uda) :\n"
+"\n"
+"    $ snapctl set :monconnector path=/dev/ttyS0\n"
 
 msgid ""
 "\n"
@@ -1665,6 +2137,11 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
+"\n"
+"La comanda start avia los servicis donats del snap. Quand es executada "
+"dempuèi\n"
+"lo punt d'acròcha « configuration », los servicis seràn reaviats a la fin "
+"del punt d'acròcha."
 
 msgid ""
 "\n"
@@ -1676,6 +2153,11 @@ msgid ""
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
+"\n"
+"La comanda stop arrèsta los servicis donats del snap. Quand es executada "
+"dempuèi\n"
+"lo punt d'acròcha « configuration », los servicis seràn reaviats a la fin "
+"del punt d'acròcha."
 
 msgid ""
 "\n"
@@ -1687,12 +2169,18 @@ msgid ""
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
+"\n"
+"La comanda switch bascula lo snap donat sus un canal diferent sens\n"
+"reactualizar.\n"
 
 msgid ""
 "\n"
 "The tasks command displays a summary of tasks associated to an individual "
 "change."
 msgstr ""
+"\n"
+"La comanda tasks aficha un résumé des tâches associées a un cambiament "
+"individuel."
 
 msgid ""
 "\n"
@@ -1709,18 +2197,39 @@ msgid ""
 "be\n"
 "found relative to current working directory.\n"
 msgstr ""
+"\n"
+"La comanda « try » installa un paquet Snap non despaquetat al dintre del "
+"sistèma dins lo quadre de tèsts.\n"
+"Lo contengut d'aqueste contunha d'èsser utilizat quitament aprèp "
+"l'installacion, las modificacions non relativas a las metadonadas\n"
+"faitas a aqueste nivèl prenon doncas efièit instantanèament. Las "
+"modificacions de metadonadas talas coma las que son\n"
+"efectuadas dins snap.yaml necessitaràn una reïnstallacion per prene efièit.\n"
+"\n"
+"Se l'argument « snap-dir » es omés, la comanda « try » ensajarà de lo "
+"deduire\n"
+"se siá lo fichièr snapcraft.yaml e lo repertòri principal, siá lo fichièr "
+"meta/snap.yaml son trobats\n"
+"a proximitat del repertòri de trabalh actual.\n"
 
 msgid ""
 "\n"
 "The unalias command tears down a manual alias when given one or disables all "
 "aliases of a snap, removing also all manual ones, when given a snap name.\n"
 msgstr ""
+"\n"
+"La comanda « unalias » enlève l'aliàs manuel donat ou, si lo nom d'un paquet "
+"Snap es donat, desactiva Totes los alias del paquet Snap, en supprimant ses "
+"alias manuels.\n"
 
 msgid ""
 "\n"
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
+"\n"
+"La comanda « version » aficha las versions del client, del servidor e del\n"
+"sistèma operatiu en cors d'execucion.\n"
 
 msgid ""
 "\n"
@@ -1728,11 +2237,17 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
+"\n"
+"La comanda « watch » espèra que la comanda « change-id » indicada\n"
+"siá acabada e aficha l'estat d'avançament (se disponible).\n"
 
 msgid ""
 "\n"
 "The whoami command prints the email the user is logged in with.\n"
 msgstr ""
+"\n"
+"La comanda « whoami » aficha l'adreça electronica amb lo qual l'utilizaire\n"
+"es connectat.\n"
 
 #, c-format
 msgid ""
@@ -1746,6 +2261,15 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
+"\n"
+"Aquesta version del paquet Snap %q es estada publicada amb un confinament "
+"classic.\n"
+"Poiriá doncas aportar de modificacions arbitràrias al sistèma, de delà de\n"
+"l'espaci memòria protegit (« sandbox ») dins lo qual los paquets Snap son\n"
+"generalament confinats, aquò pòt crear una risca per vòstre sistèma.\n"
+"\n"
+"Se comprenètz aquò e volètz contunhar malgrat tot, repetissètz la comanda \n"
+"en i apondent l'opcion « --classic ».\n"
 
 msgid ""
 "\n"
@@ -1754,154 +2278,163 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
+"un nom de paquet Snap unic es necessari per especificar los marcadors de "
+"mòde o de canal"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr ""
+msgstr "un nom de paquet Snap unic es necessari per especificar la revision"
 
 msgid "a single snap name must be specified when ignoring validation"
 msgstr ""
+"lo nom d'un sol paquet Snap deu èsser especificat quand la validacion es "
+"ignorada"
 
 msgid "active"
-msgstr ""
+msgstr "actiu"
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr ""
+msgstr "crompat"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr ""
+msgstr "copat"
 
 #, c-format
 msgid "cannot %s without a context"
-msgstr ""
+msgstr "%s impossible sens un contèxte"
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr ""
+msgstr "impossible de crompar lo paquet Snap : %v"
 
 msgid "cannot buy snap: invalid characters in name"
 msgstr ""
+"impossible de crompar lo paquet Snap : caractèrs invalids dins lo nom"
 
 msgid "cannot buy snap: it has already been bought"
-msgstr ""
+msgstr "impossible de crompar lo paquet Snap : aqueste es ja estat crompat"
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr ""
+msgstr "impossible de crear %q : %v"
 
 #, c-format
 msgid "cannot create assertions file: %v"
-msgstr ""
+msgstr "impossible de crear lo fichièr d'assercions : %v"
 
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
 msgstr ""
+"impossible d'extraire lo nom del paquet Snap a partir del fichièr local %q : "
+"%v"
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr ""
+msgstr "impossible de trobar l'aplicacion %q dins %q"
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr ""
+msgstr "impossible de trobar lo punt d'acròcha %q dins %s"
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr ""
+msgstr "impossible d'obténer de donadas per %q : %v"
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr ""
+msgstr "impossible d'obténer lo camin complet per %q : %v"
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr ""
+msgstr "impossible d'obténer l'utilizaire actual : %s"
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr ""
+msgstr "impossible d'obténer lo nom de l'utilizaire actual : %v"
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr ""
+msgstr "impossible de marcar l'aviada coma capitada : %s"
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr ""
+msgstr "impossible de dobrir la basa de donadas d'assercions : %v"
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr ""
+msgstr "impossible de legir l'assercion d'entrada : %v"
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr ""
+msgstr "impossible de legir lo ligam simbolic : %v"
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
-msgstr ""
+msgstr "impossible de corregir l'aplicacion Snap %q : %v"
 
 #, c-format
 msgid "cannot sign assertion: %v"
-msgstr ""
+msgstr "impossible de signar l'assercion : %v"
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr ""
+msgstr "impossible de metre a jorn lo ligam simbolic actual de %q : %v"
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr ""
+msgstr "impossible d'utilizar la clau %q : %v"
 
 msgid "cannot use change ID and type together"
-msgstr ""
+msgstr "impossible de cambiar l'identificant e lo tipe al meteis temps"
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr ""
+msgstr "impossible d'utilizar los marcadors devmode e jailmode ensemble"
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr ""
+msgstr "impossible de validar lo proprietari del fichièr %s"
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr ""
+msgstr "impossible d'escriure un novèl fichièr Xauthority sus %s : %s"
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr ""
+msgstr "lo cambiament s'es acabat a l'estatut %q sens message d'error"
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
+"un confinament classic necessita de snaps jos /snap o un ligam simbolic "
+"dempuèi /snap cap a %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr ""
+msgstr "utilizaire %q creat\n"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr ""
+msgstr "j"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
 msgstr "desactivat"
 
 msgid "email:"
-msgstr ""
+msgstr "corrièl :"
 
 msgid "enabled"
-msgstr ""
+msgstr "activat"
 
 #, c-format
 msgid "error: %v\n"
@@ -1910,71 +2443,83 @@ msgstr "error : %v\n"
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
 msgstr ""
+"error : l'argument <snap-dir> es pas estat provesit e a pas pogut èsser "
+"deduit"
 
 msgid "get which option?"
-msgstr ""
+msgstr "obténer quina opcion ?"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr ""
+msgstr "h"
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr ""
+msgstr "inactiu"
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
 msgstr ""
+"los atributs d'interfàcia pòdon pas èsser legits que pendent l'execucion "
+"dels punts d'acròcha d'interfàcia"
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
 msgstr ""
+"los atributs d'interfàcia pòdon pas èsser definits que pendent l'execucion "
+"dels punts d'acròcha d'interfàcia"
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr ""
+msgstr "error intèrna, senhalatz-lo : l'execucion de %q a fracassat : %v\n"
 
 msgid "internal error: cannot find attrs task"
-msgstr ""
+msgstr "error intèrna : impossible de trobar lo prètzfait attrs"
 
 msgid "internal error: cannot find plug or slot data in the appropriate task"
 msgstr ""
+"error intèrna : impossible de trobar las donadas de connector o de presa "
+"dins lo prètzfait apropriat"
 
 #, c-format
 msgid "internal error: cannot get %s from appropriate task"
-msgstr ""
+msgstr "error intèrna : impossible de trobar %s dins lo prètzfait apropriat"
 
 msgid ""
 "invalid argument for flag ‘-n’: expected a non-negative integer argument, or "
 "“all”."
 msgstr ""
+"argument invalid pel marcador « -n' » : un argument entièr positiu o « all » "
+"es esperat."
 
 #, c-format
 msgid "invalid attribute: %q (want key=value)"
-msgstr ""
+msgstr "atribut invalid : %q (clau=valor esperada)"
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr ""
+msgstr "configuracion invalida : %q (clau=valor esperada)"
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr ""
+msgstr "filtre d'entèsta invalid : %q (clau=valor esperada)"
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr ""
+msgstr "paramètre invalid : %q (clau=valor esperada)"
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr ""
+msgstr "valor invalida : %q (snap:nom o snap esperada)"
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
+"lo nom de clau %q es pas valid ; sols los nombres, las letras ASCII e los "
+"jonhents son autorizats"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
@@ -1982,38 +2527,39 @@ msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr ""
+msgstr "min"
 
 msgid "missing snap-confine: try updating your snapd package"
-msgstr ""
+msgstr "Snap-confine manquant : ensajatz de metre a jorn votre paquet Snapd"
 
 msgid "need the application to run as argument"
-msgstr ""
+msgstr "besonh que l'aplicacion siá executada coma un argument"
 
 msgid "no changes found"
-msgstr ""
+msgstr "cap de cambiament pas trobat"
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr ""
+msgstr "cap de cambiament pas trobat pel tipe %q"
 
 msgid "no interfaces currently connected"
-msgstr ""
+msgstr "cap d'interfàcia pas connectada actualament"
 
 msgid "no interfaces found"
-msgstr ""
+msgstr "cap d'interfàcia pas trobada"
 
 msgid "no matching snaps installed"
-msgstr ""
+msgstr "cap de paquet Snap correspondent pas installat"
 
 msgid "no such interface"
-msgstr ""
+msgstr "pas una tala interfàcia"
 
 msgid "no valid snaps given"
-msgstr ""
+msgstr "cap de paquet Snap valid es pas estat indicat"
 
 msgid "please provide change ID or type with --last=<type>"
 msgstr ""
+"provesissètz l'identificant de modificacion o lo tipe amb --last=<type>"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
@@ -2023,55 +2569,57 @@ msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
 "shutdown -c'"
 msgstr ""
+"redémarrage programmé per metre a jorn lo sistèma - annulation temporaire "
+"possible via « sudo shutdown -c »"
 
 msgid "repairs are not available on a classic system"
-msgstr ""
+msgstr "las reparacions son pas disponiblas sus un sistèma classic"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #, c-format
 msgid "set failed: %v"
-msgstr ""
+msgstr "lo parametratge a fracassat : %v"
 
 msgid "set which option?"
-msgstr ""
+msgstr "definir quina opcion ?"
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
 msgid "snap %%q not found (at least at revision %q)"
-msgstr ""
+msgstr "snap %%q non trobat (au moins a la revision %q)"
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --channel=foo
 #, c-format
 msgid "snap %%q not found (at least in channel %q)"
-msgstr ""
+msgstr "snap %%q non trobat (au moins dins lo canal %q)"
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr ""
+msgstr "lo snap %q a pas cap de mesa a jorn disponibla"
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
-msgstr ""
+msgstr "le paquet Snap %q es ja installat, voir « snap refresh --help »"
 
 #, c-format
 msgid "snap %q not found"
-msgstr ""
+msgstr "snap %q pas trobat"
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr ""
+msgstr "lo paquet Snap es gratuit"
 
 msgid "too many arguments for command"
-msgstr ""
+msgstr "tròp d'arguments per la comanda"
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr ""
+msgstr "tròp d'arguments pel punt d'acròcha %q : %s"
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
@@ -2086,19 +2634,19 @@ msgstr "indisponible"
 
 #, c-format
 msgid "unknown attribute %q"
-msgstr ""
+msgstr "atribut %q desconegut"
 
 #, c-format
 msgid "unknown command %q, see \"snap --help\""
-msgstr ""
+msgstr "commande %q inconnue, voir « snap --help »"
 
 #, c-format
 msgid "unknown plug or slot %q"
-msgstr ""
+msgstr "presa o connector %q desconegut(-uda)"
 
 #, c-format
 msgid "unknown service: %q"
-msgstr ""
+msgstr "servici desconegut : %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
@@ -2106,22 +2654,25 @@ msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr ""
+msgstr "a"
 
 msgid "Authenticate on snap daemon"
-msgstr ""
+msgstr "S'autentificar sul demòni Snap"
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr ""
+msgstr "L'autorizacion es requesida per l'autentificacion sul demòni snap"
 
 msgid "Install, update, or remove packages"
-msgstr ""
+msgstr "Installar, metre a jorn o suprimir de paquets"
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
+"L'autentificacion es requesida per installar, metre a jorn o suprimir de "
+"paquets"
 
 msgid "Connect, disconnect interfaces"
-msgstr ""
+msgstr "Connectar, desconnectar las interfàcias"
 
 msgid "Authentication is required to connect or disconnect interfaces"
 msgstr ""
+"L'autentificacion es requesida per connectar o desconnectar d'interfàcias"

--- a/po/pl.po
+++ b/po/pl.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,9 +24,10 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q mudado para o %q canal\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
@@ -90,7 +91,7 @@ msgstr "%s%s %s instalado\n"
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr ""
+msgstr "%s%s %s atualizado\n"
 
 msgid "--list does not take mode nor channel flags"
 msgstr "--list não aceita flags mode ou de canais"
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr "-r só pode ser usado com --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<alias>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<ficheiro de asserção>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<tipo de asserção>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<change-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<conf value>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<email>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<nome do ficheiro>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<filtro de cabeçalho>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<nome-chave>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<chave>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<modelo-asserção>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<pesquisa>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<root-dir>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<ficha>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<entrada ou ficha>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<entrada>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Abortar uma alteração pendente"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr "Adiciona uma asserção ao sistema"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "O mesmo que --perigoso (OBSOLETO)"
 
@@ -212,6 +217,7 @@ msgstr "Todos os snaps atualizados."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Comando alternativo a executar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Um email de utilizador em login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Ficheiro de asserção"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Nome do tipo de asserção"
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr "Compra um snap"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Alterar ID"
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Valor de configuração (chave=valor)"
 
@@ -306,14 +317,15 @@ msgstr "Ligue %s:%s a %s:%s"
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr "Transferir o snap %q%s do canal %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr "Procurar pacotes para instalar"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Gerar chave de dispositivo"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr "Ajuda"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr "Instalar snap %q a partir de ficheiro"
 msgid "Install %q snap from file %q"
 msgstr "Instalar snap %q a partir do ficheiro %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Instalar a partir do canal beta"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Instalar a partir do canal candidate"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Instalar a partir do canal edge"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Instalar a partir do canal stable"
 
@@ -525,16 +554,19 @@ msgstr "Instalar snap %q"
 msgid "Install snaps %s"
 msgstr "Instalar snaps %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Instala um snap no sistema"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr "Montar o snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Nome da chave a eliminar"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -689,6 +723,8 @@ msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 "Ainda sem snaps instalados. Experimente \"snap install hello-world\"."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -757,12 +793,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -820,6 +859,7 @@ msgstr "Remover dados para o snap %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Remover apenas a revisão dada"
 
@@ -844,6 +884,7 @@ msgstr "Remover o snap %q (%s) do sistema"
 msgid "Remove snaps %s"
 msgstr "Remover os snaps %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -859,6 +900,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -872,9 +914,11 @@ msgstr "Reverter o snap %q"
 msgid "Reverts the given snap to the previous state"
 msgstr "Reverter o snap dado ao estado anterior"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -914,6 +958,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -926,6 +971,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Procurar snaps privados"
 
@@ -968,9 +1014,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Mostrar todas as revisões"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -980,13 +1028,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1016,8 +1066,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Nome do snap"
 
@@ -1067,6 +1117,7 @@ msgstr "Parar serviços snap"
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1085,6 +1136,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1102,15 +1154,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1118,11 +1170,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "O snap a configurar (ex: hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr "O snap cuja configuração está a ser pedida"
 
@@ -1162,15 +1215,18 @@ msgstr "Código dois-fatores: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Usar este canal em vez do 'stable'"
 
@@ -1183,6 +1239,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -35,7 +36,7 @@ msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr ""
+msgstr "%s (разница)"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
@@ -101,98 +102,100 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr "-r можно использовать только с --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr ""
+msgstr "<псевдоним-или-пакет>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr ""
+msgstr "<псевдоним>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr ""
+msgstr "<файл подтверждения>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr ""
+msgstr "<тип подтверждения>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr ""
+msgstr "<смена ID>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr ""
+msgstr "<конфигурационное значение>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr ""
+msgstr "<почта>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr ""
+msgstr "<имя файла>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr ""
+msgstr "<фильтр заголовков>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr ""
+msgstr "<интерфейс>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr ""
+msgstr "<имя ключа>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr ""
+msgstr "<ключ>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr ""
+msgstr "<модель подтверждения>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr ""
+msgstr "<запрос>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr ""
+msgstr "<корневая директория>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
-msgstr ""
+msgstr "<сервис>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr ""
+msgstr "<пакет>:<штекер>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr ""
+msgstr "<пакет>:<гнездо или штекер>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr ""
+msgstr "<пакет>:<гнездо>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
 
 msgid "Abort a pending change"
-msgstr ""
+msgstr "Прервать отложенное внесение изменений"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr ""
+msgstr "Добавлено"
 
 msgid "Adds an assertion to the system"
 msgstr ""
@@ -200,133 +203,145 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr ""
+msgstr "Рекомендации по пакетам, которые предоставляют данную команду"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr ""
+msgstr "То же, что и --dangerous (УСТАРЕЛО)"
 
 msgid "All snaps up to date."
-msgstr ""
+msgstr "Все пакеты актуальны."
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Разрешить открытие файла?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
-msgstr ""
+msgstr "Разрешить попытку обновления неизвестного пакета в магазине"
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Разрешить изменение настроек?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr ""
+msgstr "Разрешить пакету %q изменить с %q на %q ?"
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr ""
+msgstr "Разрешить пакету %q открыть файл %q?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr ""
+msgstr "Альтернативная команда для выполнения"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr ""
+msgstr "Всегда возвращать документ, даже с одним ключом"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr ""
+msgstr "Всегда возвращать список, даже с одним ключом"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr ""
+msgstr "Адрес эл. почты пользователя login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
+"При запуске службы сейчас, упорядочивание произойдёт при начальной загрузке."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
+"При остановке службы сейчас, упорядочивание не будет производится при "
+"начальной загрузке."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr ""
+msgstr "Файл подтверждения"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr ""
+msgstr "Тип подтверждения"
 
 msgid "Authenticates on snapd and the store"
 msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
-msgstr ""
+msgstr "Автоматически обновить %d пакеты"
 
 #, c-format
 msgid "Auto-refresh snap %q"
-msgstr ""
+msgstr "Автоматически обновить %q пакет"
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Auto-refresh snaps %s"
-msgstr ""
+msgstr "Автоматически обновить пакеты %s"
 
 #, c-format
 msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr ""
+msgstr "Неправильный код. Повторите снова: "
 
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "Изменить идентификатор"
 
 msgid "Changes configuration options"
-msgstr ""
+msgstr "Изменение параметров конфигурации"
 
 msgid "Command\tAlias\tNotes"
-msgstr ""
+msgstr "Команда\tПсевдоним\tЗаметки"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr ""
+msgstr "Значение конфигурации (ключ=значение)"
 
 msgid "Confirm passphrase: "
-msgstr ""
+msgstr "Подтверждение пароля: "
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
-msgstr ""
+msgstr "Подключить %s:%s к %s:%s"
 
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr ""
+msgstr "Ограничить перечень конкретным пакетом или пакет:имя"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr ""
+msgstr "Ограничить перечень указанными интерфейсами"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr ""
+msgstr "Ограничить перечень по параметру заголовок=значение"
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr ""
+msgstr "Скопировать данные пакета %q"
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
 
 msgid "Create cryptographic key pair"
-msgstr ""
+msgstr "Создать пару криптографических ключей"
 
 msgid "Create snap build assertion"
 msgstr ""
@@ -338,95 +353,102 @@ msgid "Creates a local system user"
 msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr ""
+msgstr "Удалить криптографическую ключевую пару"
 
 msgid "Delete the local cryptographic key pair with the given name."
 msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr ""
+msgstr "Отключить %q пакет"
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr ""
+msgstr "Отключить псевдонимы для пакета %q"
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr ""
+msgstr "Отключить все псевдонимы для пакета %q"
 
 msgid "Disables a snap in the system"
 msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
-msgstr ""
+msgstr "Отклонить интерфейсные подключения к пакету %q (%s)"
 
 #, c-format
 msgid "Disconnect %s:%s from %s:%s"
-msgstr ""
+msgstr "Разъединить %s:%s от %s:%s"
 
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr ""
+msgstr "Не ждать окончания операции, но напечатать идентификатор изменений"
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr ""
+msgstr "Скачать пакет %q%s с канала %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
+"Скачать заданную ревизию пакета, к которой требуется доступ разработчика"
 
 msgid "Downloads the given snap"
 msgstr ""
 
 msgid "Email address: "
-msgstr ""
+msgstr "Адрес электронной почты: "
 
 #, c-format
 msgid "Enable %q snap"
-msgstr ""
+msgstr "Задействовать %q пакет"
 
 msgid "Enables a snap in the system"
 msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr ""
+msgstr "Проверка доступности необходимых компонентов %q"
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
 
 msgid "Export cryptographic public key"
-msgstr ""
+msgstr "Экспорт открытого криптографического ключа"
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
-msgstr ""
+msgstr "Получить и проверить подтверждение для пакета %q%s"
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr ""
+msgstr "Получение подтверждения для %q\n"
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr ""
+msgstr "Получение пакета %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
+"Принудительное добавление пользователя, даже если устройство уже под "
+"управлением"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -436,37 +458,47 @@ msgid ""
 msgstr ""
 
 msgid "Generate device key"
-msgstr ""
+msgstr "Сгенерировать ключ устройства"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr ""
+msgstr "Сгенерировать страницу man"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr ""
+msgstr "Предоставить доступ к команде sudo созданному пользователю"
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr ""
+msgstr "Перехватить для запуска"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr ""
+msgstr "Идентификатор подписавшего"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr ""
+msgstr "Идентификатор пакета, ассоциированный со сборкой"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
+"Если служба содержит команду обновления, использовать её вместо повторного "
+"запуска."
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr ""
+msgstr "Пропускать проверку другими пакетами, препятствующими обновлению"
 
 #, c-format
 msgid ""
@@ -475,15 +507,20 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
+"Чтобы приобрести %q, вам необходимо принять актуальные условия соглашения. \n"
+"Посетите https://my.ubuntu.com/payment/edit, чтобы сделать это.\n"
+"\n"
+"После завершения, вернитесь сюда и выполните 'snap buy %s' повторно."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr ""
+msgstr "Включать неиспользуемые интерфейсы"
 
 msgid "Initialize device"
-msgstr ""
+msgstr "Инициализировать устройство"
 
 msgid "Inspects devices for actionable information"
 msgstr ""
@@ -494,27 +531,31 @@ msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr ""
+msgstr "Установить %q пакет с канала %q"
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr ""
+msgstr "Установить %q пакет из файла"
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr ""
+msgstr "Установить %q пакет из файла %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr ""
+msgstr "Установить из бета-канала"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr ""
+msgstr "Установить из канала кандидатов"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr ""
+msgstr "Установить из канала стабильных версий"
 
 #, c-format
 msgid "Install snap %q"
@@ -523,20 +564,28 @@ msgstr "Установить snap-пакет %q"
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr ""
+msgstr "Установить пакеты %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
+"Установить указанную ревизию пакета, к которой требуется доступ разработчика"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
+"Установить указанный файл пакета, даже если для него, не имеется "
+"заблаговременно признанных подписей, это означает, что он не был проверен и "
+"может быть опасен (--devmode оговаривает это)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
+"Установить указанный пакет без задействования его автоматических псевдонимов"
 
 #, c-format
 msgid ""
@@ -548,31 +597,31 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
 msgid "List a change's tasks"
-msgstr ""
+msgstr "Перечислить задания изменения"
 
 msgid "List cryptographic keys"
-msgstr ""
+msgstr "Перечислить криптографические ключи"
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
 
 msgid "List installed snaps"
-msgstr ""
+msgstr "Перечислить установленные пакеты"
 
 msgid "List system changes"
-msgstr ""
+msgstr "Перечислить изменения в системе"
 
 msgid "Lists aliases in the system"
 msgstr ""
 
 msgid "Lists all repairs"
-msgstr ""
+msgstr "Перечислить все произведённые исправления"
 
 msgid "Lists interfaces in the system"
 msgstr ""
@@ -584,15 +633,15 @@ msgid "Log out of the store"
 msgstr ""
 
 msgid "Login successful"
-msgstr ""
+msgstr "Вход произведён"
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr ""
+msgstr "Сделать действующую ревизию пакета %q недоступной"
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr ""
+msgstr "Сделать пакет %q (%s) доступным в системе"
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
@@ -600,34 +649,36 @@ msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr ""
+msgstr "Сделать пакет %q недоступным в системе"
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr ""
+msgstr "Сделать пакет %q%s доступным в системе"
 
 msgid "Mark system seeded"
-msgstr ""
+msgstr "Отметить как распространяемый системой"
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr ""
+msgstr "Подключить пакет %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -635,7 +686,7 @@ msgid "Name\tSHA3-384"
 msgstr ""
 
 msgid "Name\tSummary"
-msgstr ""
+msgstr "Название\tОписание"
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
 msgstr ""
@@ -688,6 +739,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +809,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +875,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +900,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +916,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +930,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +974,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +987,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1030,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1044,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1082,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1133,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1152,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1170,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Выходной каталог"
 
@@ -1117,11 +1186,12 @@ msgstr "Выходной каталог"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1231,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,11 +1255,12 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 
 msgid "Waiting for server to restart"
-msgstr ""
+msgstr "Ожидание перезапуска сервера"
 
 msgid "Watch a change in progress"
 msgstr ""

--- a/po/sd.po
+++ b/po/sd.po
@@ -1,4 +1,4 @@
-# Swedish translation for snapd
+# Sindhi translation for snapd
 # Copyright (c) 2018 Rosetta Contributors and Canonical Ltd 2018
 # This file is distributed under the same license as the snapd package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
@@ -8,9 +8,9 @@ msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
+"PO-Revision-Date: 2018-11-11 04:40+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Swedish <sv@li.org>\n"
+"Language-Team: Sindhi <sd@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,151 +23,148 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q innehåller inte ett uppackat snap-paket.\n"
-"\n"
-"Testa \"snapcraft prime\" i din projektmapp, sedan \"snap try\" igen."
 
 #. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr "%q bytte till kanalen %q\n"
+msgstr ""
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s monterades från %s\n"
+msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr "%s (delta)"
+msgstr "%s (ڊيلٽا)"
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr "%s (se \"snap login --help\")"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr "%s (försök med sudo)"
+msgstr ""
 
 #, c-format
 msgid "%s already installed\n"
-msgstr "%s är redan installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s disabled\n"
-msgstr "%s inaktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s enabled\n"
-msgstr "%s aktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s not installed\n"
-msgstr "%s inte installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s removed\n"
-msgstr "%s borttagen\n"
+msgstr ""
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr "%s återställd till %s\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
 msgid "%s%s %s from '%s' installed\n"
-msgstr "%s%s %s från \"%s\" installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr "%s%s %s från \"%s\" uppdaterad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr "%s%s %s installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr "%s%s %s uppdaterad\n"
+msgstr ""
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "--time does not take mode nor channel flags"
-msgstr "--time tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr "-r kan bara användas med --hook"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr "<alias-eller-snap>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr "<alias>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<assert-fil>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<assert-typ>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<ändra-id>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr "<konf.värde>"
+msgstr ""
 
 #. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 #. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr "<epost>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr "<filnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr "<rubrikfilter>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr "<gränssnitt>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr "<nyckelnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr "<nyckel>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr "<modell-assert>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr "<fråga>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<root-kat>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
@@ -176,48 +173,46 @@ msgstr ""
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr "<snap>:<plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr "<snap>:<slot eller plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr "<snap>:<slot>"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
-"En tjänstespecifikation, som kan vara bara ett snappnamn (för alla tjänster "
-"i snappen), eller <snapp>.<app> för en enstaka tjänst."
 
 msgid "Abort a pending change"
-msgstr "Avbryt en väntande ändring"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr "Tillagd"
+msgstr ""
 
 msgid "Adds an assertion to the system"
-msgstr "Lägger till en assert i systemet"
+msgstr ""
 
 msgid "Advise on available snaps."
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr "Informera om snappar som tillhandahåller det givna kommandot"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr "Alias för --dangerous (FÖRÅLDRAD)"
+msgstr ""
 
 msgid "All snaps up to date."
-msgstr "Alla snap-paket uppdaterade."
+msgstr ""
 
 msgid "Allow opening file?"
 msgstr ""
@@ -231,27 +226,27 @@ msgstr ""
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr "Tillåt snapp %q att ändra %q till %q ?"
+msgstr ""
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr "Tillåt snapp %q att öppna filen %q?"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr "Alternativt kommando att köra"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr "Returnera alltid dokument, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr "Returnera alltid lista, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr "En e-postadress för en användare på login.ubuntu.com"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -266,14 +261,14 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr "Assert-fil"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr "Assert-typnamn"
+msgstr ""
 
 msgid "Authenticates on snapd and the store"
-msgstr "Autentiseras på snapd och butiken"
+msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
@@ -293,27 +288,27 @@ msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr "Felaktig kod. Försök igen: "
+msgstr ""
 
 msgid "Buys a snap"
-msgstr "Köper en snap"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr "Ändra ID"
+msgstr ""
 
 msgid "Changes configuration options"
-msgstr "Ändrar konfigurationsalternativ"
+msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr "Kommando\tAlias\tAnteckningar"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr "Konfigurationsvärde (nyckel=värde)"
+msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr "Bekräfta lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -324,57 +319,56 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr "Begränsa lista till en specifik snap eller snapp:namn"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr "Begränsa lista till specifika gränssnitt"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr "Begränsa lista till de som matchar rubrik=värde"
+msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr "Kopiera data från snapp %q"
+msgstr ""
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
-"Skapa ett kryptografiskt nyckelpar som kan användas för att signera asserts."
 
 msgid "Create cryptographic key pair"
-msgstr "Skapa kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Create snap build assertion"
-msgstr "Skapa snap-bygges-assert"
+msgstr ""
 
 msgid "Create snap-build assertion for the provided snap file."
-msgstr "Skapa snap-bygges-assert för den givna snap-filen."
+msgstr ""
 
 msgid "Creates a local system user"
-msgstr "Skapar en lokal systemanvändare"
+msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr "Radera kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Delete the local cryptographic key pair with the given name."
-msgstr "Radera det lokala kryptografiska nyckelparet med det givna namnet."
+msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr "Inaktivera %q-snap"
+msgstr ""
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr "Avaktivera alias för snapp %q"
+msgstr ""
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr "Avaktiverar alla alias för snap %q"
+msgstr ""
 
 msgid "Disables a snap in the system"
-msgstr "Avaktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
@@ -389,44 +383,41 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr "Vänta inte på att åtgärden ska slutföras, skriv bara ut ändrat ID."
+msgstr ""
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr "Ladda ned snapp %q%s från kanal %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
-"Hämta den givna revisionen av en snap, för vilket du behöver utvecklaråtkomst"
 
 msgid "Downloads the given snap"
-msgstr "Hämtar angiven snap"
+msgstr ""
 
 msgid "Email address: "
-msgstr "E-postadress: "
+msgstr ""
 
 #, c-format
 msgid "Enable %q snap"
-msgstr "Aktivera %q-snap"
+msgstr ""
 
 msgid "Enables a snap in the system"
-msgstr "Aktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr "Säkerställ att allt som %q kräver finns tillgängligt"
+msgstr ""
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
-"Exportera en öppen nyckel assert-nyttolast som kan importeras av andra "
-"system."
 
 msgid "Export cryptographic public key"
-msgstr "Exportera kryptografisk öppen nyckel"
+msgstr ""
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
@@ -434,40 +425,38 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr "Hämtar asserts för %q\n"
+msgstr ""
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr "Hämtar snap %q\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr "Filnamn för snap du vill försäkra ett bygge för"
+msgstr ""
 
 msgid "Finds packages to install"
-msgstr "Söker efter paket att installera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr "Tvinga tillägg av användare, även om enheten redan hanteras"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr "Tvinga import på klassiska system"
+msgstr ""
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
-"Formatera öppet nyckelmaterial som en begäran för en kontonyckel för detta "
-"konto-ID"
 
 msgid "Generate device key"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr "Generera manualsidan"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
@@ -475,25 +464,25 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr "Bevilja sudo-åtkomst för den skapade användaren"
+msgstr ""
 
 msgid "Help"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr "Krok att köra"
+msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr "Signerarens identifierare"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr "Identifierare för snap-paket associerat med bygge"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
@@ -501,7 +490,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr "Ignorera validering av andra snap-paket som blockerar uppdatering"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -510,73 +499,65 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
-"För att köpa %q, måste du godkänna de senaste villkoren. Gå till "
-"https://my.ubuntu.com/payment/edit för att göra detta.\n"
-"\n"
-"När du är färdig, kom tillbaka hit och kör \"snap buy %s\" igen."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
-"Inkludera en utförlig lista över ett snap-pakets anteckningar (annars "
-"sammanfattas anteckningar)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr "Inkludera gränssnitt som inte används"
+msgstr ""
 
 msgid "Initialize device"
 msgstr ""
 
 msgid "Inspects devices for actionable information"
-msgstr "Inspekterar enheter för användbar information"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installera snap-paketet %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr "Installera snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installera snap  %q från fil"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installera snap %q från fil %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installera från betakanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installera från kandidatkanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installera från spetskanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installera från stabila kanalen"
+msgstr ""
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installera snap %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installera snap-paket %s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installera den givna revisionen av en snap, för vilket du behöver ha "
-"utvecklaråtkomst"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -584,14 +565,10 @@ msgid ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installera den givna snap-filen även om det inte finns några tidigare kända "
-"signaturer för den, vilket innebär att den inte verifierades och kan vara "
-"farlig (--devmode antar detta)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installera det givna snap-paketet utan att aktivera dess automatiska alias"
 
 #, c-format
 msgid ""
@@ -599,118 +576,113 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
-"Installera snappen med:\n"
-"   snap ack %s\n"
-"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr "Installerar en snap i systemet"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr "Nyckel av intresse bland konfigurationen"
+msgstr ""
 
 msgid "List a change's tasks"
-msgstr "Lista en ändrings uppgifter"
+msgstr ""
 
 msgid "List cryptographic keys"
-msgstr "Lista kryptografiska nycklar"
+msgstr ""
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
-"Lista kryptografiska nycklar som kan användas för att signera försäkran."
 
 msgid "List installed snaps"
-msgstr "Lista installerade snap-paket"
+msgstr ""
 
 msgid "List system changes"
-msgstr "Lista systemändringar"
+msgstr ""
 
 msgid "Lists aliases in the system"
-msgstr "Lista alias i systemet"
+msgstr ""
 
 msgid "Lists all repairs"
-msgstr "Lista alla reparationer"
+msgstr ""
 
 msgid "Lists interfaces in the system"
-msgstr "Lista gränssnitt i systemet"
+msgstr ""
 
 msgid "Lists snap interfaces"
-msgstr "Lista snap-gränssnitt"
+msgstr ""
 
 msgid "Log out of the store"
-msgstr "Logga ut från butiken"
+msgstr ""
 
 msgid "Login successful"
-msgstr "Inloggning lyckades"
+msgstr ""
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr "Gör aktuell revision för snapp %q otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr "Gör snapp %q (%s) tillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr "Gör snapp %q (%s) otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr "Gör snapp %q otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr "Gör snapp %q%s tillgänglig för systemet"
+msgstr ""
 
 msgid "Mark system seeded"
 msgstr ""
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr "Montera snapp %q%s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr "Nyckelnamn att skapa; förval är \"default\""
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr "Nyckelnamn att radera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr "Nyckelnamn att exportera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
-"Namnet som GnuPG-nyckeln ska använda (förvalt nyckelnamn är \"default\")"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Nyckelnamn att använda, annars används förvald nyckel"
+msgstr ""
 
 msgid "Name\tSHA3-384"
-msgstr "Namn\tSHA3-384"
+msgstr ""
 
 msgid "Name\tSummary"
-msgstr "Namn\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr "Namn\tVersion\tUtvecklare\tAnteckningar\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr "Namn\tVersion\tRev\tUtvecklare\tAnteckningar"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr "Inga alias är definierade för snapp %q.\n"
+msgstr ""
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -732,31 +704,28 @@ msgstr ""
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr "Inga matchande snappar för %q i avsnitt %q\n"
+msgstr ""
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr "Inga matchande snappar för %q\n"
+msgstr ""
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
-"Ingen sökterm angiven. Här är några snappar att titta närmare på:\n"
-"\n"
 
 msgid "No section specified. Available sections:\n"
 msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
-"Inga snap-paket har installerats än. Testa \"snap install hello-world\"."
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr "Utdata resulterar i JSON-format"
+msgstr ""
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -766,11 +735,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr "Lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Password of %q: "
-msgstr "Lösenord för %q: "
+msgstr ""
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -778,212 +747,210 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
-"Ange ditt Ubuntu One-lösenord igen för att köpa %q från %q\n"
-"för %s. Tryck ctrl-C för att avbryta."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr "Föredra alias från en snap och inaktivera konflikter"
+msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prepare a snappy image"
-msgstr "Förbered en snappy-avbild"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr "Förbered snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr "Förbered snap %q%s"
+msgstr ""
 
 msgid "Print the version and exit"
-msgstr "Skriv ut version och avsluta"
+msgstr ""
 
 msgid "Prints configuration options"
-msgstr "Skriver ut konfigurationsalternativ"
+msgstr ""
 
 msgid "Prints the confinement mode the system operates in"
-msgstr "Skriver ut vilket inneslutningsläge systemet arbetar i"
+msgstr ""
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr "Skriver ut huruvida systemet är hanterat"
+msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr "Städa upp automatiska alias för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr "Sätt snap i klassiskt läge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr "Sätt snap i utvecklarläge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr "Sätt snap i bevakat inneslutningsläge"
+msgstr ""
 
 msgid "Query the status of services"
-msgstr "Undersök status för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr "Förnya snap %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr "Förnya snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr "Förnya alias för snap %q"
+msgstr ""
 
 msgid "Refresh all snaps: no updates"
-msgstr "Förnya alla snappar: inga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr "Förnya snapp %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr "Uppdatera snappar %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr "Förnya snappar %s: inga uppdateringar"
+msgstr ""
 
 msgid "Refresh to the given revision"
-msgstr "Uppdatera den givna revisionen"
+msgstr ""
 
 msgid "Refreshes a snap in the system"
-msgstr "Uppdaterar en snap i systemet"
+msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr "Ta bort alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr "Ta bort data för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr "Ta bort manuellt alias %q för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr "Ta endast bort den angivna revisionen"
+msgstr ""
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr "Ta bort säkerhetsprofil för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr "Ta bort säkerhetsprofiler för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr "Ta bort snap %q (%s) från systemet"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr "Ta bort snapp-paketen %s"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr "Borttagen"
+msgstr ""
 
 msgid "Removes a snap from the system"
-msgstr "Tar bort en snap från systemet"
+msgstr ""
 
 msgid "Request device serial"
-msgstr "Begär enhetens serienummer"
+msgstr ""
 
 msgid "Restart services"
-msgstr "Starta om tjänster"
+msgstr ""
 
 msgid "Restarted.\n"
-msgstr "Omstartad.\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr "Begränsa sökningen till ett givet avsnitt"
+msgstr ""
 
 msgid "Retrieve logs of services"
-msgstr "Hämta logg för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr "Rulla tillbaka snap %q"
+msgstr ""
 
 msgid "Reverts the given snap to the previous state"
-msgstr "Rulla tillbaka det givna snap-paketet till föregående tillstånd"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr "Kör ett skal istället för kommandot (hjälper vid felsökning)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr "Kör som en tidmätartjänst med ett givet schema"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr "Kör konfigureringskrok för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr "Kör konfigureringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr "Kör krok %s för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr "Kör installeringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr "Kör post-förnyelsekrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr "Kör förbered-enhets-krok"
+msgstr ""
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr "Kör borttagningskrok för snap %q om den finns"
+msgstr ""
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
@@ -995,54 +962,52 @@ msgid "Run the command with gdb"
 msgstr ""
 
 msgid "Run the given snap command"
-msgstr "Kör det givna snap-kommandot"
+msgstr ""
 
 msgid "Run the given snap command with the right confinement and environment"
-msgstr "Kör det givna snap-kommandot med korrekt inneslutning och miljö"
+msgstr ""
 
 msgid "Runs debug commands"
-msgstr "Kör felsökningskommandon"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr "Sök privata snap-paket"
+msgstr ""
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
-"Välj senaste ändring av given typ (installera, förnya, ta bort, testa, auto-"
-"förnya osv.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr "Ange automatiska alias för snap %q"
+msgstr ""
 
 msgid "Sets up a manual alias"
-msgstr "Anger ett manuellt alias"
+msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr "Ställ in alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr "Ställ in manuellt alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr "Ställ in säkerhetsprofiler för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr "Ställ in alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr "Ställ in säkerhetsprofiler för snapp %q%s"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
@@ -1103,7 +1068,7 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr "Snappnamn"
+msgstr ""
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
@@ -1116,14 +1081,14 @@ msgstr ""
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr "Starta tjänster från snapp %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr "Starta snapp %q%s-tjänster"
+msgstr ""
 
 msgid "Start snap services"
-msgstr "Starta snapptjänster"
+msgstr ""
 
 msgid "Start the userd service"
 msgstr ""
@@ -1139,21 +1104,21 @@ msgstr ""
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr "Stoppa snapp %q (%s)-tjänster"
+msgstr ""
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr "Stoppa snapp %q-tjänster"
+msgstr ""
 
 msgid "Stop snap services"
-msgstr "Stoppa snapptjänster"
+msgstr ""
 
 msgid "Stopped.\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr "Strikt inmatning med tomma och citerade strängar"
+msgstr ""
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1168,7 +1133,7 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr "Växlar snapp till en annan kanal"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
@@ -1183,8 +1148,6 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
-"Tack för att du köpte %q. Du kan nu installera det på valfri enhet med\n"
-"kommandot \"snap install %s\"."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
@@ -1192,7 +1155,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "E-postadress på login.ubuntu.com att logga in som"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
@@ -1209,11 +1172,11 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr "Snapp att konfigurera (t.ex. hello-world)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr "Snappen vars konf begärs"
+msgstr ""
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1226,10 +1189,10 @@ msgstr ""
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr "Växla snapp %q-flaggor"
+msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr "Verktyg för att interagera med snappar"
+msgstr ""
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
@@ -1240,20 +1203,20 @@ msgstr ""
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr "Testa snapp %q från %s"
+msgstr ""
 
 msgid "Try: snap install <selected snap>\n"
-msgstr "Testa: snap install <vald snapp>\n"
+msgstr ""
 
 msgid "Two-factor code: "
-msgstr "Två-faktor kod: "
+msgstr ""
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr "Använd en specifik snapprevision när krok körs"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
@@ -1308,11 +1271,6 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
-"Du måste ha en betalningsmetod associerad med ditt konto för att kunna köpa "
-"en snapp. Besök https://my.ubuntu.com/payment/edit för att lägga till en.\n"
-"\n"
-"När du har lagt till betalningsinformationen behöver du bara köra \"snap buy "
-"%s\" igen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1400,8 +1358,6 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
-"\n"
-"Kommandot buy köper en snapp från butiken.\n"
 
 msgid ""
 "\n"
@@ -1457,11 +1413,6 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
-"\n"
-"Kommandot debug innehåller ett urval av ytterligare delkommandon.\n"
-"\n"
-"Felsökningskommandon kan tas bort utan aviseringar och kanske inte\n"
-"fungerar på icke-utvecklarsystem.\n"
 
 msgid ""
 "\n"
@@ -1496,8 +1447,6 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
-"\n"
-"Kommandot enable aktiverar en snapp som tidigare avaktiverats.\n"
 
 msgid ""
 "\n"
@@ -1587,12 +1536,6 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
-"\n"
-"Kommandot interface visar detaljer om snappars gränssnitt.\n"
-"\n"
-"Om inget gränssnittsnamn anges kommer en lista över gränssnittsnamn\n"
-"med minst en anslutning att visas, eller en lista över alla gränssnitt om\n"
-"--all anges.\n"
 
 msgid ""
 "\n"
@@ -1651,9 +1594,6 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
-"\n"
-"Kommandot managed kommer att skriva ut true eller false, vilket visar\n"
-"huruvida snapd har registrerat användare.\n"
 
 msgid ""
 "\n"
@@ -1705,15 +1645,11 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
-"\n"
-"Kommandot repair visar detaljer om en eller flera reparationer.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
-"\n"
-"Kommandot repairs listar alla utförda reparationer för den här enheten.\n"
 
 msgid ""
 "\n"
@@ -1721,11 +1657,6 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot restart startar om de givna tjänsterna i snappen. Om det körs "
-"från\n"
-"kroken \"configure\" kommer tjänsterna att startas om efter att kroken "
-"slutförs."
 
 msgid ""
 "\n"
@@ -1764,18 +1695,6 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
-"\n"
-"Kommandot set ändrar de givna konfigurationsalternativen enligt begäran.\n"
-"\n"
-"    $ snap set snappnamn username=frank password=$PASSWORD\n"
-"\n"
-"Alla konfigurationsändringar är omedelbart bestående, och sparas endast "
-"efter\n"
-"att snappens konfigurationskrok slutförs med lyckat resultat.\n"
-"\n"
-"Nästlade värden kan ändras via en prickad sökväg:\n"
-"\n"
-"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1803,41 +1722,28 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot start startar de angivna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att startas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot start startar, och eventuellt aktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot stop stoppar de givna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att stoppas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot stop stoppar, och eventuellt avaktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
-"\n"
-"Kommandot switch växlar den givna snappen till en annan kanal utan att\n"
-"göra en förnyelse.\n"
 
 msgid ""
 "\n"
@@ -1872,9 +1778,6 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
-"\n"
-"Kommandot version visar versionerna för den aktiva klienten, servern,\n"
-"och operativsystemet.\n"
 
 msgid ""
 "\n"
@@ -1882,10 +1785,6 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
-"\n"
-"Kommandot watch väntar på att den givna ändrings-ID:n ska slutföras, och "
-"visar\n"
-"förloppet (om tillgängligt).\n"
 
 msgid ""
 "\n"
@@ -1904,14 +1803,6 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
-"\n"
-"Den här revisionen av snapp %q utgavs med klassisk inneslutning, och kan "
-"därför\n"
-"utföra godtyckliga systemändringar utanför den säkerhetssandlåda som "
-"snappar\n"
-"normalt avgränsas till, vilket kan utgöra en risk för ditt system.\n"
-"\n"
-"Om du förstår och vill fortsätta, upprepa kommandot med --classic.\n"
 
 msgid ""
 "\n"
@@ -1920,26 +1811,25 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
-"ett enstaka snappnamn behövs för att specificera läges- eller kanalflaggor"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr "ett enstaka snappnamn behövs för att specificera revision"
+msgstr ""
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr "ett enstaka snappnamn måste specificeras när validering ignoreras"
+msgstr ""
 
 msgid "active"
-msgstr "aktiv"
+msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr "köpt"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr "trasig"
+msgstr ""
 
 #, c-format
 msgid "cannot %s without a context"
@@ -1947,18 +1837,18 @@ msgstr ""
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr "kan inte köpa snapp: %v"
+msgstr ""
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr "kan inte köpa snapp: ogiltiga tecken i namnet"
+msgstr ""
 
 msgid "cannot buy snap: it has already been bought"
-msgstr "kan inte köpa snapp: den har redan köpts"
+msgstr ""
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr "kan inte skapa %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot create assertions file: %v"
@@ -1967,50 +1857,50 @@ msgstr ""
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr "kan inte extrahera snappnamn från lokal fil %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr "kan inte hitta program %q i %q"
+msgstr ""
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr "kan inte hitta krok %q i %q"
+msgstr ""
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr "kan inte hämta data för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr "kan inte hämta full sökväg för %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr "kan inte hämta aktuell användare: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr "kan inte hämta aktuell användare: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr "kan inte märka uppstart lyckad: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr "kan inte öppna försäkringsdatabasen: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr "kan inte läsa försäkransindata: %v"
+msgstr ""
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr "kan inte läsa symlänk: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
@@ -2022,87 +1912,86 @@ msgstr ""
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr "kan inte uppdatera \"aktuell\" symlänk för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr "kan inte använda nyckeln %q: %v"
+msgstr ""
 
 msgid "cannot use change ID and type together"
-msgstr "kan inte använda ändrings-ID och typ tillsammans"
+msgstr ""
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr "kan inte använda devmode- och jailmode-flaggorna tillsammans"
+msgstr ""
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr "kan inte validera ägare av filen %s"
+msgstr ""
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr "kan inte skriva ny Xauthority-fil på %s: %s"
+msgstr ""
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr "ändring slutförd i status %q utan felmeddelande"
+msgstr ""
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
-"klassisk inneslutning kräver snappar i /snap eller symlänk från /snap till %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr "skapade användare %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr "d"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr "avaktiverad"
+msgstr ""
 
 msgid "email:"
-msgstr "e-post:"
+msgstr ""
 
 msgid "enabled"
-msgstr "aktiverad"
+msgstr ""
 
 #, c-format
 msgid "error: %v\n"
-msgstr "fel: %v\n"
+msgstr ""
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr "fel: argumentet \"<snap-dir>\" angavs inte och kunde inte antydas"
+msgstr ""
 
 msgid "get which option?"
-msgstr "hämta vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr "t"
+msgstr ""
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr "inaktiv"
+msgstr ""
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr "gränssnittsattribut kan bara läsas när gränssnittskrokarna körs"
+msgstr ""
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
-msgstr "gränssnittsattribut kan bara sättas när förberedelsekrokarna körs"
+msgstr ""
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr "internt fel, var god rapportera: kunde inte köra %q: %v\n"
+msgstr ""
 
 msgid "internal error: cannot find attrs task"
 msgstr ""
@@ -2125,69 +2014,67 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr "ogiltig konfiguration: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr "ogiltigt huvudfilter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr "ogiltig parameter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr "ogiltigt värde: %q (vill ha snap:namn eller snapp)"
+msgstr ""
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
-"nyckelnamnet %q är ogiltigt; endast ASCII-tecken, siffror, och streck tillåts"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
-"lokal snapp %q är okänd för butiken; använd --amend för att fortsätta ändå"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr "m"
+msgstr ""
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr "kräver att programmet körs som argument"
+msgstr ""
 
 msgid "no changes found"
-msgstr "hittade inga ändringar"
+msgstr ""
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr "hittade inga ändringar av typen %q"
+msgstr ""
 
 msgid "no interfaces currently connected"
-msgstr "inga gränssnitt anslutna just nu"
+msgstr ""
 
 msgid "no interfaces found"
-msgstr "inga gränssnitt hittades"
+msgstr ""
 
 msgid "no matching snaps installed"
-msgstr "inga matchande snappar installerade"
+msgstr ""
 
 msgid "no such interface"
-msgstr "inget sådant gränssnitt"
+msgstr ""
 
 msgid "no valid snaps given"
-msgstr "inga giltiga snappar angivna"
+msgstr ""
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr "ange ändrings-ID eller typ med --last=<typ>"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr "privat"
+msgstr ""
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2195,19 +2082,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr "reparationer är inte tillgängliga på ett klassiskt system"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr "s"
+msgstr ""
 
 #, c-format
 msgid "set failed: %v"
-msgstr "set misslyckades: %v"
+msgstr ""
 
 msgid "set which option?"
-msgstr "sätt vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2221,7 +2108,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr "snapp %q har inga tillgängliga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2229,30 +2116,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr "snapp %q finns inte"
+msgstr ""
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr "snapp är gratis"
+msgstr ""
 
 msgid "too many arguments for command"
-msgstr "för många argument för kommandot"
+msgstr ""
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr "för många argument för krok %q: %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr "för många argument: %s"
+msgstr ""
 
 msgid "unable to contact snap store"
-msgstr "kan inte kontakta snap store"
+msgstr ""
 
 msgid "unavailable"
-msgstr "otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2268,31 +2155,30 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr "okänd tjänst: %q"
+msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr "varning:\tingen snapp hittades för %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr "å"
+msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr "Autentisera mot snapp-daemon"
+msgstr ""
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr "Identitskontroll krävs för att autentisera mot snapp-daemonen"
+msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr "Installera, uppdatera eller ta bort paket"
+msgstr ""
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
-"Autentisering krävs för att installera, uppdatera, eller ta bort paket"
 
 msgid "Connect, disconnect interfaces"
-msgstr "Anslut, koppla bort gränssnitt"
+msgstr ""
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr "Autentisering krävs för att ansluta eller koppla bort gränssnitt"
+msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Provo \"snapcraft prime\" në drejtorinë tënde të projektit, pastaj përsëri "
 "\"snap try\"."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -105,88 +106,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "U Shtua"
 
@@ -204,9 +207,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -216,6 +221,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +236,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -286,7 +297,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -296,7 +307,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -310,14 +321,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -373,6 +385,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -380,6 +393,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -421,16 +435,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -442,33 +458,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr "Ndihmë"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -483,6 +507,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -508,15 +533,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -529,16 +558,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -552,8 +584,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -617,21 +649,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -692,6 +726,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -760,12 +796,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -823,6 +862,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -847,6 +887,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -862,6 +903,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -875,9 +917,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -917,6 +961,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -929,6 +974,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -971,9 +1017,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -983,13 +1031,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1019,8 +1069,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1070,6 +1120,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1088,6 +1139,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1105,15 +1157,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1121,11 +1173,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1165,15 +1218,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1186,6 +1242,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/tg.po
+++ b/po/tg.po
@@ -1,16 +1,16 @@
-# Swedish translation for snapd
-# Copyright (c) 2018 Rosetta Contributors and Canonical Ltd 2018
+# Tajik translation for snapd
+# Copyright (c) 2019 Rosetta Contributors and Canonical Ltd 2019
 # This file is distributed under the same license as the snapd package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: snapd\n"
 "Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
 "POT-Creation-Date: 2018-04-03 12:06+0200\n"
-"PO-Revision-Date: 2018-09-27 14:02+0000\n"
+"PO-Revision-Date: 2019-02-19 14:40+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Swedish <sv@li.org>\n"
+"Language-Team: Tajik <tg@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,151 +23,148 @@ msgid ""
 "\n"
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
-"%q innehåller inte ett uppackat snap-paket.\n"
-"\n"
-"Testa \"snapcraft prime\" i din projektmapp, sedan \"snap try\" igen."
 
 #. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr "%q bytte till kanalen %q\n"
+msgstr ""
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
 msgid "%s %s mounted from %s\n"
-msgstr "%s %s monterades från %s\n"
+msgstr ""
 
 #, c-format
 msgid "%s (delta)"
-msgstr "%s (delta)"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (see \"snap login --help\")"
-msgstr "%s (se \"snap login --help\")"
+msgstr ""
 
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr "%s (försök med sudo)"
+msgstr ""
 
 #, c-format
 msgid "%s already installed\n"
-msgstr "%s är redan installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s disabled\n"
-msgstr "%s inaktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s enabled\n"
-msgstr "%s aktiverad\n"
+msgstr ""
 
 #, c-format
 msgid "%s not installed\n"
-msgstr "%s inte installerad\n"
+msgstr ""
 
 #, c-format
 msgid "%s removed\n"
-msgstr "%s borttagen\n"
+msgstr ""
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
 msgid "%s reverted to %s\n"
-msgstr "%s återställd till %s\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 #, c-format
 msgid "%s%s %s from '%s' installed\n"
-msgstr "%s%s %s från \"%s\" installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 #, c-format
 msgid "%s%s %s from '%s' refreshed\n"
-msgstr "%s%s %s från \"%s\" uppdaterad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr "%s%s %s installerad\n"
+msgstr ""
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
 msgid "%s%s %s refreshed\n"
-msgstr "%s%s %s uppdaterad\n"
+msgstr ""
 
 msgid "--list does not take mode nor channel flags"
-msgstr "--list tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "--time does not take mode nor channel flags"
-msgstr "--time tar inte läges- eller kanalflaggor"
+msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr "-r kan bara användas med --hook"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
-msgstr "<alias-eller-snap>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr "<alias>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
-msgstr "<assert-fil>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
-msgstr "<assert-typ>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
-msgstr "<ändra-id>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
-msgstr "<konf.värde>"
+msgstr ""
 
 #. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
 #. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
-msgstr "<epost>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
-msgstr "<filnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
-msgstr "<rubrikfilter>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
-msgstr "<gränssnitt>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
-msgstr "<nyckelnamn>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
-msgstr "<nyckel>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
-msgstr "<modell-assert>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
-msgstr "<fråga>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
-msgstr "<root-kat>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
@@ -176,48 +173,46 @@ msgstr ""
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr "<snap>:<plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr "<snap>:<slot eller plug>"
+msgstr ""
 
 #. TRANSLATORS: This needs to begin with < and end with >
 #. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr "<snap>:<slot>"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
 msgstr ""
-"En tjänstespecifikation, som kan vara bara ett snappnamn (för alla tjänster "
-"i snappen), eller <snapp>.<app> för en enstaka tjänst."
 
 msgid "Abort a pending change"
-msgstr "Avbryt en väntande ändring"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
-msgstr "Tillagd"
+msgstr ""
 
 msgid "Adds an assertion to the system"
-msgstr "Lägger till en assert i systemet"
+msgstr ""
 
 msgid "Advise on available snaps."
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
-msgstr "Informera om snappar som tillhandahåller det givna kommandot"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
-msgstr "Alias för --dangerous (FÖRÅLDRAD)"
+msgstr ""
 
 msgid "All snaps up to date."
-msgstr "Alla snap-paket uppdaterade."
+msgstr ""
 
 msgid "Allow opening file?"
 msgstr ""
@@ -231,27 +226,27 @@ msgstr ""
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
-msgstr "Tillåt snapp %q att ändra %q till %q ?"
+msgstr ""
 
 #, c-format
 msgid "Allow snap %q to open file %q?"
-msgstr "Tillåt snapp %q att öppna filen %q?"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
-msgstr "Alternativt kommando att köra"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
-msgstr "Returnera alltid dokument, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
-msgstr "Returnera alltid lista, även med enstaka nyckel"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
-msgstr "En e-postadress för en användare på login.ubuntu.com"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -266,14 +261,14 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
-msgstr "Assert-fil"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
-msgstr "Assert-typnamn"
+msgstr ""
 
 msgid "Authenticates on snapd and the store"
-msgstr "Autentiseras på snapd och butiken"
+msgstr ""
 
 #, c-format
 msgid "Auto-refresh %d snaps"
@@ -293,27 +288,27 @@ msgid "Automatically connect eligible plugs and slots of snap %q"
 msgstr ""
 
 msgid "Bad code. Try again: "
-msgstr "Felaktig kod. Försök igen: "
+msgstr ""
 
 msgid "Buys a snap"
-msgstr "Köper en snap"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr "Ändra ID"
+msgstr ""
 
 msgid "Changes configuration options"
-msgstr "Ändrar konfigurationsalternativ"
+msgstr ""
 
 msgid "Command\tAlias\tNotes"
-msgstr "Kommando\tAlias\tAnteckningar"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
-msgstr "Konfigurationsvärde (nyckel=värde)"
+msgstr ""
 
 msgid "Confirm passphrase: "
-msgstr "Bekräfta lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Connect %s:%s to %s:%s"
@@ -324,57 +319,56 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
-msgstr "Begränsa lista till en specifik snap eller snapp:namn"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
-msgstr "Begränsa lista till specifika gränssnitt"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
-msgstr "Begränsa lista till de som matchar rubrik=värde"
+msgstr ""
 
 #, c-format
 msgid "Copy snap %q data"
-msgstr "Kopiera data från snapp %q"
+msgstr ""
 
 msgid ""
 "Create a cryptographic key pair that can be used for signing assertions."
 msgstr ""
-"Skapa ett kryptografiskt nyckelpar som kan användas för att signera asserts."
 
 msgid "Create cryptographic key pair"
-msgstr "Skapa kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Create snap build assertion"
-msgstr "Skapa snap-bygges-assert"
+msgstr ""
 
 msgid "Create snap-build assertion for the provided snap file."
-msgstr "Skapa snap-bygges-assert för den givna snap-filen."
+msgstr ""
 
 msgid "Creates a local system user"
-msgstr "Skapar en lokal systemanvändare"
+msgstr ""
 
 msgid "Delete cryptographic key pair"
-msgstr "Radera kryptografiskt nyckelpar"
+msgstr ""
 
 msgid "Delete the local cryptographic key pair with the given name."
-msgstr "Radera det lokala kryptografiska nyckelparet med det givna namnet."
+msgstr ""
 
 #, c-format
 msgid "Disable %q snap"
-msgstr "Inaktivera %q-snap"
+msgstr ""
 
 #, c-format
 msgid "Disable aliases for snap %q"
-msgstr "Avaktivera alias för snapp %q"
+msgstr ""
 
 #, c-format
 msgid "Disable all aliases for snap %q"
-msgstr "Avaktiverar alla alias för snap %q"
+msgstr ""
 
 msgid "Disables a snap in the system"
-msgstr "Avaktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Discard interface connections for snap %q (%s)"
@@ -389,44 +383,41 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
-msgstr "Vänta inte på att åtgärden ska slutföras, skriv bara ut ändrat ID."
+msgstr ""
 
 #, c-format
 msgid "Download snap %q%s from channel %q"
-msgstr "Ladda ned snapp %q%s från kanal %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
 msgstr ""
-"Hämta den givna revisionen av en snap, för vilket du behöver utvecklaråtkomst"
 
 msgid "Downloads the given snap"
-msgstr "Hämtar angiven snap"
+msgstr ""
 
 msgid "Email address: "
-msgstr "E-postadress: "
+msgstr ""
 
 #, c-format
 msgid "Enable %q snap"
-msgstr "Aktivera %q-snap"
+msgstr ""
 
 msgid "Enables a snap in the system"
-msgstr "Aktiverar en snapp i systemet"
+msgstr ""
 
 #, c-format
 msgid "Ensure prerequisites for %q are available"
-msgstr "Säkerställ att allt som %q kräver finns tillgängligt"
+msgstr ""
 
 msgid ""
 "Export a public key assertion body that may be imported by other systems."
 msgstr ""
-"Exportera en öppen nyckel assert-nyttolast som kan importeras av andra "
-"system."
 
 msgid "Export cryptographic public key"
-msgstr "Exportera kryptografisk öppen nyckel"
+msgstr ""
 
 #, c-format
 msgid "Fetch and check assertions for snap %q%s"
@@ -434,40 +425,38 @@ msgstr ""
 
 #, c-format
 msgid "Fetching assertions for %q\n"
-msgstr "Hämtar asserts för %q\n"
+msgstr ""
 
 #, c-format
 msgid "Fetching snap %q\n"
-msgstr "Hämtar snap %q\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
-msgstr "Filnamn för snap du vill försäkra ett bygge för"
+msgstr ""
 
 msgid "Finds packages to install"
-msgstr "Söker efter paket att installera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
-msgstr "Tvinga tillägg av användare, även om enheten redan hanteras"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
-msgstr "Tvinga import på klassiska system"
+msgstr ""
 
 msgid ""
 "Format public key material as a request for an account-key for this account-"
 "id"
 msgstr ""
-"Formatera öppet nyckelmaterial som en begäran för en kontonyckel för detta "
-"konto-ID"
 
 msgid "Generate device key"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
-msgstr "Generera manualsidan"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
@@ -475,25 +464,25 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
-msgstr "Bevilja sudo-åtkomst för den skapade användaren"
+msgstr ""
 
 msgid "Help"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
-msgstr "Krok att köra"
+msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
-msgstr "Signerarens identifierare"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
-msgstr "Identifierare för snap-paket associerat med bygge"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
@@ -501,7 +490,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
-msgstr "Ignorera validering av andra snap-paket som blockerar uppdatering"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -510,73 +499,65 @@ msgid ""
 "\n"
 "Once completed, return here and run 'snap buy %s' again."
 msgstr ""
-"För att köpa %q, måste du godkänna de senaste villkoren. Gå till "
-"https://my.ubuntu.com/payment/edit för att göra detta.\n"
-"\n"
-"När du är färdig, kom tillbaka hit och kör \"snap buy %s\" igen."
 
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
-"Inkludera en utförlig lista över ett snap-pakets anteckningar (annars "
-"sammanfattas anteckningar)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
-msgstr "Inkludera gränssnitt som inte används"
+msgstr ""
 
 msgid "Initialize device"
 msgstr ""
 
 msgid "Inspects devices for actionable information"
-msgstr "Inspekterar enheter för användbar information"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap"
-msgstr "Installera snap-paketet %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from %q channel"
-msgstr "Installera snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file"
-msgstr "Installera snap  %q från fil"
+msgstr ""
 
 #, c-format
 msgid "Install %q snap from file %q"
-msgstr "Installera snap %q från fil %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
-msgstr "Installera från betakanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
-msgstr "Installera från kandidatkanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
-msgstr "Installera från spetskanalen"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
-msgstr "Installera från stabila kanalen"
+msgstr ""
 
 #, c-format
 msgid "Install snap %q"
-msgstr "Installera snap %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Install snaps %s"
-msgstr "Installera snap-paket %s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
-"Installera den givna revisionen av en snap, för vilket du behöver ha "
-"utvecklaråtkomst"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
@@ -584,14 +565,10 @@ msgid ""
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
-"Installera den givna snap-filen även om det inte finns några tidigare kända "
-"signaturer för den, vilket innebär att den inte verifierades och kan vara "
-"farlig (--devmode antar detta)"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
-"Installera det givna snap-paketet utan att aktivera dess automatiska alias"
 
 #, c-format
 msgid ""
@@ -599,118 +576,113 @@ msgid ""
 "   snap ack %s\n"
 "   snap install %s\n"
 msgstr ""
-"Installera snappen med:\n"
-"   snap ack %s\n"
-"   snap install %s\n"
 
 msgid "Installs a snap to the system"
-msgstr "Installerar en snap i systemet"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
-msgstr "Nyckel av intresse bland konfigurationen"
+msgstr ""
 
 msgid "List a change's tasks"
-msgstr "Lista en ändrings uppgifter"
+msgstr ""
 
 msgid "List cryptographic keys"
-msgstr "Lista kryptografiska nycklar"
+msgstr ""
 
 msgid "List cryptographic keys that can be used for signing assertions."
 msgstr ""
-"Lista kryptografiska nycklar som kan användas för att signera försäkran."
 
 msgid "List installed snaps"
-msgstr "Lista installerade snap-paket"
+msgstr ""
 
 msgid "List system changes"
-msgstr "Lista systemändringar"
+msgstr ""
 
 msgid "Lists aliases in the system"
-msgstr "Lista alias i systemet"
+msgstr ""
 
 msgid "Lists all repairs"
-msgstr "Lista alla reparationer"
+msgstr ""
 
 msgid "Lists interfaces in the system"
-msgstr "Lista gränssnitt i systemet"
+msgstr ""
 
 msgid "Lists snap interfaces"
-msgstr "Lista snap-gränssnitt"
+msgstr ""
 
 msgid "Log out of the store"
-msgstr "Logga ut från butiken"
+msgstr ""
 
 msgid "Login successful"
-msgstr "Inloggning lyckades"
+msgstr ""
 
 #, c-format
 msgid "Make current revision for snap %q unavailable"
-msgstr "Gör aktuell revision för snapp %q otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) available to the system"
-msgstr "Gör snapp %q (%s) tillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q (%s) unavailable to the system"
-msgstr "Gör snapp %q (%s) otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q unavailable to the system"
-msgstr "Gör snapp %q otillgänglig för systemet"
+msgstr ""
 
 #, c-format
 msgid "Make snap %q%s available to the system"
-msgstr "Gör snapp %q%s tillgänglig för systemet"
+msgstr ""
 
 msgid "Mark system seeded"
 msgstr ""
 
 #, c-format
 msgid "Mount snap %q%s"
-msgstr "Montera snapp %q%s"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
-msgstr "Nyckelnamn att skapa; förval är \"default\""
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
-msgstr "Nyckelnamn att radera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
-msgstr "Nyckelnamn att exportera"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
-"Namnet som GnuPG-nyckeln ska använda (förvalt nyckelnamn är \"default\")"
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
-msgstr "Nyckelnamn att använda, annars används förvald nyckel"
+msgstr ""
 
 msgid "Name\tSHA3-384"
-msgstr "Namn\tSHA3-384"
+msgstr ""
 
 msgid "Name\tSummary"
-msgstr "Namn\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tDeveloper\tNotes\tSummary"
-msgstr "Namn\tVersion\tUtvecklare\tAnteckningar\tSammanfattning"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tDeveloper\tNotes"
-msgstr "Namn\tVersion\tRev\tUtvecklare\tAnteckningar"
+msgstr ""
 
 msgid "Name\tVersion\tRev\tTracking\tDeveloper\tNotes"
 msgstr ""
 
 #, c-format
 msgid "No aliases are currently defined for snap %q.\n"
-msgstr "Inga alias är definierade för snapp %q.\n"
+msgstr ""
 
 msgid "No aliases are currently defined."
 msgstr ""
@@ -732,31 +704,28 @@ msgstr ""
 #. user entered
 #, c-format
 msgid "No matching snaps for %q in section %q\n"
-msgstr "Inga matchande snappar för %q i avsnitt %q\n"
+msgstr ""
 
 #. TRANSLATORS: the %q is the (quoted) query the user entered
 #, c-format
 msgid "No matching snaps for %q\n"
-msgstr "Inga matchande snappar för %q\n"
+msgstr ""
 
 msgid ""
 "No search term specified. Here are some interesting snaps:\n"
 "\n"
 msgstr ""
-"Ingen sökterm angiven. Här är några snappar att titta närmare på:\n"
-"\n"
 
 msgid "No section specified. Available sections:\n"
 msgstr ""
 
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
-"Inga snap-paket har installerats än. Testa \"snap install hello-world\"."
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
-msgstr "Utdata resulterar i JSON-format"
+msgstr ""
 
 msgid "Pack the given target dir as a snap"
 msgstr ""
@@ -766,11 +735,11 @@ msgid "Packages matching %q:\n"
 msgstr ""
 
 msgid "Passphrase: "
-msgstr "Lösenfras: "
+msgstr ""
 
 #, c-format
 msgid "Password of %q: "
-msgstr "Lösenord för %q: "
+msgstr ""
 
 #. TRANSLATORS: %q, %q and %s are the snap name, developer, and price. Please wrap the translation at 80 characters.
 #, c-format
@@ -778,212 +747,210 @@ msgid ""
 "Please re-enter your Ubuntu One password to purchase %q from %q\n"
 "for %s. Press ctrl-c to cancel."
 msgstr ""
-"Ange ditt Ubuntu One-lösenord igen för att köpa %q från %q\n"
-"för %s. Tryck ctrl-C för att avbryta."
 
 msgid "Please try: snap find --section=<selected section>\n"
 msgstr ""
 
 #, c-format
 msgid "Prefer aliases for snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prefer aliases from a snap and disable conflicts"
-msgstr "Föredra alias från en snap och inaktivera konflikter"
+msgstr ""
 
 #, c-format
 msgid "Prefer aliases of snap %q"
-msgstr "Föredra alias för snap %q"
+msgstr ""
 
 msgid "Prepare a snappy image"
-msgstr "Förbered en snappy-avbild"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q (%s)"
-msgstr "Förbered snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Prepare snap %q%s"
-msgstr "Förbered snap %q%s"
+msgstr ""
 
 msgid "Print the version and exit"
-msgstr "Skriv ut version och avsluta"
+msgstr ""
 
 msgid "Prints configuration options"
-msgstr "Skriver ut konfigurationsalternativ"
+msgstr ""
 
 msgid "Prints the confinement mode the system operates in"
-msgstr "Skriver ut vilket inneslutningsläge systemet arbetar i"
+msgstr ""
 
 msgid "Prints the email the user is logged in with"
 msgstr ""
 
 msgid "Prints whether system is managed"
-msgstr "Skriver ut huruvida systemet är hanterat"
+msgstr ""
 
 #, c-format
 msgid "Prune automatic aliases for snap %q"
-msgstr "Städa upp automatiska alias för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
-msgstr "Sätt snap i klassiskt läge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
-msgstr "Sätt snap i utvecklarläge och inaktivera säkerhetsinneslutning"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
-msgstr "Sätt snap i bevakat inneslutningsläge"
+msgstr ""
 
 msgid "Query the status of services"
-msgstr "Undersök status för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap"
-msgstr "Förnya snap %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh %q snap from %q channel"
-msgstr "Förnya snap %q från kanalen %q"
+msgstr ""
 
 #, c-format
 msgid "Refresh aliases for snap %q"
-msgstr "Förnya alias för snap %q"
+msgstr ""
 
 msgid "Refresh all snaps: no updates"
-msgstr "Förnya alla snappar: inga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "Refresh snap %q"
-msgstr "Förnya snapp %q"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s"
-msgstr "Uppdatera snappar %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Refresh snaps %s: no updates"
-msgstr "Förnya snappar %s: inga uppdateringar"
+msgstr ""
 
 msgid "Refresh to the given revision"
-msgstr "Uppdatera den givna revisionen"
+msgstr ""
 
 msgid "Refreshes a snap in the system"
-msgstr "Uppdaterar en snap i systemet"
+msgstr ""
 
 #, c-format
 msgid "Remove %q snap"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove aliases for snap %q"
-msgstr "Ta bort alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove data for snap %q (%s)"
-msgstr "Ta bort data för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove manual alias %q for snap %q"
-msgstr "Ta bort manuellt alias %q för snap %q"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
-msgstr "Ta endast bort den angivna revisionen"
+msgstr ""
 
 #, c-format
 msgid "Remove security profile for snap %q (%s)"
-msgstr "Ta bort säkerhetsprofil för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Remove security profiles of snap %q"
-msgstr "Ta bort säkerhetsprofiler för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q"
-msgstr "Ta bort snap %q"
+msgstr ""
 
 #, c-format
 msgid "Remove snap %q (%s) from the system"
-msgstr "Ta bort snap %q (%s) från systemet"
+msgstr ""
 
 #. TRANSLATORS: the %s is a comma-separated list of quoted snap names
 #, c-format
 msgid "Remove snaps %s"
-msgstr "Ta bort snapp-paketen %s"
+msgstr ""
 
 #. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
-msgstr "Borttagen"
+msgstr ""
 
 msgid "Removes a snap from the system"
-msgstr "Tar bort en snap från systemet"
+msgstr ""
 
 msgid "Request device serial"
-msgstr "Begär enhetens serienummer"
+msgstr ""
 
 msgid "Restart services"
-msgstr "Starta om tjänster"
+msgstr ""
 
 msgid "Restarted.\n"
-msgstr "Omstartad.\n"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
-msgstr "Begränsa sökningen till ett givet avsnitt"
+msgstr ""
 
 msgid "Retrieve logs of services"
-msgstr "Hämta logg för tjänster"
+msgstr ""
 
 #, c-format
 msgid "Revert %q snap"
-msgstr "Rulla tillbaka snap %q"
+msgstr ""
 
 msgid "Reverts the given snap to the previous state"
-msgstr "Rulla tillbaka det givna snap-paketet till föregående tillstånd"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
-msgstr "Kör ett skal istället för kommandot (hjälper vid felsökning)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
-msgstr "Kör som en tidmätartjänst med ett givet schema"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap"
-msgstr "Kör konfigureringskrok för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run configure hook of %q snap if present"
-msgstr "Kör konfigureringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run hook %s of snap %q"
-msgstr "Kör krok %s för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Run install hook of %q snap if present"
-msgstr "Kör installeringskrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run post-refresh hook of %q snap if present"
-msgstr "Kör post-förnyelsekrok för snap %q om den finns"
+msgstr ""
 
 #, c-format
 msgid "Run pre-refresh hook of %q snap if present"
 msgstr ""
 
 msgid "Run prepare-device hook"
-msgstr "Kör förbered-enhets-krok"
+msgstr ""
 
 #, c-format
 msgid "Run remove hook of %q snap if present"
-msgstr "Kör borttagningskrok för snap %q om den finns"
+msgstr ""
 
 msgid ""
 "Run the command under strace (useful for debugging). Extra strace options "
@@ -995,54 +962,52 @@ msgid "Run the command with gdb"
 msgstr ""
 
 msgid "Run the given snap command"
-msgstr "Kör det givna snap-kommandot"
+msgstr ""
 
 msgid "Run the given snap command with the right confinement and environment"
-msgstr "Kör det givna snap-kommandot med korrekt inneslutning och miljö"
+msgstr ""
 
 msgid "Runs debug commands"
-msgstr "Kör felsökningskommandon"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
-msgstr "Sök privata snap-paket"
+msgstr ""
 
 msgid ""
 "Select last change of given type (install, refresh, remove, try, auto-"
 "refresh etc.)"
 msgstr ""
-"Välj senaste ändring av given typ (installera, förnya, ta bort, testa, auto-"
-"förnya osv.)"
 
 msgid "Service\tStartup\tCurrent"
 msgstr ""
 
 #, c-format
 msgid "Set automatic aliases for snap %q"
-msgstr "Ange automatiska alias för snap %q"
+msgstr ""
 
 msgid "Sets up a manual alias"
-msgstr "Anger ett manuellt alias"
+msgstr ""
 
 #, c-format
 msgid "Setup alias %q => %q for snap %q"
-msgstr "Ställ in alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup manual alias %q => %q for snap %q"
-msgstr "Ställ in manuellt alias %q => %q för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q (%s) security profiles"
-msgstr "Ställ in säkerhetsprofiler för snap %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q aliases"
-msgstr "Ställ in alias för snap %q"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles"
-msgstr "Ställ in säkerhetsprofiler för snapp %q%s"
+msgstr ""
 
 #, c-format
 msgid "Setup snap %q%s security profiles (phase 2)"
@@ -1103,7 +1068,7 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
-msgstr "Snappnamn"
+msgstr ""
 
 msgid ""
 "Sorry, your payment method has been declined by the issuer. Please review "
@@ -1116,14 +1081,14 @@ msgstr ""
 
 #, c-format
 msgid "Start snap %q (%s) services"
-msgstr "Starta tjänster från snapp %q (%s)"
+msgstr ""
 
 #, c-format
 msgid "Start snap %q%s services"
-msgstr "Starta snapp %q%s-tjänster"
+msgstr ""
 
 msgid "Start snap services"
-msgstr "Starta snapptjänster"
+msgstr ""
 
 msgid "Start the userd service"
 msgstr ""
@@ -1139,21 +1104,21 @@ msgstr ""
 
 #, c-format
 msgid "Stop snap %q (%s) services"
-msgstr "Stoppa snapp %q (%s)-tjänster"
+msgstr ""
 
 #, c-format
 msgid "Stop snap %q services"
-msgstr "Stoppa snapp %q-tjänster"
+msgstr ""
 
 msgid "Stop snap services"
-msgstr "Stoppa snapptjänster"
+msgstr ""
 
 msgid "Stopped.\n"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
-msgstr "Strikt inmatning med tomma och citerade strängar"
+msgstr ""
 
 #, c-format
 msgid "Switch %q snap to %s"
@@ -1168,7 +1133,7 @@ msgid "Switch snap %q to %s"
 msgstr ""
 
 msgid "Switches snap to a different channel"
-msgstr "Växlar snapp till en annan kanal"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
@@ -1183,8 +1148,6 @@ msgid ""
 "Thanks for purchasing %q. You may now install it on any of your devices\n"
 "with 'snap install %s'."
 msgstr ""
-"Tack för att du köpte %q. Du kan nu installera det på valfri enhet med\n"
-"kommandot \"snap install %s\"."
 
 msgid ""
 "The get command prints configuration and interface connection settings."
@@ -1192,7 +1155,7 @@ msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
-msgstr "E-postadress på login.ubuntu.com att logga in som"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
@@ -1209,11 +1172,11 @@ msgstr ""
 #. TRANSLATORS: This should not start with a lowercase letter.
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
-msgstr "Snapp att konfigurera (t.ex. hello-world)"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
-msgstr "Snappen vars konf begärs"
+msgstr ""
 
 msgid "The userd command starts the snap user session service."
 msgstr ""
@@ -1226,10 +1189,10 @@ msgstr ""
 
 #, c-format
 msgid "Toggle snap %q flags"
-msgstr "Växla snapp %q-flaggor"
+msgstr ""
 
 msgid "Tool to interact with snaps"
-msgstr "Verktyg för att interagera med snappar"
+msgstr ""
 
 #, c-format
 msgid "Transition security profiles from %q to %q"
@@ -1240,20 +1203,20 @@ msgstr ""
 
 #, c-format
 msgid "Try %q snap from %s"
-msgstr "Testa snapp %q från %s"
+msgstr ""
 
 msgid "Try: snap install <selected snap>\n"
-msgstr "Testa: snap install <vald snapp>\n"
+msgstr ""
 
 msgid "Two-factor code: "
-msgstr "Två-faktor kod: "
+msgstr ""
 
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
-msgstr "Använd en specifik snapprevision när krok körs"
+msgstr ""
 
 #. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
@@ -1308,11 +1271,6 @@ msgid ""
 "Once you’ve added your payment details, you just need to run 'snap buy %s' "
 "again."
 msgstr ""
-"Du måste ha en betalningsmetod associerad med ditt konto för att kunna köpa "
-"en snapp. Besök https://my.ubuntu.com/payment/edit för att lägga till en.\n"
-"\n"
-"När du har lagt till betalningsinformationen behöver du bara köra \"snap buy "
-"%s\" igen."
 
 #. TRANSLATORS: the %s is the argument given by the user to "snap changes"
 #, c-format
@@ -1400,8 +1358,6 @@ msgid ""
 "\n"
 "The buy command buys a snap from the store.\n"
 msgstr ""
-"\n"
-"Kommandot buy köper en snapp från butiken.\n"
 
 msgid ""
 "\n"
@@ -1457,11 +1413,6 @@ msgid ""
 "Debug commands can be removed without notice and may not work on\n"
 "non-development systems.\n"
 msgstr ""
-"\n"
-"Kommandot debug innehåller ett urval av ytterligare delkommandon.\n"
-"\n"
-"Felsökningskommandon kan tas bort utan aviseringar och kanske inte\n"
-"fungerar på icke-utvecklarsystem.\n"
 
 msgid ""
 "\n"
@@ -1496,8 +1447,6 @@ msgid ""
 "\n"
 "The enable command enables a snap that was previously disabled.\n"
 msgstr ""
-"\n"
-"Kommandot enable aktiverar en snapp som tidigare avaktiverats.\n"
 
 msgid ""
 "\n"
@@ -1587,12 +1536,6 @@ msgid ""
 "If no interface name is provided, a list of interface names with at least\n"
 "one connection is shown, or a list of all interfaces if --all is provided.\n"
 msgstr ""
-"\n"
-"Kommandot interface visar detaljer om snappars gränssnitt.\n"
-"\n"
-"Om inget gränssnittsnamn anges kommer en lista över gränssnittsnamn\n"
-"med minst en anslutning att visas, eller en lista över alla gränssnitt om\n"
-"--all anges.\n"
 
 msgid ""
 "\n"
@@ -1651,9 +1594,6 @@ msgid ""
 "The managed command will print true or false informing whether\n"
 "snapd has registered users.\n"
 msgstr ""
-"\n"
-"Kommandot managed kommer att skriva ut true eller false, vilket visar\n"
-"huruvida snapd har registrerat användare.\n"
 
 msgid ""
 "\n"
@@ -1705,15 +1645,11 @@ msgid ""
 "\n"
 "The repair command shows the details about one or multiple repairs.\n"
 msgstr ""
-"\n"
-"Kommandot repair visar detaljer om en eller flera reparationer.\n"
 
 msgid ""
 "\n"
 "The repairs command lists all processed repairs for this device.\n"
 msgstr ""
-"\n"
-"Kommandot repairs listar alla utförda reparationer för den här enheten.\n"
 
 msgid ""
 "\n"
@@ -1721,11 +1657,6 @@ msgid ""
 "from the\n"
 "\"configure\" hook, the services will be restarted after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot restart startar om de givna tjänsterna i snappen. Om det körs "
-"från\n"
-"kroken \"configure\" kommer tjänsterna att startas om efter att kroken "
-"slutförs."
 
 msgid ""
 "\n"
@@ -1764,18 +1695,6 @@ msgid ""
 "\n"
 "    $ snap set author.name=frank\n"
 msgstr ""
-"\n"
-"Kommandot set ändrar de givna konfigurationsalternativen enligt begäran.\n"
-"\n"
-"    $ snap set snappnamn username=frank password=$PASSWORD\n"
-"\n"
-"Alla konfigurationsändringar är omedelbart bestående, och sparas endast "
-"efter\n"
-"att snappens konfigurationskrok slutförs med lyckat resultat.\n"
-"\n"
-"Nästlade värden kan ändras via en prickad sökväg:\n"
-"\n"
-"    $ snap set author.name=frank\n"
 
 msgid ""
 "\n"
@@ -1803,41 +1722,28 @@ msgid ""
 "the\n"
 "\"configure\" hook, the services will be started after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot start startar de angivna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att startas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The start command starts, and optionally enables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot start startar, och eventuellt aktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The stop command stops the given services of the snap. If executed from the\n"
 "\"configure\" hook, the services will be stopped after the hook finishes."
 msgstr ""
-"\n"
-"Kommandot stop stoppar de givna tjänsterna i snappen. Om det körs från\n"
-"kroken \"configure\" kommer tjänsterna att stoppas efter att kroken slutförs."
 
 msgid ""
 "\n"
 "The stop command stops, and optionally disables, the given services.\n"
 msgstr ""
-"\n"
-"Kommandot stop stoppar, och eventuellt avaktiverar, de givna tjänsterna.\n"
 
 msgid ""
 "\n"
 "The switch command switches the given snap to a different channel without\n"
 "doing a refresh.\n"
 msgstr ""
-"\n"
-"Kommandot switch växlar den givna snappen till en annan kanal utan att\n"
-"göra en förnyelse.\n"
 
 msgid ""
 "\n"
@@ -1872,9 +1778,6 @@ msgid ""
 "The version command displays the versions of the running client, server,\n"
 "and operating system.\n"
 msgstr ""
-"\n"
-"Kommandot version visar versionerna för den aktiva klienten, servern,\n"
-"och operativsystemet.\n"
 
 msgid ""
 "\n"
@@ -1882,10 +1785,6 @@ msgid ""
 "progress\n"
 "(if available).\n"
 msgstr ""
-"\n"
-"Kommandot watch väntar på att den givna ändrings-ID:n ska slutföras, och "
-"visar\n"
-"förloppet (om tillgängligt).\n"
 
 msgid ""
 "\n"
@@ -1904,14 +1803,6 @@ msgid ""
 "If you understand and want to proceed repeat the command including --"
 "classic.\n"
 msgstr ""
-"\n"
-"Den här revisionen av snapp %q utgavs med klassisk inneslutning, och kan "
-"därför\n"
-"utföra godtyckliga systemändringar utanför den säkerhetssandlåda som "
-"snappar\n"
-"normalt avgränsas till, vilket kan utgöra en risk för ditt system.\n"
-"\n"
-"Om du förstår och vill fortsätta, upprepa kommandot med --classic.\n"
 
 msgid ""
 "\n"
@@ -1920,26 +1811,25 @@ msgstr ""
 
 msgid "a single snap name is needed to specify mode or channel flags"
 msgstr ""
-"ett enstaka snappnamn behövs för att specificera läges- eller kanalflaggor"
 
 msgid "a single snap name is needed to specify the revision"
-msgstr "ett enstaka snappnamn behövs för att specificera revision"
+msgstr ""
 
 msgid "a single snap name must be specified when ignoring validation"
-msgstr "ett enstaka snappnamn måste specificeras när validering ignoreras"
+msgstr ""
 
 msgid "active"
-msgstr "aktiv"
+msgstr ""
 
 msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr "köpt"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
-msgstr "trasig"
+msgstr ""
 
 #, c-format
 msgid "cannot %s without a context"
@@ -1947,18 +1837,18 @@ msgstr ""
 
 #, c-format
 msgid "cannot buy snap: %v"
-msgstr "kan inte köpa snapp: %v"
+msgstr ""
 
 msgid "cannot buy snap: invalid characters in name"
-msgstr "kan inte köpa snapp: ogiltiga tecken i namnet"
+msgstr ""
 
 msgid "cannot buy snap: it has already been bought"
-msgstr "kan inte köpa snapp: den har redan köpts"
+msgstr ""
 
 #. TRANSLATORS: %q is the directory whose creation failed, %v the error message
 #, c-format
 msgid "cannot create %q: %v"
-msgstr "kan inte skapa %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot create assertions file: %v"
@@ -1967,50 +1857,50 @@ msgstr ""
 #. TRANSLATORS: %q gets the snap name, %v gets the resulting error message
 #, c-format
 msgid "cannot extract the snap-name from local file %q: %v"
-msgstr "kan inte extrahera snappnamn från lokal fil %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot find app %q in %q"
-msgstr "kan inte hitta program %q i %q"
+msgstr ""
 
 #, c-format
 msgid "cannot find hook %q in %q"
-msgstr "kan inte hitta krok %q i %q"
+msgstr ""
 
 #. TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
 #, c-format
 msgid "cannot get data for %q: %v"
-msgstr "kan inte hämta data för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q gets what the user entered, %v gets the resulting error message
 #, c-format
 msgid "cannot get full path for %q: %v"
-msgstr "kan inte hämta full sökväg för %q: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %s"
-msgstr "kan inte hämta aktuell användare: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot get the current user: %v"
-msgstr "kan inte hämta aktuell användare: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot mark boot successful: %s"
-msgstr "kan inte märka uppstart lyckad: %s"
+msgstr ""
 
 #, c-format
 msgid "cannot open the assertions database: %v"
-msgstr "kan inte öppna försäkringsdatabasen: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot read assertion input: %v"
-msgstr "kan inte läsa försäkransindata: %v"
+msgstr ""
 
 #. TRANSLATORS: %v the error message
 #, c-format
 msgid "cannot read symlink: %v"
-msgstr "kan inte läsa symlänk: %v"
+msgstr ""
 
 #, c-format
 msgid "cannot resolve snap app %q: %v"
@@ -2022,87 +1912,86 @@ msgstr ""
 
 #, c-format
 msgid "cannot update the 'current' symlink of %q: %v"
-msgstr "kan inte uppdatera \"aktuell\" symlänk för %q: %v"
+msgstr ""
 
 #. TRANSLATORS: %q is the key name, %v the error message
 #, c-format
 msgid "cannot use %q key: %v"
-msgstr "kan inte använda nyckeln %q: %v"
+msgstr ""
 
 msgid "cannot use change ID and type together"
-msgstr "kan inte använda ändrings-ID och typ tillsammans"
+msgstr ""
 
 msgid "cannot use devmode and jailmode flags together"
-msgstr "kan inte använda devmode- och jailmode-flaggorna tillsammans"
+msgstr ""
 
 #, c-format
 msgid "cannot validate owner of file %s"
-msgstr "kan inte validera ägare av filen %s"
+msgstr ""
 
 #, c-format
 msgid "cannot write new Xauthority file at %s: %s"
-msgstr "kan inte skriva ny Xauthority-fil på %s: %s"
+msgstr ""
 
 #, c-format
 msgid "change finished in status %q with no error message"
-msgstr "ändring slutförd i status %q utan felmeddelande"
+msgstr ""
 
 #, c-format
 msgid ""
 "classic confinement requires snaps under /snap or symlink from /snap to %s"
 msgstr ""
-"klassisk inneslutning kräver snappar i /snap eller symlänk från /snap till %s"
 
 #, c-format
 msgid "created user %q\n"
-msgstr "skapade användare %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "days" in e.g. 1d20h
 msgid "d"
-msgstr "d"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "disabled"
-msgstr "avaktiverad"
+msgstr ""
 
 msgid "email:"
-msgstr "e-post:"
+msgstr ""
 
 msgid "enabled"
-msgstr "aktiverad"
+msgstr ""
 
 #, c-format
 msgid "error: %v\n"
-msgstr "fel: %v\n"
+msgstr ""
 
 msgid ""
 "error: the `<snap-dir>` argument was not provided and couldn't be inferred"
-msgstr "fel: argumentet \"<snap-dir>\" angavs inte och kunde inte antydas"
+msgstr ""
 
 msgid "get which option?"
-msgstr "hämta vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
-msgstr "t"
+msgstr ""
 
 msgid "ignore-validation"
 msgstr ""
 
 msgid "inactive"
-msgstr "inaktiv"
+msgstr ""
 
 msgid ""
 "interface attributes can only be read during the execution of interface hooks"
-msgstr "gränssnittsattribut kan bara läsas när gränssnittskrokarna körs"
+msgstr ""
 
 msgid ""
 "interface attributes can only be set during the execution of prepare hooks"
-msgstr "gränssnittsattribut kan bara sättas när förberedelsekrokarna körs"
+msgstr ""
 
 #, c-format
 msgid "internal error, please report: running %q failed: %v\n"
-msgstr "internt fel, var god rapportera: kunde inte köra %q: %v\n"
+msgstr ""
 
 msgid "internal error: cannot find attrs task"
 msgstr ""
@@ -2125,69 +2014,67 @@ msgstr ""
 
 #, c-format
 msgid "invalid configuration: %q (want key=value)"
-msgstr "ogiltig konfiguration: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid header filter: %q (want key=value)"
-msgstr "ogiltigt huvudfilter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid parameter: %q (want key=value)"
-msgstr "ogiltig parameter: %q (vill ha nyckel=värde)"
+msgstr ""
 
 #, c-format
 msgid "invalid value: %q (want snap:name or snap)"
-msgstr "ogiltigt värde: %q (vill ha snap:namn eller snapp)"
+msgstr ""
 
 #, c-format
 msgid ""
 "key name %q is not valid; only ASCII letters, digits, and hyphens are allowed"
 msgstr ""
-"nyckelnamnet %q är ogiltigt; endast ASCII-tecken, siffror, och streck tillåts"
 
 #, c-format
 msgid "local snap %q is unknown to the store, use --amend to proceed anyway"
 msgstr ""
-"lokal snapp %q är okänd för butiken; använd --amend för att fortsätta ändå"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "minutes" in e.g. 1m30s
 msgid "m"
-msgstr "m"
+msgstr ""
 
 msgid "missing snap-confine: try updating your snapd package"
 msgstr ""
 
 msgid "need the application to run as argument"
-msgstr "kräver att programmet körs som argument"
+msgstr ""
 
 msgid "no changes found"
-msgstr "hittade inga ändringar"
+msgstr ""
 
 #, c-format
 msgid "no changes of type %q found"
-msgstr "hittade inga ändringar av typen %q"
+msgstr ""
 
 msgid "no interfaces currently connected"
-msgstr "inga gränssnitt anslutna just nu"
+msgstr ""
 
 msgid "no interfaces found"
-msgstr "inga gränssnitt hittades"
+msgstr ""
 
 msgid "no matching snaps installed"
-msgstr "inga matchande snappar installerade"
+msgstr ""
 
 msgid "no such interface"
-msgstr "inget sådant gränssnitt"
+msgstr ""
 
 msgid "no valid snaps given"
-msgstr "inga giltiga snappar angivna"
+msgstr ""
 
 msgid "please provide change ID or type with --last=<type>"
-msgstr "ange ändrings-ID eller typ med --last=<typ>"
+msgstr ""
 
 #. TRANSLATORS: if possible, a single short word
 msgid "private"
-msgstr "privat"
+msgstr ""
 
 msgid ""
 "reboot scheduled to update the system - temporarily cancel with 'sudo "
@@ -2195,19 +2082,19 @@ msgid ""
 msgstr ""
 
 msgid "repairs are not available on a classic system"
-msgstr "reparationer är inte tillgängliga på ett klassiskt system"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "seconds" in e.g. 1m30s
 #. (I fully expect this to always be "s", given it's a SI unit)
 msgid "s"
-msgstr "s"
+msgstr ""
 
 #, c-format
 msgid "set failed: %v"
-msgstr "set misslyckades: %v"
+msgstr ""
 
 msgid "set which option?"
-msgstr "sätt vilket alternativ?"
+msgstr ""
 
 #. TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo
 #, c-format
@@ -2221,7 +2108,7 @@ msgstr ""
 
 #, c-format
 msgid "snap %q has no updates available"
-msgstr "snapp %q har inga tillgängliga uppdateringar"
+msgstr ""
 
 #, c-format
 msgid "snap %q is already installed, see \"snap refresh --help\""
@@ -2229,30 +2116,30 @@ msgstr ""
 
 #, c-format
 msgid "snap %q not found"
-msgstr "snapp %q finns inte"
+msgstr ""
 
 #. TRANSLATORS: free as in gratis
 msgid "snap is free"
-msgstr "snapp är gratis"
+msgstr ""
 
 msgid "too many arguments for command"
-msgstr "för många argument för kommandot"
+msgstr ""
 
 #. TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 #, c-format
 msgid "too many arguments for hook %q: %s"
-msgstr "för många argument för krok %q: %s"
+msgstr ""
 
 #. TRANSLATORS: the %s is the list of extra arguments
 #, c-format
 msgid "too many arguments: %s"
-msgstr "för många argument: %s"
+msgstr ""
 
 msgid "unable to contact snap store"
-msgstr "kan inte kontakta snap store"
+msgstr ""
 
 msgid "unavailable"
-msgstr "otillgänglig"
+msgstr ""
 
 #, c-format
 msgid "unknown attribute %q"
@@ -2268,31 +2155,30 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr "okänd tjänst: %q"
+msgstr ""
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
-msgstr "varning:\tingen snapp hittades för %q\n"
+msgstr ""
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "years" in e.g. 1y45d
 msgid "y"
-msgstr "å"
+msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr "Autentisera mot snapp-daemon"
+msgstr ""
 
 msgid "Authorization is required to authenticate on the snap daemon"
-msgstr "Identitskontroll krävs för att autentisera mot snapp-daemonen"
+msgstr ""
 
 msgid "Install, update, or remove packages"
-msgstr "Installera, uppdatera eller ta bort paket"
+msgstr ""
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
-"Autentisering krävs för att installera, uppdatera, eller ta bort paket"
 
 msgid "Connect, disconnect interfaces"
-msgstr "Anslut, koppla bort gränssnitt"
+msgstr ""
 
 msgid "Authentication is required to connect or disconnect interfaces"
-msgstr "Autentisering krävs för att ansluta eller koppla bort gränssnitt"
+msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -45,7 +46,7 @@ msgstr ""
 #. TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 #, c-format
 msgid "%s (try with sudo)"
-msgstr ""
+msgstr "%s (ลองด้วย sudo)"
 
 #, c-format
 msgid "%s already installed\n"
@@ -53,11 +54,11 @@ msgstr ""
 
 #, c-format
 msgid "%s disabled\n"
-msgstr ""
+msgstr "%s ปิดใช้งานแล้ว\n"
 
 #, c-format
 msgid "%s enabled\n"
-msgstr ""
+msgstr "%s เปิดใช้งานแล้ว\n"
 
 #, c-format
 msgid "%s not installed\n"
@@ -65,7 +66,7 @@ msgstr ""
 
 #, c-format
 msgid "%s removed\n"
-msgstr ""
+msgstr "%s ลบออกแล้ว\n"
 
 #. TRANSLATORS: first %s is a snap name, second %s is a revision
 #, c-format
@@ -85,7 +86,7 @@ msgstr ""
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 #, c-format
 msgid "%s%s %s installed\n"
-msgstr ""
+msgstr "%s%s %s ติดตั้งแล้ว\n"
 
 #. TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 #, c-format
@@ -99,90 +100,91 @@ msgid "--time does not take mode nor channel flags"
 msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr ""
+msgstr "-r สามารถใช้ได้กับเฉพาะ --hook เท่านั้น"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr "--zaman kipi veya kanal bayrakları almıyor"
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<takma ad>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<onay dosyası>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<onay türü>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<ayar değeri>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<e-posta>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<dosya adı>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<başlık süzgeci>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<arayüz>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<anahtar-adı>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<anahtar>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<sorgu>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
-msgstr ""
+msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
-msgstr ""
+msgstr "<snap>:<slot or plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
-msgstr ""
+msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Bekleyen bir değişikliği iptal edin"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Eklendi"
 
@@ -200,9 +203,11 @@ msgstr "Sistemde bir onaylama ekler"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -210,13 +215,14 @@ msgid "All snaps up to date."
 msgstr ""
 
 msgid "Allow opening file?"
-msgstr ""
+msgstr "Dosya açılsın mı?"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
 msgid "Allow settings change?"
-msgstr ""
+msgstr "Ayarların değişmesine izin verilsin mi?"
 
 #, c-format
 msgid "Allow snap %q to change %q to %q ?"
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Çalıştırmak için alternatif komut"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Tek anahtarla daima belgeyi geri getirin"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Onaylama dosyası"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Onaylama türü adı"
 
@@ -282,9 +293,9 @@ msgstr "Kötü kod. Tekrar deneyin: "
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
-msgstr ""
+msgstr "ID Değiştir"
 
 msgid "Changes configuration options"
 msgstr "Yapılandırma seçeneklerini değiştirir"
@@ -292,7 +303,7 @@ msgstr "Yapılandırma seçeneklerini değiştirir"
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr "Bağlan %s:%s to %s:%s"
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -371,6 +383,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -378,6 +391,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -421,16 +435,18 @@ msgstr "%q için onaylar getiriliyor\n"
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr "Yüklenecek paketleri bulur"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr "Cihaz zaten yönetilmiş olsa dahi kullanıcıyı zorla ekleme"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Klasik sistemlerde içe aktarmayı zorla"
 
@@ -444,33 +460,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Aygıt anahtarı oluştur"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Man sayfasını oluştur"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Oluşturulan kullanıcıya sudo erişimi verin"
 
 msgid "Help"
 msgstr "Yardım"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Koşmak için kanca"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "İmzacı belirleyici"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -485,6 +509,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Kullanılmayan arabirimleri dahil et"
 
@@ -510,15 +535,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Beta kanalından yükle"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Aday kanalından yükle"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Kararlı kanaldan yükleme"
 
@@ -531,16 +560,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -554,8 +586,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -579,7 +611,7 @@ msgid "Lists aliases in the system"
 msgstr "Sistemdeki takma adları listeler"
 
 msgid "Lists all repairs"
-msgstr ""
+msgstr "Tüm onarımları listeler"
 
 msgid "Lists interfaces in the system"
 msgstr "Sistemdeki arabirimleri listeler"
@@ -620,21 +652,23 @@ msgstr "İşaretlenmiş sistem işaretle"
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Silinecek anahtarın adı"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr "Kullanılacak anahtarın adı, aksi takdirde varsayılan tuşu kullanın"
 
@@ -695,6 +729,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Çıktı sonuçları JSON formatında"
 
@@ -745,7 +781,7 @@ msgid "Prepare snap %q%s"
 msgstr ""
 
 msgid "Print the version and exit"
-msgstr ""
+msgstr "Sürümü yazdırın ve çıkın"
 
 msgid "Prints configuration options"
 msgstr "Yapılandırma seçeneklerini yazdırır"
@@ -763,12 +799,15 @@ msgstr "Sistemin yönetilip yönetilmediğini yazdırır"
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Klasik kipe geçin ve güvenlik sınırlamasını devre dışı bırakın"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr "Grliştirme kipine geçin ve güvenlik sınırlamasını devre dışı bırakın"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -826,6 +865,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -850,6 +890,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Kaldırıldı"
 
@@ -865,6 +906,7 @@ msgstr "Servisleri Yeniden Başlat"
 msgid "Restarted.\n"
 msgstr "Yeniden Başlatıldı.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Aramayı belirli bir bölüme sınırla"
 
@@ -878,9 +920,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Komut yerine bir kabuk çalıştırın (hata ayıklama için kullanışlıdır)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -920,6 +964,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -932,6 +977,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr "Hata ayıklama komutlarını çalıştırır"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -976,9 +1022,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Tüm revizyonları göster"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Otomatik yenileme bilgilerini göster ancak yenileme işlemini gerçekleştirme"
@@ -989,13 +1037,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Belirli bir arabirimin ayrıntılarını göster"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Arayüz özelliklerini göster"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1028,8 +1078,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1051,7 +1101,7 @@ msgid "Start snap %q%s services"
 msgstr ""
 
 msgid "Start snap services"
-msgstr ""
+msgstr "Snap hizmetlerini başlat"
 
 msgid "Start the userd service"
 msgstr "Kullanıcı servisini başlat"
@@ -1079,6 +1129,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr "Durduruldu.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr "Boşluklar ve tırnak işaretli dizgilerle sıkı yazma"
 
@@ -1097,6 +1148,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "İncelemeden önce geçici olarak cihaz bağlayın"
 
@@ -1114,15 +1166,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr "Get komutu yapılandırma ve arabirim bağlantı ayarlarını yazdırır."
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Model onaylama adı"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Çıktı dizini"
 
@@ -1130,11 +1182,12 @@ msgstr "Çıktı dizini"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1174,15 +1227,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Bu kanalı kararlı yerine kullanın"
 
@@ -1195,6 +1251,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "UYARI: günlüğe kaydetmeyi etkinleştirmek başarısız: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 
@@ -1212,7 +1269,7 @@ msgid "Xauthority file isn't owned by the current user %s"
 msgstr ""
 
 msgid "Yes, yes it does."
-msgstr ""
+msgstr "Evet evet öyle."
 
 msgid ""
 "You need to be logged in to purchase software. Please run 'snap login' and "
@@ -1783,7 +1840,7 @@ msgid "auto-refresh: all snaps are up-to-date"
 msgstr ""
 
 msgid "bought"
-msgstr ""
+msgstr "alınmış"
 
 #. TRANSLATORS: if possible, a single short word
 msgid "broken"
@@ -1913,7 +1970,7 @@ msgid "disabled"
 msgstr "devre dışı"
 
 msgid "email:"
-msgstr ""
+msgstr "e-posta:"
 
 msgid "enabled"
 msgstr "etkinleştirildi"
@@ -1927,7 +1984,7 @@ msgid ""
 msgstr ""
 
 msgid "get which option?"
-msgstr ""
+msgstr "hangi sürüm alınsın?"
 
 #. TRANSLATORS: this needs to be a single rune that is understood to mean "hours" in e.g. 1h30m
 msgid "h"
@@ -2113,7 +2170,7 @@ msgstr ""
 
 #, c-format
 msgid "unknown service: %q"
-msgstr ""
+msgstr "bilinmeyen hizmet: %q"
 
 #, c-format
 msgid "warning:\tno snap found for %q\n"
@@ -2124,19 +2181,24 @@ msgid "y"
 msgstr ""
 
 msgid "Authenticate on snap daemon"
-msgstr ""
+msgstr "Snap Daemon kimlik doğrulaması"
 
 msgid "Authorization is required to authenticate on the snap daemon"
 msgstr ""
+"Snap daemon'da kimlik doğrulaması yapmak için yetkilendirme gerekiyor"
 
 msgid "Install, update, or remove packages"
-msgstr ""
+msgstr "Paketleri yükleme, güncelleme veya kaldırma"
 
 msgid "Authentication is required to install, update, or remove packages"
 msgstr ""
+"Paketleri yüklemek, güncellemek veya kaldırmak için kimlik doğrulaması "
+"gerekiyor"
 
 msgid "Connect, disconnect interfaces"
-msgstr ""
+msgstr "Bağlayın, arayüzleri çıkarın"
 
 msgid "Authentication is required to connect or disconnect interfaces"
 msgstr ""
+"Arabirimleri bağlamak veya bağlantıyı kesmek için kimlik doğrulaması "
+"gerekiyor"

--- a/po/ug.po
+++ b/po/ug.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -28,6 +28,7 @@ msgstr ""
 "Спробуйте виконати «snapcraft prime» у каталозі проекту, а потім знову «snap "
 "try»."
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr "%q перемкнувся на канал %q\n"
@@ -105,88 +106,89 @@ msgstr "--time не приймає ані прапори режиму, ані п
 msgid "-r can only be used with --hook"
 msgstr "-r може бути використано лише з --hook"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr "<синонім-або-snap>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr "<синонім>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr "<файл перевірки>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr "<тип перевірки>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr "<змінити-id>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr "<значення конф>"
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr "<пошта>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr "<назва файлу>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr "<фільтр заголовку>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr "<інтерфейс>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr "<назва-ключа>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr "<ключ>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr "<модель-перевірки>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr "<запит>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr "<корен-кат>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr "<snap>:<plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr "<snap>:<slot чи plug>"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr "<snap>:<slot>"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -195,6 +197,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr "Перервати очікувану зміну"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr "Додано"
 
@@ -204,9 +207,11 @@ msgstr "Додає перевірку до системи"
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr "Синонім --dangerous (ЗАСТАРІЛО)"
 
@@ -216,6 +221,7 @@ msgstr "Всі snap-пакунки актуальні."
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -230,33 +236,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr "Альтернативна команда для запуску"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr "Завжди повертати документ, навіть з одним ключем"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr "Завжди повертати список, навіть з одним ключем"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr "Електронна пошта користувача на login.ubuntu.com"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr "Файл перевірки"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr "Назва типу перевірки"
 
@@ -286,7 +297,7 @@ msgstr "Поганий код. Спробуйте ще раз: "
 msgid "Buys a snap"
 msgstr "Купівля snap-пакунку"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr "Змінюваний ідентифікатор"
 
@@ -296,7 +307,7 @@ msgstr "Змінює параметри конфігурації"
 msgid "Command\tAlias\tNotes"
 msgstr "Команда\tСинонім\tПримітки"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr "Значення конфігурації (ключ=значення)"
 
@@ -310,14 +321,15 @@ msgstr "Приєднати %s:%s до %s:%s"
 msgid "Connects a plug to a slot"
 msgstr "Підключає надбудову до роз'єму"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr "Обмежити список зазначеним snap-пакунком або snap:назва"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr "Обмежити список зазначеними інтерфейсами"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr "Обмежити список тими, що відповідають заголовок=значення"
 
@@ -375,6 +387,7 @@ msgstr "Від'єднати %s:%s від %s:%s"
 msgid "Disconnects a plug from a slot"
 msgstr "Від'єднує надбудову від роз'єма"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr "Не чекати закінчення операції, тільки вивести змінюваний id."
 
@@ -382,6 +395,7 @@ msgstr "Не чекати закінчення операції, тільки в
 msgid "Download snap %q%s from channel %q"
 msgstr "Завантажити snap-пакунок %q%s з каналу %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -426,17 +440,19 @@ msgstr "Видобування перевірок для %q\n"
 msgid "Fetching snap %q\n"
 msgstr "Отримання snap-пакунку %q\n"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr "Назва файла snap-пакунка, який ви хочете перевірити для збірки"
 
 msgid "Finds packages to install"
 msgstr "Пошук пакунків для встановлення"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 "Примусове додавання користувача, навіть якщо пристрій вже під керуванням"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr "Примусовий імпорт на класичних системах"
 
@@ -450,34 +466,42 @@ msgstr ""
 msgid "Generate device key"
 msgstr "Генерувати ключ пристрою"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr "Генерувати довідкову сторінку (man)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 "Оцінка визначає якість збірки snap-пакунку (за умовчанням - «stable»)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr "Надати доступ до команди sudo створеному користувачеві"
 
 msgid "Help"
 msgstr "Довідка"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr "Пастка для запуску"
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr "Ідентифікатор підписувача"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr "Ідентифікатор snap-пакунка, асоційований зі збіркою"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 "Пропускати перевірку іншими snap-пакунками, що перешкоджають оновленню"
@@ -493,6 +517,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr "Долучити невикористані інтерфейси"
 
@@ -518,15 +543,19 @@ msgstr "Встановити snap-пакунок %q з файлу"
 msgid "Install %q snap from file %q"
 msgstr "Встановити snap-пакунок %q з файлу %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr "Встановити з бета-каналу"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr "Встановити з каналу-кандидата"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr "Встановити з крайнього каналу"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr "Встановити з стабільного каналу"
 
@@ -539,17 +568,20 @@ msgstr "Встановити snap-пакунок %q"
 msgid "Install snaps %s"
 msgstr "Встановити snap-пакунки %s"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 "Встановити задану ревізію snap-пакунку, до якої потрібен доступ розробника"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 "Встановити такий  snap-пакунок, не вмикаючи його автоматичні синоніми"
@@ -564,8 +596,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr "Встановлює snap-пакунок до системи"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -631,23 +663,25 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr "Змонтувати snap %q%s"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr "Назва створюваного ключа, типова назва «default»"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr "Назва ключа для видалення"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr "Назва ключа для експорту"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 "Назва ключа GnuPG для використання (типове значення для назви ключа "
 "«default»)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 "Назва ключа для використання, в іншому випадку використовувати типовий ключ"
@@ -710,6 +744,8 @@ msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 "Жодних snap-пакунків ще не встановлено. Спробуйте «snap install hello-world»"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr "Вивести результати у форматі JSON"
 
@@ -781,12 +817,15 @@ msgstr "Виведення того, чи система керована"
 msgid "Prune automatic aliases for snap %q"
 msgstr "Очистити автоматичні псевдоніми для snap-пакунку %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr "Перевести snap у класичний режим і вимкнути обмеження безпеки"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr "Перевести snap у режим розробника і вимкнути обмеження безпеки"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr "Перевести snap у примусовий режим обмеження"
 
@@ -844,6 +883,7 @@ msgstr "Вилучити дані для snap-пакунку  %q (%s)"
 msgid "Remove manual alias %q for snap %q"
 msgstr "Вилучити ручний синонім %q для  snap-пакунку %q"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr "Вилучити лише таку редакцію"
 
@@ -868,6 +908,7 @@ msgstr "Вилучити snap-пакунок %q (%s) з системи"
 msgid "Remove snaps %s"
 msgstr "Вилучити snap-пакунки %s"
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr "Вилучено"
 
@@ -883,6 +924,7 @@ msgstr "Перезапустити служби"
 msgid "Restarted.\n"
 msgstr "Перезапущено.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr "Обмежити пошук певним розділом"
 
@@ -896,9 +938,11 @@ msgstr "Повернути %q snap-пакунок"
 msgid "Reverts the given snap to the previous state"
 msgstr "Повертає даний snap-пакунок до попереднього стану"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr "Запустити оболонку замість команди (стане в нагоді для зневадження)"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -938,6 +982,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -950,6 +995,7 @@ msgstr "Запустити дану команду snap з належним об
 msgid "Runs debug commands"
 msgstr "Виконання команд зневадження"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr "Пошук серед приватних snap-пакунків"
 
@@ -992,9 +1038,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr "Показати всі редакції"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 "Показувати інформацію про автоматичне перечитування, але не виконувати "
@@ -1008,13 +1056,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr "Показати подробиці для певного інтерфейсу"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr "Показати атрибути інтерфейсу"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1047,8 +1097,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr "Назва snap-пакунку"
 
@@ -1102,6 +1152,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr "Зупинено.\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1120,6 +1171,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr "Перемикає snap-пакунок на інший канал"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr "Тимчасово змонтувати пристрій перед перевіркою"
 
@@ -1140,15 +1192,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr "Електронна адреса на login.ubuntu.com для входу як"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr "Назва моделі перевірки"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr "Вихідний каталог"
 
@@ -1156,11 +1208,12 @@ msgstr "Вихідний каталог"
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr "Snap-пакунок для налаштування (наприклад, hello-world)"
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1200,15 +1253,18 @@ msgstr "Двофакторний код: "
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr "Використовувати відомі перевірки для створення користувача"
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr "Використовувати цей канал замість стабільного"
 
@@ -1221,6 +1277,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr "ПОПЕРЕДЖЕННЯ: не вдалося активувати журналювання: %v\n"
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,6 +24,7 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
 msgstr ""
@@ -101,88 +102,89 @@ msgstr ""
 msgid "-r can only be used with --hook"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,8 +14,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2018-10-05 14:20+0000\n"
-"X-Generator: Launchpad (build 18785)\n"
+"X-Launchpad-Export-Date: 2019-11-20 06:56+0000\n"
+"X-Generator: Launchpad (build c597c3229eb023b1e626162d5947141bf7befb13)\n"
 
 #, c-format
 msgid ""
@@ -24,9 +24,10 @@ msgid ""
 "Try \"snapcraft prime\" in your project directory, then \"snap try\" again."
 msgstr ""
 
+#. TRANSLATORS: the first %q will be the (quoted) snap name, the second a channel
 #, c-format
 msgid "%q switched to the %q channel\n"
-msgstr ""
+msgstr "%q 切換到 %q 頻道\n"
 
 #. TRANSLATORS: 1. snap name, 2. snap version (keep those together please). the 3rd %s is a path (where it's mounted from).
 #, c-format
@@ -99,90 +100,91 @@ msgid "--time does not take mode nor channel flags"
 msgstr ""
 
 msgid "-r can only be used with --hook"
-msgstr ""
+msgstr "-r 只能跟  --hook 使用"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias-or-snap>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<alias>"
-msgstr ""
+msgstr "< 別名 >"
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion file>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<assertion type>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<change-id>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<conf value>"
 msgstr ""
 
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
-#. TRANSLATORS: This is a noun, and it needs to be wrapped in <>s.
+#. TRANSLATORS: This is a noun, and it needs to begin with < and end with >
+#. TRANSLATORS: This is a noun and it needs to begin with < and end with >
 msgid "<email>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<filename>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<header filter>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<interface>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key-name>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<key>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<model-assertion>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<query>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<root-dir>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<service>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot or plug>"
 msgstr ""
 
-#. TRANSLATORS: This needs to be wrapped in <>s.
-#. TRANSLATORS: This needs to be wrapped in <>s.
+#. TRANSLATORS: This needs to begin with < and end with >
+#. TRANSLATORS: This needs to begin with < and end with >
 msgid "<snap>:<slot>"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "A service specification, which can be just a snap name (for all services in "
 "the snap), or <snap>.<app> for a single service."
@@ -191,6 +193,7 @@ msgstr ""
 msgid "Abort a pending change"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were added
 msgid "Added"
 msgstr ""
 
@@ -200,9 +203,11 @@ msgstr ""
 msgid "Advise on available snaps."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Advise on snaps that provide the given command"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alias for --dangerous (DEPRECATED)"
 msgstr ""
 
@@ -212,6 +217,7 @@ msgstr ""
 msgid "Allow opening file?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Allow refresh attempt on snap unknown to the store"
 msgstr ""
 
@@ -226,33 +232,38 @@ msgstr ""
 msgid "Allow snap %q to open file %q?"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Alternative command to run"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return document, even with single key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Always return list, even with single key"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter. Also, note users on login.ubuntu.com can have multiple email addresses.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com"). Also, note users on login.ubuntu.com can have multiple email addresses.
 msgid "An email of a user on login.ubuntu.com"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as starting the service now, arrange for it to be started on boot."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "As well as stopping the service now, arrange for it to no longer be started "
 "on boot."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion file"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Assertion type name"
 msgstr ""
 
@@ -282,7 +293,7 @@ msgstr ""
 msgid "Buys a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Change ID"
 msgstr ""
 
@@ -292,7 +303,7 @@ msgstr ""
 msgid "Command\tAlias\tNotes"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Configuration value (key=value)"
 msgstr ""
 
@@ -306,14 +317,15 @@ msgstr ""
 msgid "Connects a plug to a slot"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to a specific snap or snap:name"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to specific interfaces"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Constrain listing to those matching header=value"
 msgstr ""
 
@@ -369,6 +381,7 @@ msgstr ""
 msgid "Disconnects a plug from a slot"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Do not wait for the operation to finish but just print the change id."
 msgstr ""
 
@@ -376,6 +389,7 @@ msgstr ""
 msgid "Download snap %q%s from channel %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Download the given revision of a snap, to which you must have developer "
 "access"
@@ -417,16 +431,18 @@ msgstr ""
 msgid "Fetching snap %q\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Filename of the snap you want to assert a build for"
 msgstr ""
 
 msgid "Finds packages to install"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force adding the user, even if the device is already managed"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Force import on classic systems"
 msgstr ""
 
@@ -438,33 +454,41 @@ msgstr ""
 msgid "Generate device key"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Generate the manpage"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grade states the build quality of the snap (defaults to 'stable')"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Grant sudo access to the created user"
 msgstr ""
 
 msgid "Help"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Hook to run"
 msgstr ""
 
 msgid "ID\tStatus\tSpawn\tReady\tSummary\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the signer"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Identifier of the snap package associated with the build"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "If the service has a reload command, use it instead of restarting."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Ignore validation by other snaps blocking the refresh"
 msgstr ""
 
@@ -479,6 +503,7 @@ msgstr ""
 msgid "Include a verbose list of a snap's notes (otherwise, summarise notes)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Include unused interfaces"
 msgstr ""
 
@@ -504,15 +529,19 @@ msgstr ""
 msgid "Install %q snap from file %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the beta channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the candidate channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the edge channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install from the stable channel"
 msgstr ""
 
@@ -525,16 +554,19 @@ msgstr ""
 msgid "Install snaps %s"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given revision of a snap, to which you must have developer access"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid ""
 "Install the given snap file even if there are no pre-acknowledged signatures "
 "for it, meaning it was not verified and could be dangerous (--devmode "
 "implies this)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Install the given snap without enabling its automatic aliases"
 msgstr ""
 
@@ -548,8 +580,8 @@ msgstr ""
 msgid "Installs a snap to the system"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Key of interest within the configuration"
 msgstr ""
 
@@ -613,21 +645,23 @@ msgstr ""
 msgid "Mount snap %q%s"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to create; defaults to 'default'"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to delete"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of key to export"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the GnuPG key to use (defaults to 'default' as key name)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Name of the key to use, otherwise use the default key"
 msgstr ""
 
@@ -688,6 +722,8 @@ msgstr ""
 msgid "No snaps are installed yet. Try \"snap install hello-world\"."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Output results in JSON format"
 msgstr ""
 
@@ -756,12 +792,15 @@ msgstr ""
 msgid "Prune automatic aliases for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in classic mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in development mode and disable security confinement"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Put snap in enforced confinement mode"
 msgstr ""
 
@@ -819,6 +858,7 @@ msgstr ""
 msgid "Remove manual alias %q for snap %q"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Remove only the given revision"
 msgstr ""
 
@@ -843,6 +883,7 @@ msgstr ""
 msgid "Remove snaps %s"
 msgstr ""
 
+#. TRANSLATORS: this is used to introduce a list of aliases that were removed
 msgid "Removed"
 msgstr ""
 
@@ -858,6 +899,7 @@ msgstr ""
 msgid "Restarted.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Restrict the search to a given section"
 msgstr ""
 
@@ -871,9 +913,11 @@ msgstr ""
 msgid "Reverts the given snap to the previous state"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run a shell instead of the command (useful for debugging)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run as a timer service with given schedule"
 msgstr ""
 
@@ -913,6 +957,7 @@ msgid ""
 "can be specified as well here."
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Run the command with gdb"
 msgstr ""
 
@@ -925,6 +970,7 @@ msgstr ""
 msgid "Runs debug commands"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Search private snaps"
 msgstr ""
 
@@ -967,9 +1013,11 @@ msgstr ""
 msgid "Setup snap %q%s security profiles (phase 2)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show all revisions"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show auto refresh information but do not perform a refresh"
 msgstr ""
 
@@ -979,13 +1027,15 @@ msgstr ""
 msgid "Show detailed information about a snap"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show details of a specific interface"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show interface attributes"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Show only the given number of lines, or 'all'."
 msgstr ""
 
@@ -1015,8 +1065,8 @@ msgstr ""
 msgid "Snap %s is no longer tracking %s.\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Snap name"
 msgstr ""
 
@@ -1066,6 +1116,7 @@ msgstr ""
 msgid "Stopped.\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Strict typing with nulls and quoted strings"
 msgstr ""
 
@@ -1084,6 +1135,7 @@ msgstr ""
 msgid "Switches snap to a different channel"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Temporarily mount device before inspecting"
 msgstr ""
 
@@ -1101,15 +1153,15 @@ msgid ""
 "The get command prints configuration and interface connection settings."
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 msgid "The login.ubuntu.com email to login as"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The model assertion name"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The output directory"
 msgstr ""
 
@@ -1117,11 +1169,12 @@ msgstr ""
 msgid "The program %q can be found in the following snaps:\n"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap to configure (e.g. hello-world)"
 msgstr ""
 
-#. TRANSLATORS: This should probably not start with a lowercase letter.
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "The snap whose conf is being requested"
 msgstr ""
 
@@ -1161,15 +1214,18 @@ msgstr ""
 msgid "Unalias a manual alias or an entire snap"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use a specific snap revision when running hook"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use known assertions for user creation"
 msgstr ""
 
 msgid "Use the given output format (pretty or json)"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Use this channel instead of stable"
 msgstr ""
 
@@ -1182,6 +1238,7 @@ msgstr ""
 msgid "WARNING: failed to activate logging: %v\n"
 msgstr ""
 
+#. TRANSLATORS: This should not start with a lowercase letter.
 msgid "Wait for new lines and print them as they come in."
 msgstr ""
 


### PR DESCRIPTION
This commit updates all the the translations in po/ from a
launchpad export.