### PR TITLE
configcore: fix missing error propagation

### DIFF
--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -53,7 +53,7 @@ func etcEnvironment() string {
 }
 
 func updateEtcEnvironmentConfig(path string, config map[string]string) error {
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}
@@ -64,6 +64,8 @@ func updateEtcEnvironmentConfig(path string, config map[string]string) error {
 		return err
 	}
 	if toWrite != nil {
+		// XXX: would be great to atomically write but /etc/environment
+		//      is a single bind mount :/
 		return ioutil.WriteFile(path, []byte(strings.Join(toWrite, "\n")), 0644)
 	}
 

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -55,7 +55,7 @@ func etcEnvironment() string {
 func updateEtcEnvironmentConfig(path string, config map[string]string) error {
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer f.Close()
 

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -84,6 +84,20 @@ PATH="/usr/bin"
 	c.Assert(err, IsNil)
 }
 
+func (s *proxySuite) TestConfigureProxyUnhappy(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	dirs.SetRootDir(c.MkDir())
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"proxy.http": "http://example.com",
+		},
+	})
+	c.Assert(err, ErrorMatches, "open .*/etc/environment: no such file or directory")
+}
+
 func (s *proxySuite) TestConfigureProxy(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()


### PR DESCRIPTION
The proxy configuration code has a silly mistake that prevents
error propagation which lead to a slient error on core18 systems
when trying to write the proxy configuration into /etc/environment.

#brownpaperbag