### PR TITLE
[RFC] boot,bootloader: make MakeBootable() uc20 aware

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -287,13 +287,13 @@ type BootableSet struct {
 	UnpackedGadgetDir string
 }
 
-// MakeBootable sets up the image filesystem with the given rootdir
-// such that it can be booted. This entails:
+// makeBootableUc16Uc18 setups the image filesystem for boot with UC16
+// and UC18 models. This entails:
 //  - installing the bootloader configuration from the gadget
 //  - creating symlinks for boot snaps from seed to the runtime blob dir
 //  - setting boot env vars pointing to the revisions of the boot snaps to use
 //  - extracting kernel assets as needed by the bootloader
-func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+func makeBootableUc16Uc18(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
 	// install the bootloader configuration from the gadget
 	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir); err != nil {
 		return err
@@ -360,5 +360,28 @@ func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) e
 	}
 
 	return nil
+}
 
+func makeBootableUc20(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	// install the bootloader configuration from the gadget
+	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir); err != nil {
+		return err
+	}
+
+	// XXX: extract kernel for e.g. ARM
+	//
+	// XXX2: "pseudo" symlink kernel to /systems/XXXX/kernel and add
+	//       code to grub to read it?
+
+	return nil
+}
+
+// MakeBootable sets up the image filesystem with the given rootdir
+// such that it can be booted
+func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	if model.Grade() == asserts.ModelGradeUnset {
+		return makeBootableUc16Uc18(model, rootdir, bootWith)
+	}
+
+	return makeBootableUc20(model, rootdir, bootWith)
 }

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -459,3 +459,72 @@ version: 4.0
 	// check that the bootloader (grub here) configuration was copied
 	c.Check(filepath.Join(rootdir, "boot", "grub/grub.cfg"), testutil.FileEquals, grubCfg)
 }
+
+func (s *bootSetSuite) TestMakeBootableUc20(c *C) {
+	dirs.SetRootDir("")
+
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model-uc20",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"timestamp":    "2019-11-01T08:00:00+00:00",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-linux",
+				"id":   "pclinuxdidididididididididididid",
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   "pcididididididididididididididid",
+				"type": "gadget",
+			},
+		},
+	}
+	model := assertstest.FakeAssertion(headers).(*asserts.Model)
+
+	grubRecoveryCfg := []byte("#grub cfg")
+	unpackedGadgetDir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
+	c.Assert(err, IsNil)
+
+	rootdir := c.MkDir()
+	seedSnapsDirs := filepath.Join(rootdir, "/var/lib/snapd/seed", "snaps")
+	err = os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	baseFn, baseInfo := s.makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := s.makeSnap(c, "pc-kernel", `name: pc-kernel
+type: kernel
+version: 5.0
+`, snap.R(5))
+	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	bootWith := &boot.BootableSet{
+		Base:              baseInfo,
+		BasePath:          baseInSeed,
+		Kernel:            kernelInfo,
+		KernelPath:        kernelInSeed,
+		UnpackedGadgetDir: unpackedGadgetDir,
+	}
+
+	err = boot.MakeBootable(model, rootdir, bootWith)
+	c.Assert(err, IsNil)
+
+	// check that the bootloader (grub here) configuration was copied
+	c.Check(filepath.Join(rootdir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals, grubRecoveryCfg)
+}

--- a/bootloader/recovery_grub.go
+++ b/bootloader/recovery_grub.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package bootloader
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/bootloader/grubenv"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+)
+
+type recoveryGrub struct {
+	rootdir string
+}
+
+// newRecoveryGrub create a new recovery Grub bootloader object
+func newRecoveryGrub(rootdir string) Bootloader {
+	g := &recoveryGrub{rootdir: rootdir}
+	if !osutil.FileExists(g.ConfigFile()) {
+		return nil
+	}
+
+	return g
+}
+
+func (g *recoveryGrub) Name() string {
+	return "grub-recovery"
+}
+
+func (g *recoveryGrub) setRootDir(rootdir string) {
+	g.rootdir = rootdir
+}
+
+func (g *recoveryGrub) dir() string {
+	if g.rootdir == "" {
+		panic("internal error: unset rootdir")
+	}
+	return filepath.Join(g.rootdir, "EFI/ubuntu")
+}
+
+func (g *recoveryGrub) ConfigFile() string {
+	return filepath.Join(g.dir(), "grub.cfg")
+}
+
+func (g *recoveryGrub) envFile() string {
+	return filepath.Join(g.dir(), "grubenv")
+}
+
+func (g *recoveryGrub) GetBootVars(names ...string) (map[string]string, error) {
+	out := make(map[string]string)
+
+	env := grubenv.NewEnv(g.envFile())
+	if err := env.Load(); err != nil {
+		return nil, err
+	}
+
+	for _, name := range names {
+		out[name] = env.Get(name)
+	}
+
+	return out, nil
+}
+
+func (g *recoveryGrub) SetBootVars(values map[string]string) error {
+	env := grubenv.NewEnv(g.envFile())
+	if err := env.Load(); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for k, v := range values {
+		env.Set(k, v)
+	}
+	return env.Save()
+}
+
+func (g *recoveryGrub) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
+	return nil
+}
+
+func (g *recoveryGrub) RemoveKernelAssets(s snap.PlaceInfo) error {
+	return nil
+}


### PR DESCRIPTION
The current MakeBootable() code is pretty specific to UC16/UC18.
For UC20 we need to tweak it to install the recovery boot config
in boot.MakeBootable().

This commit adds a new recoveryGrub bootloader that is similar
to the real grub except that it operations with different dirs
and will never extract the kernels. We will need to modify the
"pc" gadget for UC20 to rename the "grub.conf" symlink to
"grub-recovery.conf" so that the bootloader can find the right
grub.cfg.

This will also allow to access the recovery bootloader config
via: `bootloader.Find("/run/mnt/ubuntu-seed")`. This will be
needed in e.g. PR#7762 where after the install from the
emphemeral mode we need to set the bootloader config of the
recovery grub to `snapd_recovery_mode=run`.

If this looks good I will add the missing tests and refactor a bit
to share more code between grub/recoveryGrub.