### PR TITLE
boot,image: add skeleton boot.makeBootable20RunMode

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -288,6 +288,9 @@ type BootableSet struct {
 	RecoverySystemDir string
 
 	UnpackedGadgetDir string
+
+	// Recovery is set to make the recovery system bootable
+	Recovery bool
 }
 
 // makeBootable16 setups the image filesystem for boot with UC16
@@ -296,7 +299,11 @@ type BootableSet struct {
 //  - creating symlinks for boot snaps from seed to the runtime blob dir
 //  - setting boot env vars pointing to the revisions of the boot snaps to use
 //  - extracting kernel assets as needed by the bootloader
-func makeBootable16(model *asserts.Model, rootdir string, bootWith *BootableSet, opts *bootloader.Options) error {
+func makeBootable16(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	opts := &bootloader.Options{
+		PrepareImageTime: true,
+	}
+
 	// install the bootloader configuration from the gadget
 	if err := bootloader.InstallBootConfig(bootWith.UnpackedGadgetDir, rootdir, opts); err != nil {
 		return err
@@ -363,7 +370,7 @@ func makeBootable16(model *asserts.Model, rootdir string, bootWith *BootableSet,
 	return nil
 }
 
-func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet, opts *bootloader.Options) error {
+func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
 	// we can only make a single recovery system bootable right now
 	recoverySystems, err := filepath.Glob(filepath.Join(rootdir, "systems/*"))
 	if err != nil {
@@ -371,6 +378,12 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet,
 	}
 	if len(recoverySystems) > 1 {
 		return fmt.Errorf("cannot make multiple recovery systems bootable yet")
+	}
+
+	opts := &bootloader.Options{
+		PrepareImageTime: true,
+		// setup the recovery part of the bootloader
+		Recovery: true,
 	}
 
 	// install the bootloader configuration from the gadget
@@ -403,19 +416,40 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet,
 	return nil
 }
 
+func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
+	// XXX: move to dirs ?
+	runMnt := filepath.Join(rootdir, "/run/mnt/")
+
+	// TODO:UC20:
+	// - create grub.cfg instead of using the gadget one
+	// - extract kernel
+	// - write modeenv
+
+	// update recovery grubs grubenv to indicate that we transition
+	// to run mode now
+	bl, err := bootloader.Find(filepath.Join(runMnt, "ubuntu-seed"), nil)
+	if err != nil {
+		return fmt.Errorf("internal error: cannot find bootloader: %v", err)
+	}
+	blVars := map[string]string{
+		"snapd_recovery_mode": "run",
+	}
+	if err := bl.SetBootVars(blVars); err != nil {
+		return fmt.Errorf("cannot set recovery system environment: %v", err)
+	}
+
+	return nil
+}
+
 // MakeBootable sets up the image filesystem with the given rootdir
 // such that it can be booted.
 func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
-	opts := &bootloader.Options{
-		// XXX: allow to override this
-		PrepareImageTime: true,
-	}
-
 	if model.Grade() == asserts.ModelGradeUnset {
-		return makeBootable16(model, rootdir, bootWith, opts)
+		return makeBootable16(model, rootdir, bootWith)
 	}
 
-	// XXX: allow to override this
-	opts.Recovery = true
-	return makeBootable20(model, rootdir, bootWith, opts)
+	if !bootWith.Recovery {
+		return makeBootable20RunMode(model, rootdir, bootWith)
+	}
+	return makeBootable20(model, rootdir, bootWith)
 }

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -427,7 +427,11 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 
 	// update recovery grubs grubenv to indicate that we transition
 	// to run mode now
-	bl, err := bootloader.Find(filepath.Join(runMnt, "ubuntu-seed"), nil)
+	opts := &bootloader.Options{
+		// setup the recovery part of the bootloader
+		Recovery: true,
+	}
+	bl, err := bootloader.Find(filepath.Join(runMnt, "ubuntu-seed"), opts)
 	if err != nil {
 		return fmt.Errorf("internal error: cannot find bootloader: %v", err)
 	}

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -289,7 +289,7 @@ type BootableSet struct {
 
 	UnpackedGadgetDir string
 
-	// Recovery is set to make the recovery system bootable
+	// Recover is set when making the recovery partition bootable.
 	Recovery bool
 }
 
@@ -382,7 +382,7 @@ func makeBootable20(model *asserts.Model, rootdir string, bootWith *BootableSet)
 
 	opts := &bootloader.Options{
 		PrepareImageTime: true,
-		// setup the recovery part of the bootloader
+		// setup the recovery bootloader
 		Recovery: true,
 	}
 
@@ -425,10 +425,10 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	// - extract kernel
 	// - write modeenv
 
-	// update recovery grubs grubenv to indicate that we transition
+	// update recovery grub's grubenv to indicate that we transition
 	// to run mode now
 	opts := &bootloader.Options{
-		// setup the recovery part of the bootloader
+		// setup the recovery bootloader
 		Recovery: true,
 	}
 	bl, err := bootloader.Find(filepath.Join(runMnt, "ubuntu-seed"), opts)
@@ -445,8 +445,12 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	return nil
 }
 
-// MakeBootable sets up the image filesystem with the given rootdir
-// such that it can be booted.
+// MakeBootable sets up the given bootable set and target filesystem
+// such that the system can be booted.
+//
+// rootdir points to an image filesystem (UC 16/18), image recovery
+// filesystem (UC20 at prepare-image time) or ephemeral system (UC20
+// install mode).
 func MakeBootable(model *asserts.Model, rootdir string, bootWith *BootableSet) error {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return makeBootable16(model, rootdir, bootWith)

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -561,7 +561,7 @@ func (s *bootSetSuite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
 	c.Assert(err, ErrorMatches, "cannot make multiple recovery systems bootable yet")
 }
 
-func (s *bootSetSuite) TestMakeBootable20RecoveryFalse(c *C) {
+func (s *bootSetSuite) TestMakeBootable20RunMode(c *C) {
 	dirs.SetRootDir("")
 
 	model := makeMockUC20Model()

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -521,6 +521,7 @@ version: 5.0
 		KernelPath:        kernelInSeed,
 		RecoverySystemDir: recoverySystemDir,
 		UnpackedGadgetDir: unpackedGadgetDir,
+		Recovery:          true,
 	}
 
 	err = boot.MakeBootable(model, rootdir, bootWith)
@@ -549,7 +550,7 @@ func (s *bootSetSuite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
 
 	model := makeMockUC20Model()
 
-	bootWith := &boot.BootableSet{}
+	bootWith := &boot.BootableSet{Recovery: true}
 	rootdir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(rootdir, "systems/20191204"), 0755)
 	c.Assert(err, IsNil)
@@ -558,4 +559,23 @@ func (s *bootSetSuite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
 
 	err = boot.MakeBootable(model, rootdir, bootWith)
 	c.Assert(err, ErrorMatches, "cannot make multiple recovery systems bootable yet")
+}
+
+func (s *bootSetSuite) TestMakeBootable20RecoveryFalse(c *C) {
+	dirs.SetRootDir("")
+
+	model := makeMockUC20Model()
+	rootdir := c.MkDir()
+
+	bootWith := &boot.BootableSet{
+		Recovery: false,
+	}
+
+	err := boot.MakeBootable(model, rootdir, bootWith)
+	c.Assert(err, IsNil)
+
+	// ensure the bootvars got updated the right way
+	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
+		"snapd_recovery_mode": "run",
+	})
 }

--- a/image/image.go
+++ b/image/image.go
@@ -392,6 +392,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 
 	bootWith := &boot.BootableSet{
 		UnpackedGadgetDir: gadgetUnpackDir,
+		Recovery:          core20,
 	}
 	if label != "" {
 		bootWith.RecoverySystemDir = filepath.Join("/systems/", label)
@@ -419,8 +420,6 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 		return err
 	}
 
-	// TODO|XXX: change MakeBootable/pass right info Core 20 case
-	// (setting up recovery, not run bootenv)
 	if err := boot.MakeBootable(model, bootRootDir, bootWith); err != nil {
 		return err
 	}


### PR DESCRIPTION
This commits adds a minimal boot.makeBootable20RunMode that
will be populate the "run" system on ubuntu-boot during a
UC20 install. This is the first of multiple PRs that add
the needed support. 

Based on the excellent work in #7908.

