### PR TITLE
devicestate: use correct model constraints in remodel/gadget updates

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -381,7 +381,7 @@ func ReadInfo(gadgetSnapRootDir string, constraints *ModelConstraints) (*Info, e
 }
 
 // ReadInfoFromSnapFile reads the gadget specific metadata from
-// meta/gadget.yaml in the given snapf container. If constraints is
+// meta/gadget.yaml in the given snap container. If constraints is
 // nil, ReadInfo will just check for self-consistency, otherwise rules
 // for the classic or system seed cases are enforced.
 func ReadInfoFromSnapFile(snapf snap.Container, constraints *ModelConstraints) (*Info, error) {

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -570,13 +570,13 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 	})
 
 	// pending update
-	update, err := devicestate.PendingGadgetInfo(snapsup)
+	update, err := devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate gadget snap details: cannot find installed snap .* .*/34/meta/snap.yaml")
 
 	ui := snaptest.MockSnapWithFiles(c, snapYaml, si, nil)
 
-	update, err = devicestate.PendingGadgetInfo(snapsup)
+	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate snap gadget metadata: .*/34/meta/gadget.yaml: no such file or directory")
 
@@ -590,7 +590,7 @@ volumes:
 	// drop gadget.yaml for update snap
 	ioutil.WriteFile(filepath.Join(ui.MountDir(), "meta/gadget.yaml"), []byte(updateGadgetYaml), 0644)
 
-	update, err = devicestate.PendingGadgetInfo(snapsup)
+	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(err, IsNil)
 	c.Assert(update, DeepEquals, &gadget.GadgetData{
 		Info: &gadget.Info{

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -64,6 +64,15 @@ func (s *firstBoot20Suite) setupCore20Seed(c *C, sysLabel string) {
 volumes:
     volume-id:
         bootloader: grub
+        structure:
+        - name: ubuntu-seed
+          role: system-seed
+          type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size: 1G
+        - name: ubuntu-data
+          role: system-data
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size: 2G
 `
 
 	makeSnap := func(yamlKey string) {
@@ -159,7 +168,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%s", chg.Err()))
 
 	// verify

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -54,20 +54,20 @@ func currentGadgetInfo(st *state.State, deviceCtx snapstate.DeviceContext) (*gad
 		return nil, nil
 	}
 
-	ci, err := gadgetDataFromInfo(currentInfo, coreGadgetConstraints)
+	ci, err := gadgetDataFromInfo(currentInfo, deviceCtx.Model())
 	if err != nil {
 		return nil, fmt.Errorf("cannot read current gadget snap details: %v", err)
 	}
 	return ci, nil
 }
 
-func pendingGadgetInfo(snapsup *snapstate.SnapSetup) (*gadget.GadgetData, error) {
+func pendingGadgetInfo(snapsup *snapstate.SnapSetup, deviceCtx snapstate.DeviceContext) (*gadget.GadgetData, error) {
 	info, err := snap.ReadInfo(snapsup.InstanceName(), snapsup.SideInfo)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read candidate gadget snap details: %v", err)
 	}
 
-	gi, err := gadgetDataFromInfo(info, coreGadgetConstraints)
+	gi, err := gadgetDataFromInfo(info, deviceCtx.Model())
 	if err != nil {
 		return nil, fmt.Errorf("cannot read candidate snap gadget metadata: %v", err)
 	}
@@ -113,7 +113,7 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 			snapsup.InstanceName(), expectedGadgetSnap)
 	}
 
-	updateData, err := pendingGadgetInfo(snapsup)
+	updateData, err := pendingGadgetInfo(snapsup, remodelCtx)
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -174,10 +174,6 @@ func (m *DeviceManager) doPrepareRemodeling(t *state.Task, tmb *tomb.Tomb) error
 }
 
 var (
-	coreGadgetConstraints = &gadget.ModelConstraints{
-		Classic: false,
-	}
-
 	gadgetIsCompatible = gadget.IsCompatible
 )
 
@@ -211,12 +207,17 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		return fmt.Errorf("cannot read new gadget metadata: %v", err)
 	}
 
-	currentData, err := gadgetDataFromInfo(curInfo, coreGadgetConstraints)
+	currentData, err := gadgetDataFromInfo(curInfo, deviceCtx.Model())
 	if err != nil {
 		return fmt.Errorf("cannot read current gadget metadata: %v", err)
 	}
 
-	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, coreGadgetConstraints)
+	model := deviceCtx.Model()
+	constraints := &gadget.ModelConstraints{
+		Classic:    model.Classic(),
+		SystemSeed: model.Grade() != asserts.ModelGradeUnset,
+	}
+	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, constraints)
 	if err != nil {
 		return fmt.Errorf("cannot load new gadget metadata: %v", err)
 	}

--- a/overlord/devicestate/helpers.go
+++ b/overlord/devicestate/helpers.go
@@ -34,8 +34,15 @@ func setDeviceFromModelAssertion(st *state.State, device *auth.DeviceState, mode
 	return internal.SetDevice(st, device)
 }
 
-func gadgetDataFromInfo(info *snap.Info, constraints *gadget.ModelConstraints) (*gadget.GadgetData, error) {
-	gi, err := gadget.ReadInfo(info.MountDir(), coreGadgetConstraints)
+func gadgetDataFromInfo(info *snap.Info, model *asserts.Model) (*gadget.GadgetData, error) {
+	var constraints *gadget.ModelConstraints
+	if model != nil {
+		constraints = &gadget.ModelConstraints{
+			Classic:    model.Classic(),
+			SystemSeed: model.Grade() != asserts.ModelGradeUnset,
+		}
+	}
+	gi, err := gadget.ReadInfo(info.MountDir(), constraints)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -480,17 +480,13 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 	}
 
 	// do basic constraints check on the gadget
-	model := deviceCtx.Model()
 	if typ == snap.TypeGadget {
-		validateGadgetModelConstraints := func(model *asserts.Model, snapf snap.Container) error {
-			constraints := &gadget.ModelConstraints{
-				Classic:    model.Classic(),
-				SystemSeed: model.Grade() != asserts.ModelGradeUnset,
-			}
-			_, err = gadget.ReadInfoFromSnapFile(snapf, constraints)
-			return err
+		model := deviceCtx.Model()
+		constraints := &gadget.ModelConstraints{
+			Classic:    model.Classic(),
+			SystemSeed: model.Grade() != asserts.ModelGradeUnset,
 		}
-		if err := validateGadgetModelConstraints(model, snapf); err != nil {
+		if _, err = gadget.ReadInfoFromSnapFile(snapf, constraints); err != nil {
 			return err
 		}
 	}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -286,7 +286,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -328,7 +328,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -369,7 +369,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -410,7 +410,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -452,7 +452,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -805,6 +805,12 @@ func emptyContainer(c *C) *snapdir.SnapDir {
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
 	return snapdir.New(d)
+}
+
+func minimalGadgetContainer(c *C) *snapdir.SnapDir {
+	d := emptyContainer(c)
+	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "meta", "gadget.yaml"), []byte(gadgetYaml), 0444), IsNil)
+	return d
 }
 
 func (s *checkSnapSuite) TestCheckSnapInstanceName(c *C) {
@@ -1281,7 +1287,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2374,11 +2374,8 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 		return nil, state.ErrNoState
 	}
 
-	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// no constraints set: those should have been checked before already
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2411,11 +2408,8 @@ func GadgetConnections(st *state.State, deviceCtx DeviceContext) ([]gadget.Conne
 		return nil, err
 	}
 
-	constraints := &gadget.ModelConstraints{
-		Classic: release.OnClassic,
-	}
-
-	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), constraints)
+	// no constraints set: those should have been checked before already
+	gadgetInfo, err := gadget.ReadInfo(info.MountDir(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The current devicestate code does not set the correct gadget
constraints. It naively always sets only Classic to false. This
PR changes this so that the actual model is looked at and the
SystemSeed is set for UC20 models.

This should fix UC20 seeding.

We still should do a version where we pass an interface like gadget.Model to
gadget.ReadInfo() instead of using ModelConstraints.

The relevant https://github.com/snapcore/snapd/pull/7891/commits/3ba5dcc6e083a4c1889b3bc3c1315f81c1247f49

This is a better version of https://github.com/snapcore/snapd/pull/7887