### PR TITLE
cmd/snap, daemon: stop over-normalising channels

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -253,7 +253,7 @@ func (mx *channelMixin) setChannelFromCommandline() error {
 	}
 
 	if mx.Channel != "" {
-		if ch, err := channel.Parse(mx.Channel, ""); err != nil {
+		if _, err := channel.Parse(mx.Channel, ""); err != nil {
 			full, er := channel.Full(mx.Channel)
 			if er != nil {
 				// the parse error has more detailed info
@@ -266,10 +266,6 @@ func (mx *channelMixin) setChannelFromCommandline() error {
 			warn := fill(fmt.Sprintf(msg, mx.Channel, full), utf8.RuneCountInString(head)+1) // +1 for the space
 			fmt.Fprint(Stderr, head, " ", warn, "\n\n")
 			mx.Channel = full // so a malformed-but-eh channel will always be full, i.e. //stable// -> latest/stable
-		} else {
-			// because snap.ParseChannel calls Clean() on the channel,
-			// the name will be the short form name that we want
-			mx.Channel = ch.Name
 		}
 	}
 
@@ -322,8 +318,14 @@ func showDone(cli *client.Client, names []string, op string, opts *client.SnapOp
 	needsPathWarning := !isSnapInPath()
 	for _, snap := range snaps {
 		channelStr := ""
-		if snap.Channel != "" && snap.Channel != "stable" {
-			channelStr = fmt.Sprintf(" (%s)", snap.Channel)
+		if snap.Channel != "" {
+			ch, err := channel.Parse(snap.Channel, "")
+			if err != nil {
+				return err
+			}
+			if ch.Name != "stable" {
+				channelStr = fmt.Sprintf(" (%s)", ch.Name)
+			}
 		}
 		switch op {
 		case "install":

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -235,7 +235,7 @@ func (s *SnapOpSuite) TestInstallFromTrack(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "install",
-			"channel": "3.4/stable",
+			"channel": "3.4",
 		})
 		s.srv.channel = "3.4/stable"
 	}
@@ -276,7 +276,7 @@ func (s *SnapOpSuite) TestInstallSameRiskInTrack(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "install",
-			"channel": "stable",
+			"channel": "latest/stable",
 		})
 		s.srv.channel = "stable"
 		s.srv.trackingChannel = "latest/stable"
@@ -451,11 +451,7 @@ func (s *SnapOpSuite) TestInstallSnapRevisionNotAvailableOnChannel(c *check.C) {
 	})
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--channel=mytrack", "foo"})
-	c.Assert(err, check.NotNil)
-	c.Check(fmt.Sprintf("\nerror: %v\n", err), check.Equals, `
-error: snap "foo" not available on channel "mytrack/stable" (see 'snap info
-       foo')
-`)
+	c.Check(err, check.ErrorMatches, `snap "foo" not available on channel "mytrack" \(see 'snap info foo'\)`)
 
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Equals, "")

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -765,11 +765,10 @@ func (ropt *snapRevisionOptions) validate() error {
 	}
 
 	if ropt.Channel != "" {
-		ch, err := channel.Parse(ropt.Channel, "-")
+		_, err := channel.Parse(ropt.Channel, "-")
 		if err != nil {
 			return err
 		}
-		ropt.Channel = ch.Name
 	}
 	return nil
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2460,8 +2460,8 @@ func (s *apiSuite) testPostSnap(c *check.C, withChannel bool) {
 
 	snapInstructionDispTable["install"] = func(inst *snapInstruction, _ *state.State) (string, []*state.TaskSet, error) {
 		if withChannel {
-			// channel in -> it was parsed
-			c.Check(inst.Channel, check.Equals, "xyzzy/stable")
+			// channel in -> channel out
+			c.Check(inst.Channel, check.Equals, "xyzzy")
 		} else {
 			// no channel in -> no channel out
 			c.Check(inst.Channel, check.Equals, "")


### PR DESCRIPTION
We were being too aggressive at normalising channel names, resulting
in losing what the user requested too early. This change undoes that.
