### PR TITLE
tests/cmd/snapctl: unset SNAP_CONTEXT for the suite

### DIFF
--- a/cmd/snapctl/main_test.go
+++ b/cmd/snapctl/main_test.go
@@ -47,6 +47,8 @@ var _ = Suite(&snapctlSuite{})
 
 func (s *snapctlSuite) SetUpTest(c *C) {
 	os.Setenv("SNAP_COOKIE", "snap-context-test")
+	// don't use SNAP_CONTEXT, in case other tests accidentally leak this
+	os.Unsetenv("SNAP_CONTEXT")
 	n := 0
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch n {


### PR DESCRIPTION
This test specifically would fail when go was run from a snap, because snap-confine for the go snap would set SNAP_COOKIE from here:

https://github.com/snapcore/snapd/blob/9b212f0a9f5afb81ab28db632807c9402a69b780/cmd/snap-confine/snap-confine.c#L462-L463

which would then cause snapctl to pick up the SNAP_CONTEXT variable and not see that the SNAP_COOKIE variable is unset and show a help message. So if we unset this environment variable when running this test suite, we are protected against this possibility. 

For reference, the test would fail like this:

```
----------------------------------------------------------------------
FAIL: main_test.go:108: snapctlSuite.TestSnapctlHelp

main_test.go:61:
    c.Assert(snapctlOptions.ContextID, Equals, s.expectedContextID)
... obtained string = "dFPq0qs83PLy2tHK5YmFVss3v1V6yVGvjwDhwp1H80yD"
... expected string = ""

main_test.go:117:
    c.Check(err, IsNil)
... value client.ConnectionError = client.ConnectionError{Err:(*url.Error)(0xc0000206c0)} ("cannot communicate with server: Post http://127.0.0.1:34175/v2/snapctl: EOF")

OOPS: 2 passed, 1 FAILED
--- FAIL: TestT (0.05s)
FAIL
```