### PR TITLE
tests: cache snaps also for ubuntu core and add new snaps to cache

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -45,7 +45,7 @@ environment:
     SRU_VALIDATION: '$(HOST: echo "${SPREAD_SRU_VALIDATION:-0}")'
     # use the ppa_validation_name to install snapd from that ppa
     PPA_VALIDATION_NAME: '$(HOST: echo "${SPREAD_PPA_VALIDATION_NAME:-}")'
-    PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools test-snapd-sh
+    PRE_CACHE_SNAPS: test-snapd-tools test-snapd-sh jq
     # always skip removing the rsync snap
     SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18'
     # Use the installed snapd and reset the systems without removing snapd

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -283,15 +283,11 @@ prepare_classic() {
 
         # Cache snaps
         # shellcheck disable=SC2086
-        cache_snaps ${PRE_CACHE_SNAPS}
+        cache_snaps core ${PRE_CACHE_SNAPS}
 
         echo "Cache the snaps profiler snap"
         if [ "$PROFILE_SNAPS" = 1 ]; then
-            if is_core18_system; then
-                cache_snaps test-snapd-profiler-core18
-            else
-                cache_snaps test-snapd-profiler
-            fi
+            cache_snaps test-snapd-profiler
         fi
 
         snap list | not grep core || exit 1
@@ -678,6 +674,10 @@ prepare_ubuntu_core() {
         snap alias "$rsync_snap".rsync rsync
     fi
 
+    # Cache snaps
+    # shellcheck disable=SC2086
+    cache_snaps ${PRE_CACHE_SNAPS}
+
     echo "Ensure the core snap is cached"
     # Cache snaps
     if is_core18_system; then
@@ -688,9 +688,14 @@ prepare_ubuntu_core() {
         fi
         cache_snaps core test-snapd-sh-core18
     fi
+
     echo "Cache the snaps profiler snap"
     if [ "$PROFILE_SNAPS" = 1 ]; then
-        cache_snaps test-snapd-profiler
+        if is_core18_system; then
+            cache_snaps test-snapd-profiler-core18
+        else
+            cache_snaps test-snapd-profiler
+        fi
     fi
 
     disable_refreshes


### PR DESCRIPTION
The change includes:
. New snaps to be cached based on an evaluation done listing all the snaps
installed.
. Fixed snap profiler caching
. Caching snaps for ubuntu core in a more elegant way

