### PR TITLE
devicestate: call boot.MakeRunnable() in devicestate

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -284,6 +284,8 @@ type BootableSet struct {
 	Kernel     *snap.Info
 	KernelPath string
 
+	RecoverySystem string
+
 	UnpackedGadgetDir string
 }
 
@@ -361,4 +363,17 @@ func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) e
 
 	return nil
 
+}
+
+func MakeRunnable(model *asserts.Model, bootWith *BootableSet) error {
+	// XXX: install "run" mode grub.cfg (static, expects static names)
+	//      to /run/mnt/ubuntu-boot
+
+	// XXX: extract kernel to fixed name to /run/mnt/ubuntu-boot
+
+	// XXX: set modeenv to /run/mnt/ubuntu-data with base,kernel,recovery-system to use
+
+	// XXX: set recovery bootloader to "run" mode
+
+	return nil
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -473,6 +473,11 @@ func (m *DeviceManager) ensureBootOk() error {
 		return nil
 	}
 
+	// XXX: we need a boot-ok for recovery mode
+	if m.operatingMode() == "install" {
+		return nil
+	}
+
 	if !m.bootOkRan {
 		if err := boot.MarkBootSuccessful(); err != nil {
 			return err

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -20,10 +20,13 @@
 package devicestate_test
 
 import (
+	"fmt"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -59,26 +62,65 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	s.state.Set("seeded", true)
 }
 
-func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C) {
-	si := &snap.SideInfo{
+func (s *deviceMgrInstallModeSuite) makeMockUC20env(c *C) {
+	siGadget := &snap.SideInfo{
 		RealName: "pc",
 		Revision: snap.R(1),
 		SnapID:   "pc-ididid",
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{si},
-		Current:  si.Revision,
+		Sequence: []*snap.SideInfo{siGadget},
+		Current:  siGadget.Revision,
 		Active:   true,
 	})
-	snaptest.MockSnapWithFiles(c, "name: pc\ntype: gadget", si, [][]string{
+	snaptest.MockSnapWithFiles(c, "name: pc\ntype: gadget", siGadget, [][]string{
 		{"meta/gadget.yaml", gadgetYaml},
+		{"grub.conf", "# normal grub.cfg"},
 	})
+	siBase := &snap.SideInfo{
+		RealName: "core20",
+		Revision: snap.R(20),
+		SnapID:   "core20-ididid",
+	}
+	snapstate.Set(s.state, "core20", &snapstate.SnapState{
+		SnapType: "base",
+		Sequence: []*snap.SideInfo{siBase},
+		Current:  siBase.Revision,
+		Active:   true,
+	})
+	siKernel := &snap.SideInfo{
+		RealName: "pc-kernel",
+		Revision: snap.R(30),
+		SnapID:   "pc-kernel-ididid",
+	}
+	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
+		SnapType: "kernel",
+		Sequence: []*snap.SideInfo{siKernel},
+		Current:  siKernel.Revision,
+		Active:   true,
+	})
+	snaptest.MockSnapWithFiles(c, "name: pc-kernel\ntype: kernel", siKernel, [][]string{
+		{"meta/kernel.yaml", ""},
+	})
+
 	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+		"grade":        "dangerous",
 		"architecture": "amd64",
-		"kernel":       "pc-kernel",
-		"gadget":       "pc",
-		"base":         "core18",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              "pckernelidididididididididididid",
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              "pcididididididididididididididid",
+				"type":            "gadget",
+				"default-channel": "20",
+			}},
 	})
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
 		Brand:  "canonical",
@@ -95,7 +137,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	defer mockSnapBootstrapCmd.Restore()
 
 	s.state.Lock()
-	s.makeMockInstalledPcGadget(c)
+	s.makeMockUC20env(c)
 	devicestate.SetOperatingMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -107,14 +149,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	// the install-system change is created
 	createPartitions := s.findInstallSystem()
 	c.Assert(createPartitions, NotNil)
-
-	// and was run successfully
-	c.Check(createPartitions.Err(), IsNil)
-	c.Check(createPartitions.Status(), Equals, state.DoneStatus)
-	// in the right way
-	c.Check(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
-		{"snap-bootstrap", "create-partitions", filepath.Join(dirs.SnapMountDir, "/pc/1")},
-	})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeNotInstallmodeNoChg(c *C) {
@@ -151,4 +185,76 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNotClassic(c *C) {
 	// the install-system change is *not* created (we're on classic)
 	createPartitions := s.findInstallSystem()
 	c.Assert(createPartitions, IsNil)
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeRunthrough(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockSnapBootstrapCmd := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "echo happy-happy")
+	defer mockSnapBootstrapCmd.Restore()
+
+	var makeRunnableModel *asserts.Model
+	var makeRunnableBootsWith *boot.BootableSet
+	restore = devicestate.MockBootMakeRunnable(func(model *asserts.Model, bootWith *boot.BootableSet) error {
+		makeRunnableModel = model
+		makeRunnableBootsWith = bootWith
+		return nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.makeMockUC20env(c)
+	devicestate.SetOperatingMode(s.mgr, "install")
+	devicestate.SetRecoverySystem(s.mgr, "20191205")
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	// the install-system change is created
+	createPartitions := s.findInstallSystem()
+	c.Check(createPartitions.Err(), IsNil)
+	c.Check(createPartitions.Status(), Equals, state.DoneStatus)
+	// in the right way
+	c.Check(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
+		{"snap-bootstrap", "create-partitions", filepath.Join(dirs.SnapMountDir, "/pc/1")},
+	})
+
+	// ensure MakeRunnable was called the right way
+	c.Check(makeRunnableModel, NotNil)
+	c.Check(makeRunnableBootsWith.Base.RealName, Equals, "core20")
+	c.Check(makeRunnableBootsWith.BasePath, Matches, ".*/var/lib/snapd/snaps/core20_20.snap")
+	c.Check(makeRunnableBootsWith.Kernel.RealName, Equals, "pc-kernel")
+	c.Check(makeRunnableBootsWith.KernelPath, Matches, ".*/var/lib/snapd/snaps/pc-kernel_30.snap")
+	c.Check(makeRunnableBootsWith.RecoverySystem, Equals, "20191205")
+}
+
+func (s *deviceMgrInstallModeSuite) TestInstallModeMakeRunnableError(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockSnapBootstrapCmd := testutil.MockCommand(c, filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "echo happy-happy")
+	defer mockSnapBootstrapCmd.Restore()
+
+	restore = devicestate.MockBootMakeRunnable(func(model *asserts.Model, bootWith *boot.BootableSet) error {
+		return fmt.Errorf("booom")
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.makeMockUC20env(c)
+	devicestate.SetOperatingMode(s.mgr, "install")
+	devicestate.SetRecoverySystem(s.mgr, "20191205")
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	// the install-system change is created
+	createPartitions := s.findInstallSystem()
+	c.Check(createPartitions.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
+- Setup system for run mode \(cannot make the system runnable: booom\)`)
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -85,6 +86,10 @@ func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 
 func SetOperatingMode(m *DeviceManager, mode string) {
 	m.modeEnv.Mode = mode
+}
+
+func SetRecoverySystem(m *DeviceManager, recoverySystem string) {
+	m.modeEnv.RecoverySystem = recoverySystem
 }
 
 // XXX: will become properly exported but we probably want to make
@@ -190,5 +195,13 @@ func MockGadgetIsCompatible(mock func(current, update *gadget.Info) error) (rest
 	gadgetIsCompatible = mock
 	return func() {
 		gadgetIsCompatible = old
+	}
+}
+
+func MockBootMakeRunnable(f func(model *asserts.Model, bootWith *boot.BootableSet) error) (restore func()) {
+	old := bootMakeRunnable
+	bootMakeRunnable = f
+	return func() {
+		bootMakeRunnable = old
 	}
 }


### PR DESCRIPTION
When installing a UC20 system from the recovery partition snapd
needs to make the run system runnable. This is done via a new
boot.MakeRunnable() helper that will setup the required bootloader
and modeenv changes. This commit adds an empty MakeRunnable()
helper and the high level wiring so that the helper is called
in the right way (plus tests for this).

