### PR TITLE
snap: improve squashfs.ReadFile() error

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -180,8 +180,8 @@ func (s *Snap) ReadFile(filePath string) (content []byte, err error) {
 	defer os.RemoveAll(tmpdir)
 
 	unpackDir := filepath.Join(tmpdir, "unpack")
-	if err := exec.Command("unsquashfs", "-n", "-i", "-d", unpackDir, s.path, filePath).Run(); err != nil {
-		return nil, err
+	if output, err := exec.Command("unsquashfs", "-n", "-i", "-d", unpackDir, s.path, filePath).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("cannot run unsquashfs: %v", osutil.OutputErr(output, err))
 	}
 
 	return ioutil.ReadFile(filepath.Join(unpackDir, filePath))

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -220,6 +220,15 @@ func (s *SquashfsTestSuite) TestReadFile(c *C) {
 	c.Assert(string(content), Equals, "name: foo")
 }
 
+func (s *SquashfsTestSuite) TestReadFileFail(c *C) {
+	mockUnsquashfs := testutil.MockCommand(c, "unsquashfs", `echo boom; exit 1`)
+	defer mockUnsquashfs.Restore()
+
+	snap := makeSnap(c, "name: foo", "")
+	_, err := snap.ReadFile("meta/snap.yaml")
+	c.Assert(err, ErrorMatches, "cannot run unsquashfs: boom")
+}
+
 func (s *SquashfsTestSuite) TestListDir(c *C) {
 	snap := makeSnap(c, "name: foo", "")
 


### PR DESCRIPTION
Right now we only return "exit 1" for squashfs.ReadFile() errors.
That worked pretty well because these errors are exceedingly rare.
However with the uc20 work snap-bootstrap runs in iniramfs and
there things are very minimal so snap-bootstrap fails with odd
errors. To make debugging here easier this commit switches the
code to show proper errors from unsquashfs.
