### PR TITLE
many: pass consistently boot.Device state to boot methods

### DIFF
--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boottest
+
+import (
+	"strings"
+)
+
+// MockDevice implements boot.Device. It wraps a string like
+// <boot-snap-name>[@<mode>], no <boot-snap-name> means classic, no
+// <mode> defaults to "run".
+type MockDevice string
+
+func (d MockDevice) snapAndMode() []string {
+	parts := strings.SplitN(string(d), "@", 2)
+	if len(parts) == 1 {
+		return append(parts, "run")
+	}
+	if parts[1] == "" {
+		return []string{parts[0], "run"}
+	}
+	return parts
+}
+
+func (d MockDevice) Kernel() string { return d.snapAndMode()[0] }
+func (d MockDevice) Base() string   { return d.snapAndMode()[0] }
+func (d MockDevice) Classic() bool  { return d.snapAndMode()[0] == "" }
+func (d MockDevice) RunMode() bool  { return d.snapAndMode()[1] == "run" }

--- a/boot/boottest/device_test.go
+++ b/boot/boottest/device_test.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boottest_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot/boottest"
+)
+
+func TestBoottest(t *testing.T) { TestingT(t) }
+
+type boottestSuite struct{}
+
+var _ = Suite(&boottestSuite{})
+
+func (s *boottestSuite) TestMockDeviceClassic(c *C) {
+	dev := boottest.MockDevice("")
+	c.Check(dev.Classic(), Equals, true)
+	c.Check(dev.Kernel(), Equals, "")
+	c.Check(dev.Base(), Equals, "")
+	c.Check(dev.RunMode(), Equals, true)
+
+	dev = boottest.MockDevice("@run")
+	c.Check(dev.Classic(), Equals, true)
+	c.Check(dev.Kernel(), Equals, "")
+	c.Check(dev.Base(), Equals, "")
+	c.Check(dev.RunMode(), Equals, true)
+
+	dev = boottest.MockDevice("@recover")
+	c.Check(dev.Classic(), Equals, true)
+	c.Check(dev.Kernel(), Equals, "")
+	c.Check(dev.Base(), Equals, "")
+	c.Check(dev.RunMode(), Equals, false)
+}
+
+func (s *boottestSuite) TestMockDeviceBaseOrKernel(c *C) {
+	dev := boottest.MockDevice("boot-snap")
+	c.Check(dev.Classic(), Equals, false)
+	c.Check(dev.Kernel(), Equals, "boot-snap")
+	c.Check(dev.Base(), Equals, "boot-snap")
+	c.Check(dev.RunMode(), Equals, true)
+
+	dev = boottest.MockDevice("boot-snap@run")
+	c.Check(dev.Classic(), Equals, false)
+	c.Check(dev.Kernel(), Equals, "boot-snap")
+	c.Check(dev.Base(), Equals, "boot-snap")
+	c.Check(dev.RunMode(), Equals, true)
+
+	dev = boottest.MockDevice("boot-snap@recover")
+	c.Check(dev.Classic(), Equals, false)
+	c.Check(dev.Kernel(), Equals, "boot-snap")
+	c.Check(dev.Base(), Equals, "boot-snap")
+	c.Check(dev.RunMode(), Equals, false)
+}

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -79,6 +79,22 @@ func (dc *groundDeviceContext) OperatingMode() string {
 	return dc.operatingMode
 }
 
+func (dc groundDeviceContext) Classic() bool {
+	return dc.model.Classic()
+}
+
+func (dc groundDeviceContext) Kernel() string {
+	return dc.model.Kernel()
+}
+
+func (dc groundDeviceContext) Base() string {
+	return dc.model.Base()
+}
+
+func (dc groundDeviceContext) RunMode() bool {
+	return dc.operatingMode == "run"
+}
+
 // sanity
 var _ snapstate.DeviceContext = &groundDeviceContext{}
 

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -896,6 +896,11 @@ func (s *deviceMgrRemodelSuite) TestDeviceCtxNoTask(c *C) {
 	deviceCtx, err := devicestate.DeviceCtx(s.state, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(deviceCtx.Model().BrandID(), Equals, "canonical")
+
+	c.Check(deviceCtx.Classic(), Equals, false)
+	c.Check(deviceCtx.Kernel(), Equals, "kernel")
+	c.Check(deviceCtx.Base(), Equals, "")
+	c.Check(deviceCtx.RunMode(), Equals, true)
 }
 
 func (s *deviceMgrRemodelSuite) TestDeviceCtxGroundContext(c *C) {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -24,6 +24,7 @@ import (
 	"io"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -62,22 +63,22 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install related
-	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
+	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
-	LinkSnap(info *snap.Info, model *asserts.Model, prevDisabledSvcs []string, tm timings.Measurer) error
+	LinkSnap(info *snap.Info, dev boot.Device, prevDisabledSvcs []string, tm timings.Measurer) error
 	StartServices(svcs []*snap.AppInfo, meter progress.Meter, tm timings.Measurer) error
 	StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error
 	ServicesEnableState(info *snap.Info, meter progress.Meter) (map[string]bool, error)
 
 	// the undoers for install
-	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, meter progress.Meter) error
+	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	// cleanup
 	ClearTrashedData(oldSnap *snap.Info)
 
 	// remove related
 	UnlinkSnap(info *snap.Info, meter progress.Meter) error
-	RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, meter progress.Meter) error
+	RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error
 	RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error
 	RemoveSnapData(info *snap.Info) error
 	RemoveSnapCommonData(info *snap.Info) error

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -24,11 +24,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 	"github.com/snapcore/snapd/wrappers"
@@ -79,7 +77,7 @@ func hasFontConfigCache(info *snap.Info) bool {
 }
 
 // LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
-func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model, prevDisabledSvcs []string, tm timings.Measurer) (e error) {
+func (b Backend) LinkSnap(info *snap.Info, dev boot.Device, prevDisabledSvcs []string, tm timings.Measurer) (e error) {
 	if info.Revision.Unset() {
 		return fmt.Errorf("cannot link snap %q with unset revision", info.InstanceName())
 	}
@@ -104,7 +102,7 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model, prevDisabledSvc
 	// 'snapd' snaps
 	// for non-core snaps, fontconfig cache needs to be updated before the
 	// snap applications are runnable
-	if release.OnClassic && !hasFontConfigCache(info) {
+	if dev.Classic() && !hasFontConfigCache(info) {
 		timings.Run(tm, "update-fc-cache", "update font config caches", func(timings.Measurer) {
 			// XXX: does this need cleaning up? (afaict no)
 			if err := updateFontconfigCaches(); err != nil {
@@ -113,7 +111,8 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model, prevDisabledSvc
 		})
 	}
 
-	if err := boot.Participant(info, info.GetType(), model, release.OnClassic).SetNextBoot(); err != nil {
+	// XXX this is not tested afaict
+	if err := boot.Participant(info, info.GetType(), dev).SetNextBoot(); err != nil {
 		return err
 	}
 
@@ -125,7 +124,7 @@ func (b Backend) LinkSnap(info *snap.Info, model *asserts.Model, prevDisabledSvc
 
 	// for core snap, fontconfig cache can be updated after the snap has
 	// been made available
-	if release.OnClassic && hasFontConfigCache(info) {
+	if dev.Classic() && hasFontConfigCache(info) {
 		timings.Run(tm, "update-fc-cache", "update font config caches", func(timings.Measurer) {
 			if err := updateFontconfigCaches(); err != nil {
 				logger.Noticef("cannot update fontconfig cache: %v", err)

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -28,10 +28,10 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
@@ -95,7 +95,7 @@ apps:
 	})
 	defer r()
 
-	err := s.be.LinkSnap(info, nil, []string{"svc"}, s.perfTimings)
+	err := s.be.LinkSnap(info, mockDev, []string{"svc"}, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Assert(svcsDisabled, DeepEquals, []string{"snap.hello.bin.service"})
@@ -116,7 +116,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := s.be.LinkSnap(info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(info, mockDev, nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	l, err := filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
@@ -146,7 +146,7 @@ version: 1.0
 
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := s.be.LinkSnap(info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(info, mockDev, nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	mountDir := info.MountDir()
@@ -188,10 +188,10 @@ apps:
 
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := s.be.LinkSnap(info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(info, mockDev, nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
-	err = s.be.LinkSnap(info, nil, nil, s.perfTimings)
+	err = s.be.LinkSnap(info, mockDev, nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	l, err := filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
@@ -230,7 +230,7 @@ apps:
 
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := s.be.LinkSnap(info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(info, mockDev, nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	err = s.be.UnlinkSnap(info, progress.Null)
@@ -258,7 +258,7 @@ func (s *linkSuite) TestLinkFailsForUnsetRevision(c *C) {
 	info := &snap.Info{
 		SuggestedName: "foo",
 	}
-	err := s.be.LinkSnap(info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(info, mockDev, nil, s.perfTimings)
 	c.Assert(err, ErrorMatches, `cannot link snap "foo" with unset revision`)
 }
 
@@ -315,7 +315,7 @@ func (s *linkCleanupSuite) testLinkCleanupDirOnFail(c *C, dir string) {
 	c.Assert(os.Chmod(dir, 0), IsNil)
 	defer os.Chmod(dir, 0755)
 
-	err := s.be.LinkSnap(s.info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(s.info, mockDev, nil, s.perfTimings)
 	c.Assert(err, NotNil)
 	_, isPathError := err.(*os.PathError)
 	_, isLinkError := err.(*os.LinkError)
@@ -352,7 +352,7 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 	})
 	defer r()
 
-	err := s.be.LinkSnap(s.info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(s.info, mockDev, nil, s.perfTimings)
 	c.Assert(err, ErrorMatches, "ouchie")
 
 	for _, d := range []string{dirs.SnapBinariesDir, dirs.SnapDesktopFilesDir, dirs.SnapServicesDir} {
@@ -372,7 +372,7 @@ func (s *linkCleanupSuite) TestLinkCleansUpDataDirAndSymlinksOnSymlinkFail(c *C)
 	c.Assert(os.Chmod(d, 0), IsNil)
 	defer os.Chmod(d, 0755)
 
-	err := s.be.LinkSnap(s.info, nil, nil, s.perfTimings)
+	err := s.be.LinkSnap(s.info, mockDev, nil, s.perfTimings)
 	c.Assert(err, ErrorMatches, `(?i).*symlink.*permission denied.*`)
 
 	c.Check(s.info.DataDir(), testutil.FileAbsent)
@@ -383,21 +383,18 @@ func (s *linkCleanupSuite) TestLinkCleansUpDataDirAndSymlinksOnSymlinkFail(c *C)
 func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCachesClassic(c *C) {
 	current := filepath.Join(s.info.MountDir(), "..", "current")
 
-	for _, onClassic := range []bool{false, true} {
-		restore := release.MockOnClassic(onClassic)
-		defer restore()
-
+	for _, dev := range []boot.Device{mockDev, mockClassicDev} {
 		var updateFontconfigCaches int
-		restore = backend.MockUpdateFontconfigCaches(func() error {
+		restore := backend.MockUpdateFontconfigCaches(func() error {
 			c.Assert(osutil.FileExists(current), Equals, false)
 			updateFontconfigCaches += 1
 			return nil
 		})
 		defer restore()
 
-		err := s.be.LinkSnap(s.info, nil, nil, s.perfTimings)
+		err := s.be.LinkSnap(s.info, dev, nil, s.perfTimings)
 		c.Assert(err, IsNil)
-		if onClassic {
+		if dev.Classic() {
 			c.Assert(updateFontconfigCaches, Equals, 1)
 		} else {
 			c.Assert(updateFontconfigCaches, Equals, 0)
@@ -407,9 +404,6 @@ func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCachesClassic(c *C) {
 }
 
 func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCachesCallsFromNewCurrent(c *C) {
-	restore := release.MockOnClassic(true)
-	defer restore()
-
 	const yaml = `name: core
 version: 1.0
 type: os
@@ -430,14 +424,14 @@ type: os
 	newCmdV7 := testutil.MockCommand(c, filepath.Join(mountDirNew, "bin", "fc-cache-v7"), "")
 
 	// provide our own mock, osutil.CommandFromCore expects an ELF binary
-	restore = backend.MockCommandFromSystemSnap(func(name string, args ...string) (*exec.Cmd, error) {
+	restore := backend.MockCommandFromSystemSnap(func(name string, args ...string) (*exec.Cmd, error) {
 		cmd := filepath.Join(dirs.SnapMountDir, "core", "current", name)
 		c.Logf("command from core: %v", cmd)
 		return exec.Command(cmd, args...), nil
 	})
 	defer restore()
 
-	err = s.be.LinkSnap(infoNew, nil, nil, s.perfTimings)
+	err = s.be.LinkSnap(infoNew, mockClassicDev, nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(oldCmdV6.Calls(), HasLen, 0)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -661,7 +661,7 @@ func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo)
 	return info, f.emptyContainer, nil
 }
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
@@ -801,7 +801,7 @@ func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, p progress
 	return nil
 }
 
-func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, model *asserts.Model, disabledSvcs []string, tm timings.Measurer) error {
+func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev boot.Device, disabledSvcs []string, tm timings.Measurer) error {
 	if info.MountDir() == f.linkSnapWaitTrigger {
 		f.linkSnapWaitCh <- 1
 		<-f.linkSnapWaitCh
@@ -873,7 +873,7 @@ func (f *fakeSnappyBackend) ServicesEnableState(info *snap.Info, meter progress.
 	return m, nil
 }
 
-func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, p progress.Meter) error {
+func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, p progress.Meter) error {
 	p.Notify("setup-snap")
 	f.appendOp(&fakeOp{
 		op:    "undo-setup-snap",
@@ -910,7 +910,7 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, meter progress.Meter) er
 	return nil
 }
 
-func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, meter progress.Meter) error {
+func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error {
 	meter.Notify("remove-snap-files")
 	f.appendOp(&fakeOp{
 		op:    "remove-snap-files",

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -44,6 +45,9 @@ type DeviceContext interface {
 
 	// OperatingMode return the operating mode (run,install,recover,...).
 	OperatingMode() string
+
+	// DeviceContext should be usable as boot.Device
+	boot.Device
 }
 
 // Hook setup by devicestate to pick a device context from state,

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -32,7 +32,6 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/features"
@@ -681,7 +680,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	var snapType snap.Type
 	var installRecord *backend.InstallRecord
 	timings.Run(perfTimings, "setup-snap", fmt.Sprintf("setup snap %q", snapsup.InstanceName()), func(timings.Measurer) {
-		snapType, installRecord, err = m.backend.SetupSnap(snapsup.SnapPath, snapsup.InstanceName(), snapsup.SideInfo, pb)
+		snapType, installRecord, err = m.backend.SetupSnap(snapsup.SnapPath, snapsup.InstanceName(), snapsup.SideInfo, deviceCtx, pb)
 	})
 	if err != nil {
 		cleanup()
@@ -708,7 +707,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	if readInfoErr != nil {
 		timings.Run(perfTimings, "undo-setup-snap", fmt.Sprintf("Undo setup of snap %q", snapsup.InstanceName()), func(timings.Measurer) {
-			err = m.backend.UndoSetupSnap(snapsup.placeInfo(), snapType, installRecord, pb)
+			err = m.backend.UndoSetupSnap(snapsup.placeInfo(), snapType, installRecord, deviceCtx, pb)
 		})
 		if err != nil {
 			st.Lock()
@@ -751,6 +750,13 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	st.Lock()
+	deviceCtx, err := DeviceCtx(t.State(), t, nil)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
 	var typ snap.Type
 	err = t.Get("snap-type", &typ)
 	st.Unlock()
@@ -771,7 +777,7 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	pb := NewTaskProgressAdapterUnlocked(t)
-	if err := m.backend.UndoSetupSnap(snapsup.placeInfo(), typ, &installRecord, pb); err != nil {
+	if err := m.backend.UndoSetupSnap(snapsup.placeInfo(), typ, &installRecord, deviceCtx, pb); err != nil {
 		return err
 	}
 
@@ -889,8 +895,8 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	model, err := ModelFromTask(t)
-	if err != nil && err != state.ErrNoState {
+	deviceCtx, err := DeviceCtx(st, t, nil)
+	if err != nil {
 		return err
 	}
 
@@ -904,7 +910,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	snapst.Active = true
-	err = m.backend.LinkSnap(oldInfo, model, svcsToDisable, perfTimings)
+	err = m.backend.LinkSnap(oldInfo, deviceCtx, svcsToDisable, perfTimings)
 	if err != nil {
 		return err
 	}
@@ -919,7 +925,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// if we just put back a previous a core snap, request a restart
 	// so that we switch executing its snapd
-	maybeRestart(t, oldInfo, model)
+	maybeRestart(t, oldInfo, deviceCtx)
 
 	return nil
 }
@@ -1103,6 +1109,11 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
+	deviceCtx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return err
+	}
+
 	// find if the snap is already installed before we modify snapst below
 	isInstalled := snapst.IsInstalled()
 
@@ -1184,9 +1195,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
-	// XXX: this block is slightly ugly, find a pattern when we have more examples
-	model, _ := ModelFromTask(t)
-	err = m.backend.LinkSnap(newInfo, model, svcsToDisable, perfTimings)
+	err = m.backend.LinkSnap(newInfo, deviceCtx, svcsToDisable, perfTimings)
 	// defer a cleanup helper which will unlink the snap if anything fails after
 	// this point
 	defer func() {
@@ -1304,18 +1313,18 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 
 	// if we just installed a core snap, request a restart
 	// so that we switch executing its snapd
-	maybeRestart(t, newInfo, model)
+	maybeRestart(t, newInfo, deviceCtx)
 
 	return nil
 }
 
 // maybeRestart will schedule a reboot or restart as needed for the
 // just linked snap with info if it's a core or snapd or kernel snap.
-func maybeRestart(t *state.Task, info *snap.Info, model *asserts.Model) {
+func maybeRestart(t *state.Task, info *snap.Info, deviceCtx DeviceContext) {
 	st := t.State()
 
 	typ := info.GetType()
-	bp := boot.Participant(info, typ, model, release.OnClassic)
+	bp := boot.Participant(info, typ, deviceCtx)
 	if bp.ChangeRequiresReboot() {
 		t.Logf("Requested system restart.")
 		st.RequestRestart(state.RestartSystem)
@@ -1371,7 +1380,8 @@ func maybeUndoRemodelBootChanges(t *state.Task) error {
 	if !deviceCtx.ForRemodeling() {
 		return nil
 	}
-	oldModel := deviceCtx.GroundContext().Model()
+	groundDeviceCtx := deviceCtx.GroundContext()
+	oldModel := groundDeviceCtx.Model()
 	newModel := deviceCtx.Model()
 
 	// check type of the snap we are undoing, only kernel/base/core are
@@ -1411,13 +1421,13 @@ func maybeUndoRemodelBootChanges(t *state.Task) error {
 	if err != nil && err != ErrNoCurrent {
 		return err
 	}
-	bp := boot.Participant(info, info.GetType(), oldModel, release.OnClassic)
+	bp := boot.Participant(info, info.GetType(), groundDeviceCtx)
 	if err := bp.SetNextBoot(); err != nil {
 		return err
 	}
 	// we may just have switch back to the old kernel/base/core so
 	// we may need to restart
-	maybeRestart(t, info, oldModel)
+	maybeRestart(t, info, groundDeviceCtx)
 
 	return nil
 }
@@ -1856,6 +1866,11 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	deviceCtx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return err
+	}
+
 	if snapst.Current == snapsup.Revision() && snapst.Active {
 		return fmt.Errorf("internal error: cannot discard snap %q: still active", snapsup.InstanceName())
 	}
@@ -1883,7 +1898,7 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
-	err = m.backend.RemoveSnapFiles(snapsup.placeInfo(), typ, nil, pb)
+	err = m.backend.RemoveSnapFiles(snapsup.placeInfo(), typ, nil, deviceCtx, pb)
 	if err != nil {
 		t.Errorf("cannot remove snap file %q, will retry in 3 mins: %s", snapsup.InstanceName(), err)
 		return &state.Retry{After: 3 * time.Minute}

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -32,6 +33,12 @@ type discardSnapSuite struct {
 }
 
 var _ = Suite(&discardSnapSuite{})
+
+func (s *discardSnapSuite) SetUpTest(c *C) {
+	s.setup(c, nil)
+
+	s.AddCleanup(snapstatetest.MockDeviceModel(DefaultModel()))
+}
 
 func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 	s.state.Lock()

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -54,6 +54,22 @@ func (dc *TrivialDeviceContext) GroundContext() snapstate.DeviceContext {
 	}
 }
 
+func (dc *TrivialDeviceContext) Classic() bool {
+	return dc.DeviceModel.Classic()
+}
+
+func (dc *TrivialDeviceContext) Kernel() string {
+	return dc.DeviceModel.Kernel()
+}
+
+func (dc *TrivialDeviceContext) Base() string {
+	return dc.DeviceModel.Base()
+}
+
+func (dc *TrivialDeviceContext) RunMode() bool {
+	return dc.OperatingMode() == "run"
+}
+
 func (dc *TrivialDeviceContext) Store() snapstate.StoreService {
 	if dc.Ground {
 		panic("retrieved ground context is not intended to drive store operations")


### PR DESCRIPTION
instead of passing model and/or a classic flag to them
and adding operating mode now as well, pass a new interface
boot.Device that is implemented by DeviceContext