### PR TITLE
snapstate: check gadget model constraints in checkSnap

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -381,7 +381,7 @@ func ReadInfo(gadgetSnapRootDir string, constraints *ModelConstraints) (*Info, e
 }
 
 // ReadInfoFromSnapFile reads the gadget specific metadata from
-// meta/gadget.yaml in the given snapf container. If constraints is
+// meta/gadget.yaml in the given snap container. If constraints is
 // nil, ReadInfo will just check for self-consistency, otherwise rules
 // for the classic or system seed cases are enforced.
 func ReadInfoFromSnapFile(snapf snap.Container, constraints *ModelConstraints) (*Info, error) {

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -480,17 +480,13 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 	}
 
 	// do basic constraints check on the gadget
-	model := deviceCtx.Model()
 	if typ == snap.TypeGadget {
-		validateGadgetModelConstraints := func(model *asserts.Model, snapf snap.Container) error {
-			constraints := &gadget.ModelConstraints{
-				Classic:    model.Classic(),
-				SystemSeed: model.Grade() != asserts.ModelGradeUnset,
-			}
-			_, err = gadget.ReadInfoFromSnapFile(snapf, constraints)
-			return err
+		model := deviceCtx.Model()
+		constraints := &gadget.ModelConstraints{
+			Classic:    model.Classic(),
+			SystemSeed: model.Grade() != asserts.ModelGradeUnset,
 		}
-		if err := validateGadgetModelConstraints(model, snapf); err != nil {
+		if _, err = gadget.ReadInfoFromSnapFile(snapf, constraints); err != nil {
 			return err
 		}
 	}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -286,7 +286,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -328,7 +328,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -369,7 +369,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -410,7 +410,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -452,7 +452,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -805,6 +805,12 @@ func emptyContainer(c *C) *snapdir.SnapDir {
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
 	return snapdir.New(d)
+}
+
+func minimalGadgetContainer(c *C) *snapdir.SnapDir {
+	d := emptyContainer(c)
+	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "meta", "gadget.yaml"), []byte(gadgetYaml), 0444), IsNil)
+	return d
 }
 
 func (s *checkSnapSuite) TestCheckSnapInstanceName(c *C) {
@@ -1281,7 +1287,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()


### PR DESCRIPTION
The current code that checks snaps on refresh does not check
the model constraints. This commit changes that so that no
gadgets can be installed that violate the model constraints.

One more check in firstboot is needed in a followup.