### PR TITLE
interfaces: update system-backup tests to not check for sanitize errors related to os

### DIFF
--- a/interfaces/builtin/system_backup_test.go
+++ b/interfaces/builtin/system_backup_test.go
@@ -69,12 +69,6 @@ func (s *systemBackupInterfaceSuite) TestName(c *C) {
 
 func (s *systemBackupInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
-	slot := &snap.SlotInfo{
-		Snap:      &snap.Info{SuggestedName: "some-snap"},
-		Name:      "system-backup",
-		Interface: "system-backup",
-	}
-	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, "system-backup slots are reserved for the core snap")
 }
 
 func (s *systemBackupInterfaceSuite) TestSanitizePlug(c *C) {


### PR DESCRIPTION
PR 6950 removed the need for checking for sanitize errors related to os
and gadget snaps, but PR 6436 which added the system-backup interface
was not updated (and the tests hadn't been run since PR 6950 was
committed). This brings this interface's checks in line with all other
interfaces that have a similar setup (implicit core and classic with
same base declaration).
