### PR TITLE
[RFC] boot,devicestate: update modenv and extract kernel

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -521,6 +521,7 @@ version: 5.0
 		KernelPath:        kernelInSeed,
 		RecoverySystemDir: recoverySystemDir,
 		UnpackedGadgetDir: unpackedGadgetDir,
+		Recovery:          true,
 	}
 
 	err = boot.MakeBootable(model, rootdir, bootWith)
@@ -549,7 +550,7 @@ func (s *bootSetSuite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
 
 	model := makeMockUC20Model()
 
-	bootWith := &boot.BootableSet{}
+	bootWith := &boot.BootableSet{Recovery: true}
 	rootdir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(rootdir, "systems/20191204"), 0755)
 	c.Assert(err, IsNil)

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -79,11 +79,16 @@ func Run(gadgetRoot, device string, options *Options) error {
 	if err != nil {
 		return fmt.Errorf("cannot create the partitions: %v", err)
 	}
+
 	if err := partition.MakeFilesystems(created); err != nil {
 		return err
 	}
 
 	if err := partition.DeployContent(created, gadgetRoot); err != nil {
+		return err
+	}
+
+	if err := partition.MountFilesystems(created); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/partition/deploy.go
+++ b/cmd/snap-bootstrap/partition/deploy.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 )
 
@@ -96,6 +97,23 @@ func DeployContent(created []DeviceStructure, gadgetRoot string) error {
 			if err := deployFilesystemContent(part, gadgetRoot); err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func MountFilesystems(created []DeviceStructure) error {
+	for _, part := range created {
+		if part.Label == "" || part.Filesystem == "" {
+			continue
+		}
+		mountpoint := filepath.Join(dirs.MountPointDir, part.Label)
+		if err := os.MkdirAll(mountpoint, 0755); err != nil {
+			return fmt.Errorf("cannot create mountpoint: %v", err)
+		}
+		if err := sysMount(part.Node, mountpoint, part.Filesystem, 0, ""); err != nil {
+			return fmt.Errorf("cannot mount filesystem %q to %q: %v", part.Node, mountpoint, err)
 		}
 	}
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -138,6 +138,9 @@ const (
 	// * in daemon to spool the snap file to <SnapBlobDir>/<LocalInstallBlobTempPrefix>*
 	// * in snapstate to auto-cleans them up using the same prefix
 	LocalInstallBlobTempPrefix = ".local-install-"
+
+	// MountPointDir contains mountpoints based on the filesystem labels.
+	MountPointDir = "/run/mnt"
 )
 
 var (

--- a/image/image.go
+++ b/image/image.go
@@ -392,6 +392,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 
 	bootWith := &boot.BootableSet{
 		UnpackedGadgetDir: gadgetUnpackDir,
+		Recovery:          core20,
 	}
 	if label != "" {
 		bootWith.RecoverySystemDir = filepath.Join("/systems/", label)
@@ -419,8 +420,6 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 		return err
 	}
 
-	// TODO|XXX: change MakeBootable/pass right info Core 20 case
-	// (setting up recovery, not run bootenv)
 	if err := boot.MakeBootable(model, bootRootDir, bootWith); err != nil {
 		return err
 	}

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -20,6 +20,7 @@
 package devicestate_test
 
 import (
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -60,10 +61,31 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 }
 
 func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C) {
+	const (
+		pcSnapID       = "pcididididididididididididididid"
+		pcKernelSnapID = "pckernelidididididididididididid"
+		core20SnapID   = "core20ididididididididididididid"
+	)
 	si := &snap.SideInfo{
+		RealName: "pc-kernel",
+		Revision: snap.R(1),
+		SnapID:   pcKernelSnapID,
+	}
+	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
+		SnapType: "kernel",
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		Active:   true,
+	})
+	kernelInfo := snaptest.MockSnapWithFiles(c, "name: pc-kernel\ntype: kernel", si, nil)
+	kernelFn := snaptest.MakeTestSnapWithFiles(c, "name: pc-kernel\ntype: kernel\nversion: 1.0", nil)
+	err := os.Rename(kernelFn, kernelInfo.MountFile())
+	c.Assert(err, IsNil)
+
+	si = &snap.SideInfo{
 		RealName: "pc",
 		Revision: snap.R(1),
-		SnapID:   "pc-ididid",
+		SnapID:   pcSnapID,
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
@@ -74,16 +96,42 @@ func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C) {
 	snaptest.MockSnapWithFiles(c, "name: pc\ntype: gadget", si, [][]string{
 		{"meta/gadget.yaml", gadgetYaml},
 	})
-	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
+
+	si = &snap.SideInfo{
+		RealName: "core20",
+		Revision: snap.R(1),
+		SnapID:   core20SnapID,
+	}
+	snapstate.Set(s.state, "core20", &snapstate.SnapState{
+		SnapType: "base",
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		Active:   true,
+	})
+	snaptest.MockSnapWithFiles(c, "name: core20\ntype: base", si, nil)
+
+	s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
 		"architecture": "amd64",
-		"kernel":       "pc-kernel",
-		"gadget":       "pc",
-		"base":         "core18",
+		"base":         "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              pcKernelSnapID,
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              pcSnapID,
+				"type":            "gadget",
+				"default-channel": "20",
+			}},
 	})
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand:  "canonical",
-		Model:  "pc-model",
-		Serial: "serial",
+		Brand: "my-brand",
+		Model: "my-model",
+		// no serial in install mode
 	})
 }
 
@@ -95,22 +143,21 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	defer mockSnapBootstrapCmd.Restore()
 
 	s.state.Lock()
+	defer s.state.Unlock()
 	s.makeMockInstalledPcGadget(c)
 	devicestate.SetOperatingMode(s.mgr, "install")
+
 	s.state.Unlock()
-
 	s.settle(c)
-
 	s.state.Lock()
-	defer s.state.Unlock()
 
 	// the install-system change is created
-	createPartitions := s.findInstallSystem()
-	c.Assert(createPartitions, NotNil)
+	installSystem := s.findInstallSystem()
+	c.Assert(installSystem, NotNil)
 
 	// and was run successfully
-	c.Check(createPartitions.Err(), IsNil)
-	c.Check(createPartitions.Status(), Equals, state.DoneStatus)
+	c.Check(installSystem.Err(), IsNil)
+	c.Check(installSystem.Status(), Equals, state.DoneStatus)
 	// in the right way
 	c.Check(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
 		{"snap-bootstrap", "create-partitions", filepath.Join(dirs.SnapMountDir, "/pc/1")},
@@ -134,8 +181,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	createPartitions := s.findInstallSystem()
-	c.Check(createPartitions.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
+	installSystem := s.findInstallSystem()
+	c.Check(installSystem.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
 - Setup system for run mode \(cannot create partitions: The horror, The horror\)`)
 }
 
@@ -153,8 +200,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNotInstallmodeNoChg(c *C) {
 	defer s.state.Unlock()
 
 	// the install-system change is *not* created (not in install mode)
-	createPartitions := s.findInstallSystem()
-	c.Assert(createPartitions, IsNil)
+	installSystem := s.findInstallSystem()
+	c.Assert(installSystem, IsNil)
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeNotClassic(c *C) {
@@ -171,6 +218,6 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeNotClassic(c *C) {
 	defer s.state.Unlock()
 
 	// the install-system change is *not* created (we're on classic)
-	createPartitions := s.findInstallSystem()
-	c.Assert(createPartitions, IsNil)
+	installSystem := s.findInstallSystem()
+	c.Assert(installSystem, IsNil)
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -26,10 +26,14 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -60,8 +64,64 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot create partitions: %v", osutil.OutputErr(output, err))
 	}
 
-	// XXX: update recovery mode in grubenv
-	// XXX2: write correct modeenv
+	// XXX: there must be a better way to get this information
+	// we can only make a single recovery system bootable right now
+	recoverySystems, err := filepath.Glob(filepath.Join(dirs.MountPointDir, "ubuntu-seed/systems/*"))
+	if err != nil {
+		return fmt.Errorf("cannot find recovery systems: %v", err)
+	}
+	if len(recoverySystems) > 1 {
+		return fmt.Errorf("cannot make multiple recovery systems bootable yet")
+	}
+	logger.Noticef("recovery system is %s", recoverySystems[0])
+
+	label := filepath.Base(recoverySystems[0])
+
+	// make the partition bootable
+	seed, err := seed.Open(filepath.Join(dirs.MountPointDir, "ubuntu-seed"), label)
+	if err != nil {
+		return fmt.Errorf("cannot open seed: %v", err)
+	}
+	if err := seed.LoadAssertions(nil, nil); err != nil {
+		return fmt.Errorf("cannot load assertions: %v", err)
+	}
+	if err := seed.LoadMeta(perfTimings); err != nil {
+		return fmt.Errorf("cannot load metadata: %v", err)
+	}
+	bootWith := &boot.BootableSet{
+		RecoverySystemDir: recoverySystems[0],
+		Recovery:          true,
+	}
+	for _, sn := range seed.EssentialSnaps() {
+		snapf, err := snap.Open(sn.Path)
+		if err != nil {
+			return fmt.Errorf("cannot open snap info: %v", err)
+		}
+		info, err := snap.ReadInfoFromSnapFile(snapf, nil)
+		if err != nil {
+			return fmt.Errorf("cannot read snap info: %v", err)
+		}
+		switch info.GetType() {
+		case snap.TypeOS, snap.TypeBase:
+			bootWith.Base = info
+			bootWith.BasePath = sn.Path
+		case snap.TypeKernel:
+			bootWith.Kernel = info
+			bootWith.KernelPath = sn.Path
+		}
+	}
+
+	logger.Noticef("seed base: %s", bootWith.BasePath)
+	logger.Noticef("seed kernel: %s", bootWith.KernelPath)
+
+	model, err := seed.Model()
+	if err != nil {
+		return fmt.Errorf("cannot get seed model: %v", err)
+	}
+	bootRootDir := filepath.Join(dirs.MountPointDir, "ubuntu-boot")
+	if err := boot.MakeBootable(model, bootRootDir, bootWith); err != nil {
+		return fmt.Errorf("cannot make system bootable: %v", err)
+	}
 
 	return nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2312,6 +2312,23 @@ func GadgetInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) {
 	return infoForDeviceSnap(st, deviceCtx, "gadget", (*asserts.Model).Gadget)
 }
 
+// KernelInfo finds the kernel snap's info for the given device context.
+func KernelInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) {
+	return infoForDeviceSnap(st, deviceCtx, "kernel", (*asserts.Model).Kernel)
+}
+
+// BootBaseInfo finds the boot base snap's info for the given device context.
+func BootBaseInfo(st *state.State, deviceCtx DeviceContext) (*snap.Info, error) {
+	baseName := func(mod *asserts.Model) string {
+		base := mod.Base()
+		if base == "" {
+			return "core"
+		}
+		return base
+	}
+	return infoForDeviceSnap(st, deviceCtx, "boot base", baseName)
+}
+
 // TODO: reintroduce a KernelInfo(state.State, DeviceContext) if needed
 // KernelInfo finds the current kernel snap's info.
 


### PR DESCRIPTION
This is a draft of a few missing items in the install mode TODO list: create `(ubuntu-data)/system-data/var/lib/snapd/modenv`, update `(ubuntu-seed)/EFI/ubuntu/grubenv`, and extract the kernel image to `(ubuntu-boot)/`. Tests still to be added.