### PR TITLE
snap-bootstrap: mount filesystems after creation

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/dirs"
 )
 
 type Options struct {

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -88,7 +88,7 @@ func Run(gadgetRoot, device string, options *Options) error {
 		return err
 	}
 
-	if err := partition.MountFilesystems(created); err != nil {
+	if err := partition.MountFilesystems(created, dirs.RunMnt); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -79,11 +79,16 @@ func Run(gadgetRoot, device string, options *Options) error {
 	if err != nil {
 		return fmt.Errorf("cannot create the partitions: %v", err)
 	}
+
 	if err := partition.MakeFilesystems(created); err != nil {
 		return err
 	}
 
 	if err := partition.DeployContent(created, gadgetRoot); err != nil {
+		return err
+	}
+
+	if err := partition.MountFilesystems(created); err != nil {
 		return err
 	}
 

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
-	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 )
 
 type Options struct {
+	// Also mount the filesystems after creation
+	Mount bool
 	// will contain encryption later
 }
 
@@ -89,8 +91,10 @@ func Run(gadgetRoot, device string, options *Options) error {
 		return err
 	}
 
-	if err := partition.MountFilesystems(created, dirs.RunMnt); err != nil {
-		return err
+	if options.Mount {
+		if err := partition.MountFilesystems(created, dirs.RunMnt); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -37,6 +37,8 @@ func init() {
 }
 
 type cmdCreatePartitions struct {
+	Mount bool `short:"m" long:"mount" description:"Also mount filesystems after creation" optional:"yes"`
+
 	Positional struct {
 		GadgetRoot string `positional-arg-name:"<gadget-root>"`
 		Device     string `positional-arg-name:"<device>"`
@@ -44,8 +46,9 @@ type cmdCreatePartitions struct {
 }
 
 func (c *cmdCreatePartitions) Execute(args []string) error {
-	// XXX: add options
-	options := &bootstrap.Options{}
+	options := &bootstrap.Options{
+		Mount: c.Mount,
+	}
 
 	return bootstrapRun(c.Positional.GadgetRoot, c.Positional.Device, options)
 }

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -41,3 +41,20 @@ func (s *cmdSuite) TestCreatePartitionsHappy(c *C) {
 	c.Assert(rest, HasLen, 0)
 	c.Assert(n, Equals, 1)
 }
+
+func (s *cmdSuite) TestCreatePartitionsMount(c *C) {
+	n := 0
+	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts *bootstrap.Options) error {
+		c.Check(gadgetRoot, Equals, "gadget-dir")
+		c.Check(device, Equals, "device")
+		c.Check(opts.Mount, Equals, true)
+		n++
+		return nil
+	})
+	defer restore()
+
+	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "--mount", "gadget-dir", "device"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Assert(n, Equals, 1)
+}

--- a/cmd/snap-bootstrap/partition/deploy.go
+++ b/cmd/snap-bootstrap/partition/deploy.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 )
 
@@ -96,6 +97,23 @@ func DeployContent(created []DeviceStructure, gadgetRoot string) error {
 			if err := deployFilesystemContent(part, gadgetRoot); err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func MountFilesystems(created []DeviceStructure) error {
+	for _, part := range created {
+		if part.Label == "" || part.Filesystem == "" {
+			continue
+		}
+		mountpoint := filepath.Join(dirs.MountPointDir, part.Label)
+		if err := os.MkdirAll(mountpoint, 0755); err != nil {
+			return fmt.Errorf("cannot create mountpoint: %v", err)
+		}
+		if err := sysMount(part.Node, mountpoint, part.Filesystem, 0, ""); err != nil {
+			return fmt.Errorf("cannot mount filesystem %q to %q: %v", part.Node, mountpoint, err)
 		}
 	}
 

--- a/cmd/snap-bootstrap/partition/deploy.go
+++ b/cmd/snap-bootstrap/partition/deploy.go
@@ -108,7 +108,7 @@ func MountFilesystems(created []DeviceStructure) error {
 		if part.Label == "" || part.Filesystem == "" {
 			continue
 		}
-		mountpoint := filepath.Join(dirs.MountPointDir, part.Label)
+		mountpoint := filepath.Join(dirs.RunMnt, part.Label)
 		if err := os.MkdirAll(mountpoint, 0755); err != nil {
 			return fmt.Errorf("cannot create mountpoint: %v", err)
 		}

--- a/cmd/snap-bootstrap/partition/deploy.go
+++ b/cmd/snap-bootstrap/partition/deploy.go
@@ -43,7 +43,7 @@ func deployFilesystemContent(part DeviceStructure, gadgetRoot string) (err error
 
 	// temporarily mount the filesystem
 	if err := sysMount(part.Node, mountpoint, part.Filesystem, 0, ""); err != nil {
-		return fmt.Errorf("cannot mount filesystem %q to %q: %v", part.Node, mountpoint, err)
+		return fmt.Errorf("cannot mount filesystem %q at %q: %v", part.Node, mountpoint, err)
 	}
 	defer func() {
 		errUnmount := sysUnmount(mountpoint, 0)
@@ -113,7 +113,7 @@ func MountFilesystems(created []DeviceStructure, baseMntPoint string) error {
 			return fmt.Errorf("cannot create mountpoint: %v", err)
 		}
 		if err := sysMount(part.Node, mountpoint, part.Filesystem, 0, ""); err != nil {
-			return fmt.Errorf("cannot mount filesystem %q to %q: %v", part.Node, mountpoint, err)
+			return fmt.Errorf("cannot mount filesystem %q at %q: %v", part.Node, mountpoint, err)
 		}
 	}
 

--- a/cmd/snap-bootstrap/partition/deploy.go
+++ b/cmd/snap-bootstrap/partition/deploy.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 )
 
@@ -103,12 +102,13 @@ func DeployContent(created []DeviceStructure, gadgetRoot string) error {
 	return nil
 }
 
-func MountFilesystems(created []DeviceStructure) error {
+func MountFilesystems(created []DeviceStructure, baseMntPoint string) error {
 	for _, part := range created {
-		if part.Label == "" || part.Filesystem == "" {
+		if part.Label == "" || !part.HasFilesystem() {
 			continue
 		}
-		mountpoint := filepath.Join(dirs.RunMnt, part.Label)
+
+		mountpoint := filepath.Join(baseMntPoint, part.Label)
 		if err := os.MkdirAll(mountpoint, 0755); err != nil {
 			return fmt.Errorf("cannot create mountpoint: %v", err)
 		}

--- a/cmd/snap-bootstrap/partition/deploy_test.go
+++ b/cmd/snap-bootstrap/partition/deploy_test.go
@@ -26,6 +26,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -45,6 +46,10 @@ type deploySuite struct {
 var _ = Suite(&deploySuite{})
 
 func (s *deploySuite) SetUpTest(c *C) {
+	s.mockMountErr = nil
+	s.mockMountCalls = nil
+	s.mockUnmountCalls = nil
+
 	s.gadgetRoot = c.MkDir()
 	err := makeMockGadget(s.gadgetRoot, gadgetContent)
 	c.Assert(err, IsNil)
@@ -113,4 +118,30 @@ func (s *deploySuite) TestDeployRawContent(c *C) {
 	c.Assert(err, IsNil)
 	// note the 2 zero byte start offset
 	c.Check(string(content), Equals, "\x00\x00pc-core.img content")
+}
+
+func (s *deploySuite) TestMountFilesystems(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+
+	// mounting will only happen for devices with a label
+	mockDeviceStructureBiosBoot.Label = "bios-boot"
+	defer func() { mockDeviceStructureBiosBoot.Label = "" }()
+	mockDeviceStructureSystemSeed.Label = "ubuntu-seed"
+	defer func() { mockDeviceStructureSystemSeed.Label = "" }()
+
+	err := partition.MountFilesystems([]partition.DeviceStructure{
+		mockDeviceStructureBiosBoot,
+		mockDeviceStructureSystemSeed,
+	}, dirs.RunMnt)
+	c.Assert(err, IsNil)
+
+	// check that just a single call happend and that things got mounted
+	// to the right mount point
+	node2MountPoint := filepath.Join(dirs.RunMnt, "ubuntu-seed")
+	c.Check(s.mockMountCalls, HasLen, 1)
+	c.Check(s.mockMountCalls, DeepEquals, []struct{ source, target, fstype string }{
+		{"/dev/node2", node2MountPoint, "vfat"},
+	})
+
 }

--- a/cmd/snap-bootstrap/partition/deploy_test.go
+++ b/cmd/snap-bootstrap/partition/deploy_test.go
@@ -136,7 +136,7 @@ func (s *deploySuite) TestMountFilesystems(c *C) {
 	}, dirs.RunMnt)
 	c.Assert(err, IsNil)
 
-	// check that just a single call happend and that things got mounted
+	// check that just a single call happened and that things got mounted
 	// to the right mount point
 	node2MountPoint := filepath.Join(dirs.RunMnt, "ubuntu-seed")
 	c.Check(s.mockMountCalls, HasLen, 1)

--- a/cmd/snap-bootstrap/partition/deploy_test.go
+++ b/cmd/snap-bootstrap/partition/deploy_test.go
@@ -76,7 +76,7 @@ func (s *deploySuite) TestDeployMountedContentErr(c *C) {
 
 	node2MountPoint := filepath.Join(s.mockMountPoint, "2")
 	err := partition.DeployContent([]partition.DeviceStructure{mockDeviceStructureSystemSeed}, s.gadgetRoot)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot mount filesystem "/dev/node2" to %q: boom`, node2MountPoint))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot mount filesystem "/dev/node2" at %q: boom`, node2MountPoint))
 }
 
 func (s *deploySuite) TestDeployMountedContent(c *C) {

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -359,6 +359,7 @@ func SetRootDir(rootdir string) {
 	SysfsDir = filepath.Join(rootdir, "/sys")
 
 	FeaturesDir = filepath.Join(rootdir, snappyDir, "features")
+
 	RunMnt = filepath.Join(rootdir, "/run/mnt")
 }
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -120,6 +120,8 @@ var (
 	SysfsDir        string
 
 	FeaturesDir string
+
+	RunMnt string
 )
 
 const (
@@ -357,6 +359,7 @@ func SetRootDir(rootdir string) {
 	SysfsDir = filepath.Join(rootdir, "/sys")
 
 	FeaturesDir = filepath.Join(rootdir, snappyDir, "features")
+	RunMnt = filepath.Join(rootdir, "/run/mnt")
 }
 
 // what inside a (non-classic) snap is /usr/lib/snapd, outside can come from different places

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -113,7 +113,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	c.Check(createPartitions.Status(), Equals, state.DoneStatus)
 	// in the right way
 	c.Check(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
-		{"snap-bootstrap", "create-partitions", filepath.Join(dirs.SnapMountDir, "/pc/1")},
+		{"snap-bootstrap", "create-partitions", "--mount", filepath.Join(dirs.SnapMountDir, "/pc/1")},
 	})
 }
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -54,7 +54,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 
 	// run the create partition code
 	st.Unlock()
-	output, err := exec.Command(filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "create-partitions", gadgetDir).CombinedOutput()
+	output, err := exec.Command(filepath.Join(dirs.DistroLibExecDir, "snap-bootstrap"), "create-partitions", "--mount", gadgetDir).CombinedOutput()
 	st.Lock()
 	if err != nil {
 		return fmt.Errorf("cannot create partitions: %v", osutil.OutputErr(output, err))

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -53,6 +53,10 @@ execute: |
     # and verify that its the same
     cmp bios-boot.img ./gadget-dir/pc-core.img
 
+    echo "Check that the filesystem was not auto-mounted"
+    mount
+    mount | not MATCH /run/mnt/system-boot
+
     echo "Check that the filesystem content was deployed"
     mkdir -p ./mnt
     mount "${LOOP}p2" ./mnt
@@ -85,25 +89,23 @@ execute: |
             filesystem: ext4
             size: 130M
     EOF
-    /usr/lib/snapd/snap-bootstrap create-partitions ./gadget-dir "$LOOP"
+    /usr/lib/snapd/snap-bootstrap create-partitions --mount ./gadget-dir "$LOOP"
     sfdisk -l "$LOOP" | MATCH '110M\s* Linux filesystem'
     sfdisk -l "$LOOP" | MATCH '120M\s* Linux filesystem'
     sfdisk -l "$LOOP" | MATCH '130M\s* Linux filesystem'
 
-    echo "check that the filesystems are created"
-    mkdir -p ./mnt
+    echo "check that the filesystems are created and mounted"
+    mount
 
-    mount "${LOOP}p3" ./mnt
+    mount | MATCH /run/mnt/other-ext4
     df -T "${LOOP}p3" | MATCH ext4
-    umount ./mnt
     file -s "${LOOP}p3" | MATCH 'volume name "other-ext4"'
 
-    mount "${LOOP}p4" ./mnt
+
+    mount | MATCH /run/mnt/ubuntu-boot
     df -T "${LOOP}p4" | MATCH ext4
-    umount ./mnt
     file -s "${LOOP}p4" | MATCH 'volume name "ubuntu-boot"'
 
-    mount "${LOOP}p5" ./mnt
+    mount | MATCH /run/mnt/ubuntu-data
     df -T "${LOOP}p5" | MATCH ext4
-    umount ./mnt
     file -s "${LOOP}p5" | MATCH 'volume name "ubuntu-data"'


### PR DESCRIPTION
The newly created filesystems will needed to be accessed or populated
in the installation process. Mount them here for convenience.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
