### PR TITLE
spread: drop copr repo with F30 build dependencies

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -512,9 +512,6 @@ prepare: |
         # https://forum.snapcraft.io/t/issues-with-the-fedora-mirror-network/3489/
         sed -i -s -E -e 's@^#?baseurl=http://download.fedoraproject.org/@baseurl=http://dl.fedoraproject.org/@g' -e 's@^metalink=@#metalink@g' /etc/yum.repos.d/fedora*.repo
 
-        # TODO: disable once golang-x-xerrors is available in F30
-        dnf copr enable bboozzoo/snapd-devel-deps -y
-
         dnf --refresh -y makecache
 
         # enable audit daemon


### PR DESCRIPTION
The package has been built and published for Fedora 30.

NOTE: the update is still in testing, so the PR will likely keep failing until it's pushed to the updates repo.
