### PR TITLE
many: pass a Model to the gadget info reading functions

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -381,7 +381,7 @@ func ReadInfo(gadgetSnapRootDir string, constraints *ModelConstraints) (*Info, e
 }
 
 // ReadInfoFromSnapFile reads the gadget specific metadata from
-// meta/gadget.yaml in the given snapf container. If constraints is
+// meta/gadget.yaml in the given snap container. If constraints is
 // nil, ReadInfo will just check for self-consistency, otherwise rules
 // for the classic or system seed cases are enforced.
 func ReadInfoFromSnapFile(snapf snap.Container, constraints *ModelConstraints) (*Info, error) {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -31,6 +31,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/snap"
@@ -303,18 +304,34 @@ func (s *gadgetYamlTestSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
+type modelConstraints struct {
+	classic    bool
+	systemSeed bool
+}
+
+func (m *modelConstraints) Classic() bool {
+	return m.classic
+}
+
+func (m *modelConstraints) Grade() asserts.ModelGrade {
+	if m.systemSeed {
+		return asserts.ModelSigned
+	}
+	return asserts.ModelGradeUnset
+}
+
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlMissing(c *C) {
 	// if constraints are nil, we allow a missing yaml
 	_, err := gadget.ReadInfo("bogus-path", nil)
 	c.Assert(err, IsNil)
 
-	_, err = gadget.ReadInfo("bogus-path", &gadget.ModelConstraints{})
+	_, err = gadget.ReadInfo("bogus-path", &modelConstraints{})
 	c.Assert(err, ErrorMatches, ".*meta/gadget.yaml: no such file or directory")
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOptional(c *C) {
 	// no meta/gadget.yaml
-	gi, err := gadget.ReadInfo(s.dir, &gadget.ModelConstraints{Classic: true})
+	gi, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 	c.Check(gi, NotNil)
 }
@@ -323,7 +340,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicEmptyIsValid(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	ginfo, err := gadget.ReadInfo(s.dir, &gadget.ModelConstraints{Classic: true})
+	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 	c.Assert(ginfo, DeepEquals, &gadget.Info{})
 }
@@ -332,7 +349,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *
 	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
-	ginfo, err := gadget.ReadInfo(s.dir, &gadget.ModelConstraints{Classic: true})
+	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
 		Defaults: map[string]map[string]interface{}{
@@ -348,7 +365,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetMultilineDefaultsYaml, 0644)
 	c.Assert(err, IsNil)
 
-	ginfo, err := gadget.ReadInfo(s.dir, &gadget.ModelConstraints{Classic: true})
+	ginfo, err := gadget.ReadInfo(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 	c.Assert(ginfo, DeepEquals, &gadget.Info{
 		Defaults: map[string]map[string]interface{}{
@@ -492,7 +509,7 @@ volumes:
 	err := ioutil.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
 	c.Assert(err, IsNil)
 
-	_, err = gadget.ReadInfo(s.dir, &gadget.ModelConstraints{Classic: false})
+	_, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: false})
 	c.Assert(err, ErrorMatches, "bootloader not declared in any volume")
 }
 
@@ -500,7 +517,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlMissingBootloader(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	_, err = gadget.ReadInfo(s.dir, &gadget.ModelConstraints{Classic: false})
+	_, err = gadget.ReadInfo(s.dir, &modelConstraints{classic: false})
 	c.Assert(err, ErrorMatches, "bootloader not declared in any volume")
 }
 
@@ -672,10 +689,10 @@ func (s *gadgetYamlTestSuite) TestUnmarshalGadgetRelativeOffset(c *C) {
 	}
 }
 
-var classicModelConstraints = []*gadget.ModelConstraints{
+var classicModelConstraints = []gadget.Model{
 	nil,
-	{Classic: false, SystemSeed: false},
-	{Classic: true, SystemSeed: false},
+	&modelConstraints{classic: false, systemSeed: false},
+	&modelConstraints{classic: true, systemSeed: false},
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlPCHappy(c *C) {
@@ -990,9 +1007,9 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeDuplicateFsLabel(c *C) {
 		{true, "writable", `filesystem label "writable" is not unique`},
 		{true, "ubuntu-data", `filesystem label "ubuntu-data" is not unique`},
 	} {
-		for _, constraints := range []*gadget.ModelConstraints{
-			{Classic: false, SystemSeed: x.systemSeed},
-			{Classic: true, SystemSeed: x.systemSeed},
+		for _, constraints := range []*modelConstraints{
+			{classic: false, systemSeed: x.systemSeed},
+			{classic: true, systemSeed: x.systemSeed},
 		} {
 			err = gadget.ValidateVolume("name", &gadget.Volume{
 				Structure: []gadget.VolumeStructure{{
@@ -1564,9 +1581,9 @@ volumes:
 		err := ioutil.WriteFile(s.gadgetYamlPath, b.Bytes(), 0644)
 		c.Assert(err, IsNil)
 
-		constraints := &gadget.ModelConstraints{
-			Classic:    false,
-			SystemSeed: tc.systemSeed,
+		constraints := &modelConstraints{
+			classic:    false,
+			systemSeed: tc.systemSeed,
 		}
 
 		_, err = gadget.ReadInfo(s.dir, constraints)
@@ -1580,8 +1597,8 @@ volumes:
 	// test error with no volumes
 	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(bloader), 0644)
 	c.Assert(err, IsNil)
-	constraints := &gadget.ModelConstraints{
-		SystemSeed: true,
+	constraints := &modelConstraints{
+		systemSeed: true,
 	}
 	_, err = gadget.ReadInfo(s.dir, constraints)
 	c.Assert(err, ErrorMatches, ".*: model requires system-seed partition, but no system-seed or system-data partition found")
@@ -1591,8 +1608,8 @@ func (s *gadgetYamlTestSuite) TestGadgetReadInfoVsFromMeta(c *C) {
 	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
 	c.Assert(err, IsNil)
 
-	constraints := &gadget.ModelConstraints{
-		Classic: false,
+	constraints := &modelConstraints{
+		classic: false,
 	}
 
 	giRead, err := gadget.ReadInfo(s.dir, constraints)
@@ -1605,11 +1622,11 @@ func (s *gadgetYamlTestSuite) TestGadgetReadInfoVsFromMeta(c *C) {
 }
 
 var (
-	classicConstraints = &gadget.ModelConstraints{
-		Classic: true,
+	classicConstraints = &modelConstraints{
+		classic: true,
 	}
-	coreConstraints = &gadget.ModelConstraints{
-		Classic: false,
+	coreConstraints = &modelConstraints{
+		classic: false,
 	}
 )
 
@@ -1700,7 +1717,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlFromSnapFileMissing(c *C) {
 	_, err = gadget.ReadInfoFromSnapFile(snapf, nil)
 	c.Assert(err, IsNil)
 
-	_, err = gadget.ReadInfoFromSnapFile(snapf, &gadget.ModelConstraints{})
+	_, err = gadget.ReadInfoFromSnapFile(snapf, &modelConstraints{})
 	c.Assert(err, ErrorMatches, ".*meta/gadget.yaml: no such file or directory")
 }
 

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -52,8 +52,8 @@ func validateVolumeContentsPresence(gadgetSnapRootDir string, vol *LaidOutVolume
 // Validate checks whether the given directory contains valid gadget snap
 // metadata and a matching content, under the provided model constraints, which
 // are handled identically to ReadInfo().
-func Validate(gadgetSnapRootDir string, modelConstraints *ModelConstraints) error {
-	info, err := ReadInfo(gadgetSnapRootDir, modelConstraints)
+func Validate(gadgetSnapRootDir string, model Model) error {
+	info, err := ReadInfo(gadgetSnapRootDir, model)
 	if err != nil {
 		return fmt.Errorf("invalid gadget metadata: %v", err)
 	}

--- a/gadget/validate_test.go
+++ b/gadget/validate_test.go
@@ -149,10 +149,10 @@ func (s *validateGadgetTestSuite) TestValidateClassic(c *C) {
 	err := gadget.Validate(s.dir, nil)
 	c.Assert(err, IsNil)
 
-	err = gadget.Validate(s.dir, &gadget.ModelConstraints{Classic: true})
+	err = gadget.Validate(s.dir, &modelConstraints{classic: true})
 	c.Assert(err, IsNil)
 
-	err = gadget.Validate(s.dir, &gadget.ModelConstraints{Classic: false})
+	err = gadget.Validate(s.dir, &modelConstraints{classic: false})
 	c.Assert(err, ErrorMatches, "invalid gadget metadata: bootloader not declared in any volume")
 }
 

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -570,13 +570,13 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 	})
 
 	// pending update
-	update, err := devicestate.PendingGadgetInfo(snapsup)
+	update, err := devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate gadget snap details: cannot find installed snap .* .*/34/meta/snap.yaml")
 
 	ui := snaptest.MockSnapWithFiles(c, snapYaml, si, nil)
 
-	update, err = devicestate.PendingGadgetInfo(snapsup)
+	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(update, IsNil)
 	c.Assert(err, ErrorMatches, "cannot read candidate snap gadget metadata: .*/34/meta/gadget.yaml: no such file or directory")
 
@@ -590,7 +590,7 @@ volumes:
 	// drop gadget.yaml for update snap
 	ioutil.WriteFile(filepath.Join(ui.MountDir(), "meta/gadget.yaml"), []byte(updateGadgetYaml), 0644)
 
-	update, err = devicestate.PendingGadgetInfo(snapsup)
+	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(err, IsNil)
 	c.Assert(update, DeepEquals, &gadget.GadgetData{
 		Info: &gadget.Info{

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -964,7 +964,7 @@ volumes:
 		"gadget":       "new-gadget",
 		"kernel":       "kernel",
 	})
-	remodelCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: newModel, Remodeling: true}
+	remodelCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: newModel, Remodeling: true, OldDeviceModel: oldModel}
 
 	restore := devicestate.MockGadgetIsCompatible(func(current, update *gadget.Info) error {
 		c.Assert(current.Volumes, HasLen, 1)
@@ -1082,12 +1082,17 @@ version: 123
 
 	s.setupBrands(c)
 	// model assertion in device context
-	model := fakeMyModel(map[string]interface{}{
+	oldModel := fakeMyModel(map[string]interface{}{
 		"architecture": "amd64",
-		"gadget":       "gadget",
+		"gadget":       "new-gadget",
 		"kernel":       "krnl",
 	})
-	remodelCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model, Remodeling: true}
+	model := fakeMyModel(map[string]interface{}{
+		"architecture": "amd64",
+		"gadget":       "new-gadget",
+		"kernel":       "krnl",
+	})
+	remodelCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: model, Remodeling: true, OldDeviceModel: oldModel}
 
 	err = devicestate.CheckGadgetRemodelCompatible(s.state, info, currInfo, snapf, snapstate.Flags{}, remodelCtx)
 	if expErr == "" {

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -64,6 +64,15 @@ func (s *firstBoot20Suite) setupCore20Seed(c *C, sysLabel string) {
 volumes:
     volume-id:
         bootloader: grub
+        structure:
+        - name: ubuntu-seed
+          role: system-seed
+          type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size: 1G
+        - name: ubuntu-data
+          role: system-data
+          type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size: 2G
 `
 
 	makeSnap := func(yamlKey string) {

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -174,10 +174,6 @@ func (m *DeviceManager) doPrepareRemodeling(t *state.Task, tmb *tomb.Tomb) error
 }
 
 var (
-	coreGadgetConstraints = &gadget.ModelConstraints{
-		Classic: false,
-	}
-
 	gadgetIsCompatible = gadget.IsCompatible
 )
 
@@ -193,11 +189,12 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		// We are only interesting in a remodeling scenario.
 		return nil
 	}
+
 	if curInfo == nil {
 		// snap isn't installed yet, we are likely remodeling to a new
 		// gadget, identify the old gadget
 		groundDeviceCtx, err := DeviceCtx(st, nil, nil)
-		if err != nil || err == state.ErrNoState {
+		if err != nil {
 			return fmt.Errorf("cannot identify the current model")
 		}
 		curInfo, _ = snapstate.GadgetInfo(st, groundDeviceCtx)
@@ -211,12 +208,12 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		return fmt.Errorf("cannot read new gadget metadata: %v", err)
 	}
 
-	currentData, err := gadgetDataFromInfo(curInfo, coreGadgetConstraints)
+	currentData, err := gadgetDataFromInfo(curInfo, deviceCtx.OldModel())
 	if err != nil {
 		return fmt.Errorf("cannot read current gadget metadata: %v", err)
 	}
 
-	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, coreGadgetConstraints)
+	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, deviceCtx.Model())
 	if err != nil {
 		return fmt.Errorf("cannot load new gadget metadata: %v", err)
 	}

--- a/overlord/devicestate/helpers.go
+++ b/overlord/devicestate/helpers.go
@@ -34,8 +34,8 @@ func setDeviceFromModelAssertion(st *state.State, device *auth.DeviceState, mode
 	return internal.SetDevice(st, device)
 }
 
-func gadgetDataFromInfo(info *snap.Info, constraints *gadget.ModelConstraints) (*gadget.GadgetData, error) {
-	gi, err := gadget.ReadInfo(info.MountDir(), coreGadgetConstraints)
+func gadgetDataFromInfo(info *snap.Info, model *asserts.Model) (*gadget.GadgetData, error) {
+	gi, err := gadget.ReadInfo(info.MountDir(), model)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -480,17 +480,8 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 	}
 
 	// do basic constraints check on the gadget
-	model := deviceCtx.Model()
 	if typ == snap.TypeGadget {
-		validateGadgetModelConstraints := func(model *asserts.Model, snapf snap.Container) error {
-			constraints := &gadget.ModelConstraints{
-				Classic:    model.Classic(),
-				SystemSeed: model.Grade() != asserts.ModelGradeUnset,
-			}
-			_, err = gadget.ReadInfoFromSnapFile(snapf, constraints)
-			return err
-		}
-		if err := validateGadgetModelConstraints(model, snapf); err != nil {
+		if _, err = gadget.ReadInfoFromSnapFile(snapf, deviceCtx.Model()); err != nil {
 			return err
 		}
 	}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -286,7 +286,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -328,7 +328,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -369,7 +369,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -410,7 +410,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -452,7 +452,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -805,6 +805,12 @@ func emptyContainer(c *C) *snapdir.SnapDir {
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
 	return snapdir.New(d)
+}
+
+func minimalGadgetContainer(c *C) *snapdir.SnapDir {
+	d := emptyContainer(c)
+	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "meta", "gadget.yaml"), []byte(gadgetYaml), 0444), IsNil)
+	return d
 }
 
 func (s *checkSnapSuite) TestCheckSnapInstanceName(c *C) {
@@ -1281,7 +1287,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, emptyContainer(c), nil
+		return info, minimalGadgetContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()


### PR DESCRIPTION
Instead of an ad hoc ModelConstraints struct pass a model
to the gadget info reading methods, specified via an interface
to simplify tests.

Had to clean up some bits in devicestate to make this work.

Based on some initial work by @mvo5
