### PR TITLE
[RFC] seed,devicestate: check gadget model constraints when seeding

### DIFF
--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -547,12 +547,6 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 
 	// mock current first, but gadget.yaml is still missing
 	ci := snaptest.MockSnapWithFiles(c, snapYaml, siCurrent, nil)
-
-	current, err = devicestate.CurrentGadgetInfo(s.state, deviceCtx)
-
-	c.Assert(current, IsNil)
-	c.Assert(err, ErrorMatches, "cannot read current gadget snap details: .*/33/meta/gadget.yaml: no such file or directory")
-
 	// drop gadget.yaml for current snap
 	ioutil.WriteFile(filepath.Join(ci.MountDir(), "meta/gadget.yaml"), []byte(gadgetYaml), 0644)
 
@@ -571,14 +565,10 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 
 	// pending update
 	update, err := devicestate.PendingGadgetInfo(snapsup)
-	c.Assert(update, IsNil)
+	c.Check(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate gadget snap details: cannot find installed snap .* .*/34/meta/snap.yaml")
 
 	ui := snaptest.MockSnapWithFiles(c, snapYaml, si, nil)
-
-	update, err = devicestate.PendingGadgetInfo(snapsup)
-	c.Assert(update, IsNil)
-	c.Assert(err, ErrorMatches, "cannot read candidate snap gadget metadata: .*/34/meta/gadget.yaml: no such file or directory")
 
 	var updateGadgetYaml = `
 volumes:

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -990,9 +990,6 @@ volumes:
 	err = ioutil.WriteFile(filepath.Join(info.MountDir(), "meta/gadget.yaml"), []byte(mockGadget), 0644)
 	c.Assert(err, IsNil)
 
-	err = devicestate.CheckGadgetRemodelCompatible(s.state, info, currInfo, snapf, snapstate.Flags{}, remodelCtx)
-	c.Check(err, ErrorMatches, "cannot read current gadget metadata: .*/gadget/123/meta/gadget.yaml: no such file or directory")
-
 	// drop gadget.yaml to the current gadget
 	err = ioutil.WriteFile(filepath.Join(currInfo.MountDir(), "meta/gadget.yaml"), []byte(mockGadget), 0644)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -64,6 +64,15 @@ func (s *firstBoot20Suite) setupCore20Seed(c *C, sysLabel string) {
 volumes:
     volume-id:
         bootloader: grub
+        structure:
+        - name: ubuntu-seed
+          role: system-seed
+          type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size: 1G
+        - name: ubuntu-data
+          role: system-data
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size: 2G
 `
 
 	makeSnap := func(yamlKey string) {
@@ -159,7 +168,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%s", chg.Err()))
 
 	// verify

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -54,7 +54,7 @@ func currentGadgetInfo(st *state.State, deviceCtx snapstate.DeviceContext) (*gad
 		return nil, nil
 	}
 
-	ci, err := gadgetDataFromInfo(currentInfo, coreGadgetConstraints)
+	ci, err := gadgetDataFromInfo(currentInfo, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read current gadget snap details: %v", err)
 	}
@@ -67,7 +67,7 @@ func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.GadgetData, error)
 		return nil, fmt.Errorf("cannot read candidate gadget snap details: %v", err)
 	}
 
-	gi, err := gadgetDataFromInfo(info, coreGadgetConstraints)
+	gi, err := gadgetDataFromInfo(info, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read candidate snap gadget metadata: %v", err)
 	}

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -174,10 +174,6 @@ func (m *DeviceManager) doPrepareRemodeling(t *state.Task, tmb *tomb.Tomb) error
 }
 
 var (
-	coreGadgetConstraints = &gadget.ModelConstraints{
-		Classic: false,
-	}
-
 	gadgetIsCompatible = gadget.IsCompatible
 )
 
@@ -211,12 +207,12 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		return fmt.Errorf("cannot read new gadget metadata: %v", err)
 	}
 
-	currentData, err := gadgetDataFromInfo(curInfo, coreGadgetConstraints)
+	currentData, err := gadgetDataFromInfo(curInfo, nil)
 	if err != nil {
 		return fmt.Errorf("cannot read current gadget metadata: %v", err)
 	}
 
-	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, coreGadgetConstraints)
+	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, nil)
 	if err != nil {
 		return fmt.Errorf("cannot load new gadget metadata: %v", err)
 	}

--- a/overlord/devicestate/helpers.go
+++ b/overlord/devicestate/helpers.go
@@ -35,7 +35,7 @@ func setDeviceFromModelAssertion(st *state.State, device *auth.DeviceState, mode
 }
 
 func gadgetDataFromInfo(info *snap.Info, constraints *gadget.ModelConstraints) (*gadget.GadgetData, error) {
-	gi, err := gadget.ReadInfo(info.MountDir(), coreGadgetConstraints)
+	gi, err := gadget.ReadInfo(info.MountDir(), constraints)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -286,7 +286,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -328,7 +328,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -369,7 +369,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -410,7 +410,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -452,7 +452,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -805,6 +805,12 @@ func emptyContainer(c *C) *snapdir.SnapDir {
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
 	return snapdir.New(d)
+}
+
+func minimalGadgetContainer(c *C) *snapdir.SnapDir {
+	d := emptyContainer(c)
+	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "meta", "gadget.yaml"), []byte(gadgetYaml), 0444), IsNil)
+	return d
 }
 
 func (s *checkSnapSuite) TestCheckSnapInstanceName(c *C) {
@@ -1281,7 +1287,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2374,11 +2374,8 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, state.ErrNoState
 	}
 
-	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// no constraints set: those should have been checked before already
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2411,11 +2408,8 @@ func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Conne
 		return nil, err
 	}
 
-	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// no constraints set: those should have been checked before already
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -99,4 +100,12 @@ func readInfo(snapPath string, si *snap.SideInfo) (*snap.Info, error) {
 		return nil, err
 	}
 	return snap.ReadInfoFromSnapFile(snapf, si)
+}
+
+func readGadgetInfo(snapPath string, constraints *gadget.ModelConstraints) (*gadget.Info, error) {
+	snapf, err := snap.Open(snapPath)
+	if err != nil {
+		return nil, err
+	}
+	return gadget.ReadInfoFromSnapFile(snapf, constraints)
 }

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -287,9 +287,30 @@ var pcGadgetFiles = [][]string{
 	{"meta/gadget.yaml", pcGadgetYaml},
 }
 
+const pc20GadgetYaml = `
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+    - name: ubuntu-seed
+      role: system-seed
+      type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+      size: 1G
+    - name: ubuntu-data
+      role: system-data
+      type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+      size: 2G
+`
+
+var pc20GadgetFiles = [][]string{
+	{"meta/gadget.yaml", pc20GadgetYaml},
+}
+
 var snapFiles = map[string][][]string{
-	"pc":    pcGadgetFiles,
-	"pc=18": pcGadgetFiles,
+	"pc":                   pcGadgetFiles,
+	"pc=18":                pcGadgetFiles,
+	"pc=20":                pc20GadgetFiles,
+	"pc=20-gadget-no-seed": pcGadgetFiles,
 }
 
 var snapPublishers = map[string]string{

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
@@ -411,6 +412,15 @@ func (s *seed20) LoadMeta(tm timings.Measurer) error {
 			}
 			// TODO: when we allow extend models for classic
 			// we need to add the gadget base here
+
+			// check gadget
+			constraints := &gadget.ModelConstraints{
+				Classic:    model.Classic(),
+				SystemSeed: true,
+			}
+			if _, err := readGadgetInfo(seedSnap.Path, constraints); err != nil {
+				return fmt.Errorf("cannot use gadget snap: %v", err)
+			}
 
 			// done with essential snaps
 			essential = false

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -88,7 +88,7 @@ func (s *seed20Suite) makeSnap(c *C, yamlKey, publisher string) {
 	if publisher == "" {
 		publisher = "canonical"
 	}
-	s.MakeAssertedSnap(c, snapYaml[yamlKey], nil, snap.R(1), publisher, s.StoreSigning.Database)
+	s.MakeAssertedSnap(c, snapYaml[yamlKey], snapFiles[yamlKey], snap.R(1), publisher, s.StoreSigning.Database)
 }
 
 func (s *seed20Suite) expectedPath(snapName string) string {


### PR DESCRIPTION
This commit moves the gadget model constraints check into
the seeding phase. The gadget update does no longer need
to validate the model constraints because they get check
in checkSnap and during seeding so they should never be
wrong.

Build on https://github.com/snapcore/snapd/pull/7884.

I suspect we needs this or UC20 won't boot. 

Alternatively (hence the RFC)  we can can setup the correct constraints in https://github.com/snapcore/snapd/commit/2bd1401ebd7a9e22a67e0feef47293ab72f51252 instead of passing nil and doing the checking early (or we can do both).