### PR TITLE
boot: write modeenv when creating the run mode

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -423,7 +423,17 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	// TODO:UC20:
 	// - create grub.cfg instead of using the gadget one
 	// - extract kernel
-	// - write modeenv
+
+	// write modeenv on the ubuntu-data partition
+	modeenv := &Modeenv{
+		Mode:           "run",
+		RecoverySystem: filepath.Base(bootWith.RecoverySystemDir),
+		Base:           filepath.Base(bootWith.BasePath),
+		Kernel:         filepath.Base(bootWith.KernelPath),
+	}
+	if err := modeenv.Write(filepath.Join(runMnt, "ubuntu-data", "system-data")); err != nil {
+		return fmt.Errorf("cannot write modeenv: %v", err)
+	}
 
 	// update recovery grub's grubenv to indicate that we transition
 	// to run mode now

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -566,16 +566,28 @@ func (s *bootSetSuite) TestMakeBootable20RunMode(c *C) {
 
 	model := makeMockUC20Model()
 	rootdir := c.MkDir()
+	seedSnapsDirs := filepath.Join(rootdir, "/snaps")
+	err := os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		Recovery: false,
+		RecoverySystemDir: "20191216",
+		BasePath:          "core20_123.snap",
+		KernelPath:        "pc-kernel_456.snap",
+		Recovery:          false,
 	}
 
-	err := boot.MakeBootable(model, rootdir, bootWith)
+	err = boot.MakeBootable(model, rootdir, bootWith)
 	c.Assert(err, IsNil)
 
 	// ensure the bootvars got updated the right way
 	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_mode": "run",
 	})
+	ubuntuDataModeEnvPath := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
+	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
+recovery_system=20191216
+base=core20_123.snap
+kernel=pc-kernel_456.snap
+`)
 }


### PR DESCRIPTION
This commit adds writing the modeenv in run mode.

Based on https://github.com/snapcore/snapd/pull/7910