### PR TITLE
boot,overlord: introduce internal abstraction bootState and use it for InUse/GetCurrentBoot

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -184,7 +184,7 @@ type NameAndRevision struct {
 // GetCurrentBoot returns the currently set name and revision for boot for the given
 // type of snap, which can be snap.TypeBase (or snap.TypeOS), or snap.TypeKernel.
 // Returns ErrBootNameAndRevisionNotReady if the values are temporarily not established.
-func GetCurrentBoot(t snap.Type) (*NameAndRevision, error) {
+func GetCurrentBoot(t snap.Type, dev Device) (*NameAndRevision, error) {
 	var bootVar, errName string
 	switch t {
 	case snap.TypeKernel:

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -144,10 +144,9 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 
 // bootState exposes the boot state for a type of boot snap.
 type bootState interface {
-	// revisions retrieves the revisions for the current snap
-	// revision (which always be set) and the try snap revision
-	// (which might be not set). it also returns whether the snap
-	// is in "trying" status.
+	// revisions retrieves the revisions of the current snap and
+	// the try snap (only the latter might not be set), and
+	// whether the snap is in "trying" state.
 	revisions() (snap, try_snap *NameAndRevision, trying bool, err error)
 }
 

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -143,32 +143,54 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 	return true
 }
 
+// bootState exposes the boot state for a type of boot snap.
+type bootState interface {
+	revisions() (snap, try_snap *NameAndRevision, trying bool, err error)
+}
+
+// bootStateFor finds the right bootState implementation of the given
+// snap type and Device, if applicable.
+func bootStateFor(typ snap.Type, dev Device) (s bootState, err error) {
+	if !dev.RunMode() {
+		return nil, fmt.Errorf("internal error: no boot state handling for ephemeral modes")
+	}
+	switch typ {
+	case snap.TypeOS, snap.TypeBase:
+		return newBootState16(snap.TypeBase), nil
+	case snap.TypeKernel:
+		return newBootState16(snap.TypeKernel), nil
+	default:
+		return nil, fmt.Errorf("internal error: no boot state handling for snap type %q", typ)
+	}
+}
+
 // InUse checks if the given name/revision is used in the
 // boot environment
 func InUse(name string, rev snap.Revision, dev Device) bool {
-	if !dev.RunMode() {
-		// TODO:UC20: for now everything is in use in ephemeral mode
-		return true
-	}
-	bootloader, err := bootloader.Find("", nil)
-	if err != nil {
-		logger.Noticef("cannot get boot settings: %s", err)
-		return true
+	cands := make([]*NameAndRevision, 0, 4)
+	for _, t := range []snap.Type{snap.TypeBase, snap.TypeKernel} {
+		s, err := bootStateFor(t, dev)
+		if err != nil {
+			// be pessimistic
+			return true
+		}
+		snap, try_snap, _, err := s.revisions()
+		if err != nil {
+			logger.Noticef("cannot get boot settings: %s", err)
+			return true
+		}
+		cands = append(cands, snap)
+		cands = append(cands, try_snap)
 	}
 
-	bootVars, err := bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_core", "snap_try_core")
-	if err != nil {
-		logger.Noticef("cannot get boot vars: %s", err)
-		return true
-	}
-
-	snapFile := filepath.Base(snap.MountFile(name, rev))
-	for _, bootVar := range bootVars {
-		if bootVar == snapFile {
+	for _, cand := range cands {
+		if cand == nil {
+			continue
+		}
+		if cand.Name == name && cand.Revision == rev {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -171,6 +171,10 @@ func bootStateFor(typ snap.Type, dev Device) (s bootState, err error) {
 // InUse checks if the given name/revision is used in the
 // boot environment
 func InUse(name string, rev snap.Revision, dev Device) bool {
+	if dev.Classic() {
+		// no boot state on classic
+		return false
+	}
 	// TODO: consider passing the relevant snap type to InUse
 	// also consider returning errors and letting the caller decide
 	// what to do now that canRemove can return errors

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -145,7 +145,11 @@ func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
 
 // InUse checks if the given name/revision is used in the
 // boot environment
-func InUse(name string, rev snap.Revision) bool {
+func InUse(name string, rev snap.Revision, dev Device) bool {
+	if !dev.RunMode() {
+		// TODO:UC20: for now everything is in use in ephemeral mode
+		return true
+	}
 	bootloader, err := bootloader.Find("", nil)
 	if err != nil {
 		logger.Noticef("cannot get boot settings: %s", err)

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -41,7 +41,7 @@ type BootParticipant interface {
 	// (from the model assertion).
 	SetNextBoot() error
 	// ChangeRequiresReboot returns whether a reboot is required to switch
-	// to the snap.
+	// to the snap. TODO: return an error too
 	ChangeRequiresReboot() bool
 	// Is this a trivial implementation of the interface?
 	IsTrivial() bool
@@ -153,13 +153,13 @@ func InUse(name string, rev snap.Revision, dev Device) bool {
 	bootloader, err := bootloader.Find("", nil)
 	if err != nil {
 		logger.Noticef("cannot get boot settings: %s", err)
-		return false
+		return true
 	}
 
 	bootVars, err := bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_core", "snap_try_core")
 	if err != nil {
 		logger.Noticef("cannot get boot vars: %s", err)
-		return false
+		return true
 	}
 
 	snapFile := filepath.Base(snap.MountFile(name, rev))

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -153,13 +153,13 @@ func (s *bootSetSuite) TestInUseUnhapy(c *C) {
 
 	// make GetVars fail
 	s.bootloader.GetErr = errors.New("zap")
-	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, false)
+	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, true)
 	c.Check(logbuf.String(), testutil.Contains, "cannot get boot vars: zap")
 	s.bootloader.GetErr = nil
 
 	// make bootloader.Find fail
 	bootloader.ForceError(errors.New("broken bootloader"))
-	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, false)
+	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, true)
 	c.Check(logbuf.String(), testutil.Contains, "cannot get boot settings: broken bootloader")
 }
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -141,7 +141,7 @@ func (s *bootSetSuite) TestInUseEphemeral(c *C) {
 	c.Check(boot.InUse("whatever", snap.R(0), coreDev), Equals, true)
 }
 
-func (s *bootSetSuite) TestInUseUnhapy(c *C) {
+func (s *bootSetSuite) TestInUseUnhappy(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	logbuf, restore := logger.MockLogger()
@@ -154,7 +154,7 @@ func (s *bootSetSuite) TestInUseUnhapy(c *C) {
 	// make GetVars fail
 	s.bootloader.GetErr = errors.New("zap")
 	c.Check(boot.InUse("kernel", snap.R(41), coreDev), Equals, true)
-	c.Check(logbuf.String(), testutil.Contains, "cannot get boot vars: zap")
+	c.Check(logbuf.String(), testutil.Contains, "cannot get boot variables: zap")
 	s.bootloader.GetErr = nil
 
 	// make bootloader.Find fail

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -107,6 +107,16 @@ func BenchmarkNameAndRevno(b *testing.B) {
 	}
 }
 
+func (s *bootSetSuite) TestInUseClassic(c *C) {
+	classicDev := boottest.MockDevice("")
+
+	// make bootloader.Find fail but shouldn't matter
+	bootloader.ForceError(errors.New("broken bootloader"))
+
+	c.Check(boot.InUse("core18", snap.R(41), classicDev), Equals, false)
+
+}
+
 func (s *bootSetSuite) TestInUse(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -188,16 +188,16 @@ func (s *bootSetSuite) TestCurrentBootNameAndRevisionUnhappy(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	_, err := boot.GetCurrentBoot(snap.TypeKernel, coreDev)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot kernel: boot variable unset")
+	c.Check(err, ErrorMatches, `cannot get name and revision of kernel \(snap_kernel\): boot variable unset`)
 
 	_, err = boot.GetCurrentBoot(snap.TypeOS, coreDev)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: boot variable unset")
+	c.Check(err, ErrorMatches, `cannot get name and revision of boot base \(snap_core\): boot variable unset`)
 
 	_, err = boot.GetCurrentBoot(snap.TypeBase, coreDev)
-	c.Check(err, ErrorMatches, "cannot get name and revision of boot base: boot variable unset")
+	c.Check(err, ErrorMatches, `cannot get name and revision of boot base \(snap_core\): boot variable unset`)
 
 	_, err = boot.GetCurrentBoot(snap.TypeApp, coreDev)
-	c.Check(err, ErrorMatches, "internal error: cannot find boot revision for snap type \"app\"")
+	c.Check(err, ErrorMatches, `internal error: no boot state handling for snap type "app"`)
 
 	// sanity check
 	s.bootloader.BootVars["snap_kernel"] = "kernel_41.snap"

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -181,7 +181,10 @@ func (s *bootState16) revisions() (snap, try_snap *NameAndRevision, trying bool,
 
 	for _, vName := range vars {
 		v := m[vName]
-		if v == "" {
+		if v == "" && vName != snapVar {
+			// snap_mode & snap_try_<type> can be empty
+			// snap_<type> cannot be! and will fail parsing
+			// below
 			continue
 		}
 

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -142,3 +142,59 @@ func (k *coreKernel) ExtractKernelAssets(snapf snap.Container) error {
 	// ask bootloader to extract the kernel assets if needed
 	return bootloader.ExtractKernelAssets(k.s, snapf)
 }
+
+type bootState16 struct {
+	varSuffix string
+	errName   string
+}
+
+func newBootState16(typ snap.Type) *bootState16 {
+	var varSuffix, errName string
+	switch typ {
+	case snap.TypeKernel:
+		varSuffix = "kernel"
+		errName = "kernel"
+	case snap.TypeBase:
+		varSuffix = "core"
+		errName = "boot base"
+	default:
+		panic(fmt.Sprintf("cannot make a bootState16 for snap type %q", typ))
+	}
+	return &bootState16{varSuffix: varSuffix, errName: errName}
+}
+
+func (s *bootState16) revisions() (snap, try_snap *NameAndRevision, trying bool, err error) {
+	bloader, err := bootloader.Find("", nil)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("cannot get boot settings: %s", err)
+	}
+
+	snapVar := "snap_" + s.varSuffix
+	trySnapVar := "snap_try_" + s.varSuffix
+	vars := []string{"snap_mode", snapVar, trySnapVar}
+	snaps := make(map[string]*NameAndRevision, 2)
+
+	m, err := bloader.GetBootVars(vars...)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("cannot get boot variables: %s", err)
+	}
+
+	for _, vName := range vars {
+		v := m[vName]
+		if v == "" {
+			continue
+		}
+
+		if vName == "snap_mode" {
+			trying = v == "trying"
+		} else {
+			nameAndRevno, err := nameAndRevnoFromSnap(v)
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("cannot get name and revision of %s (%s): %v", s.errName, vName, err)
+			}
+			snaps[vName] = nameAndRevno
+		}
+	}
+
+	return snaps[snapVar], snaps[trySnapVar], trying, nil
+}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -382,7 +382,33 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureSeededHappyWithModeenv(c *C) {
 	c.Check(n, Equals, 1)
 }
 
+func (s *deviceMgrBaseSuite) makeModelAssertionInState(c *C, brandID, model string, extras map[string]interface{}) *asserts.Model {
+	modelAs := s.brands.Model(brandID, model, extras)
+
+	s.setupBrands(c)
+	assertstatetest.AddMany(s.state, modelAs)
+	return modelAs
+}
+
+func (s *deviceMgrBaseSuite) setPCModelInState(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.makeModelAssertionInState(c, "canonical", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+	})
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc",
+		Serial: "serialserialserial",
+	})
+}
+
 func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkBootloaderHappy(c *C) {
+	s.setPCModelInState(c)
+
 	s.bootloader.SetBootVars(map[string]string{
 		"snap_mode":     "trying",
 		"snap_try_core": "core_1.snap",
@@ -409,6 +435,8 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkBootloaderHappy(c *C) {
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkUpdateBootRevisionsHappy(c *C) {
+	s.setPCModelInState(c)
+
 	// simulate that we have a new core_2, tried to boot it but that failed
 	s.bootloader.SetBootVars(map[string]string{
 		"snap_mode":     "",
@@ -446,6 +474,8 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkUpdateBootRevisionsHappy(c
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkNotRunAgain(c *C) {
+	s.setPCModelInState(c)
+
 	s.bootloader.SetBootVars(map[string]string{
 		"snap_mode":     "trying",
 		"snap_try_core": "core_1.snap",
@@ -459,6 +489,8 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkNotRunAgain(c *C) {
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkError(c *C) {
+	s.setPCModelInState(c)
+
 	s.state.Lock()
 	// seeded
 	s.state.Set("seeded", true)
@@ -725,14 +757,6 @@ func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	otherKrnlInfo.InstanceKey = "foo"
 	err = devicestate.CheckGadgetOrKernel(s.state, otherKrnlInfo, nil, nil, snapstate.Flags{}, deviceCtx)
 	c.Check(err, ErrorMatches, `cannot install "krnl_foo", parallel installation of kernel or gadget snaps is not supported`)
-}
-
-func (s *deviceMgrBaseSuite) makeModelAssertionInState(c *C, brandID, model string, extras map[string]interface{}) *asserts.Model {
-	modelAs := s.brands.Model(brandID, model, extras)
-
-	s.setupBrands(c)
-	assertstatetest.AddMany(s.state, modelAs)
-	return modelAs
 }
 
 func makeSerialAssertionInState(c *C, brands *assertstest.SigningAccounts, st *state.State, brandID, model, serialN string) *asserts.Serial {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1659,6 +1659,7 @@ func (s *mgrsSuite) TestInstallCoreSnapUpdatesBootloaderEnvAndSplitsAcrossRestar
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
+	bloader.SetBootBase("core_99.snap")
 
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -1707,6 +1708,7 @@ type: os
 
 	// this is already set
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":     "core_99.snap",
 		"snap_try_core": "core_x1.snap",
 		"snap_mode":     "try",
 	})

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -55,10 +55,8 @@ func UpdateBootRevisions(st *state.State) error {
 
 	deviceCtx, err := DeviceCtx(st, nil, nil)
 	if err != nil {
-		if err == state.ErrNoState {
-			// too early anyway, no model
-			return nil
-		}
+		// if we have a kernel, we should have a model
+		return err
 	}
 
 	kernel, err := boot.GetCurrentBoot(snap.TypeKernel, deviceCtx)

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -53,11 +53,19 @@ func UpdateBootRevisions(st *state.State) error {
 		return nil
 	}
 
-	kernel, err := boot.GetCurrentBoot(snap.TypeKernel)
+	deviceCtx, err := DeviceCtx(st, nil, nil)
+	if err != nil {
+		if err == state.ErrNoState {
+			// too early anyway, no model
+			return nil
+		}
+	}
+
+	kernel, err := boot.GetCurrentBoot(snap.TypeKernel, deviceCtx)
 	if err != nil {
 		return fmt.Errorf(errorPrefix+"%s", err)
 	}
-	base, err := boot.GetCurrentBoot(snap.TypeBase)
+	base, err := boot.GetCurrentBoot(snap.TypeBase, deviceCtx)
 	if err != nil {
 		return fmt.Errorf(errorPrefix+"%s", err)
 	}

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -2,6 +2,7 @@ package snapstate
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -13,11 +14,20 @@ import (
 type Policy interface {
 	// CanRemove verifies that a snap can be removed.
 	// If rev is not unset, check for removing only that revision.
-	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision) error
+	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision, dev boot.Device) error
 }
 
 var PolicyFor func(snap.Type, *asserts.Model) Policy = policyForUnset
 
 func policyForUnset(snap.Type, *asserts.Model) Policy {
 	panic("PolicyFor unset!")
+}
+
+func inUse(dev boot.Device) func(snapName string, rev snap.Revision) bool {
+	if dev == nil {
+		return nil
+	}
+	return func(snapName string, rev snap.Revision) bool {
+		return boot.InUse(snapName, rev, dev)
+	}
 }

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -23,19 +23,11 @@ func policyForUnset(snap.Type, *asserts.Model) Policy {
 	panic("PolicyFor unset!")
 }
 
-func inUse(typ snap.Type, dev boot.Device) func(snapName string, rev snap.Revision) bool {
-	// TODO: move this kind of logic under policy
-	if dev == nil {
+func inUseFor(deviceCtx DeviceContext) func(snap.Type) (boot.InUseFunc, error) {
+	if deviceCtx == nil {
 		return nil
 	}
-	switch typ {
-	case snap.TypeBase, snap.TypeOS, snap.TypeKernel:
-		return func(snapName string, rev snap.Revision) bool {
-			return boot.InUse(snapName, rev, dev)
-		}
-	default:
-		return func(string, snap.Revision) bool {
-			return false
-		}
+	return func(typ snap.Type) (boot.InUseFunc, error) {
+		return boot.InUse(typ, deviceCtx)
 	}
 }

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -23,11 +23,19 @@ func policyForUnset(snap.Type, *asserts.Model) Policy {
 	panic("PolicyFor unset!")
 }
 
-func inUse(dev boot.Device) func(snapName string, rev snap.Revision) bool {
+func inUse(typ snap.Type, dev boot.Device) func(snapName string, rev snap.Revision) bool {
+	// TODO: move this kind of logic under policy
 	if dev == nil {
 		return nil
 	}
-	return func(snapName string, rev snap.Revision) bool {
-		return boot.InUse(snapName, rev, dev)
+	switch typ {
+	case snap.TypeBase, snap.TypeOS, snap.TypeKernel:
+		return func(snapName string, rev snap.Revision) bool {
+			return boot.InUse(snapName, rev, dev)
+		}
+	default:
+		return func(string, snap.Revision) bool {
+			return false
+		}
 	}
 }

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -32,7 +32,7 @@ type basePolicy struct {
 	modelBase string
 }
 
-func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
@@ -43,7 +43,7 @@ func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev) {
+			if boot.InUse(name, rev, dev) {
 				return errInUseForBoot
 			}
 			return nil

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -39,6 +39,10 @@ func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev
 		return errNoName
 	}
 
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if p.modelBase == name {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -47,8 +47,8 @@ func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev, dev) {
-				return errInUseForBoot
+			if err := inUse(name, rev, snap.TypeBase, dev); err != nil {
+				return err
 			}
 			return nil
 		}

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -31,6 +31,8 @@ func (s *canRemoveSuite) SetUpTest(c *check.C) {
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.bootloader)
+	s.bootloader.SetBootBase("base_99.snap")
+	s.bootloader.SetBootKernel("kernel_99.snap")
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 }
 

--- a/overlord/snapstate/policy/errors.go
+++ b/overlord/snapstate/policy/errors.go
@@ -33,6 +33,8 @@ var (
 
 	errSnapdNotRemovableOnCore       = errors.New("snapd required on core devices")
 	errSnapdNotYetRemovableOnClassic = errors.New("remove all other snaps first")
+
+	errEphemeralSnapsNotRemovalable = errors.New("no snaps are removable in any of the ephemeral modes")
 )
 
 type inUseByErr []string

--- a/overlord/snapstate/policy/export_test.go
+++ b/overlord/snapstate/policy/export_test.go
@@ -15,6 +15,8 @@ var (
 
 	ErrSnapdNotRemovableOnCore       = errSnapdNotRemovableOnCore
 	ErrSnapdNotYetRemovableOnClassic = errSnapdNotYetRemovableOnClassic
+
+	ErrEphemeralSnapsNotRemovalable = errEphemeralSnapsNotRemovalable
 )
 
 func InUseByErr(snaps ...string) error {

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -20,6 +20,7 @@
 package policy
 
 import (
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -29,7 +30,7 @@ type gadgetPolicy struct {
 	modelGadget string
 }
 
-func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -30,11 +30,15 @@ type gadgetPolicy struct {
 	modelGadget string
 }
 
-func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
+func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
 		return errNoName
+	}
+
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
 	}
 
 	if p.modelGadget != name {

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -45,8 +45,8 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, re
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev, dev) {
-				return errInUseForBoot
+			if err := inUse(name, rev, snap.TypeKernel, dev); err != nil {
+				return err
 			}
 			return nil
 		}

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -37,6 +37,10 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, re
 		return errNoName
 	}
 
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if p.modelKernel == name {
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -30,7 +30,7 @@ type kernelPolicy struct {
 	modelKernel string
 }
 
-func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
@@ -41,7 +41,7 @@ func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, re
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev) {
+			if boot.InUse(name, rev, dev) {
 				return errInUseForBoot
 			}
 			return nil

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -30,7 +30,7 @@ type osPolicy struct {
 	modelBase string
 }
 
-func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
@@ -45,7 +45,7 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev) {
+			if boot.InUse(name, rev, dev) {
 				return errInUseForBoot
 			}
 			return nil

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -37,6 +37,10 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		return errNoName
 	}
 
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if name == "ubuntu-core" {
 		return nil
 	}

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -49,8 +49,8 @@ func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev s
 		if !rev.Unset() {
 			// TODO: tweak boot.InUse so that it DTRT when rev.Unset, call
 			// it unconditionally as an extra precaution
-			if boot.InUse(name, rev, dev) {
-				return errInUseForBoot
+			if err := inUse(name, rev, snap.TypeOS, dev); err != nil {
+				return err
 			}
 			return nil
 		}

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -53,6 +53,17 @@ func ephemeral(dev boot.Device) bool {
 	return !dev.RunMode()
 }
 
+func inUse(name string, rev snap.Revision, typ snap.Type, dev boot.Device) error {
+	check, err := boot.InUse(typ, dev)
+	if err != nil {
+		return err
+	}
+	if check(name, rev) {
+		return errInUseForBoot
+	}
+	return nil
+}
+
 type appPolicy struct{}
 
 func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -49,9 +49,17 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 	}
 }
 
+func ephemeral(dev boot.Device) bool {
+	return !dev.RunMode()
+}
+
 type appPolicy struct{}
 
-func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
+	}
+
 	if !rev.Unset() {
 		return nil
 	}

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -22,6 +22,7 @@ package policy
 
 import (
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -50,7 +51,7 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 
 type appPolicy struct{}
 
-func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
 	if !rev.Unset() {
 		return nil
 	}

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -20,6 +20,7 @@
 package policy
 
 import (
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -29,7 +30,7 @@ type snapdPolicy struct {
 	onClassic bool
 }
 
-func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision) error {
+func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -30,11 +30,15 @@ type snapdPolicy struct {
 	onClassic bool
 }
 
-func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, _ boot.Device) error {
+func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.
 		return errNoName
+	}
+
+	if ephemeral(dev) {
+		return errEphemeralSnapsNotRemovalable
 	}
 
 	if !rev.Unset() {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -451,10 +451,6 @@ func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 	//       fallback into the old version (once we have
 	//       better snapd rollback support in core18).
 	if deviceCtx.RunMode() && !release.OnClassic {
-		// TODO: double check that we really rebooted
-		// otherwise this could be just a spurious restart
-		// of snapd
-
 		// get the name of the name relevant for booting
 		// based on the given type
 		model := deviceCtx.Model()
@@ -480,7 +476,7 @@ func WaitRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 		// actually booted. The bootloader may revert on a failed
 		// boot from a bad os/base/kernel to a good one and in this
 		// case we need to catch this and error accordingly
-		current, err := boot.GetCurrentBoot(snapsup.Type)
+		current, err := boot.GetCurrentBoot(snapsup.Type, deviceCtx)
 		if err == boot.ErrBootNameAndRevisionNotReady {
 			return &state.Retry{After: 5 * time.Second}
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -672,7 +672,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		InstanceKey: info.InstanceKey,
 	}
 
-	ts, err := doInstall(st, &snapst, snapsup, instFlags, "", inUse(deviceCtx))
+	ts, err := doInstall(st, &snapst, snapsup, instFlags, "", inUse(snapsup.Type, deviceCtx))
 	return ts, info, err
 }
 
@@ -826,7 +826,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 			InstanceKey:  info.InstanceKey,
 		}
 
-		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUse(deviceCtx))
+		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUse(snapsup.Type, deviceCtx))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1024,7 +1024,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 			},
 		}
 
-		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUse(deviceCtx))
+		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUse(snapsup.Type, deviceCtx))
 		if err != nil {
 			if refreshAll {
 				// doing "refresh all", just skip this snap

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -37,6 +37,9 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/interfaces"
@@ -73,6 +76,8 @@ type snapmgrTestSuite struct {
 	fakeBackend *fakeSnappyBackend
 	fakeStore   *fakeStore
 
+	bl *bootloadertest.MockBootloader
+
 	user  *auth.UserState
 	user2 *auth.UserState
 	user3 *auth.UserState
@@ -104,6 +109,13 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 		fakeBackend:         s.fakeBackend,
 		state:               s.state,
 	}
+
+	// setup a bootloader for policy and boot
+	s.bl = bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(s.bl)
+	s.AddCleanup(func() { bootloader.Force(nil) })
+	s.bl.SetBootBase("base_6789.snap")
+	s.bl.SetBootKernel("kernel_6789.snap")
 
 	oldSetupInstallHook := snapstate.SetupInstallHook
 	oldSetupPreRefreshHook := snapstate.SetupPreRefreshHook
@@ -920,8 +932,10 @@ func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
 }
 
-func dummyInUse(snapName string, rev snap.Revision) bool {
-	return false
+func dummyInUseCheck(snap.Type) (boot.InUseFunc, error) {
+	return func(string, snap.Revision) bool {
+		return false
+	}, nil
 }
 
 func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
@@ -968,7 +982,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	}
 
 	// And observe that we cannot refresh because the snap is busy.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUse)
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUseCheck)
 	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\)`)
 
 	// The state records the time of the failed refresh operation.
@@ -1022,7 +1036,7 @@ func (s snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	}
 
 	// And observe that refresh occurred regardless of the running process.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUse)
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUseCheck)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -915,9 +915,13 @@ func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 		SnapType:        "app",
 	}
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
+}
+
+func dummyInUse(snapName string, rev snap.Revision) bool {
+	return false
 }
 
 func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
@@ -964,7 +968,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	}
 
 	// And observe that we cannot refresh because the snap is busy.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUse)
 	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\)`)
 
 	// The state records the time of the failed refresh operation.
@@ -1018,7 +1022,7 @@ func (s snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	}
 
 	// And observe that refresh occurred regardless of the running process.
-	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUse)
 	c.Assert(err, IsNil)
 }
 
@@ -1027,7 +1031,7 @@ func (s snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
 	defer s.state.Unlock()
 
 	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
-	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0, "")
+	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0, "", nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot install reserved snap name 'system'`)
 }


### PR DESCRIPTION
The idea is for UC 20 bootStateFor will return different implementations for kernel vs base.

This changes also InUse to make it more targeted, avoiding reading the boot state in loops using it, and stopping it from hiding errors. This part comes with a bit of complexity though.
