### PR TITLE
devicestate: avoid adding mockModel to deviceMgrInstallModeSuite

### DIFF
--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -62,7 +62,8 @@ type seed20 struct {
 
 	auxInfos map[string]*internal.AuxInfo20
 
-	snaps             []*Snap
+	snaps []*Snap
+	// modes holds a matching applicable modes set for each snap in snaps
 	modes             [][]string
 	essentialSnapsNum int
 }


### PR DESCRIPTION
This is a small cleanup followup to PR #7921. We can avoid putting
mockModel on the deviceMgrInstallModeSuite as it's only needed
inside this one test right now.

Also adds another commit with a comment in seed20 that was asked for a while ago as a drive-by.