### PR TITLE
devicestate: implement creating partitions in "install" mode

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -20,11 +20,20 @@
 package devicestate_test
 
 import (
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type deviceMgrInstallModeSuite struct {
@@ -50,11 +59,43 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	s.state.Set("seeded", true)
 }
 
+func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C) {
+	si := &snap.SideInfo{
+		RealName: "pc",
+		Revision: snap.R(1),
+		SnapID:   "pc-ididid",
+	}
+	snapstate.Set(s.state, "pc", &snapstate.SnapState{
+		SnapType: "gadget",
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		Active:   true,
+	})
+	snaptest.MockSnapWithFiles(c, "name: pc\ntype: gadget", si, [][]string{
+		{"meta/gadget.yaml", gadgetYaml},
+	})
+	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-model",
+		Serial: "serial",
+	})
+}
+
 func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
+	mockSnapBootstrapCmd := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "")
+	defer mockSnapBootstrapCmd.Restore()
+
 	s.state.Lock()
+	s.makeMockInstalledPcGadget(c)
 	devicestate.SetOperatingMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -66,6 +107,14 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	// the install-system change is created
 	createPartitions := s.findInstallSystem()
 	c.Assert(createPartitions, NotNil)
+
+	// and was run successfully
+	c.Check(createPartitions.Err(), IsNil)
+	c.Check(createPartitions.Status(), Equals, state.DoneStatus)
+	// in the right way
+	c.Check(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
+		{"snap-bootstrap", "create-partitions", filepath.Join(dirs.SnapMountDir, "/pc/1")},
+	})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeNotInstallmodeNoChg(c *C) {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -20,8 +20,15 @@
 package devicestate
 
 import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/timings"
 )
@@ -34,7 +41,27 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	perfTimings := timings.NewForTask(t)
 	defer perfTimings.Save(st)
 
-	// XXX: add handler content
+	// get gadget dir
+	deviceCtx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return fmt.Errorf("cannot get device context: %v", err)
+	}
+	info, err := snapstate.GadgetInfo(st, deviceCtx)
+	if err != nil {
+		return fmt.Errorf("cannot get gadget info: %v", err)
+	}
+	gadgetDir := info.MountDir()
+
+	// run the create partition code
+	st.Unlock()
+	output, err := exec.Command(filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "create-partitions", gadgetDir).CombinedOutput()
+	st.Lock()
+	if err != nil {
+		return osutil.OutputErr(output, err)
+	}
+
+	// XXX: update recovery mode in grubenv
+	// XXX2: write correct modeenv
 
 	return nil
 }


### PR DESCRIPTION
This commit adds running the "snap-bootstrap create-partitions"
code to the doSetupRunSystem code and matching tests.

There are updates for the recovery boot environment and to the
modeenv file in that function missing. They will be added in
a followup.

Based on PR #7832 with lots of inspiration from #7762 (thanks Claudio!)