### PR TITLE
tests: prevent partitioning test errors

### DIFF
--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -61,6 +61,12 @@ execute: |
     ls ./mnt/EFI/ubuntu/grub.cfg
     umount ./mnt
 
+    # XXX: workaround for device consistency errors
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE
+    blockdev --rereadpt "$LOOP"
+    udevadm settle
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE
+
     echo "now add a partition"
     cat >> gadget-dir/meta/gadget.yaml <<EOF
           - name: Other ext4


### PR DESCRIPTION
Under certain circumstances lsblk's `udev_device_get_property_value()`
is returning an empty filesystem for the EFI System partition, causing
the gadget vs disk consistency check to fail. This is just a workaround
for the test while we further investigate the issue.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
