### PR TITLE
tests: update google ubuntu 16.04-64 expected host mount ns

### DIFF
--- a/tests/main/mount-ns/google.ubuntu-16.04-64/HOST.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/HOST.expected.txt
@@ -19,7 +19,7 @@
 2:3 / /snap/test-snapd-mountinfo-core16/1 ro,nodev,relatime shared:19 - squashfs /dev/loop3 ro
 2:4 / /snap/test-snapd-mountinfo-core18/1 ro,nodev,relatime shared:20 - squashfs /dev/loop4 ro
 1:14 / /sys rw,nosuid,nodev,noexec,relatime shared:21 - sysfs sysfs rw
-1:15 / /sys/fs/cgroup rw shared:22 - tmpfs tmpfs rw,mode=755
+1:15 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:22 - tmpfs tmpfs ro,mode=755
 1:16 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,blkio
 1:17 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:24 - cgroup cgroup rw,cpu,cpuacct
 1:18 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:25 - cgroup cgroup rw,cpuset


### PR DESCRIPTION
Currently unclear why this changed, but what's more unclear is why this was rw ever, because looking at systemd docs in 2014 /sys/fs/cgroup was changed to be mounted to ro, so it's not clear why this should have ever been rw.

This should unblock master for the time being until we can either revert whatever changed underneath us on Ubuntu 16.04, or figure out a better way to track these things w/o just waiting for it to break and then updating it.