### PR TITLE
tests: enable a lot of the tests of main on uc20

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -78,8 +78,7 @@ backends:
                 workers: 6
             - ubuntu-core-20-64:
                 image: ubuntu-1804-64-uefi-enabled
-                #TODO:UC20: enable more workers once we have more tests
-                workers: 1
+                workers: 6
                 storage: 20G
 
             - debian-9-64:

--- a/spread.yaml
+++ b/spread.yaml
@@ -649,8 +649,6 @@ suites:
     # All other tests run now and will heavily modify the system.
     tests/main/:
         summary: Full-system tests for snapd
-        # TODO:UC20: enable for uc20
-        systems: [-ubuntu-core-20-*]
         prepare: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |

--- a/tests/main/auto-refresh-retry/task.yaml
+++ b/tests/main/auto-refresh-retry/task.yaml
@@ -1,6 +1,8 @@
 summary: Check that auto-refresh is retried after a permanent network error
 
-systems: [-ubuntu-14.04-*]
+# TODO:UC20: enable once we have a real model assertion, currently fails with:
+#   v2/snaps/refresh -> "cannot set device session: no device serial yet"
+systems: [-ubuntu-core-20-*, -ubuntu-14.04-*]
 
 prepare: |
     snap install --devmode jq

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that auto-refresh works
 
+# TODO:UC20: enable once we have a real model assertion, currently fails with:
+#   v2/snaps/refresh -> "cannot set device session: no device serial yet"
+systems: [-ubuntu-core-20-*]
+
 environment:
     SNAP_NAME/regular: test-snapd-tools
     SNAP_NAME/parallel: test-snapd-tools_instance

--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that the system is not in "degraded" state
 
+# TODO:UC20: e2scrub_reap.service is failing on uc20 as of 20200109, enable
+#            once foundations fixes it
+systems: [-ubuntu-core-20-*]
+
 # run this early to ensure no test created failed units yet
 priority: 500
 

--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -1,7 +1,8 @@
 summary: Check that the the docker snap works basically
 
 # only run on ubuntus for now, the docker snap has issues on non-ubuntu ATM
-# TODO:UC20: enable for UC20
+# TODO:UC20: enable for UC20, fails with what looks like apparmor
+# errors trying to run kmod and open /run/system/sessions/1 and ptrace
 systems: [ubuntu-1*, ubuntu-2*, ubuntu-core-1*]
 
 debug: |

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -1,11 +1,7 @@
 summary: Ensure that ECONNRESET is handled
 
-# autopkgtest run only a subset of tests that deals with the integration
-# with the distro
-backends: [-autopkgtest]
-
-# no iptables on core18 yet
-systems: [-ubuntu-core-18-*]
+# no iptables on core18+
+systems: [-ubuntu-core-18-*, -ubuntu-core-2*]
 
 debug: |
     echo "Partial download status"

--- a/tests/main/gadget-update-pc/task.yaml
+++ b/tests/main/gadget-update-pc/task.yaml
@@ -1,5 +1,8 @@
 summary: Exercise a gadget update on a PC
 
+# TODO:UC20: fails for unknown reasons, needs investigation
+systems: [-ubuntu-core-20-*]
+
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir
     # snap-id of 'pc' gadget snap

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -70,8 +70,15 @@ execute: |
     snap install --dangerous ./test-snapd-tools_1.0_all.snap
     test-snapd-tools.success
 
-    echo "All snap blobs are 0600"
-    test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"
+    # shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB/systems.sh"
+    # TODO:UC20: fix to work on uc20 too
+    # The "seed/" dir is on a FAT partition on uc20 so the permissions are
+    # different here.
+    if ! is_core20_system; then
+        echo "All snap blobs are 0600"
+        test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"
+    fi
 
     # TODO: check we copy the data directory over
 

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -43,5 +43,12 @@ execute: |
     echo "Install a snap that contains bash-completion scripts"
     snap install --edge test-snapd-complexion
 
-    echo "All snap blobs are 0600"
-    test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"
+    # shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB/systems.sh"
+    # TODO:UC20: fix to work on uc20 too
+    # The "seed/" dir is on a FAT partition on uc20 so the permissions are
+    # different here.
+    if ! is_core20_system; then
+        echo "All snap blobs are 0600"
+        test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"
+    fi

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -43,12 +43,5 @@ execute: |
     echo "Install a snap that contains bash-completion scripts"
     snap install --edge test-snapd-complexion
 
-    # shellcheck source=tests/lib/systems.sh
-    . "$TESTSLIB/systems.sh"
-    # TODO:UC20: fix to work on uc20 too
-    # The "seed/" dir is on a FAT partition on uc20 so the permissions are
-    # different here.
-    if ! is_core20_system; then
-        echo "All snap blobs are 0600"
-        test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"
-    fi
+    echo "All snap blobs are 0600"
+    test "$( find /var/lib/snapd/{snaps,cache,seed/snaps}/ -type f -printf '%#m\n' | sort -u | xargs )" = "0600"

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that the snapd-control "refresh-schedule" attribute works.
 
+# TODO:UC20: enable once we use the canonical model assertion
+systems: [-ubuntu-core-20-*]
+
 environment:
   BLOB_DIR: $(pwd)/fake-store-blobdir
 

--- a/tests/main/interfaces-timezone-control/task.yaml
+++ b/tests/main/interfaces-timezone-control/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that timezone interface works
 
+# TODO:UC20: enable once the systemd fix:
+#  https://launchpad.net/ubuntu/+source/systemd/244-3ubuntu2 lands
+systems: [-ubuntu-core-20-*]
+
 details: |
     This test makes sure that a snap using the timezone-control interface
     can access timezone information and update it.

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -39,7 +39,7 @@ execute: |
         REV=$SIDELOAD_REV
         PUBLISHER=-
 
-    elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" ]; then
+    elif [ "$SPREAD_BACKEND" = "google" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-18-64" -o "$SPREAD_SYSTEM" = "ubuntu-core-20-64" ]; then
         echo "With customized images the snapd snap is sideloaded"
         NAME=snapd
         VERSION=$SNAPD_GIT_VERSION
@@ -56,7 +56,7 @@ execute: |
         echo "On the external device the core snap tested could be in any track"
         TRACKING="(latest/)?(edge|beta|candidate|stable)"
 
-    elif [ "$SPREAD_BACKEND" = "external" ] && [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]]; then
+    elif [ "$SPREAD_BACKEND" = "external" ] && { [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]; }; then
         echo "On the external device the snapd snap tested could be in any track"
         NAME=snapd
         VERSION=$SNAPD_GIT_VERSION

--- a/tests/main/snap-model/task.yaml
+++ b/tests/main/snap-model/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snap model works
 
+# TODO:UC20: enable for UC20 once the real model is used
+systems: [-ubuntu-core-2*]
+
 execute: |
   knownCmdAssertion=$(snap known model)
   modelCmdAssertion=$(snap model --assertion)

--- a/tests/main/snap-network-errors/task.yaml
+++ b/tests/main/snap-network-errors/task.yaml
@@ -1,11 +1,7 @@
 summary: Ensure network errors are handled gracefully
 
-# autopkgtest run only a subset of tests that deals with the integration
-# with the distro
-backends: [-autopkgtest]
-
-# no iptables on core18 yet
-systems: [-ubuntu-core-18-*]
+# no iptables on core18+
+systems: [-ubuntu-core-18-*, -ubuntu-core-2*]
 
 restore: |
     echo "Restoring iptables rules"

--- a/tests/main/snap-repair/task.yaml
+++ b/tests/main/snap-repair/task.yaml
@@ -1,6 +1,8 @@
 summary: Ensure that snap-repair is available
 
-systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
+# TODO:UC20: snap-repair fishes in /var/lib/snapd/seed/assertions for the model
+#            assertion - this no longer works on UC20
+systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*, -ubuntu-core-20-*]
 
 execute: |
     #shellcheck source=tests/lib/dirs.sh

--- a/tests/main/snapd-snap-transition/task.yaml
+++ b/tests/main/snapd-snap-transition/task.yaml
@@ -1,8 +1,8 @@
 summary: Ensure the snapd snap transition works
 
-# ubuntu-core-18 already has the snapd snap
+# ubuntu-core-18+ already has the snapd snap
 # FIXME: ubuntu-core-16 needs special code for the transition
-systems: [-ubuntu-core-18-*, -ubuntu-core-16-*]
+systems: [-ubuntu-core-18-*, -ubuntu-core-2*, -ubuntu-core-16-*]
 
 execute: |
     echo "Ensure no snapd snap is installed"

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -3,7 +3,8 @@ summary: |
    for first boot snaps
 
 # the test is only meaningful on core devices
-# TODO:UC20: enable for UC20
+# TODO:UC20: enable for UC20, it assumes /var/lib/snapd/seed/assertions/model
+#            which we don't have currently
 systems: [ubuntu-core-1*]
 
 environment:

--- a/tests/main/ubuntu-core-netplan/task.yaml
+++ b/tests/main/ubuntu-core-netplan/task.yaml
@@ -1,5 +1,9 @@
 summary: Ensure that netplan works on Ubuntu Core with network-setup-{control,observe}
 
+#TODO:UC20: enable, fails right now with: "The permission of the
+#           setuid helper is not correct"
+systems: [-ubuntu-core-20-*]
+
 details: |
     Netplan apply is used to apply network configuration to the system
 


### PR DESCRIPTION
A bunch of tests are still disabled. The ones that need attention have a `TODO:UC20:` with an explanation what needs to happen.