### PR TITLE
snap-confine: raise egid before calling setup_private_mount()

### DIFF
--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -20,6 +20,7 @@
 
 #include "../libsnap-confine-private/apparmor-support.h"
 #include "snap-confine-invocation.h"
+#include <sys/types.h>
 
 /**
  * Assuming a new mountspace, populate it accordingly.
@@ -31,7 +32,8 @@
  * - processes mount profiles
  **/
 void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
-			  const sc_invocation * inv);
+			  const sc_invocation * inv, const gid_t real_gid,
+			  const gid_t saved_gid);
 
 /**
  * Ensure that / or /snap is mounted with the SHARED option.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -689,7 +689,8 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 		if (unshare(CLONE_NEWNS) < 0) {
 			die("cannot unshare the mount namespace");
 		}
-		sc_populate_mount_ns(aa, snap_update_ns_fd, inv);
+		sc_populate_mount_ns(aa, snap_update_ns_fd, inv, real_gid,
+				     saved_gid);
 		sc_store_ns_info(inv);
 
 		/* Preserve the mount namespace. */


### PR DESCRIPTION
When the setgid snap-confine is run under the non-root user and the
base_dir already exists, the unconditional chmod() on the base_dir
causes a CAP_FSETID denial. While we could grant the capability in
the apparmor profile, we don't actually need it for the target
permissions we are setting up (and don't want the capability anyway).

Due to kernel rate limiting of apparmor capabilities, this was difficult
to track down. To reproduce the denial with hello-world, we must reload
a modified snap-confine profile, trigger a capability denial, put the
snap-confine profile back to its original state, then trigger the fsetid
capability denial. Specifically:

 1. turn off kernel rate limiting: sysctl -w kernel.printk_ratelimit=0
 2. snap-discard-ns hello-world
 3. change the snap-confine profile to remove 'capability setuid'
 4. snap run hello-world as non-root (should generate a setuid
    denial)
 5. change the snap-confine profile to add back 'capability setuid'
 6. launch hello-world as non-root, which *may* generate the fsetid
    denial in the logs

Unfortunately, the kernel doesn't always log the fsetid denial even with
the above, but it will sometimes.