### PR TITLE
boot: add boot.Modeenv that can read/write the UC20 modeenv files

### DIFF
--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -20,6 +20,7 @@
 package boot
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -58,10 +59,14 @@ func (m *Modeenv) Write(rootdir string) error {
 	if err := os.MkdirAll(filepath.Dir(modeenvPath), 0755); err != nil {
 		return err
 	}
-	modeEnvContent := fmt.Sprintf(`recovery_system=%s
-mode=%s
-`, m.RecoverySystem, m.Mode)
-	if err := osutil.AtomicWriteFile(modeenvPath, []byte(modeEnvContent), 0644, 0); err != nil {
+	buf := bytes.NewBuffer(nil)
+	if m.Mode != "" {
+		fmt.Fprintf(buf, "mode=%s\n", m.Mode)
+	}
+	if m.RecoverySystem != "" {
+		fmt.Fprintf(buf, "recovery_system=%s\n", m.RecoverySystem)
+	}
+	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {
 		return err
 	}
 	return nil

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/mvo5/goconfigparser"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// Modeenv is a file on UC20 that provides additional information
+// about the current mode (run,recover,install)
+type Modeenv struct {
+	Mode                string
+	RecoverySystemLabel string
+}
+
+func ReadModeenv(rootdir string) (*Modeenv, error) {
+	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
+	cfg := goconfigparser.New()
+	cfg.AllowNoSectionHeader = true
+	if err := cfg.ReadFile(modeenvPath); err != nil {
+		return nil, err
+	}
+	recoverySystemLabel, _ := cfg.Get("", "recovery_system")
+	mode, _ := cfg.Get("", "mode")
+	return &Modeenv{
+		Mode:                mode,
+		RecoverySystemLabel: recoverySystemLabel,
+	}, nil
+}
+
+func (m *Modeenv) Write(rootdir string) error {
+	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
+
+	if err := os.MkdirAll(filepath.Dir(modeenvPath), 0755); err != nil {
+		return err
+	}
+	modeEnvContent := fmt.Sprintf(`recovery_system=%s
+mode=%s
+`, m.RecoverySystemLabel, m.Mode)
+	if err := ioutil.WriteFile(modeenvPath, []byte(modeEnvContent), 0644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -21,13 +21,13 @@ package boot
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/mvo5/goconfigparser"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // Modeenv is a file on UC20 that provides additional information
@@ -61,7 +61,7 @@ func (m *Modeenv) Write(rootdir string) error {
 	modeEnvContent := fmt.Sprintf(`recovery_system=%s
 mode=%s
 `, m.RecoverySystem, m.Mode)
-	if err := ioutil.WriteFile(modeenvPath, []byte(modeEnvContent), 0644); err != nil {
+	if err := osutil.AtomicWriteFile(modeenvPath, []byte(modeEnvContent), 0644, 0); err != nil {
 		return err
 	}
 	return nil

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -33,8 +33,8 @@ import (
 // Modeenv is a file on UC20 that provides additional information
 // about the current mode (run,recover,install)
 type Modeenv struct {
-	Mode                string
-	RecoverySystemLabel string
+	Mode           string
+	RecoverySystem string
 }
 
 func ReadModeenv(rootdir string) (*Modeenv, error) {
@@ -44,11 +44,11 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	if err := cfg.ReadFile(modeenvPath); err != nil {
 		return nil, err
 	}
-	recoverySystemLabel, _ := cfg.Get("", "recovery_system")
+	recoverySystem, _ := cfg.Get("", "recovery_system")
 	mode, _ := cfg.Get("", "mode")
 	return &Modeenv{
-		Mode:                mode,
-		RecoverySystemLabel: recoverySystemLabel,
+		Mode:           mode,
+		RecoverySystem: recoverySystem,
 	}, nil
 }
 
@@ -60,7 +60,7 @@ func (m *Modeenv) Write(rootdir string) error {
 	}
 	modeEnvContent := fmt.Sprintf(`recovery_system=%s
 mode=%s
-`, m.RecoverySystemLabel, m.Mode)
+`, m.RecoverySystem, m.Mode)
 	if err := ioutil.WriteFile(modeenvPath, []byte(modeEnvContent), 0644); err != nil {
 		return err
 	}

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// baseBootSuite is used to setup the common test environment
+type modeenvSuite struct {
+	testutil.BaseTest
+
+	tmpdir string
+}
+
+var _ = Suite(&modeenvSuite{})
+
+func (s *modeenvSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+}
+
+func (s *modeenvSuite) TestReadEmptyErrors(c *C) {
+	modeenv, err := boot.ReadModeenv("/no/such/file")
+	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(modeenv, IsNil)
+}
+
+func (s *modeenvSuite) makeMockModeenvFile(c *C, content string) {
+	mockModeenvPath := filepath.Join(s.tmpdir, dirs.SnapModeenvFile)
+	err := os.MkdirAll(filepath.Dir(mockModeenvPath), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockModeenvPath, []byte(content), 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *modeenvSuite) TestReadEmpty(c *C) {
+	s.makeMockModeenvFile(c, "")
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "")
+	c.Check(modeenv.RecoverySystemLabel, Equals, "")
+}
+
+func (s *modeenvSuite) TestReadMode(c *C) {
+	s.makeMockModeenvFile(c, "mode: run")
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "run")
+	c.Check(modeenv.RecoverySystemLabel, Equals, "")
+}
+
+func (s *modeenvSuite) TestReadModeWithRecoverySystem(c *C) {
+	s.makeMockModeenvFile(c, `mode: recovery
+recovery_system: 20191126
+`)
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "recovery")
+	c.Check(modeenv.RecoverySystemLabel, Equals, "20191126")
+}
+
+func (s *modeenvSuite) TestWriteExisting(c *C) {
+	s.makeMockModeenvFile(c, "mode: run")
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	modeenv.Mode = "recovery"
+	err = modeenv.Write(s.tmpdir)
+	c.Assert(err, IsNil)
+}

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -64,7 +64,7 @@ func (s *modeenvSuite) TestReadEmpty(c *C) {
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
 	c.Check(modeenv.Mode, Equals, "")
-	c.Check(modeenv.RecoverySystemLabel, Equals, "")
+	c.Check(modeenv.RecoverySystem, Equals, "")
 }
 
 func (s *modeenvSuite) TestReadMode(c *C) {
@@ -73,7 +73,7 @@ func (s *modeenvSuite) TestReadMode(c *C) {
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
 	c.Check(modeenv.Mode, Equals, "run")
-	c.Check(modeenv.RecoverySystemLabel, Equals, "")
+	c.Check(modeenv.RecoverySystem, Equals, "")
 }
 
 func (s *modeenvSuite) TestReadModeWithRecoverySystem(c *C) {
@@ -84,7 +84,7 @@ recovery_system: 20191126
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
 	c.Check(modeenv.Mode, Equals, "recovery")
-	c.Check(modeenv.RecoverySystemLabel, Equals, "20191126")
+	c.Check(modeenv.RecoverySystem, Equals, "20191126")
 }
 
 func (s *modeenvSuite) TestWriteExisting(c *C) {

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -69,7 +69,7 @@ func (s *modeenvSuite) TestReadEmpty(c *C) {
 }
 
 func (s *modeenvSuite) TestReadMode(c *C) {
-	s.makeMockModeenvFile(c, "mode: run")
+	s.makeMockModeenvFile(c, "mode=run")
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)
@@ -78,8 +78,8 @@ func (s *modeenvSuite) TestReadMode(c *C) {
 }
 
 func (s *modeenvSuite) TestReadModeWithRecoverySystem(c *C) {
-	s.makeMockModeenvFile(c, `mode: recovery
-recovery_system: 20191126
+	s.makeMockModeenvFile(c, `mode=recovery
+recovery_system=20191126
 `)
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
@@ -99,7 +99,7 @@ func (s *modeenvSuite) TestWriteNonExisting(c *C) {
 }
 
 func (s *modeenvSuite) TestWriteExisting(c *C) {
-	s.makeMockModeenvFile(c, "mode: run")
+	s.makeMockModeenvFile(c, "mode=run")
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
 	c.Assert(err, IsNil)

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -91,6 +91,8 @@ var (
 	SnapDesktopIconsDir string
 	SnapBusPolicyDir    string
 
+	SnapModeenvFile string
+
 	SystemApparmorDir      string
 	SystemApparmorCacheDir string
 
@@ -277,6 +279,8 @@ func SetRootDir(rootdir string) {
 
 	SnapSeedDir = SnapSeedDirUnder(rootdir)
 	SnapDeviceDir = filepath.Join(rootdir, snappyDir, "device")
+
+	SnapModeenvFile = filepath.Join(rootdir, snappyDir, "modeenv")
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")


### PR DESCRIPTION
This commits adds basic support for the modeenv file that will be
used on UC20 systems to keep track of the run mode, the recovery
system to use (and more later).
