### PR TITLE
snap-bootstrap: write /run/mnt/ubuntu-data/var/lib/snapd/modeenv

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -66,8 +66,9 @@ var (
 )
 
 // XXX: make this more flexible if there are multiple seeds on disk, i.e.
-// read boot environment in this case
-func findSeed() (seedDir, seedLabel string, err error) {
+// read kernel commandline in this case (bootenv is off limits because
+// it's not measured).
+func findSeed() (recoverySystemDir, recoverySystemLabel string, err error) {
 	l, err := filepath.Glob(filepath.Join(runMnt, "/ubuntu-seed/systems/*"))
 	if err != nil {
 		return "", "", err
@@ -79,9 +80,9 @@ func findSeed() (seedDir, seedLabel string, err error) {
 		return "", "", fmt.Errorf("cannot use multiple recovery systems yet")
 	}
 	// load the seed and generate mounts for kernel/base
-	seedLabel = filepath.Base(l[0])
-	seedDir = filepath.Dir(filepath.Dir(l[0]))
-	return seedDir, seedLabel, nil
+	recoverySystemLabel = filepath.Base(l[0])
+	recoverySystemDir = filepath.Dir(filepath.Dir(l[0]))
+	return recoverySystemDir, recoverySystemLabel, nil
 }
 
 // generateMountsMode* is called multiple times from initramfs until it
@@ -155,7 +156,7 @@ func generateMountsModeInstall() error {
 		return nil
 	}
 
-	// 4. write $(ubuntu_data)/var/lib/snapd/modenv
+	// 4. final step: write $(ubuntu_data)/var/lib/snapd/modenv
 	_, err = boot.ReadModeenv(filepath.Join(runMnt, "ubuntu-data"))
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -156,23 +156,18 @@ func generateMountsModeInstall() error {
 		return nil
 	}
 
-	// 4. final step: write $(ubuntu_data)/var/lib/snapd/modenv
-	_, err = boot.ReadModeenv(filepath.Join(runMnt, "ubuntu-data"))
-	if err != nil && !os.IsNotExist(err) {
+	// 4. final step: write $(ubuntu_data)/var/lib/snapd/modeenv - this
+	//    is the tmpfs we just created above
+	_, seedLabel, err := findSeed()
+	if err != nil {
 		return err
 	}
-	if os.IsNotExist(err) {
-		_, seedLabel, err := findSeed()
-		if err != nil {
-			return err
-		}
-		modeEnv := &boot.Modeenv{
-			Mode:           "install",
-			RecoverySystem: seedLabel,
-		}
-		if err := modeEnv.Write(filepath.Join(runMnt, "ubuntu-data")); err != nil {
-			return err
-		}
+	modeEnv := &boot.Modeenv{
+		Mode:           "install",
+		RecoverySystem: seedLabel,
+	}
+	if err := modeEnv.Write(filepath.Join(runMnt, "ubuntu-data")); err != nil {
+		return err
 	}
 
 	// 5. done, no output, no error indicates to initramfs we are done

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -202,3 +202,34 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep3(c *C) {
 	c.Assert(n, Equals, 3)
 	c.Check(s.Stdout.String(), Equals, "--type=tmpfs tmpfs /run/mnt/ubuntu-data\n")
 }
+
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
+	n := 0
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install")
+
+	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
+		n++
+		switch n {
+		case 1:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "ubuntu-seed"))
+			return true, nil
+		case 2:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "base"))
+			return true, nil
+		case 3:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "ubuntu-data"))
+			return true, nil
+		}
+		return false, fmt.Errorf("unexpected number of calls: %v", n)
+	})
+	defer restore()
+
+	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 3)
+	c.Check(s.Stdout.String(), Equals, "")
+	modeEnv := filepath.Join(s.runMnt, "/ubuntu-data/var/lib/snapd/modeenv")
+	c.Check(modeEnv, testutil.FileEquals, `mode=install
+recovery_system=20191118
+`)
+}


### PR DESCRIPTION
The firstboot code in snapd for UC20 will need some information
from the earlier boot stage what recovery system to use and
what mode it is in. This PR implements writing the modeenv from
snap-bootstrap initramfs-mounts after the "ubuntu-data" partition
was written.
