### PR TITLE
osutil/mount: add {Unm,M}outFlagsToOpts helpers

### DIFF
--- a/osutil/mount/mount_linux.go
+++ b/osutil/mount/mount_linux.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"syscall"
+)
+
+// MountFlagsToOpts returns the symbolic representation of mount flags.
+func MountFlagsToOpts(flags int) (opts []string, unknown int) {
+	if f := syscall.MS_REMOUNT; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_REMOUNT")
+	}
+	if f := syscall.MS_BIND; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_BIND")
+	}
+	if f := syscall.MS_REC; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_REC")
+	}
+	if f := syscall.MS_RDONLY; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_RDONLY")
+	}
+	if f := syscall.MS_SHARED; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_SHARED")
+	}
+	if f := syscall.MS_SLAVE; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_SLAVE")
+	}
+	if f := syscall.MS_PRIVATE; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_PRIVATE")
+	}
+	if f := syscall.MS_UNBINDABLE; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MS_UNBINDABLE")
+	}
+	return opts, flags
+}
+
+// UnmountFlagsToOpts returns the symbolic representation of unmount flags.
+func UnmountFlagsToOpts(flags int) (opts []string, unknown int) {
+	const UMOUNT_NOFOLLOW = 8
+	if f := UMOUNT_NOFOLLOW; flags&f == f {
+		flags ^= f
+		opts = append(opts, "UMOUNT_NOFOLLOW")
+	}
+	if f := syscall.MNT_FORCE; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MNT_FORCE")
+	}
+	if f := syscall.MNT_DETACH; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MNT_DETACH")
+	}
+	if f := syscall.MNT_EXPIRE; flags&f == f {
+		flags ^= f
+		opts = append(opts, "MNT_EXPIRE")
+	}
+	return opts, flags
+}

--- a/osutil/mount/mount_linux_test.go
+++ b/osutil/mount/mount_linux_test.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount_test
+
+import (
+	"syscall"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil/mount"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type mountSuite struct{}
+
+var _ = Suite(&mountSuite{})
+
+func (s *mountSuite) TestMountFlagsToOpts(c *C) {
+	// Known flags are converted to symbolic names.
+	opts, unknown := mount.MountFlagsToOpts(syscall.MS_REMOUNT |
+		syscall.MS_BIND | syscall.MS_REC | syscall.MS_RDONLY | syscall.MS_SHARED |
+		syscall.MS_SLAVE | syscall.MS_PRIVATE | syscall.MS_UNBINDABLE)
+	c.Check(opts, DeepEquals, []string{"MS_REMOUNT", "MS_BIND", "MS_REC",
+		"MS_RDONLY", "MS_SHARED", "MS_SLAVE", "MS_PRIVATE", "MS_UNBINDABLE"})
+	c.Check(unknown, Equals, 0)
+	// Unknown flags are retained and returned.
+	opts, unknown = mount.MountFlagsToOpts(1 << 24)
+	c.Check(opts, DeepEquals, []string(nil))
+	c.Check(unknown, Equals, 1<<24)
+}
+
+func (s *mountSuite) TestUnmountFlagsToOpts(c *C) {
+	// Known flags are converted to symbolic names.
+	const UMOUNT_NOFOLLOW = 8
+	opts, unknown := mount.UnmountFlagsToOpts(syscall.MNT_FORCE |
+		syscall.MNT_DETACH | syscall.MNT_EXPIRE | UMOUNT_NOFOLLOW)
+	c.Check(opts, DeepEquals, []string{"UMOUNT_NOFOLLOW", "MNT_FORCE",
+		"MNT_DETACH", "MNT_EXPIRE"})
+	c.Check(unknown, Equals, 0)
+	// Unknown flags are retained and returned.
+	opts, unknown = mount.UnmountFlagsToOpts(1 << 24)
+	c.Check(opts, DeepEquals, []string(nil))
+	c.Check(unknown, Equals, 1<<24)
+}

--- a/osutil/mount/mount_linux_test.go
+++ b/osutil/mount/mount_linux_test.go
@@ -46,6 +46,10 @@ func (s *mountSuite) TestMountFlagsToOpts(c *C) {
 	opts, unknown = mount.MountFlagsToOpts(1 << 24)
 	c.Check(opts, DeepEquals, []string(nil))
 	c.Check(unknown, Equals, 1<<24)
+	// Known and unknown flags work in tandem.
+	opts, unknown = mount.MountFlagsToOpts(syscall.MS_BIND | 1<<24)
+	c.Check(opts, DeepEquals, []string{"MS_BIND"})
+	c.Check(unknown, Equals, 1<<24)
 }
 
 func (s *mountSuite) TestUnmountFlagsToOpts(c *C) {
@@ -59,5 +63,9 @@ func (s *mountSuite) TestUnmountFlagsToOpts(c *C) {
 	// Unknown flags are retained and returned.
 	opts, unknown = mount.UnmountFlagsToOpts(1 << 24)
 	c.Check(opts, DeepEquals, []string(nil))
+	c.Check(unknown, Equals, 1<<24)
+	// Known and unknown flags work in tandem.
+	opts, unknown = mount.UnmountFlagsToOpts(syscall.MNT_DETACH | 1<<24)
+	c.Check(opts, DeepEquals, []string{"MNT_DETACH"})
 	c.Check(unknown, Equals, 1<<24)
 }

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -28,6 +28,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/osutil/mount"
 	"github.com/snapcore/snapd/osutil/sys"
 )
 
@@ -109,41 +110,9 @@ func formatOpenFlags(flags int) string {
 // Not all flags are handled. Unknown flags cause a panic.
 // Please expand the set of recognized flags as tests require.
 func formatMountFlags(flags int) string {
-	var fl []string
-	if flags&syscall.MS_REMOUNT == syscall.MS_REMOUNT {
-		flags ^= syscall.MS_REMOUNT
-		fl = append(fl, "MS_REMOUNT")
-	}
-	if flags&syscall.MS_BIND == syscall.MS_BIND {
-		flags ^= syscall.MS_BIND
-		fl = append(fl, "MS_BIND")
-	}
-	if flags&syscall.MS_REC == syscall.MS_REC {
-		flags ^= syscall.MS_REC
-		fl = append(fl, "MS_REC")
-	}
-	if flags&syscall.MS_RDONLY == syscall.MS_RDONLY {
-		flags ^= syscall.MS_RDONLY
-		fl = append(fl, "MS_RDONLY")
-	}
-	if flags&syscall.MS_SHARED == syscall.MS_SHARED {
-		flags ^= syscall.MS_SHARED
-		fl = append(fl, "MS_SHARED")
-	}
-	if flags&syscall.MS_SLAVE == syscall.MS_SLAVE {
-		flags ^= syscall.MS_SLAVE
-		fl = append(fl, "MS_SLAVE")
-	}
-	if flags&syscall.MS_PRIVATE == syscall.MS_PRIVATE {
-		flags ^= syscall.MS_PRIVATE
-		fl = append(fl, "MS_PRIVATE")
-	}
-	if flags&syscall.MS_UNBINDABLE == syscall.MS_UNBINDABLE {
-		flags ^= syscall.MS_UNBINDABLE
-		fl = append(fl, "MS_UNBINDABLE")
-	}
-	if flags != 0 {
-		panic(fmt.Errorf("unrecognized mount flags %d", flags))
+	fl, unknown := mount.MountFlagsToOpts(flags)
+	if unknown != 0 {
+		panic(fmt.Errorf("unrecognized mount flags %d", unknown))
 	}
 	if len(fl) == 0 {
 		return "0"
@@ -156,17 +125,9 @@ func formatMountFlags(flags int) string {
 // Not all flags are handled. Unknown flags cause a panic.
 // Please expand the set of recognized flags as tests require.
 func formatUnmountFlags(flags int) string {
-	var fl []string
-	if flags&umountNoFollow == umountNoFollow {
-		flags ^= umountNoFollow
-		fl = append(fl, "UMOUNT_NOFOLLOW")
-	}
-	if flags&syscall.MNT_DETACH == syscall.MNT_DETACH {
-		flags ^= syscall.MNT_DETACH
-		fl = append(fl, "MNT_DETACH")
-	}
-	if flags != 0 {
-		panic(fmt.Errorf("unrecognized unmount flags %d", flags))
+	fl, unknown := mount.UnmountFlagsToOpts(flags)
+	if unknown != 0 {
+		panic(fmt.Errorf("unrecognized unmount flags %d", unknown))
 	}
 	if len(fl) == 0 {
 		return "0"


### PR DESCRIPTION
The pair of helpers turn numeric flags for mount(2) and umount(2) to a
list of source constants that are useful for debugging. We had,
partially, similar helpers in lowlevel test-only code. Those are now
simple wrappers around the more general logic.

Due to cyclic imports osutil -> testutil -> osutil I've added the
new helpers to osutil/mount.

The new helpers will be shortly used by snap-update-ns logging
routines.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
