### PR TITLE
gadget: extract and export new DiskFromPartition() helper

### DIFF
--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -215,11 +215,15 @@ func findParentDeviceWithWritableFallback() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return DiskFromPartition(partitionWritable)
+	return ParentDiskFromPartition(partitionWritable)
 }
 
-// XXX: move to osutil?
-func DiskFromPartition(partition string) (string, error) {
+// ParentDiskFromPartition will find the parent disk device for the
+// given partition. E.g. /dev/nvmen0n1p5 -> /dev/nvme0n1
+//
+// Note that this does not work for anything using device mapper (like
+// LUKS/LVM) yet.
+func ParentDiskFromPartition(partition string) (string, error) {
 	// /dev/sda3 -> sda3
 	devname := filepath.Base(partition)
 

--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -211,13 +211,17 @@ func findDeviceForWritable() (device string, err error) {
 }
 
 func findParentDeviceWithWritableFallback() (string, error) {
-	deviceWritable, err := findDeviceForWritable()
+	partitionWritable, err := findDeviceForWritable()
 	if err != nil {
 		return "", err
 	}
+	return DiskFromPartition(partitionWritable)
+}
 
+// XXX: move to osutil?
+func DiskFromPartition(partition string) (string, error) {
 	// /dev/sda3 -> sda3
-	devname := filepath.Base(deviceWritable)
+	devname := filepath.Base(partition)
 
 	// do not bother with investigating major/minor devices (inconsistent
 	// across block device types) or mangling strings, but look at sys


### PR DESCRIPTION
For the UC20 code that creates partitions on firstboot we will
need something that can determine the disk from a partition. We
already have such code in the gadget that is not exported, so
this PR extracts and exports it.

This should make #7762 shorter by reusing this code between the two subsystems.

If this looks like the right thing to do I will make sure this gets extra tests
added.