### PR TITLE
boot,o/devicestate: refactor MarkBootSuccessful over bootState

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -148,10 +148,9 @@ type bootState interface {
 	revisions() (snap, try_snap *NameAndRevision, trying bool, err error)
 
 	// markSuccessful lazily implements marking the boot
-	// successful for the boot snap of the type. actually
-	// committing the update is done via the threaded
-	// bootStateUpdate commit, that way different bootState
-	// markSuccessful can be chained.
+	// successful for the type's boot snap. The actual committing
+	// of the update is done via bootStateUpdate's commit, that
+	// way different markSuccessful can be folded together.
 	markSuccessful(bootStateUpdate) (bootStateUpdate, error)
 }
 

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -146,6 +146,13 @@ type bootState interface {
 	// the try snap (only the latter might not be set), and
 	// whether the snap is in "trying" state.
 	revisions() (snap, try_snap *NameAndRevision, trying bool, err error)
+
+	// markSuccessful lazily implements marking the boot
+	// successful for the boot snap of the type. actually
+	// committing the update is done via the threaded
+	// bootStateUpdate commit, that way different bootState
+	// markSuccessful can be chained.
+	markSuccessful(bootStateUpdate) (bootStateUpdate, error)
 }
 
 // bootStateFor finds the right bootState implementation of the given
@@ -262,11 +269,17 @@ func nameAndRevnoFromSnap(sn string) (*NameAndRevision, error) {
 	return &NameAndRevision{Name: name, Revision: rev}, nil
 }
 
+// bootStateUpdate carries the state for an on-going boot state update.
+// At the end it can be used to commit it.
+type bootStateUpdate interface {
+	commit() error
+}
+
 // MarkBootSuccessful marks the current boot as successful. This means
 // that snappy will consider this combination of kernel/os a valid
 // target for rollback.
 //
-// The states that a boot goes through are the following:
+// The states that a boot goes through for UC16/18 are the following:
 // - By default snap_mode is "" in which case the bootloader loads
 //   two squashfs'es denoted by variables snap_core and snap_kernel.
 // - On a refresh of core/kernel snapd will set snap_mode=try and
@@ -282,35 +295,27 @@ func nameAndRevnoFromSnap(sn string) (*NameAndRevision, error) {
 //   means snapd did not start successfully. In this case the bootloader
 //   will set snap_mode="" and the system will boot with the known good
 //   values from snap_{core,kernel}
-func MarkBootSuccessful() error {
-	bl, err := bootloader.Find("", nil)
-	if err != nil {
-		return fmt.Errorf("cannot mark boot successful: %s", err)
-	}
-	m, err := bl.GetBootVars("snap_mode", "snap_try_core", "snap_try_kernel")
-	if err != nil {
-		return err
-	}
+func MarkBootSuccessful(dev Device) error {
+	const errPrefix = "cannot mark boot successful: %s"
 
-	// snap_mode goes from "" -> "try" -> "trying" -> ""
-	// so if we are not in "trying" mode, nothing to do here
-	if m["snap_mode"] != "trying" {
-		return nil
-	}
-
-	// update the boot vars
-	for _, k := range []string{"kernel", "core"} {
-		tryBootVar := fmt.Sprintf("snap_try_%s", k)
-		bootVar := fmt.Sprintf("snap_%s", k)
-		// update the boot vars
-		if m[tryBootVar] != "" {
-			m[bootVar] = m[tryBootVar]
-			m[tryBootVar] = ""
+	var u bootStateUpdate
+	for _, t := range []snap.Type{snap.TypeBase, snap.TypeKernel} {
+		s, err := bootStateFor(t, dev)
+		if err != nil {
+			return err
+		}
+		u, err = s.markSuccessful(u)
+		if err != nil {
+			return fmt.Errorf(errPrefix, err)
 		}
 	}
-	m["snap_mode"] = ""
 
-	return bl.SetBootVars(m)
+	if u != nil {
+		if err := u.commit(); err != nil {
+			return fmt.Errorf(errPrefix, err)
+		}
+	}
+	return nil
 }
 
 // BootableSet represents the boot snaps of a system to be made bootable.

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -366,10 +366,12 @@ func (s *bootSetSuite) TestKernelWithModel(c *C) {
 }
 
 func (s *bootSetSuite) TestMarkBootSuccessfulAllSnap(c *C) {
+	coreDev := boottest.MockDevice("some-snap")
+
 	s.bootloader.BootVars["snap_mode"] = "trying"
 	s.bootloader.BootVars["snap_try_core"] = "os1"
 	s.bootloader.BootVars["snap_try_kernel"] = "k1"
-	err := boot.MarkBootSuccessful()
+	err := boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 
 	expected := map[string]string{
@@ -384,18 +386,20 @@ func (s *bootSetSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 
 	// do it again, verify its still valid
-	err = boot.MarkBootSuccessful()
+	err = boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 	c.Assert(s.bootloader.BootVars, DeepEquals, expected)
 }
 
 func (s *bootSetSuite) TestMarkBootSuccessfulKKernelUpdate(c *C) {
+	coreDev := boottest.MockDevice("some-snap")
+
 	s.bootloader.BootVars["snap_mode"] = "trying"
 	s.bootloader.BootVars["snap_core"] = "os1"
 	s.bootloader.BootVars["snap_kernel"] = "k1"
 	s.bootloader.BootVars["snap_try_core"] = ""
 	s.bootloader.BootVars["snap_try_kernel"] = "k2"
-	err := boot.MarkBootSuccessful()
+	err := boot.MarkBootSuccessful(coreDev)
 	c.Assert(err, IsNil)
 	c.Assert(s.bootloader.BootVars, DeepEquals, map[string]string{
 		// cleared

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/snap"
+)
+
+type bootState16 struct {
+	varSuffix string
+	errName   string
+}
+
+func newBootState16(typ snap.Type) *bootState16 {
+	var varSuffix, errName string
+	switch typ {
+	case snap.TypeKernel:
+		varSuffix = "kernel"
+		errName = "kernel"
+	case snap.TypeBase:
+		varSuffix = "core"
+		errName = "boot base"
+	default:
+		panic(fmt.Sprintf("cannot make a bootState16 for snap type %q", typ))
+	}
+	return &bootState16{varSuffix: varSuffix, errName: errName}
+}
+
+func (s *bootState16) revisions() (snap, try_snap *NameAndRevision, trying bool, err error) {
+	bloader, err := bootloader.Find("", nil)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("cannot get boot settings: %s", err)
+	}
+
+	snapVar := "snap_" + s.varSuffix
+	trySnapVar := "snap_try_" + s.varSuffix
+	vars := []string{"snap_mode", snapVar, trySnapVar}
+	snaps := make(map[string]*NameAndRevision, 2)
+
+	m, err := bloader.GetBootVars(vars...)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("cannot get boot variables: %s", err)
+	}
+
+	for _, vName := range vars {
+		v := m[vName]
+		if v == "" && vName != snapVar {
+			// snap_mode & snap_try_<type> can be empty
+			// snap_<type> cannot be! and will fail parsing
+			// below
+			continue
+		}
+
+		if vName == "snap_mode" {
+			trying = v == "trying"
+		} else {
+			nameAndRevno, err := nameAndRevnoFromSnap(v)
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("cannot get name and revision of %s (%s): %v", s.errName, vName, err)
+			}
+			snaps[vName] = nameAndRevno
+		}
+	}
+
+	return snaps[snapVar], snaps[trySnapVar], trying, nil
+}

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2019 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -117,63 +117,4 @@ func (k *coreKernel) ExtractKernelAssets(snapf snap.Container) error {
 
 	// ask bootloader to extract the kernel assets if needed
 	return bootloader.ExtractKernelAssets(k.s, snapf)
-}
-
-type bootState16 struct {
-	varSuffix string
-	errName   string
-}
-
-func newBootState16(typ snap.Type) *bootState16 {
-	var varSuffix, errName string
-	switch typ {
-	case snap.TypeKernel:
-		varSuffix = "kernel"
-		errName = "kernel"
-	case snap.TypeBase:
-		varSuffix = "core"
-		errName = "boot base"
-	default:
-		panic(fmt.Sprintf("cannot make a bootState16 for snap type %q", typ))
-	}
-	return &bootState16{varSuffix: varSuffix, errName: errName}
-}
-
-func (s *bootState16) revisions() (snap, try_snap *NameAndRevision, trying bool, err error) {
-	bloader, err := bootloader.Find("", nil)
-	if err != nil {
-		return nil, nil, false, fmt.Errorf("cannot get boot settings: %s", err)
-	}
-
-	snapVar := "snap_" + s.varSuffix
-	trySnapVar := "snap_try_" + s.varSuffix
-	vars := []string{"snap_mode", snapVar, trySnapVar}
-	snaps := make(map[string]*NameAndRevision, 2)
-
-	m, err := bloader.GetBootVars(vars...)
-	if err != nil {
-		return nil, nil, false, fmt.Errorf("cannot get boot variables: %s", err)
-	}
-
-	for _, vName := range vars {
-		v := m[vName]
-		if v == "" && vName != snapVar {
-			// snap_mode & snap_try_<type> can be empty
-			// snap_<type> cannot be! and will fail parsing
-			// below
-			continue
-		}
-
-		if vName == "snap_mode" {
-			trying = v == "trying"
-		} else {
-			nameAndRevno, err := nameAndRevnoFromSnap(v)
-			if err != nil {
-				return nil, nil, false, fmt.Errorf("cannot get name and revision of %s (%s): %v", s.errName, vName, err)
-			}
-			snaps[vName] = nameAndRevno
-		}
-	}
-
-	return snaps[snapVar], snaps[trySnapVar], trying, nil
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -483,8 +483,14 @@ func (m *DeviceManager) ensureBootOk() error {
 	}
 
 	if !m.bootOkRan {
-		if err := boot.MarkBootSuccessful(); err != nil {
+		deviceCtx, err := DeviceCtx(m.state, nil, nil)
+		if err != nil && err != state.ErrNoState {
 			return err
+		}
+		if err == nil {
+			if err := boot.MarkBootSuccessful(deviceCtx); err != nil {
+				return err
+			}
 		}
 		m.bootOkRan = true
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -507,7 +507,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkError(c *C) {
 	devicestate.SetBootOkRan(s.mgr, false)
 
 	err := s.mgr.Ensure()
-	c.Assert(err, ErrorMatches, "devicemgr: bootloader err")
+	c.Assert(err, ErrorMatches, "devicemgr: cannot mark boot successful: bootloader err")
 }
 
 func (s *deviceMgrBaseSuite) setupBrands(c *C) {


### PR DESCRIPTION
This refactors MarkBootSuccessful over bootState and bootStateUpdate interfaces. The latter helps combining dealing with both the kernel and base parts of the state conceptually separately but still possibly committing changes as one.

It also move bootState16 implementation to its own bootstate16.go file.
