### PR TITLE
tests: 16.04 and 18.04 now have mediating pulseaudio

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -5,8 +5,8 @@ systems: [ ubuntu-1*-*64, ubuntu-2*-*64 ]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-audio-record/current/usr/share/sounds/alsa/Noise.wav"
-    # today, only 19.04 and 19.10 have a mediating pulseaudio
-    EXFAIL: "ubuntu-1[468]"
+    # today, 16.04 and higher have a mediating pulseaudio
+    EXFAIL: "ubuntu-14"
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
References:
- https://bugs.launchpad.net/ubuntu/+source/pulseaudio/+bug/1781428

The pulseaudio SRU for the mediation passes went through today causing the interfaces-audio-playback-record to fail (ie, they correctly noticed that all of a sudden they were mediating). Adjust the test to expect mediation on xenial and bionic now.