### PR TITLE
packaging: ship var/lib/snapd/desktop/applications in the pkg

### DIFF
--- a/packaging/ubuntu-14.04/snapd.dirs
+++ b/packaging/ubuntu-14.04/snapd.dirs
@@ -2,6 +2,7 @@ snap
 var/cache/snapd
 usr/lib/snapd
 var/lib/snapd/apparmor/snap-confine
+var/lib/snapd/desktop/applications
 var/lib/snapd/auto-import
 var/lib/snapd/desktop
 var/lib/snapd/environment

--- a/packaging/ubuntu-16.04/snapd.dirs
+++ b/packaging/ubuntu-16.04/snapd.dirs
@@ -2,6 +2,7 @@ snap
 var/cache/snapd
 usr/lib/snapd
 var/lib/snapd/apparmor/snap-confine
+var/lib/snapd/desktop/applications
 var/lib/snapd/auto-import
 var/lib/snapd/desktop
 var/lib/snapd/environment


### PR DESCRIPTION
This will fix issues on systems that ship a desktop environment
without any snaps. See https://forum.snapcraft.io/t/14904
