### PR TITLE
cmd/snap-bootstrap: write /var/lib/snapd/modeenv to the right place

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -170,7 +170,7 @@ func generateMountsModeInstall() error {
 		Mode:           "install",
 		RecoverySystem: systemLabel,
 	}
-	if err := modeEnv.Write(filepath.Join(runMnt, "ubuntu-data")); err != nil {
+	if err := modeEnv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -235,7 +235,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 3)
 	c.Check(s.Stdout.String(), Equals, "")
-	modeEnv := filepath.Join(s.runMnt, "/ubuntu-data/var/lib/snapd/modeenv")
+	modeEnv := filepath.Join(s.runMnt, "/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	c.Check(modeEnv, testutil.FileEquals, `mode=install
 recovery_system=20191118
 `)


### PR DESCRIPTION
The "ubuntu-data" partition (writable) has traditionally two
toplevel dirs:
- system-data
- user-data

The user-data dir is mounted on top of /home and system-data
is /. The modeenv file from "snap-bootstrap initramfs-mounts"
is written to the wrong location (the "system-data" part is
missing). This commit fixes this.
