### PR TITLE
tests: disable apt-hooks test until it can be properly fixed

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -3,6 +3,8 @@ summary: Ensure apt hooks work
 # apt hook only available on 18.04+ and aws-cli only for amd64
 systems: [ubuntu-18.04-64, ubuntu-19.04-64, ubuntu-19.10-64]
 
+manual: true
+
 debug: |
     ls -lh /var/cache/snapd
     # low tech dump of db


### PR DESCRIPTION
It is failing constantly on travis execution. 

It fails because the store is sending an error "too many requests". The journal log  is the following. https://paste.ubuntu.com/p/JY69dz4vwP/

The test will be enabled again once it is fixed. 