### PR TITLE
daemon,snap: remove screenshot deprecation notice

### DIFF
--- a/cmd/snapinfo.go
+++ b/cmd/snapinfo.go
@@ -72,7 +72,6 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info) (*client.Snap, error) {
 		Contact:     snapInfo.Contact,
 		Title:       snapInfo.Title(),
 		License:     snapInfo.License,
-		Screenshots: snapInfo.Media.Screenshots(),
 		Media:       snapInfo.Media,
 		Prices:      snapInfo.Prices,
 		Channels:    snapInfo.Channels,

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -797,12 +797,11 @@ UnitFileState=enabled
 					},
 				},
 			},
-			Broken:      "",
-			Contact:     "",
-			License:     "GPL-3.0",
-			CommonIDs:   []string{"org.foo.cmd"},
-			Screenshots: []snap.ScreenshotInfo{{Note: snap.ScreenshotsDeprecationNotice}},
-			CohortKey:   "some-long-cohort-key",
+			Broken:    "",
+			Contact:   "",
+			License:   "GPL-3.0",
+			CommonIDs: []string{"org.foo.cmd"},
+			CohortKey: "some-long-cohort-key",
 		},
 		Meta: meta,
 	}
@@ -956,7 +955,6 @@ func (s *apiSuite) TestMapLocalFields(c *check.C) {
 		CommonIDs:        []string{"foo", "bar"},
 		MountedFrom:      filepath.Join(dirs.SnapBlobDir, "some-snap_instance_7.snap"),
 		Media:            media,
-		Screenshots:      []snap.ScreenshotInfo{{Note: snap.ScreenshotsDeprecationNotice}},
 		Apps: []client.AppInfo{
 			{Snap: "some-snap_instance", Name: "bar"},
 			{Snap: "some-snap_instance", Name: "foo"},
@@ -1787,7 +1785,6 @@ func (s *apiSuite) TestFind(c *check.C) {
 	c.Assert(snaps, check.HasLen, 1)
 	c.Assert(snaps[0]["name"], check.Equals, "store")
 	c.Check(snaps[0]["prices"], check.IsNil)
-	c.Check(snaps[0]["screenshots"], check.DeepEquals, []interface{}{map[string]interface{}{"note": snap.ScreenshotsDeprecationNotice}})
 	c.Check(snaps[0]["channels"], check.IsNil)
 
 	c.Check(rsp.SuggestedCurrency, check.Equals, "EUR")
@@ -2209,11 +2206,6 @@ func (s *apiSuite) TestFindScreenshotted(c *check.C) {
 	c.Assert(snaps, check.HasLen, 1)
 
 	c.Check(snaps[0]["name"], check.Equals, "test-screenshot")
-	c.Check(snaps[0]["screenshots"], check.DeepEquals, []interface{}{
-		map[string]interface{}{
-			"note": snap.ScreenshotsDeprecationNotice,
-		},
-	})
 	c.Check(snaps[0]["media"], check.DeepEquals, []interface{}{
 		map[string]interface{}{
 			"type":   "screenshot",

--- a/snap/info.go
+++ b/snap/info.go
@@ -820,12 +820,6 @@ type MediaInfo struct {
 
 type MediaInfos []MediaInfo
 
-const ScreenshotsDeprecationNotice = `'screenshots' is deprecated; use 'media' instead. More info at https://forum.snapcraft.io/t/8086`
-
-func (mis MediaInfos) Screenshots() []ScreenshotInfo {
-	return []ScreenshotInfo{{Note: ScreenshotsDeprecationNotice}}
-}
-
 func (mis MediaInfos) IconURL() string {
 	for _, mi := range mis {
 		if mi.Type == "icon" {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1608,8 +1608,6 @@ func (s *infoSuite) TestSortByTypeAgain(c *C) {
 }
 
 func (s *infoSuite) TestMedia(c *C) {
-	c.Check(snap.MediaInfos{}.Screenshots(), DeepEquals,
-		[]snap.ScreenshotInfo{{Note: snap.ScreenshotsDeprecationNotice}})
 	c.Check(snap.MediaInfos{}.IconURL(), Equals, "")
 
 	media := snap.MediaInfos{
@@ -1628,8 +1626,6 @@ func (s *infoSuite) TestMedia(c *C) {
 	}
 
 	c.Check(media.IconURL(), Equals, "https://example.com/icon.png")
-	c.Check(media.Screenshots(), DeepEquals,
-		[]snap.ScreenshotInfo{{Note: snap.ScreenshotsDeprecationNotice}})
 }
 
 func (s *infoSuite) TestSortApps(c *C) {


### PR DESCRIPTION
'media' has been available for some time and 'screenshots' hasn't contained any
screenshot data (just a note about the change). Older clients may accidentally
interpret the note as an invalid screenshot. Clients have either migrated or might
be confused so it's not needed anymore.
