### PR TITLE
interfaces: add login-session-observe for who, {fail,last}log and loginctl

### DIFF
--- a/interfaces/builtin/login_session_observe.go
+++ b/interfaces/builtin/login_session_observe.go
@@ -92,7 +92,6 @@ dbus (send)
 
 type loginSessionObserveInterface struct {
 	commonInterface
-	secCompSnippet string
 }
 
 func init() {

--- a/interfaces/builtin/login_session_observe.go
+++ b/interfaces/builtin/login_session_observe.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const loginSessionObserveSummary = `allows observing login and session information`
+
+const loginSessionObserveBaseDeclarationSlots = `
+  login-session-observe:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const loginSessionObserveConnectedPlugAppArmor = `
+# Allow observing login and session information
+/{,usr/}bin/who  ixr,
+/var/log/wtmp    rk,
+/{,var/}run/utmp rk,
+
+/{,usr/}bin/lastlog ixr,
+/var/log/lastlog rk,
+
+/{,usr/}bin/faillog ixr,
+/var/log/faillog rk,
+
+# systemd session information (session files, but not .ref files)
+/run/systemd/sessions/ r,
+/run/systemd/sessions/*[0-9] rk,
+
+# Supported loginctl commands:
+# - list-sessions
+# - show-session N
+# - list-users
+# - show-user N
+# - list-seats
+# - show-seat N
+
+/{,usr/}bin/loginctl ixr,
+#include <abstractions/dbus-strict>
+
+# Introspection of org.freedesktop.login1
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
+
+dbus (send)
+    bus=system
+    path=/org/freedesktop/login1{,/seat/*,/session/*,/user/*}
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All},
+
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.login1.Manager
+    member=List{Seats,Sessions,Users},
+
+dbus (send)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.login1.Manager
+    member=Get{Seat,Session,User},
+`
+
+type loginSessionObserveInterface struct {
+	commonInterface
+	secCompSnippet string
+}
+
+func init() {
+	registerIface(&loginSessionObserveInterface{commonInterface: commonInterface{
+		name:                  "login-session-observe",
+		summary:               loginSessionObserveSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  loginSessionObserveBaseDeclarationSlots,
+		connectedPlugAppArmor: loginSessionObserveConnectedPlugAppArmor,
+		reservedForOS:         true,
+	}})
+}

--- a/interfaces/builtin/login_session_observe.go
+++ b/interfaces/builtin/login_session_observe.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const loginSessionObserveSummary = `allows observing login and session information`
+const loginSessionObserveSummary = `allows reading login and session information`
 
 const loginSessionObserveBaseDeclarationSlots = `
   login-session-observe:
@@ -30,7 +30,7 @@ const loginSessionObserveBaseDeclarationSlots = `
 `
 
 const loginSessionObserveConnectedPlugAppArmor = `
-# Allow observing login and session information
+# Allow reading login and session information
 /{,usr/}bin/who  ixr,
 /var/log/wtmp    rk,
 /{,var/}run/utmp rk,

--- a/interfaces/builtin/login_session_observe_test.go
+++ b/interfaces/builtin/login_session_observe_test.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type LoginSessionObserveSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&LoginSessionObserveSuite{
+	iface: builtin.MustInterface("login-session-observe"),
+})
+
+const loginObserveMockPlugSnapInfo = `name: other
+version: 1.0
+apps:
+ app2:
+  command: foo
+  plugs: [login-session-observe]
+`
+
+func (s *LoginSessionObserveSuite) SetUpTest(c *C) {
+	s.slotInfo = &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
+		Name:      "login-session-observe",
+		Interface: "login-session-observe",
+		Apps: map[string]*snap.AppInfo{
+			"app1": {
+				Snap: &snap.Info{
+					SuggestedName: "core",
+				},
+				Name: "app1"}},
+	}
+	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
+
+	plugSnap := snaptest.MockInfo(c, loginObserveMockPlugSnapInfo, nil)
+	s.plugInfo = plugSnap.Plugs["login-session-observe"]
+	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+}
+
+func (s *LoginSessionObserveSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "login-session-observe")
+}
+
+func (s *LoginSessionObserveSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *LoginSessionObserveSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *LoginSessionObserveSuite) TestAppArmor(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "/{,usr/}bin/who")
+}
+
+func (s *LoginSessionObserveSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -206,6 +206,9 @@ apps:
   login-session-control:
     command: bin/run
     plugs: [ login-session-control ]
+  login-session-observe:
+    command: bin/run
+    plugs: [ login-session-observe ]
   lxd:
     command: bin/run
     plugs: [ lxd ]


### PR DESCRIPTION
login-session-observe supports:
- the who, lastlog and faillog commands
- reading wtmp, utmp, lastlog and failog
- loginctl for:
  - list-sessions
  - show-session N
  - list-users
  - show-user N
  - list-seats
  - show-seat N

loginctl {seat,session,user}-status is not supported at this time since
additional accesses not strictly within the scope of this interface are
required (though due to the above accesses, they are partially
supported, but will generate apparmor denials).
