### PR TITLE
cmd/snap-failure: fallback to snapd from core, extend tests

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -51,13 +51,14 @@ type sideInfo struct {
 }
 
 type snapSeq struct {
-	Current  string      `json:"current"`
-	Sequence []*sideInfo `json:"sequence"`
+	Current  string     `json:"current"`
+	Sequence []sideInfo `json:"sequence"`
 }
 
 type cmdSnapd struct{}
 
 var errNoSnapd = errors.New("no snapd sequence file found")
+var errNoPrevious = errors.New("no revision to go back to")
 
 func prevRevision(snapName string) (string, error) {
 	seqFile := filepath.Join(dirs.SnapSeqDir, snapName+".json")
@@ -71,21 +72,21 @@ func prevRevision(snapName string) (string, error) {
 
 	var seq snapSeq
 	if err := json.Unmarshal(content, &seq); err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot parse %q sequence file: %v", filepath.Base(seqFile), err)
 	}
 
 	var prev string
 	for i, si := range seq.Sequence {
 		if seq.Current == si.Revision {
 			if i == 0 {
-				return "", fmt.Errorf("no revision to go back to")
+				return "", errNoPrevious
 			}
 			prev = seq.Sequence[i-1].Revision
 			break
 		}
 	}
 	if prev == "" {
-		return "", fmt.Errorf("internal error: current not found in sequence: %v %v", seq.Current, seq.Sequence)
+		return "", fmt.Errorf("internal error: current %v not found in sequence: %+v", seq.Current, seq.Sequence)
 	}
 
 	return prev, nil
@@ -93,12 +94,23 @@ func prevRevision(snapName string) (string, error) {
 
 // FIXME: also do error reporting via errtracker
 func (c *cmdSnapd) Execute(args []string) error {
-	// find previous snapd
+	var snapdPath string
+	// find previous the snapd snap
 	prevRev, err := prevRevision("snapd")
-	if err != nil {
-		if err == errNoSnapd {
-			return nil
-		}
+	switch err {
+	case errNoSnapd:
+		// the snapd snap is not installed
+		return nil
+	case errNoPrevious:
+		// this is the first revision of snapd to be installed on the
+		// system, either a remodel or a plain snapd installation, call
+		// the snapd from the core snap
+		snapdPath = filepath.Join(dirs.SnapMountDir, "core", "current", "/usr/lib/snapd/snapd")
+		prevRev = "0"
+	case nil:
+		// the snapd snap was installed before, use the previous revision
+		snapdPath = filepath.Join(dirs.SnapMountDir, "snapd", prevRev, "/usr/lib/snapd/snapd")
+	default:
 		return err
 	}
 	// stop the socket unit so that we can start snapd on its own
@@ -108,13 +120,12 @@ func (c *cmdSnapd) Execute(args []string) error {
 	}
 
 	// start previous snapd
-	snapdPath := filepath.Join(dirs.SnapMountDir, "snapd", prevRev, "/usr/lib/snapd/snapd")
 	cmd := exec.Command(snapdPath)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SNAPD_REVERT_TO_REV="+prevRev)
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		return osutil.OutputErr(output, err)
+		return fmt.Errorf("snapd failed: %v", osutil.OutputErr(output, err))
 	}
 
 	// at this point our manually started snapd stopped and

--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -20,11 +20,17 @@
 package main_test
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
 	failure "github.com/snapcore/snapd/cmd/snap-failure"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func (r *failureSuite) TestRun(c *C) {
@@ -34,4 +40,172 @@ func (r *failureSuite) TestRun(c *C) {
 	err := failure.Run()
 	c.Check(err, IsNil)
 	c.Check(r.Stderr(), HasLen, 0)
+}
+
+func writeSeqFile(c *C, name string, current snap.Revision, seq []*snap.SideInfo) {
+	seqPath := filepath.Join(dirs.SnapSeqDir, name+".json")
+
+	err := os.MkdirAll(dirs.SnapSeqDir, 0755)
+	c.Assert(err, IsNil)
+
+	b, err := json.Marshal(&struct {
+		Sequence []*snap.SideInfo `json:"sequence"`
+		Current  string           `json:"current"`
+	}{
+		Sequence: seq,
+		Current:  current.String(),
+	})
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(seqPath, b, 0644)
+	c.Assert(err, IsNil)
+}
+
+func mockCommandInDir(c *C, path, script string) *testutil.MockCmd {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, IsNil)
+	return testutil.MockCommand(c, path, script)
+}
+
+func (r *failureSuite) TestCallPrevSnapdFromSnap(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	writeSeqFile(c, "snapd", snap.R(123), []*snap.SideInfo{
+		{Revision: snap.R(99)},
+		{Revision: snap.R(100)},
+		{Revision: snap.R(123)},
+	})
+
+	// mock snapd command from 'previous' revision
+	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
+		`test "$SNAPD_REVERT_TO_REV" = "100"`)
+	defer snapdCmd.Restore()
+
+	systemctlCmd := testutil.MockCommand(c, "systemctl", "")
+	defer systemctlCmd.Restore()
+
+	os.Args = []string{"snap-failure", "snapd"}
+	err := failure.Run()
+	c.Check(err, IsNil)
+	c.Check(r.Stderr(), HasLen, 0)
+
+	c.Check(snapdCmd.Calls(), DeepEquals, [][]string{
+		{"snapd"},
+	})
+	c.Check(systemctlCmd.Calls(), DeepEquals, [][]string{
+		{"systemctl", "stop", "snapd.socket"},
+		{"systemctl", "restart", "snapd.socket"},
+	})
+}
+
+func (r *failureSuite) TestCallPrevSnapdFromCore(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// only one entry in sequence
+	writeSeqFile(c, "snapd", snap.R(123), []*snap.SideInfo{
+		{Revision: snap.R(123)},
+	})
+
+	// mock snapd in the core snap
+	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "core", "current", "/usr/lib/snapd/snapd"),
+		`test "$SNAPD_REVERT_TO_REV" = "0"`)
+	defer snapdCmd.Restore()
+
+	systemctlCmd := testutil.MockCommand(c, "systemctl", "")
+	defer systemctlCmd.Restore()
+
+	os.Args = []string{"snap-failure", "snapd"}
+	err := failure.Run()
+	c.Check(err, IsNil)
+	c.Check(r.Stderr(), HasLen, 0)
+
+	c.Check(snapdCmd.Calls(), DeepEquals, [][]string{
+		{"snapd"},
+	})
+	c.Check(systemctlCmd.Calls(), DeepEquals, [][]string{
+		{"systemctl", "stop", "snapd.socket"},
+		{"systemctl", "restart", "snapd.socket"},
+	})
+}
+
+func (r *failureSuite) TestCallPrevSnapdFail(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	writeSeqFile(c, "snapd", snap.R(123), []*snap.SideInfo{
+		{Revision: snap.R(100)},
+		{Revision: snap.R(123)},
+	})
+
+	// mock snapd in the core snap
+	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
+		`exit 2`)
+	defer snapdCmd.Restore()
+
+	systemctlCmd := testutil.MockCommand(c, "systemctl", "")
+	defer systemctlCmd.Restore()
+
+	os.Args = []string{"snap-failure", "snapd"}
+	err := failure.Run()
+	c.Check(err, ErrorMatches, "snapd failed: exit status 2")
+	c.Check(r.Stderr(), HasLen, 0)
+
+	c.Check(snapdCmd.Calls(), DeepEquals, [][]string{
+		{"snapd"},
+	})
+	c.Check(systemctlCmd.Calls(), DeepEquals, [][]string{
+		{"systemctl", "stop", "snapd.socket"},
+	})
+}
+
+func (r *failureSuite) TestGarbageSeq(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	seqPath := filepath.Join(dirs.SnapSeqDir, "snapd.json")
+	err := os.MkdirAll(dirs.SnapSeqDir, 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(seqPath, []byte("this is garbage"), 0644)
+	c.Assert(err, IsNil)
+
+	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
+		`exit 99`)
+	defer snapdCmd.Restore()
+
+	systemctlCmd := testutil.MockCommand(c, "systemctl", "exit 98")
+	defer systemctlCmd.Restore()
+
+	os.Args = []string{"snap-failure", "snapd"}
+	err = failure.Run()
+	c.Check(err, ErrorMatches, `cannot parse "snapd.json" sequence file: invalid .*`)
+	c.Check(r.Stderr(), HasLen, 0)
+
+	c.Check(snapdCmd.Calls(), HasLen, 0)
+	c.Check(systemctlCmd.Calls(), HasLen, 0)
+}
+
+func (r *failureSuite) TestBadSeq(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	writeSeqFile(c, "snapd", snap.R(123), []*snap.SideInfo{
+		{Revision: snap.R(100)},
+		// current not in sequence
+	})
+
+	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"), "")
+	defer snapdCmd.Restore()
+	systemctlCmd := testutil.MockCommand(c, "systemctl", "")
+	defer systemctlCmd.Restore()
+
+	os.Args = []string{"snap-failure", "snapd"}
+	err := failure.Run()
+	c.Check(err, ErrorMatches, "internal error: current 123 not found in sequence: .*Revision:100.*")
+	c.Check(r.Stderr(), HasLen, 0)
+
+	c.Check(snapdCmd.Calls(), HasLen, 0)
+	c.Check(systemctlCmd.Calls(), HasLen, 0)
 }


### PR DESCRIPTION
The snapd snap has no previous revision if this is the first time it gets
installed. This can happen in a core to base remodel scenario, when the snap
gets installed before all other snapd taking part in a remodel.

Since there is no previous revision of snapd snap that we can call, fall back
and try to run snapd from the core snap.
