### PR TITLE
lkenv.go: adjust for new location of include file

### DIFF
--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -50,7 +50,7 @@ const (
 
 /**
  * Following structure has to be kept in sync with c structure defined by
- * include/snappy-boot_v1.h
+ * include/lk/snappy-boot_v1.h
  * c headerfile is used by bootloader, this ensures sync of  the environment
  * between snapd and bootloader
 


### PR DESCRIPTION
This file was moved in 381f5acc5f2a5d7a6fc8eacc6f680a85990cd7c6, but the location here in the code was not updated to reflect this.