### PR TITLE
cmd/snapd-generator: fix unit name for non /snap mount locations

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -159,6 +159,10 @@ AC_ARG_WITH([snap-mount-dir],
 AC_SUBST(SNAP_MOUNT_DIR)
 AC_DEFINE_UNQUOTED([SNAP_MOUNT_DIR], "${SNAP_MOUNT_DIR}", [Location of the snap mount points])
 
+SNAP_MOUNT_DIR_SYSTEMD_UNIT="$(systemd-escape -p "$SNAP_MOUNT_DIR")"
+AC_SUBST([SNAP_MOUNT_DIR_SYSTEMD_UNIT])
+AC_DEFINE_UNQUOTED([SNAP_MOUNT_DIR_SYSTEMD_UNIT], "${SNAP_MOUNT_DIR_SYSTEMD_UNIT}", [Systemd unit name for snap mount points location])
+
 AC_PATH_PROGS([HAVE_RST2MAN],[rst2man rst2man.py])
 AS_IF([test "x$HAVE_RST2MAN" = "x"], [AC_MSG_WARN(["cannot find the rst2man tool, install python-docutils or similar"])])
 AM_CONDITIONAL([HAVE_RST2MAN], [test "x${HAVE_RST2MAN}" != "x"])

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 	// Construct the file name for a new systemd mount unit.
 	char fname[PATH_MAX + 1] = { 0 };
 	sc_must_snprintf(fname, sizeof fname,
-			 "%s/" SNAP_MOUNT_DIR ".mount", normal_dir);
+			 "%s/" SNAP_MOUNT_DIR_SYSTEMD_UNIT ".mount", normal_dir);
 
 	// Open the mount unit and write the contents.
 	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;


### PR DESCRIPTION
When snap mount directory is different from `/snap`, eg. `/var/lib/snapd/snap` like
we have on Fedora, the generated unit name should correspond to the output of
`systemd-escape -p <path>`. In case of Fedora, it should be `var-lib-snapd-snap.mount`.


