### PR TITLE
o/ifacestate: fix binding of implicit hooks to implicit slots on core snap

### DIFF
--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -87,6 +87,30 @@ func addImplicitSlots(st *state.State, snapInfo *snap.Info) error {
 		}
 	}
 
+	// bind implicit hooks if necessary. note, implicit hooks are bound when reading snap
+	// yaml, but they did't know about implicit slots back then.
+	for _, slot := range snapInfo.Slots {
+		for _, hook := range snapInfo.Hooks {
+			// on core we only have implicit hooks, but no harm in checking
+			if hook.Explicit {
+				continue
+			}
+			// do not overwrite
+			if _, ok := slot.Hooks[hook.Name]; ok {
+				continue
+			}
+			// bind hook and slot
+			if slot.Hooks == nil {
+				slot.Hooks = make(map[string]*snap.HookInfo)
+			}
+			slot.Hooks[hook.Name] = hook
+			if hook.Slots == nil {
+				hook.Slots = make(map[string]*snap.SlotInfo)
+			}
+			hook.Slots[slot.Name] = slot
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When working on the fix of another bug - https://github.com/snapcore/snapd/pull/7830 - I found out a deeper issue undermining some of the 7830 label logic, which this PR is aiming to fix.

When we read snap yaml (ReadInfo), we also bind implicit hooks from the disk. However, in case of core, later on we also add implicit slots, and they are never considered in terms of implicit hooks.

This is a short-term fix. Long-term we should completely re-design this aspect; ideally, ReadInfo (or an enriched/smarter equivalent of it) would give a complete snap.Info with implicit slots and hooks in it; one problem with doing it right away is the fact that for implicit slots we need state (for hotplug slots), and all interfaces, so it needs a good plan.