### PR TITLE
tests: avoid mask rsyslog service in case is not enabled on the system

### DIFF
--- a/tests/main/snap-set-core-config/task.yaml
+++ b/tests/main/snap-set-core-config/task.yaml
@@ -4,7 +4,7 @@ summary: Ensure "snap set core" works
 systems: [ubuntu-core-*]
 
 prepare: |
-    if ! systemctl -l | MATCH rsyslog.service; then
+    if systemctl -l | MATCH -v rsyslog.service; then
         #shellcheck source=tests/lib/systemd.sh
         . "$TESTSLIB"/systemd.sh
 

--- a/tests/main/snap-set-core-config/task.yaml
+++ b/tests/main/snap-set-core-config/task.yaml
@@ -4,19 +4,16 @@ summary: Ensure "snap set core" works
 systems: [ubuntu-core-*]
 
 prepare: |
-    if systemctl -l | MATCH rsyslog.service; then
-        echo "rsyslog service exists on the system"
-        exit 0
+    if ! systemctl -l | MATCH rsyslog.service; then
+        #shellcheck source=tests/lib/systemd.sh
+        . "$TESTSLIB"/systemd.sh
+
+        # start fake rsyslog service
+        systemd_create_and_start_unit rsyslog "/bin/sleep 2h"
+
+        # create a flag to indicate the ryslog service is fake
+        touch rsyslog.fake
     fi
-
-    #shellcheck source=tests/lib/systemd.sh
-    . "$TESTSLIB"/systemd.sh
-
-    # start fake rsyslog service
-    systemd_create_and_start_unit rsyslog "/bin/sleep 2h"
-
-    # create a flag to indicate the ryslog service is fake
-    touch rsyslog.fake
 
 restore: |
     if [ -f rsyslog.fake ]; then

--- a/tests/main/ubuntu-core-config-defaults-once/task.yaml
+++ b/tests/main/ubuntu-core-config-defaults-once/task.yaml
@@ -12,6 +12,12 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    if ! systemctl -l | MATCH "rsyslog.service"; then
+        echo "The service to test does not exist in the system, skipping..."
+        exit
+    fi
+
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
 
@@ -39,6 +45,11 @@ prepare: |
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    if ! systemctl -l | MATCH "rsyslog.service"; then
+        echo "The service to test does not exist in the system, skipping..."
         exit
     fi
 
@@ -77,7 +88,6 @@ restore: |
        rm -f /var/lib/snapd/snaps/pc_x1.snap
        systemctl daemon-reload
     fi
-    rm /var/lib/snapd/seed/snaps/pc_x1.snap
 
     REVNO="$(readlink /snap/$SNAP/current)"
     sysp=$(systemd-escape --path "/snap/$SNAP/$REVNO.mount")
@@ -102,6 +112,11 @@ restore: |
     retry-tool -n 60 --wait 5 sh -c 'snap changes | grep -q "Done.*Initialize system state"'
 
 execute: |
+    if ! systemctl -l | MATCH "rsyslog.service"; then
+        echo "The service to test does not exist in the system, skipping..."
+        exit
+    fi
+
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 

--- a/tests/main/ubuntu-core-config-defaults-once/task.yaml
+++ b/tests/main/ubuntu-core-config-defaults-once/task.yaml
@@ -13,11 +13,6 @@ prepare: |
         exit
     fi
 
-    if ! systemctl -l | MATCH "rsyslog.service"; then
-        echo "The service to test does not exist in the system, skipping..."
-        exit
-    fi
-
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
 
@@ -45,11 +40,6 @@ prepare: |
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
-        exit
-    fi
-
-    if ! systemctl -l | MATCH "rsyslog.service"; then
-        echo "The service to test does not exist in the system, skipping..."
         exit
     fi
 
@@ -113,11 +103,6 @@ restore: |
     retry-tool -n 60 --wait 5 sh -c 'snap changes | grep -q "Done.*Initialize system state"'
 
 execute: |
-    if ! systemctl -l | MATCH "rsyslog.service"; then
-        echo "The service to test does not exist in the system, skipping..."
-        exit
-    fi
-
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
@@ -157,3 +142,8 @@ execute: |
         snap get system "service.$service.disable" | MATCH false
     done
     test ! -e /etc/ssh/sshd_not_to_be_run
+
+    # Unmask rsyslog service on core18
+    if is_core18_system; then
+        systemctl unmask rsyslog
+    fi

--- a/tests/main/ubuntu-core-config-defaults-once/task.yaml
+++ b/tests/main/ubuntu-core-config-defaults-once/task.yaml
@@ -88,6 +88,7 @@ restore: |
        rm -f /var/lib/snapd/snaps/pc_x1.snap
        systemctl daemon-reload
     fi
+    rm /var/lib/snapd/seed/snaps/pc_x1.snap
 
     REVNO="$(readlink /snap/$SNAP/current)"
     sysp=$(systemd-escape --path "/snap/$SNAP/$REVNO.mount")

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -18,7 +18,7 @@ prepare: |
         exit
     fi
 
-    if ! systemctl -l | grep -q "$SERVICE.service"; then
+    if ! systemctl -l | MATCH "$SERVICE.service"; then
         echo "The service to test does not exist in the system, skipping..."
         exit
     fi

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -20,6 +20,7 @@ prepare: |
 
     if ! systemctl -l | MATCH "$SERVICE.service"; then
         echo "The service to test does not exist in the system, skipping..."
+        touch "${SERVICE}.skip"
         exit
     fi
 
@@ -88,7 +89,7 @@ restore: |
         exit
     fi
 
-    if ! systemctl -l | MATCH "$SERVICE.service"; then
+    if [ -f "${SERVICE}.skip" ]; then
         echo "The service to test does not exist in the system, skipping..."
         exit
     fi
@@ -151,7 +152,7 @@ restore: |
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
 
 execute: |
-    if ! systemctl -l | MATCH "$SERVICE.service"; then
+    if [ -f "${SERVICE}.skip" ]; then
         echo "The service to test does not exist in the system, skipping..."
         exit
     fi

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -18,12 +18,6 @@ prepare: |
         exit
     fi
 
-    if systemctl -l | MATCH -v "$SERVICE.service"; then
-        echo "The service to test does not exist in the system, skipping..."
-        touch "${SERVICE}.skip"
-        exit
-    fi
-
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
     #shellcheck source=tests/lib/systems.sh
@@ -32,8 +26,14 @@ prepare: |
     SUFFIX=
     MODEL=developer1-pc-w-config.model
     if is_core18_system; then
-        SUFFIX=-core18
-        MODEL=developer1-pc-18-w-config.model
+        if [ "$SERVICE" = "rsyslog" ]; then
+            echo "The service to test does not exist in the core18 system, skipping..."
+            touch "${SERVICE}.skip"
+            exit
+        else
+            SUFFIX=-core18
+            MODEL=developer1-pc-18-w-config.model
+        fi
     fi
 
     systemctl stop snapd.service snapd.socket

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -23,17 +23,17 @@ prepare: |
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
+    if [ "$SERVICE" = "rsyslog" ] && is_core18_system; then
+        echo "The service to test does not exist in the core18 system, skipping..."
+        touch "${SERVICE}.skip"
+        exit
+    fi
+
     SUFFIX=
     MODEL=developer1-pc-w-config.model
     if is_core18_system; then
-        if [ "$SERVICE" = "rsyslog" ]; then
-            echo "The service to test does not exist in the core18 system, skipping..."
-            touch "${SERVICE}.skip"
-            exit
-        else
-            SUFFIX=-core18
-            MODEL=developer1-pc-18-w-config.model
-        fi
+        SUFFIX=-core18
+        MODEL=developer1-pc-18-w-config.model
     fi
 
     systemctl stop snapd.service snapd.socket

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -18,7 +18,7 @@ prepare: |
         exit
     fi
 
-    if ! systemctl -l | MATCH "$SERVICE.service"; then
+    if systemctl -l | MATCH -v "$SERVICE.service"; then
         echo "The service to test does not exist in the system, skipping..."
         touch "${SERVICE}.skip"
         exit

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -17,6 +17,12 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    if ! systemctl -l | grep -q "$SERVICE.service"; then
+        echo "The service to test does not exist in the system, skipping..."
+        exit
+    fi
+
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
     #shellcheck source=tests/lib/systems.sh
@@ -82,6 +88,11 @@ restore: |
         exit
     fi
 
+    if ! systemctl -l | MATCH "$SERVICE.service"; then
+        echo "The service to test does not exist in the system, skipping..."
+        exit
+    fi
+
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 
@@ -140,6 +151,11 @@ restore: |
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done
 
 execute: |
+    if ! systemctl -l | MATCH "$SERVICE.service"; then
+        echo "The service to test does not exist in the system, skipping..."
+        exit
+    fi
+
     #shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB"/systems.sh
 


### PR DESCRIPTION
This change is to avoid the snap-set-core-config test fail.
Changes included:
 . Unmasnk rsyslog service on tests where is remains masked after execution. This is just happening on core18 where rsyslog is not defined. It is done on ubuntu-core-config-defaults-once test
. Change the way of detecting rsyslog is not enabled on the system on snap-set-core-config test
. On test ubuntu-core-gadget-config-defaults, the idea is to skip when rsyslog is not defined because the masking does not make sense and then the system remains as masked even when it does not exist leaving the systemd status inconsistent.  



