### PR TITLE
tests: move the watchdog timeout to 2s to make the tests work in rpi

### DIFF
--- a/tests/lib/snaps/test-snapd-service-watchdog/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service-watchdog/meta/snap.yaml
@@ -4,12 +4,12 @@ apps:
   direct-watchdog-ok:
     command: bin/direct
     daemon: simple
-    watchdog-timeout: 1s
+    watchdog-timeout: 2s
     restart-condition: never
     plugs: [daemon-notify]
   direct-watchdog-bad:
     command: bin/direct --bad
     daemon: simple
-    watchdog-timeout: 1s
+    watchdog-timeout: 2s
     restart-condition: never
     plugs: [daemon-notify]


### PR DESCRIPTION
The limit of 1 second for the watchdog is not enough on some boards like
the pi2. Moving the timeout to 2 seconds it works much better.
See the error log

Dec 03 12:09:22 localhost systemd[1]: Started Service for snap
application test-snapd-service-watchdog.direct-watchdog-ok.
Dec 03 12:09:23 localhost systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Watchdog
timeout (limit 1s)!
Dec 03 12:09:23 localhost systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Killing
process 3021 (python3) with signal SIGABRT.
Dec 03 12:09:23 localhost systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Main
process exited, code=killed, status=6/ABRT
Dec 03 12:09:23 localhost systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Failed with
result 'watchdog'.
