### PR TITLE
snap-confine: revert suppress noisy classic snap file_inherit denials

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -552,9 +552,4 @@
     # Allow mounting /var/lib/jenkins from the host into the snap.
     mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
-
-    # Suppress noisy file_inherit denials (LP: #1850552) until LP: #1849753 is
-    # fixed.
-    deny unix,
-    deny /dev/shm/.org.chromium.Chromium.* rw,
 }


### PR DESCRIPTION
This reverts commit e7afbc34b1d630aeae4a7d20c34da75f4cb67546.

This is triggering a kernel bug that for some reason denies executing
snap-confine from inside snap-confine for the case of running the lxd snap
inside a nesting lxd container.

I need to add a regression test for this, will hopefully open another PR with that later tonight.