### PR TITLE
interfaces/policy: enforce plug-names/slot-names constraints

### DIFF
--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -124,7 +124,24 @@ func checkDeviceScope(c *asserts.DeviceScopeConstraint, model *asserts.Model, st
 	return nil
 }
 
+func checkNameConstraints(c *asserts.NameConstraints, iface, which, name string) error {
+	if c == nil {
+		return nil
+	}
+	special := map[string]string{
+		"$INTERFACE": iface,
+	}
+	return c.Check(which, name, special)
+}
+
 func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.PlugConnectionConstraints) error {
+	if err := checkNameConstraints(constraints.PlugNames, connc.Plug.Interface(), "plug name", connc.Plug.Name()); err != nil {
+		return err
+	}
+	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
+		return err
+	}
+
 	if err := constraints.PlugAttributes.Check(connc.Plug, connc); err != nil {
 		return err
 	}
@@ -168,6 +185,13 @@ func checkPlugConnectionAltConstraints(connc *ConnectCandidate, altConstraints [
 }
 
 func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.SlotConnectionConstraints) error {
+	if err := checkNameConstraints(constraints.PlugNames, connc.Plug.Interface(), "plug name", connc.Plug.Name()); err != nil {
+		return err
+	}
+	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
+		return err
+	}
+
 	if err := constraints.PlugAttributes.Check(connc.Plug, connc); err != nil {
 		return err
 	}
@@ -241,6 +265,10 @@ func checkMinimalSlotInstallationAltConstraints(ic *InstallCandidateMinimalCheck
 }
 
 func checkSlotInstallationConstraints1(ic *InstallCandidate, slot *snap.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
+	if err := checkNameConstraints(constraints.SlotNames, slot.Interface, "slot name", slot.Name); err != nil {
+		return err
+	}
+
 	// TODO: allow evaluated attr constraints here too?
 	if err := constraints.SlotAttributes.Check(slot, nil); err != nil {
 		return err
@@ -273,6 +301,10 @@ func checkSlotInstallationAltConstraints(ic *InstallCandidate, slot *snap.SlotIn
 }
 
 func checkPlugInstallationConstraints1(ic *InstallCandidate, plug *snap.PlugInfo, constraints *asserts.PlugInstallationConstraints) error {
+	if err := checkNameConstraints(constraints.PlugNames, plug.Interface, "plug name", plug.Name); err != nil {
+		return err
+	}
+
 	// TODO: allow evaluated attr constraints here too?
 	if err := constraints.PlugAttributes.Check(plug, nil); err != nil {
 		return err

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -2469,7 +2469,14 @@ func (s *policySuite) TestNameConstraintsAutoConnection(c *C) {
 		if t.ok {
 			c.Check(err, IsNil, Commentf("%s:%s", t.plug, t.slot))
 		} else {
-			c.Check(err, NotNil)
+			expected := ""
+			if cand.Plug.Interface() == "plugs-name-bound" {
+				expected = `auto-connection not allowed by plug rule of interface "plugs-name-bound".*`
+			} else {
+				// slots-name-bound
+				expected = `auto-connection not allowed by slot rule of interface "slots-name-bound".*`
+			}
+			c.Check(err, ErrorMatches, expected)
 		}
 	}
 

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -168,6 +168,10 @@ plugs:
         - debian
   install-plug-device-scope:
     allow-installation: false
+  install-plug-name-bound:
+    allow-installation:
+      plug-names:
+        - $INTERFACE
 slots:
   base-slot-allow: true
   base-slot-not-allow:
@@ -298,6 +302,10 @@ slots:
         - debian
   install-slot-device-scope:
     allow-installation: false
+  install-slot-name-bound:
+    allow-installation:
+      slot-names:
+        - $INTERFACE
   slots-arity-default:
     allow-auto-connection: true
   slots-arity-slot-any:
@@ -311,6 +319,10 @@ slots:
   slots-arity-slot-any-plug-default:
     deny-auto-connection: true
   slots-arity-slot-one-plug-any:
+    deny-auto-connection: true
+  slots-name-bound:
+    deny-auto-connection: true
+  plugs-name-bound:
     deny-auto-connection: true
 timestamp: 2016-09-30T12:00:00Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
@@ -499,6 +511,15 @@ plugs:
    slots-arity-slot-any-plug-two:
    slots-arity-slot-any-plug-default:
    slots-arity-slot-one-plug-any:
+
+   slots-name-bound-p1:
+     interface: slots-name-bound
+   slots-name-bound-p2:
+     interface: slots-name-bound
+   plugs-name-bound-p1:
+     interface: plugs-name-bound
+   plugs-name-bound-p2:
+     interface: plugs-name-bound
 `, nil)
 
 	s.slotSnap = snaptest.MockInfo(c, `
@@ -672,6 +693,16 @@ slots:
    slots-arity-slot-any-plug-two:
    slots-arity-slot-any-plug-default:
    slots-arity-slot-one-plug-any:
+
+   slots-name-bound-s1:
+     interface: slots-name-bound
+   slots-name-bound-s2:
+     interface: slots-name-bound
+   plugs-name-bound-s1:
+     interface: plugs-name-bound
+   plugs-name-bound-s2:
+     interface: plugs-name-bound
+
 `, nil)
 
 	a, err = asserts.Decode([]byte(`type: snap-declaration
@@ -747,6 +778,13 @@ plugs:
   slots-arity-slot-one-plug-any:
     allow-auto-connection:
       slots-per-plug: *
+  plugs-name-bound:
+    allow-auto-connection:
+      -
+        plug-names:
+          - plugs-name-bound-p1
+        slot-names:
+          - plugs-name-bound-s2
 timestamp: 2016-09-30T12:00:00Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -826,6 +864,13 @@ slots:
   slots-arity-slot-one-plug-any:
     allow-auto-connection:
       slots-per-plug: 1
+  slots-name-bound:
+    allow-auto-connection:
+      -
+        plug-names:
+          - slots-name-bound-p2
+        slot-names:
+          - slots-name-bound-s2
 timestamp: 2016-09-30T12:00:00Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -2315,4 +2360,117 @@ func (s *policySuite) TestSlotsArityAutoConnection(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(arity.SlotsPerPlugAny(), Equals, t.any)
 	}
+}
+
+func (s *policySuite) TestNameConstraintsInstallation(c *C) {
+	const plugSnap = `name: install-snap
+version: 0
+plugs:
+  install-plug-name-bound:`
+
+	const plugOtherNameSnap = `name: install-snap
+version: 0
+plugs:
+  install-plug-name-bound-other:
+    interface: install-plug-name-bound
+`
+
+	const slotSnap = `name: install-snap
+version: 0
+slots:
+  install-slot-name-bound:`
+
+	const slotOtherNameSnap = `name: install-snap
+version: 0
+slots:
+  install-slot-name-bound-other:
+    interface: install-slot-name-bound
+`
+
+	const plugOtherName = `plugs:
+  install-plug-name-bound:
+    allow-installation:
+      plug-names:
+        - install-plug-name-bound-other`
+
+	tests := []struct {
+		installYaml string
+		plugsSlots  string
+		err         string // "" => no error
+	}{
+		{plugSnap, "", ""},
+		{plugOtherNameSnap, "", `installation not allowed by "install-plug-name-bound-other" plug rule of interface "install-plug-name-bound"`},
+		{plugOtherNameSnap, plugOtherName, ""},
+		{slotSnap, "", ""},
+		{slotOtherNameSnap, "", `installation not allowed by "install-slot-name-bound-other" slot rule of interface "install-slot-name-bound"`},
+	}
+
+	for _, t := range tests {
+		installSnap := snaptest.MockInfo(c, t.installYaml, nil)
+
+		plugsSlots := strings.TrimSpace(t.plugsSlots)
+		if plugsSlots != "" {
+			plugsSlots = "\n" + plugsSlots
+		}
+
+		a, err := asserts.Decode([]byte(strings.Replace(`type: snap-declaration
+authority-id: canonical
+series: 16
+snap-name: install-snap
+snap-id: installsnap6idididididididididid
+publisher-id: publisher
+@plugsSlots@
+timestamp: 2016-09-30T12:00:00Z
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==`, "\n@plugsSlots@", plugsSlots, 1)))
+		c.Assert(err, IsNil)
+		snapDecl := a.(*asserts.SnapDeclaration)
+
+		cand := policy.InstallCandidate{
+			Snap:            installSnap,
+			SnapDeclaration: snapDecl,
+			BaseDeclaration: s.baseDecl,
+		}
+		err = cand.Check()
+		if t.err == "" {
+			c.Check(err, IsNil)
+		} else {
+			c.Check(err, ErrorMatches, t.err)
+		}
+	}
+}
+
+func (s *policySuite) TestNameConstraintsAutoConnection(c *C) {
+	tests := []struct {
+		plug, slot string
+		ok         bool
+	}{
+		{"plugs-name-bound-p1", "plugs-name-bound-s1", false},
+		{"plugs-name-bound-p2", "plugs-name-bound-s1", false},
+		{"plugs-name-bound-p1", "plugs-name-bound-s2", true},
+		{"plugs-name-bound-p2", "plugs-name-bound-s2", false},
+		{"slots-name-bound-p1", "slots-name-bound-s1", false},
+		{"slots-name-bound-p2", "slots-name-bound-s1", false},
+		{"slots-name-bound-p1", "slots-name-bound-s2", false},
+		{"slots-name-bound-p2", "slots-name-bound-s2", true},
+	}
+
+	for _, t := range tests {
+		cand := policy.ConnectCandidate{
+			Plug:                interfaces.NewConnectedPlug(s.plugSnap.Plugs[t.plug], nil, nil),
+			Slot:                interfaces.NewConnectedSlot(s.slotSnap.Slots[t.slot], nil, nil),
+			PlugSnapDeclaration: s.plugDecl,
+			SlotSnapDeclaration: s.slotDecl,
+
+			BaseDeclaration: s.baseDecl,
+		}
+		_, err := cand.CheckAutoConnect()
+		if t.ok {
+			c.Check(err, IsNil, Commentf("%s:%s", t.plug, t.slot))
+		} else {
+			c.Check(err, NotNil)
+		}
+	}
+
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -7613,3 +7613,82 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedAnyS
 
 	s.testDoSetupSnapSecurityAutoConnectsDeclBasedAnySlotsPerPlug(c, check)
 }
+
+func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsDeclBasedSlotNames(c *C) {
+	s.MockModel(c, nil)
+
+	restore := assertstest.MockBuiltinBaseDeclaration([]byte(`
+type: base-declaration
+authority-id: canonical
+series: 16
+plugs:
+  test:
+    allow-auto-connection: false
+`))
+	defer restore()
+	s.mockIfaces(c, &ifacetest.TestInterface{InterfaceName: "test"})
+
+	s.MockSnapDecl(c, "gadget", "one-publisher", nil)
+
+	const gadgetYaml = `
+name: gadget
+type: gadget
+version: 1
+slots:
+  test1:
+    interface: test
+  test2:
+    interface: test
+`
+	s.mockSnap(c, gadgetYaml)
+
+	mgr := s.manager(c)
+
+	s.MockSnapDecl(c, "consumer", "one-publisher", map[string]interface{}{
+		"format": "4",
+		"plugs": map[string]interface{}{
+			"test": map[string]interface{}{
+				"allow-auto-connection": map[string]interface{}{
+					"slot-names": []interface{}{
+						"test1",
+					},
+				},
+			},
+		}})
+
+	const consumerYaml = `
+name: consumer
+version: 1
+plugs:
+  test:
+`
+	snapInfo := s.mockSnap(c, consumerYaml)
+
+	// Run the setup-snap-security task and let it finish.
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.SnapName(),
+			SnapID:   snapInfo.SnapID,
+			Revision: snapInfo.Revision,
+		},
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	var conns map[string]interface{}
+	_ = s.state.Get("conns", &conns)
+
+	repo := mgr.Repository()
+	plug := repo.Plug("consumer", "test")
+	c.Assert(plug, Not(IsNil))
+
+	c.Check(conns, DeepEquals, map[string]interface{}{
+		"consumer:test gadget:test1": map[string]interface{}{"auto": true, "interface": "test"},
+	})
+	c.Check(repo.Interfaces().Connections, HasLen, 1)
+}


### PR DESCRIPTION
This also adds a test to ifacetest.