### PR TITLE
tests: use unbuffered python output for daemons, misc formatting

### DIFF
--- a/tests/core18/snapd-failover/task.yaml
+++ b/tests/core18/snapd-failover/task.yaml
@@ -3,6 +3,8 @@ summary: Check that snapd failure handling works
 debug: |
     # dump failure data
     journalctl -u snapd.failure.service
+    journalctl -u snapd.socket
+    systemctl status snapd.socket
 
 restore: |
     # Stop snapd.failure.service in case it is active

--- a/tests/lib/bin/apt-tool
+++ b/tests/lib/bin/apt-tool
@@ -17,10 +17,10 @@ def checkpoint():
 
 def restore(fname):
     desired = set([line.strip() for line in open(fname)])
-            
+
     cache = apt.Cache()
     for pkg in cache:
-        if pkg.is_installed and not pkg.name in desired:
+        if pkg.is_installed and pkg.name not in desired:
             print("removing", pkg)
             pkg.mark_delete(auto_fix=False)
         if not pkg.is_installed and pkg.name in desired:

--- a/tests/lib/fakegpio/fake-gpio.py
+++ b/tests/lib/fakegpio/fake-gpio.py
@@ -11,8 +11,6 @@ import subprocess
 import sys
 import tempfile
 
-from typing import Type
-
 
 def read_gpio_pin(read_fd: int) -> str:
     """

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
 
-import os
 import sys
 
 import dbus.service
@@ -14,6 +13,7 @@ APP_CHOOSER_IFACE = "org.freedesktop.impl.portal.AppChooser"
 FILE_CHOOSER_IFACE = "org.freedesktop.impl.portal.FileChooser"
 SCREENSHOT_IFACE = "org.freedesktop.impl.portal.Screenshot"
 
+
 class PortalImpl(dbus.service.Object):
     def __init__(self, connection, object_path, config):
         super(PortalImpl, self).__init__(connection, object_path)
@@ -22,14 +22,18 @@ class PortalImpl(dbus.service.Object):
     @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
                          in_signature="osssa{sv}", out_signature="ua{sv}")
     def OpenFile(self, handle, app_id, parent_window, title, options):
-        return (0, dict(uris=dbus.Array(["file:///tmp/file-to-read.txt"], signature="s"),
-                        writable=False))
+        return (0, dict(
+            uris=dbus.Array(["file:///tmp/file-to-read.txt"], signature="s"),
+            writable=False)
+        )
 
     @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
                          in_signature="osssa{sv}", out_signature="ua{sv}")
     def SaveFile(self, handle, app_id, parent_window, title, options):
-        return (0, dict(uris=dbus.Array(["file:///tmp/file-to-write.txt"], signature="s"),
-                        writable=True))
+        return (0, dict(
+            uris=dbus.Array(["file:///tmp/file-to-write.txt"], signature="s"),
+            writable=True)
+        )
 
     @dbus.service.method(dbus_interface=SCREENSHOT_IFACE,
                          in_signature="ossa{sv}", out_signature="ua{sv}")
@@ -65,6 +69,7 @@ def main(argv):
         do_not_queue=True)
 
     main_loop.run()
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/lib/snaps/test-snapd-devpts/bin/useptmx
+++ b/tests/lib/snaps/test-snapd-devpts/bin/useptmx
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import os
 import sys
-from ctypes import *
+from ctypes import CDLL
 
 files = os.listdir('/dev/pts')
 if 'ptmx' not in files or len(files) != 1:

--- a/tests/lib/snaps/test-snapd-portal-client/client.py
+++ b/tests/lib/snaps/test-snapd-portal-client/client.py
@@ -7,8 +7,8 @@ import dbus
 import dbus.mainloop.glib
 from gi.repository import GLib
 
-class Client:
 
+class Client:
     def __init__(self, bus, main_loop):
         self._bus = bus
         self._main_loop = main_loop

--- a/tests/lib/snaps/test-snapd-python-webserver/server.py
+++ b/tests/lib/snaps/test-snapd-python-webserver/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
 
 import os
 import sys

--- a/tests/lib/snaps/test-snapd-service/bin/start-stop-mode
+++ b/tests/lib/snaps/test-snapd-service/bin/start-stop-mode
@@ -1,14 +1,14 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
 import os
 import signal
 import socket
-import subprocess
 import sys
 import time
 import types
 
 
-# Re-implement sd_notify to avoid the need to tweak apparmor permissions to run systemd-notify(1)
+# Re-implement sd_notify to avoid the need to tweak apparmor permissions to
+# run systemd-notify(1)
 def sd_notify(unset_environment: bool, state: str) -> bool:
     addr = os.getenv("NOTIFY_SOCKET")
     if addr is None:
@@ -20,13 +20,15 @@ def sd_notify(unset_environment: bool, state: str) -> bool:
         os.unsetenv("NOTIFY_SOCKET")
     return True
 
+
 def write_file(name: str) -> bool:
     SNAP_COMMON = os.getenv("SNAP_COMMON")
     if SNAP_COMMON is None:
         return False
-    with open(os.path.join(SNAP_COMMON, name), "w") as stream:
+    with open(os.path.join(SNAP_COMMON, name), "w"):
         pass
     return True
+
 
 def main() -> None:
     # Keep track of the need to keep waiting for signals
@@ -36,7 +38,8 @@ def main() -> None:
     # the signal handler.
     incoming_signum = None
 
-    # When one of the signals given below arrives, record this fact and stop the loop.
+    # When one of the signals given below arrives, record this fact and stop
+    # the loop.
     def on_signal(signum: int, tb: types.FrameType) -> None:
         nonlocal incoming_signum
         incoming_signum = signum
@@ -54,14 +57,16 @@ def main() -> None:
     except PermissionError:
         raise SystemExit("cannot send systemd notification message")
 
-    # Keep looping until a signal arrives, logging message to show we are alive.
+    # Keep looping until a signal arrives, logging message to show we are
+    # alive.
     while loop:
-        print("running {} process".format(sys.argv[1] if len(sys.argv) > 1 else "???"))
+        print("running {} process".format(
+            sys.argv[1] if len(sys.argv) > 1 else "???"))
         time.sleep(1)
         if incoming_signum is not None:
             signame = signal.Signals(incoming_signum).name.lower()
             print("got {}".format(signame))
-            write_file("{}-{}".format(sys.argv[1],signame))
+            write_file("{}-{}".format(sys.argv[1], signame))
 
 
 if __name__ == "__main__":

--- a/tests/lib/snaps/test-snapd-service/bin/start-stop-mode-sigterm
+++ b/tests/lib/snaps/test-snapd-service/bin/start-stop-mode-sigterm
@@ -1,14 +1,14 @@
-#!/usr/bin/python3
-import signal
+#!/usr/bin/python3 -u
 import subprocess
 
+
 def main() -> None:
-	print("start-refresh-mode-sigkill")
-	print("running a process")
-	# This actual sleep process is (ahem) actually needed because the test is
-	# looking for it. In addition this actually checks how children are (or
-	# are not) killed by systemd.
-	subprocess.call(["sleep", "3133731337"])
+    print("start-refresh-mode-sigkill")
+    print("running a process")
+    # This actual sleep process is (ahem) actually needed because the test is
+    # looking for it. In addition this actually checks how children are (or
+    # are not) killed by systemd.
+    subprocess.call(["sleep", "3133731337"])
 
 
 if __name__ == "__main__":

--- a/tests/lib/snaps/test-snapd-tuntap/bin/tuntap.py
+++ b/tests/lib/snaps/test-snapd-tuntap/bin/tuntap.py
@@ -11,7 +11,7 @@ from typing import Iterable
 
 def if_open(dev: str) -> int:
     TUNSETIFF = 0x400454ca
-    TUNSETOWNER = TUNSETIFF + 2
+    # TUNSETOWNER = TUNSETIFF + 2
     IFF_TUN = 0x0001
     IFF_TAP = 0x0002
     IFF_NO_PI = 0x1000

--- a/tests/lib/tinyproxy/tinyproxy.py
+++ b/tests/lib/tinyproxy/tinyproxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
 
 # Tiny HTTP Proxy. Based on the work of SUZUKI Hisao.
 #
@@ -23,7 +23,7 @@ class ProxyHandler (http.server.BaseHTTPRequestHandler):
         sys.stderr.flush()
 
     def handle(self):
-        (ip, port) =  self.client_address
+        (ip, port) = self.client_address
         super().handle()
 
     def _connect_to(self, netloc, soc):
@@ -109,8 +109,8 @@ class ProxyHandler (http.server.BaseHTTPRequestHandler):
 
     do_HEAD = do_GET
     do_POST = do_GET
-    do_PUT  = do_GET
-    do_DELETE=do_GET
+    do_PUT = do_GET
+    do_DELETE = do_GET
 
 
 def maybe_sd_notify(s: str) -> None:
@@ -130,6 +130,6 @@ class ThreadingHTTPServer (socketserver.ThreadingMixIn,
 
 
 if __name__ == '__main__':
-    port=3128
+    port = 3128
     print("starting tinyproxy on port {}".format(port))
     http.server.test(ProxyHandler, ThreadingHTTPServer, port=port)

--- a/tests/main/document-portal-activation/fake-document-portal.py
+++ b/tests/main/document-portal-activation/fake-document-portal.py
@@ -11,6 +11,7 @@ BUS_NAME = "org.freedesktop.portal.Documents"
 OBJECT_PATH = "/org/freedesktop/portal/documents"
 DOC_IFACE = "org.freedesktop.portal.Documents"
 
+
 class DocPortal(dbus.service.Object):
     def __init__(self, connection, object_path, logfile, errorfile):
         super(DocPortal, self).__init__(connection, object_path)
@@ -28,8 +29,10 @@ class DocPortal(dbus.service.Object):
         with open(self._logfile, "a") as fp:
             fp.write("GetMountPoint called\n")
         if self._report_error:
-            raise dbus.DBusException("failure", name=DOC_IFACE + ".Error.Failed")
+            raise dbus.DBusException(
+                "failure", name=DOC_IFACE + ".Error.Failed")
         return '/run/user/{}/doc\x00'.format(os.getuid()).encode('ASCII')
+
 
 def main(argv):
     logfile, errorfile = argv[1:]
@@ -43,14 +46,15 @@ def main(argv):
         path="/org/freedesktop/DBus/Local",
         dbus_interface="org.freedesktop.DBus.Local")
 
-    portal = DocPortal(bus, OBJECT_PATH, logfile, errorfile)
+    DocPortal(bus, OBJECT_PATH, logfile, errorfile)
 
     # Allow other services to assume our bus name
-    bus_name = dbus.service.BusName(
+    dbus.service.BusName(
         BUS_NAME, bus, allow_replacement=True, replace_existing=True,
         do_not_queue=True)
 
     main_loop.run()
+
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/tests/main/gadget-update-pc/generate.py
+++ b/tests/main/gadget-update-pc/generate.py
@@ -11,16 +11,20 @@ def parse_arguments():
         description="pc gadget yaml variant generator for test"
     )
     parser.add_argument(
-        "gadgetyaml", type=argparse.FileType("r"), help="path to gadget.yaml input file"
+        "gadgetyaml",
+        type=argparse.FileType("r"),
+        help="path to gadget.yaml input file"
     )
-    parser.add_argument("variant", help="test data variant", choices=["v1", "v2"])
+    parser.add_argument("variant", help="test data variant",
+                        choices=["v1", "v2"])
     return parser.parse_args()
 
 
 def must_find_struct(structs, structure_type):
     structs = [s for s in structs if s["type"] == structure_type]
     if len(structs) != 1:
-        raise RuntimeError("unexpected number of structures: {}".format(cans))
+        raise RuntimeError(
+            "unexpected number of structures: {}".format(len(structs)))
     return structs[0]
 
 
@@ -28,8 +32,10 @@ def make_v1(doc):
     # add new files to 'EFI System' partition, add new image file to 'BIOS
     # Boot', bump update edition for both
     structs = doc["volumes"]["pc"]["structure"]
-    efisystem = must_find_struct(structs, "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B")
-    biosboot = must_find_struct(structs, "DA,21686148-6449-6E6F-744E-656564454649")
+    efisystem = must_find_struct(
+        structs, "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B")
+    biosboot = must_find_struct(
+        structs, "DA,21686148-6449-6E6F-744E-656564454649")
 
     # - name: EFI System
     #   (not)type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
@@ -75,8 +81,10 @@ def make_v2(doc):
     doc = make_v1(doc)
 
     structs = doc["volumes"]["pc"]["structure"]
-    efisystem = must_find_struct(structs, "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B")
-    biosboot = must_find_struct(structs, "DA,21686148-6449-6E6F-744E-656564454649")
+    efisystem = must_find_struct(
+        structs, "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B")
+    biosboot = must_find_struct(
+        structs, "DA,21686148-6449-6E6F-744E-656564454649")
     # - name: EFI System
     #   (not)type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
     #   filesystem: vfat


### PR DESCRIPTION
This makes the messages actually show up in the system journal at a reasonable and interactive time rather than all at once whenever python flushes to the journal.

Also remove unused dependencies, variables and adjust line lengths for flake8 suggested line length.