### PR TITLE
devicestate: add missing test for failing task setup-run-system

### DIFF
--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -57,7 +57,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	output, err := exec.Command(filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "create-partitions", gadgetDir).CombinedOutput()
 	st.Lock()
 	if err != nil {
-		return osutil.OutputErr(output, err)
+		return fmt.Errorf("cannot create partitions: %v", osutil.OutputErr(output, err))
 	}
 
 	// XXX: update recovery mode in grubenv


### PR DESCRIPTION
In PR#7837 it was pointed out that there is a test missing for
failure of running `snap-bootstrap create-partitions`. This
commit adds this missing test.

