### PR TITLE
run-checks: check multiline string blocks in restore/prepare/execute sections of spread tests

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -241,6 +241,15 @@ if [ "$STATIC" = 1 ]; then
     echo Checking all interfaces have minimal spread test
     missing_interface_spread_test
 
+    echo Checking for incorrect multiline strings in spread tests
+    badmultiline=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 | \
+                       xargs -0 grep -R -n -E '(restore*|prepare*|execute|debug):\s*$' || true)
+    if [ -n "$badmultiline" ]; then
+        echo "Incorrect multiline strings at the following locations:"
+        echo "$badmultiline"
+        exit 1
+    fi
+
     # FIXME: re-add staticcheck with a matching version for the used go-version
 fi
 


### PR DESCRIPTION
Missing a multiline literal string block indicator | in prepare/restore/execute
sections of spread tests, results in each separate block getting folded into a
single line. Since each section contains shell scripts, this may lead to
unexpected results, where at best the script is executed as intended, or it
fails with some weird syntax error.

Extend run-checks to catch incorrect multiline string block for spread test sections.
