### PR TITLE
boot,overlord: introduce internal abstraction bootState and use it for InUse/GetCurrentBoot

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -164,6 +164,10 @@ func bootStateFor(typ snap.Type, dev Device) (s bootState, err error) {
 // InUse checks if the given name/revision is used in the
 // boot environment
 func InUse(name string, rev snap.Revision, dev Device) bool {
+	if dev.Classic() {
+		// no boot state on classic
+		return false
+	}
 	// TODO: consider passing the relevant snap type to InUse
 	// also consider returning errors and letting the caller decide
 	// what to do now that canRemove can return errors

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -40,7 +40,7 @@ type BootParticipant interface {
 	// (from the model assertion).
 	SetNextBoot() error
 	// ChangeRequiresReboot returns whether a reboot is required to switch
-	// to the snap.
+	// to the snap. TODO: return an error too
 	ChangeRequiresReboot() bool
 	// Is this a trivial implementation of the interface?
 	IsTrivial() bool
@@ -146,13 +146,13 @@ func InUse(name string, rev snap.Revision, dev Device) bool {
 	bootloader, err := bootloader.Find("", nil)
 	if err != nil {
 		logger.Noticef("cannot get boot settings: %s", err)
-		return false
+		return true
 	}
 
 	bootVars, err := bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_core", "snap_try_core")
 	if err != nil {
 		logger.Noticef("cannot get boot vars: %s", err)
-		return false
+		return true
 	}
 
 	snapFile := filepath.Base(snap.MountFile(name, rev))

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -177,7 +177,7 @@ type NameAndRevision struct {
 // GetCurrentBoot returns the currently set name and revision for boot for the given
 // type of snap, which can be snap.TypeBase (or snap.TypeOS), or snap.TypeKernel.
 // Returns ErrBootNameAndRevisionNotReady if the values are temporarily not established.
-func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
+func GetCurrentBoot(t snap.Type, dev Device) (*NameAndRevision, error) {
 	var bootVar, errName string
 	switch t {
 	case snap.TypeKernel:

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -138,7 +138,11 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 
 // InUse checks if the given name/revision is used in the
 // boot environment
-func InUse(name string, rev snap.Revision) bool {
+func InUse(name string, rev snap.Revision, dev Device) bool {
+	if !dev.RunMode() {
+		// TODO:UC20: for now everything is in use in ephemeral mode
+		return true
+	}
 	bootloader, err := bootloader.Find("", nil)
 	if err != nil {
 		logger.Noticef("cannot get boot settings: %s", err)

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -138,6 +138,10 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 
 // bootState exposes the boot state for a type of boot snap.
 type bootState interface {
+	// revisions retrieves the revisions for the current snap
+	// revision (which always be set) and the try snap revision
+	// (which might be not set). it also returns whether the snap
+	// is in "trying" status.
 	revisions() (snap, try_snap *NameAndRevision, trying bool, err error)
 }
 
@@ -160,6 +164,9 @@ func bootStateFor(typ snap.Type, dev Device) (s bootState, err error) {
 // InUse checks if the given name/revision is used in the
 // boot environment
 func InUse(name string, rev snap.Revision, dev Device) bool {
+	// TODO: consider passing the relevant snap type to InUse
+	// also consider returning errors and letting the caller decide
+	// what to do now that canRemove can return errors
 	cands := make([]*NameAndRevision, 0, 4)
 	for _, t := range []snap.Type{snap.TypeBase, snap.TypeKernel} {
 		s, err := bootStateFor(t, dev)
@@ -200,38 +207,21 @@ type NameAndRevision struct {
 // type of snap, which can be snap.TypeBase (or snap.TypeOS), or snap.TypeKernel.
 // Returns ErrBootNameAndRevisionNotReady if the values are temporarily not established.
 func GetCurrentBoot(t snap.Type, dev Device) (*NameAndRevision, error) {
-	var bootVar, errName string
-	switch t {
-	case snap.TypeKernel:
-		bootVar = "snap_kernel"
-		errName = "kernel"
-	case snap.TypeOS, snap.TypeBase:
-		bootVar = "snap_core"
-		errName = "base"
-	default:
-		return nil, fmt.Errorf("internal error: cannot find boot revision for snap type %q", t)
-	}
-
-	bloader, err := bootloader.Find("", nil)
+	s, err := bootStateFor(t, dev)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get boot settings: %s", err)
+		return nil, err
 	}
 
-	m, err := bloader.GetBootVars(bootVar, "snap_mode")
+	snap, _, trying, err := s.revisions()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get boot variables: %s", err)
+		return nil, err
 	}
 
-	if m["snap_mode"] == "trying" {
+	if trying {
 		return nil, ErrBootNameAndRevisionNotReady
 	}
 
-	nameAndRevno, err := nameAndRevnoFromSnap(m[bootVar])
-	if err != nil {
-		return nil, fmt.Errorf("cannot get name and revision of boot %s: %v", errName, err)
-	}
-
-	return nameAndRevno, nil
+	return snap, nil
 }
 
 // nameAndRevnoFromSnap grabs the snap name and revision from the

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -153,13 +153,13 @@ func (s *bootSetSuite) TestInUseUnhapy(c *C) {
 
 	// make GetVars fail
 	s.bootloader.GetErr = errors.New("zap")
-	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, false)
+	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, true)
 	c.Check(logbuf.String(), testutil.Contains, "cannot get boot vars: zap")
 	s.bootloader.GetErr = nil
 
 	// make bootloader.Find fail
 	bootloader.ForceError(errors.New("broken bootloader"))
-	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, false)
+	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, true)
 	c.Check(logbuf.String(), testutil.Contains, "cannot get boot settings: broken bootloader")
 }
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -141,7 +141,7 @@ func (s *bootSetSuite) TestInUseEphemeral(c *C) {
 	c.Check(boot.InUse("whatever", snap.R(0), coreDev), Equals, true)
 }
 
-func (s *bootSetSuite) TestInUseUnhapy(c *C) {
+func (s *bootSetSuite) TestInUseUnhappy(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	logbuf, restore := logger.MockLogger()
@@ -154,7 +154,7 @@ func (s *bootSetSuite) TestInUseUnhapy(c *C) {
 	// make GetVars fail
 	s.bootloader.GetErr = errors.New("zap")
 	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, true)
-	c.Check(logbuf.String(), testutil.Contains, "cannot get boot vars: zap")
+	c.Check(logbuf.String(), testutil.Contains, "cannot get boot variables: zap")
 	s.bootloader.GetErr = nil
 
 	// make bootloader.Find fail

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -188,16 +188,16 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevisionUnhappy(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	_, err := boot.GetCurrentBoot(snap.TypeKernel, coreDev)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot kernel: boot variable unset")
+	c.Check(err, ErrorMatches, `cannot get name and revision of kernel \(snap_kernel\): boot variable unset`)
 
 	_, err = boot.GetCurrentBoot(snap.TypeOS, coreDev)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: boot variable unset")
+	c.Check(err, ErrorMatches, `cannot get name and revision of boot base \(snap_core\): boot variable unset`)
 
 	_, err = boot.GetCurrentBoot(snap.TypeBase, coreDev)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: boot variable unset")
+	c.Check(err, ErrorMatches, `cannot get name and revision of boot base \(snap_core\): boot variable unset`)
 
 	_, err = boot.GetCurrentBoot(snap.TypeApp, coreDev)
-	c.Check(err, ErrorMatches, "internal error: cannot find boot revision for snap type \"app\"")
+	c.Check(err, ErrorMatches, `internal error: no boot state handling for snap type "app"`)
 
 	// sanity check
 	s.bootloader.BootVars["snap_kernel"] = "kernel_41.snap"

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -181,7 +181,10 @@ func (s *bootState16) revisions() (snap, try_snap *NameAndRevision, trying bool,
 
 	for _, vName := range vars {
 		v := m[vName]
-		if v == "" {
+		if v == "" && vName != snapVar {
+			// snap_mode & snap_try_<type> can be empty
+			// snap_<type> cannot be! and will fail parsing
+			// below
 			continue
 		}
 

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -142,3 +142,59 @@ func (k *coreKernel) ExtractKernelAssets(snapf snap.Container) error {
 	// ask bootloader to extract the kernel assets if needed
 	return bootloader.ExtractKernelAssets(k.s, snapf)
 }
+
+type bootState16 struct {
+	varSuffix string
+	errName   string
+}
+
+func newBootState16(typ snap.Type) *bootState16 {
+	var varSuffix, errName string
+	switch typ {
+	case snap.TypeKernel:
+		varSuffix = "kernel"
+		errName = "kernel"
+	case snap.TypeBase:
+		varSuffix = "core"
+		errName = "boot base"
+	default:
+		panic(fmt.Sprintf("cannot make a bootState16 for snap type %q", typ))
+	}
+	return &bootState16{varSuffix: varSuffix, errName: errName}
+}
+
+func (s *bootState16) revisions() (snap, try_snap *NameAndRevision, trying bool, err error) {
+	bloader, err := bootloader.Find("", nil)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("cannot get boot settings: %s", err)
+	}
+
+	snapVar := "snap_" + s.varSuffix
+	trySnapVar := "snap_try_" + s.varSuffix
+	vars := []string{"snap_mode", snapVar, trySnapVar}
+	snaps := make(map[string]*NameAndRevision, 2)
+
+	m, err := bloader.GetBootVars(vars...)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("cannot get boot variables: %s", err)
+	}
+
+	for _, vName := range vars {
+		v := m[vName]
+		if v == "" {
+			continue
+		}
+
+		if vName == "snap_mode" {
+			trying = v == "trying"
+		} else {
+			nameAndRevno, err := nameAndRevnoFromSnap(v)
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("cannot get name and revision of %s (%s): %v", s.errName, vName, err)
+			}
+			snaps[vName] = nameAndRevno
+		}
+	}
+
+	return snaps[snapVar], snaps[trySnapVar], trying, nil
+}

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -53,11 +53,19 @@ func UpdateBootRevisions(st *state.State) error {
 		return nil
 	}
 
-	kernel, err := boot.GetCurrentBoot(snap.TypeKernel)
+	deviceCtx, err := DeviceCtx(st, nil, nil)
+	if err != nil {
+		if err == state.ErrNoState {
+			// too early anyway, no model
+			return nil
+		}
+	}
+
+	kernel, err := boot.GetCurrentBoot(snap.TypeKernel, deviceCtx)
 	if err != nil {
 		return fmt.Errorf(errorPrefix+"%s", err)
 	}
-	base, err := boot.GetCurrentBoot(snap.TypeBase)
+	base, err := boot.GetCurrentBoot(snap.TypeBase, deviceCtx)
 	if err != nil {
 		return fmt.Errorf(errorPrefix+"%s", err)
 	}

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -2,6 +2,7 @@ package snapstate
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -13,11 +14,20 @@ import (
 type Policy interface {
 	// CanRemove verifies that a snap can be removed.
 	// If rev is not unset, check for removing only that revision.
-	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision) error
+	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision, dev boot.Device) error
 }
 
 var PolicyFor func(snap.Type, *asserts.Model) Policy = policyForUnset
 
 func policyForUnset(snap.Type, *asserts.Model) Policy {
 	panic("PolicyFor unset!")
+}
+
+func inUse(dev boot.Device) func(snapName string, rev snap.Revision) bool {
+	if dev == nil {
+		return nil
+	}
+	return func(snapName string, rev snap.Revision) bool {
+		return boot.InUse(snapName, rev, dev)
+	}
 }

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -23,11 +23,19 @@ func policyForUnset(snap.Type, *asserts.Model) Policy {
 	panic("PolicyFor unset!")
 }
 
-func inUse(dev boot.Device) func(snapName string, rev snap.Revision) bool {
+func inUse(typ snap.Type, dev boot.Device) func(snapName string, rev snap.Revision) bool {
+	// TODO: move this kind of logic under policy
 	if dev == nil {
 		return nil
 	}
-	return func(snapName string, rev snap.Revision) bool {
-		return boot.InUse(snapName, rev, dev)
+	switch typ {
+	case snap.TypeBase, snap.TypeOS, snap.TypeKernel:
+		return func(snapName string, rev snap.Revision) bool {
+			return boot.InUse(snapName, rev, dev)
+		}
+	default:
+		return func(string, snap.Revision) bool {
+			return false
+		}
 	}
 }

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -32,7 +32,7 @@ type basePolicy struct {
 	modelBase string
 }
 
-func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
@@ -43,7 +43,7 @@ func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev) {
+			if boot.InUse(name, rev, dev) {
 				return errInUseForBoot
 			}
 			return nil

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -39,6 +39,10 @@ func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev
 		return errNoName
 	}
 
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if p.modelBase == name {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -31,6 +31,8 @@ func (s *canRemoveSuite) SetUpTest(c *check.C) {
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.bootloader)
+	s.bootloader.SetBootBase("base_99.snap")
+	s.bootloader.SetBootKernel("kernel_99.snap")
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 }
 

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -33,6 +33,8 @@ var (
 
 	errSnapdNotRemovableOnCore       = errors.New("snapd required on core devices")
 	errSnapdNotYetRemovableOnClassic = errors.New("remove all other snaps first")
+
+	errEphemeralSnapsNotRemovalable = errors.New("no snaps are removable in any of the ephemeral modes")
 )
 
 type inUseByErr []string

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -15,6 +15,8 @@ var (
 
 	ErrSnapdNotRemovableOnCore       = errSnapdNotRemovableOnCore
 	ErrSnapdNotYetRemovableOnClassic = errSnapdNotYetRemovableOnClassic
+
+	ErrEphemeralSnapsNotRemovalable = errEphemeralSnapsNotRemovalable
 )
 
 func InUseByErr(snaps ...string) error {

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -20,6 +20,7 @@
 package policy
 
 import (
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -29,7 +30,7 @@ type gadgetPolicy struct {
 	modelGadget string
 }
 
-func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -30,11 +30,15 @@ type gadgetPolicy struct {
 	modelGadget string
 }
 
-func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
+func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
 		return errNoName
+	}
+
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
 	}
 
 	if p.modelGadget != name {

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -37,6 +37,10 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, re
 		return errNoName
 	}
 
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if p.modelKernel == name {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -30,7 +30,7 @@ type kernelPolicy struct {
 	modelKernel string
 }
 
-func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
@@ -41,7 +41,7 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, re
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev) {
+			if boot.InUse(name, rev, dev) {
 				return errInUseForBoot
 			}
 			return nil

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -30,7 +30,7 @@ type osPolicy struct {
 	modelBase string
 }
 
-func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
@@ -45,7 +45,7 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev) {
+			if boot.InUse(name, rev, dev) {
 				return errInUseForBoot
 			}
 			return nil

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -37,6 +37,10 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return errNoName
 	}
 
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if name == "ubuntu-core" {
 		return nil
 	}

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -49,9 +49,17 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 	}
 }
 
+func ephemeral(dev boot.Device) bool {
+	return !dev.RunMode()
+}
+
 type appPolicy struct{}
 
-func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if !rev.Unset() {
 		return nil
 	}

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -22,6 +22,7 @@ package policy
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -50,7 +51,7 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 
 type appPolicy struct{}
 
-func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
 	if !rev.Unset() {
 		return nil
 	}

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -20,6 +20,7 @@
 package policy
 
 import (
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -29,7 +30,7 @@ type snapdPolicy struct {
 	onClassic bool
 }
 
-func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -30,11 +30,15 @@ type snapdPolicy struct {
 	onClassic bool
 }
 
-func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
+func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
 		return errNoName
+	}
+
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
 	}
 
 	if !rev.Unset() {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -89,7 +89,7 @@ func optedIntoSnapdSnap(st *state.State) (bool, error) {
 	return experimentalAllowSnapd, nil
 }
 
-func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int, fromChange string) (*state.TaskSet, error) {
+func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int, fromChange string, inUse func(snapName string, revision snap.Revision) bool) (*state.TaskSet, error) {
 	// NB: we should strive not to need or propagate deviceCtx
 	// here, the resulting effects/changes were not pleasant at
 	// one point
@@ -104,6 +104,11 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	}
 	if snapst.IsInstalled() && !snapst.Active {
 		return nil, fmt.Errorf("cannot update disabled snap %q", snapsup.InstanceName())
+	}
+	if snapst.IsInstalled() && !snapsup.Flags.Revert {
+		if inUse == nil {
+			return nil, fmt.Errorf("internal error: doInstall: inUse not provided for refresh")
+		}
 	}
 
 	if snapsup.Flags.Classic {
@@ -321,7 +326,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		// normal garbage collect
 		for i := 0; i <= currentIndex-retain; i++ {
 			si := seq[i]
-			if boot.InUse(snapsup.InstanceName(), si.Revision) {
+			if inUse(snapsup.InstanceName(), si.Revision) {
 				continue
 			}
 			ts := removeInactiveRevision(st, snapsup.InstanceName(), si.SnapID, si.Revision)
@@ -668,7 +673,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		InstanceKey: info.InstanceKey,
 	}
 
-	ts, err := doInstall(st, &snapst, snapsup, instFlags, "")
+	ts, err := doInstall(st, &snapst, snapsup, instFlags, "", inUse(deviceCtx))
 	return ts, info, err
 }
 
@@ -760,7 +765,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		CohortKey: opts.CohortKey,
 	}
 
-	return doInstall(st, &snapst, snapsup, 0, fromChange)
+	return doInstall(st, &snapst, snapsup, 0, fromChange, nil)
 }
 
 // InstallMany installs everything from the given list of names.
@@ -822,7 +827,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			InstanceKey:  info.InstanceKey,
 		}
 
-		ts, err := doInstall(st, &snapst, snapsup, 0, "")
+		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUse(deviceCtx))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1020,7 +1025,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			},
 		}
 
-		ts, err := doInstall(st, snapst, snapsup, 0, fromChange)
+		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUse(deviceCtx))
 		if err != nil {
 			if refreshAll {
 				// doing "refresh all", just skip this snap
@@ -1740,16 +1745,13 @@ func canDisable(si *snap.Info) bool {
 }
 
 // canRemove verifies that a snap can be removed.
-//
-// TODO: canRemove should also return the reason why the snap cannot
-//       be removed to the user
 func canRemove(st *state.State, si *snap.Info, snapst *SnapState, removeAll bool, deviceCtx DeviceContext) error {
 	rev := snap.Revision{}
 	if !removeAll {
 		rev = si.Revision
 	}
 
-	return PolicyFor(si.GetType(), deviceCtx.Model()).CanRemove(st, snapst, rev)
+	return PolicyFor(si.GetType(), deviceCtx.Model()).CanRemove(st, snapst, rev, deviceCtx)
 }
 
 // RemoveFlags are used to pass additional flags to the Remove operation.
@@ -2017,7 +2019,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
-	return doInstall(st, &snapst, snapsup, 0, "")
+	return doInstall(st, &snapst, snapsup, 0, "", nil)
 }
 
 // TransitionCore transitions from an old core snap name to a new core
@@ -2058,7 +2060,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 			DownloadInfo: &newInfo.DownloadInfo,
 			SideInfo:     &newInfo.SideInfo,
 			Type:         newInfo.GetType(),
-		}, 0, "")
+		}, 0, "", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -448,10 +448,11 @@ func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 		// otherwise this could be just a spurious restart
 		// of snapd
 
-		model, err := ModelFromTask(task)
+		deviceCtx, err := DeviceCtx(task.State(), task, nil)
 		if err != nil {
 			return err
 		}
+		model := deviceCtx.Model()
 
 		// get the name of the name relevant for booting
 		// based on the given type
@@ -477,7 +478,7 @@ func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 		// actually booted. The bootloader may revert on a failed
 		// boot from a bad os/base/kernel to a good one and in this
 		// case we need to catch this and error accordingly
-		current, err := boot.GetCurrentBoot(snapsup.Type)
+		current, err := boot.GetCurrentBoot(snapsup.Type, deviceCtx)
 		if err == boot.ErrBootNameAndRevisionNotReady {
 			return &state.Retry{After: 5 * time.Second}
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -674,7 +674,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		InstanceKey: info.InstanceKey,
 	}
 
-	ts, err := doInstall(st, &snapst, snapsup, instFlags, "", inUse(deviceCtx))
+	ts, err := doInstall(st, &snapst, snapsup, instFlags, "", inUse(snapsup.Type, deviceCtx))
 	return ts, info, err
 }
 
@@ -828,7 +828,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			InstanceKey:  info.InstanceKey,
 		}
 
-		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUse(deviceCtx))
+		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUse(snapsup.Type, deviceCtx))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1026,7 +1026,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			},
 		}
 
-		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUse(deviceCtx))
+		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUse(snapsup.Type, deviceCtx))
 		if err != nil {
 			if refreshAll {
 				// doing "refresh all", just skip this snap

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -915,9 +915,13 @@ func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 		SnapType:        "app",
 	}
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
+}
+
+func dummyInUse(snapName string, rev snap.Revision) bool {
+	return false
 }
 
 func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
@@ -964,7 +968,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	}
 
 	// And observe that we cannot refresh because the snap is busy.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUse)
 	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\)`)
 
 	// The state records the time of the failed refresh operation.
@@ -1018,7 +1022,7 @@ func (s snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	}
 
 	// And observe that refresh occurred regardless of the running process.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUse)
 	c.Assert(err, IsNil)
 }
 
@@ -1027,7 +1031,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
 	defer s.state.Unlock()
 
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
-	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0, "", nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot install reserved snap name 'system'`)
 }


### PR DESCRIPTION
The idea is for UC 20 bootStateFor will return different implementations for kernel vs base.