### PR TITLE
run-checks: complain about MATCH -v

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -250,6 +250,15 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
+    echo "Checking for potentially incorrect use of MATCH -v"
+    badMATCH=$(find tests -name 'task.yaml' -print0 -o -name 'spread.yaml' -print0 | \
+                       xargs -0 grep -R -n -E 'MATCH +-v' || true)
+    if [ -n "$badMATCH" ]; then
+        echo "Potentially incorrect use of MATCH -v at the following locations:"
+        echo "$badMATCH"
+        exit 1
+    fi
+
     # FIXME: re-add staticcheck with a matching version for the used go-version
 fi
 

--- a/tests/main/snap-set-core-config/task.yaml
+++ b/tests/main/snap-set-core-config/task.yaml
@@ -4,7 +4,11 @@ summary: Ensure "snap set core" works
 systems: [ubuntu-core-*]
 
 prepare: |
-    if systemctl -l | MATCH -v rsyslog.service; then
+    rc=0
+    systemctl status rsyslog.service || rc=$?
+    if [ $rc = 4 ]; then
+        # systemctl(1) exit code 4: no such unit
+
         #shellcheck source=tests/lib/systemd.sh
         . "$TESTSLIB"/systemd.sh
 


### PR DESCRIPTION
MATCH -v with multiline input can produce incorrect results and can be replaced
with more correct alternatives (eg. `not MATCH` , or `! MATCH`). Complain when
MATCH -v is found in the spread test code.
