### PR TITLE
overlord/snapstate: pick up system defaults when seeding the snapd snap

### DIFF
--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -23,13 +23,16 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -38,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func TestConfigState(t *testing.T) { TestingT(t) }
@@ -255,4 +259,180 @@ volumes:
 
 	err = s.handler.Before()
 	c.Check(err, ErrorMatches, `cannot apply gadget config defaults for snap "test-snap", no configure hook`)
+}
+
+type configcoreHandlerSuite struct {
+	testutil.BaseTest
+
+	o     *overlord.Overlord
+	state *state.State
+}
+
+var _ = Suite(&configcoreHandlerSuite{})
+
+func (s *configcoreHandlerSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	s.o = overlord.Mock()
+	s.state = s.o.State()
+
+	restore := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	s.AddCleanup(restore)
+
+	hookMgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
+	c.Assert(err, IsNil)
+	s.o.AddManager(hookMgr)
+	r := configstate.MockConfigcoreExportExperimentalFlags(func(_ config.Conf) error {
+		return nil
+	})
+	s.AddCleanup(r)
+
+	err = configstate.Init(s.state, hookMgr)
+
+	c.Assert(err, IsNil)
+	s.o.AddManager(s.o.TaskRunner())
+
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+		"gadget": "canonical-pc",
+	}))
+	s.AddCleanup(r)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", true)
+	snapstate.Set(s.state, "canonical-pc", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "canonical-pc", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "gadget",
+	})
+}
+
+const mockGadgetSnapYaml = `
+name: canonical-pc
+type: gadget
+`
+
+func (s *configcoreHandlerSuite) TestRunsWhenSnapdOnly(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	var mockGadgetYaml = `
+defaults:
+  system:
+      foo: bar
+
+volumes:
+    volume-id:
+        bootloader: grub
+`
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts := configstate.Configure(s.state, "core", nil, snapstate.UseConfigDefaults)
+	chg := s.state.NewChange("configure-core", "configure core")
+	chg.AddAll(ts)
+
+	snaptest.MockSnapWithFiles(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)}, [][]string{
+		{"meta/gadget.yaml", mockGadgetYaml},
+	})
+
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	witnessConfigcoreRun := func(conf config.Conf) error {
+		// called with no state lock!
+		conf.State().Lock()
+		defer conf.State().Unlock()
+		var val string
+		err := conf.Get("core", "foo", &val)
+		c.Assert(err, IsNil)
+		c.Check(val, Equals, "bar")
+		return nil
+	}
+	r = configstate.MockConfigcoreRun(witnessConfigcoreRun)
+	defer r()
+
+	s.state.Unlock()
+	err := s.o.Settle(5 * time.Second)
+	s.state.Lock()
+	// Initialize context
+	c.Assert(err, IsNil)
+
+	tr := config.NewTransaction(s.state)
+	var foo string
+	err = tr.Get("core", "foo", &foo)
+	c.Assert(err, IsNil)
+	c.Check(foo, Equals, "bar")
+}
+
+func (s *configcoreHandlerSuite) TestRunsWhenCoreOnly(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	var mockGadgetYaml = `
+defaults:
+  system:
+      foo: bar
+
+volumes:
+    volume-id:
+        bootloader: grub
+`
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts := configstate.Configure(s.state, "core", nil, snapstate.UseConfigDefaults)
+	chg := s.state.NewChange("configure-core", "configure core")
+	chg.AddAll(ts)
+
+	snaptest.MockSnapWithFiles(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)}, [][]string{
+		{"meta/gadget.yaml", mockGadgetYaml},
+	})
+
+	snapstate.Set(s.state, "core", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "core", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "os",
+	})
+
+	witnessConfigcoreRun := func(conf config.Conf) error {
+		// called with no state lock!
+		conf.State().Lock()
+		defer conf.State().Unlock()
+		var val string
+		err := conf.Get("core", "foo", &val)
+		c.Assert(err, IsNil)
+		c.Check(val, Equals, "bar")
+		return nil
+	}
+	r = configstate.MockConfigcoreRun(witnessConfigcoreRun)
+	defer r()
+
+	s.state.Unlock()
+	err := s.o.Settle(5 * time.Second)
+	s.state.Lock()
+	// Initialize context
+	c.Assert(err, IsNil)
+
+	tr := config.NewTransaction(s.state)
+	var foo string
+	err = tr.Get("core", "foo", &foo)
+	c.Assert(err, IsNil)
+	c.Check(foo, Equals, "bar")
 }

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -96,7 +96,8 @@ func (h *configureHandler) Before() error {
 		if err != nil && err != state.ErrNoState {
 			return err
 		}
-		if len(patch) != 0 {
+		// core does not need a configure hook
+		if len(patch) != 0 && instanceName != "core" {
 			// TODO: helper on context?
 			info, err := snapstate.CurrentInfo(st, instanceName)
 			if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2337,6 +2337,45 @@ func coreInfo(st *state.State) (*snap.Info, error) {
 	return nil, fmt.Errorf("unexpected number of cores, got %d", len(res))
 }
 
+func useSystemDefaults(st *state.State, snapName string) (bool, error) {
+	// there is an implicit configure task for the 'core' snap added even on
+	// systems not using core
+	if snapName != defaultCoreSnapName {
+		return false, nil
+	}
+	hasCore, err := isInstalled(st, "core")
+	if err != nil {
+		return false, err
+	}
+	hasSnapd, err := isInstalled(st, "snapd")
+	if err != nil {
+		return false, err
+	}
+	var seeded bool
+	if err = st.Get("seeded", &seeded); err != nil && err != state.ErrNoState {
+		return false, err
+	}
+	if seeded {
+		// already seeded, will not reapply defaults
+		return false, nil
+	}
+
+	// still seeding
+
+	if hasSnapd && !hasCore {
+		// seeding installs snapd first, it is already installed but no
+		// core is not (yet), snapd is considered a system snap
+		return true, nil
+	}
+
+	if hasCore && !hasSnapd {
+		// no snapd, core is considered a snap with system defaults
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // ConfigDefaults returns the configuration defaults for the snap as
 // specified in the gadget for the given device context.
 // If gadget is absent or the snap has no snap-id it returns
@@ -2347,18 +2386,25 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, err
 	}
 
-	var snapst SnapState
-	if err := Get(st, snapName, &snapst); err != nil {
+	isSystemDefaults, err := useSystemDefaults(st, snapName)
+	if err != nil {
+		fmt.Printf("use system defaults fail: %v\n", err)
 		return nil, err
 	}
 
-	isCoreDefaults := snapName == defaultCoreSnapName
+	var snapst SnapState
+	if err := Get(st, snapName, &snapst); err != nil && err != state.ErrNoState {
+		return nil, err
+	}
 
-	si := snapst.CurrentSideInfo()
-	// core snaps can be addressed even without a snap-id via the special
-	// "system" value in the config; first-boot always configures the core
-	// snap with UseConfigDefaults
-	if si.SnapID == "" && !isCoreDefaults {
+	var snapID string
+	if snapst.IsInstalled() {
+		snapID = snapst.CurrentSideInfo().SnapID
+	}
+	// system snaps (core and snapd) snaps can be addressed even without a
+	// snap-id via the special "system" value in the config; first-boot
+	// always configures the core snap with UseConfigDefaults
+	if snapID == "" && !isSystemDefaults {
 		return nil, state.ErrNoState
 	}
 
@@ -2372,9 +2418,9 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 	}
 
 	// we support setting core defaults via "system"
-	if isCoreDefaults {
+	if isSystemDefaults {
 		if defaults, ok := gadgetInfo.Defaults["system"]; ok {
-			if _, ok := gadgetInfo.Defaults[si.SnapID]; ok && si.SnapID != "" {
+			if _, ok := gadgetInfo.Defaults[snapID]; ok && snapID != "" {
 				logger.Noticef("core snap configuration defaults found under both 'system' key and core-snap-id, preferring 'system'")
 			}
 
@@ -2382,7 +2428,7 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		}
 	}
 
-	defaults, ok := gadgetInfo.Defaults[si.SnapID]
+	defaults, ok := gadgetInfo.Defaults[snapID]
 	if !ok {
 		return nil, state.ErrNoState
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2337,45 +2337,6 @@ func coreInfo(st *state.State) (*snap.Info, error) {
 	return nil, fmt.Errorf("unexpected number of cores, got %d", len(res))
 }
 
-func useSystemDefaults(st *state.State, snapName string) (bool, error) {
-	// there is an implicit configure task for the 'core' snap added even on
-	// systems not using core
-	if snapName != defaultCoreSnapName {
-		return false, nil
-	}
-	hasCore, err := isInstalled(st, "core")
-	if err != nil {
-		return false, err
-	}
-	hasSnapd, err := isInstalled(st, "snapd")
-	if err != nil {
-		return false, err
-	}
-	var seeded bool
-	if err = st.Get("seeded", &seeded); err != nil && err != state.ErrNoState {
-		return false, err
-	}
-	if seeded {
-		// already seeded, will not reapply defaults
-		return false, nil
-	}
-
-	// still seeding
-
-	if hasSnapd && !hasCore {
-		// seeding installs snapd first, it is already installed but no
-		// core is not (yet), snapd is considered a system snap
-		return true, nil
-	}
-
-	if hasCore && !hasSnapd {
-		// no snapd, core is considered a snap with system defaults
-		return true, nil
-	}
-
-	return false, nil
-}
-
 // ConfigDefaults returns the configuration defaults for the snap as
 // specified in the gadget for the given device context.
 // If gadget is absent or the snap has no snap-id it returns
@@ -2386,12 +2347,9 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, err
 	}
 
-	isSystemDefaults, err := useSystemDefaults(st, snapName)
-	if err != nil {
-		fmt.Printf("use system defaults fail: %v\n", err)
-		return nil, err
-	}
-
+	// system configuration is kept under "core" so apply its defaults when
+	// configuring "core"
+	isSystemDefaults := snapName == defaultCoreSnapName
 	var snapst SnapState
 	if err := Get(st, snapName, &snapst); err != nil && err != state.ErrNoState {
 		return nil, err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12380,7 +12380,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
-func (s *snapmgrTestSuite) TestConfigDefaultsSystem(c *C) {
+func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithCoreNoSnapd(c *C) {
 	r := release.MockOnClassic(false)
 	defer r()
 
@@ -12390,6 +12390,8 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSystem(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	s.state.Set("seeded", nil)
+
 	s.prepareGadget(c, `
 defaults:
     system:
@@ -12398,11 +12400,174 @@ defaults:
 
 	deviceCtx := deviceWithGadgetContext("the-gadget")
 
+	snapstate.Set(s.state, "core", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", Revision: snap.R(11), SnapID: "the-core-ididididididididididid"},
+		},
+		Current:  snap.R(11),
+		SnapType: "os",
+	})
+
 	makeInstalledMockCoreSnap(c)
 
 	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
 	c.Assert(err, IsNil)
 	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
+}
+
+var snapdSnapYaml = `name: snapd
+version: 1.0
+type: snapd
+`
+
+func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithSnapdNoCore(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	// using MockSnapReadInfo, we want to read the bits on disk
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", nil)
+
+	s.prepareGadget(c, `
+defaults:
+    system:
+        foo: bar
+`)
+
+	deviceCtx := &snapstatetest.TrivialDeviceContext{
+		DeviceModel: MakeModel(map[string]interface{}{
+			"gadget": "the-gadget",
+			"base":   "the-base",
+		}),
+	}
+
+	snapstate.Set(s.state, "core", nil)
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", SnapID: "the-snapd-snapidididididididididi", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	snaptest.MockSnap(c, snapdSnapYaml, &snap.SideInfo{
+		RealName: "snapd",
+		Revision: snap.R(1),
+	})
+
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
+	c.Assert(err, IsNil)
+	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
+}
+
+func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithSnapdAndCoreInSeeding(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	// using MockSnapReadInfo, we want to read the bits on disk
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", nil)
+
+	s.prepareGadget(c, `
+defaults:
+    system:
+        foo: bar
+`)
+
+	deviceCtx := &snapstatetest.TrivialDeviceContext{
+		DeviceModel: MakeModel(map[string]interface{}{
+			"gadget": "the-gadget",
+			"base":   "the-base",
+		}),
+	}
+
+	// core already configured by test set up
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", SnapID: "the-snapd-snapidididididididididi", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	snaptest.MockSnap(c, snapdSnapYaml, &snap.SideInfo{
+		RealName: "snapd",
+		Revision: snap.R(1),
+	})
+
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
+	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(defls, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestConfigDefaultsSystemSeeded(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	// using MockSnapReadInfo, we want to read the bits on disk
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.state.Set("seeded", true)
+
+	s.prepareGadget(c, `
+defaults:
+    system:
+        foo: bar
+`)
+
+	deviceCtx := &snapstatetest.TrivialDeviceContext{
+		DeviceModel: MakeModel(map[string]interface{}{
+			"gadget": "the-gadget",
+		}),
+	}
+
+	snaptest.MockSnap(c, snapdSnapYaml, &snap.SideInfo{
+		RealName: "snapd",
+		Revision: snap.R(1),
+	})
+
+	snapdSnapst := &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", SnapID: "the-snapd-snapidididididididididi", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	}
+	// core already configured by test set up
+	snapstate.Set(s.state, "snapd", snapdSnapst)
+
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
+	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(defls, IsNil)
+
+	// snapd disappears, core remains
+	snapstate.Set(s.state, "snapd", nil)
+
+	defls, err = snapstate.ConfigDefaults(s.state, deviceCtx, "core")
+	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(defls, IsNil)
+
+	snapstate.Set(s.state, "core", nil)
+	snapstate.Set(s.state, "snapd", snapdSnapst)
+
+	defls, err = snapstate.ConfigDefaults(s.state, deviceCtx, "core")
+	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(defls, IsNil)
 }
 
 func (s *snapmgrTestSuite) TestConfigDefaultsSystemConflictsCoreSnapId(c *C) {
@@ -12414,6 +12579,8 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSystemConflictsCoreSnapId(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	s.state.Set("seeded", nil)
 
 	s.prepareGadget(c, `
 defaults:

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12380,7 +12380,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
-func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithCoreNoSnapd(c *C) {
+func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithCore(c *C) {
 	r := release.MockOnClassic(false)
 	defer r()
 
@@ -12389,8 +12389,6 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithCoreNoSnapd(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	s.state.Set("seeded", nil)
 
 	s.prepareGadget(c, `
 defaults:
@@ -12431,8 +12429,6 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithSnapdNoCore(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.state.Set("seeded", nil)
-
 	s.prepareGadget(c, `
 defaults:
     system:
@@ -12466,110 +12462,6 @@ defaults:
 	c.Assert(defls, DeepEquals, map[string]interface{}{"foo": "bar"})
 }
 
-func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithSnapdAndCoreInSeeding(c *C) {
-	r := release.MockOnClassic(false)
-	defer r()
-
-	// using MockSnapReadInfo, we want to read the bits on disk
-	snapstate.MockSnapReadInfo(snap.ReadInfo)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	s.state.Set("seeded", nil)
-
-	s.prepareGadget(c, `
-defaults:
-    system:
-        foo: bar
-`)
-
-	deviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel(map[string]interface{}{
-			"gadget": "the-gadget",
-			"base":   "the-base",
-		}),
-	}
-
-	// core already configured by test set up
-	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Active: true,
-		Sequence: []*snap.SideInfo{
-			{RealName: "snapd", SnapID: "the-snapd-snapidididididididididi", Revision: snap.R(1)},
-		},
-		Current:  snap.R(1),
-		SnapType: "snapd",
-	})
-
-	snaptest.MockSnap(c, snapdSnapYaml, &snap.SideInfo{
-		RealName: "snapd",
-		Revision: snap.R(1),
-	})
-
-	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
-	c.Assert(err, Equals, state.ErrNoState)
-	c.Assert(defls, IsNil)
-}
-
-func (s *snapmgrTestSuite) TestConfigDefaultsSystemSeeded(c *C) {
-	r := release.MockOnClassic(false)
-	defer r()
-
-	// using MockSnapReadInfo, we want to read the bits on disk
-	snapstate.MockSnapReadInfo(snap.ReadInfo)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	s.state.Set("seeded", true)
-
-	s.prepareGadget(c, `
-defaults:
-    system:
-        foo: bar
-`)
-
-	deviceCtx := &snapstatetest.TrivialDeviceContext{
-		DeviceModel: MakeModel(map[string]interface{}{
-			"gadget": "the-gadget",
-		}),
-	}
-
-	snaptest.MockSnap(c, snapdSnapYaml, &snap.SideInfo{
-		RealName: "snapd",
-		Revision: snap.R(1),
-	})
-
-	snapdSnapst := &snapstate.SnapState{
-		Active: true,
-		Sequence: []*snap.SideInfo{
-			{RealName: "snapd", SnapID: "the-snapd-snapidididididididididi", Revision: snap.R(1)},
-		},
-		Current:  snap.R(1),
-		SnapType: "snapd",
-	}
-	// core already configured by test set up
-	snapstate.Set(s.state, "snapd", snapdSnapst)
-
-	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "core")
-	c.Assert(err, Equals, state.ErrNoState)
-	c.Assert(defls, IsNil)
-
-	// snapd disappears, core remains
-	snapstate.Set(s.state, "snapd", nil)
-
-	defls, err = snapstate.ConfigDefaults(s.state, deviceCtx, "core")
-	c.Assert(err, Equals, state.ErrNoState)
-	c.Assert(defls, IsNil)
-
-	snapstate.Set(s.state, "core", nil)
-	snapstate.Set(s.state, "snapd", snapdSnapst)
-
-	defls, err = snapstate.ConfigDefaults(s.state, deviceCtx, "core")
-	c.Assert(err, Equals, state.ErrNoState)
-	c.Assert(defls, IsNil)
-}
-
 func (s *snapmgrTestSuite) TestConfigDefaultsSystemConflictsCoreSnapId(c *C) {
 	r := release.MockOnClassic(false)
 	defer r()
@@ -12579,8 +12471,6 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSystemConflictsCoreSnapId(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	s.state.Set("seeded", nil)
 
 	s.prepareGadget(c, `
 defaults:

--- a/tests/lib/assertions/developer1-pc-18-w-config.model
+++ b/tests/lib/assertions/developer1-pc-18-w-config.model
@@ -1,0 +1,24 @@
+type: model
+authority-id: developer1
+series: 16
+brand-id: developer1
+model: my-model-w-config-18
+architecture: amd64
+base: core18
+gadget: pc=18
+kernel: pc-kernel=18
+required-snaps:
+  - test-snapd-with-configure-core18
+timestamp: 2019-11-26T09:42:00+00:00
+sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+
+AcLBUgQAAQoABgUCXdzmtgAANuQQAAAhKcYThYCAvCbGwFdhAs8JELgWv6jSNDvYEMXG1ZVfjL7C
+DxKpeJhiEJ5fKkbRIAZJ7cEhISv9k6ht266B9DsCgcWx65yGksg8bRDAPoy5N68EWMGM0Xxz+kzR
+96I+qCLqR1BrnCPuZmjsiPYwG/R6aS1vSo7tEiy3v/Z0E5CeLjP1p2RXqqqcTBA2jh+OjzGIPY2w
+K9Py1L7gBl0XiAnBtbp9ikxB+8g/2L0FbjcsJLNxw0fUosmlgkwZWoJ3W0ys3gydyXR4J3UZRD6v
+iL3pVIjMzRRwrNUAS30UmSGkp3yK6CQ335/mlB7KIXuOBtf5iufBdHK26j/4ltyiPPpWLcXfI5q6
+/Qljki3XC5r4kqZLDsvuQKE8AnkzgLPP/C1uanJA83s/DkNlUncLefbkVgBerY+ueD/P9U4ovQl7
+YXMSgbS7WpXQvI7BISrYl7fut6HP8mHWdWPqdsXDGFDzQULLAG17l1nqmoZ8eXM1SUuZuhlL+Muu
+75timOX62cEydEEb4zf4HNuhYx/a++LircrQl7WNZT9dzqCpDq3ewOMO2isjvHtF2rWWptG6FJhf
+Fbmi6eGvwu+xy8pzH2IvdyQ9n/Z9mZh+QiwooVNs40FnKbZHtBgobjZnGBvxXiBeKOUfqmp1VwUE
+UVwevw1Rgpq36YUc/WkTIvtomfRi

--- a/tests/lib/assertions/developer1-pc-18-w-config.model.json
+++ b/tests/lib/assertions/developer1-pc-18-w-config.model.json
@@ -1,0 +1,12 @@
+{
+    "type": "model",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "my-model-w-config-18",
+    "architecture": "amd64",
+    "base": "core18",
+    "gadget": "pc=18",
+    "kernel": "pc-kernel=18",
+    "required-snaps": ["test-snapd-with-configure-core18"],
+    "timestamp": "2019-11-26T09:42:00+00:00"
+}

--- a/tests/main/ubuntu-core-gadget-config-defaults/manip_seed.py
+++ b/tests/main/ubuntu-core-gadget-config-defaults/manip_seed.py
@@ -1,5 +1,6 @@
 import sys
 import yaml
+from os import path
 
 with open(sys.argv[1]) as f:
     seed = yaml.load(f)
@@ -17,8 +18,10 @@ while i < len(snaps):
         break
     i += 1
 
+# test-snapd-with-configure_123.snap -> test-snapd-configure
+snapname = path.basename(sys.argv[2]).split('_')[0]
 snaps.append({
-    "name": "test-snapd-with-configure",
+    "name": snapname,
     "channel": "edge",
     "file": sys.argv[2],
 })

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -2,7 +2,7 @@ summary: |
    Test that config defaults specified in the gadget are picked up
    for first boot snaps
 
-systems: [ubuntu-core-16-64]
+systems: [ubuntu-core-*]
 
 environment:
     SERVICE/rsyslog: rsyslog
@@ -19,19 +19,41 @@ prepare: |
     fi
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+
+    SUFFIX=
+    MODEL=developer1-pc-w-config.model
+    if is_core18_system; then
+        SUFFIX=-core18
+        MODEL=developer1-pc-18-w-config.model
+    fi
+
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/assertions/*
     rm -rf /var/lib/snapd/device
     rm -rf /var/lib/snapd/state.json
-    snap download --edge test-snapd-with-configure
+    snap download --edge "test-snapd-with-configure${SUFFIX}"
     unsquashfs -no-progress /var/lib/snapd/snaps/pc_*.snap
 
     # fill in defaults
     TEST_SNAP_ID=
     if [ "$SNAPPY_USE_STAGING_STORE" = 1 ]; then
+        # test-snapd-with-configure
         TEST_SNAP_ID=jHxWQxtGqu7tHwiq7F8Ojk5qazcEeslT
+
+        if is_core18_system; then
+            # test-snapd-with-configure-core18
+            TEST_SNAP_ID=jHxWQxtGqu7tHwiq7F8Ojk5qazcEeslT
+        fi
     else
+        # test-snapd-with-configure
         TEST_SNAP_ID=aLcJorEJZgJNUGL2GMb3WR9SoVyHUNAd
+
+        if is_core18_system; then
+            # test-snapd-with-configure-core18
+            TEST_SNAP_ID=BzMG26hwO2ccNBzV5BxK4DZgulJ2AXsa
+        fi
     fi
 
     # Update the gadget config file
@@ -41,15 +63,15 @@ prepare: |
     mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments -no-progress
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
-    cp test-snapd-with-configure_*.snap /var/lib/snapd/seed/snaps/
+    cp "test-snapd-with-configure${SUFFIX}"_*.snap /var/lib/snapd/seed/snaps/
     mv /var/lib/snapd/seed/assertions/model model.bak
     cp /var/lib/snapd/seed/seed.yaml seed.yaml.bak
-    python3 ./manip_seed.py /var/lib/snapd/seed/seed.yaml test-snapd-with-configure_*.snap
+    python3 ./manip_seed.py /var/lib/snapd/seed/seed.yaml "test-snapd-with-configure${SUFFIX}"_*.snap
     cp "$TESTSLIB"/assertions/developer1.account /var/lib/snapd/seed/assertions
     cp "$TESTSLIB"/assertions/developer1.account-key /var/lib/snapd/seed/assertions
-    cp "$TESTSLIB"/assertions/developer1-pc-w-config.model /var/lib/snapd/seed/assertions
+    cp "$TESTSLIB/assertions/$MODEL" /var/lib/snapd/seed/assertions
     cp "$TESTSLIB"/assertions/testrootorg-store.account-key /var/lib/snapd/seed/assertions
-    cp test-snapd-with-configure_*.assert /var/lib/snapd/seed/assertions
+    cp "test-snapd-with-configure${SUFFIX}"_*.assert /var/lib/snapd/seed/assertions
 
     # kick first boot again
     systemctl start snapd.service snapd.socket
@@ -58,6 +80,16 @@ restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
+    fi
+
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+
+    SUFFIX=
+    MODEL=developer1-pc-w-config.model
+    if is_core18_system; then
+        SUFFIX=-core18
+        MODEL=developer1-pc-18-w-config.model
     fi
 
     echo "Undo the service disable"
@@ -85,22 +117,22 @@ restore: |
     fi
     rm /var/lib/snapd/seed/snaps/pc_x1.snap
 
-    TEST_REVNO=$(awk "/^snap-revision: / {print \$2}" test-snapd-with-configure_*.assert)
-    if systemctl status "$(systemd-escape --path /snap/test-snapd-with-configure/"$TEST_REVNO".mount)"; then
-       systemctl stop "$(systemd-escape --path /snap/test-snapd-with-configure/"$TEST_REVNO".mount)"
-       rm -f "/etc/systemd/system/snap-test-snapd-with-configure-${TEST_REVNO}.mount"
-       rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure-${TEST_REVNO}.mount"
-       rm -f /var/lib/snapd/snaps/test-snapd-with-configure_*.snap
+    TEST_REVNO=$(awk "/^snap-revision: / {print \$2}" "test-snapd-with-configure${SUFFIX}"_*.assert)
+    if systemctl status "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"; then
+       systemctl stop "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"
+       rm -f "/etc/systemd/system/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
+       rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
+       rm -f "/var/lib/snapd/snaps/test-snapd-with-configure${SUFFIX}"_*.snap
        systemctl daemon-reload
     fi
-    rm /var/lib/snapd/seed/snaps/test-snapd-with-configure_*.snap
+    rm "/var/lib/snapd/seed/snaps/test-snapd-with-configure${SUFFIX}"_*.snap
 
     cp seed.yaml.bak /var/lib/snapd/seed/seed.yaml
     rm -f /var/lib/snapd/seed/assertions/developer1.account
     rm -f /var/lib/snapd/seed/assertions/developer1.account-key
-    rm -f /var/lib/snapd/seed/assertions/developer1-pc-w-config.model
+    rm -f "/var/lib/snapd/seed/assertions/$MODEL"
     rm -f /var/lib/snapd/seed/assertions/testrootorg-store.account-key
-    rm -f /var/lib/snapd/seed/assertions/test-snapd-with-configure_*.assert
+    rm -f "/var/lib/snapd/seed/assertions/test-snapd-with-configure${SUFFIX}"_*.assert
     cp model.bak /var/lib/snapd/seed/assertions/model
     # kick first boot again
     systemctl start snapd.service snapd.socket
@@ -108,6 +140,14 @@ restore: |
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
 
 execute: |
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+
+    SUFFIX=
+    if is_core18_system; then
+        SUFFIX=-core18
+    fi
+
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
@@ -118,11 +158,11 @@ execute: |
     snap model --verbose|MATCH "model:\s* my-model-w-config"
 
     echo "The configurable snap was installed"
-    snap list|MATCH "test-snapd-with-configure"
+    snap list|MATCH "test-snapd-with-configure${SUFFIX}"
 
     echo "The configuration defaults from the gadget where applied"
-    snap get test-snapd-with-configure a|MATCH "^A$"
-    snap get test-snapd-with-configure b|MATCH "^B$"
+    snap get "test-snapd-with-configure${SUFFIX}" a|MATCH "^A$"
+    snap get "test-snapd-with-configure${SUFFIX}" b|MATCH "^B$"
 
     echo "The configuration for core is applied"
     snap get core "service.$SERVICE.disable" | MATCH true


### PR DESCRIPTION
On a system with bases, the snapd snap is considered a 'system' snap, thus we
consider it as source of system configuration defaults. Capture this in the
code, make sure that system defaults are only applied when in the seeding mode.
Distinguish cases when both snapd and core snaps are installed, or just one of
those.


