### PR TITLE
snap-repair: use dirs.SnapSeedDir instead of seed.yaml

### DIFF
--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -569,8 +569,9 @@ func (run *Runner) initState() error {
 	// best-effort remove old
 	os.Remove(dirs.SnapRepairStateFile)
 	run.state = state{}
-	// initialize time lower bound with image built time/seed.yaml time
-	info, err := os.Stat(filepath.Join(dirs.SnapSeedDir, "seed.yaml"))
+	// initialize time lower bound with image built time/seed dir time
+	// (not using seed.yaml here because it's different on UC20).
+	info, err := os.Stat(dirs.SnapSeedDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit uses the dirs.SnapSeedDir to initialize the lower bound instead of looking for seed.yaml. The seed.yaml file is not available on UC20 systems but the seed dir should have the same date as it's created during image creation/firstboot.