### PR TITLE
gadget: add missing test for duplicate detection of roles

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -439,17 +439,17 @@ func validateVolume(name string, vol *Volume, constraints *ModelConstraints) err
 		switch s.Role {
 		case SystemSeed:
 			if state.SystemSeed != nil {
-				return fmt.Errorf("cannot have more than one system-seed role")
+				return fmt.Errorf("cannot have more than one partition with system-seed role")
 			}
 			state.SystemSeed = &vol.Structure[idx]
 		case SystemData:
 			if state.SystemData != nil {
-				return fmt.Errorf("cannot have more than one system-data role")
+				return fmt.Errorf("cannot have more than one partition with system-data role")
 			}
 			state.SystemData = &vol.Structure[idx]
 		case SystemBoot:
 			if state.SystemBoot != nil {
-				return fmt.Errorf("cannot have more than one system-boot role")
+				return fmt.Errorf("cannot have more than one partition with system-boot role")
 			}
 			state.SystemBoot = &vol.Structure[idx]
 		}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -385,6 +385,7 @@ func fmtIndexAndName(idx int, name string) string {
 type validationState struct {
 	SystemSeed *VolumeStructure
 	SystemData *VolumeStructure
+	SystemBoot *VolumeStructure
 }
 
 func validateVolume(name string, vol *Volume, constraints *ModelConstraints) error {
@@ -438,14 +439,19 @@ func validateVolume(name string, vol *Volume, constraints *ModelConstraints) err
 		switch s.Role {
 		case SystemSeed:
 			if state.SystemSeed != nil {
-				return fmt.Errorf("cannot have more than one system-data role")
+				return fmt.Errorf("cannot have more than one system-seed role")
 			}
 			state.SystemSeed = &vol.Structure[idx]
 		case SystemData:
 			if state.SystemData != nil {
-				return fmt.Errorf("cannot have more than one system-seed role")
+				return fmt.Errorf("cannot have more than one system-data role")
 			}
 			state.SystemData = &vol.Structure[idx]
+		case SystemBoot:
+			if state.SystemBoot != nil {
+				return fmt.Errorf("cannot have more than one system-boot role")
+			}
+			state.SystemBoot = &vol.Structure[idx]
 		}
 
 		previousEnd = end

--- a/gadget/validate_test.go
+++ b/gadget/validate_test.go
@@ -175,6 +175,6 @@ volumes:
 `, role)
 		makeSizedFile(c, filepath.Join(s.dir, "meta/gadget.yaml"), 0, []byte(gadgetYamlContent))
 		err := gadget.Validate(s.dir, nil)
-		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid gadget metadata: invalid volume "pc": cannot have more than one %s role`, role))
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid gadget metadata: invalid volume "pc": cannot have more than one partition with %s role`, role))
 	}
 }

--- a/gadget/validate_test.go
+++ b/gadget/validate_test.go
@@ -20,6 +20,7 @@
 package gadget_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -153,4 +154,27 @@ func (s *validateGadgetTestSuite) TestValidateClassic(c *C) {
 
 	err = gadget.Validate(s.dir, &gadget.ModelConstraints{Classic: false})
 	c.Assert(err, ErrorMatches, "invalid gadget metadata: bootloader not declared in any volume")
+}
+
+func (s *validateGadgetTestSuite) TestValidateSystemSeedRoleTwice(c *C) {
+
+	for _, role := range []string{"system-seed", "system-data", "system-boot"} {
+		gadgetYamlContent := fmt.Sprintf(`
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: foo
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        role: %[1]s
+      - name: bar
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        role: %[1]s
+`, role)
+		makeSizedFile(c, filepath.Join(s.dir, "meta/gadget.yaml"), 0, []byte(gadgetYamlContent))
+		err := gadget.Validate(s.dir, nil)
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid gadget metadata: invalid volume "pc": cannot have more than one %s role`, role))
+	}
 }


### PR DESCRIPTION
During the review for PR#7832 it was noticed that the gadget
validation seems to lack a unittest for the detection of
duplicated roles (like "system-seed") in gadget.yaml.

This commit fixes the missing test and also fixes a bug in
the error message and adds duplication detection for system-boot.
