### PR TITLE
boot: write compat UC16 bootvars in makeBootable20RunMode

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -601,6 +601,7 @@ func (s *bootSetSuite) TestMakeBootable20RunMode(c *C) {
 	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
+	c.Assert(err, IsNil)
 
 	baseFn, baseInfo := s.makeSnap(c, "core20", `name: core20
 type: base

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -563,11 +563,29 @@ func (s *bootSetSuite) TestMakeBootable20MultipleRecoverySystemsError(c *C) {
 
 func (s *bootSetSuite) TestMakeBootable20RunMode(c *C) {
 	dirs.SetRootDir("")
+	bootloader.Force(nil)
 
 	model := makeMockUC20Model()
 	rootdir := c.MkDir()
 	seedSnapsDirs := filepath.Join(rootdir, "/snaps")
 	err := os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	// grub on ubuntu-seed
+	runMnt := filepath.Join(rootdir, "/run/mnt/")
+	mockSeedGrubDir := filepath.Join(runMnt, "ubuntu-seed", "EFI", "ubuntu")
+	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
+	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockSeedGrubCfg, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// grub on ubuntu-boot
+	mockBootGrubDir := filepath.Join(runMnt, "ubuntu-boot", "EFI", "ubuntu")
+	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
+	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
@@ -581,9 +599,17 @@ func (s *bootSetSuite) TestMakeBootable20RunMode(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure the bootvars got updated the right way
-	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
-		"snapd_recovery_mode": "run",
-	})
+	mockSeedGrubenv := filepath.Join(mockSeedGrubDir, "grubenv")
+	c.Check(mockSeedGrubenv, testutil.FilePresent)
+	c.Check(mockSeedGrubenv, testutil.FileContains, "snapd_recovery_mode=run")
+	// TODO:UC20: update once we write the static UC20 kernels and stop
+	// using the UC16 bootmode
+	mockBootGrubenv := filepath.Join(mockBootGrubDir, "grubenv")
+	c.Check(mockBootGrubenv, testutil.FilePresent)
+	c.Check(mockBootGrubenv, testutil.FileContains, "snap_kernel=pc-kernel_456.snap")
+	c.Check(mockBootGrubenv, testutil.FileContains, "snap_core=core20_123.snap")
+
+	// ensure modeenv looks correct
 	ubuntuDataModeEnvPath := filepath.Join(rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
 recovery_system=20191216


### PR DESCRIPTION
This commit writes the old UC16 boot environment variables. With
that we can seed correctly in run mode. This is just a step on
the way to the full UC20 boot where we need to use a static
filename for the "good" kernel and the "try" kernel. But it
unblocks seeding and allows us to move forward with writing
end-to-end tests.

This is cheating a bit but we will get rid of this cheat as soon as we can.
