### PR TITLE
tests: enable regression suite on core20

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -716,8 +716,6 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
-        # TODO:UC20: enable for uc20
-        systems: [-ubuntu-core-20-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -94,6 +94,12 @@ reset_classic() {
 
 reset_all_snap() {
     # remove all leftover snaps
+
+    # make sure snapd is running before we attempt to remove snaps, in case a test stopped it
+    if ! systemctl status snapd.service snapd.socket >/dev/null; then
+        systemctl start snapd.service snapd.socket
+    fi
+
     # shellcheck source=tests/lib/names.sh
     . "$TESTSLIB/names.sh"
 
@@ -105,10 +111,6 @@ reset_all_snap() {
             "bin" | "$gadget_name" | "$kernel_name" | "$core_name" | "snapd" |README)
                 ;;
             *)
-                # make sure snapd is running before we attempt to remove snaps, in case a test stopped it
-                if ! systemctl status snapd.service snapd.socket >/dev/null; then
-                    systemctl start snapd.service snapd.socket
-                fi
                 # Check if a snap should be kept, there's a list of those in spread.yaml.
                 keep=0
                 for precious_snap in $SKIP_REMOVE_SNAPS; do

--- a/tests/regression/lp-1606277/task.yaml
+++ b/tests/regression/lp-1606277/task.yaml
@@ -1,5 +1,9 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1606277 
 
+# TODO:UC20: no logs on a fresh uc20 system, discuss with foundations if
+#            that is expected
+systems: [-ubuntu-core-20-*]
+
 details: |
     A missing bind mount for /var/log prevents access to system log files
     even if the log-observe interface is being used.


### PR DESCRIPTION
Mostly trivial, for regression/lp-1606277 I pinged foundations to figure out if that is ok or a real issue.