### PR TITLE
devicestate: make /var/lib/snapd/seed available in install mode

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -144,7 +144,25 @@ func generateMountsModeInstall() error {
 		return nil
 	}
 
-	// 4. done, no output, no error indicates to initramfs we are done
+	// 4. make ubuntu-seed available inside
+	//      ${ubuntu_data}/var/lib/snapd/seed
+	//    so that seeding in uc20 works (it expects the seeds there)
+	isMounted, err = osutilIsMounted(filepath.Join(runMnt, "ubuntu-data/var/lib/snapd/seed"))
+	if err != nil {
+		return err
+	}
+	if !isMounted {
+		seedDir := filepath.Join(runMnt, "ubuntu-data/var/lib/snapd/seed")
+		if err := os.MkdirAll(seedDir, 0755); err != nil {
+			return err
+		}
+
+		// XXX: can we do this? should we --move instead?
+		fmt.Fprintf(stdout, "--bind /run/mnt/ubuntu-seed %s\n", seedDir)
+		return nil
+	}
+
+	//    done, no output, no error indicates to initramfs we are done
 	//    with mounting stuff
 	return nil
 }

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -202,3 +202,35 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep3(c *C) {
 	c.Assert(n, Equals, 3)
 	c.Check(s.Stdout.String(), Equals, "--type=tmpfs tmpfs /run/mnt/ubuntu-data\n")
 }
+
+func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
+	n := 0
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install")
+
+	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
+		n++
+		switch n {
+		case 1:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "ubuntu-seed"))
+			return true, nil
+		case 2:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "base"))
+			return true, nil
+		case 3:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "ubuntu-data"))
+			return true, nil
+		case 4:
+			c.Check(path, Equals, filepath.Join(s.runMnt, "ubuntu-data/var/lib/snapd/seed"))
+			return false, nil
+		}
+		return false, fmt.Errorf("unexpected number of calls: %v", n)
+	})
+	defer restore()
+
+	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+	c.Check(s.Stdout.String(), Equals, fmt.Sprintf("--bind /run/mnt/ubuntu-seed %s/ubuntu-data/var/lib/snapd/seed\n", s.runMnt))
+	seedDir := filepath.Join(s.runMnt, "/ubuntu-data/var/lib/snapd/seed")
+	c.Check(seedDir, testutil.FilePresent)
+}


### PR DESCRIPTION
So far we don't bind mount /var/lib/snapd/seed in the uc20. We
need the ubuntu-seed partition mounted here. This commit implements
this.

