### PR TITLE
interfaces/browser-support: allow reading status of huge pages

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -76,6 +76,10 @@ owner /{dev,run}/shm/.io.nwjs.* mrw,
 # miscellaneous accesses
 @{PROC}/vmstat r,
 
+# Chromium content api sometimes queries about huge pages. Allow status of
+# hugepages and transparent_hugepage, but not the pages themselves.
+/sys/kernel/mm/{hugepages,transparent_hugepage}/{,**} r,
+
 # Chromium content api in gnome-shell reads this
 /etc/opt/chrome/{,**} r,
 /etc/chromium/{,**} r,


### PR DESCRIPTION
Recent chromium content api snaps are checking the status of huge pages.
While this (will be) allowed in the hardware-observe interface, also
include it here so browser snaps don't have to plugs it and get more
access than required. Importantly, this access only allows checking the
status of huge pages, not altering the use of them. Allow querying both
the new transparent hugepages and falling back to the older hugetlbfs.

References:
- https://www.kernel.org/doc/Documentation/vm/transhuge.txt