### PR TITLE
tests/many: quiet lxc launching, file pushing

### DIFF
--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -26,14 +26,14 @@ execute: |
     # The snapd package we build as part of the tests will only run on the
     # distro we build on. So we need to launch the right ubuntu version.
     . /etc/os-release
-    lxd.lxc launch "ubuntu:${VERSION_ID}" my-ubuntu
+    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
 
     echo "Remove fuse to trigger the fuse sanity check"
     lxd.lxc exec my-ubuntu -- apt autoremove -y fuse
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
-    lxd.lxc file push "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
+    lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
     lxd.lxc exec my-ubuntu -- apt install -y "$GOHOME"/snapd_*.deb
 
     echo "And validate that we get a useful error"

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -32,11 +32,11 @@ execute: |
     # The snapd package we build as part of the tests will only run on the
     # distro we build on. So we need to launch the right ubuntu version.
     . /etc/os-release
-    lxd.lxc launch "ubuntu:${VERSION_ID}" my-ubuntu
+    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
-    lxd.lxc file push "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
+    lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
     lxd.lxc exec my-ubuntu -- apt install -y "$GOHOME"/snapd_*.deb
 
     echo "And validate that we can use snaps"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -65,7 +65,7 @@ execute: |
     # The snapd package we build as part of the tests will only run on the
     # distro we build on. So we need to launch the right ubuntu version.
     . /etc/os-release
-    lxd.lxc launch "ubuntu:${VERSION_ID}" my-ubuntu
+    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
 
     echo "Ensure we can run things inside"
     lxd.lxc exec my-ubuntu echo hello | MATCH hello
@@ -78,7 +78,7 @@ execute: |
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
-    lxd.lxc file push "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
+    lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
     lxd.lxc exec my-ubuntu -- apt install -y "$GOHOME"/snapd_*.deb
 
     echo "Setting up proxy *inside* the container"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -46,7 +46,7 @@ execute: |
         lxd.lxc config set core.proxy_https "$http_proxy"
     fi
 
-    lxd.lxc launch "ubuntu:18.04" my-ubuntu
+    lxd.lxc launch --quiet "ubuntu:18.04" my-ubuntu
 
     echo "Ensure we can run things inside"
     lxd.lxc exec my-ubuntu echo hello | MATCH hello

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -22,7 +22,7 @@ prepare: |
     fi
 
     # Launch a xenial container.
-    lxc launch ubuntu:xenial xenial
+    lxc launch --quiet ubuntu:xenial xenial
 
     # Set the proxy inside the container.
     if [ -n "${http_proxy:-}" ]; then
@@ -35,7 +35,7 @@ prepare: |
     # Install snapd we've built inside the container.
     lxc exec xenial -- apt autoremove --purge -y snapd ubuntu-core-launcher
     lxc exec xenial -- mkdir -p "$GOHOME"
-    lxc file push "$GOHOME"/snapd_*.deb "xenial/$GOHOME/"
+    lxc file push --quiet "$GOHOME"/snapd_*.deb "xenial/$GOHOME/"
     lxc exec xenial -- apt install -y "$GOHOME"/snapd_*.deb
 
     # Wait until snapd inside container is ready.
@@ -46,7 +46,7 @@ prepare: |
 
     # Make a directory outside of home, specifically in /var/lib for "logs"
     lxc exec xenial -- mkdir /var/lib/test
-    lxc file push hello.py xenial/var/lib/test/hello.py
+    lxc file push --quiet hello.py xenial/var/lib/test/hello.py
 
     # Copy our python script there.
     lxc exec xenial -- chown ubuntu.ubuntu /var/lib/test


### PR DESCRIPTION
The progress indicator just wastes log output and doesn't provide any helpful info in these cases.

See for example:

<details>

```
+ lxd.lxc launch ubuntu:18.04 my-ubuntu
Creating my-ubuntu

Retrieving image: metadata: 100% (1.98GB/s)
                                            
Retrieving image: rootfs: 1% (746.82kB/s)
                                            
Retrieving image: rootfs: 2% (1.11MB/s)
                                            
Retrieving image: rootfs: 3% (1.46MB/s)
                                            
Retrieving image: rootfs: 4% (1.77MB/s)
                                            
Retrieving image: rootfs: 5% (2.07MB/s)
                                            
Retrieving image: rootfs: 6% (2.38MB/s)
                                            
Retrieving image: rootfs: 7% (2.66MB/s)
                                            
Retrieving image: rootfs: 8% (2.93MB/s)
                                            
Retrieving image: rootfs: 9% (3.21MB/s)
                                            
Retrieving image: rootfs: 10% (3.47MB/s)
                                            
Retrieving image: rootfs: 10% (3.72MB/s)
                                            
Retrieving image: rootfs: 11% (3.99MB/s)
                                            
Retrieving image: rootfs: 12% (4.22MB/s)
                                            
Retrieving image: rootfs: 13% (4.47MB/s)
                                            
Retrieving image: rootfs: 14% (4.71MB/s)
                                            
Retrieving image: rootfs: 15% (4.95MB/s)
                                            
Retrieving image: rootfs: 16% (5.20MB/s)
                                            
Retrieving image: rootfs: 17% (5.43MB/s)
                                            
Retrieving image: rootfs: 18% (5.66MB/s)
                                            
Retrieving image: rootfs: 19% (5.89MB/s)
                                            
Retrieving image: rootfs: 20% (6.12MB/s)
                                            
Retrieving image: rootfs: 20% (6.35MB/s)
                                            
Retrieving image: rootfs: 21% (6.57MB/s)
                                            
Retrieving image: rootfs: 22% (6.79MB/s)
                                            
Retrieving image: rootfs: 23% (7.01MB/s)
                                            
Retrieving image: rootfs: 24% (7.23MB/s)
                                            
Retrieving image: rootfs: 25% (7.44MB/s)
                                            
Retrieving image: rootfs: 26% (7.66MB/s)
                                            
Retrieving image: rootfs: 27% (7.86MB/s)
                                            
Retrieving image: rootfs: 28% (8.07MB/s)
                                            
Retrieving image: rootfs: 29% (8.27MB/s)
                                            
Retrieving image: rootfs: 29% (8.46MB/s)
                                            
Retrieving image: rootfs: 30% (8.66MB/s)
                                            
Retrieving image: rootfs: 31% (8.85MB/s)
                                            
Retrieving image: rootfs: 32% (9.05MB/s)
                                            
Retrieving image: rootfs: 33% (9.22MB/s)
                                            
Retrieving image: rootfs: 34% (9.42MB/s)
                                            
Retrieving image: rootfs: 35% (9.59MB/s)
                                            
Retrieving image: rootfs: 36% (9.77MB/s)
                                            
Retrieving image: rootfs: 37% (9.94MB/s)
                                            
Retrieving image: rootfs: 38% (10.11MB/s)
                                            
Retrieving image: rootfs: 39% (10.28MB/s)
                                            
Retrieving image: rootfs: 39% (10.45MB/s)
                                            
Retrieving image: rootfs: 40% (10.61MB/s)
                                            
Retrieving image: rootfs: 41% (10.77MB/s)
                                            
Retrieving image: rootfs: 42% (10.93MB/s)
                                            
Retrieving image: rootfs: 43% (11.09MB/s)
                                            
Retrieving image: rootfs: 44% (11.25MB/s)
                                            
Retrieving image: rootfs: 45% (11.40MB/s)
                                            
Retrieving image: rootfs: 46% (11.55MB/s)
                                            
Retrieving image: rootfs: 47% (11.70MB/s)
                                            
Retrieving image: rootfs: 48% (11.84MB/s)
                                            
Retrieving image: rootfs: 48% (11.99MB/s)
                                            
Retrieving image: rootfs: 49% (12.13MB/s)
                                            
Retrieving image: rootfs: 50% (12.27MB/s)
                                            
Retrieving image: rootfs: 51% (12.41MB/s)
                                            
Retrieving image: rootfs: 52% (12.55MB/s)
                                            
Retrieving image: rootfs: 53% (12.69MB/s)
                                            
Retrieving image: rootfs: 54% (12.82MB/s)
                                            
Retrieving image: rootfs: 55% (12.96MB/s)
                                            
Retrieving image: rootfs: 56% (13.09MB/s)
                                            
Retrieving image: rootfs: 57% (13.22MB/s)
                                            
Retrieving image: rootfs: 58% (13.34MB/s)
                                            
Retrieving image: rootfs: 58% (13.47MB/s)
                                            
Retrieving image: rootfs: 59% (13.59MB/s)
                                            
Retrieving image: rootfs: 60% (13.71MB/s)
                                            
Retrieving image: rootfs: 61% (13.83MB/s)
                                            
Retrieving image: rootfs: 62% (13.95MB/s)
                                            
Retrieving image: rootfs: 63% (14.07MB/s)
                                            
Retrieving image: rootfs: 64% (14.19MB/s)
                                            
Retrieving image: rootfs: 65% (14.31MB/s)
                                            
Retrieving image: rootfs: 66% (14.41MB/s)
                                            
Retrieving image: rootfs: 67% (14.53MB/s)
                                            
Retrieving image: rootfs: 68% (14.64MB/s)
                                            
Retrieving image: rootfs: 68% (14.74MB/s)
                                            
Retrieving image: rootfs: 69% (14.85MB/s)
                                            
Retrieving image: rootfs: 70% (14.96MB/s)
                                            
Retrieving image: rootfs: 71% (15.07MB/s)
                                            
Retrieving image: rootfs: 72% (15.16MB/s)
                                            
Retrieving image: rootfs: 73% (15.27MB/s)
                                            
Retrieving image: rootfs: 74% (15.37MB/s)
                                            
Retrieving image: rootfs: 75% (15.47MB/s)
                                            
Retrieving image: rootfs: 76% (15.57MB/s)
                                            
Retrieving image: rootfs: 77% (15.67MB/s)
                                            
Retrieving image: rootfs: 77% (15.76MB/s)
                                            
Retrieving image: rootfs: 78% (15.86MB/s)
                                            
Retrieving image: rootfs: 79% (15.95MB/s)
                                            
Retrieving image: rootfs: 80% (16.05MB/s)
                                            
Retrieving image: rootfs: 81% (16.14MB/s)
                                            
Retrieving image: rootfs: 82% (16.23MB/s)
                                            
Retrieving image: rootfs: 83% (16.32MB/s)
                                            
Retrieving image: rootfs: 84% (16.41MB/s)
                                            
Retrieving image: rootfs: 85% (16.50MB/s)
                                            
Retrieving image: rootfs: 86% (16.59MB/s)
                                            
Retrieving image: rootfs: 87% (16.68MB/s)
                                            
Retrieving image: rootfs: 87% (16.75MB/s)
                                            
Retrieving image: rootfs: 88% (16.85MB/s)
                                            
Retrieving image: rootfs: 89% (16.92MB/s)
                                            
Retrieving image: rootfs: 90% (17.01MB/s)
                                            
Retrieving image: rootfs: 91% (17.09MB/s)
                                            
Retrieving image: rootfs: 92% (17.18MB/s)
                                            
Retrieving image: rootfs: 93% (17.26MB/s)
                                            
Retrieving image: rootfs: 94% (17.34MB/s)
                                            
Retrieving image: rootfs: 95% (17.42MB/s)
                                            
Retrieving image: rootfs: 96% (17.49MB/s)
                                            
Retrieving image: rootfs: 96% (17.57MB/s)
                                            
Retrieving image: rootfs: 97% (17.64MB/s)
                                            
Retrieving image: rootfs: 98% (17.72MB/s)
                                            
Retrieving image: rootfs: 99% (17.79MB/s)
                                            
Retrieving image: rootfs: 100% (17.87MB/s)
                                            
Retrieving image: rootfs: 100% (17.87MB/s)
                                            
Starting my-ubuntu

Remapping container filesystem
                               

                               

                               
+ echo 'Install snapd'
Install snapd
+ lxd.lxc exec my-ubuntu -- mkdir -p /home/gopath
+ lxd.lxc file push /home/gopath/snapd_1337.2.42.5_amd64.deb my-ubuntu//home/gopath/

Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 2% (804.34MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 3% (80.70MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 4% (101.06MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 5% (128.85MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 6% (147.03MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 7% (147.12MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 8% (132.56MB/s)
                                                                                                                                   
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 9% (142.30MB/s)
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 10% (156.77MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 11% (164.88MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 12% (172.51MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 13% (174.07MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 14% (185.45MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 15% (190.74MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 16% (196.66MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 17% (200.21MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 18% (209.84MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 19% (215.09MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 20% (217.19MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 21% (220.32MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 22% (221.83MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 23% (229.40MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 24% (232.38MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 25% (232.84MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 26% (235.80MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 27% (242.59MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 28% (244.75MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 29% (245.27MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 30% (246.38MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 31% (252.13MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 32% (224.03MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 33% (222.97MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 34% (224.48MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 35% (226.98MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 36% (229.44MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 37% (233.28MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 38% (235.34MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 39% (237.13MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 40% (237.64MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 41% (242.06MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 42% (243.56MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 43% (244.32MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 44% (215.25MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 45% (218.62MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 46% (213.25MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 47% (213.51MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 48% (211.46MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 49% (211.89MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 50% (215.14MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 51% (216.34MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 52% (218.30MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 53% (220.15MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 54% (220.77MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 55% (222.41MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 56% (224.17MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 57% (224.51MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 58% (224.85MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 59% (224.90MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 60% (225.50MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 61% (225.02MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 62% (226.38MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 63% (226.36MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 64% (227.16MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 65% (228.43MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 66% (229.04MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 67% (230.22MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 68% (230.62MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 69% (231.98MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 70% (233.22MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 71% (234.19MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 72% (236.62MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 73% (237.13MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 74% (238.06MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 75% (239.08MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 76% (241.35MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 77% (241.85MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 78% (242.88MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 79% (243.84MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 80% (246.03MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 81% (247.06MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 82% (247.80MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 83% (248.78MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 84% (246.87MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 85% (248.22MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 86% (248.11MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 87% (246.48MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 88% (247.34MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 89% (249.71MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 90% (250.60MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 91% (251.87MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 92% (253.03MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 93% (254.04MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 94% (255.02MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 95% (256.11MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 96% (256.89MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 97% (257.55MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 98% (258.33MB/s)
                                                                                                                                    
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 99% (259.14MB/s)
Pushing /var/lib/snapd/hostfs/home/gopath/snapd_1337.2.42.5_amd64.deb to /home/gopath/snapd_1337.2.42.5_amd64.deb: 100% (259.99MB/s)
                                                                                                                                     

```

</details>