### PR TITLE
cmd/snap-bootstrap: stub out snap.SanitizePlugsSlots for real

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -46,6 +46,8 @@ func init() {
 	if _, err := parser.AddCommand("initramfs-mounts", short, long, &cmdInitramfsMounts{}); err != nil {
 		panic(err)
 	}
+
+	snap.SanitizePlugsSlots = func(*snap.Info) {}
 }
 
 type cmdInitramfsMounts struct{}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -54,11 +54,8 @@ var _ = Suite(&initramfsMountsSuite{})
 func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	restore := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
-	s.BaseTest.AddCleanup(restore)
-
 	s.Stdout = bytes.NewBuffer(nil)
-	restore = main.MockStdout(s.Stdout)
+	restore := main.MockStdout(s.Stdout)
 	s.AddCleanup(restore)
 
 	// mock /run/mnt


### PR DESCRIPTION
we were stubbing it out in the tests but not in the actual code...
