### PR TITLE
overlord: replace DeviceContext.OldModel with GroundContext 

### DIFF
--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -34,8 +34,6 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if providedDeviceCtx != nil {
 		return providedDeviceCtx, nil
 	}
-	devMgr := deviceMgr(st)
-
 	// use the remodelContext if the task is part of a remodel change
 	remodCtx, err := remodelCtxFromTask(task)
 	if err == nil {
@@ -49,6 +47,7 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 		return nil, err
 	}
 
+	devMgr := deviceMgr(st)
 	return modelDeviceContext{
 		model:         modelAs,
 		operatingMode: devMgr.OperatingMode(),

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -48,36 +48,47 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	}
 
 	devMgr := deviceMgr(st)
-	return &modelDeviceContext{
+	return &modelDeviceContext{groundDeviceContext{
 		model:         modelAs,
 		operatingMode: devMgr.OperatingMode(),
-	}, nil
+	}}, nil
 }
 
-type modelDeviceContext struct {
+type groundDeviceContext struct {
 	model         *asserts.Model
 	operatingMode string
 }
 
-// sanity
-var _ snapstate.DeviceContext = &modelDeviceContext{}
-
-func (dc *modelDeviceContext) Model() *asserts.Model {
+func (dc *groundDeviceContext) Model() *asserts.Model {
 	return dc.model
 }
 
-func (dc *modelDeviceContext) OldModel() *asserts.Model {
-	return nil
+func (dc *groundDeviceContext) GroundContext() snapstate.DeviceContext {
+	return dc
+}
+
+func (dc *groundDeviceContext) Store() snapstate.StoreService {
+	panic("retrieved ground context is not intended to drive store operations")
+}
+
+func (dc *groundDeviceContext) ForRemodeling() bool {
+	return false
+}
+
+func (dc *groundDeviceContext) OperatingMode() string {
+	return dc.operatingMode
+}
+
+// sanity
+var _ snapstate.DeviceContext = &groundDeviceContext{}
+
+type modelDeviceContext struct {
+	groundDeviceContext
 }
 
 func (dc *modelDeviceContext) Store() snapstate.StoreService {
 	return nil
 }
 
-func (dc *modelDeviceContext) ForRemodeling() bool {
-	return false
-}
-
-func (dc *modelDeviceContext) OperatingMode() string {
-	return dc.operatingMode
-}
+// sanity
+var _ snapstate.DeviceContext = &modelDeviceContext{}

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -34,6 +34,8 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if providedDeviceCtx != nil {
 		return providedDeviceCtx, nil
 	}
+	devMgr := deviceMgr(st)
+
 	// use the remodelContext if the task is part of a remodel change
 	remodCtx, err := remodelCtxFromTask(task)
 	if err == nil {
@@ -46,11 +48,16 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if err != nil {
 		return nil, err
 	}
-	return modelDeviceContext{model: modelAs}, nil
+
+	return modelDeviceContext{
+		model:         modelAs,
+		operatingMode: devMgr.OperatingMode(),
+	}, nil
 }
 
 type modelDeviceContext struct {
-	model *asserts.Model
+	model         *asserts.Model
+	operatingMode string
 }
 
 // sanity
@@ -70,4 +77,8 @@ func (dc modelDeviceContext) Store() snapstate.StoreService {
 
 func (dc modelDeviceContext) ForRemodeling() bool {
 	return false
+}
+
+func (dc modelDeviceContext) OperatingMode() string {
+	return dc.operatingMode
 }

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -48,7 +48,7 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	}
 
 	devMgr := deviceMgr(st)
-	return modelDeviceContext{
+	return &modelDeviceContext{
 		model:         modelAs,
 		operatingMode: devMgr.OperatingMode(),
 	}, nil
@@ -60,24 +60,24 @@ type modelDeviceContext struct {
 }
 
 // sanity
-var _ snapstate.DeviceContext = modelDeviceContext{}
+var _ snapstate.DeviceContext = &modelDeviceContext{}
 
-func (dc modelDeviceContext) Model() *asserts.Model {
+func (dc *modelDeviceContext) Model() *asserts.Model {
 	return dc.model
 }
 
-func (dc modelDeviceContext) OldModel() *asserts.Model {
+func (dc *modelDeviceContext) OldModel() *asserts.Model {
 	return nil
 }
 
-func (dc modelDeviceContext) Store() snapstate.StoreService {
+func (dc *modelDeviceContext) Store() snapstate.StoreService {
 	return nil
 }
 
-func (dc modelDeviceContext) ForRemodeling() bool {
+func (dc *modelDeviceContext) ForRemodeling() bool {
 	return false
 }
 
-func (dc modelDeviceContext) OperatingMode() string {
+func (dc *modelDeviceContext) OperatingMode() string {
 	return dc.operatingMode
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -258,7 +258,7 @@ func setClassicFallbackModel(st *state.State, device *auth.DeviceState) error {
 	return nil
 }
 
-func (m *DeviceManager) operatingMode() string {
+func (m *DeviceManager) OperatingMode() string {
 	if m.modeEnv.Mode == "" {
 		return "run"
 	}
@@ -269,7 +269,7 @@ func (m *DeviceManager) ensureOperational() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	if m.operatingMode() != "run" {
+	if m.OperatingMode() != "run" {
 		// avoid doing registration in ephemeral mode
 		return nil
 	}
@@ -477,7 +477,7 @@ func (m *DeviceManager) ensureBootOk() error {
 	}
 
 	// book-ok/update-boot-revision is only relevant in run-mode
-	if m.operatingMode() != "run" {
+	if m.OperatingMode() != "run" {
 		return nil
 	}
 
@@ -511,7 +511,7 @@ func (m *DeviceManager) ensureInstalled() error {
 	}
 
 	// Note: thisalso stop auto-refreshes indirectly
-	if m.operatingMode() != "install" {
+	if m.OperatingMode() != "install" {
 		return nil
 	}
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -271,6 +271,7 @@ func (m *DeviceManager) ensureOperational() error {
 
 	if m.OperatingMode() != "run" {
 		// avoid doing registration in ephemeral mode
+		// note: this also stop auto-refreshes indirectly
 		return nil
 	}
 
@@ -476,7 +477,7 @@ func (m *DeviceManager) ensureBootOk() error {
 		return nil
 	}
 
-	// book-ok/update-boot-revision is only relevant in run-mode
+	// boot-ok/update-boot-revision is only relevant in run-mode
 	if m.OperatingMode() != "run" {
 		return nil
 	}
@@ -510,7 +511,6 @@ func (m *DeviceManager) ensureInstalled() error {
 		return nil
 	}
 
-	// Note: thisalso stop auto-refreshes indirectly
 	if m.OperatingMode() != "install" {
 		return nil
 	}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1038,7 +1038,7 @@ volumes:
 	// when remodeling to completely new gadget snap, there is no current
 	// snap passed to the check callback
 	err = devicestate.CheckGadgetRemodelCompatible(s.state, info, nil, snapf, snapstate.Flags{}, remodelCtx)
-	c.Check(err, ErrorMatches, "cannot identify the current model")
+	c.Check(err, ErrorMatches, "cannot identify the current gadget snap")
 
 	// mock data to obtain current gadget info
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1071,7 +1071,7 @@ func (s *deviceMgrSuite) TestDeviceManagerReadsModeenv(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
 	c.Assert(err, IsNil)
 	c.Assert(mgr, NotNil)
-	c.Assert(devicestate.OperatingMode(mgr), Equals, "install")
+	c.Assert(mgr.OperatingMode(), Equals, "install")
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEmptyOperatingModeRun(c *C) {
@@ -1079,5 +1079,5 @@ func (s *deviceMgrSuite) TestDeviceManagerEmptyOperatingModeRun(c *C) {
 	devicestate.SetOperatingMode(s.mgr, "")
 
 	// empty is returned as "run"
-	c.Check(devicestate.OperatingMode(s.mgr), Equals, "run")
+	c.Check(s.mgr.OperatingMode(), Equals, "run")
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -87,12 +87,6 @@ func SetOperatingMode(m *DeviceManager, mode string) {
 	m.modeEnv.Mode = mode
 }
 
-// XXX: will become properly exported but we probably want to make
-//      mode a type and not a string before we do that
-func OperatingMode(m *DeviceManager) string {
-	return m.operatingMode()
-}
-
 func MockRepeatRequestSerial(label string) (restore func()) {
 	old := repeatRequestSerial
 	repeatRequestSerial = label

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -593,6 +593,11 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	o.AddManager(ifacemgr)
 	c.Assert(o.StartUp(), IsNil)
 
+	hookMgr, err := hookstate.Manager(st, o.TaskRunner())
+	c.Assert(err, IsNil)
+	_, err = devicestate.Manager(st, hookMgr, o.TaskRunner(), nil)
+	c.Assert(err, IsNil)
+
 	st.Lock()
 	assertstate.ReplaceDB(st, db.(*asserts.Database))
 	st.Unlock()

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -92,16 +92,12 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 		return err
 	}
 
-	groundDeviceCtx, err := DeviceCtx(st, nil, nil)
-	if err != nil {
-		return fmt.Errorf("cannot identify the current model")
-	}
-
 	remodelCtx, err := DeviceCtx(st, t, nil)
 	if err != nil {
 		return err
 	}
 	isRemodel := remodelCtx.ForRemodeling()
+	groundDeviceCtx := remodelCtx.GroundContext()
 
 	// be extra paranoid when checking we are installing the right gadget
 	expectedGadgetSnap := groundDeviceCtx.Model().Gadget()

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -208,7 +208,7 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		return fmt.Errorf("cannot read new gadget metadata: %v", err)
 	}
 
-	currentData, err := gadgetDataFromInfo(curInfo, deviceCtx.OldModel())
+	currentData, err := gadgetDataFromInfo(curInfo, deviceCtx.GroundContext().Model())
 	if err != nil {
 		return fmt.Errorf("cannot read current gadget metadata: %v", err)
 	}

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -193,11 +193,7 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 	if curInfo == nil {
 		// snap isn't installed yet, we are likely remodeling to a new
 		// gadget, identify the old gadget
-		groundDeviceCtx, err := DeviceCtx(st, nil, nil)
-		if err != nil {
-			return fmt.Errorf("cannot identify the current model")
-		}
-		curInfo, _ = snapstate.GadgetInfo(st, groundDeviceCtx)
+		curInfo, _ = snapstate.GadgetInfo(st, deviceCtx.GroundContext())
 	}
 	if curInfo == nil {
 		return fmt.Errorf("cannot identify the current gadget snap")

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -206,32 +206,32 @@ type baseRemodelContext struct {
 	operatingMode      string
 }
 
-func (rc baseRemodelContext) ForRemodeling() bool {
+func (rc *baseRemodelContext) ForRemodeling() bool {
 	return true
 }
 
-func (rc baseRemodelContext) Model() *asserts.Model {
+func (rc *baseRemodelContext) Model() *asserts.Model {
 	return rc.newModel
 }
 
-func (rc baseRemodelContext) OldModel() *asserts.Model {
+func (rc *baseRemodelContext) OldModel() *asserts.Model {
 	return rc.oldModel
 }
 
-func (rc baseRemodelContext) initialDevice(*auth.DeviceState) error {
+func (rc *baseRemodelContext) initialDevice(*auth.DeviceState) error {
 	// do nothing
 	return nil
 }
 
-func (rc baseRemodelContext) cacheViaChange(chg *state.Change, remodCtx remodelContext) {
+func (rc *baseRemodelContext) cacheViaChange(chg *state.Change, remodCtx remodelContext) {
 	chg.State().Cache(remodelCtxKey{chg.ID()}, remodCtx)
 }
 
-func (rc baseRemodelContext) init(chg *state.Change) {
+func (rc *baseRemodelContext) init(chg *state.Change) {
 	chg.Set("new-model", string(asserts.Encode(rc.newModel)))
 }
 
-func (rc baseRemodelContext) OperatingMode() string {
+func (rc *baseRemodelContext) OperatingMode() string {
 	return rc.operatingMode
 }
 

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -135,7 +135,11 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 	switch kind := ClassifyRemodel(oldModel, newModel); kind {
 	case UpdateRemodel:
 		// simple context for the simple case
-		remodCtx = &updateRemodelContext{baseRemodelContext{newModel, oldModel, devMgr.OperatingMode()}}
+		groundCtx := groundDeviceContext{
+			model:         newModel,
+			operatingMode: devMgr.OperatingMode(),
+		}
+		remodCtx = &updateRemodelContext{baseRemodelContext{groundCtx, oldModel}}
 	case StoreSwitchRemodel:
 		remodCtx = newNewStoreRemodelContext(st, devMgr, newModel, oldModel)
 	case ReregRemodel:
@@ -202,20 +206,19 @@ func remodelCtxFromTask(t *state.Task) (remodelContext, error) {
 }
 
 type baseRemodelContext struct {
-	newModel, oldModel *asserts.Model
-	operatingMode      string
+	groundDeviceContext
+	oldModel *asserts.Model
 }
 
 func (rc *baseRemodelContext) ForRemodeling() bool {
 	return true
 }
 
-func (rc *baseRemodelContext) Model() *asserts.Model {
-	return rc.newModel
-}
-
-func (rc *baseRemodelContext) OldModel() *asserts.Model {
-	return rc.oldModel
+func (rc *baseRemodelContext) GroundContext() snapstate.DeviceContext {
+	return &groundDeviceContext{
+		model:         rc.oldModel,
+		operatingMode: rc.operatingMode,
+	}
 }
 
 func (rc *baseRemodelContext) initialDevice(*auth.DeviceState) error {
@@ -228,7 +231,7 @@ func (rc *baseRemodelContext) cacheViaChange(chg *state.Change, remodCtx remodel
 }
 
 func (rc *baseRemodelContext) init(chg *state.Change) {
-	chg.Set("new-model", string(asserts.Encode(rc.newModel)))
+	chg.Set("new-model", string(asserts.Encode(rc.model)))
 }
 
 func (rc *baseRemodelContext) OperatingMode() string {
@@ -282,7 +285,11 @@ type newStoreRemodelContext struct {
 
 func newNewStoreRemodelContext(st *state.State, devMgr *DeviceManager, newModel, oldModel *asserts.Model) *newStoreRemodelContext {
 	rc := &newStoreRemodelContext{}
-	rc.baseRemodelContext = baseRemodelContext{newModel, oldModel, devMgr.OperatingMode()}
+	groundCtx := groundDeviceContext{
+		model:         newModel,
+		operatingMode: devMgr.OperatingMode(),
+	}
+	rc.baseRemodelContext = baseRemodelContext{groundCtx, oldModel}
 	rc.st = st
 	rc.deviceMgr = devMgr
 	rc.store = devMgr.newStore(rc.deviceBackend())
@@ -372,7 +379,7 @@ func (b remodelDeviceBackend) SetDevice(device *auth.DeviceState) error {
 }
 
 func (b remodelDeviceBackend) Model() (*asserts.Model, error) {
-	return b.newModel, nil
+	return b.model, nil
 }
 
 func (b remodelDeviceBackend) Serial() (*asserts.Serial, error) {
@@ -416,8 +423,8 @@ func (rc *reregRemodelContext) initialDevice(device *auth.DeviceState) error {
 
 	// starting almost from scratch with only device-key
 	rc.deviceState = &auth.DeviceState{
-		Brand: rc.newModel.BrandID(),
-		Model: rc.newModel.Model(),
+		Brand: rc.model.BrandID(),
+		Model: rc.model.Model(),
 		KeyID: device.KeyID,
 	}
 	return nil
@@ -448,7 +455,7 @@ func (rc *reregRemodelContext) SerialRequestExtraHeaders() map[string]interface{
 }
 
 func (rc *reregRemodelContext) SerialRequestAncillaryAssertions() []asserts.Assertion {
-	return []asserts.Assertion{rc.newModel, rc.origSerial}
+	return []asserts.Assertion{rc.model, rc.origSerial}
 }
 
 func (rc *reregRemodelContext) FinishRegistration(serial *asserts.Serial) error {

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -135,7 +135,7 @@ func remodelCtx(st *state.State, oldModel, newModel *asserts.Model) (remodelCont
 	switch kind := ClassifyRemodel(oldModel, newModel); kind {
 	case UpdateRemodel:
 		// simple context for the simple case
-		remodCtx = &updateRemodelContext{baseRemodelContext{newModel, oldModel}}
+		remodCtx = &updateRemodelContext{baseRemodelContext{newModel, oldModel, devMgr.OperatingMode()}}
 	case StoreSwitchRemodel:
 		remodCtx = newNewStoreRemodelContext(st, devMgr, newModel, oldModel)
 	case ReregRemodel:
@@ -203,6 +203,7 @@ func remodelCtxFromTask(t *state.Task) (remodelContext, error) {
 
 type baseRemodelContext struct {
 	newModel, oldModel *asserts.Model
+	operatingMode      string
 }
 
 func (rc baseRemodelContext) ForRemodeling() bool {
@@ -228,6 +229,10 @@ func (rc baseRemodelContext) cacheViaChange(chg *state.Change, remodCtx remodelC
 
 func (rc baseRemodelContext) init(chg *state.Change) {
 	chg.Set("new-model", string(asserts.Encode(rc.newModel)))
+}
+
+func (rc baseRemodelContext) OperatingMode() string {
+	return rc.operatingMode
 }
 
 // updateRemodelContext: model assertion revision-only update remodel
@@ -277,7 +282,7 @@ type newStoreRemodelContext struct {
 
 func newNewStoreRemodelContext(st *state.State, devMgr *DeviceManager, newModel, oldModel *asserts.Model) *newStoreRemodelContext {
 	rc := &newStoreRemodelContext{}
-	rc.baseRemodelContext = baseRemodelContext{newModel, oldModel}
+	rc.baseRemodelContext = baseRemodelContext{newModel, oldModel, devMgr.OperatingMode()}
 	rc.st = st
 	rc.deviceMgr = devMgr
 	rc.store = devMgr.newStore(rc.deviceBackend())

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -174,6 +174,10 @@ func (s *remodelLogicSuite) TestUpdateRemodelContext(c *C) {
 
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
 	c.Check(remodCtx.Kind(), Equals, devicestate.UpdateRemodel)
+	groundCtx := remodCtx.GroundContext()
+	c.Check(groundCtx.ForRemodeling(), Equals, false)
+	c.Check(groundCtx.Model().Revision(), Equals, 0)
+	c.Check(groundCtx.Store, PanicMatches, `retrieved ground context is not intended to drive store operations`)
 
 	chg := s.state.NewChange("remodel", "...")
 
@@ -212,6 +216,9 @@ func (s *remodelLogicSuite) TestNewStoreRemodelContextInit(c *C) {
 
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
 	c.Check(remodCtx.Kind(), Equals, devicestate.StoreSwitchRemodel)
+	groundCtx := remodCtx.GroundContext()
+	c.Check(groundCtx.ForRemodeling(), Equals, false)
+	c.Check(groundCtx.Model().Revision(), Equals, 0)
 
 	chg := s.state.NewChange("remodel", "...")
 
@@ -763,6 +770,9 @@ func (s *remodelLogicSuite) TestReregRemodelContextInit(c *C) {
 
 	c.Check(remodCtx.ForRemodeling(), Equals, true)
 	c.Check(remodCtx.Kind(), Equals, devicestate.ReregRemodel)
+	groundCtx := remodCtx.GroundContext()
+	c.Check(groundCtx.ForRemodeling(), Equals, false)
+	c.Check(groundCtx.Model().BrandID(), Equals, "my-brand")
 
 	chg := s.state.NewChange("remodel", "...")
 

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -606,6 +606,45 @@ func (s *remodelLogicSuite) TestRemodelDeviceBackendKeptSerial(c *C) {
 	c.Check(serial0.Serial(), Equals, "serialserialserial1")
 }
 
+func (s *remodelLogicSuite) TestRemodelContextOperatingModeDefaultRun(c *C) {
+	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{"revision": "2"})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	assertstatetest.AddMany(s.state, oldModel)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx.OperatingMode(), Equals, "run")
+}
+
+func (s *remodelLogicSuite) TestRemodelContextOperatingModeWorks(c *C) {
+	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
+	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{"revision": "2"})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	assertstatetest.AddMany(s.state, oldModel)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "my-brand",
+		Model:  "my-model",
+		Serial: "serialserialserial",
+	})
+	devicestate.SetOperatingMode(s.mgr, "install")
+
+	remodCtx, err := devicestate.RemodelCtx(s.state, oldModel, newModel)
+	c.Assert(err, IsNil)
+	c.Check(remodCtx.OperatingMode(), Equals, "install")
+}
+
 func (s *remodelLogicSuite) TestRemodelContextForTaskAndCaching(c *C) {
 	oldModel := s.brands.Model("my-brand", "my-model", modelDefaults)
 	newModel := s.brands.Model("my-brand", "my-model", modelDefaults, map[string]interface{}{

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -30,8 +30,11 @@ type DeviceContext interface {
 	// Model returns the governing device model assertion for the context.
 	Model() *asserts.Model
 
-	// OldModel returns the old model assertion for the device. This will only return something for a remodel context.
-	OldModel() *asserts.Model
+	// GroundContext returns a context corresponding to the
+	// original model of the device for a remodel, or a context
+	// equivalent to this one otherwise, except in both cases
+	// Store cannot be used and must panic.
+	GroundContext() DeviceContext
 
 	// Store returns the store service to use under this context or nil if the snapstate store is appropriate.
 	Store() StoreService

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -39,7 +39,7 @@ type DeviceContext interface {
 	// ForRemodeling returns whether this context is for use over a remodeling.
 	ForRemodeling() bool
 
-	// OperatingMode return the operating mode (run,install,recover,...)
+	// OperatingMode return the operating mode (run,install,recover,...).
 	OperatingMode() string
 }
 

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -38,6 +38,9 @@ type DeviceContext interface {
 
 	// ForRemodeling returns whether this context is for use over a remodeling.
 	ForRemodeling() bool
+
+	// OperatingMode return the operating mode (run,install,recover,...)
+	OperatingMode() string
 }
 
 // Hook setup by devicestate to pick a device context from state,

--- a/overlord/snapstate/devicectx_test.go
+++ b/overlord/snapstate/devicectx_test.go
@@ -119,6 +119,23 @@ func (s *deviceCtxSuite) TestDevicePastSeedingReady(c *C) {
 	deviceCtx, err := snapstate.DevicePastSeeding(s.st, nil)
 	c.Assert(err, IsNil)
 	c.Check(deviceCtx.Model().Model(), Equals, "baz-3000")
+	c.Check(deviceCtx.OperatingMode(), Equals, "run")
+}
+
+func (s *deviceCtxSuite) TestDevicePastSeedingReadyInstallMode(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// seeded and model assertion
+	s.st.Set("seeded", true)
+
+	r := snapstatetest.MockDeviceModelAndMode(DefaultModel(), "install")
+	defer r()
+
+	deviceCtx, err := snapstate.DevicePastSeeding(s.st, nil)
+	c.Assert(err, IsNil)
+	c.Check(deviceCtx.Model().Model(), Equals, "baz-3000")
+	c.Check(deviceCtx.OperatingMode(), Equals, "install")
 }
 
 func (s *deviceCtxSuite) TestDevicePastSeedingButRemodeling(c *C) {
@@ -199,19 +216,4 @@ func (s *deviceCtxSuite) TestDeviceCtxFromStateTooEarly(c *C) {
 	s.st.Set("seeded", true)
 	_, err = snapstate.DeviceCtxFromState(s.st, nil)
 	c.Assert(err, DeepEquals, expectedErr)
-}
-
-func (s *deviceCtxSuite) TestDeviceOperatingModeDefaults(c *C) {
-	s.st.Lock()
-	defer s.st.Unlock()
-
-	// seeded and model assertion
-	s.st.Set("seeded", true)
-
-	r := snapstatetest.MockOperatingMode("install")
-	defer r()
-
-	deviceCtx, err := snapstate.DevicePastSeeding(s.st, nil)
-	c.Assert(err, IsNil)
-	c.Check(deviceCtx.OperatingMode(), Equals, "install")
 }

--- a/overlord/snapstate/devicectx_test.go
+++ b/overlord/snapstate/devicectx_test.go
@@ -200,3 +200,18 @@ func (s *deviceCtxSuite) TestDeviceCtxFromStateTooEarly(c *C) {
 	_, err = snapstate.DeviceCtxFromState(s.st, nil)
 	c.Assert(err, DeepEquals, expectedErr)
 }
+
+func (s *deviceCtxSuite) TestDeviceOperatingModeDefaults(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// seeded and model assertion
+	s.st.Set("seeded", true)
+
+	r := snapstatetest.MockOperatingMode("install")
+	defer r()
+
+	deviceCtx, err := snapstate.DevicePastSeeding(s.st, nil)
+	c.Assert(err, IsNil)
+	c.Check(deviceCtx.OperatingMode(), Equals, "install")
+}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1368,10 +1368,10 @@ func maybeUndoRemodelBootChanges(t *state.Task) error {
 		return err
 	}
 	// we only have an old model if we are in a remodel situation
-	oldModel := deviceCtx.OldModel()
-	if oldModel == nil {
+	if !deviceCtx.ForRemodeling() {
 		return nil
 	}
+	oldModel := deviceCtx.GroundContext().Model()
 	newModel := deviceCtx.Model()
 
 	// check type of the snap we are undoing, only kernel/base/core are

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1010,6 +1010,7 @@ func (s *linkSnapSuite) setMockKernelRemodelCtx(c *C, oldKernel, newKernel strin
 	mockRemodelCtx := &snapstatetest.TrivialDeviceContext{
 		DeviceModel:    newModel,
 		OldDeviceModel: oldModel,
+		Remodeling:     true,
 	}
 	restore := snapstatetest.MockDeviceContext(mockRemodelCtx)
 	s.AddCleanup(restore)

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -32,17 +32,32 @@ type TrivialDeviceContext struct {
 	Remodeling     bool
 	CtxStore       snapstate.StoreService
 	OpMode         string
+	Ground         bool
 }
 
 func (dc *TrivialDeviceContext) Model() *asserts.Model {
 	return dc.DeviceModel
 }
 
-func (dc *TrivialDeviceContext) OldModel() *asserts.Model {
-	return dc.OldDeviceModel
+func (dc *TrivialDeviceContext) GroundContext() snapstate.DeviceContext {
+	if dc.ForRemodeling() && dc.OldDeviceModel != nil {
+		return &TrivialDeviceContext{
+			DeviceModel: dc.OldDeviceModel,
+			OpMode:      dc.OpMode,
+			Ground:      true,
+		}
+	}
+	return &TrivialDeviceContext{
+		DeviceModel: dc.DeviceModel,
+		OpMode:      dc.OpMode,
+		Ground:      true,
+	}
 }
 
 func (dc *TrivialDeviceContext) Store() snapstate.StoreService {
+	if dc.Ground {
+		panic("retrieved ground context is not intended to drive store operations")
+	}
 	return dc.CtxStore
 }
 

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -51,7 +51,11 @@ func (dc *TrivialDeviceContext) ForRemodeling() bool {
 }
 
 func (dc *TrivialDeviceContext) OperatingMode() string {
-	return dc.OpMode
+	mode := dc.OpMode
+	if mode == "" {
+		return "run"
+	}
+	return mode
 }
 
 func MockDeviceModel(model *asserts.Model) (restore func()) {
@@ -62,8 +66,8 @@ func MockDeviceModel(model *asserts.Model) (restore func()) {
 	return MockDeviceContext(deviceCtx)
 }
 
-func MockOperatingMode(operatingMode string) (restore func()) {
-	deviceCtx := &TrivialDeviceContext{OpMode: operatingMode}
+func MockDeviceModelAndMode(model *asserts.Model, operatingMode string) (restore func()) {
+	deviceCtx := &TrivialDeviceContext{DeviceModel: model, OpMode: operatingMode}
 	return MockDeviceContext(deviceCtx)
 }
 

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -31,6 +31,7 @@ type TrivialDeviceContext struct {
 	OldDeviceModel *asserts.Model
 	Remodeling     bool
 	CtxStore       snapstate.StoreService
+	OpMode         string
 }
 
 func (dc *TrivialDeviceContext) Model() *asserts.Model {
@@ -49,11 +50,20 @@ func (dc *TrivialDeviceContext) ForRemodeling() bool {
 	return dc.Remodeling
 }
 
+func (dc *TrivialDeviceContext) OperatingMode() string {
+	return dc.OpMode
+}
+
 func MockDeviceModel(model *asserts.Model) (restore func()) {
 	var deviceCtx snapstate.DeviceContext
 	if model != nil {
 		deviceCtx = &TrivialDeviceContext{DeviceModel: model}
 	}
+	return MockDeviceContext(deviceCtx)
+}
+
+func MockOperatingMode(operatingMode string) (restore func()) {
+	deviceCtx := &TrivialDeviceContext{OpMode: operatingMode}
 	return MockDeviceContext(deviceCtx)
 }
 


### PR DESCRIPTION
this replaces DeviceContext.OldModel with a more general GroundContext
method returning a full context again corresponding to the original
model in case of a remodel

one of the motivations for the change is making sure that snapstate
tests just need to fake one context and not the full device state

to achieve that, most places facing a remodeling and needing to
use/consider the original model should use GroundContext instead of
calling DeviceCtx again with task nil

this is in preparation of a larger change that will start using
DeviceContext more
