### PR TITLE
snapstate: relax gadget constraints in ConfigDefaults Et al.

### DIFF
--- a/overlord/snapstate/models_test.go
+++ b/overlord/snapstate/models_test.go
@@ -22,6 +22,7 @@ package snapstate_test
 import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 func ModelWithBase(baseName string) *asserts.Model {
@@ -51,6 +52,35 @@ func MakeModel(override map[string]interface{}) *asserts.Model {
 		"gadget":       "brand-gadget",
 		"kernel":       "kernel",
 		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(model, override).(*asserts.Model)
+}
+
+func MakeModel20(gadgetName string, override map[string]interface{}) *asserts.Model {
+	model := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "brand",
+		"series":       "16",
+		"brand-id":     "brand",
+		"model":        "baz-3000",
+		"architecture": "armhf",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "kernel",
+				"id":              "kerneldididididididididididididi",
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            gadgetName,
+				"id":              snaptest.AssertedSnapID(gadgetName),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
 	}
 	return assertstest.FakeAssertion(model, override).(*asserts.Model)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2374,11 +2374,8 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, state.ErrNoState
 	}
 
-	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// no constraints set: those should have been checked before already
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2411,11 +2408,8 @@ func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Conne
 		return nil, err
 	}
 
-	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// no constraints set: those should have been checked before already
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2374,7 +2374,7 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, state.ErrNoState
 	}
 
-	// no constraints set: those should have been checked before already
+	// no constraints enforced: those should have been checked before already
 	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
@@ -2408,7 +2408,7 @@ func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Conne
 		return nil, err
 	}
 
-	// no constraints set: those should have been checked before already
+	// no constraints enforced: those should have been checked before already
 	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -12341,6 +12341,12 @@ func deviceWithGadgetContext(gadgetName string) snapstate.DeviceContext {
 	}
 }
 
+func deviceWithGadgetContext20(gadgetName string) snapstate.DeviceContext {
+	return &snapstatetest.TrivialDeviceContext{
+		DeviceModel: MakeModel20(gadgetName, nil),
+	}
+}
+
 func deviceWithoutGadgetContext() snapstate.DeviceContext {
 	return &snapstatetest.TrivialDeviceContext{
 		DeviceModel: ClassicModel(),
@@ -12418,8 +12424,8 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
           type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
           size: 1G
 `)
-	// XXX: in reality this will be a UC20 model context
-	deviceCtx := deviceWithGadgetContext("the-gadget")
+	// use a UC20 model context
+	deviceCtx := deviceWithGadgetContext20("the-gadget")
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
@@ -15399,8 +15405,8 @@ func (s *snapmgrTestSuite) TestGadgetConnectionsUC20(c *C) {
 	// using MockSnap, we want to read the bits on disk
 	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
-	// XXX: in reality this will be a UC20 model context
-	deviceCtx := deviceWithGadgetContext("the-gadget")
+	// use a UC20 model context
+	deviceCtx := deviceWithGadgetContext20("the-gadget")
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -55,8 +54,7 @@ func (ss *SeedSnaps) SetupAssertSigning(storeBrandID string) {
 }
 
 func (ss *SeedSnaps) AssertedSnapID(snapName string) string {
-	cleanedName := strings.Replace(snapName, "-", "", -1)
-	return (cleanedName + strings.Repeat("id", 16)[len(cleanedName):])
+	return snaptest.AssertedSnapID(snapName)
 }
 
 func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/check.v1"
 
@@ -182,6 +183,11 @@ func PopulateDir(dir string, files [][]string) {
 			panic(err)
 		}
 	}
+}
+
+func AssertedSnapID(snapName string) string {
+	cleanedName := strings.Replace(snapName, "-", "", -1)
+	return (cleanedName + strings.Repeat("id", 16)[len(cleanedName):])
 }
 
 // MakeTestSnapWithFiles makes a squashfs snap file with the given


### PR DESCRIPTION
The ConfigDefaults and GadgetConnections current read the
gadget data and sets constraints there. There is no need
at this point to check the constraints. This should have
happend earlier already and just complicated this particular
code.

This will unblock seeding in "install" mode for UC20.

There is more todo - i.e. we need to ensure we check gadget
consistency, see https://github.com/snapcore/snapd/pull/7880#issuecomment-564062194

But having this should unblock UC20.