### PR TITLE
tests: use test-snapd-sh snap instead of test-snapd-tools - Part 2

### DIFF
--- a/tests/main/selinux-snap-restorecon/task.yaml
+++ b/tests/main/selinux-snap-restorecon/task.yaml
@@ -5,7 +5,7 @@ description: |
 
 systems: [fedora-*, centos-*]
 prepare: |
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     if [ -d /home/test/snap ]; then
         mv /home/test/snap /home/test/snap.old
     fi
@@ -21,35 +21,35 @@ execute: |
     # TODO: use snap debug sandbox-features once selinux backend is added
 
     test ! -d /home/test/snap
-    su -c "test-snapd-tools.cmd sh -c 'touch \$SNAP_USER_DATA/foo'" test
+    su -c "test-snapd-sh.sh -c 'touch \$SNAP_USER_DATA/foo'" test
     test -d /home/test/snap
 
     echo "The snap user directory and data inside has the right context"
 
-    ls -dZ /home/test/snap /home/test/snap/test-snapd-tools /home/test/snap/test-snapd-tools/current/foo > test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap$'                              < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools$'             < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools/current/foo$' < test-labels
+    ls -dZ /home/test/snap /home/test/snap/test-snapd-sh /home/test/snap/test-snapd-sh/current/foo > test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap$'                           < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh$'             < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh/current/foo$' < test-labels
 
     echo "When the context of \$HOME/snap is changed"
     chcon -t unlabeled_t -R /home/test/snap
-    chcon -t unlabeled_t -R /home/test/snap/test-snapd-tools/current/foo
+    chcon -t unlabeled_t -R /home/test/snap/test-snapd-sh/current/foo
     #shellcheck disable=SC2012
     ls -dZ /home/test/snap | MATCH ':unlabeled_t:'
 
     echo "It gets restored recursively"
-    su -c 'test-snapd-tools.cmd id -Z' test
+    su -c "test-snapd-sh.sh -c 'id -Z'" test
 
-    ls -dZ /home/test/snap /home/test/snap/test-snapd-tools /home/test/snap/test-snapd-tools/current/foo > test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap$'                              < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools$'             < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools/current/foo$' < test-labels
+    ls -dZ /home/test/snap /home/test/snap/test-snapd-sh /home/test/snap/test-snapd-sh/current/foo > test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap$'                           < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh$'             < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh/current/foo$' < test-labels
 
     echo "Restoring happens only when the context of \$HOME/snap is incorrect"
-    chcon -t unlabeled_t -R /home/test/snap/test-snapd-tools/current/foo
-    su -c 'test-snapd-tools.cmd id -Z' test
+    chcon -t unlabeled_t -R /home/test/snap/test-snapd-sh/current/foo
+    su -c "test-snapd-sh.sh -c 'id -Z'" test
 
-    ls -dZ /home/test/snap /home/test/snap/test-snapd-tools /home/test/snap/test-snapd-tools/current/foo > test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap$'                            < test-labels
-    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-tools$'           < test-labels
-    MATCH '^.*:unlabeled_t:.*/home/test/snap/test-snapd-tools/current/foo$' < test-labels
+    ls -dZ /home/test/snap /home/test/snap/test-snapd-sh /home/test/snap/test-snapd-sh/current/foo > test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap$'                         < test-labels
+    MATCH '^.*:snappy_home_t:.*/home/test/snap/test-snapd-sh$'           < test-labels
+    MATCH '^.*:unlabeled_t:.*/home/test/snap/test-snapd-sh/current/foo$' < test-labels

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -4,8 +4,8 @@ summary: Test that snap-confine is run from core on re-exec
 systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 
 prepare: |
-    echo "Installing test-snapd-tools"
-    snap install test-snapd-tools
+    echo "Installing test-snapd-sh"
+    snap install test-snapd-sh
     echo "Breaking host snap-confine"
     chmod 0755 /usr/lib/snapd/snap-confine
 
@@ -30,7 +30,7 @@ execute: |
     check_journalctl_log "DEBUG: restarting into"
 
     echo "Ensure snap-confine from the core snap is run"
-    test-snapd-tools.echo hello
+    test-snapd-sh.sh -c 'echo hello'
 
 
     echo "Check if snap-confine profile generation test is applicable"

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -6,7 +6,7 @@ systems: [-ubuntu-core-*, -debian-*]
 
 prepare: |
     echo "Install test snap"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
 restore: |
     #shellcheck source=tests/lib/dirs.sh
@@ -21,8 +21,8 @@ execute: |
 
     echo "Simulating broken current symlink for core"
     mv $SNAP_MOUNT_DIR/core/current $SNAP_MOUNT_DIR/core/current.renamed
-    if test-snapd-tools.echo hello 2>snap-confine.stderr; then
-        echo "test-snapd-tools.echo should fail to run, test broken"
+    if test-snapd-sh.sh -c 'echo hello' 2>snap-confine.stderr; then
+        echo "test-snapd-sh.sh should fail to run, test broken"
     fi
     MATCH 'cannot locate base snap core: No such file or directory' < snap-confine.stderr
     mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
@@ -30,16 +30,16 @@ execute: |
     echo "Test nvidia device fix"
     # For https://github.com/snapcore/snapd/pull/4042
     echo "Simulate nvidia device tags"
-    mkdir -p /run/udev/tags/snap_test-snapd-tools_echo
+    mkdir -p /run/udev/tags/snap_test-snapd-sh_sh
     for f in c226:0 +module:nvidia +module:nvidia_modeset; do
-        touch /run/udev/tags/snap_test-snapd-tools_echo/$f
+        touch /run/udev/tags/snap_test-snapd-sh_sh/$f
     done
-    test-snapd-tools.echo hello | MATCH hello
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
     echo "Non nvidia files are still there"
-    test -f /run/udev/tags/snap_test-snapd-tools_echo/c226:0
+    test -f /run/udev/tags/snap_test-snapd-sh_sh/c226:0
     echo "But nvidia files are gone"
-    not test -f /run/udev/tags/snap_test-snapd-tools_echo/+module:nvidia
-    not test -f /run/udev/tags/snap_test-snapd-tools_echo/+module:nvidia_modeset
+    not test -f /run/udev/tags/snap_test-snapd-sh_sh/+module:nvidia
+    not test -f /run/udev/tags/snap_test-snapd-sh_sh/+module:nvidia_modeset
 
     echo "Ensure apparmor profile for snap-confine is parsable"
     while IFS= read -r -d '' file; do

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -12,8 +12,8 @@ prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
 
-    snap install test-snapd-tools
-    snap list | MATCH test-snapd-tools
+    snap install test-snapd-sh
+    snap list | MATCH test-snapd-sh
 
     # a snap with services
     install_local test-snapd-service

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -8,13 +8,13 @@ systems: [ubuntu-16*, ubuntu-18*]
 priority: 100
 
 environment:
-    PROFILE: /var/lib/snapd/seccomp/bpf/snap.test-snapd-tools.echo
+    PROFILE: /var/lib/snapd/seccomp/bpf/snap.test-snapd-sh.sh
     SNAP_SECCOMP: /usr/lib/snapd/snap-seccomp
 
 execute: |
-    echo "Install test-snapd-tools and verify it works"
-    snap install test-snapd-tools
-    test-snapd-tools.echo hello | MATCH hello
+    echo "Install test-snapd-sh and verify it works"
+    snap install test-snapd-sh
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # FIXME: use dirs.sh in 2.27+
     echo "Ensure snap-seccomp is statically linked"
@@ -32,7 +32,7 @@ execute: |
     EOF
     $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
     echo "Ensure the code still runs"
-    test-snapd-tools.echo hello | MATCH hello
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # from the old test_complain_missed
     rm -f "${PROFILE}.bin"
@@ -46,7 +46,7 @@ execute: |
     EOF
     $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
     echo "Ensure the code cannot not run due to impossible filtering"
-    if test-snapd-tools.echo hello; then
+    if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
@@ -60,7 +60,7 @@ execute: |
     EOF
     $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
     echo "Ensure the code still runs"
-    test-snapd-tools.echo hello | MATCH hello
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # from the old test_unrestricted_missed
     rm -f "${PROFILE}.bin"
@@ -74,7 +74,7 @@ execute: |
     EOF
     $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
     echo "Ensure the code cannot not run due to impossible filtering"
-    if test-snapd-tools.echo hello; then
+    if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
@@ -82,23 +82,23 @@ execute: |
     # from the old test_noprofile
     rm -f "${PROFILE}.bin"
     echo "Ensure the code cannot not run due to missing filter"
-    if SNAP_CONFINE_MAX_PROFILE_WAIT=3 test-snapd-tools.echo hello; then
+    if SNAP_CONFINE_MAX_PROFILE_WAIT=3 test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
 
-    echo "Break snapd.test-snapd-tools.bin to ensure (kernel) validation works"
+    echo "Break snapd.test-snapd-sh.bin to ensure (kernel) validation works"
     dd if=/dev/urandom of="${PROFILE}.bin" count=1 bs=1024
-    if output=$(test-snapd-tools.echo hello 2>&1 ); then
-        echo "test-snapd-tools.echo should fail with invalid seccomp profile"
+    if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
+        echo "test-snapd-sh.sh should fail with invalid seccomp profile"
         exit 1
     fi
     echo "$output" | MATCH "cannot apply seccomp profile: Invalid argument"
 
-    echo "Add huge snapd.test-snapd-tools.bin to ensure size limit works"
+    echo "Add huge snapd.test-snapd-sh.bin to ensure size limit works"
     dd if=/dev/zero of="${PROFILE}.bin" count=50 bs=1M
-    if output=$(test-snapd-tools.echo hello 2>&1 ); then
-        echo "test-snapd-tools.echo should fail with big seccomp profile"
+    if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
+        echo "test-snapd-sh.sh should fail with big seccomp profile"
         exit 1
     fi
     echo "$output" | MATCH "cannot fit .* to memory buffer"
@@ -106,7 +106,7 @@ execute: |
     
     echo "Ensure the code cannot not run with a missing .bin profile"
     rm -f "${PROFILE}.bin"
-    if test-snapd-tools.echo hello; then
+    if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
@@ -115,7 +115,7 @@ execute: |
     rm -f "${PROFILE}.bin"
     echo "" > "${PROFILE}.src"
     $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
-    if test-snapd-tools.echo hello; then
+    if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
@@ -127,7 +127,7 @@ execute: |
     EOF
     ( (sleep 3; $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin") &)
     echo "Ensure the code still runs"
-    test-snapd-tools.echo hello | MATCH hello
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     if [ "$(uname -p)" = "x86_64" ]; then
         echo "Ensure secondary arch works for amd64 with i386 binaries"

--- a/tests/main/snap-switch/task.yaml
+++ b/tests/main/snap-switch/task.yaml
@@ -1,11 +1,11 @@
 summary: Ensure that the snap switch command works
 
 execute: |
-    snap install test-snapd-tools
-    snap info test-snapd-tools|MATCH "tracking: +latest/stable"
+    snap install test-snapd-sh
+    snap info test-snapd-sh | MATCH "tracking: +latest/stable"
 
-    snap switch --edge test-snapd-tools > stdout.txt
-    snap info test-snapd-tools|MATCH "tracking: +latest/edge"
+    snap switch --edge test-snapd-sh > stdout.txt
+    snap info test-snapd-sh | MATCH "tracking: +latest/edge"
 
     echo "Ensure we don't print incorrect and confusing information"
     not grep "is closed; temporarily forwarding to stable." < stdout.txt

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -50,11 +50,11 @@ execute: |
     fi
 
     echo "Ensure snap run waits for system key updates"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     echo "Change system-key, this ensure that snap run will wait"
     printf '{"version":1}' > /var/lib/snapd/system-key
     stop_snapd
-    if SNAPD_DEBUG_SYSTEM_KEY_RETRY=1 test-snapd-tools.echo bad; then
+    if SNAPD_DEBUG_SYSTEM_KEY_RETRY=1 test-snapd-sh.sh -c 'echo bad'; then
         echo "snap run should have errored because of changed system-key"
         exit 1
     fi
@@ -63,11 +63,11 @@ execute: |
     echo "Ensure snap run does not wait when it can talk to snapd"
     echo "Change system-key, with running snapd"
     printf '{"version":1}' > /var/lib/snapd/system-key
-    test-snapd-tools.echo good
+    test-snapd-sh.sh -c 'echo good'
     
     echo "Things work again after a restart of snapd"
     restart_snapd
-    test-snapd-tools.echo good-again
+    test-snapd-sh.sh -c 'echo good-again'
     if grep '{"version":1}' /var/lib/snapd/system-key; then
         echo "system-key *not* rewriten test broken"
         exit 1

--- a/tests/main/snapd-go-socket-activated/task.yaml
+++ b/tests/main/snapd-go-socket-activated/task.yaml
@@ -32,8 +32,8 @@ execute: |
     snap list
     snap find
     echo "And install works as well"
-    snap install test-snapd-tools
-    test-snapd-tools.echo hello | MATCH hello
+    snap install test-snapd-sh
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     echo "And snapd is running"
     systemctl status snapd.service | MATCH "Active: active"

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -14,13 +14,13 @@ execute: |
     snap list | grep -c -v "^Name " | MATCH 0
 
     echo "Install a snap that needs core18 only"
-    snap install test-snapd-tools-core18
+    snap install test-snapd-sh-core18
 
     echo "Ensure that the snapd snap got installed as well"
     snap list | grep -c -v "^Name " | MATCH 3
     snap list | MATCH ^snapd
     snap list | MATCH ^core18
-    snap list | MATCH ^test-snapd-tools
+    snap list | MATCH ^test-snapd-sh
 
 restore: |
-    snap remove test-snapd-tools-core18
+    snap remove test-snapd-sh-core18

--- a/tests/main/snapd-snap-removal/task.yaml
+++ b/tests/main/snapd-snap-removal/task.yaml
@@ -17,14 +17,14 @@ execute: |
     test "$(snap list | grep -v -c ^Name)" = 1
     snap install core18
     test "$(snap list | grep -v -c ^Name)" = 2
-    snap install test-snapd-tools-core18
+    snap install test-snapd-sh-core18
     test "$(snap list | grep -v -c ^Name)" = 3
 
     echo "then we cannot remove snapd"
     not snap remove snapd
 
     echo "Now we remove the leaf snap"
-    snap remove test-snapd-tools-core18
+    snap remove test-snapd-sh-core18
     test "$(snap list | grep -v -c ^Name)" = 2
 
     echo "we still cannot remove snapd"

--- a/tests/main/snapd-without-core/task.yaml
+++ b/tests/main/snapd-without-core/task.yaml
@@ -35,10 +35,10 @@ execute: |
     check_journalctl_log  'restarting into "/snap/snapd/'
 
     echo "Now install a core18 based snap and ensure it works"
-    snap install test-snapd-tools-core18
-    test-snapd-tools-core18.echo hello | MATCH hello
+    snap install test-snapd-sh-core18
+    test-snapd-sh-core18.sh -c 'echo hello' | MATCH hello
     echo "No core was installed"
     snap list | not grep ^"core "
 
     echo "Ensure we re-exec to the snapd snap"
-    SNAPD_DEBUG=1 test-snapd-tools-core18.echo 2>&1 | MATCH 'restarting into "/snap/snapd/current'
+    SNAPD_DEBUG=1 test-snapd-sh-core18.sh -c 'true' 2>&1 | MATCH 'restarting into "/snap/snapd/current'

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that the basic snapshots functionality is ok
 
 prepare: |
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     snap install --edge test-snapd-just-edge
 
 debug: |
@@ -11,20 +11,20 @@ debug: |
 
 execute: |
     # use the snaps, so they create the dirs:
-    test-snapd-tools.echo
+    test-snapd-sh.sh -c 'true'
     test-snapd-just-edge.snap-name >/dev/null
     # drop in canaries:
-    for snap in test-snapd-tools test-snapd-just-edge; do
+    for snap in test-snapd-sh test-snapd-just-edge; do
        echo "hello versioned $snap"  > ~/snap/$snap/current/canary.txt
        echo "hello common $snap" > ~/snap/$snap/common/canary.txt
     done
     # create snapshot, grab its id
-    SET_ID=$( snap save test-snapd-tools test-snapd-just-edge | cut -d\  -f1 | tail -n1 )
+    SET_ID=$( snap save test-snapd-sh test-snapd-just-edge | cut -d\  -f1 | tail -n1 )
 
     # check it includes both snaps
-    snap saved | MATCH test-snapd-tools
+    snap saved | MATCH test-snapd-sh
     snap saved | MATCH test-snapd-just-edge
-    snap saved --id="$SET_ID" | grep test-snapd-tools
+    snap saved --id="$SET_ID" | grep test-snapd-sh
     snap saved --id="$SET_ID" | grep test-snapd-just-edge
     # and is valid
     snap check-snapshot "$SET_ID"
@@ -33,9 +33,9 @@ execute: |
     rm ~/snap/*/{current,common}/canary.txt
 
     # restore one of them
-    snap restore "$SET_ID" test-snapd-tools
-    test -e ~/snap/test-snapd-tools/current/canary.txt
-    test -e ~/snap/test-snapd-tools/common/canary.txt
+    snap restore "$SET_ID" test-snapd-sh
+    test -e ~/snap/test-snapd-sh/current/canary.txt
+    test -e ~/snap/test-snapd-sh/common/canary.txt
     # it didn't restore the other one
     test ! -e ~/snap/test-snapd-just-edge/current/canary.txt
     test ! -e ~/snap/test-snapd-just-edge/common/canary.txt
@@ -44,7 +44,7 @@ execute: |
     snap restore "$SET_ID" test-snapd-just-edge
 
     # now check everything's as we expect
-    for snap in test-snapd-tools test-snapd-just-edge; do
+    for snap in test-snapd-sh test-snapd-just-edge; do
         test "$( cat ~/snap/$snap/current/canary.txt )" = "hello versioned $snap"
         test "$( cat ~/snap/$snap/common/canary.txt )" = "hello common $snap"
     done
@@ -55,25 +55,25 @@ execute: |
 
     # check automatic snapshot can be disabled
     snap set core snapshots.automatic.retention=no
-    snap remove test-snapd-tools
-    if snap saved | MATCH "test-snapd-tools"; then
-        echo "did not expect a snapshot for test-snapd-tools"
+    snap remove test-snapd-sh
+    if snap saved | MATCH "test-snapd-sh"; then
+        echo "did not expect a snapshot for test-snapd-sh"
         exit 1
     fi
 
     # re-enable snapshots, check automatic snapshot is created on snap remove
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     snap set core snapshots.automatic.retention=30h
-    snap remove test-snapd-tools
-    snap saved test-snapd-tools | MATCH "auto"
-    SET_ID=$( snap saved test-snapd-tools | cut -d\  -f1 | tail -n1 )
+    snap remove test-snapd-sh
+    snap saved test-snapd-sh | MATCH "auto"
+    SET_ID=$( snap saved test-snapd-sh | cut -d\  -f1 | tail -n1 )
     snap forget "$SET_ID"
 
     # removing with --purge doesn't create automatic snapshot
     snap set core snapshots.automatic.retention=30h
-    snap install test-snapd-tools
-    snap remove --purge test-snapd-tools
-    if snap saved test-snapd-tools | MATCH "auto" ; then
+    snap install test-snapd-sh
+    snap remove --purge test-snapd-sh
+    if snap saved test-snapd-sh | MATCH "auto" ; then
         echo "automatic snapshot is not expected"
         exit 1
     fi

--- a/tests/main/snapshot-users/task.yaml
+++ b/tests/main/snapshot-users/task.yaml
@@ -1,45 +1,45 @@
 summary: Check that the basic snapshots functionality works for different users
 
 prepare: |
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
 
     # use the snaps, so they create the dirs
-    test-snapd-tools.echo
-    su -p -c "$SNAP_MOUNT_DIR/bin/test-snapd-tools.echo" test
+    test-snapd-sh.sh -c 'true'
+    su -p -c "$SNAP_MOUNT_DIR/bin/test-snapd-sh.sh -c 'true'" test
 
     # drop in canaries for both users
-    echo "hello versioned test-snapd-tools"  > /root/snap/test-snapd-tools/current/canary.txt
-    echo "hello common test-snapd-tools" > /root/snap/test-snapd-tools/common/canary.txt
-    echo "hello versioned test-snapd-tools"  > /home/test/snap/test-snapd-tools/current/canary.txt
-    echo "hello common test-snapd-tools" > /home/test/snap/test-snapd-tools/common/canary.txt
+    echo "hello versioned test-snapd-sh"  > /root/snap/test-snapd-sh/current/canary.txt
+    echo "hello common test-snapd-sh" > /root/snap/test-snapd-sh/common/canary.txt
+    echo "hello versioned test-snapd-sh"  > /home/test/snap/test-snapd-sh/current/canary.txt
+    echo "hello common test-snapd-sh" > /home/test/snap/test-snapd-sh/common/canary.txt
 
     # create different snapshots for each user
-    SET_ID_ROOT=$( snap save --users=root test-snapd-tools | cut -d\  -f1 | tail -n1 )
-    SET_ID_TEST=$( snap save --users=test test-snapd-tools | cut -d\  -f1 | tail -n1 )
+    SET_ID_ROOT=$( snap save --users=root test-snapd-sh | cut -d\  -f1 | tail -n1 )
+    SET_ID_TEST=$( snap save --users=test test-snapd-sh | cut -d\  -f1 | tail -n1 )
 
     # Update content on canary files
-    echo "content updated"  > /root/snap/test-snapd-tools/current/canary.txt
-    echo "content updated" > /root/snap/test-snapd-tools/common/canary.txt
-    echo "content updated"  > /home/test/snap/test-snapd-tools/current/canary.txt
-    echo "content updated" > /home/test/snap/test-snapd-tools/common/canary.txt
+    echo "content updated"  > /root/snap/test-snapd-sh/current/canary.txt
+    echo "content updated" > /root/snap/test-snapd-sh/common/canary.txt
+    echo "content updated"  > /home/test/snap/test-snapd-sh/current/canary.txt
+    echo "content updated" > /home/test/snap/test-snapd-sh/common/canary.txt
 
     # create snapshots for both users
-    SET_ID_BOTH=$( snap save --users=root,test test-snapd-tools | cut -d\  -f1 | tail -n1 )
+    SET_ID_BOTH=$( snap save --users=root,test test-snapd-sh | cut -d\  -f1 | tail -n1 )
 
     # Add more files and dirs for the test user and save snapshot for both users
-    mkdir -p /home/test/snap/test-snapd-tools/current/canary/
-    echo "content updated"  > /home/test/snap/test-snapd-tools/current/canary/canary.txt
-    SET_ID_NONE=$( snap save test-snapd-tools | cut -d\  -f1 | tail -n1 )
+    mkdir -p /home/test/snap/test-snapd-sh/current/canary/
+    echo "content updated"  > /home/test/snap/test-snapd-sh/current/canary/canary.txt
+    SET_ID_NONE=$( snap save test-snapd-sh | cut -d\  -f1 | tail -n1 )
 
     # check all the snapshots include the correct snap
-    snap saved --id="$SET_ID_ROOT" | MATCH test-snapd-tools
-    snap saved --id="$SET_ID_TEST" | MATCH test-snapd-tools
-    snap saved --id="$SET_ID_BOTH" | MATCH test-snapd-tools
-    snap saved --id="$SET_ID_NONE" | MATCH test-snapd-tools
+    snap saved --id="$SET_ID_ROOT" | MATCH test-snapd-sh
+    snap saved --id="$SET_ID_TEST" | MATCH test-snapd-sh
+    snap saved --id="$SET_ID_BOTH" | MATCH test-snapd-sh
+    snap saved --id="$SET_ID_NONE" | MATCH test-snapd-sh
 
     # check the snapshots
     snap check-snapshot "$SET_ID_ROOT"
@@ -48,70 +48,70 @@ execute: |
     snap check-snapshot "$SET_ID_NONE"
 
     # remove the canaries for both users
-    rm -f /root/snap/test-snapd-tools/{current,common}/canary.txt
-    rm -f /home/test/snap/test-snapd-tools/{current,common}/canary.txt
+    rm -f /root/snap/test-snapd-sh/{current,common}/canary.txt
+    rm -f /home/test/snap/test-snapd-sh/{current,common}/canary.txt
 
     # restore the snapshot for the root user and check the files
-    snap restore "$SET_ID_ROOT" test-snapd-tools
-    MATCH "hello versioned test-snapd-tools" < /root/snap/test-snapd-tools/current/canary.txt
-    MATCH "hello common test-snapd-tools" < /root/snap/test-snapd-tools/common/canary.txt
-    test ! -e /home/test/snap/test-snapd-tools/current/canary.txt
-    test ! -e /home/test/snap/test-snapd-tools/common/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/current/canary/canary.txt
+    snap restore "$SET_ID_ROOT" test-snapd-sh
+    MATCH "hello versioned test-snapd-sh" < /root/snap/test-snapd-sh/current/canary.txt
+    MATCH "hello common test-snapd-sh" < /root/snap/test-snapd-sh/common/canary.txt
+    test ! -e /home/test/snap/test-snapd-sh/current/canary.txt
+    test ! -e /home/test/snap/test-snapd-sh/common/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/current/canary/canary.txt
 
     # restore the snapshot for the test user and check the files
-    snap restore "$SET_ID_TEST" test-snapd-tools
-    MATCH "hello versioned test-snapd-tools" < /home/test/snap/test-snapd-tools/current/canary.txt
-    MATCH "hello common test-snapd-tools" < /home/test/snap/test-snapd-tools/common/canary.txt
-    test ! -d /home/test/snap/test-snapd-tools/current/canary
+    snap restore "$SET_ID_TEST" test-snapd-sh
+    MATCH "hello versioned test-snapd-sh" < /home/test/snap/test-snapd-sh/current/canary.txt
+    MATCH "hello common test-snapd-sh" < /home/test/snap/test-snapd-sh/common/canary.txt
+    test ! -d /home/test/snap/test-snapd-sh/current/canary
 
     # remove the canaries for both users
-    rm -f /root/snap/test-snapd-tools/{current,common}/canary.txt
-    rm -f /home/test/snap/test-snapd-tools/{current,common}/canary.txt
+    rm -f /root/snap/test-snapd-sh/{current,common}/canary.txt
+    rm -f /home/test/snap/test-snapd-sh/{current,common}/canary.txt
 
     # restore the snapshot for both users and check the files
-    snap restore "$SET_ID_BOTH" test-snapd-tools
-    MATCH "content updated" < /root/snap/test-snapd-tools/current/canary.txt
-    MATCH "content updated" < /root/snap/test-snapd-tools/common/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/current/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/common/canary.txt
-    test ! -d /home/test/snap/test-snapd-tools/current/canary
+    snap restore "$SET_ID_BOTH" test-snapd-sh
+    MATCH "content updated" < /root/snap/test-snapd-sh/current/canary.txt
+    MATCH "content updated" < /root/snap/test-snapd-sh/common/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/current/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/common/canary.txt
+    test ! -d /home/test/snap/test-snapd-sh/current/canary
 
     # remove the canaries for both users
-    rm -f /root/snap/test-snapd-tools/{current,common}/canary.txt
-    rm -f /home/test/snap/test-snapd-tools/{current,common}/canary.txt
+    rm -f /root/snap/test-snapd-sh/{current,common}/canary.txt
+    rm -f /home/test/snap/test-snapd-sh/{current,common}/canary.txt
 
     # restore the snapshot for root user and check the files
     snap restore "$SET_ID_BOTH" --users=root
-    MATCH "content updated" < /root/snap/test-snapd-tools/current/canary.txt
-    MATCH "content updated" < /root/snap/test-snapd-tools/common/canary.txt
-    test ! -e /home/test/snap/test-snapd-tools/current/canary.txt
-    test ! -e /home/test/snap/test-snapd-tools/common/canary.txt
-    test ! -d /home/test/snap/test-snapd-tools/current/canary
+    MATCH "content updated" < /root/snap/test-snapd-sh/current/canary.txt
+    MATCH "content updated" < /root/snap/test-snapd-sh/common/canary.txt
+    test ! -e /home/test/snap/test-snapd-sh/current/canary.txt
+    test ! -e /home/test/snap/test-snapd-sh/common/canary.txt
+    test ! -d /home/test/snap/test-snapd-sh/current/canary
 
     # remove the canaries for both users
-    rm -f /root/snap/test-snapd-tools/{current,common}/canary.txt
-    rm -f /home/test/snap/test-snapd-tools/{current,common}/canary.txt
+    rm -f /root/snap/test-snapd-sh/{current,common}/canary.txt
+    rm -f /home/test/snap/test-snapd-sh/{current,common}/canary.txt
 
     # restore the snapshot for test user and check the files
     snap restore "$SET_ID_NONE" --users=test
-    test ! -e /root/snap/test-snapd-tools/current/canary.txt
-    test ! -e /root/snap/test-snapd-tools/common/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/current/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/common/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/current/canary/canary.txt
+    test ! -e /root/snap/test-snapd-sh/current/canary.txt
+    test ! -e /root/snap/test-snapd-sh/common/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/current/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/common/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/current/canary/canary.txt
 
     # remove the canaries for both users
-    rm -f /root/snap/test-snapd-tools/{current,common}/canary.txt
-    rm -rf /home/test/snap/test-snapd-tools/{current,common,current/canary}/canary.txt
+    rm -f /root/snap/test-snapd-sh/{current,common}/canary.txt
+    rm -rf /home/test/snap/test-snapd-sh/{current,common,current/canary}/canary.txt
 
     # restore the snapshot for both user and check the files
     snap restore "$SET_ID_NONE" --users=test,root
-    MATCH "content updated" < /root/snap/test-snapd-tools/current/canary.txt
-    MATCH "content updated" < /root/snap/test-snapd-tools/common/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/current/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/common/canary.txt
-    MATCH "content updated" < /home/test/snap/test-snapd-tools/current/canary/canary.txt
+    MATCH "content updated" < /root/snap/test-snapd-sh/current/canary.txt
+    MATCH "content updated" < /root/snap/test-snapd-sh/common/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/current/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/common/canary.txt
+    MATCH "content updated" < /home/test/snap/test-snapd-sh/current/canary/canary.txt
 
     # check removal works
     snap forget "$SET_ID_NONE"

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -36,7 +36,7 @@ prepare: |
     fi
 
     snap list | awk "/^${TARGET_SNAP} / {print(\$3)}" > nextBoot
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/boot.sh
@@ -93,7 +93,7 @@ execute: |
     while ! journalctl -b -u snapd|grep -q "Waiting for system reboot" ; do sleep 1 ; done
 
     echo "Ensure the test snap still runs"
-    test-snapd-tools.echo hello | MATCH hello
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     echo "Ensure the bootloader is correct before reboot"
     readlink "/snap/${TARGET_SNAP}/current" > nextBoot

--- a/tests/main/upgrade-from-2.15/task.yaml
+++ b/tests/main/upgrade-from-2.15/task.yaml
@@ -49,7 +49,7 @@ execute: |
     wait_for_service snap.go-example-webserver.webserver.service
 
     echo "Install a test snap"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     
     echo "upgrade to current snapd"
     apt install -y "$GOHOME"/snapd*.deb
@@ -77,4 +77,4 @@ execute: |
     test ! -f /etc/apparmor.d/usr.lib.snapd.snap-confine
 
     echo "Smoke test, this should fail if profiles were wrong"
-    test-snapd-tools.echo hello | MATCH hello
+    test-snapd-sh.sh -c 'echo hello' | MATCH hello

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -2,34 +2,34 @@ summary: Check that the refresh data copy works.
 
 execute: |
     echo "For an installed snap"
-    snap install test-snapd-tools
-    rev=$(snap list test-snapd-tools|tail -n1|tr -s ' '|cut -f3 -d' ')
+    snap install test-snapd-sh
+    rev=$(snap list test-snapd-sh|tail -n1|tr -s ' '|cut -f3 -d' ')
 
     homes=(/root/ /home/test/)
     echo "That has some user data"
     for h in "${homes[@]}"; do
         test -d "$h"
-        d="${h}snap/test-snapd-tools/$rev"
+        d="${h}snap/test-snapd-sh/$rev"
         mkdir -p "$d"
         touch "$d/mock-data"
         chown --recursive --reference="$h" "${h}snap/"
     done
 
     echo "When the snap is refreshed"
-    snap refresh --channel=edge test-snapd-tools
-    new_rev=$(snap list test-snapd-tools|tail -n1|tr -s ' '|cut -f3 -d' ')
+    snap refresh --channel=edge test-snapd-sh
+    new_rev=$(snap list test-snapd-sh|tail -n1|tr -s ' '|cut -f3 -d' ')
 
     echo "Then the user data gets copied"
     for h in "${homes[@]}"; do
-        test -e "${h}snap/test-snapd-tools/$new_rev/mock-data"
-        test -e "${h}snap/test-snapd-tools/$rev/mock-data"
+        test -e "${h}snap/test-snapd-sh/$new_rev/mock-data"
+        test -e "${h}snap/test-snapd-sh/$rev/mock-data"
     done
 
     echo "When the snap is removed"
-    snap remove test-snapd-tools
+    snap remove test-snapd-sh
 
     echo "Then all user data and root data is gone"
     for h in "${homes[@]}"; do
-        test ! -e "${h}snap/test-snapd-tools/$new_rev/mock-data"
-        test ! -e "${h}snap/test-snapd-tools/$rev/mock-data"
+        test ! -e "${h}snap/test-snapd-sh/$new_rev/mock-data"
+        test ! -e "${h}snap/test-snapd-sh/$rev/mock-data"
     done

--- a/tests/main/xauth-migration/task.yaml
+++ b/tests/main/xauth-migration/task.yaml
@@ -14,17 +14,17 @@ details: |
     inside `snap run`.
 
 execute: |
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
     ensure_xauth_path() {
         export XAUTHORITY="$1"
         # Get rid of things to ensure a clean test bed
-        rm -f /var/snap/test-snapd-tools/common/xauth-content /run/user/0/.Xauthority
-        snap run --shell test-snapd-tools.sh <<'EOF'
-    echo $XAUTHORITY > /var/snap/test-snapd-tools/common/xauth-content
+        rm -f /var/snap/test-snapd-sh/common/xauth-content /run/user/0/.Xauthority
+        snap run --shell test-snapd-sh.sh <<'EOF'
+    echo $XAUTHORITY > /var/snap/test-snapd-sh/common/xauth-content
     exit
     EOF
-        env_path="$(cat /var/snap/test-snapd-tools/common/xauth-content)"
+        env_path="$(cat /var/snap/test-snapd-sh/common/xauth-content)"
         test "$env_path" = "$2" || exit 1
         test "$(sh256sum "$env_path")" = "$(sh256sum "$1")"
         unset XAUTHORITY

--- a/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
+++ b/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
@@ -12,7 +12,7 @@ prepare: |
     copy_remote "${GOHOME}"/snapd_*.deb
     execute_remote "sudo apt update"
     execute_remote "sudo apt install -y ./snapd_*.deb"
-    execute_remote "sudo snap install test-snapd-tools"
+    execute_remote "sudo snap install test-snapd-sh"
     execute_remote "sudo snap install test-snapd-rsync"
 
 execute: |
@@ -23,18 +23,18 @@ execute: |
     execute_remote "sudo snap refresh core --${CORE_CHANNEL}"
 
     # use the snaps, so they create the dirs:
-    execute_remote "sudo test-snapd-tools.echo"
+    execute_remote "sudo test-snapd-sh.sh -c 'true'"
     execute_remote "sudo test-snapd-rsync.rsync --version >/dev/null"
-    for snap in test-snapd-tools test-snapd-rsync; do
+    for snap in test-snapd-sh test-snapd-rsync; do
        execute_remote "echo "hello versioned $snap" | sudo tee /root/snap/$snap/current/canary.txt"
        execute_remote "echo "hello common $snap" | sudo tee /root/snap/$snap/common/canary.txt"
     done
 
     # create snapshot, grab its id
-    SET_ID=$( execute_remote "sudo snap save test-snapd-tools test-snapd-rsync" | cut -d\  -f1 | tail -n1 )
+    SET_ID=$( execute_remote "sudo snap save test-snapd-sh test-snapd-rsync" | cut -d\  -f1 | tail -n1 )
 
     # delete the canary files
-    execute_remote "sudo rm /root/snap/test-snapd-tools/{current,common}/canary.txt"
+    execute_remote "sudo rm /root/snap/test-snapd-sh/{current,common}/canary.txt"
     execute_remote "sudo rm /root/snap/test-snapd-rsync/{current,common}/canary.txt"
 
     # when the core is refreshed the snap snapshot can be restored"
@@ -42,14 +42,14 @@ execute: |
     execute_remote "sudo snap restore $SET_ID test-snapd-rsync"
     test "$( execute_remote "sudo cat /root/snap/test-snapd-rsync/current/canary.txt" )" = "hello versioned test-snapd-rsync"
     test "$( execute_remote "sudo cat /root/snap/test-snapd-rsync/common/canary.txt" )" = "hello common test-snapd-rsync"
-    execute_remote "sudo test ! -f /root/snap/test-snapd-tools/common/canary.txt"
-    execute_remote "sudo test ! -f /root/snap/test-snapd-tools/current/canary.txt"
+    execute_remote "sudo test ! -f /root/snap/test-snapd-sh/common/canary.txt"
+    execute_remote "sudo test ! -f /root/snap/test-snapd-sh/current/canary.txt"
 
     # when the core is reverted the snap snapshot can be restored"
     execute_remote "sudo snap revert core"
-    execute_remote "sudo snap restore $SET_ID test-snapd-tools"
-    test "$( execute_remote "sudo cat /root/snap/test-snapd-tools/current/canary.txt" )" = "hello versioned test-snapd-tools"
-    test "$( execute_remote "sudo cat /root/snap/test-snapd-tools/common/canary.txt" )" = "hello common test-snapd-tools"
+    execute_remote "sudo snap restore $SET_ID test-snapd-sh"
+    test "$( execute_remote "sudo cat /root/snap/test-snapd-sh/current/canary.txt" )" = "hello versioned test-snapd-sh"
+    test "$( execute_remote "sudo cat /root/snap/test-snapd-sh/common/canary.txt" )" = "hello common test-snapd-sh"
 
     echo "And the snapshot can be removed"
     execute_remote "sudo snap forget $SET_ID"

--- a/tests/nested/core/core-snap-refresh-on-core/task.yaml
+++ b/tests/nested/core/core-snap-refresh-on-core/task.yaml
@@ -19,10 +19,10 @@ execute: |
     NEW_REV="$(get_nested_core_revision_for_channel "${NEW_CORE_CHANNEL}")"
 
     # Install test snap
-    execute_remote "snap install test-snapd-tools"
+    execute_remote "snap install test-snapd-sh"
 
     # Ensure we have a good starting place
-    execute_remote "test-snapd-tools.echo hello" | MATCH hello
+    execute_remote "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     # go to known good starting place
     execute_remote "snap download core --${CORE_CHANNEL}"
@@ -32,8 +32,8 @@ execute: |
     # Check the initial core is installed and snaps can be executed
     test "$(get_nested_core_revision_installed)" = "${INITIAL_REV}"
 
-    # Ensure test-snapd-tools works
-    execute_remote "test-snapd-tools.echo hello" | MATCH hello
+    # Ensure test-snapd-sh works
+    execute_remote "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     # Refresh
     refresh_to_new_core "$NEW_CORE_CHANNEL"
@@ -41,8 +41,8 @@ execute: |
     # After refresh, check new core is installed  
     test "$(get_nested_core_revision_installed)" = "${NEW_REV}"
 
-    # Ensure test-snapd-tools works
-    execute_remote "test-snapd-tools.echo hello" | MATCH hello
+    # Ensure test-snapd-sh works
+    execute_remote "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     # Revert core
     execute_remote "snap revert core" || true
@@ -52,5 +52,5 @@ execute: |
     # After revert, check initial core is installed  
     test "$(get_nested_core_revision_installed)" = "${INITIAL_REV}"
 
-    # Ensure test-snapd-tools works
-    execute_remote "test-snapd-tools.echo hello" | MATCH hello
+    # Ensure test-snapd-sh works
+    execute_remote "test-snapd-sh.sh -c 'echo hello'" | MATCH hello

--- a/tests/regression/lp-1801955/task.yaml
+++ b/tests/regression/lp-1801955/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that snapshot works with unknown users in /home/*/snap
 
 prepare: |
-    snap install test-snapd-tools
+    snap install test-snapd-sh
     not grep :9999: /etc/passwd
     mkdir -pv /home/potato/snap/
     chown -vR 9999:9999 /home/potato
@@ -10,4 +10,4 @@ restore: |
     rm -rfv /home/potato
 
 execute: |
-    snap save test-snapd-tools
+    snap save test-snapd-sh

--- a/tests/regression/rhbz-1584461/task.yaml
+++ b/tests/regression/rhbz-1584461/task.yaml
@@ -35,11 +35,11 @@ execute: |
 
     find /etc/ssl/ -ls | sort > on-host
 
-    snap install test-snapd-tools
-    test-snapd-tools.echo hello
+    snap install test-snapd-sh
+    test-snapd-sh.sh -c 'echo hello'
 
     mount | not MATCH /etc/ssl-backup
 
-    test-snapd-tools.cmd find /etc/ssl/ -ls | sort > in-snap
+    test-snapd-sh.sh -c 'find /etc/ssl/ -ls' | sort > in-snap
     # same thing is visible in and out
     diff -upw on-host in-snap

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -15,10 +15,10 @@ execute: |
     . "$TESTSLIB"/systems.sh
 
     echo "Ensure install from the store works"
-    snap install test-snapd-tools
+    snap install test-snapd-sh
 
     echo "Ensure that the snap can be run as root"
-    test-snapd-tools.echo hello > stdout.log 2> stderr.log
+    test-snapd-sh.sh -c 'echo hello' > stdout.log 2> stderr.log
     MATCH "^hello$" < stdout.log
     if is_cgroupv2; then
         # snap-confine issues a warning on a cgroupv2 system
@@ -32,7 +32,7 @@ execute: |
     fi
 
     echo "Ensure that the snap can be run as the user"
-    su -l -c "test-snapd-tools.echo hello > stdout.log 2> stderr.log" test
+    su -l -c "test-snapd-sh.sh -c 'echo hello' > stdout.log 2> stderr.log" test
     MATCH "^hello$" < stdout.log
     if is_cgroupv2; then
         # snap-confine issues a warning on a cgroupv2 system
@@ -46,7 +46,7 @@ execute: |
     fi
 
     echo "Ensure the snap is listed"
-    snap list | grep ^test-snapd-tools
+    snap list | grep ^test-snapd-sh
 
     echo "Ensure a change was generated for the install"
-    snap changes | MATCH 'Install "test-snapd-tools" snap'
+    snap changes | MATCH 'Install "test-snapd-sh" snap'

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -71,7 +71,7 @@ execute: |
         fi
 
         echo "Install sanity check snaps with it"
-        snap install test-snapd-tools
+        snap install test-snapd-sh
         snap install test-snapd-auto-aliases
 
         do_classic=no
@@ -83,8 +83,8 @@ execute: |
         fi
 
         echo "Sanity check installs"
-        test-snapd-tools.echo Hello | grep Hello
-        test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
+        test-snapd-sh.sh -c 'echo Hello' | grep Hello
+        test-snapd-sh.sh -c 'env' | grep SNAP_NAME=test-snapd-sh
         test_snapd_wellknown1|MATCH "ok wellknown 1"
         test_snapd_wellknown2|MATCH "ok wellknown 2"
 
@@ -144,9 +144,9 @@ execute: |
 
     echo "Sanity check already installed snaps after upgrade"
     snap list | grep core
-    snap list | grep test-snapd-tools
-    test-snapd-tools.echo Hello | MATCH "Hello"
-    test-snapd-tools.env | MATCH "SNAP_NAME=test-snapd-tools"
+    snap list | grep test-snapd-sh
+    test-snapd-sh.sh -c 'echo Hello' | MATCH "Hello"
+    test-snapd-sh.sh -c 'env' | MATCH "SNAP_NAME=test-snapd-sh"
     if [ "$do_classic" = yes ]; then
         test-snapd-classic-confinement.recurse 5
     fi
@@ -156,7 +156,7 @@ execute: |
     # plumbing for that into the snap command.
     if [ -e /sys/kernel/security/apparmor ]; then
         echo Hello > /var/tmp/myevil.txt
-        if test-snapd-tools.cat /var/tmp/myevil.txt; then
+        if test-snapd-sh.cat /var/tmp/myevil.txt; then
             exit 1
         fi
     fi
@@ -169,6 +169,6 @@ execute: |
 
     echo "Check migrating to types in state"
     coreType=$(jq -r '.data.snaps["core"].type' /var/lib/snapd/state.json)
-    testSnapType=$(jq -r '.data.snaps["test-snapd-tools"].type' /var/lib/snapd/state.json)
+    testSnapType=$(jq -r '.data.snaps["test-snapd-sh"].type' /var/lib/snapd/state.json)
     [ "$coreType" = "os" ]
     [ "$testSnapType" = "app" ]


### PR DESCRIPTION
Seconds part of the change. Using a simple snap like the test-snapd-sh instead of test-snapd-tools. This implies an improvement on performance mostly on boards.

The test-snapd-sh which is in the store is not pluging any interface, it is a reduced snap which is defined in https://code.launchpad.net/~snappy-dev/snappy-hub/test-snapd-sh and like it is defined int he PR #7815
