### PR TITLE
boot: always return the trivial boot participant in ephemeral mode

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -112,6 +112,12 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 	if dev.Classic() {
 		return false
 	}
+	// In ephemeral modes we never need to care about updating the boot
+	// config. This will be done via boot.MakeBootable().
+	if !dev.RunMode() {
+		return false
+	}
+
 	if t != snap.TypeOS && t != snap.TypeKernel && t != snap.TypeBase {
 		// note we don't currently have anything useful to do with gadgets
 		return false

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -228,6 +228,7 @@ func (s *bootSetSuite) TestParticipant(c *C) {
 		c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(info, typ))
 	}
 }
+
 func (s *bootSetSuite) TestParticipantBaseWithModel(c *C) {
 	core := &snap.Info{SideInfo: snap.SideInfo{RealName: "core"}, SnapType: snap.TypeOS}
 	core18 := &snap.Info{SideInfo: snap.SideInfo{RealName: "core18"}, SnapType: snap.TypeBase}
@@ -267,6 +268,16 @@ func (s *bootSetSuite) TestParticipantBaseWithModel(c *C) {
 			model: "core18",
 			nop:   false,
 		},
+		{
+			with:  core18,
+			model: "core18@install",
+			nop:   true,
+		},
+		{
+			with:  core,
+			model: "core@install",
+			nop:   true,
+		},
 	}
 
 	for i, t := range table {
@@ -300,6 +311,10 @@ func (s *bootSetSuite) TestKernelWithModel(c *C) {
 			krn:   expected,
 		}, {
 			model: "",
+			nop:   true,
+			krn:   boot.Trivial{},
+		}, {
+			model: "kernel@install",
 			nop:   true,
 			krn:   boot.Trivial{},
 		},


### PR DESCRIPTION
The boot participant is only relevant in "run" mode. This commit
changes the code to always return the trivial boot participant
when in ephemeral mode.

