### PR TITLE
interfaces: misc updates for u2f-devices, browser-support, hardware-observe, et al (2.42)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -60,6 +60,8 @@ var defaultTemplate = `
   /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,
   owner @{PROC}/@{pid}/maps k,
+  owner @{HOME}/.Private/ r,
+  owner @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
 
   # for python apps/services
   #include <abstractions/python>

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -60,6 +60,9 @@ var defaultTemplate = `
   /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,
   owner @{PROC}/@{pid}/maps k,
+  # While the base abstraction has rules for encryptfs encrypted home and
+  # private directories, it is missing rules for directory read on the toplevel
+  # directory of the mount (LP: #1848919)
   owner @{HOME}/.Private/ r,
   owner @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -714,6 +714,11 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   /dev/random r,
   /dev/urandom r,
 
+  # Allow access to the uuidd daemon (this daemon is a thin wrapper around
+  # time and getrandom()/{,u}random and, when available, runs under an
+  # unprivilged, dedicated user).
+  /run/uuidd/request r,
+
   # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
   @{PROC}/@{pid}/cmdline r,
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -64,6 +64,13 @@ var defaultTemplate = `
   # for python apps/services
   #include <abstractions/python>
   /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,
+  # additional accesses needed for newer pythons in later bases
+  /usr/lib{,32,64}/python3.[0-9]/**.{pyc,so}           mr,
+  /usr/lib{,32,64}/python3.[0-9]/**.{egg,py,pth}       r,
+  /usr/lib{,32,64}/python3.[0-9]/{site,dist}-packages/ r,
+  /usr/lib{,32,64}/python3.[0-9]/lib-dynload/*.so      mr,
+  /etc/python3.[0-9]/**                                r,
+  /usr/include/python3.[0-9]*/pyconfig.h               r,
 
   # explicitly deny noisy denials to read-only filesystems (see LP: #1496895
   # for details)

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -197,6 +197,7 @@ var defaultTemplate = `
   /{,usr/}bin/nohup ixr,
   /{,usr/}bin/od ixr,
   /{,usr/}bin/openssl ixr, # may cause harmless capability block_suspend denial
+  /{,usr/}bin/paste ixr,
   /{,usr/}bin/pgrep ixr,
   /{,usr/}bin/printenv ixr,
   /{,usr/}bin/printf ixr,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -110,6 +110,14 @@ const browserSupportConnectedPlugAppArmorWithSandbox = `
 # Leaks installed applications
 # TODO: should this be somewhere else?
 /etc/mailcap r,
+# Snaps should be using xdg-open from the runtime instead of reading these
+# files directly since the snap is unable to do anything with these files
+# but these accesses have been allowed for a long time and remain so as not
+# to break existing snaps. These could be changed to explicit deny rules,
+# but that provides a worse debugging experience. Combined, the risks
+# outweigh the benefits of closing this information leak for the small
+# number of snaps allowed to use allow-sandbox: true. Reference:
+# https://forum.snapcraft.io/t/cannot-open-pdf-attachment-with-thunderbird/11845
 /usr/share/applications/{,*} r,
 /var/lib/snapd/desktop/applications/{,*} r,
 owner @{PROC}/@{pid}/fd/[0-9]* w,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -122,13 +122,6 @@ const browserSupportConnectedPlugAppArmorWithSandbox = `
 /var/lib/snapd/desktop/applications/{,*} r,
 owner @{PROC}/@{pid}/fd/[0-9]* w,
 
-# Clearing the PG_Referenced and ACCESSED/YOUNG bits provides a method to
-# measure approximately how much memory a process is using via /proc/self/smaps
-# (man 5 proc). This access allows the snap to clear references for pids from
-# other snaps and the system, so it is limited to snaps that specify:
-# allow-sandbox: true.
-owner @{PROC}/@{pid}/clear_refs w,
-
 # Various files in /run/udev/data needed by Chrome Settings. Leaks device
 # information.
 # input
@@ -245,6 +238,13 @@ owner /{dev,run}/shm/WK2SharedMemory.* mrw,
 
 # Chromium content api on (at least) later versions of Ubuntu just use this
 owner /{dev,run}/shm/shmfd-* mrw,
+
+# Clearing the PG_Referenced and ACCESSED/YOUNG bits provides a method to
+# measure approximately how much memory a process is using via /proc/self/smaps
+# (man 5 proc). This access allows the snap to clear references for pids from
+# other snaps and the system, so it is limited to snaps that specify:
+# allow-sandbox: true.
+owner @{PROC}/@{pid}/clear_refs w,
 `
 
 const browserSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -122,6 +122,13 @@ const browserSupportConnectedPlugAppArmorWithSandbox = `
 /var/lib/snapd/desktop/applications/{,*} r,
 owner @{PROC}/@{pid}/fd/[0-9]* w,
 
+# Clearing the PG_Referenced and ACCESSED/YOUNG bits provides a method to
+# measure approximately how much memory a process is using via /proc/self/smaps
+# (man 5 proc). This access allows the snap to clear references for pids from
+# other snaps and the system, so it is limited to snaps that specify:
+# allow-sandbox: true.
+owner @{PROC}/@{pid}/clear_refs w,
+
 # Various files in /run/udev/data needed by Chrome Settings. Leaks device
 # information.
 # input

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -198,6 +198,10 @@ dbus (receive, send)
     interface=org.freedesktop.DBus.Properties
     path=/org/freedesktop/portal/{desktop,documents}{,/**}
     peer=(label=unconfined),
+
+# These accesses are noisy and applications can't do anything with the found
+# icon files, so explicitly deny to silence the denials
+deny /var/lib/snapd/desktop/icons/ r,
 `
 
 type desktopInterface struct{}

--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -228,6 +228,7 @@ dbus (send)
 # This leaks the names of snaps with desktop files
 /var/lib/snapd/desktop/applications/ r,
 /var/lib/snapd/desktop/applications/mimeinfo.cache r,
+# Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
 # parallel-installs: this leaks read access to desktop files owned by keyed
 # instances of @{SNAP_NAME} to @{SNAP_NAME} snap
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -95,6 +95,7 @@ unix (bind,listen) type=stream addr="@/containerd-shim/k8s.io/*/shim.sock\x00",
 
 # Limited read access to specific bits of /sys
 /sys/kernel/mm/hugepages/ r,
+/sys/kernel/mm/transparent_hugepage/{,**} r,
 /sys/fs/cgroup/cpuset/cpuset.cpus r,
 /sys/fs/cgroup/cpuset/cpuset.mems r,
 /sys/module/apparmor/parameters/enabled r,

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -66,6 +66,7 @@ capability kill,
 
 capability sys_resource,
 /sys/kernel/mm/hugepages/ r,
+/sys/kernel/mm/transparent_hugepage/{,**} r,
 owner @{PROC}/[0-9]*/oom_score_adj rw,
 
 capability sys_ptrace,

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -144,15 +144,17 @@ pivot_root
 /sys/devices/virtual/block/loop[0-9]*/loop/autoclear r,
 /sys/devices/virtual/block/loop[0-9]*/loop/backing_file r,
 
-# greengrassd needs protected hardlinks and symlinks to run securely, but 
-# won't turn them on itself, hence only read access for these things - 
-# the user is clearly informed if these are disabled and so the user can 
+# greengrassd needs protected hardlinks, symlinks, etc to run securely, but
+# won't turn them on itself, hence only read access for these things -
+# the user is clearly informed if these are disabled and so the user can
 # enable these themselves rather than give the snap permission to turn these
 # on
 @{PROC}/sys/fs/protected_hardlinks r,
 @{PROC}/sys/fs/protected_symlinks r,
+@{PROC}/sys/fs/protected_fifos r,
+@{PROC}/sys/fs/protected_regular r,
 
-# mount tries to access this, but it doesn't really need it 
+# mount tries to access this, but it doesn't really need it
 deny /run/mount/utab rw,
 
 # these accesses are needed in order to mount a squashfs file for the rootfs

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -316,6 +316,13 @@ owner /state/server/{,**} rw,
 /etc/ r,
 /etc/debian_version r,
 #include <abstractions/python>
+# additional accesses needed for newer pythons in later bases
+/usr/lib{,32,64}/python3.[0-9]/**.{pyc,so}           mr,
+/usr/lib{,32,64}/python3.[0-9]/**.{egg,py,pth}       r,
+/usr/lib{,32,64}/python3.[0-9]/{site,dist}-packages/ r,
+/usr/lib{,32,64}/python3.[0-9]/lib-dynload/*.so      mr,
+/etc/python3.[0-9]/**                                r,
+/usr/include/python3.[0-9]*/pyconfig.h               r,
 
 # manually add java certs here
 # see also https://bugs.launchpad.net/apparmor/+bug/1816372

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -97,6 +97,9 @@ network netlink raw,
 /sys/kernel/debug/usb/devices r,
 @{PROC}/sys/abi/{,*} r,
 
+# status of hugepages and transparent_hugepage, but not the pages themselves
+/sys/kernel/mm/{hugepages,transparent_hugepage}/{,**} r,
+
 # systemd-detect-virt
 /{,usr/}bin/systemd-detect-virt ixr,
 # VMs

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -113,11 +113,12 @@ network netlink raw,
 # its first line a pid that != 1 and systemd-detect-virt tries to detect this.
 # This doesn't seem to be the case on (at least) systemd 240 on Ubuntu. This
 # file is somewhat sensitive for arbitrary pids, but is not overly so for pid
-# 1. systemd won't normally look at this file since it has access to
-# /run/systemd/container and 'container' from the environment, and systemd
-# fails gracefully when it doesn't have access to /proc/1/sched, so for now,
-# disallow it. See src/basic/virt.c from systemd sources for details.
-#@{PROC}/1/sched r,
+# 1. For containers, systemd won't normally look at this file since it has
+# access to /run/systemd/container and 'container' from the environment, and
+# systemd fails gracefully when it doesn't have access to /proc/1/sched. For
+# VMs, systemd requires access to /proc/1/sched in its detection algorithm.
+# See src/basic/virt.c from systemd sources for details.
+@{PROC}/1/sched r,
 
 # systemd-detect-virt --private-users will look at these and the access is
 # better added to system-observe. Since snaps typically only care about

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -59,6 +59,7 @@ capability sys_resource,
 @{PROC}/@{pid}/oom_score_adj rw,
 @{PROC}/sys/vm/overcommit_memory rw,
 /sys/kernel/mm/hugepages/{,**} r,
+/sys/kernel/mm/transparent_hugepage/{,**} r,
 
 capability dac_override,
 

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -35,7 +35,7 @@ const rawusbConnectedPlugAppArmor = `
 /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
 
 # Allow access to all ttyUSB devices too
-/dev/tty{USB,ACM}[0-9]* rw,
+/dev/tty{USB,ACM}[0-9]* rwk,
 
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -156,7 +156,7 @@ func (iface *serialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		// This apparmor rule is an approximation of serialDeviceNodePattern
 		// (AARE is different than regex, so we must approximate).
 		// UDev tagging and device cgroups will restrict down to the specific device
-		spec.AddSnippet("/dev/tty[A-Z]*[0-9] rw,")
+		spec.AddSnippet("/dev/tty[A-Z]*[0-9] rwk,")
 		return nil
 	}
 
@@ -166,7 +166,7 @@ func (iface *serialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		return nil
 	}
 	cleanedPath := filepath.Clean(path)
-	spec.AddSnippet(fmt.Sprintf("%s rw,", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rwk,", cleanedPath))
 	return nil
 }
 

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -451,36 +451,36 @@ func (s *SerialPortInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 		c.Assert(snippet, DeepEquals, expectedSnippet)
 	}
 
-	expectedSnippet1 := `/dev/ttyS0 rw,`
+	expectedSnippet1 := `/dev/ttyS0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot1, expectedSnippet1)
-	expectedSnippet2 := `/dev/ttyUSB927 rw,`
+	expectedSnippet2 := `/dev/ttyUSB927 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot2, expectedSnippet2)
 
-	expectedSnippet3 := `/dev/ttyS42 rw,`
+	expectedSnippet3 := `/dev/ttyS42 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot3, expectedSnippet3)
 
-	expectedSnippet4 := `/dev/ttyO0 rw,`
+	expectedSnippet4 := `/dev/ttyO0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot4, expectedSnippet4)
 
-	expectedSnippet5 := `/dev/ttyACM0 rw,`
+	expectedSnippet5 := `/dev/ttyACM0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot5, expectedSnippet5)
 
-	expectedSnippet6 := `/dev/ttyAMA0 rw,`
+	expectedSnippet6 := `/dev/ttyAMA0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot6, expectedSnippet6)
 
-	expectedSnippet7 := `/dev/ttyXRUSB0 rw,`
+	expectedSnippet7 := `/dev/ttyXRUSB0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot7, expectedSnippet7)
 
-	expectedSnippet8 := `/dev/ttymxc2 rw,`
+	expectedSnippet8 := `/dev/ttymxc2 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot8, expectedSnippet8)
 
-	expectedSnippet9 := `/dev/tty[A-Z]*[0-9] rw,`
+	expectedSnippet9 := `/dev/tty[A-Z]*[0-9] rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testUDev1, expectedSnippet9)
 
-	expectedSnippet10 := `/dev/tty[A-Z]*[0-9] rw,`
+	expectedSnippet10 := `/dev/tty[A-Z]*[0-9] rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort2, s.testUDev2, expectedSnippet10)
 
-	expectedSnippet11 := `/dev/tty[A-Z]*[0-9] rw,`
+	expectedSnippet11 := `/dev/tty[A-Z]*[0-9] rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort2, s.testUDev3, expectedSnippet11)
 }
 

--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -102,9 +102,14 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "5026",
 	},
 	{
-		Name:             "Tomu board + chopstx U2F",
+		Name:             "Tomu board + chopstx U2F + SoloKeys",
 		VendorIDPattern:  "0483",
-		ProductIDPattern: "cdab",
+		ProductIDPattern: "cdab|a2ca",
+	},
+	{
+		Name:             "SoloKeys",
+		VendorIDPattern:  "1209",
+		ProductIDPattern: "5070|50b0",
 	},
 }
 
@@ -122,6 +127,7 @@ const u2fDevicesConnectedPlugAppArmor = `
 # misc required accesses
 /run/udev/data/+power_supply:hid* r,
 /run/udev/data/c14:[0-9]* r,
+/sys/devices/**/i2c*/**/report_descriptor r,
 /sys/devices/**/usb*/**/report_descriptor r,
 `
 

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -86,7 +86,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 14)
+	c.Assert(spec.Snippets(), HasLen, 15)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -482,6 +482,7 @@ dbus (receive)
 # this leaks the names of snaps with desktop files
 /var/lib/snapd/desktop/applications/ r,
 /var/lib/snapd/desktop/applications/mimeinfo.cache r,
+# Support BAMF_DESKTOP_FILE_HINT by allowing reading our desktop files
 # parallel-installs: when @{SNAP_INSTANCE_NAME} == @{SNAP_NAME},
 # this leaks read access to desktop files of parallel installs of the snap
 /var/lib/snapd/desktop/applications/@{SNAP_INSTANCE_NAME}_*.desktop r,


### PR DESCRIPTION
Port of https://github.com/snapcore/snapd/pull/7779 to 2.42