### PR TITLE
travis-ci: split integration tests into parts (>4MB log limit)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
         - git fetch --unshallow
         - ./tests/lib/cla_check.py
     - stage: integration
-      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, Core 16, Core 18
+      name: Ubuntu 14.04, 16.04, 18.04
       dist: xenial
       addons:
         apt:
@@ -59,9 +59,9 @@ matrix:
         # override the default install for language:go
         - true
       script:
-        - ./run-checks --spread-ubuntu
+        - ./run-checks --spread-ubuntu-lts
     - stage: integration
-      name: Debian, Fedora, CentOS, Amazon Linux 2, openSUSE, Arch
+      name: Ubuntu 18.10, 19.04
       dist: xenial
       addons:
         apt:
@@ -71,7 +71,55 @@ matrix:
         # override the default install for language:go
         - true
       script:
-        - ./run-checks --spread-no-ubuntu
+        - ./run-checks --spread-ubuntu-next
+    - stage: integration
+      name: Ubuntu Core 16, Core 18
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-ubuntu-core
+    - stage: integration
+      name: Debian
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-no-ubuntu-deb
+    - stage: integration
+      name: Fedora, CentOS, openSUSE
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-no-ubuntu-rpm
+    - stage: integration
+      name: Amazon Linux 2, Arch
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - xdelta3
+      install:
+        # override the default install for language:go
+        - true
+      script:
+        - ./run-checks --spread-no-ubuntu-others
     - stage: integration
       name: Unstable systems
       dist: xenial

--- a/run-checks
+++ b/run-checks
@@ -60,8 +60,26 @@ case "${1:-all}" in
     --spread-ubuntu)
         SPREAD=ubuntu-only
         ;;
+    --spread-ubuntu-lts)
+        SPREAD=ubuntu-lts
+        ;;
+    --spread-ubuntu-core)
+        SPREAD=ubuntu-core
+        ;;
+    --spread-ubuntu-next)
+        SPREAD=ubuntu-next
+        ;;
     --spread-no-ubuntu)
         SPREAD=no-ubuntu
+        ;;
+    --spread-no-ubuntu-deb)
+        SPREAD=no-ubuntu-deb
+        ;;
+    --spread-no-ubuntu-rpm)
+        SPREAD=no-ubuntu-rpm
+        ;;
+    --spread-no-ubuntu-others)
+        SPREAD=no-ubuntu-others
         ;;
     --spread-unstable)
         SPREAD=unstable
@@ -297,6 +315,24 @@ if [ -n "$SPREAD" ]; then
             ;;
         ubuntu-only)
             spread "google:[u]...:tests/..."
+            ;;
+        ubuntu-lts)
+            spread "google:[u]...-(14|16|18).04-...:tests/..."
+            ;;
+        ubuntu-core)
+            spread "google:[u]...-core-...:tests/..."
+            ;;
+        ubuntu-next)
+            spread "google:[u]...-(19|20|21)...:tests/..."
+            ;;
+        no-ubuntu-deb)
+            spread "google:debian...:tests/..."
+            ;;
+        no-ubuntu-rpm)
+            spread "google:(fedora|centos|opensuse)...:tests/..."
+            ;;
+        no-ubuntu-others)
+            spread "google:(arch|amazon)...:tests/..."
             ;;
         no-ubuntu)
             spread "google:[^u]...:tests/..."


### PR DESCRIPTION
Split integrations tests into smaller parts. 

Travis failed because of 4MB limit.