### PR TITLE
cmd/snap-failure: passthrough snapd logs, add informational logging

### DIFF
--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -121,7 +121,7 @@ func (c *cmdSnapd) Execute(args []string) error {
 		return osutil.OutputErr(output, err)
 	}
 
-	logger.Noticef("restoring with snapd from: %v", snapdPath)
+	logger.Noticef("restoring invoking snapd from: %v", snapdPath)
 	// start previous snapd
 	cmd := exec.Command(snapdPath)
 	cmd.Env = os.Environ()

--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 )
 
@@ -113,21 +114,25 @@ func (c *cmdSnapd) Execute(args []string) error {
 	default:
 		return err
 	}
+	logger.Noticef("stopping snapd socket")
 	// stop the socket unit so that we can start snapd on its own
 	output, err := exec.Command("systemctl", "stop", "snapd.socket").CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(output, err)
 	}
 
+	logger.Noticef("restoring with snapd from: %v", snapdPath)
 	// start previous snapd
 	cmd := exec.Command(snapdPath)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SNAPD_REVERT_TO_REV="+prevRev)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("snapd failed: %v", osutil.OutputErr(output, err))
+	cmd.Stdout = Stdout
+	cmd.Stderr = Stderr
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("snapd failed: %v", err)
 	}
 
+	logger.Noticef("restarting snapd socket")
 	// at this point our manually started snapd stopped and
 	// removed the /run/snap* sockets (this is a feature of
 	// golang) - we need to restart snapd.socket to make them

--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -209,3 +209,33 @@ func (r *failureSuite) TestBadSeq(c *C) {
 	c.Check(snapdCmd.Calls(), HasLen, 0)
 	c.Check(systemctlCmd.Calls(), HasLen, 0)
 }
+
+func (r *failureSuite) TestSnapdOutputPassthrough(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	writeSeqFile(c, "snapd", snap.R(123), []*snap.SideInfo{
+		{Revision: snap.R(100)},
+		{Revision: snap.R(123)},
+	})
+
+	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"), `
+echo 'stderr: hello from snapd' >&2
+echo 'stdout: hello from snapd'
+exit 123
+`)
+	defer snapdCmd.Restore()
+	systemctlCmd := testutil.MockCommand(c, "systemctl", "")
+	defer systemctlCmd.Restore()
+
+	os.Args = []string{"snap-failure", "snapd"}
+	err := failure.Run()
+	c.Check(err, ErrorMatches, "snapd failed: exit status 123")
+	c.Check(r.Stderr(), Equals, "stderr: hello from snapd\n")
+	c.Check(r.Stdout(), Equals, "stdout: hello from snapd\n")
+
+	c.Check(snapdCmd.Calls(), HasLen, 1)
+	c.Check(systemctlCmd.Calls(), DeepEquals, [][]string{
+		{"systemctl", "stop", "snapd.socket"},
+	})
+}

--- a/cmd/snap-failure/main.go
+++ b/cmd/snap-failure/main.go
@@ -32,6 +32,7 @@ import (
 
 var (
 	Stderr io.Writer = os.Stderr
+	Stdout io.Writer = os.Stdout
 
 	opts   struct{}
 	parser *flags.Parser = flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)


### PR DESCRIPTION
When examining snapd recovery, it may be useful to be able to see the log output
generated by snapd. Currently, the output is captured and shown only when there
is an error.

Add some INFO level logs about steps taken by snap-failure, this is helpful when
investigating the logs manually.
