### PR TITLE
cmd/snap-bootstrap: actually parse snapd_recovery_system label

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -71,27 +71,9 @@ var (
 	osutilIsMounted = osutil.IsMounted
 )
 
-// XXX: make this more flexible if there are multiple seeds on disk, i.e.
-// read kernel commandline in this case (bootenv is off limits because
-// it's not measured).
-func findRecoverySystem(seedDir string) (systemLabel string, err error) {
-	l, err := filepath.Glob(filepath.Join(seedDir, "systems/*"))
-	if err != nil {
-		return "", err
-	}
-	if len(l) == 0 {
-		return "", fmt.Errorf("cannot find a recovery system")
-	}
-	if len(l) > 1 {
-		return "", fmt.Errorf("cannot use multiple recovery systems yet")
-	}
-	systemLabel = filepath.Base(l[0])
-	return systemLabel, nil
-}
-
 // generateMountsMode* is called multiple times from initramfs until it
 // no longer generates more mount points and just returns an empty output.
-func generateMountsModeInstall() error {
+func generateMountsModeInstall(version string) error {
 	seedDir := filepath.Join(runMnt, "ubuntu-seed")
 
 	// 1. always ensure seed partition is mounted
@@ -103,7 +85,6 @@ func generateMountsModeInstall() error {
 		fmt.Fprintf(stdout, "/dev/disk/by-label/ubuntu-seed %s\n", seedDir)
 		return nil
 	}
-	// XXX: how do we select a different recover system from the cmdline?
 
 	// 2. (auto) select recovery system for now
 	isBaseMounted, err := osutilIsMounted(filepath.Join(runMnt, "base"))
@@ -116,11 +97,7 @@ func generateMountsModeInstall() error {
 	}
 	if !isBaseMounted || !isKernelMounted {
 		// load the recovery system  and generate mounts for kernel/base
-		systemLabel, err := findRecoverySystem(seedDir)
-		if err != nil {
-			return err
-		}
-		systemSeed, err := seed.Open(seedDir, systemLabel)
+		systemSeed, err := seed.Open(seedDir, version)
 		if err != nil {
 			return err
 		}
@@ -171,13 +148,9 @@ func generateMountsModeInstall() error {
 
 	// 4. final step: write $(ubuntu_data)/var/lib/snapd/modeenv - this
 	//    is the tmpfs we just created above
-	systemLabel, err := findRecoverySystem(seedDir)
-	if err != nil {
-		return err
-	}
 	modeEnv := &boot.Modeenv{
 		Mode:           "install",
-		RecoverySystem: systemLabel,
+		RecoverySystem: version,
 	}
 	if err := modeEnv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
 		return err
@@ -188,7 +161,7 @@ func generateMountsModeInstall() error {
 	return nil
 }
 
-func generateMountsModeRecover() error {
+func generateMountsModeRecover(version string) error {
 	return fmt.Errorf("recover mode mount generation not implemented yet")
 }
 
@@ -238,26 +211,37 @@ func generateMountsModeRun() error {
 }
 
 var validModes = []string{"install", "recover", "run"}
+var versionlessModes = []string{"run"}
 
-func whichMode(content []byte) (string, error) {
+func whichMode(content []byte) (string, string, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(content))
 	scanner.Split(bufio.ScanWords)
+	mode := ""
+	version := ""
 	for scanner.Scan() {
 		if strings.HasPrefix(scanner.Text(), "snapd_recovery_mode=") {
-			mode := strings.SplitN(scanner.Text(), "=", 2)[1]
+			mode = strings.SplitN(scanner.Text(), "=", 2)[1]
 			if mode == "" {
 				mode = "install"
 			}
 			if !strutil.ListContains(validModes, mode) {
-				return "", fmt.Errorf("cannot use unknown mode %q", mode)
+				return "", "", fmt.Errorf("cannot use unknown mode %q", mode)
 			}
-			return mode, nil
+			if strutil.ListContains(versionlessModes, mode) {
+				return mode, "", nil
+			}
+		}
+		if strings.HasPrefix(scanner.Text(), "snapd_recovery_system=") {
+			version = strings.SplitN(scanner.Text(), "=", 2)[1]
+		}
+		if mode != "" && version != "" {
+			return mode, version, nil
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return "", fmt.Errorf("cannot detect if in run,install,recover mode")
+	return "", "", fmt.Errorf("cannot detect if in run,install,recover mode or version")
 }
 
 func generateInitramfsMounts() error {
@@ -265,15 +249,15 @@ func generateInitramfsMounts() error {
 	if err != nil {
 		return err
 	}
-	mode, err := whichMode(content)
+	mode, version, err := whichMode(content)
 	if err != nil {
 		return err
 	}
 	switch mode {
 	case "recover":
-		return generateMountsModeRecover()
+		return generateMountsModeRecover(version)
 	case "install":
-		return generateMountsModeInstall()
+		return generateMountsModeInstall(version)
 	case "run":
 		return generateMountsModeRun()
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -118,7 +118,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsNoModeError(c *C) {
 	s.mockProcCmdlineContent(c, "nothing-to-see")
 
 	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, ErrorMatches, "cannot detect if in run,install,recover mode or version")
+	c.Assert(err, ErrorMatches, "cannot detect mode nor recovery system to use")
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsUnknonwnMode(c *C) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -46,8 +46,9 @@ type initramfsMountsSuite struct {
 
 	Stdout *bytes.Buffer
 
-	seedDir string
-	runMnt  string
+	seedDir  string
+	runMnt   string
+	sysLabel string
 }
 
 var _ = Suite(&initramfsMountsSuite{})
@@ -84,8 +85,8 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	seed20.MakeAssertedSnap(c, "name: pc-kernel\nversion: 1\ntype: kernel", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 	seed20.MakeAssertedSnap(c, "name: core20\nversion: 1\ntype: base", nil, snap.R(1), "canonical", seed20.StoreSigning.Database)
 
-	sysLabel := "20191118"
-	seed20.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+	s.sysLabel = "20191118"
+	seed20.MakeSeed(c, s.sysLabel, "my-brand", "my-model", map[string]interface{}{
 		"display-name": "my model",
 		"architecture": "amd64",
 		"base":         "core20",
@@ -117,7 +118,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsNoModeError(c *C) {
 	s.mockProcCmdlineContent(c, "nothing-to-see")
 
 	_, err := main.Parser.ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, ErrorMatches, "cannot detect if in run,install,recover mode")
+	c.Assert(err, ErrorMatches, "cannot detect if in run,install,recover mode or version")
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsUnknonwnMode(c *C) {
@@ -129,7 +130,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsUnknonwnMode(c *C) {
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep1(c *C) {
 	n := 0
-	s.mockProcCmdlineContent(c, "snapd_recovery_mode=")
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode= snapd_recovery_system="+s.sysLabel)
 
 	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
 		n++
@@ -150,7 +151,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep1(c *C) {
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep2(c *C) {
 	n := 0
-	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install")
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
 
 	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
 		n++
@@ -183,7 +184,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep2(c *C) {
 
 func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeStep4(c *C) {
 	n := 0
-	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install")
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=install snapd_recovery_system="+s.sysLabel)
 
 	restore := main.MockOsutilIsMounted(func(path string) (bool, error) {
 		n++


### PR DESCRIPTION
At the moment snap-bootstrap is behind the-modeenv. Fix snap-bootstrap to correctly parse the right sysLabel, instead of just finding any random system on disk.