### PR TITLE
tests/main/snap-sign: add test for non-stdin signing

### DIFF
--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -39,7 +39,7 @@ of the assertion can be specified through a "body" pseudo-header.
 
 type cmdSign struct {
 	Positional struct {
-		Filename flags.Filename `positional-arg-name:"<filename>"`
+		Filename flags.Filename
 	} `positional-args:"yes"`
 
 	KeyName keyName `short:"k" default:"default"`

--- a/tests/main/snap-sign/sign-model.exp
+++ b/tests/main/snap-sign/sign-model.exp
@@ -1,7 +1,13 @@
 spawn bash
 
-expect {
-    "# " { send "cat pi3-model.json | snap sign -k default &> pi3.model ; cat pi3.model\n" }
+if {$env(VARIANT) == "stdin"} {
+    expect {
+        "# " { send "cat pi3-model.json | snap sign -k default &> pi3.model ; cat pi3.model\n" }
+    }
+} else {
+    expect {
+        "# " { send "snap sign -k default pi3-model.json &> pi3.model ; cat pi3.model\n" }
+    }
 }
 
 # fun!

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -4,6 +4,10 @@ summary: Run snap sign to sign a model assertion
 # amazon: requires extra gpg-agent setup
 systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -amazon-*, -centos-*]
 
+environment:
+  VARIANT/stdin: stdin
+  VARIANT/file: file
+
 prepare: |
     #shellcheck source=tests/lib/mkpinentry.sh
     . "$TESTSLIB"/mkpinentry.sh


### PR DESCRIPTION
also cleans up a nit in cmd/snap/cmd_sign.go itself