### PR TITLE
seccomp: allow chown 'snap_daemon:root' and 'root:snap_daemon'

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -763,4 +763,22 @@ fchown32 - -1 g:###GROUP###
 fchownat - - -1 g:###GROUP###
 lchown - -1 g:###GROUP###
 lchown32 - -1 g:###GROUP###
+
+# allow chown to ###USERNAME###:root
+chown - u:###USERNAME### g:root
+chown32 - u:###USERNAME### g:root
+fchown - u:###USERNAME### g:root
+fchown32 - u:###USERNAME### g:root
+fchownat - - u:###USERNAME### g:root
+lchown - u:###USERNAME### g:root
+lchown32 - u:###USERNAME### g:root
+
+# allow chown to root:###GROUP###
+chown - u:root g:###GROUP###
+chown32 - u:root g:###GROUP###
+fchown - u:root g:###GROUP###
+fchown32 - u:root g:###GROUP###
+fchownat - - u:root g:###GROUP###
+lchown - u:root g:###GROUP###
+lchown32 - u:root g:###GROUP###
 `

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -401,15 +401,15 @@ execute: |
     snap run test-snapd-daemon-user.setresuid -1 snap_daemon -1 2>&1           | MATCH "After: ruid=0, euid=$user, suid=0, rgid=0, egid=0, sgid=0, groups="
     snap run test-snapd-daemon-user.setresuid32 -1 snap_daemon -1 2>&1         | MATCH "After: ruid=0, euid=$user, suid=0, rgid=0, egid=0, sgid=0, groups="
 
-    echo "'setresuid u:daemon u:daemon -1' allowed"
+    echo "'setresuid u:snap_daemon u:snap_daemon -1' allowed"
     snap run test-snapd-daemon-user.setresuid snap_daemon snap_daemon -1 2>&1       | MATCH "After: ruid=$user, euid=$user, suid=0, rgid=0, egid=0, sgid=0, groups="
     snap run test-snapd-daemon-user.setresuid32 snap_daemon snap_daemon -1 2>&1     | MATCH "After: ruid=$user, euid=$user, suid=0, rgid=0, egid=0, sgid=0, groups="
 
-    echo "'setresuid u:daemon u:daemon u:root' allowed"
+    echo "'setresuid u:snap_daemon u:snap_daemon u:root' allowed"
     snap run test-snapd-daemon-user.setresuid snap_daemon snap_daemon root 2>&1     | MATCH "After: ruid=$user, euid=$user, suid=0, rgid=0, egid=0, sgid=0, groups="
     snap run test-snapd-daemon-user.setresuid32 snap_daemon snap_daemon root 2>&1   | MATCH "After: ruid=$user, euid=$user, suid=0, rgid=0, egid=0, sgid=0, groups="
 
-    echo "'setresuid u:daemon u:root u:root' allowed"
+    echo "'setresuid u:snap_daemon u:root u:root' allowed"
     snap run test-snapd-daemon-user.setresuid snap_daemon root root 2>&1       | MATCH "After: ruid=$user, euid=0, suid=0, rgid=0, egid=0, sgid=0, groups="
     snap run test-snapd-daemon-user.setreuid32 snap_daemon root root 2>&1      | MATCH "After: ruid=$user, euid=0, suid=0, rgid=0, egid=0, sgid=0, groups="
 
@@ -465,27 +465,27 @@ execute: |
     snap run test-snapd-daemon-user.setresuid test test root 2>&1         | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 test test root 2>&1       | MATCH "Operation not permitted"
 
-    echo "'setresuid u:daemon u:daemon u:test' denied"
+    echo "'setresuid u:snap_daemon u:snap_daemon u:test' denied"
     snap run test-snapd-daemon-user.setresuid snap_daemon snap_daemon test 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 snap_daemon snap_daemon test 2>&1   | MATCH "Operation not permitted"
 
-    echo "'setresuid u:daemon u:test u:daemon' denied"
+    echo "'setresuid u:snap_daemon u:test u:snap_daemon' denied"
     snap run test-snapd-daemon-user.setresuid snap_daemon test snap_daemon 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 snap_daemon test snap_daemon 2>&1   | MATCH "Operation not permitted"
 
-    echo "'setresuid u:daemon u:test u:test' denied"
+    echo "'setresuid u:snap_daemon u:test u:test' denied"
     snap run test-snapd-daemon-user.setresuid snap_daemon test test 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 snap_daemon test test 2>&1     | MATCH "Operation not permitted"
 
-    echo "'setresuid u:test u:daemon u:daemon' denied"
+    echo "'setresuid u:test u:snap_daemon u:snap_daemon' denied"
     snap run test-snapd-daemon-user.setresuid test snap_daemon snap_daemon 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 test snap_daemon snap_daemon 2>&1   | MATCH "Operation not permitted"
 
-    echo "'setresuid u:test u:daemon u:test' denied"
+    echo "'setresuid u:test u:snap_daemon u:test' denied"
     snap run test-snapd-daemon-user.setresuid test snap_daemon test 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 test snap_daemon test 2>&1     | MATCH "Operation not permitted"
 
-    echo "'setresuid u:test u:test u:daemon' denied"
+    echo "'setresuid u:test u:test u:snap_daemon' denied"
     snap run test-snapd-daemon-user.setresuid test test snap_daemon 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.setresuid32 test test snap_daemon 2>&1     | MATCH "Operation not permitted"
 
@@ -508,20 +508,30 @@ execute: |
     snap run test-snapd-daemon-user.chown "$P2" -1 root 2>&1         | MATCH "After: .* uid=0, gid=0"
     snap run test-snapd-daemon-user.chown32 "$P3" -1 root 2>&1       | MATCH "After: .* uid=0, gid=0"
 
-    echo "'chown - u:daemon g:daemon' allowed"
+    echo "'chown - u:snap_daemon g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.chown "$P2" snap_daemon snap_daemon 2>&1   | MATCH "After: .* uid=$user, gid=$group"
     snap run test-snapd-daemon-user.chown32 "$P3" snap_daemon snap_daemon 2>&1 | MATCH "After: .* uid=$user, gid=$group"
 
-    echo "'chown - u:daemon -1' allowed"
+    echo "'chown - u:snap_daemon -1' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.chown "$P2" snap_daemon -1 2>&1       | MATCH "After: .* uid=$user, gid=0"
     snap run test-snapd-daemon-user.chown32 "$P3" snap_daemon -1 2>&1     | MATCH "After: .* uid=$user, gid=0"
 
-    echo "'chown - -1 g:daemon' allowed"
+    echo "'chown - -1 g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.chown "$P2" -1 snap_daemon 2>&1       | MATCH "After: .* uid=0, gid=$group"
     snap run test-snapd-daemon-user.chown32 "$P3" -1 snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+
+    echo "'chown - u:snap_daemon g:root' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.chown "$P2" snap_daemon root 2>&1     | MATCH "After: .* uid=$user, gid=0"
+    snap run test-snapd-daemon-user.chown32 "$P3" snap_daemon root 2>&1   | MATCH "After: .* uid=$user, gid=0"
+
+    echo "'chown - u:root g:snap_daemon' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.chown "$P2" root snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+    snap run test-snapd-daemon-user.chown32 "$P3" root snap_daemon 2>&1   | MATCH "After: .* uid=0, gid=$group"
 
     echo "'chown - u:test g:test' denied"
     chown root:root "$P2" "$P3"
@@ -548,12 +558,12 @@ execute: |
     snap run test-snapd-daemon-user.chown "$P2" root test 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.chown32 "$P3" root test 2>&1     | MATCH "Operation not permitted"
 
-    echo "'chown - u:test g:daemon' denied"
+    echo "'chown - u:test g:snap_daemon' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.chown "$P2" test snap_daemon 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.chown32 "$P3" test snap_daemon 2>&1   | MATCH "Operation not permitted"
 
-    echo "'chown - u:daemon g:test' denied"
+    echo "'chown - u:snap_daemon g:test' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.chown "$P2" snap_daemon test 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.chown32 "$P3" snap_daemon test 2>&1   | MATCH "Operation not permitted"
@@ -575,20 +585,30 @@ execute: |
     snap run test-snapd-daemon-user.lchown "$P2" -1 root 2>&1         | MATCH "After: .* uid=0, gid=0"
     snap run test-snapd-daemon-user.lchown32 "$P3" -1 root 2>&1       | MATCH "After: .* uid=0, gid=0"
 
-    echo "'lchown - u:daemon g:daemon' allowed"
+    echo "'lchown - u:snap_daemon g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.lchown "$P2" snap_daemon snap_daemon 2>&1   | MATCH "After: .* uid=$user, gid=$group"
     snap run test-snapd-daemon-user.lchown32 "$P3" snap_daemon snap_daemon 2>&1 | MATCH "After: .* uid=$user, gid=$group"
 
-    echo "'lchown - u:daemon -1' allowed"
+    echo "'lchown - u:snap_daemon -1' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.lchown "$P2" snap_daemon -1 2>&1       | MATCH "After: .* uid=$user, gid=0"
     snap run test-snapd-daemon-user.lchown32 "$P3" snap_daemon -1 2>&1     | MATCH "After: .* uid=$user, gid=0"
 
-    echo "'lchown - -1 g:daemon' allowed"
+    echo "'lchown - -1 g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.lchown "$P2" -1 snap_daemon 2>&1       | MATCH "After: .* uid=0, gid=$group"
     snap run test-snapd-daemon-user.lchown32 "$P3" -1 snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+
+    echo "'lchown - u:snap_daemon g:root' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.lchown "$P2" snap_daemon root 2>&1     | MATCH "After: .* uid=$user, gid=0"
+    snap run test-snapd-daemon-user.lchown32 "$P3" snap_daemon root 2>&1   | MATCH "After: .* uid=$user, gid=0"
+
+    echo "'lchown - u:root g:snap_daemon' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.lchown "$P2" root snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+    snap run test-snapd-daemon-user.lchown32 "$P3" root snap_daemon 2>&1   | MATCH "After: .* uid=0, gid=$group"
 
     echo "'lchown - u:test g:test' denied"
     chown root:root "$P2" "$P3"
@@ -615,12 +635,12 @@ execute: |
     snap run test-snapd-daemon-user.lchown "$P2" root test 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.lchown32 "$P3" root test 2>&1     | MATCH "Operation not permitted"
 
-    echo "'lchown - u:test g:daemon' denied"
+    echo "'lchown - u:test g:snap_daemon' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.lchown "$P2" test snap_daemon 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.lchown32 "$P3" test snap_daemon 2>&1   | MATCH "Operation not permitted"
 
-    echo "'lchown - u:daemon g:test' denied"
+    echo "'lchown - u:snap_daemon g:test' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.lchown "$P2" snap_daemon test 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.lchown32 "$P3" snap_daemon test 2>&1   | MATCH "Operation not permitted"
@@ -642,20 +662,30 @@ execute: |
     snap run test-snapd-daemon-user.fchown "$P2" -1 root 2>&1         | MATCH "After: .* uid=0, gid=0"
     snap run test-snapd-daemon-user.fchown32 "$P3" -1 root 2>&1       | MATCH "After: .* uid=0, gid=0"
 
-    echo "'fchown - u:daemon g:daemon' allowed"
+    echo "'fchown - u:snap_daemon g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchown "$P2" snap_daemon snap_daemon 2>&1   | MATCH "After: .* uid=$user, gid=$group"
     snap run test-snapd-daemon-user.fchown32 "$P3" snap_daemon snap_daemon 2>&1 | MATCH "After: .* uid=$user, gid=$group"
 
-    echo "'fchown - u:daemon -1' allowed"
+    echo "'fchown - u:snap_daemon -1' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchown "$P2" snap_daemon -1 2>&1       | MATCH "After: .* uid=$user, gid=0"
     snap run test-snapd-daemon-user.fchown32 "$P3" snap_daemon -1 2>&1     | MATCH "After: .* uid=$user, gid=0"
 
-    echo "'fchown - -1 g:daemon' allowed"
+    echo "'fchown - -1 g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchown "$P2" -1 snap_daemon 2>&1       | MATCH "After: .* uid=0, gid=$group"
     snap run test-snapd-daemon-user.fchown32 "$P3" -1 snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+
+    echo "'fchown - u:snap_daemon g:root' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.fchown "$P2" snap_daemon root 2>&1     | MATCH "After: .* uid=$user, gid=0"
+    snap run test-snapd-daemon-user.fchown32 "$P3" snap_daemon root 2>&1   | MATCH "After: .* uid=$user, gid=0"
+
+    echo "'fchown - u:root g:snap_daemon' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.fchown "$P2" root snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+    snap run test-snapd-daemon-user.fchown32 "$P3" root snap_daemon 2>&1   | MATCH "After: .* uid=0, gid=$group"
 
     echo "'fchown - u:test g:test' denied"
     chown root:root "$P2" "$P3"
@@ -682,12 +712,12 @@ execute: |
     snap run test-snapd-daemon-user.fchown "$P2" root test 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.fchown32 "$P3" root test 2>&1     | MATCH "Operation not permitted"
 
-    echo "'fchown - u:test g:daemon' denied"
+    echo "'fchown - u:test g:snap_daemon' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchown "$P2" test snap_daemon 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.fchown32 "$P3" test snap_daemon 2>&1   | MATCH "Operation not permitted"
 
-    echo "'fchown - u:daemon g:test' denied"
+    echo "'fchown - u:snap_daemon g:test' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchown "$P2" snap_daemon test 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.fchown32 "$P3" snap_daemon test 2>&1   | MATCH "Operation not permitted"
@@ -709,20 +739,30 @@ execute: |
     snap run test-snapd-daemon-user.fchownat "$P2" -1 root 2>&1         | MATCH "After: .* uid=0, gid=0"
     snap run test-snapd-daemon-user.fchownat32 "$P3" -1 root 2>&1       | MATCH "After: .* uid=0, gid=0"
 
-    echo "'fchownat - u:daemon g:daemon' allowed"
+    echo "'fchownat - u:snap_daemon g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchownat "$P2" snap_daemon snap_daemon 2>&1   | MATCH "After: .* uid=$user, gid=$group"
     snap run test-snapd-daemon-user.fchownat32 "$P3" snap_daemon snap_daemon 2>&1 | MATCH "After: .* uid=$user, gid=$group"
 
-    echo "'fchownat - u:daemon -1' allowed"
+    echo "'fchownat - u:snap_daemon -1' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchownat "$P2" snap_daemon -1 2>&1       | MATCH "After: .* uid=$user, gid=0"
     snap run test-snapd-daemon-user.fchownat32 "$P3" snap_daemon -1 2>&1     | MATCH "After: .* uid=$user, gid=0"
 
-    echo "'fchownat - -1 g:daemon' allowed"
+    echo "'fchownat - -1 g:snap_daemon' allowed"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchownat "$P2" -1 snap_daemon 2>&1       | MATCH "After: .* uid=0, gid=$group"
     snap run test-snapd-daemon-user.fchownat32 "$P3" -1 snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+
+    echo "'fchownat - u:snap_daemon g:root' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.fchownat "$P2" snap_daemon root 2>&1     | MATCH "After: .* uid=$user, gid=0"
+    snap run test-snapd-daemon-user.fchownat32 "$P3" snap_daemon root 2>&1   | MATCH "After: .* uid=$user, gid=0"
+
+    echo "'fchownat - u:root g:snap_daemon' allowed"
+    chown root:root "$P2" "$P3"
+    snap run test-snapd-daemon-user.fchownat "$P2" root snap_daemon 2>&1     | MATCH "After: .* uid=0, gid=$group"
+    snap run test-snapd-daemon-user.fchownat32 "$P3" root snap_daemon 2>&1   | MATCH "After: .* uid=0, gid=$group"
 
     echo "'fchownat - u:test g:test' denied"
     chown root:root "$P2" "$P3"
@@ -749,12 +789,12 @@ execute: |
     snap run test-snapd-daemon-user.fchownat "$P2" root test 2>&1       | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.fchownat32 "$P3" root test 2>&1     | MATCH "Operation not permitted"
 
-    echo "'fchownat - u:test g:daemon' denied"
+    echo "'fchownat - u:test g:snap_daemon' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchownat "$P2" test snap_daemon 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.fchownat32 "$P3" test snap_daemon 2>&1   | MATCH "Operation not permitted"
 
-    echo "'fchownat - u:daemon g:test' denied"
+    echo "'fchownat - u:snap_daemon g:test' denied"
     chown root:root "$P2" "$P3"
     snap run test-snapd-daemon-user.fchownat "$P2" snap_daemon test 2>&1     | MATCH "Operation not permitted"
     snap run test-snapd-daemon-user.fchownat32 "$P3" snap_daemon test 2>&1   | MATCH "Operation not permitted"


### PR DESCRIPTION
The current implementation omits rules for allowing use of:

  chown(..., <snap_daemon uid>, 0)
  chown(..., 0, <snap_daemon uid>)

which means people may need to jump through an extra hoop (eg, chown
plus chgrp instead of just chown) when trying to create a file with
'&lt;user&gt;:root' permissions, which is an important use case to avoid
CAP_DAC_OVERRIDE or CAP_DAC_READ_SEARCH.

Also correct some test output strings for s/daemon/snap_daemon/

References:
- https://forum.snapcraft.io/t/system-usernames/13386
