### PR TITLE
snap-confine: revert, with comment, explicit unix deny for nested lxd

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -555,6 +555,11 @@
 
     # Suppress noisy file_inherit denials (LP: #1850552) until LP: #1849753 is
     # fixed.
-    deny unix,
     deny /dev/shm/.org.chromium.Chromium.* rw,
+
+    # While snap-confine itself doesn't require unix rules and therefore all
+    # unix rules are implicitly denied, adding an explicit deny for unix to
+    # silence noisy denials breaks nested lxd. Until the cause is determined,
+    # do not use an explicit deny for unix. (LP: #1855355)
+    #deny unix,
 }


### PR DESCRIPTION
While snap-confine itself doesn't require unix rules and therefore all
unix rules are implicitly denied, adding an explicit deny for unix to
silence noisy denials breaks nested lxd when it shouldn't:
```
  $ sudo snap install lxd
  $ sudo lxd init
  $ sudo lxc launch ubuntu:18.04 c1 -c security.nesting=true
  $ lxc exec c1 -- snap install lxd
  error: cannot perform the following tasks:
  - Start snap "lxd" (12631) services ([start snap.lxd.activate.service]
    failed with exit status 1: Job for snap.lxd.activate.service failed
    because the control process exited with error code.
```
Until the cause is determined, do not use an explicit deny for unix.

Reference:
- https://bugs.launchpad.net/snapd/+bug/1855355