### PR TITLE
boot,o/snapstate: SetNextBoot/LinkSnap return whether to reboot, use the information

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -41,10 +41,6 @@ type BootParticipant interface {
 	// Otherwise it returns whether a reboot is required.
 	SetNextBoot() (rebootRequired bool, err error)
 
-	// ChangeRequiresReboot returns whether a reboot is required to switch
-	// to the snap. TODO: return an error too
-	ChangeRequiresReboot() bool
-
 	// Is this a trivial implementation of the interface?
 	IsTrivial() bool
 }
@@ -65,7 +61,6 @@ type BootKernel interface {
 type trivial struct{}
 
 func (trivial) SetNextBoot() (bool, error)               { return false, nil }
-func (trivial) ChangeRequiresReboot() bool               { return false }
 func (trivial) IsTrivial() bool                          { return true }
 func (trivial) RemoveKernelAssets() error                { return nil }
 func (trivial) ExtractKernelAssets(snap.Container) error { return nil }

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -37,11 +37,14 @@ import (
 type BootParticipant interface {
 	// SetNextBoot will schedule the snap to be used in the next boot. For
 	// base snaps it is up to the caller to select the right bootable base
-	// (from the model assertion).
-	SetNextBoot() error
+	// (from the model assertion). It is a noop for not relevant snaps.
+	// Otherwise it returns whether a reboot is required.
+	SetNextBoot() (rebootRequired bool, err error)
+
 	// ChangeRequiresReboot returns whether a reboot is required to switch
 	// to the snap. TODO: return an error too
 	ChangeRequiresReboot() bool
+
 	// Is this a trivial implementation of the interface?
 	IsTrivial() bool
 }
@@ -61,7 +64,7 @@ type BootKernel interface {
 
 type trivial struct{}
 
-func (trivial) SetNextBoot() error                       { return nil }
+func (trivial) SetNextBoot() (bool, error)               { return false, nil }
 func (trivial) ChangeRequiresReboot() bool               { return false }
 func (trivial) IsTrivial() bool                          { return true }
 func (trivial) RemoveKernelAssets() error                { return nil }

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -88,37 +87,6 @@ func (bs *coreBootParticipant) SetNextBoot() (rebootRequired bool, err error) {
 	}
 
 	return rebootRequired, nil
-}
-
-func (bs *coreBootParticipant) ChangeRequiresReboot() bool {
-	bootloader, err := bootloader.Find("", nil)
-	if err != nil {
-		logger.Noticef("cannot get boot settings: %s", err)
-		return false
-	}
-
-	var nextBoot, goodBoot string
-	switch bs.t {
-	case snap.TypeKernel:
-		nextBoot = "snap_try_kernel"
-		goodBoot = "snap_kernel"
-	case snap.TypeOS, snap.TypeBase:
-		nextBoot = "snap_try_core"
-		goodBoot = "snap_core"
-	}
-
-	m, err := bootloader.GetBootVars(nextBoot, goodBoot)
-	if err != nil {
-		logger.Noticef("cannot get boot variables: %s", err)
-		return false
-	}
-
-	squashfsName := filepath.Base(bs.s.MountFile())
-	if m[nextBoot] == squashfsName && m[goodBoot] != m[nextBoot] {
-		return true
-	}
-
-	return false
 }
 
 type coreKernel struct {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -65,7 +65,7 @@ type managerBackend interface {
 	// install related
 	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
-	LinkSnap(info *snap.Info, dev boot.Device, prevDisabledSvcs []string, tm timings.Measurer) error
+	LinkSnap(info *snap.Info, dev boot.Device, prevDisabledSvcs []string, tm timings.Measurer) (rebootRequired bool, err error)
 	StartServices(svcs []*snap.AppInfo, meter progress.Meter, tm timings.Measurer) error
 	StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error
 	ServicesEnableState(info *snap.Info, meter progress.Meter) (map[string]bool, error)

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -501,6 +501,44 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnCoreWithBase(c *C) {
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
 }
 
+func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBase(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	r := snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	defer r()
+
+	s.fakeBackend.linkSnapMaybeReboot = true
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// we need to init the boot-id
+	err := s.state.VerifyReboot("some-boot-id")
+	c.Assert(err, IsNil)
+
+	si := &snap.SideInfo{
+		RealName: "core18",
+		SnapID:   "core18-id",
+		Revision: snap.R(22),
+	}
+	t := s.state.NewTask("link-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si,
+	})
+	s.state.NewChange("dummy", "...").AddTask(t)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartSystem})
+	c.Assert(t.Log(), HasLen, 1)
+	c.Check(t.Log()[0], Matches, `.*INFO Requested system restart.*`)
+}
+
 func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
@@ -720,6 +758,64 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCore(c *C) {
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
 	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+}
+
+func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCoreBase(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	r := snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	defer r()
+
+	s.fakeBackend.linkSnapMaybeReboot = true
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	// we need to init the boot-id
+	err := s.state.VerifyReboot("some-boot-id")
+	c.Assert(err, IsNil)
+
+	si1 := &snap.SideInfo{
+		RealName: "core18",
+		Revision: snap.R(1),
+	}
+	si2 := &snap.SideInfo{
+		RealName: "core18",
+		Revision: snap.R(2),
+	}
+	snapstate.Set(s.state, "core18", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+		Active:   true,
+		SnapType: "base",
+	})
+	t := s.state.NewTask("unlink-current-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si2,
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, "core18", &snapst)
+	c.Assert(err, IsNil)
+	c.Check(snapst.Active, Equals, true)
+	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Current, Equals, snap.R(1))
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+
+	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartSystem})
 }
 
 func (s *linkSnapSuite) TestDoUndoLinkSnapCoreClassic(c *C) {


### PR DESCRIPTION
SetNextBoot knows already whether a reboot is needed or not, just propagate the info.

Drop Participant.ChangeRequiresReboot, it's unused now.
