### PR TITLE
boot,bootloader: make MakeBootable() uc20 aware

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -287,13 +287,13 @@ type BootableSet struct {
 	UnpackedGadgetDir string
 }
 
-// MakeBootable sets up the image filesystem with the given rootdir
-// such that it can be booted. This entails:
+// makeBootableUc16Uc18 setups the image filesystem for boot with UC16
+// and UC18 models. This entails:
 //  - installing the bootloader configuration from the gadget
 //  - creating symlinks for boot snaps from seed to the runtime blob dir
 //  - setting boot env vars pointing to the revisions of the boot snaps to use
 //  - extracting kernel assets as needed by the bootloader
-func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+func makeBootableUc16Uc18(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
 	// install the bootloader configuration from the gadget
 	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir); err != nil {
 		return err
@@ -360,5 +360,28 @@ func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) e
 	}
 
 	return nil
+}
 
+func makeBootableUc20(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	// install the bootloader configuration from the gadget
+	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir); err != nil {
+		return err
+	}
+
+	// XXX: extract kernel for e.g. ARM
+	//
+	// XXX2: "pseudo" symlink kernel to /systems/XXXX/kernel and add
+	//       code to grub to read it?
+
+	return nil
+}
+
+// MakeBootable sets up the image filesystem with the given rootdir
+// such that it can be booted
+func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	if model.Grade() == asserts.ModelGradeUnset {
+		return makeBootableUc16Uc18(model, rootdir, bootWith)
+	}
+
+	return makeBootableUc20(model, rootdir, bootWith)
 }

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -459,3 +459,72 @@ version: 4.0
 	// check that the bootloader (grub here) configuration was copied
 	c.Check(filepath.Join(rootdir, "boot", "grub/grub.cfg"), testutil.FileEquals, grubCfg)
 }
+
+func (s *bootSetSuite) TestMakeBootableUc20(c *C) {
+	dirs.SetRootDir("")
+
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model-uc20",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"timestamp":    "2019-11-01T08:00:00+00:00",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-linux",
+				"id":   "pclinuxdidididididididididididid",
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   "pcididididididididididididididid",
+				"type": "gadget",
+			},
+		},
+	}
+	model := assertstest.FakeAssertion(headers).(*asserts.Model)
+
+	grubRecoveryCfg := []byte("#grub cfg")
+	unpackedGadgetDir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
+	c.Assert(err, IsNil)
+
+	rootdir := c.MkDir()
+	seedSnapsDirs := filepath.Join(rootdir, "/var/lib/snapd/seed", "snaps")
+	err = os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	baseFn, baseInfo := s.makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := s.makeSnap(c, "pc-kernel", `name: pc-kernel
+type: kernel
+version: 5.0
+`, snap.R(5))
+	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	bootWith := &boot.BootableSet{
+		Base:              baseInfo,
+		BasePath:          baseInSeed,
+		Kernel:            kernelInfo,
+		KernelPath:        kernelInSeed,
+		UnpackedGadgetDir: unpackedGadgetDir,
+	}
+
+	err = boot.MakeBootable(model, rootdir, bootWith)
+	c.Assert(err, IsNil)
+
+	// check that the bootloader (grub here) configuration was copied
+	c.Check(filepath.Join(rootdir, "EFI/ubuntu/grub.cfg"), testutil.FileEquals, grubRecoveryCfg)
+}

--- a/bootloader/androidboot.go
+++ b/bootloader/androidboot.go
@@ -56,6 +56,12 @@ func (a *androidboot) dir() string {
 	return filepath.Join(a.rootdir, "/boot/androidboot")
 }
 
+func (a *androidboot) InstallBootConfig(gadgetDir string) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, a.Name()+".conf")
+	systemFile := a.ConfigFile()
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (a *androidboot) ConfigFile() string {
 	return filepath.Join(a.dir(), "androidboot.env")
 }

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -108,6 +108,6 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfig(c *C) {
 		err = bootloader.InstallBootConfig(mockGadgetDir, s.rootdir)
 		c.Assert(err, IsNil)
 		fn := filepath.Join(s.rootdir, t.systemFile)
-		c.Assert(osutil.FileExists(fn), Equals, true)
+		c.Check(osutil.FileExists(fn), Equals, true, Commentf("boot config missing for %s", t.gadgetFile))
 	}
 }

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -73,6 +73,10 @@ func (b *MockBootloader) Name() string {
 	return b.name
 }
 
+func (b *MockBootloader) InstallBootConfig(gadgetDir string) (bool, error) {
+	return false, nil
+}
+
 func (b *MockBootloader) ConfigFile() string {
 	return filepath.Join(b.bootdir, "mockboot/mockboot.cfg")
 }

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -22,6 +22,7 @@ package bootloader
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
@@ -63,10 +64,9 @@ func NewGrub(rootdir string) Bootloader {
 }
 
 func MockGrubFiles(c *C, rootdir string) {
-	g := &grub{rootdir: rootdir}
-	err := os.MkdirAll(g.dir(), 0755)
+	err := os.MkdirAll(filepath.Join(rootdir, "/boot/grub"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(g.ConfigFile(), nil, 0644)
+	err = ioutil.WriteFile(filepath.Join(rootdir, "/boot/grub/grub.cfg"), nil, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -68,8 +68,9 @@ func (s *grubTestSuite) grubEditenvSet(c *C, key, value string) {
 		c.Skip("grub{,2}-editenv is not available")
 	}
 
-	err := exec.Command(grubEditenvCmd(), grubEnvPath(s.rootdir), "set", fmt.Sprintf("%s=%s", key, value)).Run()
-	c.Assert(err, IsNil)
+	output, err := exec.Command(grubEditenvCmd(), grubEnvPath(s.rootdir), "set", fmt.Sprintf("%s=%s", key, value)).CombinedOutput()
+	c.Check(err, IsNil)
+	c.Check(string(output), Equals, "")
 }
 
 func (s *grubTestSuite) grubEditenvGet(c *C, key string) string {

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -76,6 +76,12 @@ func (l *lk) dir() string {
 	}
 }
 
+func (l *lk) InstallBootConfig(gadgetDir string) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, l.Name()+".conf")
+	systemFile := l.ConfigFile()
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (l *lk) ConfigFile() string {
 	return l.envFile()
 }

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -56,6 +56,12 @@ func (u *uboot) dir() string {
 	return filepath.Join(u.rootdir, "/boot/uboot")
 }
 
+func (u *uboot) InstallBootConfig(gadgetDir string) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, u.Name()+".conf")
+	systemFile := u.ConfigFile()
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (u *uboot) ConfigFile() string {
 	return u.envFile()
 }


### PR DESCRIPTION
The current MakeBootable() code is pretty specific to UC16/UC18.
For UC20 we need to tweak it to install the recovery boot config
in boot.MakeBootable().

This commit adds a new InstallBootCofig to the bootloader
interface. Most bootloader use the generic uc16 implementation
but for uc20 aware bootloader we will need to deal with the
recovery in a special way. We will also need to be able to
look at different base directories for grub (and potentially
the other bootloaders) as UC20 will have /boot/grub (system-boot)
and EFI/ubuntu (system-seed).

The pc=20 gadget will have to be tweaked to contain a
grub-recovery.conf for this to work but this change is trivial.

This will also allow to access the recovery bootloader config
via: `bootloader.Find("/run/mnt/ubuntu-seed")`. This will be
needed in e.g. PR#7762 where after the install from the
emphemeral mode we need to set the bootloader config of the
recovery grub to `snapd_recovery_mode=run`.

This is an alternative implementation of https://github.com/snapcore/snapd/pull/7763