### PR TITLE
tests: fix use of MATCH -v

### DIFF
--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -45,8 +45,8 @@ execute: |
     # longer registers there.
     kill "$pid1"
     wait "$pid1" || true  # wait returns the exit code and we kill the process
-    MATCH -v "$pid1" < /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks
+    not MATCH "$pid1" < /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks
 
     kill "$pid2"
     wait "$pid2" || true  # same as above
-    MATCH -v "$pid2" < /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks
+    not MATCH "$pid2" < /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks

--- a/tests/main/cgroup-pids/task.yaml
+++ b/tests/main/cgroup-pids/task.yaml
@@ -52,11 +52,11 @@ execute: |
     # longer registers there.
     kill "$pid1"
     wait "$pid1" || true  # wait returns the exit code and we kill the process
-    MATCH -v "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    not MATCH "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
 
     kill "$pid2"
     wait "$pid2" || true  # same as above
-    MATCH -v "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    not MATCH "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
 
     # If a snap command forks a child process it is also tracked.
     #shellcheck disable=SC2016

--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -16,10 +16,10 @@ prepare: |
 execute: |
   touch foo
   # no immutable flag:
-  lsattr foo | MATCH -v i
+  lsattr foo | not MATCH i
   test "$(./toggle foo)" = "mutable -> immutable"
   # and now an immutable flag!:
   lsattr foo | MATCH i
   test "$(./toggle foo)" = "immutable -> mutable"
   # no immutable flag again:
-  lsattr foo | MATCH -v i
+  lsattr foo | not MATCH i

--- a/tests/main/cohorts/task.yaml
+++ b/tests/main/cohorts/task.yaml
@@ -24,4 +24,4 @@ execute: |
     snap info test-snapd-tools | MATCH ^installed:.*in-cohort
 
     snap switch --leave-cohort test-snapd-tools
-    snap info test-snapd-tools | grep installed: | MATCH -v in-cohort
+    snap info test-snapd-tools | grep installed: | not MATCH in-cohort

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -3,7 +3,7 @@ summary: Verify sandbox is correctly reported
 execute: |
     case "$SPREAD_SYSTEM" in
     ubuntu-core*)
-        snap debug sandbox-features | grep "confinement-options: " | MATCH -v "classic"
+        snap debug sandbox-features | grep "confinement-options: " | not MATCH "classic"
         snap debug sandbox-features | MATCH "apparmor: .+"
         ;;
     ubuntu-*)
@@ -12,7 +12,7 @@ execute: |
     fedora-*|debian-*|opensuse-*)
         # Fedora because it uses SELinux
         # Debian and openSUSE because partial apparmor is not enabled
-        snap debug sandbox-features | MATCH -v "apparmor: .+"
+        snap debug sandbox-features | not MATCH "apparmor: .+"
         ;;
     esac
     snap debug sandbox-features | MATCH "dbus: .+"

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -6,12 +6,12 @@ execute: |
         snap debug sandbox-features | grep "confinement-options: " | not MATCH "classic"
         snap debug sandbox-features | MATCH "apparmor: .+"
         ;;
-    ubuntu-*)
+    ubuntu-*|opensuse-*|debian-sid-*|arch-linux-*)
+        # Debian, openSUSE, Arch because partial apparmor is enabled
         snap debug sandbox-features | MATCH "apparmor: .+"
         ;;
-    fedora-*|debian-*|opensuse-*)
+    fedora-*|debian-*)
         # Fedora because it uses SELinux
-        # Debian and openSUSE because partial apparmor is not enabled
         snap debug sandbox-features | not MATCH "apparmor: .+"
         ;;
     esac

--- a/tests/main/enable-disable/task.yaml
+++ b/tests/main/enable-disable/task.yaml
@@ -28,7 +28,7 @@ execute: |
     fi
 
     echo "Enable test-snapd-tools again and ensure it is no longer listed as disabled"
-    snap enable test-snapd-tools|MATCH -v disabled
+    snap enable test-snapd-tools | MATCH 'test-snapd-tools enabled'
 
     if [ "$(snap debug confinement)" = strict ]; then
         echo "Ensure the test-snapd-tools security profiles are present"

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -34,18 +34,18 @@ execute: |
         echo "Then a private snap belonging to that user shows up in the find results and nothing else"
         result=$(snap find test-snapd-private2 --private)
         echo "$result" | MATCH 'test-snapd-private2 +[0-9]+\.[0-9]+'
-        echo "$result" | MATCH -v 'test-snapd-private +[0-9]+\.[0-9]+'
-        echo "$result" | MATCH -v 'test-snapd-public +[0-9]+\.[0-9]+'
+        echo "$result" | not MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
+        echo "$result" | not MATCH 'test-snapd-public +[0-9]+\.[0-9]+'
 
         echo "And searching for private snaps shows all of them and anything else"
         result=$(snap find --private)
         echo "$result" | MATCH 'test-snapd-private2 +[0-9]+\.[0-9]+'
         echo "$result" | MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
-        echo "$result" | MATCH -v 'test-snapd-public +[0-9]+\.[0-9]+'
+        echo "$result" | not MATCH 'test-snapd-public +[0-9]+\.[0-9]+'
 
         echo "And searching for public snaps does not show private ones"
         result=$(snap find test-snapd)
-        echo "$result" | MATCH -v 'test-snapd-private2 +[0-9]+\.[0-9]+'
-        echo "$result" | MATCH -v 'test-snapd-private +[0-9]+\.[0-9]+'
+        echo "$result" | not MATCH 'test-snapd-private2 +[0-9]+\.[0-9]+'
+        echo "$result" | not MATCH 'test-snapd-private +[0-9]+\.[0-9]+'
         echo "$result" | MATCH 'test-snapd-public +[0-9]+\.[0-9]+'
     fi

--- a/tests/main/install-remove-multi/task.yaml
+++ b/tests/main/install-remove-multi/task.yaml
@@ -8,8 +8,8 @@ execute: |
 
     echo "Remove of multiple snaps works"
     snap remove test-snapd-sh test-snapd-control-consumer
-    snap list | MATCH -v test-snapd-sh
-    snap list | MATCH -v test-snapd-control-consumer
+    not snap list test-snapd-sh
+    not snap list test-snapd-control-consumer
 
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"

--- a/tests/main/interfaces-adb-support/task.yaml
+++ b/tests/main/interfaces-adb-support/task.yaml
@@ -13,8 +13,8 @@ execute: |
     # some systems have the network manager installed and such systems will get
     # additional rules.
     if [ "$(find /etc/udev/rules.d -name '70-snap.*.rules' | wc -l)" -gt 0 ]; then
-        MATCH -v adb-support /etc/udev/rules.d/70-snap.*.rules
-        MATCH -v 'MODE="0666"' /etc/udev/rules.d/70-snap.*.rules
+        not MATCH adb-support /etc/udev/rules.d/70-snap.*.rules
+        not MATCH 'MODE="0666"' /etc/udev/rules.d/70-snap.*.rules
     fi
     snap connect test-snapd-adb-support:adb-support
     # Once the snap is connected there are adb-support udev rules that grant

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -57,7 +57,7 @@ execute: |
         touch module_present
         rmmod "$MODULE"
     fi
-    lsmod | MATCH -v "$MODULE"
+    lsmod | not MATCH "$MODULE"
     test-snapd-kernel-module-consumer.insmod "$MODULE_PATH"
 
     echo "And the snap is able to read /sys/module"
@@ -72,7 +72,7 @@ execute: |
 
     echo "And the snap is able to remove a module"
     test-snapd-kernel-module-consumer.rmmod "$MODULE"
-    lsmod | MATCH -v "$MODULE"
+    lsmod | not MATCH "$MODULE"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
@@ -97,7 +97,7 @@ execute: |
 
     echo "And the snap is not able to remove a module"
     # first we need to insert the module
-    lsmod | MATCH -v "$MODULE"
+    lsmod | not MATCH "$MODULE"
     insmod "$MODULE_PATH"
     lsmod | MATCH "$MODULE"
     if test-snapd-kernel-module-consumer.rmmod "$MODULE" 2> remove.error; then

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -56,7 +56,7 @@ execute: |
 
     echo "And the snap is able to destroy the unikernel domain"
     su -l -c "test-snapd-libvirt-consumer.machine-down" test
-    virsh list | MATCH -v ping-unikernel
+    virsh list | not MATCH ping-unikernel
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-libvirt-consumer:libvirt

--- a/tests/main/interfaces-network-control-ip-netns/task.yaml
+++ b/tests/main/interfaces-network-control-ip-netns/task.yaml
@@ -25,7 +25,7 @@ execute: |
     echo "Network namespace deleted from global is removed from snap"
     ip netns delete canary
     test ! -e /run/netns/canary
-    snapd-hacker-toolbelt.busybox sh -c '/bin/ip netns list' | MATCH -v canary
+    snapd-hacker-toolbelt.busybox sh -c '/bin/ip netns list' | not MATCH canary
 
     echo "Network namespace created from global exists in snap"
     ip netns add canary

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -110,7 +110,7 @@ execute: |
     network-control-consumer.cmd ip link set veth1 netns test-ns
 
     ip link list | MATCH "veth0"
-    ip link list | MATCH -v "veth1"
+    ip link list | not MATCH "veth1"
 
     echo "And a command can be executed in the context of the namespace"
     network-control-consumer.cmd ip netns exec test-ns ip link list | MATCH "veth1"

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -111,7 +111,7 @@ execute: |
     ensure_normal_perms() {
         if [ "$(snap debug confinement)" = strict ]; then
             test ! -e /var/lib/snapd/apparmor/snap-confine/nfs-support
-            MATCH -v 'network inet,' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh.with-home-plug
+            not MATCH 'network inet,' < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh.with-home-plug
         fi
     }
 

--- a/tests/main/non-home/task.yaml
+++ b/tests/main/non-home/task.yaml
@@ -28,4 +28,4 @@ execute: |
     echo "Ensure we get a useful error message"
     MATCH "Sorry, home directories outside of /home" < stderr.log
     # ensure no (useless) "Read-only file system..." error is shown to the user
-    MATCH -v "Read-only file system" < stderr.log
+    not MATCH "Read-only file system" < stderr.log

--- a/tests/main/op-install-failed-undone/task.yaml
+++ b/tests/main/op-install-failed-undone/task.yaml
@@ -29,7 +29,7 @@ execute: |
     fi
 
     echo "Then the snap isn't installed"
-    snap list | MATCH -v test-snapd-tools
+    not snap list test-snapd-tools
 
     echo "And the installation task is reported as an error"
     failed_task_id=$(snap changes | perl -ne 'print $1 if /(\d+) +Error.*?Install \"test-snapd-tools\" snap/')

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -67,7 +67,7 @@ execute: |
     snap list | MATCH -E "${GOOD_SNAP}.*?fake1"
 
     echo "But the bad snap did not get updated"
-    snap list | MATCH -E "${BAD_SNAP}"| MATCH -v "fake"
+    snap list | MATCH -E "${BAD_SNAP}"| not MATCH "fake"
 
     #shellcheck source=tests/lib/changes.sh
     . "$TESTSLIB"/changes.sh

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -54,7 +54,7 @@ execute: |
         # actual output:
         # Name           Version  Publisher  Notes  Summary
         # mjpg-streamer  2.0      ogra       -      UVC webcam streaming tool
-        snap find --section=photo-and-video vlc 2>&1 | MATCH -v vlc
+        snap find --section=photo-and-video vlc 2>&1 | not MATCH vlc
     fi
 
     # LP: 1740605

--- a/tests/main/security-device-cgroups-classic/task.yaml
+++ b/tests/main/security-device-cgroups-classic/task.yaml
@@ -33,7 +33,7 @@ execute: |
 
     # classic snaps don't use 'plugs', so just test the accesses after install
     echo "the classic snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-classic-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    "$SNAP_MOUNT_DIR"/bin/test-classic-cgroup.read-fb 2>&1 | not MATCH '(Permission denied|Operation not permitted)'
 
     echo "the classic snap can access other devices"
     test "$($SNAP_MOUNT_DIR/bin/test-classic-cgroup.read-kmsg)"

--- a/tests/main/security-device-cgroups-devmode/task.yaml
+++ b/tests/main/security-device-cgroups-devmode/task.yaml
@@ -37,16 +37,16 @@ execute: |
     snap connect test-devmode-cgroup:framebuffer
 
     echo "the devmode snap can access the framebuffer"
-    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | not MATCH '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test-devmode-cgroup.read-dev test1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev test1 | not MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
 
     echo "the devmode snap can access the framebuffer"
-    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | not MATCH '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
-    test-devmode-cgroup.read-dev test1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev test1 | not MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -40,7 +40,7 @@ execute: |
     snap connect test-devmode-cgroup:framebuffer
 
     echo "the jailmode snap can access the framebuffer"
-    test-devmode-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-devmode-cgroup.read-dev fb0 2>&1 | not MATCH '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
     test-devmode-cgroup.read-dev test1 2>&1 | MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -36,7 +36,7 @@ execute: |
     echo "And the device is not shown in the snap device list"
     # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
     if [ -e /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list ]; then
-        MATCH -v "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+        not MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
     fi
 
     echo "When a udev rule assigning the device to the snap is added"

--- a/tests/main/security-device-cgroups-strict/task.yaml
+++ b/tests/main/security-device-cgroups-strict/task.yaml
@@ -30,7 +30,7 @@ execute: |
     snap connect test-strict-cgroup:framebuffer
 
     echo "the strict snap can access the framebuffer"
-    test-strict-cgroup.read-dev fb0 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
+    test-strict-cgroup.read-dev fb0 2>&1 | not MATCH '(Permission denied|Operation not permitted)'
 
     echo "the strict snap cannot access other devices"
     test-strict-cgroup.read-dev mem 2>&1 | MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -87,7 +87,7 @@ execute: |
     echo "And the device is not shown in the snap device list"
     # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
     if [ -e /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list ]; then
-        MATCH -v "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+        not MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
     fi
 
     echo "When a udev rule assigning the device to the snap is added"
@@ -102,7 +102,7 @@ execute: |
     udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-tools_env"
 
     echo "And other devices are not shown as assigned to the snap"
-    udevadm info "$OTHER_UDEVADM_PATH" | MATCH -v "E: TAGS=.*snap_test-snapd-tools_env"
+    udevadm info "$OTHER_UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-tools_env"
 
     echo "When a snap command is called"
     test-snapd-tools.env
@@ -111,7 +111,7 @@ execute: |
     MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "And other devices are not shown in the snap device list"
-    MATCH -v "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    not MATCH "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "But existing nvidia devices are in the snap's device cgroup"
     MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
@@ -119,7 +119,7 @@ execute: |
     MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "But nonexisting nvidia devices are not"
-    MATCH -v "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    not MATCH "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "But the existing uhid device is in the snap's device cgroup"
     MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list

--- a/tests/main/snap-connections/task.yaml
+++ b/tests/main/snap-connections/task.yaml
@@ -51,8 +51,8 @@ execute: |
     # show connected only
     snap connections > connected.out
     MATCH 'content\[mylib\] +test-snapd-content-plug:shared-content-plug +test-snapd-content-slot:shared-content-slot +-' < connected.out
-    MATCH -v 'network-consumer' < connected.out
-    MATCH -v 'test-snapd-daemon-notify' < connected.out
+    not MATCH 'network-consumer' < connected.out
+    not MATCH 'test-snapd-daemon-notify' < connected.out
 
     # show all
     snap connections --all > all.out

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -31,7 +31,7 @@ execute: |
     snap remove "$SNAP_NAME"
 
     echo And is gone afterwards
-    snap list |MATCH -v "$SNAP_NAME"
+    not snap list "$SNAP_NAME"
 
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -69,4 +69,4 @@ execute: |
 
 
     execute_remote "sudo snap refresh"
-    execute_remote "sudo cat /var/log/syslog" | MATCH -v "hsearch_r failed for.* No such process"
+    execute_remote "sudo cat /var/log/syslog" | not MATCH "hsearch_r failed for.* No such process"

--- a/tests/nightly/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/nightly/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -71,7 +71,7 @@ execute: |
         exit 1
     fi
 
-    if ! snap list|MATCH -v ubuntu-core; then
+    if ! snap list ubuntu-core; then
         echo "ubuntu-core still installed, transition failed"
         exit 1
     fi

--- a/tests/nightly/interfaces-openvswitch/task.yaml
+++ b/tests/nightly/interfaces-openvswitch/task.yaml
@@ -65,11 +65,11 @@ execute: |
 
     echo "And the snap is able to delete a port"
     test-snapd-openvswitch-consumer.ovs-vsctl del-port br0 tap1
-    ovs-vsctl list-ports br0 | MATCH -v tap1
+    ovs-vsctl list-ports br0 | not MATCH tap1
 
     echo "And the snap is able to delete a bridge"
     test-snapd-openvswitch-consumer.ovs-vsctl del-br br0
-    ovs-vsctl list-br | MATCH -v br0
+    ovs-vsctl list-br | not MATCH br0
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0

--- a/tests/regression/lp-1641885/task.yaml
+++ b/tests/regression/lp-1641885/task.yaml
@@ -19,9 +19,9 @@ execute: |
     echo "Ensure that the snap is installed in jailmode"
     snap list | MATCH 'test-snapd-devmode.*jailmode'
     echo "Ensure that the apparmor profile doesn't use the complain mode"
-    grep attach_disconnected /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode | MATCH -v complain
+    grep attach_disconnected /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode | not MATCH complain
     echo "Ensure that the seccomp profile doesn't use the complain mode"
-    MATCH -v '@complain' < /var/lib/snapd/seccomp/bpf/snap.test-snapd-devmode.test-snapd-devmode.src
+    not MATCH '@complain' < /var/lib/snapd/seccomp/bpf/snap.test-snapd-devmode.test-snapd-devmode.src
 
 debug: |
     echo "Apparmor profile (first 30 lines)"

--- a/tests/regression/lp-1732555/task.yaml
+++ b/tests/regression/lp-1732555/task.yaml
@@ -15,5 +15,5 @@ execute: |
     echo "The snap was installed and can be used"
     test-snapd-unknown-interfaces -c true
     echo "The bogus plugs and slots are not added"
-    snap interfaces | MATCH -v bogus-plug
-    snap interfaces | MATCH -v bogus-slot
+    snap interfaces | not MATCH bogus-plug
+    snap interfaces | not MATCH bogus-slot

--- a/tests/regression/lp-1764977/task.yaml
+++ b/tests/regression/lp-1764977/task.yaml
@@ -26,5 +26,4 @@ execute: |
 
     mv test-snapd-sh/meta/snap.yaml.moved test-snapd-sh/meta/snap.yaml
     snap list # should still just work
-    snap list test-snapd-sh | MATCH -v broken
-
+    snap list test-snapd-sh | not MATCH broken

--- a/tests/regression/lp-1825883/task.yaml
+++ b/tests/regression/lp-1825883/task.yaml
@@ -21,7 +21,7 @@ execute: |
     #shellcheck disable=SC2016
     test-snapd-app.sh -c 'cat $SNAP/things/*/thing' | MATCH THING-B
     #shellcheck disable=SC2016
-    test-snapd-app.sh -c 'cat $SNAP/things/*/thing' | MATCH -v THING-C
+    test-snapd-app.sh -c 'cat $SNAP/things/*/thing' | not MATCH THING-C
 
     # Install the 2nd version of the content snap, it should also provide THING-C
     snap install --dangerous test-snapd-content_2_all.snap


### PR DESCRIPTION
MATCH is a wrapper around grep -E -q, thus MATCH -v ends up being grep -E -q -v.
However, grep -v is peculiar as far as exit codes are concerned, and returns 0
when lines not matching the pattern were found in the input.

For example, this command returns 1:

```
$ cat <<EOF | grep -E -v foo
foo
foo
foo
EOF
```

but this one returns 0,even though the pattern we don't want is part of the input:

```
cat <<EOF | grep -E -v foo; echo $?
foo
bar
baz
EOF
```

In the tests, MATCH -v is used to check that the pattern does not appear in the
input, which is incorrect.
