### PR TITLE
snap-bootstrap: trigger udev for new partitions

### DIFF
--- a/tests/main/uc20-snap-recovery-autodetect/task.yaml
+++ b/tests/main/uc20-snap-recovery-autodetect/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary autodetect
 
 # one system is enough, its a very specialized test for now
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-19.10-64]
 
 debug: |
     cat /proc/partitions

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary
 
 # one system is enough, its a very specialized test for now
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-19.10-64]
 
 debug: |
     cat /proc/partitions


### PR DESCRIPTION
Call `udevadm trigger --settle` on new partitions after reloading the
partition table and before creating filesystems to keep the udev
database consistent.
