### PR TITLE
overlord/snapstate: tweak assumes error hint

### DIFF
--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -188,7 +188,7 @@ func checkAssumes(si *snap.Info) error {
 		}
 	}
 	if len(missing) > 0 {
-		hint := "try to refresh the core snap"
+		hint := "try to refresh the core or snapd snaps"
 		if release.OnClassic {
 			hint = "try to update snapd and refresh the core snap"
 		}

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -101,7 +101,7 @@ var assumesTests = []struct {
 	assumes: "[common-data-dir]",
 }, {
 	assumes: "[f1, f2]",
-	error:   `snap "foo" assumes unsupported features: f1, f2 \(try to refresh the core snap\)`,
+	error:   `snap "foo" assumes unsupported features: f1, f2 \(try to refresh the core or snapd snaps\)`,
 }, {
 	assumes: "[f1, f2]",
 	classic: true,


### PR DESCRIPTION
Tweak the hint returned with assumes check errors to mention core or snapd
snapd. More precise hint would require passing around the state information.

Fixes: https://bugs.launchpad.net/snapd/+bug/1856051
