### PR TITLE
tests: demand silence from check_journalctl_log

### DIFF
--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -37,10 +37,17 @@ check_journalctl_log(){
     expression=$1
     shift
     for _ in $(seq 10); do
+        # forcibly silence this particular bit because it produces GOBS of 
+        # output and we really don't need to see all the output when we are 
+        # checking the output for an expression, as if it is missing we want to 
+        # check the journal once at the end of this loop, likely in the debug 
+        # section
+        set +x
         log=$(get_journalctl_log "$@")
         if echo "$log" | grep -q -E "$expression"; then
             return 0
         fi
+        set -x
         echo "Match for \"$expression\" failed, retrying"
         sleep 1
     done

--- a/tests/main/refresh-delta/task.yaml
+++ b/tests/main/refresh-delta/task.yaml
@@ -1,8 +1,5 @@
 summary: Check that the refresh command uses deltas
 
-# delta downloads are currently disabled by default on core
-systems: [-ubuntu-core-*]
-
 environment:
     SNAP_NAME: test-snapd-delta-refresh
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1


### PR DESCRIPTION
This does 2 things:
* enable the refresh-delta test on UC, because those should work fine now that deltas work everywhere
* attempt to silence a rather noisy bit of code in spread tests where we often times break the Travis job because so much log output is generated that outputting it here will hit the Travis job output limit. 

If silencing proves to be controversial I can propose the refresh-delta test enabling separately