### PR TITLE
many: add DeviceCtx.OperatingMode()

### DIFF
--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -34,6 +34,8 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if providedDeviceCtx != nil {
 		return providedDeviceCtx, nil
 	}
+	devMgr := deviceMgr(st)
+
 	// use the remodelContext if the task is part of a remodel change
 	remodCtx, err := remodelCtxFromTask(task)
 	if err == nil {
@@ -46,11 +48,16 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if err != nil {
 		return nil, err
 	}
-	return modelDeviceContext{model: modelAs}, nil
+
+	return modelDeviceContext{
+		model:         modelAs,
+		operatingMode: devMgr.OperatingMode(),
+	}, nil
 }
 
 type modelDeviceContext struct {
-	model *asserts.Model
+	model         *asserts.Model
+	operatingMode string
 }
 
 // sanity
@@ -70,4 +77,8 @@ func (dc modelDeviceContext) Store() snapstate.StoreService {
 
 func (dc modelDeviceContext) ForRemodeling() bool {
 	return false
+}
+
+func (dc modelDeviceContext) OperatingMode() string {
+	return dc.operatingMode
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -258,7 +258,7 @@ func setClassicFallbackModel(st *state.State, device *auth.DeviceState) error {
 	return nil
 }
 
-func (m *DeviceManager) operatingMode() string {
+func (m *DeviceManager) OperatingMode() string {
 	if m.modeEnv.Mode == "" {
 		return "run"
 	}
@@ -269,7 +269,7 @@ func (m *DeviceManager) ensureOperational() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	if m.operatingMode() != "run" {
+	if m.OperatingMode() != "run" {
 		// avoid doing registration in ephemeral mode
 		return nil
 	}
@@ -477,7 +477,7 @@ func (m *DeviceManager) ensureBootOk() error {
 	}
 
 	// book-ok/update-boot-revision is only relevant in run-mode
-	if m.operatingMode() != "run" {
+	if m.OperatingMode() != "run" {
 		return nil
 	}
 
@@ -511,7 +511,7 @@ func (m *DeviceManager) ensureInstalled() error {
 	}
 
 	// Note: thisalso stop auto-refreshes indirectly
-	if m.operatingMode() != "install" {
+	if m.OperatingMode() != "install" {
 		return nil
 	}
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1071,7 +1071,7 @@ func (s *deviceMgrSuite) TestDeviceManagerReadsModeenv(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
 	c.Assert(err, IsNil)
 	c.Assert(mgr, NotNil)
-	c.Assert(devicestate.OperatingMode(mgr), Equals, "install")
+	c.Assert(mgr.OperatingMode(), Equals, "install")
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEmptyOperatingModeRun(c *C) {
@@ -1079,5 +1079,5 @@ func (s *deviceMgrSuite) TestDeviceManagerEmptyOperatingModeRun(c *C) {
 	devicestate.SetOperatingMode(s.mgr, "")
 
 	// empty is returned as "run"
-	c.Check(devicestate.OperatingMode(s.mgr), Equals, "run")
+	c.Check(s.mgr.OperatingMode(), Equals, "run")
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -87,12 +87,6 @@ func SetOperatingMode(m *DeviceManager, mode string) {
 	m.modeEnv.Mode = mode
 }
 
-// XXX: will become properly exported but we probably want to make
-//      mode a type and not a string before we do that
-func OperatingMode(m *DeviceManager) string {
-	return m.operatingMode()
-}
-
 func MockRepeatRequestSerial(label string) (restore func()) {
 	old := repeatRequestSerial
 	repeatRequestSerial = label

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -593,6 +593,11 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	o.AddManager(ifacemgr)
 	c.Assert(o.StartUp(), IsNil)
 
+	hookMgr, err := hookstate.Manager(st, o.TaskRunner())
+	c.Assert(err, IsNil)
+	_, err = devicestate.Manager(st, hookMgr, o.TaskRunner(), nil)
+	c.Assert(err, IsNil)
+
 	st.Lock()
 	assertstate.ReplaceDB(st, db.(*asserts.Database))
 	st.Unlock()

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -135,7 +135,7 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 	switch kind := ClassifyRemodel(oldModel, newModel); kind {
 	case UpdateRemodel:
 		// simple context for the simple case
-		remodCtx = &updateRemodelContext{baseRemodelContext{newModel, oldModel}}
+		remodCtx = &updateRemodelContext{baseRemodelContext{newModel, oldModel, devMgr.OperatingMode()}}
 	case StoreSwitchRemodel:
 		remodCtx = newNewStoreRemodelContext(st, devMgr, newModel, oldModel)
 	case ReregRemodel:
@@ -203,6 +203,7 @@ func remodelCtxFromTask(t *state.Task) (remodelContext, error) {
 
 type baseRemodelContext struct {
 	newModel, oldModel *asserts.Model
+	operatingMode      string
 }
 
 func (rc baseRemodelContext) ForRemodeling() bool {
@@ -228,6 +229,10 @@ func (rc baseRemodelContext) cacheViaChange(chg *state.Change, remodCtx remodelC
 
 func (rc baseRemodelContext) init(chg *state.Change) {
 	chg.Set("new-model", string(asserts.Encode(rc.newModel)))
+}
+
+func (rc baseRemodelContext) OperatingMode() string {
+	return rc.operatingMode
 }
 
 // updateRemodelContext: model assertion revision-only update remodel
@@ -277,7 +282,7 @@ type newStoreRemodelContext struct {
 
 func newNewStoreRemodelContext(st *state.State, devMgr *DeviceManager, newModel, oldModel *asserts.Model) *newStoreRemodelContext {
 	rc := &newStoreRemodelContext{}
-	rc.baseRemodelContext = baseRemodelContext{newModel, oldModel}
+	rc.baseRemodelContext = baseRemodelContext{newModel, oldModel, devMgr.OperatingMode()}
 	rc.st = st
 	rc.deviceMgr = devMgr
 	rc.store = devMgr.newStore(rc.deviceBackend())

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -606,6 +606,45 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendKeptSerial(c *C) {
 	c.Check(serial0.Serial(), Equals, "serialserialserial1")
 }
 
+func (s *remodelLogicSuite) TestRemodelContextOperatingModeDefaultRun(c *C) {
+	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{"revision": "2"})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	assertstatetest.AddMany(s.state, oldModel)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx.OperatingMode(), Equals, "run")
+}
+
+func (s *remodelLogicSuite) TestRemodelContextOperatingModeWorks(c *C) {
+	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{"revision": "2"})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	assertstatetest.AddMany(s.state, oldModel)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	devicestate.SetOperatingMode(s.mgr, "install")
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx.OperatingMode(), Equals, "install")
+}
+
 func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
 	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
 	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -38,6 +38,9 @@ type DeviceContext interface {
 
 	// ForRemodeling returns whether this context is for use over a remodeling.
 	ForRemodeling() bool
+
+	// OperatingMode return the operating mode (run,install,recover,...)
+	OperatingMode() string
 }
 
 // Hook setup by devicestate to pick a device context from state,

--- a/overlord/snapstate/devicectx_test.go
+++ b/overlord/snapstate/devicectx_test.go
@@ -200,3 +200,18 @@ func (s *deviceCtxSuite) TestDeviceCtxFromStateTooEarly(c *C) {
 	_, err = snapstate.DeviceCtxFromState(s.st, nil)
 	c.Assert(err, DeepEquals, expectedErr)
 }
+
+func (s *deviceCtxSuite) TestDeviceOperatingModeDefaults(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// seeded and model assertion
+	s.st.Set("seeded", true)
+
+	r := snapstatetest.MockOperatingMode("install")
+	defer r()
+
+	deviceCtx, err := snapstate.DevicePastSeeding(s.st, nil)
+	c.Assert(err, IsNil)
+	c.Check(deviceCtx.OperatingMode(), Equals, "install")
+}

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -31,6 +31,7 @@ type TrivialDeviceContext struct {
 	OldDeviceModel *asserts.Model
 	Remodeling     bool
 	CtxStore       snapstate.StoreService
+	OpMode         string
 }
 
 func (dc *TrivialDeviceContext) Model() *asserts.Model {
@@ -49,11 +50,20 @@ func (dc *TrivialDeviceContext) ForRemodeling() bool {
 	return dc.Remodeling
 }
 
+func (dc *TrivialDeviceContext) OperatingMode() string {
+	return dc.OpMode
+}
+
 func MockDeviceModel(model *asserts.Model) (restore func()) {
 	var deviceCtx snapstate.DeviceContext
 	if model != nil {
 		deviceCtx = &TrivialDeviceContext{DeviceModel: model}
 	}
+	return MockDeviceContext(deviceCtx)
+}
+
+func MockOperatingMode(operatingMode string) (restore func()) {
+	deviceCtx := &TrivialDeviceContext{OpMode: operatingMode}
 	return MockDeviceContext(deviceCtx)
 }
 


### PR DESCRIPTION
This commit will allow access to the operating mode from the
device context. This will allow us to take certain actions
in snapstate depending on what mode we are in.

The next step will be to avoid trying to install a bootloader
during the seeding in ephemeral modes.

