### PR TITLE
tests: add core20 tests

### DIFF
--- a/data/systemd/snapd.autoimport.service.in
+++ b/data/systemd/snapd.autoimport.service.in
@@ -3,6 +3,7 @@ Description=Auto import assertions from block devices
 After=snapd.service snapd.socket snapd.seeded.service
 # don't run on classic
 ConditionKernelCommandLine=|snap_core
+# TODO:UC20: only enable this in run mode?
 ConditionKernelCommandLine=|snapd_recovery_mode
 
 [Service]

--- a/data/systemd/snapd.autoimport.service.in
+++ b/data/systemd/snapd.autoimport.service.in
@@ -2,7 +2,8 @@
 Description=Auto import assertions from block devices
 After=snapd.service snapd.socket snapd.seeded.service
 # don't run on classic
-ConditionKernelCommandLine=snap_core
+ConditionKernelCommandLine=|snap_core
+ConditionKernelCommandLine=|snapd_recovery_mode
 
 [Service]
 Type=oneshot

--- a/data/systemd/snapd.core-fixup.service.in
+++ b/data/systemd/snapd.core-fixup.service.in
@@ -2,7 +2,8 @@
 Description=Automatically repair incorrect owner/permissions on core devices
 Before=snapd.service
 # don't run on classic
-ConditionKernelCommandLine=snap_core
+ConditionKernelCommandLine=|snap_core
+ConditionKernelCommandLine=|snapd_recovery_mode
 Documentation=man:snap(1)
 
 [Service]

--- a/data/systemd/snapd.snap-repair.service.in
+++ b/data/systemd/snapd.snap-repair.service.in
@@ -2,7 +2,8 @@
 Description=Automatically fetch and run repair assertions
 Documentation=man:snap(1)
 # don't run on classic
-ConditionKernelCommandLine=snap_core
+ConditionKernelCommandLine=|snap_core
+ConditionKernelCommandLine=|snapd_recovery_mode
 
 [Service]
 Type=oneshot

--- a/data/systemd/snapd.snap-repair.service.in
+++ b/data/systemd/snapd.snap-repair.service.in
@@ -3,6 +3,7 @@ Description=Automatically fetch and run repair assertions
 Documentation=man:snap(1)
 # don't run on classic
 ConditionKernelCommandLine=|snap_core
+# TODO:UC20: only enable this in run mode?
 ConditionKernelCommandLine=|snapd_recovery_mode
 
 [Service]

--- a/data/systemd/snapd.snap-repair.timer
+++ b/data/systemd/snapd.snap-repair.timer
@@ -1,7 +1,9 @@
 [Unit]
 Description=Timer to automatically fetch and run repair assertions
 # don't run on classic
-ConditionKernelCommandLine=snap_core
+ConditionKernelCommandLine=|snap_core
+# TODO:UC20: only enable this in run mode?
+ConditionKernelCommandLine=|snapd_recovery_mode
 
 [Timer]
 OnCalendar=*-*-* 5,11,17,23:00

--- a/spread.yaml
+++ b/spread.yaml
@@ -47,7 +47,7 @@ environment:
     PPA_VALIDATION_NAME: '$(HOST: echo "${SPREAD_PPA_VALIDATION_NAME:-}")'
     PRE_CACHE_SNAPS: test-snapd-tools test-snapd-sh jq
     # always skip removing the rsync snap
-    SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18'
+    SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18 test-snapd-rsync-core20'
     # Use the installed snapd and reset the systems without removing snapd
     REUSE_SNAPD: "$(HOST: echo \"${SPREAD_REUSE_SNAPD:-0}\")"
     PROFILE_SNAPS: "$(HOST: echo \"${SPREAD_PROFILE_SNAPS:-0}\")"
@@ -76,6 +76,11 @@ backends:
             - ubuntu-core-18-64:
                 image: ubuntu-16.04-64
                 workers: 6
+            - ubuntu-core-20-64:
+                image: ubuntu-1804-64-uefi-enabled
+                #TODO:UC20: enable more workers once we have more tests
+                workers: 1
+                storage: 20G
 
             - debian-9-64:
                 workers: 6
@@ -147,6 +152,8 @@ backends:
                 workers: 1
 
     qemu:
+        # TODO:UC20: uc20 needs 2G or grub will not loopback the kernel snap
+        memory: 2G
         systems:
             - ubuntu-14.04-32:
                 username: ubuntu
@@ -168,6 +175,11 @@ backends:
                 image: ubuntu-16.04-64
                 username: ubuntu
                 password: ubuntu
+            - ubuntu-core-20-64:
+                image: ubuntu-18.04-64
+                username: ubuntu
+                password: ubuntu
+                flags: [virtio]
             - ubuntu-17.10-64:
                 username: ubuntu
                 password: ubuntu
@@ -628,6 +640,8 @@ suites:
     # These tests are executed on all other plattforms as they
     # are designed to run on pristine systems
     tests/smoke/:
+        # TODO:UC20: enable for uc20
+        systems: [-ubuntu-core-20-*]
         summary: Essential system level tests for snapd
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -639,6 +653,8 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite
     # All other tests run now and will heavily modify the system.
     tests/main/:
+        # TODO:UC20: enable for uc20
+        systems: [-ubuntu-core-20-*]
         summary: Full-system tests for snapd
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -656,6 +672,17 @@ suites:
     tests/core18/:
         summary: Subset of core18 specific tests
         systems: [ubuntu-core-18-*]
+        prepare: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
+        prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+        restore: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
+    tests/core20/:
+        summary: Subset of core20 specific tests
+        systems: [ubuntu-core-20-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -640,8 +640,6 @@ suites:
     # These tests are executed on all other plattforms as they
     # are designed to run on pristine systems
     tests/smoke/:
-        # TODO:UC20: enable for uc20
-        systems: [-ubuntu-core-20-*]
         summary: Essential system level tests for snapd
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -653,9 +651,9 @@ suites:
             "$TESTSLIB"/prepare-restore.sh --restore-suite
     # All other tests run now and will heavily modify the system.
     tests/main/:
+        summary: Full-system tests for snapd
         # TODO:UC20: enable for uc20
         systems: [-ubuntu-core-20-*]
-        summary: Full-system tests for snapd
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
@@ -721,6 +719,8 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
+        # TODO:UC20: enable for uc20
+        systems: [-ubuntu-core-20-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |

--- a/tests/core20/basic/task.yaml
+++ b/tests/core20/basic/task.yaml
@@ -1,0 +1,26 @@
+summary: Check basic core20 system functionality
+
+execute: |
+    echo "Check that the system snaps are there"
+    snap list | MATCH core20
+    snap list | MATCH snapd
+    if snap list | grep '^core +'; then
+        echo "The old core snap is installed but should not"
+        exit 1
+    fi
+
+    echo "Ensure that the system is fully seeded"
+    snap changes | MATCH "Done.*Initialize system state"
+
+    echo "Check that a simple shell snap"
+    # TODO:UC20: add test-snapd-sh-core20
+    snap install test-snapd-sh-core18
+    test-snapd-sh-core18.sh -c 'echo hello' | MATCH hello
+
+    if python3 -m json.tool < /var/lib/snapd/system-key | grep '"build-id": ""'; then
+        echo "The build-id of snapd must not be empty."
+        exit 1
+    fi
+
+    echo "Ensure passwd/group is available for snaps"
+    test-snapd-sh-core18.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test

--- a/tests/core20/basic/task.yaml
+++ b/tests/core20/basic/task.yaml
@@ -2,9 +2,9 @@ summary: Check basic core20 system functionality
 
 execute: |
     echo "Check that the system snaps are there"
-    snap list | MATCH core20
-    snap list | MATCH snapd
-    if snap list | grep '^core +'; then
+    snap list core20
+    snap list snapd
+    if snap list core; then
         echo "The old core snap is installed but should not"
         exit 1
     fi

--- a/tests/lib/assertions/ubuntu-core-20-amd64.model
+++ b/tests/lib/assertions/ubuntu-core-20-amd64.model
@@ -1,0 +1,46 @@
+type: model
+authority-id: vxj7EkYOlg15uAHRswTXIUpzWqO2sTBi
+series: 16
+brand-id: vxj7EkYOlg15uAHRswTXIUpzWqO2sTBi
+model: ubuntu-core-20-mvo-amd64
+architecture: amd64
+base: core20
+grade: dangerous
+snaps:
+  -
+    default-channel: 20/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    track: 20
+    type: gadget
+  -
+    default-channel: latest/edge
+    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+    name: core20
+    track: latest
+    type: base
+  -
+    default-channel: 20/edge
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    track: 20
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    track: latest
+    type: snapd
+timestamp: 2019-08-26T00:00:00.0Z
+sign-key-sha3-384: 2XxnFfNz1CCA6OZ5v03QjbFaK_A6-FjnNzNYJSMhSm_RC77iriSBh9X_olPNmupv
+
+AcLBcwQAAQoAHRYhBNPJP7iUC6HvARf0BQG87hgg441ZBQJdwpNWAAoJEAG87hgg441ZjKIP/ie8
+TaRMRg72onq8q3xyPqfzBALIkvZV0rN3QNc+CvASMrA5a1K/Tf2LHIjDLNq4SK49yMlehIsB8uVy
+oczPX2eO2cIaxc/LGDVlTOmVY4q2+J0z18ZMEs7UysGq/B+p6r0Bdv409R92fciaYCt0dfCCUyBG
+bO8L8/FDMBNsKY944UxVD3IU5F96jwSU7Zv6M5fzIZLrlElM0MOHLmtG6Qwxc7WfOAXIb3IEGiGz
+Y4hgEyPA8F+Z4HEUYSbQaZ2L0Mh4G5ssIP3W6BGN0uKe+VtrfUZerEoKQCqZk34+INNmPCzVxHmp
+VDKsGS3gDyTJUgkzOa84FH2PYq6t79mBNnqV8WWZIP4tJtf9zyUlptagf1mIbt/2EVNpxxHYhACb
+jxNWoDPgkKsSiAPEpLTztgXlzxhWtirAIgEk+8v/lxSsbPNlZM5yYA57CKh5s/TfK3Mc4oer9/iD
+NTAhmxDpl6MSgKojoJFGhADrmTFs+LZqMhclIrcq9Qm7bNEIpGHFRDxQd6CQc1B/zgEUzkRfAgpl
+440+Z9Vwcd26SdlMhk5C4Oxp4jE+4cAROjxoT7VIxrnqbcYk9oBrfGL8WW5hsYs/qBqVulbesThk
+/pWXzxpIubZT7fdFLHx2dwEIfwLoPcGm3gAbzdVNTFYNCWGHxd4kevGxIPnT4EYqWiksOHoh

--- a/tests/lib/assertions/ubuntu-core-20-amd64.model
+++ b/tests/lib/assertions/ubuntu-core-20-amd64.model
@@ -11,36 +11,32 @@ snaps:
     default-channel: 20/edge
     id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
     name: pc
-    track: 20
     type: gadget
   -
     default-channel: latest/edge
     id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
     name: core20
-    track: latest
     type: base
   -
     default-channel: 20/edge
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
-    track: 20
     type: kernel
   -
     default-channel: latest/edge
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
-    track: latest
     type: snapd
 timestamp: 2019-08-26T00:00:00.0Z
 sign-key-sha3-384: 2XxnFfNz1CCA6OZ5v03QjbFaK_A6-FjnNzNYJSMhSm_RC77iriSBh9X_olPNmupv
 
-AcLBcwQAAQoAHRYhBNPJP7iUC6HvARf0BQG87hgg441ZBQJdwpNWAAoJEAG87hgg441ZjKIP/ie8
-TaRMRg72onq8q3xyPqfzBALIkvZV0rN3QNc+CvASMrA5a1K/Tf2LHIjDLNq4SK49yMlehIsB8uVy
-oczPX2eO2cIaxc/LGDVlTOmVY4q2+J0z18ZMEs7UysGq/B+p6r0Bdv409R92fciaYCt0dfCCUyBG
-bO8L8/FDMBNsKY944UxVD3IU5F96jwSU7Zv6M5fzIZLrlElM0MOHLmtG6Qwxc7WfOAXIb3IEGiGz
-Y4hgEyPA8F+Z4HEUYSbQaZ2L0Mh4G5ssIP3W6BGN0uKe+VtrfUZerEoKQCqZk34+INNmPCzVxHmp
-VDKsGS3gDyTJUgkzOa84FH2PYq6t79mBNnqV8WWZIP4tJtf9zyUlptagf1mIbt/2EVNpxxHYhACb
-jxNWoDPgkKsSiAPEpLTztgXlzxhWtirAIgEk+8v/lxSsbPNlZM5yYA57CKh5s/TfK3Mc4oer9/iD
-NTAhmxDpl6MSgKojoJFGhADrmTFs+LZqMhclIrcq9Qm7bNEIpGHFRDxQd6CQc1B/zgEUzkRfAgpl
-440+Z9Vwcd26SdlMhk5C4Oxp4jE+4cAROjxoT7VIxrnqbcYk9oBrfGL8WW5hsYs/qBqVulbesThk
-/pWXzxpIubZT7fdFLHx2dwEIfwLoPcGm3gAbzdVNTFYNCWGHxd4kevGxIPnT4EYqWiksOHoh
+AcLBcwQAAQoAHRYhBNPJP7iUC6HvARf0BQG87hgg441ZBQJeFYBTAAoJEAG87hgg441Zh8EQAKUj
+XYZAf8OlKDRD5uRPjV0eX4RA+UGieu/l392cNWsN18ngEMewFEKtLXltqeLF9SO/mwTVWPVn8jl4
+RbJESfxA8jDKYnfmMNT/kiytRMSxXkOcrxpW54LuFSg9LkZx4vQOQR1Snjic7z2HHLpq3Ain5Pry
+zjWddYi68ew2MDM2Y6jxGa/V651w5B1YTev4rNcmVkvXQFxFuZe5CYaFswpfZMtqk1N6K7pPF2RT
+OQh1Wl9fYA7tBjgt4jFcEr6L9qWj4oQbFXElhlvZGbKkjdv3A0b3BGyqKxA/1ptsAcp9DfWUNcXd
+/ya28u+n3bZkgKxJY/pL5Q9R90DaoIxoDKK4vzzQQ6twVQi/6ug0J7F8obkhuvGrMwhhmEltn2hr
+z5xMO6EZcQY1YxLXsPmH/5uZI4V4wH3+DAmpOBzNMRRFZOQjC8ngJIeKQI1e8rzH9qUzKXNvJRXC
+GMoHE7zqwe9z2lTAN1wHAHpctwepb/XNe+tRIcxxBpo83rbwii6zkikNRhsSF9djk0hUF1OM7dst
+e3wC0wi0wpp3tbmEvKOhWXbCQK0lZywkV6KpASM5uXn4Q4vC+Y8sp6CPhEnXCDCrfM7WolmjUeUC
+KHTZSZjNA94TZ/KUYvqeBWC2G9D9NMhdUVN+77y8AERz9mm9wjbMQuStpUM4dQXw5GEB5fBU

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -379,7 +379,7 @@ if [ -e /root/spread-setup-done ]; then
 fi
 
 # extract data from previous stage
-(cd / && tar xvf /run/mnt/ubuntu-seed/wormhole.tar.gz)
+(cd / && tar xvf /run/mnt/ubuntu-seed/run-mode-overlay-data.tar.gz)
 
 # user db - it's complicated
 for f in group gshadow passwd shadow; do
@@ -668,7 +668,7 @@ EOF
           --exclude /gopath/pkg/ \
           /home/gopath /mnt/user-data/
     elif is_core20_system; then
-        # prepare passwd for wormhole
+        # prepare passwd for run-mode-overlay-data
         mkdir -p /root/test-etc
         mkdir -p /var/lib/extrausers
         touch /var/lib/extrausers/sub{uid,gid}
@@ -690,7 +690,7 @@ EOF
           --exclude /gopath/.cache/ \
           --exclude /gopath/bin/govendor \
           --exclude /gopath/pkg/ \
-          -f /mnt/wormhole.tar.gz \
+          -f /mnt/run-mode-overlay-data.tar.gz \
           /home/gopath /root/test-etc /var/lib/extrausers
     fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -336,7 +336,7 @@ repack_snapd_snap_with_deb_content() {
 
     local UNPACK_DIR="/tmp/snapd-unpack"
     unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
-    # clean snap apparmor.d to ensure the put the right snap-confine apparmor
+    # clean snap apparmor.d to ensure we put the right snap-confine apparmor
     # file in place. Its called usr.lib.snapd.snap-confine on 14.04 but
     # usr.lib.snapd.snap-confine.real everywhere else
     rm -f "$UNPACK_DIR"/etc/apparmor.d/*
@@ -353,7 +353,7 @@ repack_snapd_snap_with_deb_content_and_firstboot_tweaks() {
     local UNPACK_DIR="/tmp/snapd-unpack"
     unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
 
-    # clean snap apparmor.d to ensure the put the right snap-confine apparmor
+    # clean snap apparmor.d to ensure we put the right snap-confine apparmor
     # file in place. Its called usr.lib.snapd.snap-confine on 14.04 but
     # usr.lib.snapd.snap-confine.real everywhere else
     rm -f "$UNPACK_DIR"/etc/apparmor.d/*

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -673,13 +673,13 @@ EOF
         mkdir -p /var/lib/extrausers
         touch /var/lib/extrausers/sub{uid,gid}
         for f in group gshadow passwd shadow; do
-            grep -v "^root:" "/etc/$f" > /root/test-etc/"$f"
+            grep -v "^root:" /etc/"$f" > /root/test-etc/"$f"
             grep "^root:" /etc/"$f" >> /root/test-etc/"$f"
-            chgrp --reference "/etc/$f" /root/test-etc/"$f"
+            chgrp --reference /etc/"$f" /root/test-etc/"$f"
             # create /var/lib/extrausers/$f
             # append ubuntu, test user for the testing
-            grep "^test:" /etc/$f >> /var/lib/extrausers/"$f"
-            grep "^ubuntu:" /etc/$f >> /var/lib/extrausers/"$f"
+            grep "^test:" /etc/"$f" >> /var/lib/extrausers/"$f"
+            grep "^ubuntu:" /etc/"$f" >> /var/lib/extrausers/"$f"
             # check test was copied
             MATCH "^test:" </var/lib/extrausers/"$f"
             MATCH "^ubuntu:" </var/lib/extrausers/"$f"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -347,7 +347,7 @@ repack_snapd_snap_with_deb_content() {
     rm -rf "$UNPACK_DIR"
 }
 
-repack_snapd_snap_with_deb_content_and_firstboot_tweaks() {
+repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks() {
     local TARGET="$1"
 
     local UNPACK_DIR="/tmp/snapd-unpack"
@@ -560,7 +560,7 @@ setup_reflash_magic() {
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
         IMAGE=core18-amd64.img
     elif is_core20_system; then
-        repack_snapd_snap_with_deb_content_and_firstboot_tweaks "$IMAGE_HOME"
+        repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
         # TODO:UC20: use canonical model instead of "mvo" one
         cp "$TESTSLIB/assertions/ubuntu-core-20-amd64.model" "$IMAGE_HOME/pc.model"
         IMAGE=core20-amd64.img

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -58,6 +58,9 @@ ensure_jq() {
     if is_core18_system; then
         snap install --devmode jq-core18
         snap alias jq-core18.jq jq
+    elif is_core20_system; then
+        snap install --devmode --edge jq-core20
+        snap alias jq-core20.jq jq
     else
         snap install --devmode jq
     fi
@@ -78,7 +81,7 @@ disable_refreshes() {
     snap refresh --time --abs-time | MATCH "last: 2[0-9]{3}"
 
     echo "Ensure jq is gone"
-    snap remove jq jq-core18
+    snap remove jq jq-core18 jq-core20
 }
 
 setup_systemd_snapd_overrides() {
@@ -344,6 +347,80 @@ repack_snapd_snap_with_deb_content() {
     rm -rf "$UNPACK_DIR"
 }
 
+repack_snapd_snap_with_deb_content_and_firstboot_tweaks() {
+    local TARGET="$1"
+
+    local UNPACK_DIR="/tmp/snapd-unpack"
+    unsquashfs -no-progress -d "$UNPACK_DIR" snapd_*.snap
+
+    # clean snap apparmor.d to ensure the put the right snap-confine apparmor
+    # file in place. Its called usr.lib.snapd.snap-confine on 14.04 but
+    # usr.lib.snapd.snap-confine.real everywhere else
+    rm -f "$UNPACK_DIR"/etc/apparmor.d/*
+
+    dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
+    cp /usr/lib/snapd/info "$UNPACK_DIR"/usr/lib/
+
+    # now install a unit that setups enough so that we can connect
+    
+    # TODO:UC20: use something other than "snapd.core-fixup.sh"
+    # (ok for now because nothing will happen with snapd.core-fixup.sh on UC20)
+    # XXX: this duplicates a lot of setup_test_user_by_modify_writable()
+    cat > "$UNPACK_DIR"/usr/lib/snapd/snapd.core-fixup.sh <<'EOF'
+#!/bin/sh
+set -e
+# ensure we don't enable ssh in install mode or spread will get confused
+if ! grep 'snapd_recovery_mode=run' /proc/cmdline; then
+    echo "not in run mode - script not running"
+    exit 0
+fi
+if [ -e /root/spread-setup-done ]; then
+    exit 0
+fi
+
+# extract data from previous stage
+(cd / && tar xvf /run/mnt/ubuntu-seed/wormhole.tar.gz)
+
+# user db - it's complicated
+for f in group gshadow passwd shadow; do
+    # now bind mount read-only those passwd files on boot
+    cat >/etc/systemd/system/etc-"$f".mount <<EOF2
+[Unit]
+Description=Mount root/test-etc/$f over system etc/$f
+Before=ssh.service
+
+[Mount]
+What=/root/test-etc/$f
+Where=/etc/$f
+Type=none
+Options=bind,ro
+
+[Install]
+WantedBy=multi-user.target
+EOF2
+    systemctl enable etc-"$f".mount
+    systemctl start etc-"$f".mount
+done
+
+mkdir -p /home/test
+chown 12345:12345 /home/test
+mkdir -p /home/ubuntu
+chown 1000:1000 /home/ubuntu
+mkdir -p /etc/sudoers.d/
+echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-test-user
+echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-ubuntu-user
+sed -i 's/\#\?\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+echo "MaxAuthTries 120" >> /etc/ssh/sshd_config
+grep '^PermitRootLogin yes' /etc/ssh/sshd_config
+systemctl reload ssh
+
+touch /root/spread-setup-done
+EOF
+    chmod 0755 "$UNPACK_DIR"/usr/lib/snapd/snapd.core-fixup.sh
+    snap pack "$UNPACK_DIR" "$TARGET"
+    rm -rf "$UNPACK_DIR"
+}
+
 setup_core_for_testing_by_modify_writable() {
     UNPACK_DIR="$1"
 
@@ -456,6 +533,9 @@ setup_reflash_magic() {
     if is_core18_system; then
         snap download "--channel=${SNAPD_CHANNEL}" snapd
         core_name="core18"
+    elif is_core20_system; then
+        snap download "--channel=${SNAPD_CHANNEL}" snapd
+        core_name="core20"
     fi
     snap install "--channel=${CORE_CHANNEL}" "$core_name"
 
@@ -476,10 +556,14 @@ setup_reflash_magic() {
 
     if is_core18_system; then
         repack_snapd_snap_with_deb_content "$IMAGE_HOME"
-
         # FIXME: fetch directly once its in the assertion service
         cp "$TESTSLIB/assertions/ubuntu-core-18-amd64.model" "$IMAGE_HOME/pc.model"
         IMAGE=core18-amd64.img
+    elif is_core20_system; then
+        repack_snapd_snap_with_deb_content_and_firstboot_tweaks "$IMAGE_HOME"
+        # TODO:UC20: use canonical model instead of "mvo" one
+        cp "$TESTSLIB/assertions/ubuntu-core-20-amd64.model" "$IMAGE_HOME/pc.model"
+        IMAGE=core20-amd64.img
     else
         # modify the core snap so that the current root-pw works there
         # for spread to do the first login
@@ -539,7 +623,7 @@ EOF
 
     # on core18 we need to use the modified snapd snap and on core16
     # it is the modified core that contains our freshly build snapd
-    if is_core18_system; then
+    if is_core18_system || is_core20_system; then
         extra_snap=("$IMAGE_HOME"/snapd_*.snap)
     else
         extra_snap=("$IMAGE_HOME"/core_*.snap)
@@ -563,6 +647,9 @@ EOF
     # FIXME: hardcoded mapper location, parse from kpartx
     if is_core18_system; then
         mount /dev/mapper/loop3p3 /mnt
+    elif is_core20_system; then
+        # (ab)use ubuntu-seed
+        mount /dev/mapper/loop3p2 /mnt
     else
         mount /dev/mapper/loop2p3 /mnt
     fi
@@ -572,22 +659,52 @@ EOF
     # - built debs
     # - golang archive files and built packages dir
     # - govendor .cache directory and the binary,
-    rsync -a -C \
+    if is_core16_system || is_core18_system; then
+        rsync -a -C \
           --exclude '*.a' \
           --exclude '*.deb' \
           --exclude /gopath/.cache/ \
           --exclude /gopath/bin/govendor \
           --exclude /gopath/pkg/ \
           /home/gopath /mnt/user-data/
+    elif is_core20_system; then
+        # prepare passwd for wormhole
+        mkdir -p /root/test-etc
+        mkdir -p /var/lib/extrausers
+        touch /var/lib/extrausers/sub{uid,gid}
+        for f in group gshadow passwd shadow; do
+            grep -v "^root:" "/etc/$f" > /root/test-etc/"$f"
+            grep "^root:" /etc/"$f" >> /root/test-etc/"$f"
+            chgrp --reference "/etc/$f" /root/test-etc/"$f"
+            # create /var/lib/extrausers/$f
+            # append ubuntu, test user for the testing
+            grep "^test:" /etc/$f >> /var/lib/extrausers/"$f"
+            grep "^ubuntu:" /etc/$f >> /var/lib/extrausers/"$f"
+            # check test was copied
+            MATCH "^test:" </var/lib/extrausers/"$f"
+            MATCH "^ubuntu:" </var/lib/extrausers/"$f"
+        done
+        tar -c -z \
+          --exclude '*.a' \
+          --exclude '*.deb' \
+          --exclude /gopath/.cache/ \
+          --exclude /gopath/bin/govendor \
+          --exclude /gopath/pkg/ \
+          -f /mnt/wormhole.tar.gz \
+          /home/gopath /root/test-etc /var/lib/extrausers
+    fi
 
-    # now modify the image
+    # now modify the image writable partition
     if is_core18_system; then
         UNPACK_DIR="/tmp/core18-snap"
         unsquashfs -no-progress -d "$UNPACK_DIR" /var/lib/snapd/snaps/core18_*.snap
     fi
-
-    # modify the writable partition of "core" so that we have the test user
-    setup_core_for_testing_by_modify_writable "$UNPACK_DIR"
+    # modifying "writable" is only possible on uc16/uc18
+    if is_core16_system || is_core18_system; then
+        # modify the writable partition of "core" so that we have the
+        # test user
+        setup_core_for_testing_by_modify_writable "$UNPACK_DIR"
+    fi
 
     # the reflash magic
     # FIXME: ideally in initrd, but this is good enough for now
@@ -598,7 +715,11 @@ cp /bin/busybox /tmp
 cp $IMAGE_HOME/$IMAGE /tmp
 sync
 # blow away everything
-/tmp/busybox dd if=/tmp/$IMAGE of=/dev/sda bs=4M
+OF=/dev/sda
+if [ -e /dev/vda ]; then
+    OF=/dev/vda
+fi
+/tmp/busybox dd if=/tmp/$IMAGE of=\$OF bs=4M
 # and reboot
 /tmp/busybox sync
 /tmp/busybox echo b > /proc/sysrq-trigger
@@ -676,6 +797,8 @@ prepare_ubuntu_core() {
         rsync_snap="test-snapd-rsync"
         if is_core18_system; then
             rsync_snap="test-snapd-rsync-core18"
+        elif is_core20_system; then
+            rsync_snap="test-snapd-rsync-core20"
         fi
         snap install --devmode "$rsync_snap"
         snap alias "$rsync_snap".rsync rsync

--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -1,8 +1,8 @@
 summary: Check that the the docker snap works basically
 
 # only run on ubuntus for now, the docker snap has issues on non-ubuntu ATM
-systems:
-  - ubuntu-*
+# TODO:UC20: enable for UC20
+systems: [ubuntu-1*, ubuntu-2*, ubuntu-core-1*]
 
 debug: |
   journalctl -u snap.docker.dockerd

--- a/tests/main/gadget-update-pc/task.yaml
+++ b/tests/main/gadget-update-pc/task.yaml
@@ -6,7 +6,9 @@ environment:
     PC_SNAP_ID: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
     START_REVISION: 1000
 
-systems: [ubuntu-core-*]
+# the test is only meaningful on core devices
+# TODO:UC20: enable for UC20
+systems: [ubuntu-core-1*]
 
 prepare: |
     # external backends do not enable test keys

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -2,8 +2,8 @@ summary: Ensure that lxd works
 
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
-# No ubuntu 18.10 imaga available so far
-systems: [ubuntu-16*, ubuntu-18.04*, ubuntu-2*, ubuntu-core-*]
+# TODO:UC20: enable for UC20
+systems: [ubuntu-16*, ubuntu-18.04*, ubuntu-2*, ubuntu-core-1*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/snap-set-core-config/task.yaml
+++ b/tests/main/snap-set-core-config/task.yaml
@@ -1,7 +1,8 @@
 summary: Ensure "snap set core" works
 
 # the test is only meaningful on core devices
-systems: [ubuntu-core-*]
+# TODO:UC20: enable for UC20
+systems: [ubuntu-core-1*]
 
 prepare: |
     rc=0

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -2,7 +2,9 @@ summary: |
    Test that config defaults specified in the gadget are picked up
    for first boot snaps
 
-systems: [ubuntu-core-*]
+# the test is only meaningful on core devices
+# TODO:UC20: enable for UC20
+systems: [ubuntu-core-1*]
 
 environment:
     SERVICE/rsyslog: rsyslog

--- a/tests/main/ubuntu-core-netplan/task.yaml
+++ b/tests/main/ubuntu-core-netplan/task.yaml
@@ -6,9 +6,9 @@ details: |
 environment:
     NETPLAN: io.netplan.Netplan
 
-# only run on ubuntu core systems
-systems:
-    - ubuntu-core-*
+# the test is only meaningful on core devices
+# TODO:UC20: enable for UC20
+systems: [ubuntu-core-1*]
 
 prepare: |
     snap install test-snapd-netplan-apply --edge

--- a/tests/main/ubuntu-core-network-config/task.yaml
+++ b/tests/main/ubuntu-core-network-config/task.yaml
@@ -1,6 +1,8 @@
 summary: Check that `snap set {system,core} network.disable-ipv6` works
 
-systems: [ubuntu-core-*]
+# the test is only meaningful on core devices
+# TODO:UC20: enable for UC20
+systems: [ubuntu-core-1*]
 
 environment:
     snap_nick/system: system

--- a/tests/main/ubuntu-core-refresh/task.yaml
+++ b/tests/main/ubuntu-core-refresh/task.yaml
@@ -5,7 +5,9 @@ details: |
     a reboot is triggered and the command would exit after the first phase of the installation
     reporting "snapd is about to reboot the system"
 
-systems: [ubuntu-core-*]
+# the test is only meaningful on core devices
+# TODO:UC20: enable for UC20
+systems: [ubuntu-core-1*]
 
 execute: |
     #shellcheck source=tests/lib/journalctl.sh

--- a/tests/regression/lp-1805485/task.yaml
+++ b/tests/regression/lp-1805485/task.yaml
@@ -9,7 +9,7 @@ details: |
     Make sure that apparmor backend is not disabled on systems where apparmor
     tooling is recent enough.
 
-systems: [ubuntu-*, opensuse-*, arch-linux-*]
+systems: [ubuntu-1*, opensuse-*, arch-linux-*]
 
 execute: |
     snap debug sandbox-features | MATCH "^apparmor:"


### PR DESCRIPTION
Add a first minimal core20 test suite.

This works in qemu with the following patches for spread:
  * https://github.com/snapcore/spread/pull/95
  * https://github.com/snapcore/spread/pull/96

Then it needs to be run like this: 
```
$ SPREAD_QEMU_BIOS=/usr/share/OVMF/OVMF_CODE.ms.fd spread qemu:ubuntu-core-20-64:tests/core20/
```

It should also work with google and an uefi enabled image. Maybe @sergiocazzolato can have a look at this.

Obviously this is just the start, we need to run more tests and start enabling the smoke suite etc.

Full run (for reference):
```
$ SPREAD_QEMU_BIOS=/usr/share/OVMF/OVMF_CODE.ms.fd spread  -debug qemu:ubuntu-core-20-64:tests/core20/
2019-12-19 14:58:45 Project content is packed for delivery (9.13MB).
2019-12-19 14:58:45 If killed, discard servers with: spread -reuse-pid=21201 -discard
2019-12-19 14:58:45 Allocating qemu:ubuntu-core-20-64...
2019-12-19 14:58:45 Serial and monitor for qemu:ubuntu-core-20-64 available at ports 59469 and 59569.
2019-12-19 14:58:45 Waiting for qemu:ubuntu-core-20-64 to make SSH available...
2019-12-19 14:58:46 Allocated qemu:ubuntu-core-20-64.
2019-12-19 14:58:46 Connecting to qemu:ubuntu-core-20-64...
2019-12-19 14:59:04 Connected to qemu:ubuntu-core-20-64 at localhost:59369.
2019-12-19 14:59:04 Sending project content to qemu:ubuntu-core-20-64...
2019-12-19 14:59:05 Preparing qemu:ubuntu-core-20-64...
2019-12-19 15:04:05 WARNING: qemu:ubuntu-core-20-64 (qemu:ubuntu-core-20-64) running late. Current output:
-----
(... 1299 lines above ...)
dpkg-deb: building package 'snapd-dbgsym' in 'debian/.debhelper/scratch-space/build-snapd/snapd-dbgsym_1337.2.43~pre1_amd64.deb'.
	Renaming snapd-dbgsym_1337.2.43~pre1_amd64.deb to snapd-dbgsym_1337.2.43~pre1_amd64.ddeb
dpkg-deb: building package 'ubuntu-snappy' in '../ubuntu-snappy_1337.2.43~pre1_all.deb'.
dpkg-deb: building package 'ubuntu-snappy-cli' in '../ubuntu-snappy-cli_1337.2.43~pre1_all.deb'.
dpkg-deb: building package 'ubuntu-core-snapd-units' in '../ubuntu-core-snapd-units_1337.2.43~pre1_all.deb'.
dpkg-deb: building package 'snap-confine' in '../snap-confine_1337.2.43~pre1_amd64.deb'.
dpkg-deb: building package 'ubuntu-core-launcher' in '../ubuntu-core-launcher_1337.2.43~pre1_amd64.deb'.
dpkg-deb: building package 'snapd-xdg-open' in '../snapd-xdg-open_1337.2.43~pre1_amd64.deb'.
 dpkg-genbuildinfo --build=binary
 dpkg-genchanges --build=binary >../snapd_1337.2.43~pre1_amd64.changes
-----
.
2019-12-19 15:04:14 Preparing qemu:ubuntu-core-20-64:tests/core20/...
2019-12-19 15:06:34 Rebooting on qemu:ubuntu-core-20-64 (qemu:ubuntu-core-20-64:tests/core20/) as requested...
2019-12-19 15:11:50 Preparing qemu:ubuntu-core-20-64:tests/core20/basic...
2019-12-19 15:11:52 Executing qemu:ubuntu-core-20-64:tests/core20/basic (1/1)...
2019-12-19 15:12:04 Restoring qemu:ubuntu-core-20-64:tests/core20/basic...
2019-12-19 15:12:04 Restoring qemu:ubuntu-core-20-64:tests/core20/...
2019-12-19 15:12:07 Restoring qemu:ubuntu-core-20-64...
2019-12-19 15:12:07 Discarding qemu:ubuntu-core-20-64...
2019-12-19 15:12:07 Successful tasks: 1
2019-12-19 15:12:07 Aborted tasks: 0
```
