### PR TITLE
tests: use test-snapd-sh snap instead of test-snapd-tools - Part 3 (2.43)

### DIFF
--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -152,7 +152,7 @@ snapd (2.43~pre1) xenial; urgency=medium
       test
     - cmd/snap-confine: add support for parallel instances of classic
       snaps, global mount ns initialization
-    - overlord: add kernel rollback accross reboots manager test and
+    - overlord: add kernel rollback across reboots manager test and
       fixes
     - o/devicestate: the basics of Core 20 firstboot support with test
     - asserts: support and parsing for slots-per-plug/plugs-per-slotSee
@@ -255,7 +255,7 @@ snapd (2.43~pre1) xenial; urgency=medium
     - overlord: set fake serial in TestRemodelSwitchToDifferentKernel
     - overlord/many: extend check snap callback to take snap container
     - recovery-tool: add sfdisk wrapper
-    - tests: launch the lxd images folowing the pattern
+    - tests: launch the lxd images following the pattern
       ubuntu:${VERSION_ID}
     - sandbox/cgroup: move freeze/thaw code
     - gadget: accept system-seed role and ubuntu-data label

--- a/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
@@ -3,5 +3,5 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 apps:
-    test-snapd-sh:
+    sh:
         command: bin/sh

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -18,7 +18,7 @@ execute: |
     trap 'killall test-snapd-sh || true' EXIT
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
-    test-snapd-sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
+    test-snapd-sh.sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
     pid1=$!
     # Ensure that snap-confine has finished its task and that the snap process
     # is active. Note that we don't want to wait forever either.
@@ -33,7 +33,7 @@ execute: |
     # Start a second process so that we can check adding tasks to an existing
     # control group.
     #shellcheck disable=SC2016
-    test-snapd-sh -c 'touch $SNAP_DATA/2.stamp && exec sleep 1h' &
+    test-snapd-sh.sh -c 'touch $SNAP_DATA/2.stamp && exec sleep 1h' &
     pid2=$!
     for _ in $(seq 30); do
         test -e /var/snap/test-snapd-sh/current/2.stamp && break

--- a/tests/main/cgroup-pids/task.yaml
+++ b/tests/main/cgroup-pids/task.yaml
@@ -15,7 +15,7 @@ prepare: |
     install_local test-snapd-sh
 
 restore: |
-    rmdir /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh || true
+    rmdir /sys/fs/cgroup/pids/snap.test-snapd-sh.sh || true
 
     # TODO: There is currently no way to unset configuration options.
     # Once this is fixed please uncomment this line:
@@ -25,7 +25,7 @@ execute: |
     trap 'killall test-snapd-sh || true' EXIT
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
-    test-snapd-sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
+    test-snapd-sh.sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
     pid1=$!
     # Ensure that snap-confine has finished its task and that the snap process
     # is active. Note that we don't want to wait forever either.
@@ -35,32 +35,32 @@ execute: |
     done
     # While the process is alive its PID can be seen in the cgroup.procs file
     # of the pid controller.
-    MATCH "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    MATCH "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs
 
     # Start a second process so that we can check adding tasks to an existing
     # control group.
     #shellcheck disable=SC2016
-    test-snapd-sh -c 'touch $SNAP_DATA/2.stamp && exec sleep 1h' &
+    test-snapd-sh.sh -c 'touch $SNAP_DATA/2.stamp && exec sleep 1h' &
     pid2=$!
     for _ in $(seq 30); do
         test -e /var/snap/test-snapd-sh/current/2.stamp && break
         sleep 0.1
     done
-    MATCH "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    MATCH "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs
 
     # When the process terminates the control group is updated and the task no
     # longer registers there.
     kill "$pid1"
     wait "$pid1" || true  # wait returns the exit code and we kill the process
-    MATCH -v "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    MATCH -v "$pid1" < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs
 
     kill "$pid2"
     wait "$pid2" || true  # same as above
-    MATCH -v "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    MATCH -v "$pid2" < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs
 
     # If a snap command forks a child process it is also tracked.
     #shellcheck disable=SC2016
-    test-snapd-sh -c 'touch $SNAP_DATA/3.stamp && sleep 1h' &
+    test-snapd-sh.sh -c 'touch $SNAP_DATA/3.stamp && sleep 1h' &
     pid3=$!
 
     # Ensure that snap-confine has finished its task and that the snap process
@@ -71,16 +71,16 @@ execute: |
     done
     # While the process is alive its PID can be seen in the cgroup.procs file
     # of the pid controller.
-    MATCH "$pid3" < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    MATCH "$pid3" < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs
 
     # Because the script above used "sleep 1h" instead of "exec sleep 1h" there
     # are now two processes: the shell and sleep.
-    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 2
+    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs)" -eq 2
     kill "$pid3"
-    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 1
+    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs)" -eq 1
     # Kill the remaining cgroup process.
     while read -r pid; do
         kill "$pid"
-    done < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs
+    done < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs
     wait "$pid3" || true  # same as above
-    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.test-snapd-sh/cgroup.procs)" -eq 0
+    test "$(wc -l < /sys/fs/cgroup/pids/snap.test-snapd-sh.sh/cgroup.procs)" -eq 0

--- a/tests/main/cwd/task.yaml
+++ b/tests/main/cwd/task.yaml
@@ -15,21 +15,21 @@ restore: |
 execute: |
     # The current working directory that exists in the snap mount namespace and
     # represents the same inode is is preserved.
-    test "$(cd "$HOME" && test-snapd-sh -c pwd)" = "$HOME"
-    test "$(cd "$HOME" && test-snapd-sh -c 'stat -c %i .')" = "$(cd "$HOME" && stat -c %i .)"
+    test "$(cd "$HOME" && test-snapd-sh.sh -c pwd)" = "$HOME"
+    test "$(cd "$HOME" && test-snapd-sh.sh -c 'stat -c %i .')" = "$(cd "$HOME" && stat -c %i .)"
     # The current working directory that is visible in the snap mount namespace
     # but represents a different inode is re-interpreted to give the view on
     # the inside.
-    test "$(cd /tmp && test-snapd-sh -c pwd)" = "/tmp"
-    test "$(cd /tmp && test-snapd-sh -c 'stat -c %i .')" != "$(cd /tmp && stat -c %i .)"
+    test "$(cd /tmp && test-snapd-sh.sh -c pwd)" = "/tmp"
+    test "$(cd /tmp && test-snapd-sh.sh -c 'stat -c %i .')" != "$(cd /tmp && stat -c %i .)"
     # The current working directory that does not exist in the snap mount
     # namespace is re-mapped to a special directory.
-    test "$(mkdir -p /tmp/test && cd /tmp/test && test-snapd-sh -c pwd)" = "/var/lib/snapd/void"
+    test "$(mkdir -p /tmp/test && cd /tmp/test && test-snapd-sh.sh -c pwd)" = "/var/lib/snapd/void"
     # The current working directory that does exist in the snap mount
     # namespace but has permissions preventing the user to enter it (e.g.
     # via a symlink attack in /tmp) is remapped to a special directory.
     # FIXME: su doesn't have /snap/bin in PATH.
-    test "$(cd /root && su -c "snap run test-snapd-sh -c pwd" test)" = "/var/lib/snapd/void"
+    test "$(cd /root && su -c "snap run test-snapd-sh.sh -c pwd" test)" = "/var/lib/snapd/void"
     # Since the void directory is used when there are insufficient permissions
     # to enter the regular directory we must be able to go there in the first
     # place. The directory is sometimes created on demand so check for the

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -17,7 +17,7 @@ prepare: |
     echo "Having installed the test snap"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
@@ -29,7 +29,7 @@ execute: |
     else
         core_inode=$(stat -c '%i' "$SNAP_MOUNT_DIR/ubuntu-core/current/$DIRECTORY")
     fi
-    effective_inode=$(test-snapd-tools.cmd stat -c '%i' "$DIRECTORY")
+    effective_inode=$(test-snapd-sh.sh -c "stat -c '%i' $DIRECTORY")
     echo "The inode number as seen from a confined snap should be that of the $DIRECTORY from the core snap"
     [ "$host_inode" != "$core_inode" ]
     [ "$effective_inode" = "$core_inode" ]

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -28,7 +28,7 @@ prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-desktop
-    install_local test-snapd-tools
+    install_local test-snapd-sh
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
     mkdir -p "$XDG_RUNTIME_DIR"
     rm -rf "${XDG_RUNTIME_DIR:?}/*" "${XDG_RUNTIME_DIR:?}/.[!.]*"
@@ -100,6 +100,6 @@ execute: |
 
     echo "Snaps not using the desktop interface will not try to contact the document portal"
     : > doc-portal.log
-    test-snapd-tools.success 2>stderr.log
+    test-snapd-sh.sh -c 'true' 2>stderr.log
     check_stderr stderr.log
     [ "$(wc -c < doc-portal.log)" -eq 0 ]

--- a/tests/main/enable-disable/task.yaml
+++ b/tests/main/enable-disable/task.yaml
@@ -1,45 +1,45 @@
 summary: Check that enable/disable works
 
 prepare: |
-    echo "Install test-snapd-tools and ensure it runs"
+    echo "Install test-snapd-sh and ensure it runs"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
-    test-snapd-tools.echo Hello | MATCH Hello
+    install_local test-snapd-sh
+    test-snapd-sh.sh -c 'echo Hello' | MATCH Hello
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
-    echo "Disable test-snapd-tools and ensure it is listed as disabled"
-    snap disable test-snapd-tools|MATCH disabled
+    echo "Disable test-snapd-sh and ensure it is listed as disabled"
+    snap disable test-snapd-sh | MATCH disabled
 
-    echo "Ensure the test-snapd-tools command is no longer there"
-    if ls $SNAP_MOUNT_DIR/bin/test-snapd-tools*; then
-        echo "test-snapd-tools binaries are not disabled"
+    echo "Ensure the test-snapd-sh command is no longer there"
+    if ls $SNAP_MOUNT_DIR/bin/test-snapd-sh*; then
+        echo "test-snapd-sh binaries are not disabled"
         exit 1
     fi
 
     if [ "$(snap debug confinement)" = strict ]; then
-        echo "Ensure the test-snapd-tools security profiles are no longer there"
-        if ls /var/lib/snapd/apparmor/profiles/snap.test-snapd-tools*; then
-            echo "test-snapd-tools securiry profiles are not disabled"
+        echo "Ensure the test-snapd-sh security profiles are no longer there"
+        if ls /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh*; then
+            echo "test-snapd-sh securiry profiles are not disabled"
             exit 1
         fi
     fi
 
-    echo "Enable test-snapd-tools again and ensure it is no longer listed as disabled"
-    snap enable test-snapd-tools|MATCH -v disabled
+    echo "Enable test-snapd-sh again and ensure it is no longer listed as disabled"
+    snap enable test-snapd-sh | MATCH -v disabled
 
     if [ "$(snap debug confinement)" = strict ]; then
-        echo "Ensure the test-snapd-tools security profiles are present"
-        if ! ls /var/lib/snapd/apparmor/profiles/snap.test-snapd-tools*; then
-            echo "test-snapd-tools securiry profiles are not present"
+        echo "Ensure the test-snapd-sh security profiles are present"
+        if ! ls /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh*; then
+            echo "test-snapd-sh securiry profiles are not present"
             exit 1
         fi
     fi
 
-    echo "Ensure test-snapd-tools runs normally after it was enabled"
-    test-snapd-tools.echo Hello |MATCH Hello
+    echo "Ensure test-snapd-sh runs normally after it was enabled"
+    test-snapd-sh.sh -c 'echo Hello' |MATCH Hello
 
     echo "Ensure the important snaps can not be disabled"
     #shellcheck source=tests/lib/names.sh

--- a/tests/main/interfaces-mount-observe/task.yaml
+++ b/tests/main/interfaces-mount-observe/task.yaml
@@ -38,10 +38,10 @@ execute: |
     echo "And a new mount is created"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     echo "Then the new mount info is reachable"
-    expected="$SNAP_MOUNT_DIR/test-snapd-tools"
+    expected="$SNAP_MOUNT_DIR/test-snapd-sh"
     su -l -c "mount-observe-consumer" test | grep -Pq "$expected"
 
     if [ "$(snap debug confinement)" = partial ] ; then

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -3,10 +3,10 @@ summary: Check snap listings
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     snap set system experimental.parallel-instances=true
-    install_local_as test-snapd-tools test-snapd-tools_foo
+    install_local_as test-snapd-sh test-snapd-sh_foo
 
 restore: |
     snap set system experimental.parallel-instances=null
@@ -71,18 +71,18 @@ execute: |
     snap list --unicode=never | MATCH "$expected"
 
     echo "List prints installed snaps and versions"
-    snap list | MATCH "^test-snapd-tools +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
-    snap list | MATCH "^test-snapd-tools_foo +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
+    snap list | MATCH "^test-snapd-sh +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
+    snap list | MATCH "^test-snapd-sh_foo +$NUMERIC_VERSION +$SIDELOAD_REV +- +- +- *$"
 
-    echo "Install test-snapd-tools again"
+    echo "Install test-snapd-sh again"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     echo "And run snap list --all"
-    output=$(snap list --all | grep 'test-snapd-tools ')
-    if [ "$(grep -c test-snapd-tools <<< "$output")" != "2" ]; then
-        echo "Expected two test-snapd-tools in the output, got:"
+    output=$(snap list --all | grep 'test-snapd-sh ')
+    if [ "$(grep -c test-snapd-sh <<< "$output")" != "2" ]; then
+        echo "Expected two test-snapd-sh in the output, got:"
         echo "$output"
         exit 1
     fi
@@ -92,4 +92,4 @@ execute: |
         exit 1
     fi
 
-    snap list --all | MATCH 'test-snapd-tools_foo '
+    snap list --all | MATCH 'test-snapd-sh_foo '

--- a/tests/main/op-install-failed-undone/task.yaml
+++ b/tests/main/op-install-failed-undone/task.yaml
@@ -5,7 +5,7 @@ systems: [-ubuntu-core-*]
 restore: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
-    rm -rf $SNAP_MOUNT_DIR/test-snapd-tools
+    rm -rf $SNAP_MOUNT_DIR/test-snapd-sh
 
 execute: |
     check_empty_glob(){
@@ -18,39 +18,39 @@ execute: |
     . "$TESTSLIB"/dirs.sh
 
     echo "Given we make a snap uninstallable"
-    mkdir -p $SNAP_MOUNT_DIR/test-snapd-tools/current/foo
+    mkdir -p $SNAP_MOUNT_DIR/test-snapd-sh/current/foo
 
     echo "And we try to install it"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    if install_local test-snapd-tools; then
+    if install_local test-snapd-sh; then
         echo "A snap shouldn't be installable if its mount point is busy"
         exit 1
     fi
 
     echo "Then the snap isn't installed"
-    snap list | MATCH -v test-snapd-tools
+    snap list | MATCH -v test-snapd-sh
 
     echo "And the installation task is reported as an error"
-    failed_task_id=$(snap changes | perl -ne 'print $1 if /(\d+) +Error.*?Install \"test-snapd-tools\" snap/')
+    failed_task_id=$(snap changes | perl -ne 'print $1 if /(\d+) +Error.*?Install \"test-snapd-sh\" snap/')
     if [ -z "$failed_task_id" ]; then
         echo "Installation task should be reported as error"
         exit 1
     fi
 
     echo "And the Mount subtask is actually undone"
-    snap change "$failed_task_id" | grep -Pq "Undone +.*?Mount snap \"test-snapd-tools\""
-    check_empty_glob $SNAP_MOUNT_DIR/test-snapd-tools [0-9]+
-    check_empty_glob /var/lib/snapd/snaps test-snapd-tools_[0-9]+.snap
+    snap change "$failed_task_id" | grep -Pq "Undone +.*?Mount snap \"test-snapd-sh\""
+    check_empty_glob $SNAP_MOUNT_DIR/test-snapd-sh [0-9]+
+    check_empty_glob /var/lib/snapd/snaps test-snapd-sh_[0-9]+.snap
 
     echo "And the Data Copy subtask is actually undone"
-    snap change "$failed_task_id" | grep -Pq "Undone +.*?Copy snap \"test-snapd-tools\" data"
-    check_empty_glob "$HOME"/snap/test-snapd-tools [0-9]+
-    check_empty_glob /var/snap/test-snapd-tools [0-9]+
+    snap change "$failed_task_id" | grep -Pq "Undone +.*?Copy snap \"test-snapd-sh\" data"
+    check_empty_glob "$HOME"/snap/test-snapd-sh [0-9]+
+    check_empty_glob /var/snap/test-snapd-sh [0-9]+
 
     echo "And the Security Profiles Setup subtask is actually undone"
-    snap change "$failed_task_id" | grep -Pq 'Undone +.*?Setup snap "test-snapd-tools" \(unset\) security profiles'
-    check_empty_glob /var/lib/snapd/apparmor/profiles snap.test-snapd-tools.*
-    check_empty_glob /var/lib/snapd/seccomp/bpf snap.test-snapd-tools.*
-    check_empty_glob /etc/dbus-1/system.d snap.test-snapd-tools.*.conf
-    check_empty_glob /etc/udev/rules.d 70-snap.test-snapd-tools.*.rules
+    snap change "$failed_task_id" | grep -Pq 'Undone +.*?Setup snap "test-snapd-sh" \(unset\) security profiles'
+    check_empty_glob /var/lib/snapd/apparmor/profiles snap.test-snapd-sh.*
+    check_empty_glob /var/lib/snapd/seccomp/bpf snap.test-snapd-sh.*
+    check_empty_glob /etc/dbus-1/system.d snap.test-snapd-sh.*.conf
+    check_empty_glob /etc/udev/rules.d 70-snap.test-snapd-sh.*.rules

--- a/tests/main/parallel-install-basic/task.yaml
+++ b/tests/main/parallel-install-basic/task.yaml
@@ -3,7 +3,7 @@ summary: Checks for parallel installation of a local snap files
 prepare: |
     # ensure we have no snap user data directory yet
     rm -rf /home/test/snap
-    rm -rf /var/snap/test-snapd-tools /var/snap/test-snapd-tools_foo
+    rm -rf /var/snap/test-snapd-sh /var/snap/test-snapd-sh_foo
 
     snap set system experimental.parallel-instances=true
 
@@ -11,75 +11,75 @@ execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
 
-    install_local test-snapd-tools
-    install_local_as test-snapd-tools test-snapd-tools_foo
+    install_local test-snapd-sh
+    install_local_as test-snapd-sh test-snapd-sh_foo
 
-    su -l -c '! test -d ~/snap/test-snapd-tools' test
-    su -l -c '! test -d ~/snap/test-snapd-tools_foo' test
+    su -l -c '! test -d ~/snap/test-snapd-sh' test
+    su -l -c '! test -d ~/snap/test-snapd-sh_foo' test
 
-    su -l -c 'test-snapd-tools_foo.cmd echo foo' test | MATCH foo
-    su -l -c 'test -d ~/snap/test-snapd-tools' test
-    su -l -c 'test -d ~/snap/test-snapd-tools_foo' test
+    su -l -c 'test-snapd-sh_foo.sh -c "echo foo"' test | MATCH foo
+    su -l -c 'test -d ~/snap/test-snapd-sh' test
+    su -l -c 'test -d ~/snap/test-snapd-sh_foo' test
 
     # instance environment variables are correctly set up
-    su -l -c 'test-snapd-tools_foo.env' test > snap_foo-env.txt
-    MATCH 'SNAP_INSTANCE_NAME=test-snapd-tools_foo'                      < snap_foo-env.txt
-    MATCH 'SNAP_NAME=test-snapd-tools'                                   < snap_foo-env.txt
+    su -l -c 'test-snapd-sh_foo.sh -c "env"' test > snap_foo-env.txt
+    MATCH 'SNAP_INSTANCE_NAME=test-snapd-sh_foo'                         < snap_foo-env.txt
+    MATCH 'SNAP_NAME=test-snapd-sh'                                      < snap_foo-env.txt
     MATCH 'SNAP_INSTANCE_KEY=foo'                                        < snap_foo-env.txt
-    MATCH 'SNAP=/snap/test-snapd-tools/x1'                               < snap_foo-env.txt
-    MATCH 'SNAP_COMMON=/var/snap/test-snapd-tools/common'                < snap_foo-env.txt
-    MATCH 'SNAP_DATA=/var/snap/test-snapd-tools/x1'                      < snap_foo-env.txt
-    MATCH 'SNAP_USER_DATA=/home/test/snap/test-snapd-tools_foo/x1'       < snap_foo-env.txt
-    MATCH 'SNAP_USER_COMMON=/home/test/snap/test-snapd-tools_foo/common' < snap_foo-env.txt
+    MATCH 'SNAP=/snap/test-snapd-sh/x1'                                  < snap_foo-env.txt
+    MATCH 'SNAP_COMMON=/var/snap/test-snapd-sh/common'                   < snap_foo-env.txt
+    MATCH 'SNAP_DATA=/var/snap/test-snapd-sh/x1'                         < snap_foo-env.txt
+    MATCH 'SNAP_USER_DATA=/home/test/snap/test-snapd-sh_foo/x1'          < snap_foo-env.txt
+    MATCH 'SNAP_USER_COMMON=/home/test/snap/test-snapd-sh_foo/common'    < snap_foo-env.txt
 
     # and non-instance one's are too
-    su -l -c 'test-snapd-tools.env' test > snap-env.txt
-    MATCH 'SNAP_INSTANCE_NAME=test-snapd-tools'           < snap-env.txt
-    MATCH 'SNAP_NAME=test-snapd-tools'                    < snap-env.txt
+    su -l -c 'test-snapd-sh.sh -c env' test > snap-env.txt
+    MATCH 'SNAP_INSTANCE_NAME=test-snapd-sh'              < snap-env.txt
+    MATCH 'SNAP_NAME=test-snapd-sh'                       < snap-env.txt
     MATCH 'SNAP_INSTANCE_KEY=$'                           < snap-env.txt
-    MATCH 'SNAP=/snap/test-snapd-tools/x1'                < snap-env.txt
+    MATCH 'SNAP=/snap/test-snapd-sh/x1'                   < snap-env.txt
 
-    mkdir /var/snap/test-snapd-tools_foo/common/foobar
-    echo canary-instance > /var/snap/test-snapd-tools_foo/common/foobar/data
-    chown -R test:test /var/snap/test-snapd-tools_foo/common/foobar
+    mkdir /var/snap/test-snapd-sh_foo/common/foobar
+    echo canary-instance > /var/snap/test-snapd-sh_foo/common/foobar/data
+    chown -R test:test /var/snap/test-snapd-sh_foo/common/foobar
 
-    mkdir /var/snap/test-snapd-tools/common/foobar
-    echo canary-regular > /var/snap/test-snapd-tools/common/foobar/data
-    chown -R test:test /var/snap/test-snapd-tools/common/foobar
+    mkdir /var/snap/test-snapd-sh/common/foobar
+    echo canary-regular > /var/snap/test-snapd-sh/common/foobar/data
+    chown -R test:test /var/snap/test-snapd-sh/common/foobar
 
     echo "Make sure snap data writes and reads work"
 
     # instance can access its data
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_COMMON/foobar/data'" test | MATCH canary-instance
+    su -l -c "test-snapd-sh_foo.sh -c 'cat \$SNAP_COMMON/foobar/data'" test | MATCH canary-instance
     # non-instance sees its data
-    su -l -c "test-snapd-tools.cmd sh -c 'cat \$SNAP_COMMON/foobar/data'" test | MATCH canary-regular
+    su -l -c "test-snapd-sh.sh -c 'cat \$SNAP_COMMON/foobar/data'" test | MATCH canary-regular
 
     # instance can write data
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello from instance \$SNAP_INSTANCE_NAME > \$SNAP_COMMON/foobar/hello'" test
-    MATCH 'hello from instance test-snapd-tools_foo' < /var/snap/test-snapd-tools_foo/common/foobar/hello
+    su -l -c "test-snapd-sh_foo.sh -c 'echo hello from instance \$SNAP_INSTANCE_NAME > \$SNAP_COMMON/foobar/hello'" test
+    MATCH 'hello from instance test-snapd-sh_foo' < /var/snap/test-snapd-sh_foo/common/foobar/hello
     # and the file is not visible in non instance snap
-    su -l -c "test-snapd-tools.cmd sh -c 'cat \$SNAP_COMMON/foobar/hello || true'" test 2>&1 | MATCH 'cat: /var/snap/test-snapd-tools/common/foobar/hello: No such file or directory'
+    su -l -c "test-snapd-sh.sh -c 'cat \$SNAP_COMMON/foobar/hello || true'" test 2>&1 | MATCH 'cat: /var/snap/test-snapd-sh/common/foobar/hello: No such file or directory'
 
     echo "Make sure snap user data writes work"
-    echo canary-instance-snap > /home/test/snap/test-snapd-tools_foo/x1/canary
-    chown test:test /home/test/snap/test-snapd-tools_foo/x1/canary
-    echo canary-instance-common > /home/test/snap/test-snapd-tools_foo/common/canary
-    chown test:test /home/test/snap/test-snapd-tools_foo/common/canary
+    echo canary-instance-snap > /home/test/snap/test-snapd-sh_foo/x1/canary
+    chown test:test /home/test/snap/test-snapd-sh_foo/x1/canary
+    echo canary-instance-common > /home/test/snap/test-snapd-sh_foo/common/canary
+    chown test:test /home/test/snap/test-snapd-sh_foo/common/canary
 
     # instance snap can write to user data
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
-    MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/x1/data
+    su -l -c "test-snapd-sh_foo.sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
+    MATCH 'hello user data from test-snapd-sh_foo' < /home/test/snap/test-snapd-sh_foo/x1/data
     # the file not present in non-instance snap data
-    not test -f /home/test/snap/test-snapd-tools/x1/data
+    not test -f /home/test/snap/test-snapd-sh/x1/data
 
     # instance snap can write to common user data
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_COMMON/data'" test
-    MATCH 'hello user data from test-snapd-tools_foo' < /home/test/snap/test-snapd-tools_foo/common/data
+    su -l -c "test-snapd-sh_foo.sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_COMMON/data'" test
+    MATCH 'hello user data from test-snapd-sh_foo' < /home/test/snap/test-snapd-sh_foo/common/data
     # the file not present in non-instance snap data
-    not test -f /home/test/snap/test-snapd-tools/common/data
+    not test -f /home/test/snap/test-snapd-sh/common/data
 
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_USER_COMMON/canary'" test | MATCH canary-instance-common
-    su -l -c "test-snapd-tools_foo.cmd sh -c 'cat \$SNAP_USER_DATA/canary'" test | MATCH canary-instance-snap
+    su -l -c "test-snapd-sh_foo.sh -c 'cat \$SNAP_USER_COMMON/canary'" test | MATCH canary-instance-common
+    su -l -c "test-snapd-sh_foo.sh -c 'cat \$SNAP_USER_DATA/canary'" test | MATCH canary-instance-snap
 
 restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -13,72 +13,72 @@ execute: |
     . "$TESTSLIB"/dirs.sh
 
     echo "Install a snap with instance key set"
-    install_local_as test-snapd-tools test-snapd-tools_foo
+    install_local_as test-snapd-sh test-snapd-sh_foo
 
     # foo instance directories are present
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools_foo"
-    test -d "/var/snap/test-snapd-tools_foo"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh_foo"
+    test -d "/var/snap/test-snapd-sh_foo"
 
     # and so are the common directories
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    test -d "/var/snap/test-snapd-tools"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    test -d "/var/snap/test-snapd-sh"
 
-    # get another revision of test-snapd-tools_foo
-    install_local_as test-snapd-tools test-snapd-tools_foo
+    # get another revision of test-snapd-sh_foo
+    install_local_as test-snapd-sh test-snapd-sh_foo
 
     # install instance-key-less snap
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     # and a bar instance
-    install_local_as test-snapd-tools test-snapd-tools_bar
+    install_local_as test-snapd-sh test-snapd-sh_bar
     # bar instance directories are present
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools_bar"
-    test -d "/var/snap/test-snapd-tools_bar"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh_bar"
+    test -d "/var/snap/test-snapd-sh_bar"
 
     # remove foo instance, rev x1
-    snap remove --revision=x1 test-snapd-tools_foo
+    snap remove --revision=x1 test-snapd-sh_foo
     # foo instance directories are present
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools_foo"
-    test -d "/var/snap/test-snapd-tools_foo"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh_foo"
+    test -d "/var/snap/test-snapd-sh_foo"
     # and so are the common directories, required by other revision of foo
     # instance and other snaps
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    test -d "/var/snap/test-snapd-tools"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    test -d "/var/snap/test-snapd-sh"
 
     # remove foo instance snap
-    snap remove test-snapd-tools_foo
+    snap remove test-snapd-sh_foo
     # foo instance directories should be gone now
-    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools_foo"
-    not test -d "/var/snap/test-snapd-tools_foo"
-    # common directories are still around, required by test-snapd-tools and
-    # test-snapd-tools_bar
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    test -d "/var/snap/test-snapd-tools"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-sh_foo"
+    not test -d "/var/snap/test-snapd-sh_foo"
+    # common directories are still around, required by test-snapd-sh and
+    # test-snapd-sh_bar
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    test -d "/var/snap/test-snapd-sh"
 
     # remove instance-key-less one
-    snap remove test-snapd-tools
-    # common directories are still around, required by test-snapd-tools_bar
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    test -d "/var/snap/test-snapd-tools"
+    snap remove test-snapd-sh
+    # common directories are still around, required by test-snapd-sh_bar
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    test -d "/var/snap/test-snapd-sh"
 
     # remove bar instance
-    snap remove test-snapd-tools_bar
-    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools_bar"
-    not test -d "/var/snap/test-snapd-tools_bar"
+    snap remove test-snapd-sh_bar
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-sh_bar"
+    not test -d "/var/snap/test-snapd-sh_bar"
 
     # common directors should be gone now too
-    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    not test -d "/var/snap/test-snapd-tools"
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    not test -d "/var/snap/test-snapd-sh"
 
     # make sure that the sole snap without instance key is handled correctly too
-    install_local test-snapd-tools
+    install_local test-snapd-sh
     # another revision
-    install_local test-snapd-tools
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    test -d "/var/snap/test-snapd-tools"
-    snap remove test-snapd-tools
-    not test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
-    not test -d "/var/snap/test-snapd-tools"
+    install_local test-snapd-sh
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    test -d "/var/snap/test-snapd-sh"
+    snap remove test-snapd-sh
+    not test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
+    not test -d "/var/snap/test-snapd-sh"
 
 restore: |
     snap set system experimental.parallel-instances=null

--- a/tests/main/parallel-install-local/task.yaml
+++ b/tests/main/parallel-install-local/task.yaml
@@ -8,12 +8,12 @@ execute: |
     . "$TESTSLIB"/snaps.sh
 
     echo "Install the regular snap"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
-    if install_local_as test-snapd-tools test-snapd-tools_foo 2>run.err; then
+    if install_local_as test-snapd-sh test-snapd-sh_foo 2>run.err; then
         echo "install_local_as was expected to fail"
         exit 1
     fi
@@ -22,27 +22,27 @@ execute: |
     snap set system experimental.parallel-instances=true
 
     for instance in foo longname; do
-        echo "Install snap instance named test-snapd-tools_$instance"
-        expected="^test-snapd-tools_$instance 1.0 installed\$"
-        install_local_as test-snapd-tools "test-snapd-tools_$instance" | MATCH "$expected"
+        echo "Install snap instance named test-snapd-sh_$instance"
+        expected="^test-snapd-sh_$instance 1.0 installed\$"
+        install_local_as test-snapd-sh "test-snapd-sh_$instance" | MATCH "$expected"
 
-        test -d "$SNAP_MOUNT_DIR/test-snapd-tools_$instance/x1"
+        test -d "$SNAP_MOUNT_DIR/test-snapd-sh_$instance/x1"
 
         #shellcheck disable=SC2016
-        "test-snapd-tools_$instance.cmd" sh -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
-        MATCH "hello data from test-snapd-tools_$instance" < "/var/snap/test-snapd-tools_$instance/x1/data"
+        "test-snapd-sh_$instance.sh" -c 'echo hello data from $SNAP_INSTANCE_NAME > $SNAP_DATA/data'
+        MATCH "hello data from test-snapd-sh_$instance" < "/var/snap/test-snapd-sh_$instance/x1/data"
 
-        su -l -c "test-snapd-tools_$instance.cmd sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
-        MATCH "hello user data from test-snapd-tools_$instance" < "/home/test/snap/test-snapd-tools_$instance/x1/data"
+        su -l -c "test-snapd-sh_$instance.sh -c 'echo hello user data from \$SNAP_INSTANCE_NAME > \$SNAP_USER_DATA/data'" test
+        MATCH "hello user data from test-snapd-sh_$instance" < "/home/test/snap/test-snapd-sh_$instance/x1/data"
     done
 
     echo "All snaps are listed"
-    snap list | MATCH '^test-snapd-tools '
-    snap list | MATCH '^test-snapd-tools_foo '
-    snap list | MATCH '^test-snapd-tools_longname '
+    snap list | MATCH '^test-snapd-sh '
+    snap list | MATCH '^test-snapd-sh_foo '
+    snap list | MATCH '^test-snapd-sh_longname '
 
     echo "Removing one instance does not remove other instances' directories"
-    snap remove test-snapd-tools_foo
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools_longname/x1"
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools/x1"
+    snap remove test-snapd-sh_foo
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh_longname/x1"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh/x1"
 

--- a/tests/main/regression-home-snap-root-owned/task.yaml
+++ b/tests/main/regression-home-snap-root-owned/task.yaml
@@ -6,19 +6,19 @@ prepare: |
     rm -rf /root/snap
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
 
     # run a snap command via sudo
-    output=$(su -l -c "sudo $SNAP_MOUNT_DIR/bin/test-snapd-tools.env" test)
+    output=$(su -l -c "sudo $SNAP_MOUNT_DIR/bin/test-snapd-sh.sh -c 'env'" test)
 
     # ensure SNAP_USER_DATA points to the right place
-    echo "$output" | MATCH SNAP_USER_DATA=/root/snap/test-snapd-tools/x[0-9]+
-    echo "$output" | MATCH HOME=/root/snap/test-snapd-tools/x[0-9]+
-    echo "$output" | MATCH SNAP_USER_COMMON=/root/snap/test-snapd-tools/common
+    echo "$output" | MATCH SNAP_USER_DATA=/root/snap/test-snapd-sh/x[0-9]+
+    echo "$output" | MATCH HOME=/root/snap/test-snapd-sh/x[0-9]+
+    echo "$output" | MATCH SNAP_USER_COMMON=/root/snap/test-snapd-sh/common
 
     echo "Verify that the /root/snap directory created and root owned"
     if [ "$(stat -c '%U' /root/snap)" != "root" ]; then

--- a/tests/main/security-apparmor/task.yaml
+++ b/tests/main/security-apparmor/task.yaml
@@ -4,19 +4,19 @@ prepare: |
     echo "Given a basic snap is installed"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
 execute: |
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
     echo "Then an unconfined action should succeed"
-    test-snapd-tools.cmd touch /dev/shm/snap.test-snapd-tools.foo
-    test -f /dev/shm/snap.test-snapd-tools.foo
+    test-snapd-sh.sh -c 'touch /dev/shm/snap.test-snapd-sh.foo'
+    test -f /dev/shm/snap.test-snapd-sh.foo
 
     echo "Then a confined action should fail"
-    if test-snapd-tools.cmd touch /dev/shm/snap.not-test-snapd-tools.foo 2>touch.error; then
+    if test-snapd-sh.sh -c 'touch /dev/shm/snap.not-test-snapd-sh.foo' 2>touch.error; then
         echo "Expected error"
         exit 1
     fi
-    [ "$(cat touch.error)" = "touch: cannot touch '/dev/shm/snap.not-test-snapd-tools.foo': Permission denied" ]
+    [ "$(cat touch.error)" = "touch: cannot touch '/dev/shm/snap.not-test-snapd-sh.foo': Permission denied" ]

--- a/tests/main/security-device-cgroups-serial-port/task.yaml
+++ b/tests/main/security-device-cgroups-serial-port/task.yaml
@@ -23,11 +23,11 @@ execute: |
     echo "Given a snap is installed"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     echo "Then the device is not assigned to that snap"
     if udevadm info /dev/ttyS4 > info.txt; then
-        not MATCH "E: TAGS=.*snap_test-snapd-tools_env" < info.txt
+        not MATCH "E: TAGS=.*snap_test-snapd-sh_sh" < info.txt
     else
         echo "No hardware for node /dev/ttyS4"
         exit 0
@@ -35,23 +35,23 @@ execute: |
 
     echo "And the device is not shown in the snap device list"
     # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
-    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list ]; then
-        MATCH -v "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
+        MATCH -v "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
     fi
 
     echo "When a udev rule assigning the device to the snap is added"
-    content="SUBSYSTEM==\"tty\", KERNEL==\"ttyS4\", TAG+=\"snap_test-snapd-tools_env\""
-    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-tools.rules
+    content="SUBSYSTEM==\"tty\", KERNEL==\"ttyS4\", TAG+=\"snap_test-snapd-sh_sh\""
+    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
     udevadm control --reload-rules
     udevadm settle
     udevadm trigger
     udevadm settle
 
     echo "Then the device is shown as assigned to the snap"
-    udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-tools_env"
+    udevadm info /dev/ttyS4 | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
 
     echo "When a snap command is called"
-    test-snapd-tools.env
+    test-snapd-sh.sh -c 'true'
 
     echo "Then the device is shown in the snap device list"
-    MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH "c 4:68 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -65,7 +65,7 @@ restore: |
     if [ -e /dev/uhid.spread ]; then
         rm -f /dev/uhid /dev/uhid.spread
     fi
-    rm -f /etc/udev/rules.d/70-snap.test-snapd-tools.rules
+    rm -f /etc/udev/rules.d/70-snap.test-snapd-sh.rules
     udevadm control --reload-rules
     udevadm trigger
 
@@ -79,49 +79,49 @@ execute: |
     echo "Given a snap is installed"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     echo "Then the device is not assigned to that snap"
-    udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-tools_env"
+    udevadm info "$UDEVADM_PATH" | not MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
 
     echo "And the device is not shown in the snap device list"
     # FIXME: this is, apparently, a layered can of worms. Zyga says he needs to fix it.
-    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list ]; then
-        MATCH -v "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    if [ -e /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list ]; then
+        MATCH -v "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
     fi
 
     echo "When a udev rule assigning the device to the snap is added"
-    content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-tools_env\""
-    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-tools.rules
+    content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-sh_sh\""
+    echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-sh.rules
     udevadm control --reload-rules
     udevadm settle
     udevadm trigger
     udevadm settle
 
     echo "Then the device is shown as assigned to the snap"
-    udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-tools_env"
+    udevadm info "$UDEVADM_PATH" | MATCH "E: TAGS=.*snap_test-snapd-sh_sh"
 
     echo "And other devices are not shown as assigned to the snap"
-    udevadm info "$OTHER_UDEVADM_PATH" | MATCH -v "E: TAGS=.*snap_test-snapd-tools_env"
+    udevadm info "$OTHER_UDEVADM_PATH" | MATCH -v "E: TAGS=.*snap_test-snapd-sh_sh"
 
     echo "When a snap command is called"
-    test-snapd-tools.env
+    test-snapd-sh.sh -c 'true'
 
     echo "Then the device is shown in the snap device list"
-    MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH "$DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
     echo "And other devices are not shown in the snap device list"
-    MATCH -v "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH -v "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
     echo "But existing nvidia devices are in the snap's device cgroup"
-    MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
-    MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
-    MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+    MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
+    MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
     echo "But nonexisting nvidia devices are not"
-    MATCH -v "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH -v "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
     echo "But the existing uhid device is in the snap's device cgroup"
-    MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-sh.sh/devices.list
 
     # TODO: check device unassociated after removing the udev file and rebooting

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -10,14 +10,14 @@ prepare: |
     echo "Given a basic snap is installed"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     echo "And another basic snap is installed"
     mkdir -p "$SNAP_INSTALL_DIR"
-    cp -ra "$TESTSLIB"/snaps/test-snapd-tools/* "$SNAP_INSTALL_DIR"
-    sed -i 's/test-snapd-tools/not-test-snapd-tools/g' "$SNAP_INSTALL_DIR/meta/snap.yaml"
+    cp -ra "$TESTSLIB"/snaps/test-snapd-sh/* "$SNAP_INSTALL_DIR"
+    sed -i 's/test-snapd-sh/not-test-snapd-sh/g' "$SNAP_INSTALL_DIR/meta/snap.yaml"
     snap pack "$SNAP_INSTALL_DIR"
-    snap install --dangerous not-test-snapd-tools_1.0_all.snap
+    snap install --dangerous not-test-snapd-sh_1.0_all.snap
 
 restore: |
     rm -rf "$SNAP_INSTALL_DIR" /tmp/foo
@@ -31,20 +31,20 @@ execute: |
 
     if [ -e "$LIBEXECDIR/snapd/snap-discard-ns" ]; then
         echo "Then that file is accessible from other calls of commands from the same snap"
-        if ! test-snapd-tools.cmd stat /tmp/foo 2>same-stat.error; then
+        if ! test-snapd-sh.sh -c 'stat /tmp/foo' 2>same-stat.error; then
             echo "Expected the file to be present"
             exit 1
         fi
     else
         echo "Then that file is not accessible from other calls of commands from the same snap"
-        if test-snapd-tools.cmd stat /tmp/foo 2>same-stat.error; then
+        if test-snapd-sh.sh -c 'stat /tmp/foo' 2>same-stat.error; then
             echo "Expected the file to be absent"
             exit 1
         fi
     fi
 
     echo "And that file is not accessible by other snaps"
-    if not-test-snapd-tools.cmd stat /tmp/foo 2>other-stat.error; then
+    if not-test-snapd-sh.sh -c 'stat /tmp/foo' 2>other-stat.error; then
         echo "Expected error not present"
         exit 1
     fi

--- a/tests/main/security-private-tmp/tmp-create.exp
+++ b/tests/main/security-private-tmp/tmp-create.exp
@@ -5,8 +5,8 @@ set timeout 20
 spawn bash
 
 # Test private /tmp, allowed access
-spawn su -l -c "$env(SNAP_MOUNT_DIR)/bin/test-snapd-tools.sh" test
-expect "bash-4.3\\$" {} timeout { exit 1 }
+spawn su -l -c "$env(SNAP_MOUNT_DIR)/bin/test-snapd-sh.sh" test
+expect "$" {} timeout { exit 1 }
 send "touch /tmp/foo\n"
 send "stat /tmp/foo\n"
 expect {

--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -12,7 +12,7 @@ systems: [-debian-*, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
     echo "Ensure the snap-confine profiles on core are not loaded"
     for p in /var/lib/snapd/apparmor/profiles/snap-confine.*; do
         apparmor_parser -R "$p"
@@ -37,8 +37,8 @@ execute: |
     # NOTE: This has to run as the test user because the protection is only
     # active if user gains elevated permissions as a result of using setuid
     # root snap-confine.
-    if su test -c "sh -c \"SNAP_NAME=test-snapd-tools SNAP_INSTANCE_NAME=test-snapd-tools $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>/dev/null\""; then
+    if su test -c "sh -c \"SNAP_NAME=test-snapd-sh SNAP_INSTANCE_NAME=test-snapd-sh $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-sh.sh -c '/bin/true' 2>/dev/null\""; then
         echo "snap-confine didn't refuse to run!"
         exit 1
     fi
-    su test -c "sh -c \"SNAP_NAME=test-snapd-tools SNAP_INSTANCE_NAME=test-snapd-tools $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"
+    su test -c "sh -c \"SNAP_NAME=test-snapd-sh SNAP_INSTANCE_NAME=test-snapd-sh $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine snap.test-snapd-sh.sh -c '/bin/true' 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"

--- a/tests/main/snap-confine-drops-sys-admin/task.yaml
+++ b/tests/main/snap-confine-drops-sys-admin/task.yaml
@@ -42,17 +42,17 @@ execute: |
     # as there are two shell expansions done. Also, we are using "snap run
     # test-snapd-sh" in order to ensure that we can start the program even if
     # su/sudo's secure PATH does not contain the snap bin directory.
-    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/has-sys-admin'" test | MATCH 'Does not have cap_sys_admin'
+    su -l -c "snap run test-snapd-sh.sh -c '\$SNAP_COMMON/has-sys-admin'" test | MATCH 'Does not have cap_sys_admin'
     #shellcheck disable=SC2016
-    snap run test-snapd-sh -c '$SNAP_COMMON/has-sys-admin'                  | MATCH 'Has cap_sys_admin'
+    snap run test-snapd-sh.sh -c '$SNAP_COMMON/has-sys-admin'                  | MATCH 'Has cap_sys_admin'
 
     # We should preserve CAP_SYS_ADMIN when run under sudo from non-root or
     # root
     echo "Running under sudo and under snap-confine from non-root and root"
-    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/has-sys-admin'" test | MATCH 'Has cap_sys_admin'
-    sudo snap run test-snapd-sh -c '$SNAP_COMMON/has-sys-admin'                  | MATCH 'Has cap_sys_admin'
+    su -l -c "sudo snap run test-snapd-sh.sh -c '\$SNAP_COMMON/has-sys-admin'" test | MATCH 'Has cap_sys_admin'
+    sudo snap run test-snapd-sh.sh -c '$SNAP_COMMON/has-sys-admin'                  | MATCH 'Has cap_sys_admin'
 
     # We should drop CAP_SYS_ADMIN when run with sudo -u test
     echo "Running under sudo -u non-root under snap-confine from non-root and root"
-    su -l -c "sudo -u test snap run test-snapd-sh -c '\$SNAP_COMMON/has-sys-admin'" test | MATCH 'Does not have cap_sys_admin'
-    sudo -u test snap run test-snapd-sh -c '$SNAP_COMMON/has-sys-admin'                  | MATCH 'Does not have cap_sys_admin'
+    su -l -c "sudo -u test snap run test-snapd-sh.sh -c '\$SNAP_COMMON/has-sys-admin'" test | MATCH 'Does not have cap_sys_admin'
+    sudo -u test snap run test-snapd-sh.sh -c '$SNAP_COMMON/has-sys-admin'                  | MATCH 'Does not have cap_sys_admin'

--- a/tests/main/snap-confine-privs/task.yaml
+++ b/tests/main/snap-confine-privs/task.yaml
@@ -61,12 +61,12 @@ execute: |
     # expansions done. Note that we are using "snap run test-snapd-sh" in order
     # to ensure that we can start the progam even if su/sudo's secure PATH does
     # not contain the snap bin directory.
-    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=12345 sgid=12345'
-    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=12345 euid=0     suid=0     rgid=12345 egid=12345 sgid=12345'
-    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=0     sgid=0    '
+    su -l -c "snap run test-snapd-sh.sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=12345 sgid=12345'
+    su -l -c "snap run test-snapd-sh.sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=12345 euid=0     suid=0     rgid=12345 egid=12345 sgid=12345'
+    su -l -c "snap run test-snapd-sh.sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=0     sgid=0    '
 
     echo "Running as regular user, uder snap-conifne under sudo"
     # This is the same one as the previous one but also using sudo.
-    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
-    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
-    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo snap run test-snapd-sh.sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo snap run test-snapd-sh.sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo snap run test-snapd-sh.sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '

--- a/tests/main/snap-debug-timings/task.yaml
+++ b/tests/main/snap-debug-timings/task.yaml
@@ -5,7 +5,7 @@ execute: |
     . "$TESTSLIB/snaps.sh"
 
     echo "When a snap gets installed"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     echo "There is timing data available for it"
     snap debug timings --last=install | MATCH 'Done +[0-9]+'

--- a/tests/main/snap-run-userdata-current/task.yaml
+++ b/tests/main/snap-run-userdata-current/task.yaml
@@ -5,37 +5,37 @@ systems: [-ubuntu-core-*]
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB"/dirs.sh
     echo "Test that 'current' symlink is created in user data dir"
-    CURRENT=$(readlink $SNAP_MOUNT_DIR/test-snapd-tools/current)
+    CURRENT=$(readlink $SNAP_MOUNT_DIR/test-snapd-sh/current)
     if [ -z "$CURRENT" ]; then
       echo "Could not determine current version of $SNAP"
       exit 1
     fi
 
-    $SNAP_MOUNT_DIR/bin/test-snapd-tools.echo -n
-    UDATA_CURRENT=$(readlink "$HOME/snap/test-snapd-tools/current")
+    $SNAP_MOUNT_DIR/bin/test-snapd-sh.sh -c 'echo -n'
+    UDATA_CURRENT=$(readlink "$HOME/snap/test-snapd-sh/current")
     if [ "$CURRENT" != "$UDATA_CURRENT" ]; then
       echo "Invalid 'current' symlink in user-data directory, expected $CURRENT, got $UDATA_CURRENT"
       exit 1
     fi
 
     echo "Test that 'current' symlink is recreated"
-    rm -rf "$HOME/snap/test-snapd-tools/current"
-    $SNAP_MOUNT_DIR/bin/test-snapd-tools.echo -n
-    if [ ! -L "$HOME/snap/test-snapd-tools/current" ]; then
+    rm -rf "$HOME/snap/test-snapd-sh/current"
+    $SNAP_MOUNT_DIR/bin/test-snapd-sh.sh -c 'echo -n'
+    if [ ! -L "$HOME/snap/test-snapd-sh/current" ]; then
       echo "The 'current' symlink not present in user-data directory"
       exit 1
     fi
 
     echo "Test that 'current' symlink is updated if incorrect"
-    ln -fs "$HOME/snap/test-snapd-tools/wrong" "$HOME/snap/test-snapd-tools/current"
-    $SNAP_MOUNT_DIR/bin/test-snapd-tools.echo -n
-    UDATA_CURRENT=$(readlink "$HOME/snap/test-snapd-tools/current")
+    ln -fs "$HOME/snap/test-snapd-sh/wrong" "$HOME/snap/test-snapd-sh/current"
+    $SNAP_MOUNT_DIR/bin/test-snapd-sh.sh -c 'echo -n'
+    UDATA_CURRENT=$(readlink "$HOME/snap/test-snapd-sh/current")
     if [ "$CURRENT" != "$UDATA_CURRENT" ]; then
       echo "Invalid 'current' symlink in user-data directory, expected $CURRENT, got $UDATA_CURRENT"
       exit 1

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh
     install_local basic-run
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
 debug: |
     if [ -f stderr ]; then
@@ -21,7 +21,7 @@ execute: |
 
     if command -v gdb; then
        echo "Test snap run --gdb works"
-       echo "c" | snap run --gdb test-snapd-tools.echo hello > stdout
+       echo "c" | snap run --gdb test-snapd-sh.sh -c 'echo hello' > stdout
        MATCH 'Continuing.' < stdout
        MATCH hello < stdout
     fi
@@ -40,7 +40,7 @@ execute: |
     fi
 
     echo "Test snap --strace invalid works"
-    if snap run --strace="invalid" test-snapd-tools.echo hello 2>stderr ; then
+    if snap run --strace="invalid" test-snapd-sh.sh -c 'echo hello' 2>stderr ; then
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
@@ -58,7 +58,7 @@ execute: |
     # XXX: any tests that execute strace should be added below this point
 
     echo "Test snap run --strace"
-    snap run --strace test-snapd-tools.echo "hello-world" >stdout 2>stderr
+    snap run --strace test-snapd-sh.sh -c 'echo hello-world' >stdout 2>stderr
     MATCH hello-world < stdout
     MATCH 'write\(1, \"hello-world\\n\",' < stderr
     if grep "snap-confine" stderr; then
@@ -68,11 +68,11 @@ execute: |
     fi
 
     echo "Test snap run --strace with options works"
-    snap run --strace="-V" test-snapd-tools.echo "hello-world" >stdout 2>stderr
+    snap run --strace="-V" test-snapd-sh.sh -c 'echo hello-world' >stdout 2>stderr
     MATCH "strace -- version" < stdout
     [ ! -s stderr ]
 
-    snap run --trace-exec test-snapd-tools.echo hello 2> stderr
+    snap run --trace-exec test-snapd-sh.sh -c 'echo hello' 2> stderr
     MATCH "Slowest [0-9]+ exec calls during snap run" < stderr
     MATCH "  [0-9.]+s .*/snap-exec" < stderr
     MATCH "  [0-9.]+s .*/snap-confine" < stderr

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -51,7 +51,7 @@ execute: |
 
     # Start a "sleep" process in the background
     #shellcheck disable=SC2016
-    test-snapd-sh -c 'touch $SNAP_DATA/stamp && exec sleep 1h' &
+    test-snapd-sh.sh -c 'touch $SNAP_DATA/stamp && exec sleep 1h' &
     pid=$!
 
     # Ensure that snap-confine has finished its task and that the snap process
@@ -68,7 +68,7 @@ execute: |
     if is_cgroupv2 ; then
         # stale mount namespace is always discarded with cgroupv2, because we
         # cannot currently determine whether there are processes using it
-        test-snapd-sh -c "test -e /customized"
+        test-snapd-sh.sh -c "test -e /customized"
 
         # Kill our helper process.
         kill -9 "$pid"
@@ -79,7 +79,7 @@ execute: |
 
     # Now we are in a situation where the core snap is stale but our sleeper
     # application is still alive so we cannot use it.
-    test-snapd-sh -c "test ! -e /customized"
+    test-snapd-sh.sh -c "test ! -e /customized"
 
     # Kill our helper process.
     kill -9 "$pid"
@@ -87,4 +87,4 @@ execute: |
 
     # Now when the process terminates, we no longer need to hold back.
     # The next process will use a fresh mount namespace.
-    test-snapd-sh -c "test -e /customized"
+    test-snapd-sh.sh -c "test -e /customized"

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -33,7 +33,7 @@ execute: |
     # expect a seccomp denial with 'chown' operation
     echo "Running 'chown' without any system-usernames"
     touch "$P1"
-    snap run test-snapd-sh -c "chown daemon:daemon $P1" 2>&1 | MATCH 'Operation not permitted'
+    snap run test-snapd-sh.sh -c "chown daemon:daemon $P1" 2>&1 | MATCH 'Operation not permitted'
 
     # We want this test to run on all systems since the end goal is for all
     # systems that have a new enough libseccomp (>= 2.4.0) and golang-seccomp
@@ -42,7 +42,7 @@ execute: |
     # check for support in an existing snap's seccomp profile header, then go
     # from there.
     supported="no"
-    header=$(head -2 /var/lib/snapd/seccomp/bpf/snap.test-snapd-sh.test-snapd-sh.src | grep -A1 'snap-seccomp version information' | tail -1)
+    header=$(head -2 /var/lib/snapd/seccomp/bpf/snap.test-snapd-sh.sh.src | grep -A1 'snap-seccomp version information' | tail -1)
     echo "snap-seccomp version information is '$header'"
     if [ -n "$header" ]; then
         features=$(echo "$header" | cut -d ' ' -f 5)

--- a/tests/main/umask/task.yaml
+++ b/tests/main/umask/task.yaml
@@ -11,14 +11,14 @@ restore: |
     rm -rf ~/snap
 execute: |
     # See if umask 777 is respected.
-    ( umask 777 && test-snapd-sh -c /bin/true )
+    ( umask 777 && test-snapd-sh.sh -c /bin/true )
     # shellcheck disable=SC2016
-    ( umask 777 && test-snapd-sh -c 'touch "$SNAP_USER_COMMON"/canary' )
+    ( umask 777 && test-snapd-sh.sh -c 'touch "$SNAP_USER_COMMON"/canary' )
     test "$(stat -c %a "$HOME"/snap/test-snapd-sh/common/canary)" = 0
     rm -rf ~/snap
 
     # See if umask 000 is respected.
-    ( umask 000 && test-snapd-sh -c /bin/true )
+    ( umask 000 && test-snapd-sh.sh -c /bin/true )
     # shellcheck disable=SC2016
-    ( umask 000 && test-snapd-sh -c 'touch "$SNAP_USER_COMMON"/canary' )
+    ( umask 000 && test-snapd-sh.sh -c 'touch "$SNAP_USER_COMMON"/canary' )
     test "$(stat -c %a "$HOME"/snap/test-snapd-sh/common/canary)" = 666

--- a/tests/regression/lp-1595444/task.yaml
+++ b/tests/regression/lp-1595444/task.yaml
@@ -12,7 +12,7 @@ prepare: |
     echo "Having installed the test snap"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
     echo "Hanving created a directory not present in the core snap"
     mkdir -p "/foo"
 
@@ -24,9 +24,9 @@ restore: |
 execute: |
     echo "We can go to a location that is available in all snaps (/tmp)"
     echo "We can run the 'pwd' tool and it reports /tmp"
-    [ "$(cd /tmp && test-snapd-tools.cmd pwd)" = "/tmp" ]
+    [ "$(cd /tmp && test-snapd-sh.sh -c 'pwd')" = "/tmp" ]
     echo "But if we go to a location that is not available to snaps (e.g. /foo)"
     echo "Then snap-confine moves us to /var/lib/snapd/void"
-    [ "$(cd /foo && test-snapd-tools.cmd pwd)" = "/var/lib/snapd/void" ]
+    [ "$(cd /foo && test-snapd-sh.sh -c 'pwd')" = "/var/lib/snapd/void" ]
     echo "And that directory is not readable or writable"
-    [ "$(cd /foo && test-snapd-tools.cmd ls 2>&1)" = "ls: cannot open directory '.': Permission denied" ];
+    [ "$(cd /foo && test-snapd-sh.sh -c 'ls' 2>&1)" = "ls: cannot open directory '.': Permission denied" ];

--- a/tests/regression/lp-1597839/task.yaml
+++ b/tests/regression/lp-1597839/task.yaml
@@ -11,8 +11,8 @@ prepare: |
     echo "Having installed the test snap"
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
 execute: |
     echo "We can ensure that the /lib/modules/$(uname -r) directory exists"
-    test-snapd-tools.cmd test -d "/lib/modules/$(uname -r)"
+    test-snapd-sh.sh -c "test -d /lib/modules/$(uname -r)"

--- a/tests/regression/lp-1665004/task.yaml
+++ b/tests/regression/lp-1665004/task.yaml
@@ -9,11 +9,11 @@ details: |
 prepare: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
     if [ -d /var/lib/snapd/hostfs ]; then
         rmdir /var/lib/snapd/hostfs;
     fi
 
 execute: |
-    test-snapd-tools.cmd true
+    test-snapd-sh.sh -c 'true'
     [ "$(stat -c '%g' /var/lib/snapd/hostfs)" -eq 0 ]

--- a/tests/regression/lp-1800004/task.yaml
+++ b/tests/regression/lp-1800004/task.yaml
@@ -8,4 +8,4 @@ restore: |
 
 execute: |
     ( cd /tmp && snap try test-snapd-sh )
-    test-snapd-sh -c /bin/true
+    test-snapd-sh.sh -c /bin/true

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -48,6 +48,6 @@ execute: |
             ;;
     esac
     # We can run snap-confine and it will do the right thing.
-    test-snapd-sh -c /bin/true
+    test-snapd-sh.sh -c /bin/true
     # verify that no mount tags are set, private propagation does not set any
     test "$(grep '/snapd/ns /run/snapd/ns' < /proc/self/mountinfo | awk '{print $7}')" = -

--- a/tests/regression/lp-1813963/task.yaml
+++ b/tests/regression/lp-1813963/task.yaml
@@ -86,7 +86,7 @@ execute: |
     # snap-confine process is the regular "failed" rather than "failed due to
     # signal SIGPIPE".
     set +e
-    test-snapd-sh -c /bin/true
+    test-snapd-sh.sh -c /bin/true
     retcode=$?
     set -e
     test "$retcode" -eq 1

--- a/tests/smoke/remove/task.yaml
+++ b/tests/smoke/remove/task.yaml
@@ -3,18 +3,18 @@ summary: Check that install/remove works
 execute: |
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
-    install_local test-snapd-tools
+    install_local test-snapd-sh
 
     #shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
-    test -d "$SNAP_MOUNT_DIR/test-snapd-tools"
+    test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
 
     echo "Ensure remove works"
-    snap remove test-snapd-tools
-    test ! -d "$SNAP_MOUNT_DIR/test-snapd-tools"
+    snap remove test-snapd-sh
+    test ! -d "$SNAP_MOUNT_DIR/test-snapd-sh"
 
-    if snap list | grep -E ^test-snapd-tools; then
-        echo "test-snapd-tools should be removed but it is not"
+    if snap list | grep -E ^test-snapd-sh; then
+        echo "test-snapd-sh should be removed but it is not"
         snap list
         exit 1
     fi


### PR DESCRIPTION
Port of https://github.com/snapcore/snapd/pull/7851 to 2.43