### PR TITLE
boot: copy kernel/base to data partition in makeBootable20RunMode

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -423,6 +424,19 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	// TODO:UC20:
 	// - create grub.cfg instead of using the gadget one
 	// - extract kernel
+
+	// copy kernel/base into the ubuntu-date partition
+	ubuntuDataMnt := filepath.Join(runMnt, "ubuntu-data")
+	snapBlobDir := dirs.SnapBlobDirUnder(filepath.Join(ubuntuDataMnt, "system-data"))
+	if err := os.MkdirAll(snapBlobDir, 0755); err != nil {
+		return err
+	}
+	for _, fn := range []string{bootWith.BasePath, bootWith.KernelPath} {
+		dst := filepath.Join(snapBlobDir, filepath.Base(fn))
+		if err := osutil.CopyFile(fn, dst, 0); err != nil {
+			return err
+		}
+	}
 
 	// write modeenv on the ubuntu-data partition
 	modeenv := &Modeenv{

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -425,7 +425,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	// - create grub.cfg instead of using the gadget one
 	// - extract kernel
 
-	// copy kernel/base into the ubuntu-date partition
+	// copy kernel/base into the ubuntu-data partition
 	ubuntuDataMnt := filepath.Join(runMnt, "ubuntu-data")
 	snapBlobDir := dirs.SnapBlobDirUnder(filepath.Join(ubuntuDataMnt, "system-data"))
 	if err := os.MkdirAll(snapBlobDir, 0755); err != nil {

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -433,7 +433,7 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 	}
 	for _, fn := range []string{bootWith.BasePath, bootWith.KernelPath} {
 		dst := filepath.Join(snapBlobDir, filepath.Base(fn))
-		if err := osutil.CopyFile(fn, dst, 0); err != nil {
+		if err := osutil.CopyFile(fn, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync); err != nil {
 			return err
 		}
 	}

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -570,24 +570,47 @@ func (s *bootSetSuite) TestMakeBootable20RunMode(c *C) {
 	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)
 
+	baseFn, baseInfo := s.makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, filepath.Base(baseInfo.MountFile()))
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := s.makeSnap(c, "pc-kernel", `name: pc-kernel
+type: kernel
+version: 5.0
+`, snap.R(5))
+	kernelInSeed := filepath.Join(seedSnapsDirs, filepath.Base(kernelInfo.MountFile()))
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
 	bootWith := &boot.BootableSet{
 		RecoverySystemDir: "20191216",
-		BasePath:          "core20_123.snap",
-		KernelPath:        "pc-kernel_456.snap",
+		BasePath:          baseInSeed,
+		Base:              baseInfo,
+		KernelPath:        kernelInSeed,
+		Kernel:            kernelInfo,
 		Recovery:          false,
 	}
 
 	err = boot.MakeBootable(model, rootdir, bootWith)
 	c.Assert(err, IsNil)
 
+	// ensure base/kernel got copied to /var/lib/snapd/snaps
+	runMntUbuntuData := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data")
+	c.Check(filepath.Join(runMntUbuntuData, dirs.SnapBlobDir, "core20_3.snap"), testutil.FilePresent)
+	c.Check(filepath.Join(runMntUbuntuData, dirs.SnapBlobDir, "pc-kernel_5.snap"), testutil.FilePresent)
+
 	// ensure the bootvars got updated the right way
 	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
 		"snapd_recovery_mode": "run",
 	})
+	// ensure modeenv got written
 	ubuntuDataModeEnvPath := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
 recovery_system=20191216
-base=core20_123.snap
-kernel=pc-kernel_456.snap
+base=core20_3.snap
+kernel=pc-kernel_5.snap
 `)
 }


### PR DESCRIPTION
The kernel/base must be copied into the ubuntu-data partition
when making the system runnable. This commit adds the needed
code to do this.

