### PR TITLE
devicestate: read modeenv early and store in devicestate

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -46,6 +46,9 @@ import (
 // DeviceManager is responsible for managing the device identity and device
 // policies.
 type DeviceManager struct {
+	// operatingMode of a UC20 system. "","run","install","recover"
+	operatingMode string
+
 	state      *state.State
 	keypairMgr asserts.KeypairManager
 
@@ -61,10 +64,6 @@ type DeviceManager struct {
 	becomeOperationalBackoff     time.Duration
 	registered                   bool
 	reg                          chan struct{}
-
-	// XXX: is that the best name?
-	// runMode of a UC20 system. "","run","install","recover"
-	runMode string
 }
 
 // Manager returns a new device manager.
@@ -89,7 +88,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		return nil, err
 	}
 	if modeEnv != nil {
-		m.runMode = modeEnv.Mode
+		m.operatingMode = modeEnv.Mode
 	}
 
 	s.Lock()
@@ -261,7 +260,7 @@ func (m *DeviceManager) ensureOperational() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	if m.runMode == "install" {
+	if m.operatingMode == "install" {
 		// avoid doing registration in install mode
 		return nil
 	}

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1645,7 +1645,7 @@ func (s *deviceMgrSerialSuite) TestDeviceManagerReadsModeenv(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
 	c.Assert(err, IsNil)
 	c.Assert(mgr, NotNil)
-	c.Assert(devicestate.RunMode(mgr), Equals, "install")
+	c.Assert(devicestate.OperatingMode(mgr), Equals, "install")
 }
 
 func (s *deviceMgrSerialSuite) TestDeviceRegistrationNotInInstallMode(c *C) {
@@ -1664,7 +1664,7 @@ func (s *deviceMgrSerialSuite) TestDeviceRegistrationNotInInstallMode(c *C) {
 	// mark it as seeded
 	st.Set("seeded", true)
 	// set run mode to "install"
-	devicestate.SetRunMode(s.mgr, "install")
+	devicestate.SetOperatingMode(s.mgr, "install")
 	st.Unlock()
 
 	// runs the whole device registration process

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -1634,18 +1633,6 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialReregistrationDoubleSerialStre
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus, Commentf("%s", t.Log()))
 	c.Check(chg.Err(), ErrorMatches, `(?ms).*cannot accept more than a single device serial assertion from the device service.*`)
-}
-
-func (s *deviceMgrSerialSuite) TestDeviceManagerReadsModeenv(c *C) {
-	modeEnv := &boot.Modeenv{Mode: "install"}
-	err := modeEnv.Write("")
-	c.Assert(err, IsNil)
-
-	runner := s.o.TaskRunner()
-	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
-	c.Assert(err, IsNil)
-	c.Assert(mgr, NotNil)
-	c.Assert(devicestate.OperatingMode(mgr), Equals, "install")
 }
 
 func (s *deviceMgrSerialSuite) TestDeviceRegistrationNotInInstallMode(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
@@ -1012,4 +1013,16 @@ func (s *deviceMgrSuite) TestDevicemgrCanStandby(c *C) {
 
 	st.Set("seeded", true)
 	c.Check(mgr.CanStandby(), Equals, true)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerReadsModeenv(c *C) {
+	modeEnv := &boot.Modeenv{Mode: "install"}
+	err := modeEnv.Write("")
+	c.Assert(err, IsNil)
+
+	runner := s.o.TaskRunner()
+	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
+	c.Assert(err, IsNil)
+	c.Assert(mgr, NotNil)
+	c.Assert(devicestate.OperatingMode(mgr), Equals, "install")
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -87,6 +87,8 @@ func SetOperatingMode(m *DeviceManager, mode string) {
 	m.operatingMode = mode
 }
 
+// XXX: will become properly exported but we probably want to make
+//      mode a type and not a string before we do that
 func OperatingMode(m *DeviceManager) string {
 	return m.operatingMode
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -83,12 +83,12 @@ func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 	m.lastBecomeOperationalAttempt = t
 }
 
-func SetRunMode(m *DeviceManager, mode string) {
-	m.runMode = mode
+func SetOperatingMode(m *DeviceManager, mode string) {
+	m.operatingMode = mode
 }
 
-func RunMode(m *DeviceManager) string {
-	return m.runMode
+func OperatingMode(m *DeviceManager) string {
+	return m.operatingMode
 }
 
 func MockRepeatRequestSerial(label string) (restore func()) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -83,6 +83,14 @@ func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 	m.lastBecomeOperationalAttempt = t
 }
 
+func SetRunMode(m *DeviceManager, mode string) {
+	m.runMode = mode
+}
+
+func RunMode(m *DeviceManager) string {
+	return m.runMode
+}
+
 func MockRepeatRequestSerial(label string) (restore func()) {
 	old := repeatRequestSerial
 	repeatRequestSerial = label


### PR DESCRIPTION
On UC20 systems the "run-mode" (install,recover,run) is an important
part of the device state. Read it early in the devicemanager code
and keep around. Also avoid registration when in "install" mode.

Extracted parts of #7762 for this.