### PR TITLE
tests: fix partitioning test debug message

### DIFF
--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -62,10 +62,10 @@ execute: |
     umount ./mnt
 
     # XXX: workaround for device consistency errors
-    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
     blockdev --rereadpt "$LOOP"
     udevadm settle
-    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
 
     echo "now add a partition"
     cat >> gadget-dir/meta/gadget.yaml <<EOF


### PR DESCRIPTION
Allow the partitioning test to continue normally when ID_FS_TYPE
is not found in the property list.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
