### PR TITLE
tests: fix fwupd version regular expression

### DIFF
--- a/tests/main/interfaces-fwupd-classic/task.yaml
+++ b/tests/main/interfaces-fwupd-classic/task.yaml
@@ -34,4 +34,4 @@ execute: |
        systemctl start fwupd.service
     fi
     echo "With the plug connected, we can talk to fwupd"
-    test-snapd-fwupd.get-version | MATCH 'variant +string "[0-9.]+"'
+    test-snapd-fwupd.get-version | MATCH 'variant +string "[0-9.]+(-[0-9a-g-]+)?"'


### PR DESCRIPTION
Allow version strings such as 1.3.5-615-g7fb6cbc5, currently used
in Debian Sid.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>