### PR TITLE
tests: 16.04 and 18.04 now have mediating pulseaudio - 2.43

### DIFF
--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -5,8 +5,8 @@ systems: [ ubuntu-1*-*64, ubuntu-2*-*64 ]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-audio-record/current/usr/share/sounds/alsa/Noise.wav"
-    # today, only 19.04 and 19.10 have a mediating pulseaudio
-    EXFAIL: "ubuntu-1[468]"
+    # today, 16.04 and higher have a mediating pulseaudio
+    EXFAIL: "ubuntu-14"
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
References:
- https://bugs.launchpad.net/ubuntu/+source/pulseaudio/+bug/1781428

https://github.com/snapcore/snapd/pull/7885 for 2.43