### PR TITLE
overlord,o/snapstate: make sure we never leave config behind

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1571,6 +1571,12 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 			snapst.LastActiveDisabledServices,
 			disabledServices...,
 		)
+	} else {
+		// in the case of an install we need to clear any config
+		err = config.DeleteSnapConfig(st, snapsup.InstanceName())
+		if err != nil {
+			return err
+		}
 	}
 
 	err = m.backend.UnlinkSnap(newInfo, NewTaskProgressAdapterLocked(t))


### PR DESCRIPTION
In the case of undoing an install we need to make sure that no config is left behind.
