### PR TITLE
bootloader: add new bootloader.InstallBootConfig()

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -294,8 +294,10 @@ type BootableSet struct {
 //  - setting boot env vars pointing to the revisions of the boot snaps to use
 //  - extracting kernel assets as needed by the bootloader
 func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	opts := &bootloader.Options{PrepareImageTime: true}
+
 	// install the bootloader configuration from the gadget
-	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir); err != nil {
+	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir, opts); err != nil {
 		return err
 	}
 
@@ -323,9 +325,7 @@ func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) e
 	// Set bootvars for kernel/core snaps so the system boots and
 	// does the first-time initialization. There is also no
 	// mounted kernel/core/base snap, but just the blobs.
-	bl, err := bootloader.Find(rootdir, &bootloader.Options{
-		PrepareImageTime: true,
-	})
+	bl, err := bootloader.Find(rootdir, opts)
 	if err != nil {
 		return fmt.Errorf("cannot set kernel/core boot variables: %s", err)
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -224,7 +224,7 @@ func (s *ubootBootSetSuite) forceUbootBootloader(c *C) bootloader.Bootloader {
 	mockGadgetDir := c.MkDir()
 	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), nil, 0644)
 	c.Assert(err, IsNil)
-	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir)
+	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir, nil)
 	c.Assert(err, IsNil)
 
 	bloader, err := bootloader.Find("", nil)
@@ -303,7 +303,7 @@ func (s *grubBootSetSuite) forceGrubBootloader(c *C) bootloader.Bootloader {
 	mockGadgetDir := c.MkDir()
 	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "grub.conf"), nil, 0644)
 	c.Assert(err, IsNil)
-	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir)
+	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir, nil)
 	c.Assert(err, IsNil)
 
 	bloader, err := bootloader.Find("", nil)

--- a/bootloader/androidboot.go
+++ b/bootloader/androidboot.go
@@ -56,6 +56,12 @@ func (a *androidboot) dir() string {
 	return filepath.Join(a.rootdir, "/boot/androidboot")
 }
 
+func (a *androidboot) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, a.Name()+".conf")
+	systemFile := a.ConfigFile()
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (a *androidboot) ConfigFile() string {
 	return filepath.Join(a.dir(), "androidboot.env")
 }

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -91,7 +91,7 @@ func (s *bootenvTestSuite) TestForceBootloaderError(c *C) {
 }
 
 func (s *bootenvTestSuite) TestInstallBootloaderConfigNoConfig(c *C) {
-	err := bootloader.InstallBootConfig(c.MkDir(), s.rootdir)
+	err := bootloader.InstallBootConfig(c.MkDir(), s.rootdir, nil)
 	c.Assert(err, ErrorMatches, `cannot find boot config in.*`)
 }
 
@@ -105,9 +105,9 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfig(c *C) {
 		mockGadgetDir := c.MkDir()
 		err := ioutil.WriteFile(filepath.Join(mockGadgetDir, t.gadgetFile), nil, 0644)
 		c.Assert(err, IsNil)
-		err = bootloader.InstallBootConfig(mockGadgetDir, s.rootdir)
+		err = bootloader.InstallBootConfig(mockGadgetDir, s.rootdir, nil)
 		c.Assert(err, IsNil)
 		fn := filepath.Join(s.rootdir, t.systemFile)
-		c.Assert(osutil.FileExists(fn), Equals, true)
+		c.Check(osutil.FileExists(fn), Equals, true, Commentf("boot config missing for %s", t.gadgetFile))
 	}
 }

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -39,6 +39,10 @@ type MockBootloader struct {
 
 	ExtractKernelAssetsCalls []snap.PlaceInfo
 	RemoveKernelAssetsCalls  []snap.PlaceInfo
+
+	InstallBootConfigCalled []string
+	InstallBootConfigResult bool
+	InstallBootConfigErr    error
 }
 
 // ensure MockBootloader implements the Bootloader interface
@@ -124,4 +128,9 @@ func (b *MockBootloader) SetRollbackAcrossReboot() error {
 	b.BootVars["snap_try_core"] = ""
 	b.BootVars["snap_try_kernel"] = ""
 	return nil
+}
+
+func (b *MockBootloader) InstallBootConfig(gadgetDir string, opts *bootloader.Options) (bool, error) {
+	b.InstallBootConfigCalled = append(b.InstallBootConfigCalled, gadgetDir)
+	return b.InstallBootConfigResult, b.InstallBootConfigErr
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -57,6 +57,12 @@ func (g *grub) dir() string {
 	return filepath.Join(g.rootdir, "/boot/grub")
 }
 
+func (g *grub) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, g.Name()+".conf")
+	systemFile := filepath.Join(g.rootdir, "/boot/grub/grub.cfg")
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (g *grub) ConfigFile() string {
 	return filepath.Join(g.dir(), "grub.cfg")
 }

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -76,6 +76,12 @@ func (l *lk) dir() string {
 	}
 }
 
+func (l *lk) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, l.Name()+".conf")
+	systemFile := l.ConfigFile()
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (l *lk) ConfigFile() string {
 	return l.envFile()
 }

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -56,6 +56,12 @@ func (u *uboot) dir() string {
 	return filepath.Join(u.rootdir, "/boot/uboot")
 }
 
+func (u *uboot) InstallBootConfig(gadgetDir string, opts *Options) (bool, error) {
+	gadgetFile := filepath.Join(gadgetDir, u.Name()+".conf")
+	systemFile := u.ConfigFile()
+	return genericInstallBootConfig(gadgetFile, systemFile)
+}
+
 func (u *uboot) ConfigFile() string {
 	return u.envFile()
 }


### PR DESCRIPTION
This commit adds a new InstallBootCofig to the bootloader
interface. The bootloaders use the generic uc16 implementation
currently so nothing changes. But this will make it possible
to have different behavior for the install of the bootconfig
for uc20 where we will need to install a recovery boot config
and also a "run" mode boot config.
