### PR TITLE
many: share single implementation to list needed default-providers

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -696,25 +696,6 @@ var contentLinkRetryTimeout = 30 * time.Second
 // timeout for retrying hotplug-related tasks
 var hotplugRetryTimeout = 300 * time.Millisecond
 
-// defaultContentProviders returns a dict of the default-providers for the
-// content plugs for the given instanceName
-func (m *InterfaceManager) defaultContentProviders(instanceName string) map[string]bool {
-	plugs := m.repo.Plugs(instanceName)
-	defaultProviders := make(map[string]bool, len(plugs))
-	for _, plug := range plugs {
-		if plug.Interface == "content" {
-			var s string
-			if err := plug.Attr("content", &s); err == nil && s != "" {
-				var dprovider string
-				if err := plug.Attr("default-provider", &dprovider); err == nil && dprovider != "" {
-					defaultProviders[dprovider] = true
-				}
-			}
-		}
-	}
-	return defaultProviders
-}
-
 func obsoleteCorePhase2SetupProfiles(kind string, task *state.Task) (bool, error) {
 	if kind != "setup-profiles" {
 		return false, nil
@@ -998,7 +979,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 	// wait for auto-install, started by prerequisites code, for
 	// the default-providers of content ifaces so we can
 	// auto-connect to them
-	defaultProviders := m.defaultContentProviders(snapName)
+	defaultProviders := snap.DefaultContentProviders(m.repo.Plugs(snapName))
 	for _, chg := range st.Changes() {
 		if chg.Status().Ready() {
 			continue
@@ -1014,7 +995,8 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 				// Only retry if the task that installs the
 				// content provider is not waiting for us
 				// (or this will just hang forever).
-				if defaultProviders[snapsup.InstanceName()] && !inSameChangeWaitChain(task, t) {
+				_, ok := defaultProviders[snapsup.InstanceName()]
+				if ok && !inSameChangeWaitChain(task, t) {
 					return &state.Retry{After: contentLinkRetryTimeout}
 				}
 			}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -978,7 +978,13 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	// wait for auto-install, started by prerequisites code, for
 	// the default-providers of content ifaces so we can
-	// auto-connect to them
+	// auto-connect to them; snapstate prerequisites does a bit
+	// more filtering than this so defaultProviders here can
+	// contain some more snaps; should not be an issue in practice
+	// given the check below checks for same chain and we don't
+	// forcefully wait for defaultProviders; we just retry for
+	// things in the intersection between defaultProviders here and
+	// snaps with not ready link-snap|setup-profiles tasks
 	defaultProviders := snap.DefaultContentProviders(m.repo.Plugs(snapName))
 	for _, chg := range st.Changes() {
 		if chg.Status().Ready() {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -504,15 +504,11 @@ func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
 	avail := contentIfaceAvailable(st)
 	out := []string{}
 	for snapInstance, contentTags := range needed {
-		snapNeeded := false
 		for _, contentTag := range contentTags {
 			if !avail[contentTag] {
-				snapNeeded = true
+				out = append(out, snapInstance)
 				break
 			}
-		}
-		if snapNeeded {
-			out = append(out, snapInstance)
 		}
 	}
 	return out

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
@@ -481,44 +480,39 @@ func contentAttr(attrer interfaces.Attrer) string {
 	return s
 }
 
-func contentIfaceAvailable(st *state.State, contentTag string) bool {
+func contentIfaceAvailable(st *state.State) map[string]bool {
 	repo := ifacerepo.Get(st)
-	for _, slot := range repo.AllSlots("content") {
-		if contentAttr(slot) == "" {
+	contentSlots := repo.AllSlots("content")
+	avail := make(map[string]bool, len(contentSlots))
+	for _, slot := range contentSlots {
+		contentTag := contentAttr(slot)
+		if contentTag == "" {
 			continue
 		}
-		if contentAttr(slot) == contentTag {
-			return true
-		}
+		avail[contentTag] = true
 	}
-	return false
+	return avail
 }
 
 // defaultContentPlugProviders takes a snap.Info and returns what
 // default providers there are.
 func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
+	needed := snap.NeededDefaultProviders(info)
+	if len(needed) == 0 {
+		return nil
+	}
+	avail := contentIfaceAvailable(st)
 	out := []string{}
-	seen := map[string]bool{}
-	for _, plug := range info.Plugs {
-		if plug.Interface == "content" {
-			if contentAttr(plug) == "" {
-				continue
+	for snapInstance, contentTags := range needed {
+		snapNeeded := false
+		for _, contentTag := range contentTags {
+			if !avail[contentTag] {
+				snapNeeded = true
+				break
 			}
-			if !contentIfaceAvailable(st, contentAttr(plug)) {
-				var dprovider string
-				err := plug.Attr("default-provider", &dprovider)
-				if err != nil || dprovider == "" {
-					continue
-				}
-				// The default-provider is a name. However old
-				// documentation said it is "snapname:ifname",
-				// we deal with this gracefully by just
-				// stripping of the part after the ":"
-				if name := strings.SplitN(dprovider, ":", 2)[0]; !seen[name] {
-					out = append(out, name)
-					seen[name] = true
-				}
-			}
+		}
+		if snapNeeded {
+			out = append(out, snapInstance)
 		}
 	}
 	return out

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -841,7 +841,7 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap) error {
 			return err
 		}
 		// error about missing default providers
-		for _, dp := range snap.NeededDefaultProviders(info) {
+		for dp := range snap.NeededDefaultProviders(info) {
 			if !w.availableSnaps.Contains(naming.Snap(dp)) {
 				// TODO: have a way to ignore this issue on a snap by snap basis?
 				return fmt.Errorf("cannot use snap %q without its default content provider %q being added explicitly", info.SnapName(), dp)

--- a/snap/info.go
+++ b/snap/info.go
@@ -665,6 +665,39 @@ func (slot *SlotInfo) String() string {
 	return fmt.Sprintf("%s:%s", slot.Snap.InstanceName(), slot.Name)
 }
 
+func gatherDefaultContentProvider(providerSnapsToContentTag map[string][]string, plug *PlugInfo) {
+	if plug.Interface == "content" {
+		var dprovider string
+		if err := plug.Attr("default-provider", &dprovider); err == nil && dprovider != "" {
+			// usage can be "snap:slot" but slot
+			// is ignored/unused
+			name := strings.Split(dprovider, ":")[0]
+			var contentTag string
+			plug.Attr("content", &contentTag)
+			tags := providerSnapsToContentTag[name]
+			if tags == nil {
+				tags = []string{contentTag}
+			} else {
+				if !strutil.SortedListContains(tags, contentTag) {
+					tags = append(tags, contentTag)
+					sort.Strings(tags)
+				}
+			}
+			providerSnapsToContentTag[name] = tags
+		}
+	}
+}
+
+// DefaultContentProviders returns the set of default provider snaps
+// requested by the given plugs, mapped to their content tags.
+func DefaultContentProviders(plugs []*PlugInfo) (providerSnapsToContentTag map[string][]string) {
+	providerSnapsToContentTag = make(map[string][]string)
+	for _, plug := range plugs {
+		gatherDefaultContentProvider(providerSnapsToContentTag, plug)
+	}
+	return providerSnapsToContentTag
+}
+
 // SlotInfo provides information about a slot.
 type SlotInfo struct {
 	Snap *Info

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1380,6 +1380,19 @@ func (s *infoSuite) TestDottedPathPlug(c *C) {
 	c.Assert(ok, Equals, false)
 }
 
+func (s *infoSuite) TestDefaultContentProviders(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(yamlNeedDf))
+	c.Assert(err, IsNil)
+
+	plugs := make([]*snap.PlugInfo, 0, len(info.Plugs))
+	for _, plug := range info.Plugs {
+		plugs = append(plugs, plug)
+	}
+
+	dps := snap.DefaultContentProviders(plugs)
+	c.Check(dps, DeepEquals, map[string][]string{"gtk-common-themes": {"gtk-3-themes", "icon-themes"}})
+}
+
 func (s *infoSuite) TestExpandSnapVariables(c *C) {
 	dirs.SetRootDir("")
 	info, err := snap.InfoFromSnapYaml([]byte(`name: foo`))

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1580,7 +1580,13 @@ version: 1.0
 plugs:
   gtk-3-themes:
     interface: content
+    content: gtk-3-themes
     default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    content: icon-themes
+    default-provider: gtk-common-themes
+
 `
 
 func (s *ValidateSuite) TestNeededDefaultProviders(c *C) {
@@ -1589,7 +1595,7 @@ func (s *ValidateSuite) TestNeededDefaultProviders(c *C) {
 	c.Assert(err, IsNil)
 
 	dps := NeededDefaultProviders(info)
-	c.Check(dps, DeepEquals, []string{"gtk-common-themes"})
+	c.Check(dps, DeepEquals, map[string][]string{"gtk-common-themes": {"gtk-3-themes", "icon-themes"}})
 }
 
 const yamlNeedDfWithSlot = `name: need-df
@@ -1606,7 +1612,7 @@ func (s *ValidateSuite) TestNeededDefaultProvidersLegacyColonSyntax(c *C) {
 	c.Assert(err, IsNil)
 
 	dps := NeededDefaultProviders(info)
-	c.Check(dps, DeepEquals, []string{"gtk-common-themes2"})
+	c.Check(dps, DeepEquals, map[string][]string{"gtk-common-themes2": {""}})
 }
 
 func (s *validateSuite) TestValidateSnapMissingCore(c *C) {


### PR DESCRIPTION
Let snap export actually two helpers related to this, one taking []*snap.PlugInfo, the other starting from *snap.Info. The core logic is shared though.