### PR TITLE
o/hookstate/ctlcmd: fix command name in snapctl -h

### DIFF
--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -124,7 +124,7 @@ func (f *ForbiddenCommand) Execute(args []string) error {
 
 // Run runs the requested command.
 func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr []byte, err error) {
-	parser := flags.NewParser(nil, flags.PassDoubleDash|flags.HelpFlag)
+	parser := flags.NewNamedParser("snapctl", flags.PassDoubleDash|flags.HelpFlag)
 
 	// Create stdout/stderr buffers, and make sure commands use them.
 	var stdoutBuffer bytes.Buffer

--- a/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -105,6 +105,8 @@ func (s *ctlcmdSuite) TestHiddenCommand(c *C) {
 	// Type as flags.ErrHelp
 	c.Assert(err, FitsTypeOf, &flags.Error{})
 	c.Check(err.(*flags.Error).Type, Equals, flags.ErrHelp)
+	// snapctl is mentioned (not snapd)
+	c.Check(err.Error(), testutil.Contains, "snapctl")
 	// mock-shown is in the help message
 	c.Check(err.Error(), testutil.Contains, "  mock-shown\n")
 	// mock-hidden is not in the help message


### PR DESCRIPTION
It was wrongly "snapd" instead of "snapctl" because of where the code actually runs and go-flags default of os.Args[0].

