### PR TITLE
devicestate: ensure system installation

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -106,7 +106,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	runner.AddHandler("generate-device-key", m.doGenerateDeviceKey, nil)
 	runner.AddHandler("request-serial", m.doRequestSerial, nil)
 	runner.AddHandler("mark-seeded", m.doMarkSeeded, nil)
-	runner.AddHandler("make-run-system", m.doMakeRunSystem, nil)
+	runner.AddHandler("setup-run-system", m.doSetupRunSystem, nil)
 	runner.AddHandler("prepare-remodeling", m.doPrepareRemodeling, nil)
 	runner.AddCleanup("prepare-remodeling", m.cleanupRemodel)
 	// this *must* always run last and finalizes a remodel
@@ -514,8 +514,8 @@ func (m *DeviceManager) ensureInstalled() error {
 	m.ensureInstalledRan = true
 
 	tasks := []*state.Task{}
-	makeRunSystem := m.state.NewTask("make-run-system", i18n.G("Prepare system for run mode"))
-	tasks = append(tasks, makeRunSystem)
+	setupRunSystem := m.state.NewTask("setup-run-system", i18n.G("Setup system for run mode"))
+	tasks = append(tasks, setupRunSystem)
 
 	chg := m.state.NewChange("install-system", i18n.G("Install the system"))
 	chg.AddAll(state.NewTaskSet(tasks...))

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -270,11 +270,6 @@ func (m *DeviceManager) ensureOperational() error {
 
 	perfTimings := timings.New(map[string]string{"ensure": "become-operational"})
 
-	if m.operatingMode == "install" {
-		// avoid doing registration in install mode
-		return nil
-	}
-
 	device, err := m.device()
 	if err != nil {
 		return err

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
+)
+
+type deviceMgrInstallModeSuite struct {
+	deviceMgrBaseSuite
+}
+
+var _ = Suite(&deviceMgrInstallModeSuite{})
+
+func (s *deviceMgrInstallModeSuite) findInstallSystem() *state.Change {
+	for _, chg := range s.state.Changes() {
+		if chg.Kind() == "install-system" {
+			return chg
+		}
+	}
+	return nil
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	release.OnClassic = false
+	s.state.Set("seeded", true)
+	devicestate.SetOperatingMode(s.mgr, "install")
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	// the install-system change is created
+	createPartitions := s.findInstallSystem()
+	c.Assert(createPartitions, NotNil)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeNotInstallmodeNoChg(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	release.OnClassic = false
+	s.state.Set("seeded", true)
+	devicestate.SetOperatingMode(s.mgr, "")
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	// the install-system change is *not* created (not in install mode)
+	createPartitions := s.findInstallSystem()
+	c.Assert(createPartitions, IsNil)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeNotClassic(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	release.OnClassic = true
+	s.state.Set("seeded", true)
+	devicestate.SetOperatingMode(s.mgr, "install")
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	// the install-system change is *not* created (we're on classic)
+	createPartitions := s.findInstallSystem()
+	c.Assert(createPartitions, IsNil)
+}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-func (m *DeviceManager) doMakeRunSystem(t *state.Task, _ *tomb.Tomb) error {
+func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -36,7 +36,5 @@ func (m *DeviceManager) doMakeRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	// XXX: add handler content
 
-	t.SetStatus(state.DoneStatus)
-
 	return nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate
+
+import (
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/timings"
+)
+
+func (m *DeviceManager) doMakeRunSystem(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	perfTimings := timings.NewForTask(t)
+	defer perfTimings.Save(st)
+
+	// XXX: add handler content
+
+	t.SetStatus(state.DoneStatus)
+
+	return nil
+}


### PR DESCRIPTION
Core20 systems start with only the seed partition on disk and should
be properly installed in order to boot in run mode.  After the system
boots in ephemeral mode and is properly seeded, we should invoke the
install handler. This commit adds infrastructure to invoke this
handler, actual handler contents will be added at a later moment.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>