### PR TITLE
snap-confine: suppress noisy classic snap file_inherit denials

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -552,4 +552,9 @@
     # Allow mounting /var/lib/jenkins from the host into the snap.
     mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+
+    # Suppress noisy file_inherit denials (LP: #1850552) until LP: #1849753 is
+    # fixed.
+    deny unix,
+    deny /dev/shm/.org.chromium.Chromium.* rw,
 }


### PR DESCRIPTION
Classic snaps that use the chromium content api create a lot of log spam
due to bug #1849753. Eg:

audit[3275]: AVC apparmor="DENIED" operation="file_inherit"
profile="/snap/core/7917/usr/lib/snapd/snap-confine" pid=3275
comm="snap-confine" family="unix" sock_type="stream" protocol=0
requested_mask="send receive" denied_mask="send receive" addr=none
peer_addr=none
audit[3275]: AVC apparmor="DENIED" operation="file_inherit"
profile="/snap/core/7917/usr/lib/snapd/snap-confine"
name="/dev/shm/.org.chromium.Chromium.6xtos6" pid=3275
comm="snap-confine" requested_mask="wr" denied_mask="wr" fsuid=1000
ouid=1000

On a system with vscode and slack, there are thousands of these per day:

$ grep file_inherit ./audit.log |\
  grep -E '(family="unix" .* addr=none peer_addr=none|\
            /dev/shm/\.org\.chromium\.Chromium)'|wc -l
101912

As a temporary stop-gap, explicitly deny the noisiest denials until
bug #1849753 is fixed.

There is no chance of regression for this since snap-confine is already
denying them. We could consider making these allowed rather than
explicit deny, but people haven't been complaining about these classic
chromium content api snaps not working, so I'd like to continue denying
for now.

References:
- https://launchpad.net/bugs/1850552
- https://launchpad.net/bugs/1849753
