### PR TITLE
cmd/snap-mgmt, packaging/postrm: stop and remove socket units when purging

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -106,8 +106,8 @@ purge() {
                 if [ -d /etc/dbus-1/system.d ]; then
                     find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
                 fi
-                # timer files
-                find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+                # timer and socket units
+                find /etc/systemd/system -name "snap.${snap}.*.timer" -o -name "snap.${snap}.*.socket" | while read -r f; do
                     systemctl_stop "$(basename "$f")"
                     rm -f "$f"
                 done

--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -76,8 +76,8 @@ if [ "$1" = "purge" ]; then
             if [ -d /etc/dbus-1/system.d ]; then
                 find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             fi
-            # timer files
-            find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+            # timer and socket units
+            find /etc/systemd/system -name "snap.${snap}.*.timer" -o -name "snap.${snap}.*.socket" | while read -r f; do
                 systemctl_stop "$(basename "$f")"
                 rm -f "$f"
             done

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -76,8 +76,8 @@ if [ "$1" = "purge" ]; then
             if [ -d /etc/dbus-1/system.d ]; then
                 find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             fi
-            # timer files
-            find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+            # timer and socket units
+            find /etc/systemd/system -name "snap.${snap}.*.timer" -o -name "snap.${snap}.*.socket" | while read -r f; do
                 systemctl_stop "$(basename "$f")"
                 rm -f "$f"
             done

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -82,8 +82,8 @@ if [ "$1" = "purge" ]; then
             if [ -d /etc/dbus-1/system.d ]; then
                 find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             fi
-            # timer files
-            find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+            # timer and socket units
+            find /etc/systemd/system -name "snap.${snap}.*.timer" -o -name "snap.${snap}.*.socket" | while read -r f; do
                 systemctl_stop "$(basename "$f")"
                 rm -f "$f"
             done

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -363,6 +363,11 @@ prepare_project() {
         ubuntu-*)
             # Ubuntu is the only system where snapd is preinstalled
             distro_purge_package snapd
+            # XXX: the original package's purge may have left socket units behind
+            find /etc/systemd/system -name "snap.*.socket" | while read -r f; do
+                systemctl stop "$(basename "$f")" || true
+                rm -f "$f"
+            done
             ;;
         *)
             # snapd state directory must not exist when the package is not

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -27,6 +27,9 @@ prepare: |
     snap install test-snapd-network-status-provider
     snap list | MATCH test-snapd-network-status-provider
 
+    # with socket activation
+    install_local socket-activation
+
     before=$(find ${SNAP_MOUNT_DIR} -type d | wc -l)
     if [ "$before" -lt 2 ]; then
         echo "${SNAP_MOUNT_DIR} empty - test setup broken"
@@ -40,6 +43,7 @@ prepare: |
     test "$(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l)" -gt 0
     test "$(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l)" -gt 0
     test "$(find /etc/systemd/system -name 'snap.*.timer' | wc -l)" -gt 0
+    test "$(find /etc/systemd/system -name 'snap.*.socket' | wc -l)" -gt 0
 
 execute: |
     echo "Stop snapd before purging"
@@ -88,3 +92,4 @@ execute: |
     test "$(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l)" -eq 0
     test "$(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l)" -eq 0
     test "$(find /etc/systemd/system -name 'snap.*.timer' | wc -l)" -eq 0
+    test "$(find /etc/systemd/system -name 'snap.*.socket' | wc -l)" -eq 0


### PR DESCRIPTION
When purging the snap/snapd related data from the system, we did not remove the
socket units. This caused the socket units to remain active and tracked by
systemd.

In particular, this broke spread tests, where a test would leak the socket units
breaking tests executing later. For instance, the tests/main/selinux-context test in #7570 broke because of this.

