### PR TITLE
snap-confine: support nvidia driver microversion string

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -122,7 +122,7 @@ static const size_t nvidia_globs_len =
     sizeof nvidia_globs / sizeof *nvidia_globs;
 
 #define LIBNVIDIA_GLCORE_SO_PATTERN "libnvidia-glcore.so.%d.%d"
-#define LIBNVIDIA_GLCORE_SO_PATTERN_MICRO "libnvidia-glcore.so.%d.%d.%d"
+#define LIBNVIDIA_GLCORE_SO_PATTERN_MICRO "libnvidia-glcore.so.%d.%d.%02d"
 
 #endif				// defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -371,7 +371,7 @@ static void sc_probe_nvidia_driver(struct sc_nvidia_driver *driver)
 	// integers. We can use sscanf to parse this data.
 	if (fscanf
 	    (file, "%d.%d.%d", &driver->major_version,
-	     &driver->minor_version, &driver->micro_version) != 2) {
+	     &driver->minor_version, &driver->micro_version) < 2) {
 		die("cannot parse nvidia driver version string");
 	}
 	debug("parsed nvidia driver version: %d.%d.%d", driver->major_version,

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -370,7 +370,7 @@ static void sc_probe_nvidia_driver(struct sc_nvidia_driver *driver)
 	// Driver version format is MAJOR.MINOR where both MAJOR and MINOR are
 	// integers. We can use sscanf to parse this data.
 	if (fscanf
-	    (file, "%d.%d", &driver->major_version,
+	    (file, "%d.%d.%d", &driver->major_version,
 	     &driver->minor_version, &driver->micro_version) != 2) {
 		die("cannot parse nvidia driver version string");
 	}

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -15,7 +15,7 @@
  *
  */
 
-#include "../config.h"
+#include "config.h"
 #include "mount-support-nvidia.h"
 
 #include <errno.h>


### PR DESCRIPTION
recent nvidia drivers add micro version to version string
```
# cat /sys/module/nvidia/version
440.33.01
```
existing code expects `major.minor` and fails to mount nvidia GL libraries in case `libnvidia-glcore.so.%d.%d` is not found

this PR fixes it by probing for  `libnvidia-glcore.so.%d.%d.%d` in addition to existing behavior

it helped me run GL enabled snaps on latest nvidia drivers
see https://forum.snapcraft.io/t/nvidia-beta-drivers-completely-break-snaps/12392
for a sample problem

