### PR TITLE
snap-bootstrap: make cmdline parsing robust

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -122,6 +122,13 @@ func (s *initramfsMountsSuite) TestInitramfsMountsNoModeError(c *C) {
 	c.Assert(err, ErrorMatches, "cannot detect if in run,install,recover mode")
 }
 
+func (s *initramfsMountsSuite) TestInitramfsMountsUnknonwnMode(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install-foo")
+
+	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, ErrorMatches, `cannot use unknown mode "install-foo"`)
+}
+
 func (s *initramfsMountsSuite) TestInitramfsMountsNoRunModeYet(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 


### PR DESCRIPTION
The code that was parsing the kernels /proc/cmdline was very
naive and did not handle whitespaces etc well. This commit fixes
this by using a proper scanner.
