### PR TITLE
boot: add boot.Modeenv.Kernel support

### DIFF
--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -37,6 +37,7 @@ type Modeenv struct {
 	Mode           string
 	RecoverySystem string
 	Base           string
+	Kernel         string
 }
 
 func ReadModeenv(rootdir string) (*Modeenv, error) {
@@ -49,10 +50,12 @@ func ReadModeenv(rootdir string) (*Modeenv, error) {
 	recoverySystem, _ := cfg.Get("", "recovery_system")
 	mode, _ := cfg.Get("", "mode")
 	base, _ := cfg.Get("", "base")
+	kernel, _ := cfg.Get("", "kernel")
 	return &Modeenv{
 		Mode:           mode,
 		RecoverySystem: recoverySystem,
 		Base:           base,
+		Kernel:         kernel,
 	}, nil
 }
 
@@ -71,6 +74,9 @@ func (m *Modeenv) Write(rootdir string) error {
 	}
 	if m.Base != "" {
 		fmt.Fprintf(buf, "base=%s\n", m.Base)
+	}
+	if m.Kernel != "" {
+		fmt.Fprintf(buf, "kernel=%s\n", m.Kernel)
 	}
 	if err := osutil.AtomicWriteFile(modeenvPath, buf.Bytes(), 0644, 0); err != nil {
 		return err

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -93,6 +93,7 @@ func (s *modeenvSuite) TestReadModeWithBase(c *C) {
 	s.makeMockModeenvFile(c, `mode=recovery
 recovery_system=20191126
 base=core20_123.snap
+kernel=pc-kernel_987.snap
 `)
 
 	modeenv, err := boot.ReadModeenv(s.tmpdir)
@@ -100,6 +101,7 @@ base=core20_123.snap
 	c.Check(modeenv.Mode, Equals, "recovery")
 	c.Check(modeenv.RecoverySystem, Equals, "20191126")
 	c.Check(modeenv.Base, Equals, "core20_123.snap")
+	c.Check(modeenv.Kernel, Equals, "pc-kernel_987.snap")
 }
 
 func (s *modeenvSuite) TestWriteNonExisting(c *C) {
@@ -131,6 +133,7 @@ func (s *modeenvSuite) TestWriteNonExistingFull(c *C) {
 		Mode:           "run",
 		RecoverySystem: "20191128",
 		Base:           "core20_321.snap",
+		Kernel:         "pc-kernel_456.snap",
 	}
 	err := modeenv.Write(s.tmpdir)
 	c.Assert(err, IsNil)
@@ -138,5 +141,6 @@ func (s *modeenvSuite) TestWriteNonExistingFull(c *C) {
 	c.Assert(s.mockModeenvPath, testutil.FileEquals, `mode=run
 recovery_system=20191128
 base=core20_321.snap
+kernel=pc-kernel_456.snap
 `)
 }


### PR DESCRIPTION
For the grub bootloader on the ubuntu-boot partition we want to
keep the kernel commandline as static as possible to avoid TPM
reseal operations for each kernel update.

This means that we will have a kernel with a fixed name on the
ubuntu-boot partition. But the initramfs needs information what
kernel snap we expect so that it can mount the kernel snap
and make the kernel modules available early in initramfs.

This commit adds "kernel" to the modeenv so that snapd can
set what kernel snap is expected via the modeenv mechanism
that is already used to set what base to use. The snap-bootstrap
initramfs-mounts code will have to do a cross-check to ensure
that the booted kernel matches the expected kernel and deal
with kernel reverts from the bootloader. This will happen in
subsequent commits.
