### PR TITLE
boot: add boot.Modeenv.Base support

### DIFF
--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -36,6 +36,7 @@ import (
 type Modeenv struct {
 	Mode           string
 	RecoverySystem string
+	Base           string
 }
 
 func ReadModeenv(rootdir string) (*Modeenv, error) {
@@ -47,9 +48,11 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	}
 	recoverySystem, _ := cfg.Get("", "recovery_system")
 	mode, _ := cfg.Get("", "mode")
+	base, _ := cfg.Get("", "base")
 	return &Modeenv{
 		Mode:           mode,
 		RecoverySystem: recoverySystem,
+		Base:           base,
 	}, nil
 }
 
@@ -65,6 +68,9 @@ func (m *Modeenv) Write(rootdir string) error {
 	}
 	if m.RecoverySystem != "" {
 		fmt.Fprintf(buf, "recovery_system=%s\n", m.RecoverySystem)
+	}
+	if m.Base != "" {
+		fmt.Fprintf(buf, "base=%s\n", m.Base)
 	}
 	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {
 		return err

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -75,6 +75,7 @@ func (s *modeenvSuite) TestReadMode(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(modeenv.Mode, Equals, "run")
 	c.Check(modeenv.RecoverySystem, Equals, "")
+	c.Check(modeenv.Base, Equals, "")
 }
 
 func (s *modeenvSuite) TestReadModeWithRecoverySystem(c *C) {
@@ -86,6 +87,19 @@ recovery_system=20191126
 	c.Assert(err, IsNil)
 	c.Check(modeenv.Mode, Equals, "recovery")
 	c.Check(modeenv.RecoverySystem, Equals, "20191126")
+}
+
+func (s *modeenvSuite) TestReadModeWithBase(c *C) {
+	s.makeMockModeenvFile(c, `mode=recovery
+recovery_system=20191126
+base=core20_123.snap
+`)
+
+	modeenv, err := boot.ReadModeenv(s.tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(modeenv.Mode, Equals, "recovery")
+	c.Check(modeenv.RecoverySystem, Equals, "20191126")
+	c.Check(modeenv.Base, Equals, "core20_123.snap")
 }
 
 func (s *modeenvSuite) TestWriteNonExisting(c *C) {
@@ -108,4 +122,21 @@ func (s *modeenvSuite) TestWriteExisting(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, "mode=recovery\n")
+}
+
+func (s *modeenvSuite) TestWriteNonExistingFull(c *C) {
+	c.Assert(s.mockModeenvPath, testutil.FileAbsent)
+
+	modeenv := &boot.Modeenv{
+		Mode:           "run",
+		RecoverySystem: "20191128",
+		Base:           "core20_321.snap",
+	}
+	err := modeenv.Write(s.tmpdir)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=run
+recovery_system=20191128
+base=core20_321.snap
+`)
 }


### PR DESCRIPTION
For the "run" mode of UC20 we will need a way to specifc what
base the system should use. This commit adds the required groundwork.
