### PR TITLE
snap-bootstrap: trigger udev after filesystem creation

### DIFF
--- a/cmd/snap-bootstrap/partition/mkfs.go
+++ b/cmd/snap-bootstrap/partition/mkfs.go
@@ -30,6 +30,9 @@ func MakeFilesystems(created []DeviceStructure) error {
 			if err := mkfs(part.Node, part.VolumeStructure.Label, part.VolumeStructure.Filesystem); err != nil {
 				return err
 			}
+			if err := udevTrigger(part.Node); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/cmd/snap-bootstrap/partition/mkfs_test.go
+++ b/cmd/snap-bootstrap/partition/mkfs_test.go
@@ -31,6 +31,7 @@ type mkfsSuite struct {
 
 	mockMkfsVfat *testutil.MockCmd
 	mockMkfsExt4 *testutil.MockCmd
+	mockUdevadm  *testutil.MockCmd
 }
 
 var _ = Suite(&mkfsSuite{})
@@ -40,6 +41,8 @@ func (s *mkfsSuite) SetUpTest(c *C) {
 	s.AddCleanup(s.mockMkfsVfat.Restore)
 	s.mockMkfsExt4 = testutil.MockCommand(c, "mkfs.ext4", "")
 	s.AddCleanup(s.mockMkfsExt4.Restore)
+	s.mockUdevadm = testutil.MockCommand(c, "udevadm", "")
+	s.AddCleanup(s.mockUdevadm.Restore)
 }
 
 func (s *mkfsSuite) TestMkfsUnhappy(c *C) {
@@ -67,6 +70,7 @@ func (s *mkfsSuite) TestMakefilesystemsNothing(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.mockMkfsExt4.Calls(), HasLen, 0)
 	c.Assert(s.mockMkfsVfat.Calls(), HasLen, 0)
+	c.Assert(s.mockUdevadm.Calls(), HasLen, 0)
 }
 
 func (s *mkfsSuite) TestMakefilesystems(c *C) {
@@ -126,4 +130,9 @@ func (s *mkfsSuite) TestMakefilesystems(c *C) {
 	calls = s.mockMkfsExt4.Calls()[1]
 	c.Assert(calls[len(calls)-1:], DeepEquals, []string{"/dev/node4"})
 	c.Assert(s.mockMkfsVfat.Calls(), HasLen, 1)
+	c.Assert(s.mockUdevadm.Calls(), DeepEquals, [][]string{
+		{"udevadm", "trigger", "--settle", "/dev/node2"},
+		{"udevadm", "trigger", "--settle", "/dev/node3"},
+		{"udevadm", "trigger", "--settle", "/dev/node4"},
+	})
 }

--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -153,9 +153,8 @@ func ensureNodesExistImpl(ds []DeviceStructure, timeout time.Duration) error {
 			time.Sleep(100 * time.Millisecond)
 		}
 		if found {
-			output, err := exec.Command("udevadm", "trigger", "--settle", part.Node).CombinedOutput()
-			if err != nil {
-				return osutil.OutputErr(output, err)
+			if err := udevTrigger(part.Node); err != nil {
+				return err
 			}
 		} else {
 			return fmt.Errorf("device %s not available", part.Node)
@@ -272,6 +271,15 @@ func buildPartitionList(ptable *sfdiskPartitionTable, pv *gadget.LaidOutVolume) 
 	}
 
 	return buf, toBeCreated
+}
+
+// udevTrigger triggers udev for the specified device and waits until
+// all events in the udev queue are handled.
+func udevTrigger(device string) error {
+	if output, err := exec.Command("udevadm", "trigger", "--settle", device).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
 }
 
 func partitionType(label, ptype string) string {

--- a/tests/main/uc20-snap-recovery-autodetect/task.yaml
+++ b/tests/main/uc20-snap-recovery-autodetect/task.yaml
@@ -40,6 +40,10 @@ prepare: |
 
 execute: |
     LOOP="$(cat loop.txt)"
+
+    # debug message to see if the udev database is correctly updated
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
+
     echo "Run the snap-bootstrap tool in auto-detect mode"
     /usr/lib/snapd/snap-bootstrap create-partitions ./gadget-dir
 

--- a/tests/main/uc20-snap-recovery/task.yaml
+++ b/tests/main/uc20-snap-recovery/task.yaml
@@ -65,10 +65,7 @@ execute: |
     ls ./mnt/EFI/ubuntu/grub.cfg
     umount ./mnt
 
-    # XXX: workaround for device consistency errors
-    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
-    blockdev --rereadpt "$LOOP"
-    udevadm settle
+    # debug message to see if the udev database is correctly updated
     udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
 
     echo "now add a partition"


### PR DESCRIPTION
Call udevadm trigger --settle after new filesystems are created, and
remove the workaround used to force udev database updates in the
integration tests.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>