### PR TITLE
snapstate: add support for UC20 gadget in {Config,Gadget}Defaults

### DIFF
--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -550,7 +550,7 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 
 	current, err = devicestate.CurrentGadgetInfo(s.state, deviceCtx)
 
-	c.Assert(current, IsNil)
+	c.Check(current, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read current gadget snap details: .*/33/meta/gadget.yaml: no such file or directory")
 
 	// drop gadget.yaml for current snap
@@ -570,13 +570,13 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 	})
 
 	// pending update
-	update, err := devicestate.PendingGadgetInfo(snapsup)
+	update, err := devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate gadget snap details: cannot find installed snap .* .*/34/meta/snap.yaml")
 
 	ui := snaptest.MockSnapWithFiles(c, snapYaml, si, nil)
 
-	update, err = devicestate.PendingGadgetInfo(snapsup)
+	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate snap gadget metadata: .*/34/meta/gadget.yaml: no such file or directory")
 
@@ -590,7 +590,7 @@ volumes:
 	// drop gadget.yaml for update snap
 	ioutil.WriteFile(filepath.Join(ui.MountDir(), "meta/gadget.yaml"), []byte(updateGadgetYaml), 0644)
 
-	update, err = devicestate.PendingGadgetInfo(snapsup)
+	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(err, IsNil)
 	c.Assert(update, DeepEquals, &gadget.GadgetData{
 		Info: &gadget.Info{

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -64,6 +64,15 @@ func (s *firstBoot20Suite) setupCore20Seed(c *C, sysLabel string) {
 volumes:
     volume-id:
         bootloader: grub
+        structure:
+        - name: ubuntu-seed
+          role: system-seed
+          type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size: 1G
+        - name: ubuntu-data
+          role: system-data
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size: 2G
 `
 
 	makeSnap := func(yamlKey string) {
@@ -159,7 +168,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%s", chg.Err()))
 
 	// verify

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -211,11 +211,13 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		return fmt.Errorf("cannot read new gadget metadata: %v", err)
 	}
 
+	coreGadgetConstraints.SystemSeed = deviceCtx.Model().Grade() != asserts.ModelGradeUnset
 	currentData, err := gadgetDataFromInfo(curInfo, coreGadgetConstraints)
 	if err != nil {
 		return fmt.Errorf("cannot read current gadget metadata: %v", err)
 	}
 
+	coreGadgetConstraints.SystemSeed = deviceCtx.Model().Grade() != asserts.ModelGradeUnset
 	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, coreGadgetConstraints)
 	if err != nil {
 		return fmt.Errorf("cannot load new gadget metadata: %v", err)

--- a/overlord/devicestate/helpers.go
+++ b/overlord/devicestate/helpers.go
@@ -35,7 +35,7 @@ func setDeviceFromModelAssertion(st *state.State, device *auth.DeviceState, mode
 }
 
 func gadgetDataFromInfo(info *snap.Info, constraints *gadget.ModelConstraints) (*gadget.GadgetData, error) {
-	gi, err := gadget.ReadInfo(info.MountDir(), coreGadgetConstraints)
+	gi, err := gadget.ReadInfo(info.MountDir(), constraints)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2374,8 +2374,10 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, state.ErrNoState
 	}
 
+	needsSystemSeed := deviceCtx.Model().Grade() != asserts.ModelGradeUnset
 	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
+		Classic:    release.OnClassic,
+		SystemSeed: needsSystemSeed,
 	}
 
 	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
@@ -2411,8 +2413,10 @@ func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Conne
 		return nil, err
 	}
 
+	needsSystemSeed := deviceCtx.Model().Grade() != asserts.ModelGradeUnset
 	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
+		Classic:    release.OnClassic,
+		SystemSeed: needsSystemSeed,
 	}
 
 	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2374,13 +2374,8 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, state.ErrNoState
 	}
 
-	needsSystemSeed := deviceCtx.Model().Grade() != asserts.ModelGradeUnset
-	constraints := &gadget.ModelConstraints{
-		Classic:    release.OnClassic,
-		SystemSeed: needsSystemSeed,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// at this point we don't need constraints checks, they happend earlier
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2413,13 +2408,8 @@ func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Conne
 		return nil, err
 	}
 
-	needsSystemSeed := deviceCtx.Model().Grade() != asserts.ModelGradeUnset
-	constraints := &gadget.ModelConstraints{
-		Classic:    release.OnClassic,
-		SystemSeed: needsSystemSeed,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// at this point we don't need constraints checks, they happend earlier
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12418,7 +12418,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
           type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
           size: 1G
 `)
-
+	// XXX: in reality this will be a UC20 model context
 	deviceCtx := deviceWithGadgetContext("the-gadget")
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -15399,6 +15399,7 @@ func (s *snapmgrTestSuite) TestGadgetConnectionsUC20(c *C) {
 	// using MockSnap, we want to read the bits on disk
 	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
+	// XXX: in reality this will be a UC20 model context
 	deviceCtx := deviceWithGadgetContext("the-gadget")
 
 	s.state.Lock()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12387,6 +12387,55 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
+func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	// using MockSnap, we want to read the bits on disk
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// provide a uc20 gadget structure
+	s.prepareGadget(c, `
+        bootloader: grub
+        structure:
+        - name: ubuntu-seed
+          role: system-seed
+          filesystem: vfat
+          type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size: 1200M
+        - name: ubuntu-boot
+          role: system-boot
+          filesystem: ext4
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          # whats the appropriate size?
+          size: 750M
+        - name: ubuntu-data
+          role: system-data
+          filesystem: ext4
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size: 1G
+`)
+
+	deviceCtx := deviceWithGadgetContext("the-gadget")
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", Revision: snap.R(11), SnapID: "some-snap-ididididididididididid"},
+		},
+		Current:  snap.R(11),
+		SnapType: "app",
+	})
+	makeInstalledMockCoreSnap(c)
+
+	defls, err := snapstate.ConfigDefaults(s.state, deviceCtx, "some-snap")
+	c.Assert(err, IsNil)
+	c.Assert(defls, DeepEquals, map[string]interface{}{"key": "value"})
+}
+
 func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
 	r := release.MockOnClassic(false)
 	defer r()
@@ -15332,6 +15381,49 @@ func (s *snapmgrTestSuite) TestGadgetConnections(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 
 	s.prepareGadget(c, `
+connections:
+  - plug: snap1idididididididididididididi:plug
+    slot: snap2idididididididididididididi:slot
+`)
+
+	conns, err := snapstate.GadgetConnections(s.state, deviceCtx)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []gadget.Connection{
+		{Plug: gadget.ConnectionPlug{SnapID: "snap1idididididididididididididi", Plug: "plug"}, Slot: gadget.ConnectionSlot{SnapID: "snap2idididididididididididididi", Slot: "slot"}}})
+}
+
+func (s *snapmgrTestSuite) TestGadgetConnectionsUC20(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	// using MockSnap, we want to read the bits on disk
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
+
+	deviceCtx := deviceWithGadgetContext("the-gadget")
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// provide a uc20 gadget structure
+	s.prepareGadget(c, `
+        bootloader: grub
+        structure:
+        - name: ubuntu-seed
+          role: system-seed
+          filesystem: vfat
+          type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size: 1200M
+        - name: ubuntu-boot
+          role: system-boot
+          filesystem: ext4
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          # whats the appropriate size?
+          size: 750M
+        - name: ubuntu-data
+          role: system-data
+          filesystem: ext4
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size: 1G
 connections:
   - plug: snap1idididididididididididididi:plug
     slot: snap2idididididididididididididi:slot

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -99,4 +100,17 @@ func readInfo(snapPath string, si *snap.SideInfo) (*snap.Info, error) {
 		return nil, err
 	}
 	return snap.ReadInfoFromSnapFile(snapf, si)
+}
+
+func readGadgetInfo(snapPath string, constraints *gadget.ModelConstraints) (*gadget.Info, error) {
+	snapf, err := snap.Open(snapPath)
+	if err != nil {
+		return nil, err
+	}
+	gmeta, err := snapf.ReadFile("meta/gadget.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	return gadget.InfoFromGadgetYaml(gmeta, constraints)
 }

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -287,9 +287,30 @@ var pcGadgetFiles = [][]string{
 	{"meta/gadget.yaml", pcGadgetYaml},
 }
 
+const pc20GadgetYaml = `
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+    - name: ubuntu-seed
+      role: system-seed
+      type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+      size: 1G
+    - name: ubuntu-data
+      role: system-data
+      type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+      size: 2G
+`
+
+var pc20GadgetFiles = [][]string{
+	{"meta/gadget.yaml", pc20GadgetYaml},
+}
+
 var snapFiles = map[string][][]string{
-	"pc":    pcGadgetFiles,
-	"pc=18": pcGadgetFiles,
+	"pc":                   pcGadgetFiles,
+	"pc=18":                pcGadgetFiles,
+	"pc=20":                pc20GadgetFiles,
+	"pc=20-gadget-no-seed": pcGadgetFiles,
 }
 
 var snapPublishers = map[string]string{

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
@@ -408,6 +409,14 @@ func (s *seed20) LoadMeta(tm timings.Measurer) error {
 			}
 			if info.Base != model.Base() {
 				return fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, model.Base())
+			}
+			// check gadget
+			constraints := &gadget.ModelConstraints{
+				Classic:    model.Classic(),
+				SystemSeed: true,
+			}
+			if _, err := readGadgetInfo(seedSnap.Path, constraints); err != nil {
+				return fmt.Errorf("cannot use gadget snap: %v", err)
 			}
 			// TODO: when we allow extend models for classic
 			// we need to add the gadget base here

--- a/seed/seedtest/sample.go
+++ b/seed/seedtest/sample.go
@@ -85,6 +85,12 @@ type: gadget
 base: core20
 version: 1.0
 `,
+	"pc=20-gadget-no-seed": `name: pc
+type: gadget
+base: core20
+version: 1.0
+`,
+
 	"required20": `name: required20
 type: app
 base: core20


### PR DESCRIPTION
Right now we don't set the constraints.SystemSeed property when
parsing the gadget.yaml from snapstate. This breaks seeding on
a UC20 system when it reaches the gadget default stage.

Tests are missing and we probably need a check in image.go as well
so that we detect if someone tries to build a UC20 image with an
incompatible gadget early. But I have many meetings today so may not
get to it today :(