### PR TITLE
snapstate: do not try up update bootloader in ephemeral mode

### DIFF
--- a/boot/boottest/participant.go
+++ b/boot/boottest/participant.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boottest
+
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/snap"
+)
+
+// ensure MockBootParticipant is a BootParticipant
+var _ boot.BootParticipant = &MockBootParticipant{}
+
+// ensure MockBootParticipant is a Kernel
+var _ boot.BootKernel = &MockBootParticipant{}
+
+type MockBootParticipant struct {
+	SetNextBootCalled         int
+	ChangeRequiresRebootValue bool
+
+	ExtractKernelAssetsCalled int
+	ExtractKernelAssetsErr    error
+	RemoveKernelAssetsCalled  int
+	RemoveKernelAssetsErr     error
+}
+
+func (m *MockBootParticipant) SetNextBoot() error {
+	m.SetNextBootCalled++
+	return nil
+}
+
+func (m *MockBootParticipant) ChangeRequiresReboot() bool {
+	return m.ChangeRequiresRebootValue
+}
+
+func (m *MockBootParticipant) IsTrivial() bool {
+	return false
+}
+
+func (m *MockBootParticipant) RemoveKernelAssets() error {
+	m.RemoveKernelAssetsCalled++
+	return m.RemoveKernelAssetsErr
+}
+
+func (m *MockBootParticipant) ExtractKernelAssets(snap.Container) error {
+	m.ExtractKernelAssetsCalled++
+	return m.ExtractKernelAssetsErr
+}

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -21,6 +21,9 @@ package backend
 
 import (
 	"os/exec"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/snap"
 )
 
 var (
@@ -41,5 +44,13 @@ func MockCommandFromSystemSnap(f func(string, ...string) (*exec.Cmd, error)) (re
 	commandFromSystemSnap = f
 	return func() {
 		commandFromSystemSnap = old
+	}
+}
+
+func MockBootParticipant(f func(s snap.PlaceInfo, t snap.Type, dev boot.Device) boot.BootParticipant) (restore func()) {
+	old := bootParticipant
+	bootParticipant = f
+	return func() {
+		bootParticipant = old
 	}
 }

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -76,6 +76,9 @@ func hasFontConfigCache(info *snap.Info) bool {
 	return false
 }
 
+// overriden for tests
+var bootParticipant = boot.Participant
+
 // LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
 func (b Backend) LinkSnap(info *snap.Info, dev boot.Device, prevDisabledSvcs []string, tm timings.Measurer) (e error) {
 	if info.Revision.Unset() {
@@ -111,9 +114,11 @@ func (b Backend) LinkSnap(info *snap.Info, dev boot.Device, prevDisabledSvcs []s
 		})
 	}
 
-	// XXX this is not tested afaict
-	if err := boot.Participant(info, info.GetType(), dev).SetNextBoot(); err != nil {
-		return err
+	// We only to update the bootloader in run-mode.
+	if dev.RunMode() {
+		if err := bootParticipant(info, info.GetType(), dev).SetNextBoot(); err != nil {
+			return err
+		}
 	}
 
 	if err := updateCurrentSymlinks(info); err != nil {

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -85,8 +85,10 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 	}
 
 	t := s.GetType()
-	if err := boot.Kernel(s, t, dev).ExtractKernelAssets(snapf); err != nil {
-		return snapType, nil, fmt.Errorf("cannot install kernel: %s", err)
+	if dev.RunMode() {
+		if err := boot.Kernel(s, t, dev).ExtractKernelAssets(snapf); err != nil {
+			return snapType, nil, fmt.Errorf("cannot install kernel: %s", err)
+		}
 	}
 
 	installRecord = &InstallRecord{TargetSnapExisted: didNothing}


### PR DESCRIPTION
When installing/seeding a base/kernel in ephemeral mode there
is no need to update the bootloader because kernel/base will
come from the recovery system and it does not make sense to
try to update the bootloader at this point.

This commit adds code that detects when the system is in
ephemeral mode and will skip setting the bootloader then.

Alternatively (instead of doing it as outlined in this PR) we could
do the check one level deeper:
```
diff --git a/boot/boot.go b/boot/boot.go
index 0ce1796d3b..3288273a86 100644
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -92,6 +92,12 @@ type Device interface {
 // Currently, on classic, nothing is a boot participant (returned will
 // always be NOP).
 func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
+       // In ephemeral modes we never need to care about updating the boot
+       // config. This will be done via boot.MakeBootable().
+       if !dev.RunMode() {
+               return trivial{}
+       }
+
        if applicable(s, t, dev) {
                return &coreBootParticipant{s: s, t: t}
        }
```
WDYT?
