### PR TITLE
snap-bootstrap: read only stdout when parsing the sfdisk json

### DIFF
--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -80,7 +80,7 @@ type DeviceStructure struct {
 // NewDeviceLayout obtains the partitioning and filesystem information from the
 // block device.
 func DeviceLayoutFromDisk(device string) (*DeviceLayout, error) {
-	output, err := exec.Command("sfdisk", "--json", "-d", device).CombinedOutput()
+	output, err := exec.Command("sfdisk", "--json", "-d", device).Output()
 	if err != nil {
 		return nil, osutil.OutputErr(output, err)
 	}

--- a/cmd/snap-bootstrap/partition/sfdisk_test.go
+++ b/cmd/snap-bootstrap/partition/sfdisk_test.go
@@ -31,7 +31,9 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-const mockSfdiskScriptBiosAndRecovery = `echo '{
+const mockSfdiskScriptBiosAndRecovery = `
+>&2 echo "Some warning from sfdisk"
+echo '{
    "partitiontable": {
       "label": "gpt",
       "id": "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA",


### PR DESCRIPTION
The sfdisk output may contain warnings on stderr. This is the case
for the qemu based spread test I'm working on. To avoid failing
completely in this case only parse the stdout output from sfdisk.
