### PR TITLE
testutil, many: make MockCommand() create prefix of absolute paths

### DIFF
--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -213,7 +213,7 @@ func (r *failureSuite) TestSnapdOutputPassthrough(c *C) {
 		{Revision: snap.R(123)},
 	})
 
-	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"), `
+	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"), `
 echo 'stderr: hello from snapd' >&2
 echo 'stdout: hello from snapd'
 exit 123

--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -61,12 +61,6 @@ func writeSeqFile(c *C, name string, current snap.Revision, seq []*snap.SideInfo
 	c.Assert(err, IsNil)
 }
 
-func mockCommandInDir(c *C, path, script string) *testutil.MockCmd {
-	err := os.MkdirAll(filepath.Dir(path), 0755)
-	c.Assert(err, IsNil)
-	return testutil.MockCommand(c, path, script)
-}
-
 func (r *failureSuite) TestCallPrevSnapdFromSnap(c *C) {
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()
@@ -78,7 +72,7 @@ func (r *failureSuite) TestCallPrevSnapdFromSnap(c *C) {
 	})
 
 	// mock snapd command from 'previous' revision
-	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
+	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
 		`test "$SNAPD_REVERT_TO_REV" = "100"`)
 	defer snapdCmd.Restore()
 
@@ -109,7 +103,7 @@ func (r *failureSuite) TestCallPrevSnapdFromCore(c *C) {
 	})
 
 	// mock snapd in the core snap
-	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "core", "current", "/usr/lib/snapd/snapd"),
+	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "core", "current", "/usr/lib/snapd/snapd"),
 		`test "$SNAPD_REVERT_TO_REV" = "0"`)
 	defer snapdCmd.Restore()
 
@@ -140,7 +134,7 @@ func (r *failureSuite) TestCallPrevSnapdFail(c *C) {
 	})
 
 	// mock snapd in the core snap
-	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
+	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
 		`exit 2`)
 	defer snapdCmd.Restore()
 
@@ -171,7 +165,7 @@ func (r *failureSuite) TestGarbageSeq(c *C) {
 	err = ioutil.WriteFile(seqPath, []byte("this is garbage"), 0644)
 	c.Assert(err, IsNil)
 
-	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
+	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
 		`exit 99`)
 	defer snapdCmd.Restore()
 
@@ -196,7 +190,7 @@ func (r *failureSuite) TestBadSeq(c *C) {
 		// current not in sequence
 	})
 
-	snapdCmd := mockCommandInDir(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"), "")
+	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"), "")
 	defer snapdCmd.Restore()
 	systemctlCmd := testutil.MockCommand(c, "systemctl", "")
 	defer systemctlCmd.Restore()

--- a/cmd/snap/cmd_repair_repairs_test.go
+++ b/cmd/snap/cmd_repair_repairs_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -32,10 +31,7 @@ import (
 )
 
 func mockSnapRepair(c *C) *testutil.MockCmd {
-	coreLibExecDir := filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir)
-	err := os.MkdirAll(coreLibExecDir, 0755)
-	c.Assert(err, IsNil)
-	return testutil.MockCommand(c, filepath.Join(coreLibExecDir, "snap-repair"), "")
+	return testutil.MockCommand(c, filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir, "snap-repair"), "")
 }
 
 func (s *SnapSuite) TestSnapShowRepair(c *C) {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -76,8 +76,6 @@ func (s *backendSuite) SetUpTest(c *C) {
 		return filepath.Join(dirs.DistroLibExecDir, "snapd"), nil
 	})
 	snapSeccompPath := filepath.Join(dirs.DistroLibExecDir, "snap-seccomp")
-	err = os.MkdirAll(filepath.Dir(snapSeccompPath), 0755)
-	c.Assert(err, IsNil)
 	s.snapSeccomp = testutil.MockCommand(c, snapSeccompPath, `
 if [ "$1" = "version-info" ]; then
     echo "abcdef 1.2.3 1234abcd -"
@@ -154,15 +152,13 @@ func (s *backendSuite) TestInstallingSnapWritesProfilesWithReexec(c *C) {
 
 	// ensure we have a mocked snap-seccomp on core
 	snapSeccompOnCorePath := filepath.Join(dirs.SnapMountDir, "core/42/usr/lib/snapd/snap-seccomp")
-	err := os.MkdirAll(filepath.Dir(snapSeccompOnCorePath), 0755)
-	c.Assert(err, IsNil)
 	snapSeccompOnCore := testutil.MockCommand(c, snapSeccompOnCorePath, `if [ "$1" = "version-info" ]; then
 echo "2345cdef 2.3.4 2345cdef -"
 fi`)
 	defer snapSeccompOnCore.Restore()
 
 	// rerun initialization
-	err = s.Backend.Initialize()
+	err := s.Backend.Initialize()
 	c.Assert(err, IsNil)
 
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 0)

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -22,7 +22,6 @@ package hookstate_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sync/atomic"
@@ -865,8 +864,6 @@ func checkTaskLogContains(c *C, task *state.Task, pattern string) {
 
 func (s *hookManagerSuite) TestHookTaskRunsRightSnapCmd(c *C) {
 	coreSnapCmdPath := filepath.Join(dirs.SnapMountDir, "core/12/usr/bin/snap")
-	err := os.MkdirAll(filepath.Dir(coreSnapCmdPath), 0755)
-	c.Assert(err, IsNil)
 	cmd := testutil.MockCommand(c, coreSnapCmdPath, "")
 	defer cmd.Restore()
 

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -420,17 +420,11 @@ type: os
 	err := os.Symlink(filepath.Base(mountDirOld), filepath.Join(mountDirOld, "..", "current"))
 	c.Assert(err, IsNil)
 
-	err = os.MkdirAll(filepath.Join(mountDirOld, "bin"), 0755)
-	c.Assert(err, IsNil)
-
 	oldCmdV6 := testutil.MockCommand(c, filepath.Join(mountDirOld, "bin", "fc-cache-v6"), "")
 	oldCmdV7 := testutil.MockCommand(c, filepath.Join(mountDirOld, "bin", "fc-cache-v7"), "")
 
 	infoNew := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(12)})
 	mountDirNew := infoNew.MountDir()
-
-	err = os.MkdirAll(filepath.Join(mountDirNew, "bin"), 0755)
-	c.Assert(err, IsNil)
 
 	newCmdV6 := testutil.MockCommand(c, filepath.Join(mountDirNew, "bin", "fc-cache-v6"), "")
 	newCmdV7 := testutil.MockCommand(c, filepath.Join(mountDirNew, "bin", "fc-cache-v7"), "")

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -101,9 +101,9 @@ printf '\0' >> %[1]q
 %s
 `
 
-// MockCommand adds a mocked command. If the basename argument is a command
-// it is added to PATH. If it is an absolute path it is just created there.
-// the caller is responsible for the cleanup in this case.
+// MockCommand adds a mocked command. If the basename argument is a command it
+// is added to PATH. If it is an absolute path it is just created there, along
+// with the full prefix. The caller is responsible for the cleanup in this case.
 //
 // The command logs all invocations to a dedicated log file. If script is
 // non-empty then it is used as is and the caller is responsible for how the
@@ -114,6 +114,10 @@ func MockCommand(c *check.C, basename, script string) *MockCmd {
 	var binDir, exeFile, logFile string
 	if filepath.IsAbs(basename) {
 		binDir = filepath.Dir(basename)
+		err := os.MkdirAll(binDir, 0755)
+		if err != nil {
+			panic(fmt.Sprintf("cannot create the directory for mocked command %q: %v", basename, err))
+		}
 		exeFile = basename
 		logFile = basename + ".log"
 	} else {

--- a/usersession/autostart/autostart_test.go
+++ b/usersession/autostart/autostart_test.go
@@ -213,8 +213,6 @@ func (s *autostartSuite) TestTryAutostartAppValid(c *C) {
 	si := snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
 
 	appWrapperPath := si.Apps["foo"].WrapperPath()
-	err := os.MkdirAll(filepath.Dir(appWrapperPath), 0755)
-	c.Assert(err, IsNil)
 
 	appCmd := testutil.MockCommand(c, appWrapperPath, "")
 	defer appCmd.Restore()


### PR DESCRIPTION
Followup on #7755. We have some code that mocks commands at absolute paths. Normally this would require the caller to create the prefix manually. The patches extend MockCommand() to create prefix.
