### PR TITLE
tests: use test-snapd-sh snap instead of test-snapd-tools - Part 1

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -45,7 +45,7 @@ environment:
     SRU_VALIDATION: '$(HOST: echo "${SPREAD_SRU_VALIDATION:-0}")'
     # use the ppa_validation_name to install snapd from that ppa
     PPA_VALIDATION_NAME: '$(HOST: echo "${SPREAD_PPA_VALIDATION_NAME:-}")'
-    PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
+    PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools test-snapd-sh
     # always skip removing the rsync snap
     SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18'
     # Use the installed snapd and reset the systems without removing snapd

--- a/tests/core18/basic/task.yaml
+++ b/tests/core18/basic/task.yaml
@@ -12,9 +12,9 @@ execute: |
     echo "Ensure that the system is fully seeded"
     snap changes | MATCH "Done.*Initialize system state"
 
-    echo "Check that snapd tools for core18 works"
-    snap install test-snapd-tools-core18
-    test-snapd-tools-core18.echo hello | MATCH hello
+    echo "Check that snapd sh for core18 works"
+    snap install test-snapd-sh-core18
+    test-snapd-sh-core18.sh -c 'echo hello' | MATCH hello
 
     if python3 -m json.tool < /var/lib/snapd/system-key | grep '"build-id": ""'; then
         echo "The build-id of snapd must not be empty."
@@ -22,4 +22,4 @@ execute: |
     fi
 
     echo "Ensure passwd/group is available for snaps"
-    test-snapd-tools-core18.cat /var/lib/extrausers/passwd | MATCH test
+    test-snapd-sh-core18.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test

--- a/tests/core18/basic/task.yaml
+++ b/tests/core18/basic/task.yaml
@@ -12,7 +12,7 @@ execute: |
     echo "Ensure that the system is fully seeded"
     snap changes | MATCH "Done.*Initialize system state"
 
-    echo "Check that snapd sh for core18 works"
+    echo "Check that a simple shell snap"
     snap install test-snapd-sh-core18
     test-snapd-sh-core18.sh -c 'echo hello' | MATCH hello
 

--- a/tests/core18/compat/task.yaml
+++ b/tests/core18/compat/task.yaml
@@ -8,4 +8,4 @@ execute: |
     snap list | MATCH "^core +"
 
     echo "Check test-snapd-sh see the core16 environment"
-    test-snapd-sh -c 'cat /etc/os-release' | MATCH "Ubuntu Core 16"
+    test-snapd-sh.sh -c 'cat /etc/os-release' | MATCH "Ubuntu Core 16"

--- a/tests/core18/compat/task.yaml
+++ b/tests/core18/compat/task.yaml
@@ -1,11 +1,11 @@
 summary: Ensure that core(16) compatibility is there
 
 execute: |
-    echo "Install test-snapd-tools (which uses the core snap)"
-    snap install test-snapd-tools
+    echo "Install test-snapd-sh (which uses the core snap)"
+    snap install test-snapd-sh
 
     echo "Ensure that this pulled in core"
     snap list | MATCH "^core +"
 
-    echo "Check test-snapd-tools see the core16 environment"
-    test-snapd-tools.cat /etc/os-release | MATCH "Ubuntu Core 16"
+    echo "Check test-snapd-sh see the core16 environment"
+    test-snapd-sh -c 'cat /etc/os-release' | MATCH "Ubuntu Core 16"

--- a/tests/core18/remove/task.yaml
+++ b/tests/core18/remove/task.yaml
@@ -13,7 +13,7 @@ execute: |
     fi
 
     echo "Install a snap that requires core as the base"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     snap list | MATCH '^core '
     if snap remove core; then
         echo "core should not be removalble because test-snapd-tools needs it"
@@ -21,7 +21,7 @@ execute: |
     fi
 
     echo "But core can be removed again once nothing on the system needs it"
-    snap remove test-snapd-tools
+    snap remove test-snapd-sh
     snap remove core
 
     if snap list | MATCH '^core '; then

--- a/tests/core18/snapd-refresh/task.yaml
+++ b/tests/core18/snapd-refresh/task.yaml
@@ -36,5 +36,5 @@ execute: |
     fi
 
     snap list | MATCH "snapd.*$current "
-    snap install test-snapd-tools-core18
-    test-snapd-tools-core18.echo hello | MATCH hello
+    snap install test-snapd-sh-core18
+    test-snapd-sh-core18.sh -c 'echo hello' | MATCH hello

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -686,7 +686,7 @@ prepare_ubuntu_core() {
             snap list
             exit 1
         fi
-        cache_snaps core
+        cache_snaps core test-snapd-sh-core18
     fi
     echo "Cache the snaps profiler snap"
     if [ "$PROFILE_SNAPS" = 1 ]; then

--- a/tests/lib/snaps/test-snapd-sh-core18/bin/sh
+++ b/tests/lib/snaps/test-snapd-sh-core18/bin/sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+exec /bin/sh "$@"
+

--- a/tests/lib/snaps/test-snapd-sh-core18/bin/sh
+++ b/tests/lib/snaps/test-snapd-sh-core18/bin/sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 exec /bin/sh "$@"
-

--- a/tests/lib/snaps/test-snapd-sh-core18/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh-core18/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-sh-core18
+version: 1.0
+architectures: ["all"]
+base: core18
+
+apps:
+    sh:
+        command: bin/sh

--- a/tests/main/auth-errors/task.yaml
+++ b/tests/main/auth-errors/task.yaml
@@ -12,7 +12,7 @@ restore: |
 
 execute: |
     echo "An unauthenticated user cannot install snaps"
-    if su - -c "snap install test-snapd-tools" test 2> install.output; then
+    if su - -c "snap install test-snapd-sh" test 2> install.output; then
         echo "Expected error installing snap from unauthenticated account"
         exit 1
     fi

--- a/tests/main/install-cache/task.yaml
+++ b/tests/main/install-cache/task.yaml
@@ -4,7 +4,7 @@ execute: |
     # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
-    snap install test-snapd-tools
-    snap remove test-snapd-tools
-    snap install test-snapd-tools
-    check_journalctl_log 'using cache for .*/test-snapd-tools.*\.snap' -u snapd
+    snap install test-snapd-sh
+    snap remove test-snapd-sh
+    snap install test-snapd-sh
+    check_journalctl_log 'using cache for .*/test-snapd-sh.*\.snap' -u snapd

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -15,6 +15,6 @@ execute: |
     rm /var/cache/fontconfig/*
 
     echo "Installing a snap generates a fontconfig cache"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     ls /var/cache/fontconfig/*.cache-6
     ls /var/cache/fontconfig/*.cache-7

--- a/tests/main/install-remove-multi/task.yaml
+++ b/tests/main/install-remove-multi/task.yaml
@@ -2,13 +2,13 @@ summary: Check that install/remove of multiple snaps works
 
 execute: |
     echo "Install multiple snaps from the store"
-    snap install test-snapd-tools test-snapd-control-consumer
-    snap list | MATCH test-snapd-tools
+    snap install test-snapd-sh test-snapd-control-consumer
+    snap list | MATCH test-snapd-sh
     snap list | MATCH test-snapd-control-consumer
 
     echo "Remove of multiple snaps works"
-    snap remove test-snapd-tools test-snapd-control-consumer
-    snap list | MATCH -v test-snapd-tools
+    snap remove test-snapd-sh test-snapd-control-consumer
+    snap list | MATCH -v test-snapd-sh
     snap list | MATCH -v test-snapd-control-consumer
 
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/install-store-laaaarge/task.yaml
+++ b/tests/main/install-store-laaaarge/task.yaml
@@ -19,5 +19,5 @@ restore: |
 
 execute: |
     # test-snapd-tools is about 8k, tmpfs is 4k :-)
-    snap install test-snapd-tools
-    snap remove test-snapd-tools
+    snap install test-snapd-sh
+    snap remove test-snapd-sh

--- a/tests/main/install-store-laaaarge/task.yaml
+++ b/tests/main/install-store-laaaarge/task.yaml
@@ -18,6 +18,6 @@ restore: |
     systemctl start snapd.{socket,service}
 
 execute: |
-    # test-snapd-tools is about 8k, tmpfs is 4k :-)
+    # test-snapd-sh is about 8k, tmpfs is 4k :-)
     snap install test-snapd-sh
     snap remove test-snapd-sh

--- a/tests/main/kernel-snap-refresh-on-core/task.yaml
+++ b/tests/main/kernel-snap-refresh-on-core/task.yaml
@@ -14,7 +14,7 @@ environment:
     NEW_KERNEL_CHANNEL: edge
 
 prepare: |
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
 debug: |
     grub-editenv list
@@ -35,7 +35,7 @@ execute: |
         # ensure we have a good starting place
     
         # sanity
-        test-snapd-tools.echo hello | MATCH hello
+        test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
         # go to known good starting place
         snap refresh pc-kernel "--${KERNEL_CHANNEL}"
@@ -62,8 +62,8 @@ execute: |
             test "$(bootenv snap_try_kernel)" = "pc-kernel_$(cat nextBoot).snap"
         fi
 
-        # test-snapd-tools works
-        test-snapd-tools.echo hello | MATCH hello
+        # test-snapd-sh works
+        test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
         REBOOT
     elif [  "$SPREAD_REBOOT" = 2 ]; then
@@ -81,8 +81,8 @@ execute: |
             exit 0
         fi
         
-        # test-snapd-tools works
-        test-snapd-tools.echo hello | MATCH hello
+        # test-snapd-sh works
+        test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
         # revert kernel
         snap revert pc-kernel
@@ -102,6 +102,6 @@ execute: |
         echo we are back to the original kernel
         diff -u /proc/version_signature prevKernelSignature
         
-        # test-snapd-tools works
-        test-snapd-tools.echo hello | MATCH hello
+        # test-snapd-sh works
+        test-snapd-sh.sh -c 'echo hello' | MATCH hello
     fi

--- a/tests/main/local-install-w-metadata/task.yaml
+++ b/tests/main/local-install-w-metadata/task.yaml
@@ -5,19 +5,19 @@ systems: [-ubuntu-core-*]
 
 execute: |
     echo "Get the snap"
-    snap download test-snapd-tools
+    snap download test-snapd-sh
 
     echo "Try to install the snap without assertions"
-    (snap install test-snapd-tools_*.snap 2>&1 || true) | MATCH 'cannot find signatures with metadata for snap "test-snapd-tools.*\.snap"'
+    (snap install test-snapd-sh_*.snap 2>&1 || true) | MATCH 'cannot find signatures with metadata for snap "test-snapd-sh.*\.snap"'
 
     echo "Add its assertions"
-    snap ack test-snapd-tools_*.assert
+    snap ack test-snapd-sh_*.assert
 
     echo "Installing the snap file will use the metadata from assertions"
-    snap install test-snapd-tools_*.snap
+    snap install test-snapd-sh_*.snap
 
     echo "The revision is not a local revision"
-    snap list|MATCH '^test-snapd-tools.* [0-9]+\s+-\s+canonical'
+    snap list|MATCH '^test-snapd-sh.* [0-9]+\s+-\s+cachio'
 
     echo "Test it"
-    test-snapd-tools.success
+    test-snapd-sh.sh -c 'true'

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -37,7 +37,7 @@ execute: |
     lxd.lxc exec my-ubuntu -- apt install -y "$GOHOME"/snapd_*.deb
 
     echo "And validate that we get a useful error"
-    if lxd.lxc exec my-ubuntu snap install test-snapd-tools 2> err.txt; then
+    if lxd.lxc exec my-ubuntu snap install test-snapd-sh 2> err.txt; then
         echo "snap install should fail but it did not?"
         exit 1
     fi

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -40,14 +40,14 @@ execute: |
     lxd.lxc exec my-ubuntu -- apt install -y "$GOHOME"/snapd_*.deb
 
     echo "And validate that we can use snaps"
-    lxd.lxc exec my-ubuntu -- snap install test-snapd-tools
+    lxd.lxc exec my-ubuntu -- snap install test-snapd-sh
     echo "And we can run snaps as regular users"
-    lxd.lxc exec my-ubuntu -- su -c "/snap/bin/test-snapd-tools.echo from-the-inside" ubuntu | MATCH from-the-inside
+    lxd.lxc exec my-ubuntu -- su -c "/snap/bin/test-snapd-sh.sh -c 'echo from-the-inside'" ubuntu | MATCH from-the-inside
     echo "And as root"
-    lxd.lxc exec my-ubuntu -- test-snapd-tools.echo from-the-inside | MATCH from-the-inside
+    lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c 'echo from-the-inside' | MATCH from-the-inside
 
     echo "And snapfuse is actually running"
     ps afx | MATCH snapfuse
 
     echo "We can also remove snaps successfully"
-    lxd.lxc exec my-ubuntu -- snap remove test-snapd-tools
+    lxd.lxc exec my-ubuntu -- snap remove test-snapd-sh

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -97,13 +97,13 @@ execute: |
     #        will only work with an up-to-date xenial kernel (4.4.0-78+)
 
     echo "Ensure we can use snapd inside lxd"
-    lxd.lxc exec my-ubuntu snap install test-snapd-tools
+    lxd.lxc exec my-ubuntu snap install test-snapd-sh
     echo "And we can run snaps as regular users"
-    lxd.lxc exec my-ubuntu -- su -c "/snap/bin/test-snapd-tools.echo from-the-inside" ubuntu | MATCH from-the-inside
+    lxd.lxc exec my-ubuntu -- su -c "/snap/bin/test-snapd-sh.sh -c 'echo from-the-inside'" ubuntu | MATCH from-the-inside
     echo "And as root"
-    lxd.lxc exec my-ubuntu -- test-snapd-tools.echo from-the-inside | MATCH from-the-inside
+    lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c 'echo from-the-inside' | MATCH from-the-inside
     echo "We can also remove snaps successfully"
-    lxd.lxc exec my-ubuntu -- snap remove test-snapd-tools
+    lxd.lxc exec my-ubuntu -- snap remove test-snapd-sh
 
     echo "Install lxd-demo server to exercise the lxd interface"
     snap install lxd-demo-server

--- a/tests/main/network-retry/task.yaml
+++ b/tests/main/network-retry/task.yaml
@@ -29,8 +29,8 @@ execute: |
     fi
 
     echo "Try to install a snap with broken DNS"
-    if snap install test-snapd-tools; then
-        echo "Installing test-snapd-tools with broken DNS should not work"
+    if snap install test-snapd-sh; then
+        echo "Installing test-snapd-sh with broken DNS should not work"
         echo "Test broken"
         exit 1
     fi

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -17,13 +17,13 @@ restore: |
 
 execute: |
     echo "Install a snap"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
     echo "Run as the test user (normal home dir)"
-    su -c "snap run test-snapd-tools.echo foo" test | MATCH foo
+    su -c "snap run test-snapd-sh.sh -c 'echo foo'" test | MATCH foo
 
     echo "Run as the non-home user (home dir outside of /home) - this will fail"
-    not su -c "snap run test-snapd-tools.echo foo" "$TUSER" 2>stderr.log
+    not su -c "snap run test-snapd-sh.sh -c 'echo foo'" "$TUSER" 2>stderr.log
 
     echo "Ensure we get a useful error message"
     MATCH "Sorry, home directories outside of /home" < stderr.log

--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -1,31 +1,31 @@
 summary: Checks for parallel installation of snaps from the store
 
 execute: |
-    not snap install test-snapd-sh_foo 2> run.err
+    not snap install test-snapd-tools_foo 2> run.err
     MATCH 'experimental feature disabled' < run.err
 
     snap set system experimental.parallel-instances=true
 
-    snap install test-snapd-sh_foo | MATCH '^test-snapd-sh_foo .* installed'
+    snap install test-snapd-tools_foo | MATCH '^test-snapd-tools_foo .* installed'
 
     echo "The snap is listed"
-    snap list | MATCH '^test-snapd-sh_foo '
+    snap list | MATCH '^test-snapd-tools_foo '
 
     echo "The snap application can be run"
     #shellcheck disable=SC2016
-    test-snapd-sh_foo.sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
-    MATCH 'hello data from test-snapd-sh_foo' < /var/snap/test-snapd-sh_foo/current/data
-    su -l -c "test-snapd-sh_foo.sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
-    MATCH 'hello user data from test-snapd-sh_foo' < /home/test/snap/test-snapd-sh_foo/current/data
+    test-snapd-tools_foo.cmd sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
+    MATCH 'hello data from test-snapd-tools_foo' < /var/snap/test-snapd-tools_foo/current/data
+    su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
+    MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/current/data
 
     echo "Installing another instance, without instance key, succeeds"
-    snap install test-snapd-sh
+    snap install test-snapd-tools
 
     echo "And so does another one, but with different instance key"
-    snap install test-snapd-sh_bar
+    snap install test-snapd-tools_bar
 
     echo "Installing more than one instance at a time works too"
-    snap install test-snapd-sh_baz test-snapd-sh_zed
+    snap install test-snapd-tools_baz test-snapd-tools_zed
 
 restore: |
     snap set system experimental.parallel-instances=

--- a/tests/main/parallel-install-store/task.yaml
+++ b/tests/main/parallel-install-store/task.yaml
@@ -1,31 +1,31 @@
 summary: Checks for parallel installation of snaps from the store
 
 execute: |
-    not snap install test-snapd-tools_foo 2> run.err
+    not snap install test-snapd-sh_foo 2> run.err
     MATCH 'experimental feature disabled' < run.err
 
     snap set system experimental.parallel-instances=true
 
-    snap install test-snapd-tools_foo | MATCH '^test-snapd-tools_foo .* installed'
+    snap install test-snapd-sh_foo | MATCH '^test-snapd-sh_foo .* installed'
 
     echo "The snap is listed"
-    snap list | MATCH '^test-snapd-tools_foo '
+    snap list | MATCH '^test-snapd-sh_foo '
 
     echo "The snap application can be run"
     #shellcheck disable=SC2016
-    test-snapd-tools_foo.cmd sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
-    MATCH 'hello data from test-snapd-tools_foo' < /var/snap/test-snapd-tools_foo/current/data
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
-    MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/current/data
+    test-snapd-sh_foo.sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
+    MATCH 'hello data from test-snapd-sh_foo' < /var/snap/test-snapd-sh_foo/current/data
+    su -l -c "test-snapd-sh_foo.sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
+    MATCH 'hello user data from test-snapd-sh_foo' < /home/test/snap/test-snapd-sh_foo/current/data
 
     echo "Installing another instance, without instance key, succeeds"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
     echo "And so does another one, but with different instance key"
-    snap install test-snapd-tools_bar
+    snap install test-snapd-sh_bar
 
     echo "Installing more than one instance at a time works too"
-    snap install test-snapd-tools_baz test-snapd-tools_zed
+    snap install test-snapd-sh_baz test-snapd-sh_zed
 
 restore: |
     snap set system experimental.parallel-instances=

--- a/tests/main/sanitycheck/task.yaml
+++ b/tests/main/sanitycheck/task.yaml
@@ -30,4 +30,4 @@ execute: |
     snap list | MATCH core
     
     echo "Ensure snap commands reply with sanity check error"
-    snap install test-snapd-tools 2>&1 | MATCH "system does not fully support snapd: cannot mount squashfs image"
+    snap install test-snapd-sh 2>&1 | MATCH "system does not fully support snapd: cannot mount squashfs image"

--- a/tests/main/selinux-clean/task.yaml
+++ b/tests/main/selinux-clean/task.yaml
@@ -27,10 +27,10 @@ restore: |
     rm -f stamp enforcing.mode
 
 execute: |
-    snap install test-snapd-tools
-    test-snapd-tools.cmd echo 'hello world'
-    su -c 'test-snapd-tools.cmd echo hello world' test
-    snap remove test-snapd-tools
+    snap install test-snapd-sh
+    test-snapd-sh.sh -c 'echo hello world'
+    su -c 'test-snapd-sh.sh -c "echo hello world"' test
+    snap remove test-snapd-sh
     ausearch -i --checkpoint stamp --start checkpoint -m AVC 2>&1 | MATCH 'no matches'
 
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/selinux-data-context/task.yaml
+++ b/tests/main/selinux-data-context/task.yaml
@@ -17,23 +17,23 @@ execute: |
     # verify that we're actually running on a SELinux system
     selinuxenabled
 
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
-    test-snapd-tools.cmd id -Z | MATCH ':unconfined_t:'
-    test-snapd-tools.cmd sh -c "mkdir -p \$SNAP_USER_DATA/foo && echo hello world > \$SNAP_USER_DATA/foo/bar"
+    test-snapd-sh.sh -c 'id -Z' | MATCH ':unconfined_t:'
+    test-snapd-sh.sh -c "mkdir -p \$SNAP_USER_DATA/foo && echo hello world > \$SNAP_USER_DATA/foo/bar"
 
-    su -c 'test-snapd-tools.cmd id -Z' test | MATCH ':unconfined_t:'
-    su -c "test-snapd-tools.cmd sh -c 'mkdir -p \$SNAP_USER_DATA/foo && echo hello world > \$SNAP_USER_DATA/foo/bar'" test
+    su -c 'test-snapd-sh.sh -c "id -Z"' test | MATCH ':unconfined_t:'
+    su -c "test-snapd-sh.sh -c 'mkdir -p \$SNAP_USER_DATA/foo && echo hello world > \$SNAP_USER_DATA/foo/bar'" test
 
-    ls -Zd /root/snap /root/snap/test-snapd-tools/current/foo /root/snap/test-snapd-tools/current/foo/bar > root-labels
+    ls -Zd /root/snap /root/snap/test-snapd-sh/current/foo /root/snap/test-snapd-sh/current/foo/bar > root-labels
     MATCH '^.*:snappy_home_t:.*/root/snap$'                                  < root-labels
-    MATCH '^.*:snappy_home_t:.*/root/snap/test-snapd-tools/current/foo$'     < root-labels
-    MATCH '^.*:snappy_home_t:.*/root/snap/test-snapd-tools/current/foo/bar$' < root-labels
+    MATCH '^.*:snappy_home_t:.*/root/snap/test-snapd-sh/current/foo$'     < root-labels
+    MATCH '^.*:snappy_home_t:.*/root/snap/test-snapd-sh/current/foo/bar$' < root-labels
 
-    ls -Zd /home/test/snap /home/test/snap/test-snapd-tools/current/foo /home/test/snap/test-snapd-tools/current/foo/bar > test-labels
+    ls -Zd /home/test/snap /home/test/snap/test-snapd-sh/current/foo /home/test/snap/test-snapd-sh/current/foo/bar > test-labels
     MATCH '^.*:snappy_home_t:.*/home/test/snap$'                                  < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools/current/foo$'     < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools/current/foo/bar$' < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh/current/foo$'     < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh/current/foo/bar$' < test-labels
 
     #shellcheck disable=SC2012
     ls -Zd /run/snapd | MATCH ':snappy_var_run_t:'


### PR DESCRIPTION
Using a simple snap like the test-snapd-sh instead of test-snapd-tools. This implies an improvement on performance mostly on boards. 

The test-snapd-sh which is in the store is not pluging any interface, it is a reduced snap which is  defined in https://code.launchpad.net/~snappy-dev/snappy-hub/test-snapd-sh and like it is defined int he PR #7815

The idea is that once we merge the #7815 and this one the performance of the tests should be much better. 

After this PR a new one is gonna be created to complete the missing tests and also apply that change to the tests which are doing install_local test_snapd_tools. This PR depends on the #7815.