### PR TITLE
tests: reduce the complexity of the test-snapd-sh snap

### DIFF
--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -2,11 +2,12 @@
 
 make_snap() {
     local SNAP_NAME="$1"
-    shift;
-    local SNAP_FILE="$TESTSLIB/snaps/${SNAP_NAME}/${SNAP_NAME}_1.0_all.snap"
-    local SNAP_DIR
+    local SNAP_DIR="$2"
+    if [ -z "$SNAP_DIR" ]; then
+        SNAP_DIR="$TESTSLIB/snaps/${SNAP_NAME}"
+    fi
+    local SNAP_FILE="${SNAP_DIR}/${SNAP_NAME}_1.0_all.snap"
     # assigned in a separate step to avoid hiding a failure
-    SNAP_DIR="$(dirname "$SNAP_FILE")"
     if [ ! -f "$SNAP_FILE" ]; then
         snap pack "$SNAP_DIR" "$SNAP_DIR" >/dev/null || return 1
     fi
@@ -14,14 +15,19 @@ make_snap() {
     if [ -f "$SNAP_FILE" ]; then
         echo "$SNAP_FILE"
     else
-        find "$TESTSLIB/snaps/${SNAP_NAME}" -name '*.snap' | head -n1
+        find "$SNAP_DIR" -name '*.snap' | head -n1
     fi
 }
 
 install_local() {
     local SNAP_NAME="$1"
+    local SNAP_DIR="$TESTSLIB/snaps/${SNAP_NAME}"
     shift
-    SNAP_FILE=$(make_snap "$SNAP_NAME")
+
+    if [ -d "$SNAP_NAME" ]; then
+        SNAP_DIR="$PWD/$SNAP_NAME"
+    fi
+    SNAP_FILE=$(make_snap "$SNAP_NAME" "$SNAP_DIR")
 
     snap install --dangerous "$@" "$SNAP_FILE"
 }

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -2,9 +2,9 @@
 
 make_snap() {
     local SNAP_NAME="$1"
-    local SNAP_DIR="$2"
-    if [ -z "$SNAP_DIR" ]; then
-        SNAP_DIR="$TESTSLIB/snaps/${SNAP_NAME}"
+    local SNAP_DIR="$TESTSLIB/snaps/${SNAP_NAME}"
+    if [ $# -gt 1 ]; then
+        SNAP_DIR="$2"
     fi
     local SNAP_FILE="${SNAP_DIR}/${SNAP_NAME}_1.0_all.snap"
     # assigned in a separate step to avoid hiding a failure

--- a/tests/lib/snaps/config-versions-v2/bin/sh
+++ b/tests/lib/snaps/config-versions-v2/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/config-versions/bin/sh
+++ b/tests/lib/snaps/config-versions/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-classic-confinement/bin/sh
+++ b/tests/lib/snaps/test-snapd-classic-confinement/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-advanced-plug/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-advanced-plug/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-advanced-slot/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-advanced-slot/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-mimic-plug/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-mimic-plug/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-content-mimic-slot/bin/sh
+++ b/tests/lib/snaps/test-snapd-content-mimic-slot/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-illegal-system-username/bin/sh
+++ b/tests/lib/snaps/test-snapd-illegal-system-username/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-layout/bin/sh
+++ b/tests/lib/snaps/test-snapd-layout/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-sh-core16/bin/sh
+++ b/tests/lib/snaps/test-snapd-sh-core16/bin/sh
@@ -1,4 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"
-

--- a/tests/lib/snaps/test-snapd-sh/bin/sh
+++ b/tests/lib/snaps/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-unknown-interfaces/bin/sh
+++ b/tests/lib/snaps/test-snapd-unknown-interfaces/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-appstream-metadata/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-appstream-metadata/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-appstream-metadata/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-appstream-metadata/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-appstream-metadata/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-appstream-metadata/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-appstream-metadata-plug:
         command: bin/sh
+        plugs: [appstream-metadata]

--- a/tests/main/interfaces-broadcom-asic-control/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-broadcom-asic-control/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-broadcom-asic-control/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-broadcom-asic-control/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-broadcom-asic-control/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-broadcom-asic-control/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-broadcom-asic-control-plug:
         command: bin/sh
+        plugs: [broadcom-asic-control]

--- a/tests/main/interfaces-device-buttons/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-device-buttons/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-device-buttons/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-device-buttons/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-device-buttons/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-device-buttons/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-device-buttons-plug:
         command: bin/sh
+        plugs: [device-buttons]

--- a/tests/main/interfaces-dvb/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-dvb/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-dvb/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-dvb/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-dvb/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-dvb/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-dvb-plug:
         command: bin/sh
+        plugs: [dvb]

--- a/tests/main/interfaces-gpg-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-gpg-keys/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-gpg-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-gpg-keys/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-gpg-keys/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-gpg-keys/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-gpg-keys-plug:
         command: bin/sh
+        plugs: [gpg-keys]

--- a/tests/main/interfaces-gpg-public-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-gpg-public-keys/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-gpg-public-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-gpg-public-keys/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-gpg-public-keys/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-gpg-public-keys/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-gpg-public-keys-plug:
         command: bin/sh
+        plugs: [gpg-public-keys]

--- a/tests/main/interfaces-hostname-control/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-hostname-control/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-hostname-control/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-hostname-control/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-hostname-control/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-hostname-control/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-hostname-control-plug:
         command: bin/sh
+        plugs: [hostname-control]

--- a/tests/main/interfaces-joystick/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-joystick/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-joystick/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-joystick/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-joystick/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-joystick/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-joystick-plug:
         command: bin/sh
+        plugs: [joystick]

--- a/tests/main/interfaces-juju-client-observe/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-juju-client-observe/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-juju-client-observe/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-juju-client-observe/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-juju-client-observe/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-juju-client-observe/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-juju-client-observe-plug:
         command: bin/sh
+        plugs: [juju-client-observe]

--- a/tests/main/interfaces-kvm/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-kvm/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-kvm/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-kvm/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-kvm/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-kvm/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-kvm-plug:
         command: bin/sh
+        plugs: [kvm]

--- a/tests/main/interfaces-network-setup-control/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-network-setup-control/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-network-setup-control/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-network-setup-control/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-network-setup-control/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-network-setup-control/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-network-setup-control-plug:
         command: bin/sh
+        plugs: [network-setup-control]

--- a/tests/main/interfaces-network-setup-observe/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-network-setup-observe/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-network-setup-observe/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-network-setup-observe/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-network-setup-observe/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-network-setup-observe/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-network-setup-observe-plug:
         command: bin/sh
+        plugs: [network-setup-observe]

--- a/tests/main/interfaces-personal-files/task.yaml
+++ b/tests/main/interfaces-personal-files/task.yaml
@@ -46,9 +46,6 @@ execute: |
     echo "When the interface is connected"
     snap connect test-snapd-sh:personal-files
 
-    echo "And not other interfaces are connected"
-    snap disconnect test-snapd-sh:home
-
     echo "Then the snap is able to access all the files and dirs in $HOME"
     test-snapd-sh.with-personal-files-plug -c "cat /root/.testfile1" | MATCH "content for /root/.testfile1"
     test-snapd-sh.with-personal-files-plug -c "cat /root/testfile1" | MATCH "content for /root/testfile1"

--- a/tests/main/interfaces-personal-files/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-personal-files/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-personal-files/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-personal-files/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-personal-files/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-personal-files/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,13 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+plugs:
+    personal-files:
+        read: [$HOME/.testdir1, $HOME/.testfile1, $HOME/testfile1, $HOME/testdir1]
+        write: [$HOME/.testdir1, $HOME/.testfile1]
+
+apps:
+    with-personal-files-plug:
+        command: bin/sh
+        plugs: [personal-files]

--- a/tests/main/interfaces-raw-usb/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-raw-usb/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-raw-usb/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-raw-usb/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-raw-usb/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-raw-usb/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-raw-usb-plug:
         command: bin/sh
+        plugs: [raw-usb]

--- a/tests/main/interfaces-removable-media/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-removable-media/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-removable-media/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-removable-media/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-removable-media/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-removable-media/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-removable-media-plug:
         command: bin/sh
+        plugs: [removable-media]

--- a/tests/main/interfaces-ssh-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-ssh-keys/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-ssh-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-ssh-keys/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-ssh-keys/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-ssh-keys/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-ssh-keys-plug:
         command: bin/sh
+        plugs: [ssh-keys]

--- a/tests/main/interfaces-ssh-public-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-ssh-public-keys/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-ssh-public-keys/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-ssh-public-keys/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-ssh-public-keys/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-ssh-public-keys/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-ssh-public-keys-plug:
         command: bin/sh
+        plugs: [ssh-public-keys]

--- a/tests/main/interfaces-system-files/task.yaml
+++ b/tests/main/interfaces-system-files/task.yaml
@@ -46,9 +46,6 @@ execute: |
     echo "When the interface is connected"
     snap connect test-snapd-sh:system-files
 
-    echo "And not other interfaces are connected"
-    snap disconnect test-snapd-sh:home
-
     echo "Then the snap is able to access all the files and dirs in /testdir"
     test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testfile1" | MATCH "content for $TESTDIR/.testfile1"
     test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/readonly_file1" MATCH "content for $TESTDIR/readonly_file1"

--- a/tests/main/interfaces-system-files/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-system-files/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/interfaces-system-files/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-system-files/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/interfaces-system-files/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-system-files/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,13 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+plugs:
+    system-files:
+        read: [/mnt/testdir]
+        write: [/mnt/testdir/.testdir1, /mnt/testdir/.testfile1]
+
+apps:
+    with-system-files-plug:
+        command: bin/sh
+        plugs: [system-files]

--- a/tests/main/nfs-support/test-snapd-sh/bin/sh
+++ b/tests/main/nfs-support/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/nfs-support/test-snapd-sh/bin/sh
+++ b/tests/main/nfs-support/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/main/nfs-support/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/nfs-support/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-home-plug:
         command: bin/sh
+        plugs: [home]

--- a/tests/regression/lp-1797556/test-snapd-sh/bin/sh
+++ b/tests/regression/lp-1797556/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/regression/lp-1797556/test-snapd-sh/bin/sh
+++ b/tests/regression/lp-1797556/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/regression/lp-1797556/test-snapd-sh/meta/snap.yaml
+++ b/tests/regression/lp-1797556/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-home-plug:
         command: bin/sh
+        plugs: [home]

--- a/tests/smoke/sandbox/test-snapd-sh/bin/sh
+++ b/tests/smoke/sandbox/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/smoke/sandbox/test-snapd-sh/bin/sh
+++ b/tests/smoke/sandbox/test-snapd-sh/bin/sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
 exec /bin/sh "$@"

--- a/tests/smoke/sandbox/test-snapd-sh/meta/snap.yaml
+++ b/tests/smoke/sandbox/test-snapd-sh/meta/snap.yaml
@@ -3,6 +3,8 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
+    test-snapd-sh:
+        command: bin/sh
     with-home-plug:
         command: bin/sh
         plugs: [home]

--- a/tests/smoke/sandbox/test-snapd-sh/meta/snap.yaml
+++ b/tests/smoke/sandbox/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,6 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    with-home-plug:
         command: bin/sh
+        plugs: [home]


### PR DESCRIPTION
To install test-snapd-sh in taking about 40 seconds in a board like pi3.
Whithe this change the istallation takes about 12 seconds.

Also the install local takes as defult path the local test directory, so it is possible to install snaps and is it not needed to pack and install with --dangerous manually.