### PR TITLE
devicestate: use httputil.ShouldRetryError() in prepareSerialRequest

### DIFF
--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -331,7 +330,7 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 
 	resp, err := client.Do(req)
 	if err != nil {
-		if netErr, ok := err.(net.Error); ok && !netErr.Temporary() {
+		if !httputil.ShouldRetryError(err) {
 			// a non temporary net error, like a DNS no
 			// host, error out and do full retries
 			return "", fmt.Errorf("cannot retrieve request-id for making a request for a serial: %v", err)

--- a/store/store.go
+++ b/store/store.go
@@ -1528,7 +1528,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		if finalErr != nil {
-			if httputil.ShouldRetryError(attempt, finalErr) {
+			if httputil.ShouldRetryAttempt(attempt, finalErr) {
 				continue
 			}
 			break
@@ -1565,7 +1565,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 		_, finalErr = io.Copy(mw, limiter)
 		pbar.Finished()
 		if finalErr != nil {
-			if httputil.ShouldRetryError(attempt, finalErr) {
+			if httputil.ShouldRetryAttempt(attempt, finalErr) {
 				// error while downloading should resume
 				var seekerr error
 				resume, seekerr = w.Seek(0, os.SEEK_END)


### PR DESCRIPTION
We got a bugreport that the detection of temporary vs permanent
network errors is not reliable when requesting serials. This
commit changes the code to use the more elaborate code from
httputil to detect the failure condition.
