### PR TITLE
osutil: handle "rw" mount flag in ParseMountEntry

### DIFF
--- a/osutil/mountentry_linux.go
+++ b/osutil/mountentry_linux.go
@@ -170,6 +170,8 @@ func ParseMountEntry(s string) (MountEntry, error) {
 func MountOptsToCommonFlags(opts []string) (flags int, unparsed []string) {
 	for _, opt := range opts {
 		switch opt {
+		case "rw":
+			// There's no flag for rw
 		case "ro":
 			flags |= syscall.MS_RDONLY
 		case "nosuid":

--- a/osutil/mountentry_linux_test.go
+++ b/osutil/mountentry_linux_test.go
@@ -210,6 +210,12 @@ func (s *entrySuite) TestMountOptsToCommonFlags(c *C) {
 	flags, unparsed = osutil.MountOptsToCommonFlags([]string{"x-snapd.foo"})
 	c.Assert(flags, Equals, 0)
 	c.Assert(unparsed, HasLen, 0)
+	// The "rw" flag is recognized but doesn't translate to an actual value
+	// since read-write is the implicit default and there are no kernel level
+	// flags to express it.
+	flags, unparsed = osutil.MountOptsToCommonFlags([]string{"rw"})
+	c.Assert(flags, Equals, 0)
+	c.Assert(unparsed, DeepEquals, []string(nil))
 }
 
 func (s *entrySuite) TestOptStr(c *C) {


### PR DESCRIPTION
The "rw" flag is just for show, there's no corresponding flag in the
kernel. "rw" is simply the absence of MS_RDONLY. While this flag was
not parsed by ParseMountEntry the "rw" flag was passed to mount(2) as
unparsed string. This is harmless but undesired.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
