### PR TITLE
devicestate: request reboot after successful doSetupRunSystem()

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -115,6 +115,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeCreatesChangeHappy(c *C) {
 	c.Check(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
 		{"snap-bootstrap", "create-partitions", "--mount", filepath.Join(dirs.SnapMountDir, "/pc/1")},
 	})
+
+	c.Check(s.restartRequests, DeepEquals, []state.RestartType{state.RestartSystem})
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
@@ -137,6 +139,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	createPartitions := s.findInstallSystem()
 	c.Check(createPartitions.Err(), ErrorMatches, `(?ms)cannot perform the following tasks:
 - Setup system for run mode \(cannot create partitions: The horror, The horror\)`)
+	// no restart request on failure
+	c.Check(s.restartRequests, HasLen, 0)
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallModeNotInstallmodeNoChg(c *C) {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -87,7 +87,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot make run system bootable: %v", err)
 	}
 
-	// request a restart as the last action after a successful installc
+	// request a restart as the last action after a successful install
 	st.RequestRestart(state.RestartSystem)
 
 	return nil

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -63,5 +63,8 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	// XXX: update recovery mode in grubenv
 	// XXX2: write correct modeenv
 
+	// request a restart as the last action after a successful installc
+	st.RequestRestart(state.RestartSystem)
+
 	return nil
 }


### PR DESCRIPTION
After the system was succesfully installed from the recover
mode we need to reboot. This commit adds a reboot request at
the end of the install and the coresponding tests.

