### PR TITLE
selinux: update policy to allow modifications related to kmod backend

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -160,6 +160,10 @@ optional_policy(`
   allow snappy_t dbusd_etc_t:lnk_file { read };
 ')
 
+# Allow snapd to manage kmod-backend (/etc/modules-load.d/) files
+allow snappy_t etc_t:dir { write remove_name };
+allow snappy_t etc_t:file unlink;
+
 # Allow snapd to manage udev rules for snaps and trigger events
 optional_policy(`
   udev_manage_rules_files(snappy_t)


### PR DESCRIPTION
Update SELinux policy to allow modifications related to kmod backend (`/etc/modules-load.d/`). This should fix occasional failure of selinux-clean spread test, depending on test execution order it could pick denials from interfaces-kvm:

```
type=AVC msg=audit(12/06/19 08:59:52.986:2067) : avc:  denied  { write } for  pid=27829 comm=snapd name=modules-load.d dev="sda1" ino=1581 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=1 
----
type=AVC msg=audit(12/06/19 08:59:52.987:2068) : avc:  denied  { remove_name } for  pid=27829 comm=snapd name=snap.test-snapd-sh.conf dev="sda1" ino=2986 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=1 
----
type=AVC msg=audit(12/06/19 08:59:52.987:2069) : avc:  denied  { unlink } for  pid=27829 comm=snapd name=snap.test-snapd-sh.conf dev="sda1" ino=2986 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:etc_t:s0 tclass=file permissive=1
```
