### PR TITLE
many: test various kinds of overriding for the snapd snap in Core 20

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -64,6 +64,7 @@ func (s *ModelSnap) ID() string {
 }
 
 type modelSnaps struct {
+	snapd            *ModelSnap
 	base             *ModelSnap
 	gadget           *ModelSnap
 	kernel           *ModelSnap
@@ -82,6 +83,7 @@ func (ms *modelSnaps) list() (allSnaps []*ModelSnap, requiredWithEssentialSnaps 
 		}
 	}
 
+	addSnap(ms.snapd, 1)
 	addSnap(ms.kernel, 1)
 	addSnap(ms.base, 1)
 	addSnap(ms.gadget, 1)
@@ -131,6 +133,13 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 
 		essential := false
 		switch {
+		case modelSnap.SnapType == "snapd":
+			// TODO: allow to be explicit only in grade: dangerous?
+			essential = true
+			if modelSnaps.snapd != nil {
+				return nil, fmt.Errorf("cannot specify multiple snapd snaps: %q and %q", modelSnaps.snapd.Name, modelSnap.Name)
+			}
+			modelSnaps.snapd = modelSnap
 		case modelSnap.SnapType == "kernel":
 			essential = true
 			if modelSnaps.kernel != nil {

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -692,25 +692,13 @@ func (mods *modelSuite) TestCore20ExplictSnapd(c *C) {
     name: snapd
     id: snapdidididididididididididididd
     type: snapd
-    modes:
-      - run
-      - ephemeral
     default-channel: latest/edge
 `, 1)
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.ModelType)
 	model := a.(*asserts.Model)
-	find := func(snapName string, haystack []*asserts.ModelSnap) *asserts.ModelSnap {
-		for _, s := range haystack {
-			if s.Name == snapName {
-				return s
-			}
-		}
-		return nil
-	}
-	snapdSnap := find("snapd", model.AllSnaps())
-	c.Assert(snapdSnap, NotNil)
+	snapdSnap := model.AllSnaps()[0]
 	c.Check(snapdSnap, DeepEquals, &asserts.ModelSnap{
 		Name:           "snapd",
 		SnapID:         "snapdidididididididididididididd",

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -361,13 +361,17 @@ func (s *seed20) LoadMeta(tm timings.Measurer) error {
 		return err
 	}
 
-	snapdSnap := internal.MakeSystemSnap("snapd", "latest/stable", []string{"run", "ephemeral"})
-	if _, err := s.addModelSnap(snapdSnap, true, tm); err != nil {
-		return err
+	allSnaps := model.AllSnaps()
+	// an explicit snapd is the first of all of snaps
+	if allSnaps[0].SnapType != "snapd" {
+		snapdSnap := internal.MakeSystemSnap("snapd", "latest/stable", []string{"run", "ephemeral"})
+		if _, err := s.addModelSnap(snapdSnap, true, tm); err != nil {
+			return err
+		}
 	}
 
 	essential := true
-	for _, modelSnap := range model.AllSnaps() {
+	for _, modelSnap := range allSnaps {
 		seedSnap, err := s.addModelSnap(modelSnap, essential, tm)
 		if err != nil {
 			return err


### PR DESCRIPTION
This also fixes issues related to support listing it explicitly in the model, in that regard is a follow up to #7720.
