### PR TITLE
snap-bootstrap: remove SNAPPY_TESTING check, we use it for real now

### DIFF
--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -23,8 +23,6 @@ import (
 	"os"
 
 	"github.com/jessevdk/go-flags"
-
-	"github.com/snapcore/snapd/osutil"
 )
 
 var (
@@ -47,9 +45,6 @@ func main() {
 }
 
 func run(args []string) error {
-	if !osutil.GetenvBool("SNAPPY_TESTING") {
-		return fmt.Errorf("cannot use outside of tests yet")
-	}
 	if os.Getuid() != 0 {
 		return fmt.Errorf("please run as root")
 	}


### PR DESCRIPTION
The code of snap-bootstrap was checking for the SNAPPY_TESTING
flag to ensure it only runs during spread testing. This is no
longer needed, we use the code now for real in our UC20 initramfs
so this check can go.
