### PR TITLE
xdgopenproxy: forward requests to the desktop portal

### DIFF
--- a/tests/main/xdg-open-portal/editor.sh
+++ b/tests/main/xdg-open-portal/editor.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+filename="$1"
+editor_history="$2"
+
+echo "Editing $filename"
+
+echo "$filename" >> "$editor_history"

--- a/tests/main/xdg-open-portal/task.yaml
+++ b/tests/main/xdg-open-portal/task.yaml
@@ -1,0 +1,98 @@
+summary: Verify xdg-open forwarding requests to the desktop portal
+
+# Only enable the test on systems we know portals to function on.
+# Expand as needed.
+systems:
+  - ubuntu-18.04-*
+  - ubuntu-19.10-*
+
+environment:
+    BROWSER_HISTORY: /tmp/browser-history.txt
+    EDITOR_HISTORY: /tmp/editor-history.txt
+
+prepare: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    setup_portals
+
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB/snaps.sh"
+
+    install_local test-snapd-desktop
+
+    # Configure fake web browser
+    mkdir -p ~test/.local/share/applications
+    cat << EOF > ~test/.local/share/applications/test-browser.desktop
+    [Desktop Entry]
+    Type=Application
+    Name=Test Web Browser
+    Exec=$(pwd)/web-browser.sh %u $BROWSER_HISTORY
+    MimeType=x-scheme-handler/http;
+    EOF
+
+    # Configure a fake editor
+    cat << EOF > ~test/.local/share/applications/test-editor.desktop
+    [Desktop Entry]
+    Type=Application
+    Name=Test Editor
+    Exec=$(pwd)/editor.sh %f $EDITOR_HISTORY
+    MimeType=text/plain;
+    EOF
+
+    # Set up file type handlers
+    mkdir -p ~test/.config
+    cat << EOF > ~test/.config/mimeapps.list
+    [Default Applications]
+    x-scheme-handler/http=test-browser.desktop
+    text/plain=test-editor.desktop
+    EOF
+
+    # Prepare test data for editor
+    commondir=~test/snap/test-snapd-desktop/common
+    testfile="$commondir/test.txt"
+    mkdir -p "$commondir"
+    echo "Hello World" > "$testfile"
+    chown -R test:test ~test/snap
+
+restore: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    teardown_portals
+
+    rm -f ~test/.config/mimeapps.list
+    rm -f ~test/.local/share/applications/test-browser.desktop
+    rm -f ~test/.local/share/applications/test-editor.desktop
+    rm -f "$EDITOR_HISTORY"
+    rm -f "$BROWSER_HISTORY"
+
+execute: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+    #shellcheck source=tests/lib/files.sh
+    . "$TESTSLIB"/files.sh
+
+    echo "Request is forwarded to the default browser"
+    as_user test-snapd-desktop.cmd xdg-open http://www.example.org
+
+    echo "The test-browser process was invoked with the URL"
+    wait_for_file "$BROWSER_HISTORY" 4 .5
+    MATCH http://www.example.org < "$BROWSER_HISTORY"
+
+    echo "Access the file via URI handler"
+    as_user test-snapd-desktop.cmd xdg-open file:///home/test/snap/test-snapd-desktop/common/test.txt
+    wait_for_file "$EDITOR_HISTORY" 4 .5
+    MATCH /home/test/snap/test-snapd-desktop/common/test.txt < "$EDITOR_HISTORY"
+    rm -f "$EDITOR_HISTORY"
+
+    echo "Access the file directly"
+    as_user test-snapd-desktop.cmd xdg-open /home/test/snap/test-snapd-desktop/common/test.txt
+    wait_for_file "$EDITOR_HISTORY" 4 .5
+    MATCH /home/test/snap/test-snapd-desktop/common/test.txt < "$EDITOR_HISTORY"
+
+debug: |
+    #shellcheck source=tests/lib/desktop-portal.sh
+    . "$TESTSLIB"/desktop-portal.sh
+
+    ls -la "/run/user/$TEST_UID/" || true
+    #shellcheck disable=SC2009
+    ps -ef | grep xdg || true

--- a/tests/main/xdg-open-portal/web-browser.sh
+++ b/tests/main/xdg-open-portal/web-browser.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+url="$1"
+echo "Browsing to $url"
+
+echo "$url" >> /tmp/browser-history.txt

--- a/xdgopenproxy/export_test.go
+++ b/xdgopenproxy/export_test.go
@@ -19,4 +19,12 @@
 
 package xdgopenproxy
 
-var Launch = launch
+type Bus = bus
+
+func MockSessionBus(m func() (Bus, error)) (restore func()) {
+	old := sessionBus
+	sessionBus = m
+	return func() {
+		sessionBus = old
+	}
+}

--- a/xdgopenproxy/export_test.go
+++ b/xdgopenproxy/export_test.go
@@ -19,6 +19,10 @@
 
 package xdgopenproxy
 
+import (
+	"time"
+)
+
 type Bus = bus
 
 func MockSessionBus(m func() (Bus, error)) (restore func()) {
@@ -26,5 +30,13 @@ func MockSessionBus(m func() (Bus, error)) (restore func()) {
 	sessionBus = m
 	return func() {
 		sessionBus = old
+	}
+}
+
+func MockPortalTimeout(t time.Duration) (restore func()) {
+	old := defaultPortalRequestTimeout
+	defaultPortalRequestTimeout = t
+	return func() {
+		defaultPortalRequestTimeout = old
 	}
 }

--- a/xdgopenproxy/xdgopenproxy.go
+++ b/xdgopenproxy/xdgopenproxy.go
@@ -21,25 +21,43 @@
 package xdgopenproxy
 
 import (
+	"fmt"
 	"net/url"
 	"syscall"
+	"time"
 
 	"github.com/godbus/dbus"
+	"golang.org/x/xerrors"
 )
 
 type bus interface {
 	Object(name string, objectPath dbus.ObjectPath) dbus.BusObject
+	AddMatchSignal(options ...dbus.MatchOption) error
+	RemoveMatchSignal(options ...dbus.MatchOption) error
+	Signal(ch chan<- *dbus.Signal)
+	RemoveSignal(ch chan<- *dbus.Signal)
 	Close() error
 }
 
-var sessionBus = func() (bus, error) { return dbus.SessionBus() }
+type responseError struct {
+	msg string
+}
+
+func (u *responseError) Error() string { return u.msg }
+
+func (u *responseError) Is(err error) bool {
+	_, ok := err.(*responseError)
+	return ok
+}
 
 type desktopLauncher interface {
 	openFile(path string) error
 	openURL(url string) error
 }
 
+// portalLauncher is a launcher that forwards the requests to xdg-desktop-portal DBus API
 type portalLauncher struct {
+	bus     bus
 	service dbus.BusObject
 }
 
@@ -50,26 +68,90 @@ func (p *portalLauncher) openFile(filename string) error {
 	}
 	defer syscall.Close(fd)
 
-	return p.service.Call("org.freedesktop.portal.OpenURI.OpenFile", 0, "", dbus.UnixFD(fd),
-		map[string]dbus.Variant{}).Err
+	return p.portalCall("org.freedesktop.portal.OpenURI.OpenFile", 0, "", dbus.UnixFD(fd),
+		map[string]dbus.Variant{})
 }
 
 func (p *portalLauncher) openURL(path string) error {
-	return p.service.Call("org.freedesktop.portal.OpenURI.OpenURI", 0, "", path,
-		map[string]dbus.Variant{}).Err
+	return p.portalCall("org.freedesktop.portal.OpenURI.OpenURI", 0, "", path,
+		map[string]dbus.Variant{})
 }
 
-func newPortalLauncher(bus bus) (desktopLauncher, error) {
-	obj := bus.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+// portalResponseSuccess is a numeric value indicating a success carrying out
+// the request, returned by the `response` member of
+// org.freedesktop.portal.Request.Response signal
+const portalResponseSuccess = 0
 
-	err := obj.Call("org.freedesktop.DBus.Peer.Ping", 0).Err
-	if err != nil {
-		return nil, err
+// timeout for asking the user to make a choice, same value as in usersession/userd/launcher.go
+var defaultPortalRequestTimeout = 5 * time.Minute
+
+func (p *portalLauncher) portalCall(member string, flags dbus.Flags, args ...interface{}) error {
+	// see https://flatpak.github.io/xdg-desktop-portal/portal-docs.html for
+	// details of the interaction, in short:
+	// 1. caller issues a request to the desktop portal
+	// 2. desktop portal responds with a handle to a dbus object capturing the Request
+	// 3. caller waits for the org.freedesktop.portal.Request.Response
+	// 3a. caller can terminate the request earlier by calling close
+
+	// set up signal handling before we call the portal, so that we do not
+	// miss the signals
+	signals := make(chan *dbus.Signal, 1)
+	match := []dbus.MatchOption{
+		dbus.WithMatchSender("org.freedesktop.portal.Desktop"),
+		dbus.WithMatchInterface("org.freedesktop.portal.Request"),
+		dbus.WithMatchMember("Response"),
 	}
 
-	return &portalLauncher{service: obj}, nil
+	p.bus.Signal(signals)
+	p.bus.AddMatchSignal(match...)
+
+	defer func() {
+		p.bus.RemoveMatchSignal(match...)
+		p.bus.RemoveSignal(signals)
+		close(signals)
+	}()
+
+	var handle dbus.ObjectPath
+	if err := p.service.Call(member, flags, args...).Store(&handle); err != nil {
+		// failure to launch the request is not a response error
+		return err
+	}
+
+	responseObject := p.bus.Object("org.freedesktop.portal.Desktop", handle)
+
+	timeout := time.NewTicker(defaultPortalRequestTimeout)
+	defer timeout.Stop()
+	for {
+		select {
+		case <-timeout.C:
+			responseObject.Call("org.freedesktop.portal.Request.Close", 0)
+			return &responseError{msg: "timeout waiting for user response"}
+		case signal := <-signals:
+			if signal.Path != responseObject.Path() {
+				// different object path
+				continue
+			}
+
+			var response uint
+			var results map[string]interface{} // don't care
+			if err := dbus.Store(signal.Body, &response, &results); err != nil {
+				return &responseError{msg: fmt.Sprintf("cannot unpack response: %v", err)}
+			}
+			if response == portalResponseSuccess {
+				return nil
+			}
+			return &responseError{msg: fmt.Sprintf("request declined by the user (code %v)", response)}
+		}
+	}
 }
 
+func newPortalLauncher(bus bus) desktopLauncher {
+	obj := bus.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+
+	return &portalLauncher{service: obj, bus: bus}
+}
+
+// snapcraftLauncher is a launcher that forwards the requests to `snap userd` DBus API
 type snapcraftLauncher struct {
 	service dbus.BusObject
 }
@@ -94,22 +176,22 @@ func newSnapcraftLauncher(bus bus) desktopLauncher {
 	return &snapcraftLauncher{service: obj}
 }
 
+var sessionBus = func() (bus, error) { return dbus.SessionBus() }
+
+// Run attempts to open given file or URL using one of available launchers
 func Run(urlOrFile string) error {
 	sbus, err := sessionBus()
 	if err != nil {
 		return err
 	}
-
-	launcher, err := newPortalLauncher(sbus)
-	if err != nil {
-		launcher = newSnapcraftLauncher(sbus)
-	}
+	// launchers to try in order, prefer portal launcher over snap userd one
+	launchers := []desktopLauncher{newPortalLauncher(sbus), newSnapcraftLauncher(sbus)}
 
 	defer sbus.Close()
-	return launch(launcher, urlOrFile)
+	return launch(launchers, urlOrFile)
 }
 
-func launch(l desktopLauncher, urlOrFile string) error {
+func launchWithOne(l desktopLauncher, urlOrFile string) error {
 	if u, err := url.Parse(urlOrFile); err == nil {
 		if u.Scheme == "file" {
 			return l.openFile(u.Path)
@@ -118,4 +200,21 @@ func launch(l desktopLauncher, urlOrFile string) error {
 		}
 	}
 	return l.openFile(urlOrFile)
+}
+
+func launch(launchers []desktopLauncher, urlOrFile string) error {
+	var err error
+	for _, l := range launchers {
+		err = launchWithOne(l, urlOrFile)
+		if err == nil {
+			break
+		}
+		if xerrors.Is(err, &responseError{}) {
+			// got a response which indicates the action was either
+			// explicitly rejected by the user or abandoned due to
+			// other reasons eg. timeout waiting for user to respond
+			break
+		}
+	}
+	return err
 }


### PR DESCRIPTION
The desktop portal is expected to be the main entity to handle such requests.
When proxying a request to open a file or an url, try poking the desktop portal
first, and then fall back to the snapd user session helper.

Fixes: https://bugs.launchpad.net/snappy/+bug/1857128

@jhenstridge can you take a look?