### PR TITLE
interfaces: remove reservedForOS from commonInterface

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -120,6 +120,5 @@ func init() {
 		connectedPlugAppArmor: accountControlConnectedPlugAppArmor,
 		// handled by SecCompConnectedPlug
 		connectedPlugSecComp: "",
-		reservedForOS:        true,
 	}})
 }

--- a/interfaces/builtin/accounts_service.go
+++ b/interfaces/builtin/accounts_service.go
@@ -74,7 +74,6 @@ func init() {
 		name:                  "accounts-service",
 		summary:               accountsServiceSummary,
 		implicitOnClassic:     true,
-		reservedForOS:         true,
 		baseDeclarationSlots:  accountsServiceBaseDeclarationSlots,
 		connectedPlugAppArmor: accountsServiceConnectedPlugAppArmor,
 	})

--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -65,6 +65,5 @@ func init() {
 		baseDeclarationSlots:  alsaBaseDeclarationSlots,
 		connectedPlugAppArmor: alsaConnectedPlugAppArmor,
 		connectedPlugUDev:     alsaConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/appstream_metadata.go
+++ b/interfaces/builtin/appstream_metadata.go
@@ -111,7 +111,6 @@ func init() {
 		name:                 "appstream-metadata",
 		summary:              appstreamMetadataSummary,
 		implicitOnClassic:    true,
-		reservedForOS:        true,
 		baseDeclarationSlots: appstreamMetadataBaseDeclarationSlots,
 	}})
 }

--- a/interfaces/builtin/autopilot.go
+++ b/interfaces/builtin/autopilot.go
@@ -71,6 +71,5 @@ func init() {
 		baseDeclarationSlots:  autopilotIntrospectionBaseDeclarationSlots,
 		connectedPlugAppArmor: autopilotIntrospectionPlugAppArmor,
 		connectedPlugSecComp:  autopilotIntrospectionPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -93,6 +93,5 @@ func init() {
 		baseDeclarationSlots:  blockDevicesBaseDeclarationSlots,
 		connectedPlugAppArmor: blockDevicesConnectedPlugAppArmor,
 		connectedPlugUDev:     blockDevicesConnectedPlugUDev,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -73,6 +73,5 @@ func init() {
 		connectedPlugAppArmor: bluetoothControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  bluetoothControlConnectedPlugSecComp,
 		connectedPlugUDev:     bluetoothControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/broadcom_asic_control.go
+++ b/interfaces/builtin/broadcom_asic_control.go
@@ -70,7 +70,6 @@ func init() {
 		summary:                  broadcomAsicControlSummary,
 		implicitOnCore:           true,
 		implicitOnClassic:        true,
-		reservedForOS:            true,
 		baseDeclarationSlots:     broadcomAsicControlBaseDeclarationSlots,
 		connectedPlugAppArmor:    broadcomAsicControlConnectedPlugAppArmor,
 		connectedPlugKModModules: broadcomAsicControlConnectedPlugKMod,

--- a/interfaces/builtin/calendar_service.go
+++ b/interfaces/builtin/calendar_service.go
@@ -135,7 +135,6 @@ func init() {
 		name:                  "calendar-service",
 		summary:               calendarServiceSummary,
 		implicitOnClassic:     !(release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04"),
-		reservedForOS:         true,
 		baseDeclarationSlots:  calendarServiceBaseDeclarationSlots,
 		connectedPlugAppArmor: calendarServiceConnectedPlugAppArmor,
 	})

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -65,6 +65,5 @@ func init() {
 		baseDeclarationSlots:  cameraBaseDeclarationSlots,
 		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
 		connectedPlugUDev:     cameraConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/can_bus.go
+++ b/interfaces/builtin/can_bus.go
@@ -51,6 +51,5 @@ func init() {
 		baseDeclarationSlots:  canBusBaseDeclarationSlots,
 		connectedPlugAppArmor: canBusConnectedPlugAppArmor,
 		connectedPlugSecComp:  canBusConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/cifs_mount.go
+++ b/interfaces/builtin/cifs_mount.go
@@ -73,6 +73,5 @@ func init() {
 		baseDeclarationSlots:  cifsMountBaseDeclarationSlots,
 		connectedPlugAppArmor: cifsMountConnectedPlugAppArmor,
 		connectedPlugSecComp:  cifsMountConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -53,7 +53,6 @@ type commonInterface struct {
 	connectedPlugAppArmor  string
 	connectedPlugSecComp   string
 	connectedPlugUDev      []string
-	reservedForOS          bool
 	rejectAutoConnectPairs bool
 
 	connectedPlugKModModules []string

--- a/interfaces/builtin/contacts_service.go
+++ b/interfaces/builtin/contacts_service.go
@@ -154,7 +154,6 @@ func init() {
 		name:                  "contacts-service",
 		summary:               contactsServiceSummary,
 		implicitOnClassic:     !(release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04"),
-		reservedForOS:         true,
 		baseDeclarationSlots:  contactsServiceBaseDeclarationSlots,
 		connectedPlugAppArmor: contactsServiceConnectedPlugAppArmor,
 	})

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -47,6 +47,5 @@ func init() {
 		implicitOnClassic:    true,
 		baseDeclarationPlugs: coreSupportBaseDeclarationPlugs,
 		baseDeclarationSlots: coreSupportBaseDeclarationSlots,
-		reservedForOS:        true,
 	})
 }

--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -45,6 +45,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  cpuControlBaseDeclarationSlots,
 		connectedPlugAppArmor: cpuControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -44,6 +44,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  cupsControlBaseDeclarationSlots,
 		connectedPlugAppArmor: cupsControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/daemon_notify.go
+++ b/interfaces/builtin/daemon_notify.go
@@ -99,6 +99,5 @@ func init() {
 		implicitOnCore:       true,
 		implicitOnClassic:    true,
 		baseDeclarationSlots: daemonNotifyBaseDeclarationSlots,
-		reservedForOS:        true,
 	}})
 }

--- a/interfaces/builtin/dcdbas_control.go
+++ b/interfaces/builtin/dcdbas_control.go
@@ -59,6 +59,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  dcdbasControlBaseDeclarationSlots,
 		connectedPlugAppArmor: dcdbasControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -251,6 +251,5 @@ func init() {
 		baseDeclarationSlots:  desktopLegacyBaseDeclarationSlots,
 		connectedPlugAppArmor: desktopLegacyConnectedPlugAppArmor,
 		connectedPlugSecComp:  desktopLegacyConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/device_buttons.go
+++ b/interfaces/builtin/device_buttons.go
@@ -88,6 +88,5 @@ func init() {
 		baseDeclarationSlots:  deviceButtonsBaseDeclarationSlots,
 		connectedPlugAppArmor: deviceButtonsConnectedPlugAppArmor,
 		connectedPlugUDev:     deviceButtonsConnectedPlugUDev,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/display_control.go
+++ b/interfaces/builtin/display_control.go
@@ -132,6 +132,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  displayControlBaseDeclarationSlots,
 		connectedPlugAppArmor: displayControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/dvb.go
+++ b/interfaces/builtin/dvb.go
@@ -47,6 +47,5 @@ func init() {
 		baseDeclarationSlots:  dvbBaseDeclarationSlots,
 		connectedPlugAppArmor: dvbConnectedPlugAppArmor,
 		connectedPlugUDev:     dvbConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -176,6 +176,5 @@ func init() {
 		connectedPlugAppArmor:    firewallControlConnectedPlugAppArmor,
 		connectedPlugSecComp:     firewallControlConnectedPlugSecComp,
 		connectedPlugKModModules: firewallControlConnectedPlugKmod,
-		reservedForOS:            true,
 	})
 }

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -48,6 +48,5 @@ func init() {
 		baseDeclarationSlots:  framebufferBaseDeclarationSlots,
 		connectedPlugAppArmor: framebufferConnectedPlugAppArmor,
 		connectedPlugUDev:     framebufferConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -100,7 +100,6 @@ func init() {
 		implicitOnCore:        true,
 		implicitOnClassic:     !(release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04"),
 		baseDeclarationSlots:  fuseSupportBaseDeclarationSlots,
-		reservedForOS:         true,
 		connectedPlugAppArmor: fuseSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  fuseSupportConnectedPlugSecComp,
 		connectedPlugUDev:     fuseSupportConnectedPlugUDev,

--- a/interfaces/builtin/gpg_keys.go
+++ b/interfaces/builtin/gpg_keys.go
@@ -59,6 +59,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  gpgKeysBaseDeclarationSlots,
 		connectedPlugAppArmor: gpgKeysConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/gpg_public_keys.go
+++ b/interfaces/builtin/gpg_public_keys.go
@@ -57,6 +57,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  gpgPublicKeysBaseDeclarationSlots,
 		connectedPlugAppArmor: gpgPublicKeysConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/gpio_control.go
+++ b/interfaces/builtin/gpio_control.go
@@ -55,6 +55,5 @@ func init() {
 		baseDeclarationPlugs:  gpioControlBaseDeclarationPlugs,
 		baseDeclarationSlots:  gpioControlBaseDeclarationSlots,
 		connectedPlugAppArmor: gpioControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/gpio_memory_control.go
+++ b/interfaces/builtin/gpio_memory_control.go
@@ -49,6 +49,5 @@ func init() {
 		baseDeclarationSlots:  gpioMemoryControlBaseDeclarationSlots,
 		connectedPlugAppArmor: gpioMemoryControlConnectedPlugAppArmor,
 		connectedPlugUDev:     gpioMemoryControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -398,7 +398,6 @@ func init() {
 		baseDeclarationSlots: greengrassSupportBaseDeclarationSlots,
 		baseDeclarationPlugs: greengrassSupportBaseDeclarationPlugs,
 		connectedPlugSecComp: greengrassSupportConnectedPlugSeccomp,
-		reservedForOS:        true,
 		controlsDeviceCgroup: true,
 	}})
 }

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -51,6 +51,5 @@ func init() {
 		implicitOnClassic:     true,
 		connectedPlugAppArmor: gsettingsConnectedPlugAppArmor,
 		baseDeclarationSlots:  gsettingsBaseDeclarationSlots,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -161,6 +161,5 @@ func init() {
 		baseDeclarationSlots:  hardwareObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: hardwareObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  hardwareObserveConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -56,6 +56,5 @@ func init() {
 		baseDeclarationSlots:  hardwareRandomControlBaseDeclarationSlots,
 		connectedPlugAppArmor: hardwareRandomControlConnectedPlugAppArmor,
 		connectedPlugUDev:     hardwareRandomControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -51,6 +51,5 @@ func init() {
 		baseDeclarationSlots:  hardwareRandomObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: hardwareRandomObserveConnectedPlugAppArmor,
 		connectedPlugUDev:     hardwareRandomObserveConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -127,6 +127,5 @@ func init() {
 		implicitOnCore:       true,
 		implicitOnClassic:    true,
 		baseDeclarationSlots: homeBaseDeclarationSlots,
-		reservedForOS:        true,
 	}})
 }

--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -85,7 +85,6 @@ func init() {
 		baseDeclarationSlots:  hostnameControlBaseDeclarationSlots,
 		connectedPlugAppArmor: hostnameControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  hostnameControlConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 
 }

--- a/interfaces/builtin/intel_mei.go
+++ b/interfaces/builtin/intel_mei.go
@@ -48,6 +48,5 @@ func init() {
 		baseDeclarationSlots:  intelMEIBaseDeclarationSlots,
 		connectedPlugAppArmor: intelMEIConnectedPlugAppArmor,
 		connectedPlugUDev:     intelMEIConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -60,6 +60,5 @@ func init() {
 		connectedPlugAppArmor: ioPortsControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  ioPortsControlConnectedPlugSecComp,
 		connectedPlugUDev:     ioPortsControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/jack1.go
+++ b/interfaces/builtin/jack1.go
@@ -42,6 +42,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  jack1BaseDeclarationSlots,
 		connectedPlugAppArmor: jack1ConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -105,6 +105,5 @@ func init() {
 		baseDeclarationSlots:  joystickBaseDeclarationSlots,
 		connectedPlugAppArmor: joystickConnectedPlugAppArmor,
 		connectedPlugUDev:     joystickConnectedPlugUDev,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/juju_client_observe.go
+++ b/interfaces/builtin/juju_client_observe.go
@@ -41,6 +41,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  jujuClientObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: jujuClientObserveConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -79,6 +79,5 @@ func init() {
 		connectedPlugAppArmor: kernelModuleControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  kernelModuleControlConnectedPlugSecComp,
 		connectedPlugUDev:     kernelModuleControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/kernel_module_observe.go
+++ b/interfaces/builtin/kernel_module_observe.go
@@ -55,6 +55,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  kernelModuleObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: kernelModuleObserveConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -109,6 +109,5 @@ func init() {
 		baseDeclarationSlots:  kvmBaseDeclarationSlots,
 		connectedPlugAppArmor: kvmConnectedPlugAppArmor,
 		connectedPlugUDev:     kvmConnectedPlugUDev,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -48,6 +48,5 @@ func init() {
 		baseDeclarationSlots:  libvirtBaseDeclarationSlots,
 		connectedPlugAppArmor: libvirtConnectedPlugAppArmor,
 		connectedPlugSecComp:  libvirtConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -44,6 +44,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  localeControlBaseDeclarationSlots,
 		connectedPlugAppArmor: localeControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -69,6 +69,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  logObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: logObserveConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/login_session_control.go
+++ b/interfaces/builtin/login_session_control.go
@@ -64,6 +64,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  loginSessionControlBaseDeclarationSlots,
 		connectedPlugAppArmor: loginSessionControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -62,6 +62,5 @@ func init() {
 		baseDeclarationPlugs:  lxdSupportBaseDeclarationPlugs,
 		connectedPlugAppArmor: lxdSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  lxdSupportConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -72,6 +72,5 @@ func init() {
 		baseDeclarationSlots:  mountObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: mountObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  mountObserveConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/multipass_support.go
+++ b/interfaces/builtin/multipass_support.go
@@ -124,6 +124,5 @@ func init() {
 		baseDeclarationPlugs:  multipassSupportBaseDeclarationPlugs,
 		connectedPlugAppArmor: multipassSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  multipassSupportConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/netlink_audit.go
+++ b/interfaces/builtin/netlink_audit.go
@@ -60,6 +60,5 @@ func init() {
 		baseDeclarationSlots:  netlinkAuditBaseDeclarationSlots,
 		connectedPlugSecComp:  netlinkAuditConnectedPlugSecComp,
 		connectedPlugAppArmor: netlinkAuditConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/netlink_connector.go
+++ b/interfaces/builtin/netlink_connector.go
@@ -57,6 +57,5 @@ func init() {
 		baseDeclarationSlots:  netlinkConnectorBaseDeclarationSlots,
 		connectedPlugSecComp:  netlinkConnectorConnectedPlugSecComp,
 		connectedPlugAppArmor: netlinkConnectorConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -87,6 +87,5 @@ func init() {
 		baseDeclarationSlots:  networkBaseDeclarationSlots,
 		connectedPlugAppArmor: networkConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -103,6 +103,5 @@ func init() {
 		baseDeclarationSlots:  networkBindBaseDeclarationSlots,
 		connectedPlugAppArmor: networkBindConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkBindConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -290,7 +290,6 @@ func init() {
 		connectedPlugAppArmor: networkControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkControlConnectedPlugSecComp,
 		connectedPlugUDev:     networkControlConnectedPlugUDev,
-		reservedForOS:         true,
 		suppressPtraceTrace:   true,
 	})
 

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -159,6 +159,5 @@ func init() {
 		baseDeclarationSlots:  networkObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: networkObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkObserveConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -74,6 +74,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  networkSetupControlBaseDeclarationSlots,
 		connectedPlugAppArmor: networkSetupControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/network_setup_observe.go
+++ b/interfaces/builtin/network_setup_observe.go
@@ -62,6 +62,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  networkSetupObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: networkSetupObserveConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -139,6 +139,5 @@ func init() {
 		baseDeclarationSlots:  openglBaseDeclarationSlots,
 		connectedPlugAppArmor: openglConnectedPlugAppArmor,
 		connectedPlugUDev:     openglConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/openvswitch.go
+++ b/interfaces/builtin/openvswitch.go
@@ -45,6 +45,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  openvswitchBaseDeclarationSlots,
 		connectedPlugAppArmor: openvswitchConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/openvswitch_support.go
+++ b/interfaces/builtin/openvswitch_support.go
@@ -44,6 +44,5 @@ func init() {
 		baseDeclarationSlots:     openvswitchSupportBaseDeclarationSlots,
 		connectedPlugKModModules: openvswitchSupportConnectedPlugKmod,
 		connectedPlugAppArmor:    openvswitchSupportConnectedPlugAppArmor,
-		reservedForOS:            true,
 	})
 }

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -107,6 +107,5 @@ func init() {
 		implicitOnClassic:    true,
 		baseDeclarationSlots: opticalDriveBaseDeclarationSlots,
 		connectedPlugUDev:    opticalDriveConnectedPlugUDev,
-		reservedForOS:        true,
 	}})
 }

--- a/interfaces/builtin/packagekit_control.go
+++ b/interfaces/builtin/packagekit_control.go
@@ -105,7 +105,6 @@ func init() {
 		name:                  "packagekit-control",
 		summary:               packageKitControlSummary,
 		implicitOnClassic:     true,
-		reservedForOS:         true,
 		baseDeclarationPlugs:  packageKitControlBaseDeclarationPlugs,
 		baseDeclarationSlots:  packageKitControlBaseDeclarationSlots,
 		connectedPlugAppArmor: packageKitControlConnectedPlugAppArmor,

--- a/interfaces/builtin/password_manager_service.go
+++ b/interfaces/builtin/password_manager_service.go
@@ -88,6 +88,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  passwordManagerBaseDeclarationSlots,
 		connectedPlugAppArmor: passwordManagerServiceConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/personal_files.go
+++ b/interfaces/builtin/personal_files.go
@@ -70,7 +70,6 @@ func init() {
 				implicitOnClassic:    true,
 				baseDeclarationPlugs: personalFilesBaseDeclarationPlugs,
 				baseDeclarationSlots: personalFilesBaseDeclarationSlots,
-				reservedForOS:        true,
 			},
 			apparmorHeader:    personalFilesConnectedPlugAppArmor,
 			extraPathValidate: validateSinglePathHome,

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -52,6 +52,5 @@ func init() {
 		baseDeclarationSlots:  physicalMemoryControlBaseDeclarationSlots,
 		connectedPlugAppArmor: physicalMemoryControlConnectedPlugAppArmor,
 		connectedPlugUDev:     physicalMemoryControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -48,6 +48,5 @@ func init() {
 		baseDeclarationSlots:  physicalMemoryObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: physicalMemoryObserveConnectedPlugAppArmor,
 		connectedPlugUDev:     physicalMemoryObserveConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -70,6 +70,5 @@ func init() {
 		connectedPlugAppArmor:    pppConnectedPlugAppArmor,
 		connectedPlugKModModules: pppConnectedPlugKmod,
 		connectedPlugUDev:        pppConnectedPlugUDev,
-		reservedForOS:            true,
 	})
 }

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -71,6 +71,5 @@ func init() {
 		baseDeclarationSlots:  processControlBaseDeclarationSlots,
 		connectedPlugAppArmor: processControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  processControlConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -71,6 +71,5 @@ func init() {
 		connectedPlugAppArmor: rawusbConnectedPlugAppArmor,
 		connectedPlugSecComp:  rawusbConnectedPlugSecComp,
 		connectedPlugUDev:     rawusbConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/removable_media.go
+++ b/interfaces/builtin/removable_media.go
@@ -57,6 +57,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  removableMediaBaseDeclarationSlots,
 		connectedPlugAppArmor: removableMediaConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -88,6 +88,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  screenInhibitBaseDeclarationSlots,
 		connectedPlugAppArmor: screenInhibitControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/screencast_legacy.go
+++ b/interfaces/builtin/screencast_legacy.go
@@ -59,6 +59,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  screencastLegacyBaseDeclarationSlots,
 		connectedPlugAppArmor: screencastLegacyConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -70,6 +70,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  shutdownBaseDeclarationSlots,
 		connectedPlugAppArmor: shutdownConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -70,6 +70,5 @@ func init() {
 		baseDeclarationPlugs:  snapdControlBaseDeclarationPlugs,
 		baseDeclarationSlots:  snapdControlBaseDeclarationSlots,
 		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/ssh_keys.go
+++ b/interfaces/builtin/ssh_keys.go
@@ -46,6 +46,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  sshKeysBaseDeclarationSlots,
 		connectedPlugAppArmor: sshKeysConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/ssh_public_keys.go
+++ b/interfaces/builtin/ssh_public_keys.go
@@ -46,6 +46,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  sshPublicKeysBaseDeclarationSlots,
 		connectedPlugAppArmor: sshPublicKeysConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/system_backup.go
+++ b/interfaces/builtin/system_backup.go
@@ -57,6 +57,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  systemBackupBaseDeclarationSlots,
 		connectedPlugAppArmor: systemBackupConnectedPlugAppArmor,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/system_files.go
+++ b/interfaces/builtin/system_files.go
@@ -70,7 +70,6 @@ func init() {
 				implicitOnClassic:    true,
 				baseDeclarationPlugs: systemFilesBaseDeclarationPlugs,
 				baseDeclarationSlots: systemFilesBaseDeclarationSlots,
-				reservedForOS:        true,
 			},
 			apparmorHeader:    systemFilesConnectedPlugAppArmor,
 			extraPathValidate: validateSinglePathSystem,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -134,7 +134,6 @@ func init() {
 		baseDeclarationSlots:  systemObserveBaseDeclarationSlots,
 		connectedPlugAppArmor: systemObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemObserveConnectedPlugSecComp,
-		reservedForOS:         true,
 		suppressPtraceTrace:   true,
 	})
 }

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -70,6 +70,5 @@ func init() {
 		baseDeclarationSlots:  systemTraceBaseDeclarationSlots,
 		connectedPlugAppArmor: systemTraceConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemTraceConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -130,6 +130,5 @@ func init() {
 		connectedPlugAppArmor: timeControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  timeControlConnectedPlugSecComp,
 		connectedPlugUDev:     timeControlConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -95,6 +95,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  timeserverControlBaseDeclarationSlots,
 		connectedPlugAppArmor: timeserverControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -97,6 +97,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  timezoneControlBaseDeclarationSlots,
 		connectedPlugAppArmor: timezoneControlConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -51,6 +51,5 @@ func init() {
 		baseDeclarationSlots:  tpmBaseDeclarationSlots,
 		connectedPlugAppArmor: tpmConnectedPlugAppArmor,
 		connectedPlugUDev:     tpmConnectedPlugUDev,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -155,6 +155,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  u2fDevicesBaseDeclarationSlots,
 		connectedPlugAppArmor: u2fDevicesConnectedPlugAppArmor,
-		reservedForOS:         true,
 	}})
 }

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -47,6 +47,5 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  uhidBaseDeclarationSlots,
 		connectedPlugAppArmor: uhidConnectedPlugAppArmor,
-		reservedForOS:         true,
 	})
 }


### PR DESCRIPTION
This is a leftover from old sanitization / validation code. Nothing is
using this variable anymore.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>