### PR TITLE
o/devicestate,o/snapstate: move the gadget.yaml check

### DIFF
--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -153,6 +153,7 @@ func RemodelDeviceBackend(remodCtx remodelContext) storecontext.DeviceBackend {
 var (
 	ImportAssertionsFromSeed     = importAssertionsFromSeed
 	CheckGadgetOrKernel          = checkGadgetOrKernel
+	CheckGadgetValid             = checkGadgetValid
 	CheckGadgetRemodelCompatible = checkGadgetRemodelCompatible
 	CanAutoRefresh               = canAutoRefresh
 	NewEnoughProxy               = newEnoughProxy

--- a/overlord/devicestate/handlers_remodel.go
+++ b/overlord/devicestate/handlers_remodel.go
@@ -199,7 +199,7 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 		return fmt.Errorf("cannot identify the current gadget snap")
 	}
 
-	newGadgetYaml, err := snapf.ReadFile("meta/gadget.yaml")
+	pendingInfo, err := gadget.ReadInfoFromSnapFile(snapf, deviceCtx.Model())
 	if err != nil {
 		return fmt.Errorf("cannot read new gadget metadata: %v", err)
 	}
@@ -207,11 +207,6 @@ func checkGadgetRemodelCompatible(st *state.State, snapInfo, curInfo *snap.Info,
 	currentData, err := gadgetDataFromInfo(curInfo, deviceCtx.GroundContext().Model())
 	if err != nil {
 		return fmt.Errorf("cannot read current gadget metadata: %v", err)
-	}
-
-	pendingInfo, err := gadget.InfoFromGadgetYaml(newGadgetYaml, deviceCtx.Model())
-	if err != nil {
-		return fmt.Errorf("cannot load new gadget metadata: %v", err)
 	}
 
 	if err := gadgetIsCompatible(currentData.Info, pendingInfo); err != nil {

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/cmd"
-	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -477,13 +476,6 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 	// first install rules are in devicestate!
 	if !ok {
 		return nil
-	}
-
-	// do basic constraints check on the gadget
-	if typ == snap.TypeGadget {
-		if _, err = gadget.ReadInfoFromSnapFile(snapf, deviceCtx.Model()); err != nil {
-			return err
-		}
 	}
 
 	currentSnap, err := infoForDeviceSnap(st, deviceCtx, kind, whichName)

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -253,12 +253,6 @@ version: 1.0`
 	c.Check(err, Equals, fail)
 }
 
-func minimalGadgetContainer(c *C) snap.Container {
-	return snaptest.MockContainer(c, [][]string{
-		{"meta/gadget.yaml", gadgetYaml},
-	})
-}
-
 func (s *checkSnapSuite) TestCheckSnapGadgetUpdate(c *C) {
 	reset := release.MockOnClassic(false)
 	defer reset()
@@ -290,7 +284,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, minimalGadgetContainer(c), nil
+		return info, emptyContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -332,7 +326,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, minimalGadgetContainer(c), nil
+		return info, emptyContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -373,7 +367,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, minimalGadgetContainer(c), nil
+		return info, emptyContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -414,7 +408,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, minimalGadgetContainer(c), nil
+		return info, emptyContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -456,7 +450,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, minimalGadgetContainer(c), nil
+		return info, emptyContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()
@@ -1274,7 +1268,7 @@ version: 2
 	c.Assert(err, IsNil)
 
 	var openSnapFile = func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error) {
-		return info, minimalGadgetContainer(c), nil
+		return info, emptyContainer(c), nil
 	}
 	restore := snapstate.MockOpenSnapFile(openSnapFile)
 	defer restore()

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/pack"
+	"github.com/snapcore/snapd/snap/snapdir"
 )
 
 func mockSnap(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
@@ -276,4 +277,16 @@ func RenameSlot(snapInfo *snap.Info, oldName, newName string) error {
 	}
 
 	return nil
+}
+
+// MockContainer returns a mock snap.Container with the given content.
+// If files is empty it still produces a minimal container that passes
+// ValidateContainer: / and /meta exist and are 0755, and
+// /meta/snap.yaml is a regular world-readable file.
+func MockContainer(c *check.C, files [][]string) snap.Container {
+	d := c.MkDir()
+	c.Assert(os.Chmod(d, 0755), check.IsNil)
+	files = append([][]string{{"meta/snap.yaml", ""}}, files...)
+	PopulateDir(d, files)
+	return snapdir.New(d)
 }


### PR DESCRIPTION
Move the gadget.yaml basic check to its own checker (checkGadgetValid in devicestate.go) that will be
invoked both for install and refresh. The current placement runs it only on refreshes.

To help write the test introduce snaptest.MockContainer.

drive-by: use gadget.ReadInfoFromSnapFile in checkGadgetRemodelCompatible