### PR TITLE
many: run black formatter on all python files

### DIFF
--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -10,6 +10,7 @@ import urllib.request
 
 from html.parser import HTMLParser
 
+
 class InvalidPRTitle(Exception):
     def __init__(self, invalid_title):
         self.invalid_title = invalid_title
@@ -20,10 +21,13 @@ class GithubTitleParser(HTMLParser):
         HTMLParser.__init__(self)
         self._cur_tag = ""
         self.title = ""
+
     def handle_starttag(self, tag, attributes):
         self._cur_tag = tag
+
     def handle_endtag(self, tag):
         self._cur_tag = ""
+
     def handle_data(self, data):
         if self._cur_tag == "title":
             self.title = data
@@ -38,7 +42,9 @@ def check_pr_title(pr_number: int):
     # so instead we just scrape the html title which is unlikely to change
     # radically
     parser = GithubTitleParser()
-    with urllib.request.urlopen('https://github.com/snapcore/snapd/pull/{}'.format(pr_number)) as f:
+    with urllib.request.urlopen(
+        "https://github.com/snapcore/snapd/pull/{}".format(pr_number)
+    ) as f:
         parser.feed(f.read().decode("utf-8"))
     # the title has the format:
     #  "Added api endpoint for downloading snaps by glower · Pull Request #6958 · snapcore/snapd · GitHub"
@@ -51,19 +57,20 @@ def check_pr_title(pr_number: int):
     # package, otherpackage/subpackage: this is a title
     # tests/regression/lp-12341234: foo
     # [RFC] foo: bar
-    if not re.match(r'[a-zA-Z0-9_\-/,. \[\]{}]+: .*', title):
+    if not re.match(r"[a-zA-Z0-9_\-/,. \[\]{}]+: .*", title):
         raise InvalidPRTitle(title)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        'pr_number', metavar='PR number', help='the github PR number to check')
+        "pr_number", metavar="PR number", help="the github PR number to check"
+    )
     args = parser.parse_args()
     try:
         check_pr_title(args.pr_number)
     except InvalidPRTitle as e:
-        print("Invalid PR title: \"{}\"\n".format(e.invalid_title))
+        print('Invalid PR title: "{}"\n'.format(e.invalid_title))
         print("Please provide a title in the following format:")
         print("module: short description")
         print("E.g.:")

--- a/mdlint.py
+++ b/mdlint.py
@@ -9,6 +9,7 @@
 import sys
 import codecs
 
+
 def lint_li(fname, text):
     """Ensure that the list-items are multiplies of 4"""
     is_clean = True

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -27,23 +27,26 @@ import snapcraft
 def patch_snapcraft():
     import snapcraft.internal.common
     import snapcraft.internal.sources._local
+
     # very hacky but gets the job done for now, right now
     # SNAPCRAFT_FILES is only used to know what to exclude
     snapcraft.internal.common.SNAPCRAFT_FILES.remove("snap")
+
     def _patched_check(self, target):
         return False
+
     snapcraft.internal.sources._local.Local._check = _patched_check
+
+
 patch_snapcraft()
 
 
-
 class XBuildDeb(snapcraft.BasePlugin):
-
     def build(self):
         super().build()
         self.run(["sudo", "apt-get", "build-dep", "-y", "./"])
         # ensure we have go in our PATH
-        env=os.environ.copy()
+        env = os.environ.copy()
         # ensure build with go-1.10 if available
         if os.path.exists("/usr/lib/go-1.10/bin"):
             env["PATH"] = "/usr/lib/go-1.10/bin:{}".format(env["PATH"])

--- a/tests/lib/best_golang.py
+++ b/tests/lib/best_golang.py
@@ -3,10 +3,16 @@
 import apt
 import re
 
-best_golang=None
+best_golang = None
 for p in apt.Cache():
     if re.match(r"golang-([0-9.]+)$", p.name):
-        if best_golang is None or apt.apt_pkg.version_compare(best_golang.candidate.version, p.candidate.version) < 0:
+        if (
+            best_golang is None
+            or apt.apt_pkg.version_compare(
+                best_golang.candidate.version, p.candidate.version
+            )
+            < 0
+        ):
             best_golang = p
 
 print(best_golang.name)

--- a/tests/lib/fakegpio/fake-gpio.py
+++ b/tests/lib/fakegpio/fake-gpio.py
@@ -31,7 +31,7 @@ def export_ready(read_fd: int, _) -> bool:
     """export_ready is run when the "export" file is ready for reading"""
     pin = read_gpio_pin(read_fd)
     # allow quit
-    if pin == 'quit':
+    if pin == "quit":
         return False
     if pin:
         with open(pin, "w"):
@@ -61,7 +61,7 @@ def dispatch(sel):
 
 
 def maybe_sd_notify(s: str) -> None:
-    addr = os.getenv('NOTIFY_SOCKET')
+    addr = os.getenv("NOTIFY_SOCKET")
     if not addr:
         return
     soc = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
@@ -79,8 +79,7 @@ def main():
     mock_gpio_dir = tempfile.mkdtemp("mock-gpio")
     atexit.register(shutil.rmtree, mock_gpio_dir)
     os.chdir(mock_gpio_dir)
-    subprocess.check_call(
-        ["mount", "--bind", mock_gpio_dir, "/sys/class/gpio"])
+    subprocess.check_call(["mount", "--bind", mock_gpio_dir, "/sys/class/gpio"])
     atexit.register(lambda: subprocess.call(["umount", "/sys/class/gpio"]))
 
     # fake gpio export/unexport files

--- a/tests/lib/fakeportalui/portalui.py
+++ b/tests/lib/fakeportalui/portalui.py
@@ -14,32 +14,52 @@ APP_CHOOSER_IFACE = "org.freedesktop.impl.portal.AppChooser"
 FILE_CHOOSER_IFACE = "org.freedesktop.impl.portal.FileChooser"
 SCREENSHOT_IFACE = "org.freedesktop.impl.portal.Screenshot"
 
+
 class PortalImpl(dbus.service.Object):
     def __init__(self, connection, object_path, config):
         super(PortalImpl, self).__init__(connection, object_path)
         self._config = config
 
-    @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
-                         in_signature="osssa{sv}", out_signature="ua{sv}")
+    @dbus.service.method(
+        dbus_interface=FILE_CHOOSER_IFACE,
+        in_signature="osssa{sv}",
+        out_signature="ua{sv}",
+    )
     def OpenFile(self, handle, app_id, parent_window, title, options):
-        return (0, dict(uris=dbus.Array(["file:///tmp/file-to-read.txt"], signature="s"),
-                        writable=False))
+        return (
+            0,
+            dict(
+                uris=dbus.Array(["file:///tmp/file-to-read.txt"], signature="s"),
+                writable=False,
+            ),
+        )
 
-    @dbus.service.method(dbus_interface=FILE_CHOOSER_IFACE,
-                         in_signature="osssa{sv}", out_signature="ua{sv}")
+    @dbus.service.method(
+        dbus_interface=FILE_CHOOSER_IFACE,
+        in_signature="osssa{sv}",
+        out_signature="ua{sv}",
+    )
     def SaveFile(self, handle, app_id, parent_window, title, options):
-        return (0, dict(uris=dbus.Array(["file:///tmp/file-to-write.txt"], signature="s"),
-                        writable=True))
+        return (
+            0,
+            dict(
+                uris=dbus.Array(["file:///tmp/file-to-write.txt"], signature="s"),
+                writable=True,
+            ),
+        )
 
-    @dbus.service.method(dbus_interface=SCREENSHOT_IFACE,
-                         in_signature="ossa{sv}", out_signature="ua{sv}")
+    @dbus.service.method(
+        dbus_interface=SCREENSHOT_IFACE, in_signature="ossa{sv}", out_signature="ua{sv}"
+    )
     def Screenshot(self, handle, app_id, parent_window, options):
         return (0, dict(uri="file:///tmp/screenshot.txt"))
 
-    @dbus.service.method(dbus_interface=APP_CHOOSER_IFACE,
-                         in_signature="ossasa{sv}", out_signature="ua{sv}")
-    def ChooseApplication(self, handle, app_id, parent_window, choices,
-                          options):
+    @dbus.service.method(
+        dbus_interface=APP_CHOOSER_IFACE,
+        in_signature="ossasa{sv}",
+        out_signature="ua{sv}",
+    )
+    def ChooseApplication(self, handle, app_id, parent_window, choices, options):
         if options["content_type"] == "text/plain":
             return (0, dict(choice="test-editor"))
         else:
@@ -53,18 +73,21 @@ def main(argv):
     bus = dbus.SessionBus()
     # Make sure we quit when the bus shuts down
     bus.add_signal_receiver(
-        main_loop.quit, signal_name="Disconnected",
+        main_loop.quit,
+        signal_name="Disconnected",
         path="/org/freedesktop/DBus/Local",
-        dbus_interface="org.freedesktop.DBus.Local")
+        dbus_interface="org.freedesktop.DBus.Local",
+    )
 
     portal = PortalImpl(bus, OBJECT_PATH, None)
 
     # Allow other services to assume our bus name
     bus_name = dbus.service.BusName(
-        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
-        do_not_queue=True)
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True, do_not_queue=True
+    )
 
     main_loop.run()
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/lib/snaps/test-snapd-autopilot-consumer/provider.py
+++ b/tests/lib/snaps/test-snapd-autopilot-consumer/provider.py
@@ -8,21 +8,29 @@ from dbus.mainloop.glib import DBusGMainLoop
 
 DBusGMainLoop(set_as_default=True)
 
+
 class DBusProvider(dbus.service.Object):
     def __init__(self):
         bus = dbus.SessionBus()
-        bus_name = dbus.service.BusName("com.canonical.Autopilot.Introspection", bus=bus)
-        dbus.service.Object.__init__(self, bus_name, "/com/canonical/Autopilot/Introspection")
+        bus_name = dbus.service.BusName(
+            "com.canonical.Autopilot.Introspection", bus=bus
+        )
+        dbus.service.Object.__init__(
+            self, bus_name, "/com/canonical/Autopilot/Introspection"
+        )
 
-    @dbus.service.method(dbus_interface="com.canonical.Autopilot.Introspection",
-                         out_signature="s")
+    @dbus.service.method(
+        dbus_interface="com.canonical.Autopilot.Introspection", out_signature="s"
+    )
     def GetVersion(self):
         return "my-ap-version"
 
-    @dbus.service.method(dbus_interface="com.canonical.Autopilot.Introspection",
-                         out_signature="s")
+    @dbus.service.method(
+        dbus_interface="com.canonical.Autopilot.Introspection", out_signature="s"
+    )
     def GetState(self):
         return "my-ap-state"
+
 
 if __name__ == "__main__":
     DBusProvider()

--- a/tests/lib/snaps/test-snapd-dbus-consumer/consumer.py
+++ b/tests/lib/snaps/test-snapd-dbus-consumer/consumer.py
@@ -2,9 +2,11 @@
 import dbus
 import sys
 
+
 def run(bus):
     obj = bus.get_object("com.dbustest.HelloWorld", "/com/dbustest/HelloWorld")
     print(obj.SayHello(dbus_interface="com.dbustest.HelloWorld"))
+
 
 if __name__ == "__main__":
     if sys.argv[1] == "system":

--- a/tests/lib/snaps/test-snapd-dbus-provider/consumer.py
+++ b/tests/lib/snaps/test-snapd-dbus-provider/consumer.py
@@ -2,9 +2,11 @@
 import dbus
 import sys
 
+
 def run(bus):
     obj = bus.get_object("com.dbustest.HelloWorld", "/com/dbustest/HelloWorld")
     print(obj.SayHello(dbus_interface="com.dbustest.HelloWorld"))
+
 
 if __name__ == "__main__":
     if sys.argv[1] == "system":

--- a/tests/lib/snaps/test-snapd-dbus-provider/provider.py
+++ b/tests/lib/snaps/test-snapd-dbus-provider/provider.py
@@ -8,15 +8,16 @@ from dbus.mainloop.glib import DBusGMainLoop
 
 DBusGMainLoop(set_as_default=True)
 
+
 class DBusProvider(dbus.service.Object):
     def __init__(self, bus):
         bus_name = dbus.service.BusName("com.dbustest.HelloWorld", bus=bus)
         dbus.service.Object.__init__(self, bus_name, "/com/dbustest/HelloWorld")
 
-    @dbus.service.method(dbus_interface="com.dbustest.HelloWorld",
-                         out_signature="s")
+    @dbus.service.method(dbus_interface="com.dbustest.HelloWorld", out_signature="s")
     def SayHello(self):
         return "hello world"
+
 
 if __name__ == "__main__":
     if sys.argv[1] == "system":

--- a/tests/lib/snaps/test-snapd-location-control-provider/provider.py
+++ b/tests/lib/snaps/test-snapd-location-control-provider/provider.py
@@ -6,8 +6,8 @@ import dbus.service
 
 from dbus.mainloop.glib import DBusGMainLoop
 
-INTERFACE = 'com.ubuntu.location.Service'
-PATH = '/com/ubuntu/location/Service'
+INTERFACE = "com.ubuntu.location.Service"
+PATH = "/com/ubuntu/location/Service"
 
 DBusGMainLoop(set_as_default=True)
 
@@ -20,7 +20,7 @@ class DBusProvider(dbus.service.Object):
 
     @dbus.service.method(dbus_interface=INTERFACE, out_signature="s")
     def AddProvider(self):
-        return 'location-provider-added'
+        return "location-provider-added"
 
 
 if __name__ == "__main__":

--- a/tests/lib/snaps/test-snapd-network-status-provider/provider.py
+++ b/tests/lib/snaps/test-snapd-network-status-provider/provider.py
@@ -6,8 +6,8 @@ import dbus.service
 
 from dbus.mainloop.glib import DBusGMainLoop
 
-INTERFACE = 'com.ubuntu.connectivity1.NetworkingStatus'
-PATH = '/com/ubuntu/connectivity1/NetworkingStatus'
+INTERFACE = "com.ubuntu.connectivity1.NetworkingStatus"
+PATH = "/com/ubuntu/connectivity1/NetworkingStatus"
 
 DBusGMainLoop(set_as_default=True)
 

--- a/tests/lib/snaps/test-snapd-portal-client/client.py
+++ b/tests/lib/snaps/test-snapd-portal-client/client.py
@@ -7,8 +7,8 @@ import dbus
 import dbus.mainloop.glib
 from gi.repository import GLib
 
-class Client:
 
+class Client:
     def __init__(self, bus, main_loop):
         self._bus = bus
         self._main_loop = main_loop
@@ -20,10 +20,13 @@ class Client:
             signal_name="Response",
             dbus_interface="org.freedesktop.portal.Request",
             bus_name="org.freedesktop.portal.Desktop",
-            path_keyword="object_path")
-        self._portal = self._bus.get_object("org.freedesktop.portal.Desktop",
-                                            "/org/freedesktop/portal/desktop",
-                                            introspect=False)
+            path_keyword="object_path",
+        )
+        self._portal = self._bus.get_object(
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            introspect=False,
+        )
 
     def _response_cb(self, response, results, object_path):
         if object_path == self._request_path:
@@ -40,10 +43,10 @@ class Client:
         return command(*args)
 
     def cmd_open_file(self):
-        iface = dbus.Interface(
-            self._portal, "org.freedesktop.portal.FileChooser")
+        iface = dbus.Interface(self._portal, "org.freedesktop.portal.FileChooser")
         self._request_path = iface.OpenFile(
-            "", "test open file", dbus.Dictionary(signature="sv"))
+            "", "test open file", dbus.Dictionary(signature="sv")
+        )
         self._main_loop.run()
         if self._response == 0:
             for uri in self._results["uris"]:
@@ -60,10 +63,10 @@ class Client:
             return 1
 
     def cmd_save_file(self, content):
-        iface = dbus.Interface(
-            self._portal, "org.freedesktop.portal.FileChooser")
+        iface = dbus.Interface(self._portal, "org.freedesktop.portal.FileChooser")
         self._request_path = iface.SaveFile(
-            "", "test save file", dbus.Dictionary(signature="sv"))
+            "", "test save file", dbus.Dictionary(signature="sv")
+        )
         self._main_loop.run()
         if self._response == 0:
             uris = self._results["uris"]
@@ -81,10 +84,8 @@ class Client:
             return 1
 
     def cmd_open_uri(self, uri):
-        iface = dbus.Interface(
-            self._portal, "org.freedesktop.portal.OpenURI")
-        self._request_path = iface.OpenURI(
-            "", uri, dbus.Dictionary(signature="sv"))
+        iface = dbus.Interface(self._portal, "org.freedesktop.portal.OpenURI")
+        self._request_path = iface.OpenURI("", uri, dbus.Dictionary(signature="sv"))
         self._main_loop.run()
         if self._response == 0:
             pass
@@ -97,11 +98,11 @@ class Client:
             return 1
 
     def cmd_launch_file(self, filename):
-        iface = dbus.Interface(
-            self._portal, "org.freedesktop.portal.OpenURI")
-        with open(filename, 'rb') as fp:
+        iface = dbus.Interface(self._portal, "org.freedesktop.portal.OpenURI")
+        with open(filename, "rb") as fp:
             self._request_path = iface.OpenFile(
-                "", dbus.types.UnixFd(fp), dbus.Dictionary(signature="sv"))
+                "", dbus.types.UnixFd(fp), dbus.Dictionary(signature="sv")
+            )
         self._main_loop.run()
         if self._response == 0:
             pass
@@ -114,10 +115,8 @@ class Client:
             return 1
 
     def cmd_screenshot(self):
-        iface = dbus.Interface(
-            self._portal, "org.freedesktop.portal.Screenshot")
-        self._request_path = iface.Screenshot(
-            "", dbus.Dictionary(signature="sv"))
+        iface = dbus.Interface(self._portal, "org.freedesktop.portal.Screenshot")
+        self._request_path = iface.Screenshot("", dbus.Dictionary(signature="sv"))
         self._main_loop.run()
         if self._response == 0:
             uri = self._results["uri"]
@@ -143,5 +142,5 @@ def main(argv):
     return client.run(argv[1:])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/lib/snaps/test-snapd-portal-client/setup.py
+++ b/tests/lib/snaps/test-snapd-portal-client/setup.py
@@ -3,9 +3,5 @@
 import setuptools
 
 setuptools.setup(
-    name="test-snapd-portal-client",
-    version="1.0",
-    scripts=[
-        "client.py"
-    ],
+    name="test-snapd-portal-client", version="1.0", scripts=["client.py"],
 )

--- a/tests/lib/snaps/test-snapd-profiler-core18/profiler.py
+++ b/tests/lib/snaps/test-snapd-profiler-core18/profiler.py
@@ -8,30 +8,30 @@ import os
 import psutil
 import time
 
-PROCATTRS = 'proc.attrs'
-PROCS = 'proc.names'
-RATE = 'iter.rate'
-INTERVAL = 'iter.interval'
-RATE_CONFIG = 'iter.rate.config'
+PROCATTRS = "proc.attrs"
+PROCS = "proc.names"
+RATE = "iter.rate"
+INTERVAL = "iter.interval"
+RATE_CONFIG = "iter.rate.config"
 
-SNAP_DIR = os.getenv('SNAP', '.')
-COMMON_DIR = os.getenv('SNAP_COMMON', '.')
-LOG_PATH = os.path.join(COMMON_DIR, 'profiler.log')
-DEFAULTS_PATH = os.path.join(SNAP_DIR, 'etc', 'config.ini')
-CONFIG_PATH = os.path.join(COMMON_DIR, 'profiler.conf')
-CONFIG_PATH_FLAG = os.path.join(COMMON_DIR, 'reconfigured')
+SNAP_DIR = os.getenv("SNAP", ".")
+COMMON_DIR = os.getenv("SNAP_COMMON", ".")
+LOG_PATH = os.path.join(COMMON_DIR, "profiler.log")
+DEFAULTS_PATH = os.path.join(SNAP_DIR, "etc", "config.ini")
+CONFIG_PATH = os.path.join(COMMON_DIR, "profiler.conf")
+CONFIG_PATH_FLAG = os.path.join(COMMON_DIR, "reconfigured")
 
 
 def prepare_config(config):
     new_config = dict(config)
-    new_config[PROCATTRS] = [proc.strip() for proc in config.get(PROCATTRS).split(',')]
-    new_config[PROCS] = [proc.strip() for proc in config.get(PROCS).split(',')]
+    new_config[PROCATTRS] = [proc.strip() for proc in config.get(PROCATTRS).split(",")]
+    new_config[PROCS] = [proc.strip() for proc in config.get(PROCS).split(",")]
     new_config[INTERVAL] = float(config.get(INTERVAL, 1))
     for key, val in config.items():
         if RATE in key:
             new_config[key] = int(config.get(key, 1))
 
-    logging.info('Using config: {}'.format(new_config))
+    logging.info("Using config: {}".format(new_config))
     return new_config
 
 
@@ -39,9 +39,9 @@ def read_config(config_path):
     config = configparser.ConfigParser()
     if os.path.isfile(config_path):
         config.read(config_path)
-        return prepare_config(config['DEFAULT'])
+        return prepare_config(config["DEFAULT"])
     else:
-        logging.error('Config file {} not found'.format(config_path))
+        logging.error("Config file {} not found".format(config_path))
         exit(1)
 
 
@@ -56,14 +56,19 @@ def get_config():
 def check_config():
     if os.path.isfile(CONFIG_PATH) and not os.path.isfile(CONFIG_PATH_FLAG):
         new_config = read_config(CONFIG_PATH)
-        open(CONFIG_PATH_FLAG, 'a').close()
+        open(CONFIG_PATH_FLAG, "a").close()
         return new_config
     else:
         return None
 
 
 def main():
-    logging.basicConfig(filename=LOG_PATH, filemode='w', level=logging.INFO, format='%(asctime)s - %(message)s')
+    logging.basicConfig(
+        filename=LOG_PATH,
+        filemode="w",
+        level=logging.INFO,
+        format="%(asctime)s - %(message)s",
+    )
     config = get_config()
 
     count = 0
@@ -73,14 +78,18 @@ def main():
             if new_config:
                 config = new_config
 
-        procs = [proc for proc in psutil.process_iter() if proc.name() in config.get(PROCS, [])]
+        procs = [
+            proc
+            for proc in psutil.process_iter()
+            if proc.name() in config.get(PROCS, [])
+        ]
         for proc in procs:
-            if count % config.get('{}.{}'.format(RATE, proc.name()), 1) == 0:
+            if count % config.get("{}.{}".format(RATE, proc.name()), 1) == 0:
                 logging.info(json.dumps(proc.as_dict(attrs=config.get(PROCATTRS))))
 
         time.sleep(config.get(INTERVAL))
         count = count + 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/lib/snaps/test-snapd-profiler/profiler.py
+++ b/tests/lib/snaps/test-snapd-profiler/profiler.py
@@ -8,30 +8,30 @@ import os
 import psutil
 import time
 
-PROCATTRS = 'proc.attrs'
-PROCS = 'proc.names'
-RATE = 'iter.rate'
-INTERVAL = 'iter.interval'
-RATE_CONFIG = 'iter.rate.config'
+PROCATTRS = "proc.attrs"
+PROCS = "proc.names"
+RATE = "iter.rate"
+INTERVAL = "iter.interval"
+RATE_CONFIG = "iter.rate.config"
 
-SNAP_DIR = os.getenv('SNAP', '.')
-COMMON_DIR = os.getenv('SNAP_COMMON', '.')
-LOG_PATH = os.path.join(COMMON_DIR, 'profiler.log')
-DEFAULTS_PATH = os.path.join(SNAP_DIR, 'etc', 'config.ini')
-CONFIG_PATH = os.path.join(COMMON_DIR, 'profiler.conf')
-CONFIG_PATH_FLAG = os.path.join(COMMON_DIR, 'reconfigured')
+SNAP_DIR = os.getenv("SNAP", ".")
+COMMON_DIR = os.getenv("SNAP_COMMON", ".")
+LOG_PATH = os.path.join(COMMON_DIR, "profiler.log")
+DEFAULTS_PATH = os.path.join(SNAP_DIR, "etc", "config.ini")
+CONFIG_PATH = os.path.join(COMMON_DIR, "profiler.conf")
+CONFIG_PATH_FLAG = os.path.join(COMMON_DIR, "reconfigured")
 
 
 def prepare_config(config):
     new_config = dict(config)
-    new_config[PROCATTRS] = [proc.strip() for proc in config.get(PROCATTRS).split(',')]
-    new_config[PROCS] = [proc.strip() for proc in config.get(PROCS).split(',')]
+    new_config[PROCATTRS] = [proc.strip() for proc in config.get(PROCATTRS).split(",")]
+    new_config[PROCS] = [proc.strip() for proc in config.get(PROCS).split(",")]
     new_config[INTERVAL] = float(config.get(INTERVAL, 1))
     for key, val in config.items():
         if RATE in key:
             new_config[key] = int(config.get(key, 1))
 
-    logging.info('Using config: {}'.format(new_config))
+    logging.info("Using config: {}".format(new_config))
     return new_config
 
 
@@ -39,9 +39,9 @@ def read_config(config_path):
     config = configparser.ConfigParser()
     if os.path.isfile(config_path):
         config.read(config_path)
-        return prepare_config(config['DEFAULT'])
+        return prepare_config(config["DEFAULT"])
     else:
-        logging.error('Config file {} not found'.format(config_path))
+        logging.error("Config file {} not found".format(config_path))
         exit(1)
 
 
@@ -56,14 +56,19 @@ def get_config():
 def check_config():
     if os.path.isfile(CONFIG_PATH) and not os.path.isfile(CONFIG_PATH_FLAG):
         new_config = read_config(CONFIG_PATH)
-        open(CONFIG_PATH_FLAG, 'a').close()
+        open(CONFIG_PATH_FLAG, "a").close()
         return new_config
     else:
         return None
 
 
 def main():
-    logging.basicConfig(filename=LOG_PATH, filemode='w', level=logging.INFO, format='%(asctime)s - %(message)s')
+    logging.basicConfig(
+        filename=LOG_PATH,
+        filemode="w",
+        level=logging.INFO,
+        format="%(asctime)s - %(message)s",
+    )
     config = get_config()
 
     count = 0
@@ -73,14 +78,18 @@ def main():
             if new_config:
                 config = new_config
 
-        procs = [proc for proc in psutil.process_iter() if proc.name() in config.get(PROCS, [])]
+        procs = [
+            proc
+            for proc in psutil.process_iter()
+            if proc.name() in config.get(PROCS, [])
+        ]
         for proc in procs:
-            if count % config.get('{}.{}'.format(RATE, proc.name()), 1) == 0:
+            if count % config.get("{}.{}".format(RATE, proc.name()), 1) == 0:
                 logging.info(json.dumps(proc.as_dict(attrs=config.get(PROCATTRS))))
 
         time.sleep(config.get(INTERVAL))
         count = count + 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/lib/snaps/test-snapd-python-webserver/server.py
+++ b/tests/lib/snaps/test-snapd-python-webserver/server.py
@@ -24,10 +24,10 @@ class XkcdRequestHandler(SimpleHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.startswith("/xkcd/"):
-            url = self.XKCD_URL + self.path[len("/xkcd/"):]
+            url = self.XKCD_URL + self.path[len("/xkcd/") :]
             return self._mini_proxy(url)
         elif self.path.startswith("/img/xkcd/"):
-            url = self.XKCD_IMG_URL + self.path[len("/img/xkcd/"):]
+            url = self.XKCD_IMG_URL + self.path[len("/img/xkcd/") :]
             return self._mini_proxy(url)
         else:
             return super(XkcdRequestHandler, self).do_GET()
@@ -42,5 +42,5 @@ if __name__ == "__main__":
     else:
         port = 80
 
-    httpd = HTTPServer(('', port), XkcdRequestHandler)
+    httpd = HTTPServer(("", port), XkcdRequestHandler)
     httpd.serve_forever()

--- a/tests/lib/snaps/test-snapd-statx/bin/statx.py
+++ b/tests/lib/snaps/test-snapd-statx/bin/statx.py
@@ -9,11 +9,12 @@ from errno import ENOSYS, EPERM
 from os import uname
 
 
-__all__ = ('SyscallStatus', 'evaluate_statx_support')
+__all__ = ("SyscallStatus", "evaluate_statx_support")
 
 
 class SyscallStatus(Enum):
     """Syscall status encodes the status of a system call."""
+
     SUPPORTED = "supported"
     MISSING = "missing"
     BLOCKED = "blocked"
@@ -35,13 +36,10 @@ def evaluate_statx_support() -> SyscallStatus:
         "i686": 383,
         "i386": 383,
         "x86_64": 332,
-
         "arm": 397,
         "aarch64": 291,
-
         "ppc": 383,
         "ppcel64": 383,
-
         "s390x": 379,
     }
     try:
@@ -71,8 +69,14 @@ def evaluate_statx_support() -> SyscallStatus:
     #
     #   char dummy_buf[4096];
     #   syscall(SYS_STATX, AT_FDCWD, "", AT_EMPTY_PATH, 0, dummy_buf);
-    retval = syscall(c_long(SYS_STATX), c_long(AT_FDCWD), empty_string,
-                     c_long(AT_EMPTY_PATH), c_long(0), dummy_buf)
+    retval = syscall(
+        c_long(SYS_STATX),
+        c_long(AT_FDCWD),
+        empty_string,
+        c_long(AT_EMPTY_PATH),
+        c_long(0),
+        dummy_buf,
+    )
     errno = get_errno()
     if retval == 0:
         return SyscallStatus.SUPPORTED
@@ -80,8 +84,9 @@ def evaluate_statx_support() -> SyscallStatus:
         return SyscallStatus.MISSING
     elif retval == -1 and errno == EPERM:
         return SyscallStatus.BLOCKED
-    raise Exception("unexpected result of statx, retval: {}, errno: {}".format(
-        retval, errno))
+    raise Exception(
+        "unexpected result of statx, retval: {}, errno: {}".format(retval, errno)
+    )
 
 
 def main() -> None:

--- a/tests/lib/snaps/test-snapd-system-observe-consumer/consumer.py
+++ b/tests/lib/snaps/test-snapd-system-observe-consumer/consumer.py
@@ -3,9 +3,11 @@
 import os
 import sys
 
+
 def run():
-    with open('/proc/tty/drivers', 'r') as f:
+    with open("/proc/tty/drivers", "r") as f:
         print(f.read())
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(run())

--- a/tests/lib/snaps/test-snapd-system-observe-consumer/dbus-introspect.py
+++ b/tests/lib/snaps/test-snapd-system-observe-consumer/dbus-introspect.py
@@ -2,9 +2,13 @@
 import dbus
 import sys
 
+
 def run():
-    obj = dbus.SystemBus().get_object("org.freedesktop.hostname1", "/org/freedesktop/hostname1")
+    obj = dbus.SystemBus().get_object(
+        "org.freedesktop.hostname1", "/org/freedesktop/hostname1"
+    )
     print(obj.Introspect(dbus_interface="org.freedesktop.DBus.Introspectable"))
+
 
 if __name__ == "__main__":
     sys.exit(run())

--- a/tests/lib/snaps/test-snapd-tuntap/bin/tuntap.py
+++ b/tests/lib/snaps/test-snapd-tuntap/bin/tuntap.py
@@ -10,7 +10,7 @@ from typing import Iterable
 
 
 def if_open(dev: str) -> int:
-    TUNSETIFF = 0x400454ca
+    TUNSETIFF = 0x400454CA
     TUNSETOWNER = TUNSETIFF + 2
     IFF_TUN = 0x0001
     IFF_TAP = 0x0002
@@ -22,9 +22,9 @@ def if_open(dev: str) -> int:
         raise SystemExit(e)
 
     if_flags = None
-    if dev.startswith('tun'):
+    if dev.startswith("tun"):
         if_flags = IFF_TUN | IFF_NO_PI
-    elif dev.startswith('tap'):
+    elif dev.startswith("tap"):
         if_flags = IFF_TAP | IFF_NO_PI
 
     fcntl.ioctl(fd, TUNSETIFF, struct.pack("16sH", str.encode(dev), if_flags))
@@ -40,7 +40,7 @@ def device_exists(dev: str) -> bool:
 
 
 def valid_device_name(dev: str) -> None:
-    if not re.search(r'^t(ap|un)[0-9]+$', dev):
+    if not re.search(r"^t(ap|un)[0-9]+$", dev):
         raise ValueError("device should be of form tun0-tun255 or tap0-tap255")
 
     if_num = int(dev[3:])

--- a/tests/lib/tinyproxy/tinyproxy.py
+++ b/tests/lib/tinyproxy/tinyproxy.py
@@ -14,7 +14,7 @@ import sys
 import urllib.parse
 
 
-class ProxyHandler (http.server.BaseHTTPRequestHandler):
+class ProxyHandler(http.server.BaseHTTPRequestHandler):
     server_version = "testsproxy/1.0"
 
     def log_request(self, m=""):
@@ -23,13 +23,13 @@ class ProxyHandler (http.server.BaseHTTPRequestHandler):
         sys.stderr.flush()
 
     def handle(self):
-        (ip, port) =  self.client_address
+        (ip, port) = self.client_address
         super().handle()
 
     def _connect_to(self, netloc, soc):
-        i = netloc.find(':')
+        i = netloc.find(":")
         if i >= 0:
-            host_port = netloc[:i], int(netloc[i+1:])
+            host_port = netloc[:i], int(netloc[i + 1 :])
         else:
             host_port = netloc, 80
         try:
@@ -60,8 +60,9 @@ class ProxyHandler (http.server.BaseHTTPRequestHandler):
 
     def do_GET(self):
         (scm, netloc, path, params, query, fragment) = urllib.parse.urlparse(
-            self.path, 'http')
-        if scm != 'http' or fragment or not netloc:
+            self.path, "http"
+        )
+        if scm != "http" or fragment or not netloc:
             s = "bad url {}".format(self.path)
             self.send_error(400, s.encode())
             return
@@ -71,11 +72,12 @@ class ProxyHandler (http.server.BaseHTTPRequestHandler):
                 self.log_request()
                 s = "{} {} {}\r\n".format(
                     self.command,
-                    urllib.parse.urlunparse(('', '', path, params, query, '')),
-                    self.request_version)
+                    urllib.parse.urlunparse(("", "", path, params, query, "")),
+                    self.request_version,
+                )
                 soc.send(s.encode())
-                self.headers['Connection'] = 'close'
-                del self.headers['Proxy-Connection']
+                self.headers["Connection"] = "close"
+                del self.headers["Proxy-Connection"]
                 for key, val in self.headers.items():
                     s = "{}: {}\r\n".format(key, val)
                     soc.send(s.encode())
@@ -109,12 +111,12 @@ class ProxyHandler (http.server.BaseHTTPRequestHandler):
 
     do_HEAD = do_GET
     do_POST = do_GET
-    do_PUT  = do_GET
-    do_DELETE=do_GET
+    do_PUT = do_GET
+    do_DELETE = do_GET
 
 
 def maybe_sd_notify(s: str) -> None:
-    addr = os.getenv('NOTIFY_SOCKET')
+    addr = os.getenv("NOTIFY_SOCKET")
     if not addr:
         return
     soc = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
@@ -122,14 +124,13 @@ def maybe_sd_notify(s: str) -> None:
     soc.sendall(s.encode())
 
 
-class ThreadingHTTPServer (socketserver.ThreadingMixIn,
-                           http.server.HTTPServer):
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     def __init__(self, *args):
         super().__init__(*args)
         maybe_sd_notify("READY=1")
 
 
-if __name__ == '__main__':
-    port=3128
+if __name__ == "__main__":
+    port = 3128
     print("starting tinyproxy on port {}".format(port))
     http.server.test(ProxyHandler, ThreadingHTTPServer, port=port)

--- a/tests/main/document-portal-activation/fake-document-portal.py
+++ b/tests/main/document-portal-activation/fake-document-portal.py
@@ -11,6 +11,7 @@ BUS_NAME = "org.freedesktop.portal.Documents"
 OBJECT_PATH = "/org/freedesktop/portal/documents"
 DOC_IFACE = "org.freedesktop.portal.Documents"
 
+
 class DocPortal(dbus.service.Object):
     def __init__(self, connection, object_path, logfile, errorfile):
         super(DocPortal, self).__init__(connection, object_path)
@@ -19,17 +20,17 @@ class DocPortal(dbus.service.Object):
 
     @property
     def _report_error(self):
-        with open(self._errorfile, 'r') as fp:
-            return 'error' in fp.read()
+        with open(self._errorfile, "r") as fp:
+            return "error" in fp.read()
 
-    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
-                         out_signature="ay")
+    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="", out_signature="ay")
     def GetMountPoint(self):
         with open(self._logfile, "a") as fp:
             fp.write("GetMountPoint called\n")
         if self._report_error:
             raise dbus.DBusException("failure", name=DOC_IFACE + ".Error.Failed")
-        return '/run/user/{}/doc\x00'.format(os.getuid()).encode('ASCII')
+        return "/run/user/{}/doc\x00".format(os.getuid()).encode("ASCII")
+
 
 def main(argv):
     logfile, errorfile = argv[1:]
@@ -39,18 +40,21 @@ def main(argv):
     bus = dbus.SessionBus()
     # Make sure we quit when the bus shuts down
     bus.add_signal_receiver(
-        main_loop.quit, signal_name="Disconnected",
+        main_loop.quit,
+        signal_name="Disconnected",
         path="/org/freedesktop/DBus/Local",
-        dbus_interface="org.freedesktop.DBus.Local")
+        dbus_interface="org.freedesktop.DBus.Local",
+    )
 
     portal = DocPortal(bus, OBJECT_PATH, logfile, errorfile)
 
     # Allow other services to assume our bus name
     bus_name = dbus.service.BusName(
-        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
-        do_not_queue=True)
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True, do_not_queue=True
+    )
 
     main_loop.run()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/main/fake-netplan-apply/fake-netplan-service.py
+++ b/tests/main/fake-netplan-apply/fake-netplan-service.py
@@ -15,16 +15,16 @@ class NetplanApplyService(dbus.service.Object):
         super().__init__(connection, object_path)
         self._logfile = logfile
 
-    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
-                         out_signature="b")
+    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="", out_signature="b")
     def Apply(self):
         # log that we were called and always return True
         with open(self._logfile, "a+") as fp:
             fp.write("Apply called\n")
         return True
 
-    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
-                         out_signature="a(sv)")
+    @dbus.service.method(
+        dbus_interface=DOC_IFACE, in_signature="", out_signature="a(sv)"
+    )
     def Info(self):
         # log that we were called and always return a dbus struct (i.e. python
         # tuple) with Features in it
@@ -41,19 +41,21 @@ def main(argv):
     bus = dbus.SystemBus()
     # Make sure we quit when the bus shuts down
     bus.add_signal_receiver(
-        main_loop.quit, signal_name="Disconnected",
+        main_loop.quit,
+        signal_name="Disconnected",
         path="/org/freedesktop/DBus/Local",
-        dbus_interface="org.freedesktop.DBus.Local")
+        dbus_interface="org.freedesktop.DBus.Local",
+    )
 
     NetplanApplyService(bus, OBJECT_PATH, logfile)
 
     # Allow other services to assume our bus name
     dbus.service.BusName(
-        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
-        do_not_queue=True)
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True, do_not_queue=True
+    )
 
     main_loop.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/main/snap-discard-ns/mount.py
+++ b/tests/main/snap-discard-ns/mount.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     pass
 
-__all__ = ('mount', )
+__all__ = ("mount",)
 
 
 PY2 = version_info[0] == 2
@@ -38,11 +38,12 @@ def mount(source, target, fstype, flags=0, data=""):
         raise Exception("cannot find the C library")
     libc = CDLL(libc_name, use_errno=True)
     retval = libc.mount(
-            c_char_p(source.encode("UTF-8")),
-            c_char_p(target.encode("UTF-8")),
-            c_char_p(fstype.encode("UTF-8")),
-            c_long(flags),
-            None if data == "" else c_char_p(data.encode("UTF-8")))
+        c_char_p(source.encode("UTF-8")),
+        c_char_p(target.encode("UTF-8")),
+        c_char_p(fstype.encode("UTF-8")),
+        c_long(flags),
+        None if data == "" else c_char_p(data.encode("UTF-8")),
+    )
     if retval < 0:
         errno = get_errno()
         raise OSError(errno, strerror(errno))
@@ -54,8 +55,12 @@ def main():
     parser.add_argument("source", help="path of the device or bind source")
     parser.add_argument("target", help="path of the new mount point")
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--bind", action="store_const", const="bind",
-                       help="create a new mount point of existing path")
+    group.add_argument(
+        "--bind",
+        action="store_const",
+        const="bind",
+        help="create a new mount point of existing path",
+    )
     group.add_argument("-t", "--type", help="filesystem type to mount")
     opts = parser.parse_args()
     if opts.bind is not None:

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -3,53 +3,65 @@ import re
 import sys
 import yaml
 
+
 def die(s):
     print(s, file=sys.stderr)
     sys.exit(1)
+
 
 def equals(name, s1, s2):
     if s1 != s2:
         die("in %s expected %r, got %r" % (name, s2, s1))
 
+
 def matches(name, s, r):
     if not re.search(r, s):
         die("in %s expected to match %s, got %r" % (name, r, s))
+
 
 def check(name, d, *a):
     ka = set()
     for k, op, *args in a:
         if op == maybe:
-            d[k] = d.get(k,"")
+            d[k] = d.get(k, "")
         if k not in d:
             die("in %s expected to have a key %r" % (name, k))
-        op(name+"."+k, d[k], *args)
+        op(name + "." + k, d[k], *args)
         ka.add(k)
     kd = set(d)
     if ka < kd:
-        die("in %s: extra keys: %r" % (name, kd-ka))
+        die("in %s: extra keys: %r" % (name, kd - ka))
+
 
 def exists(name, d):
     pass
+
 
 def maybe(name, d):
     pass
 
 
 verNotesRx = re.compile(r"^\w\S*\s+-$")
+
+
 def verRevNotesRx(s):
     return re.compile(r"^\w\S*\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$")
 
-def verRelRevNotesRx(s):
-    return re.compile(r"^\w\S*\s+\d{4}-\d{2}-\d{2}\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$")
 
-if os.environ['SNAPPY_USE_STAGING_STORE'] == '1':
-    snap_ids={
+def verRelRevNotesRx(s):
+    return re.compile(
+        r"^\w\S*\s+\d{4}-\d{2}-\d{2}\s+\(\d+\)\s+[1-9][0-9]*\w+\s+" + s + "$"
+    )
+
+
+if os.environ["SNAPPY_USE_STAGING_STORE"] == "1":
+    snap_ids = {
         "test-snapd-tools": "02AHdOomTzby7gTaiLX3M3SGMmXDfLJp",
         "test-snapd-devmode": "FcHyKyMiQh71liP8P82SsyMXtZI5mvVj",
         "test-snapd-python-webserver": "uHjTANBWSXSiYzNOUXZNDnOSH3POSqWS",
     }
 else:
-    snap_ids={
+    snap_ids = {
         "test-snapd-tools": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
         "test-snapd-devmode": "821MII7GAzoRnPvTEb8R51Z1s9e0XmK5",
         "test-snapd-python-webserver": "Wcs8QL2iRQMjsPYQ4qz4V1uOlElZ1ZOb",
@@ -59,103 +71,136 @@ res = list(yaml.load_all(sys.stdin))
 
 equals("number of entries", len(res), 7)
 
-check("basic", res[0],
-   ("name", equals, "basic"),
-   ("summary", equals, "Basic snap"),
-   ("path", matches, r"^basic_[0-9.]+_all\.snap$"),
-   ("version", matches, verNotesRx),
-   ("license", equals, "unset"),
-   ("description", equals, "A basic buildable snap\n"),
-   ("build-date", exists),
+check(
+    "basic",
+    res[0],
+    ("name", equals, "basic"),
+    ("summary", equals, "Basic snap"),
+    ("path", matches, r"^basic_[0-9.]+_all\.snap$"),
+    ("version", matches, verNotesRx),
+    ("license", equals, "unset"),
+    ("description", equals, "A basic buildable snap\n"),
+    ("build-date", exists),
 )
 
-check("basic-desktop", res[1],
-   ("name", equals, "basic-desktop"),
-   ("path", matches, "snaps/basic-desktop/$"), # note the trailing slash
-   ("summary", equals, ""),
-   ("version", matches, verNotesRx),
-   ("description", equals, "A basic snap with desktop apps\n"),
-   ("license", equals, "GPL-3.0"),
-   ("commands", exists),
+check(
+    "basic-desktop",
+    res[1],
+    ("name", equals, "basic-desktop"),
+    ("path", matches, "snaps/basic-desktop/$"),  # note the trailing slash
+    ("summary", equals, ""),
+    ("version", matches, verNotesRx),
+    ("description", equals, "A basic snap with desktop apps\n"),
+    ("license", equals, "GPL-3.0"),
+    ("commands", exists),
 )
 
-check("test-snapd-tools", res[2],
-   ("name", equals, "test-snapd-tools"),
-   ("publisher", matches, r"(Canonical✓|canonical)"),
-   ("store-url", equals, "https://snapcraft.io/test-snapd-tools"),
-   ("contact", equals, "snaps@canonical.com"),
-   ("summary", equals, "Tools for testing the snapd application"),
-   ("description", equals, "A tool to test snapd\n"),
-   ("commands", exists),
-   ("tracking", equals, "latest/stable"),
-   ("installed", matches, verRevNotesRx("-")),
-   ("refresh-date", exists),
-   ("channels", check,
-    ("stable", matches, verRelRevNotesRx("-")),
-    ("candidate", equals, "↑"),
-    ("beta", equals, "↑"),
-    ("edge", matches, verRelRevNotesRx("-")),
-    ("2.0/stable", exists),
-    ("2.0/candidate", exists),
-    ("2.0/beta", exists),
-    ("2.0/edge", exists),
-   ),
-   ("snap-id", equals, snap_ids["test-snapd-tools"]),
-   ("license", matches, r"(unknown|unset)"), # TODO: update once snap.yaml contains the right license
+check(
+    "test-snapd-tools",
+    res[2],
+    ("name", equals, "test-snapd-tools"),
+    ("publisher", matches, r"(Canonical✓|canonical)"),
+    ("store-url", equals, "https://snapcraft.io/test-snapd-tools"),
+    ("contact", equals, "snaps@canonical.com"),
+    ("summary", equals, "Tools for testing the snapd application"),
+    ("description", equals, "A tool to test snapd\n"),
+    ("commands", exists),
+    ("tracking", equals, "latest/stable"),
+    ("installed", matches, verRevNotesRx("-")),
+    ("refresh-date", exists),
+    (
+        "channels",
+        check,
+        ("stable", matches, verRelRevNotesRx("-")),
+        ("candidate", equals, "↑"),
+        ("beta", equals, "↑"),
+        ("edge", matches, verRelRevNotesRx("-")),
+        ("2.0/stable", exists),
+        ("2.0/candidate", exists),
+        ("2.0/beta", exists),
+        ("2.0/edge", exists),
+    ),
+    ("snap-id", equals, snap_ids["test-snapd-tools"]),
+    (
+        "license",
+        matches,
+        r"(unknown|unset)",
+    ),  # TODO: update once snap.yaml contains the right license
 )
 
-check("test-snapd-devmode", res[3],
-   ("name", equals, "test-snapd-devmode"),
-   ("publisher", matches, r"(Canonical✓|canonical)"),
-   ("store-url", equals, "https://snapcraft.io/test-snapd-devmode"),
-   ("contact", equals, "snaps@canonical.com"),
-   ("summary", equals, "Basic snap with devmode confinement"),
-   ("description", equals, "A basic buildable snap that asks for devmode confinement\n"),
-   ("tracking", equals, "latest/beta"),
-   ("installed", matches, verRevNotesRx("devmode")),
-   ("refresh-date", exists),
-   ("channels", check,
-    ("stable", equals, "–"),
-    ("candidate", equals, "–"),
-    ("beta", matches, verRelRevNotesRx("devmode")),
-    ("edge", matches, verRelRevNotesRx("devmode")),
-   ),
-   ("snap-id", equals, snap_ids["test-snapd-devmode"]),
-   ("license", matches, r"(unknown|unset)"), # TODO: update once snap.yaml contains the right license
+check(
+    "test-snapd-devmode",
+    res[3],
+    ("name", equals, "test-snapd-devmode"),
+    ("publisher", matches, r"(Canonical✓|canonical)"),
+    ("store-url", equals, "https://snapcraft.io/test-snapd-devmode"),
+    ("contact", equals, "snaps@canonical.com"),
+    ("summary", equals, "Basic snap with devmode confinement"),
+    (
+        "description",
+        equals,
+        "A basic buildable snap that asks for devmode confinement\n",
+    ),
+    ("tracking", equals, "latest/beta"),
+    ("installed", matches, verRevNotesRx("devmode")),
+    ("refresh-date", exists),
+    (
+        "channels",
+        check,
+        ("stable", equals, "–"),
+        ("candidate", equals, "–"),
+        ("beta", matches, verRelRevNotesRx("devmode")),
+        ("edge", matches, verRelRevNotesRx("devmode")),
+    ),
+    ("snap-id", equals, snap_ids["test-snapd-devmode"]),
+    (
+        "license",
+        matches,
+        r"(unknown|unset)",
+    ),  # TODO: update once snap.yaml contains the right license
 )
 
-check("core", res[4],
-      ("name", equals, "core"),
-      ("type", equals, "core"), # attenti al cane
-      ("publisher", exists),
-      ("store-url", exists),
-      ("summary", exists),
-      ("description", exists),
-      # tracking not there for local snaps
-      ("tracking", maybe),
-      ("installed", exists),
-      ("refresh-date", exists),
-      ("channels", exists),
-      # contacts is set on classic but not on Ubuntu Core where we
-      # sideload "core"
-      ("contact", maybe),
-      ("snap-id", maybe),
-      ("license", matches, r"(unknown|unset)"), # TODO: update once snap.yaml contains the right license
+check(
+    "core",
+    res[4],
+    ("name", equals, "core"),
+    ("type", equals, "core"),  # attenti al cane
+    ("publisher", exists),
+    ("store-url", exists),
+    ("summary", exists),
+    ("description", exists),
+    # tracking not there for local snaps
+    ("tracking", maybe),
+    ("installed", exists),
+    ("refresh-date", exists),
+    ("channels", exists),
+    # contacts is set on classic but not on Ubuntu Core where we
+    # sideload "core"
+    ("contact", maybe),
+    ("snap-id", maybe),
+    (
+        "license",
+        matches,
+        r"(unknown|unset)",
+    ),  # TODO: update once snap.yaml contains the right license
 )
 
-check("error", res[5],
-   ("warning", equals, 'no snap found for "/etc/passwd"'),
+check(
+    "error", res[5], ("warning", equals, 'no snap found for "/etc/passwd"'),
 )
 
 # not installed snaps have "contact" information
-check("test-snapd-python-webserver", res[6],
-   ("name", equals, "test-snapd-python-webserver"),
-   ("publisher", matches, r"(Canonical✓|canonical)"),
-   ("store-url", equals, "https://snapcraft.io/test-snapd-python-webserver"),
-   ("contact", equals, "snaps@canonical.com"),
-   ("summary", exists),
-   ("description", exists),
-   ("channels", exists),
-   ("snap-id", equals, snap_ids["test-snapd-python-webserver"]),
-   ("license", equals, "Other Open Source"),
+check(
+    "test-snapd-python-webserver",
+    res[6],
+    ("name", equals, "test-snapd-python-webserver"),
+    ("publisher", matches, r"(Canonical✓|canonical)"),
+    ("store-url", equals, "https://snapcraft.io/test-snapd-python-webserver"),
+    ("contact", equals, "snaps@canonical.com"),
+    ("summary", exists),
+    ("description", exists),
+    ("channels", exists),
+    ("snap-id", equals, snap_ids["test-snapd-python-webserver"]),
+    ("license", equals, "Other Open Source"),
 )
+

--- a/tests/main/ubuntu-core-config-defaults-once/manip_seed.py
+++ b/tests/main/ubuntu-core-config-defaults-once/manip_seed.py
@@ -6,17 +6,17 @@ with open(sys.argv[1]) as f:
     seed = yaml.load(f)
 
 i = 0
-snaps = seed['snaps']
+snaps = seed["snaps"]
 while i < len(snaps):
     entry = snaps[i]
-    if entry['name'] == 'pc':
+    if entry["name"] == "pc":
         snaps[i] = {
             "name": "pc",
             "unasserted": True,
             "file": "pc_x1.snap",
-            }
+        }
         break
     i += 1
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], "w") as f:
     yaml.dump(seed, stream=f, indent=2, default_flow_style=False)

--- a/tests/main/ubuntu-core-custom-device-reg-extras/manip_seed.py
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/manip_seed.py
@@ -5,17 +5,17 @@ with open(sys.argv[1]) as f:
     seed = yaml.load(f)
 
 i = 0
-snaps = seed['snaps']
+snaps = seed["snaps"]
 while i < len(snaps):
     entry = snaps[i]
-    if entry['name'] == 'pc':
+    if entry["name"] == "pc":
         snaps[i] = {
             "name": "pc",
             "unasserted": True,
             "file": "pc_x1.snap",
-            }
+        }
         break
     i += 1
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], "w") as f:
     yaml.dump(seed, stream=f, indent=2, default_flow_style=False)

--- a/tests/main/ubuntu-core-custom-device-reg/manip_seed.py
+++ b/tests/main/ubuntu-core-custom-device-reg/manip_seed.py
@@ -5,17 +5,17 @@ with open(sys.argv[1]) as f:
     seed = yaml.load(f)
 
 i = 0
-snaps = seed['snaps']
+snaps = seed["snaps"]
 while i < len(snaps):
     entry = snaps[i]
-    if entry['name'] == 'pc':
+    if entry["name"] == "pc":
         snaps[i] = {
             "name": "pc",
             "unasserted": True,
             "file": "pc_x1.snap",
-            }
+        }
         break
     i += 1
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], "w") as f:
     yaml.dump(seed, stream=f, indent=2, default_flow_style=False)

--- a/tests/main/ubuntu-core-gadget-config-defaults/manip_seed.py
+++ b/tests/main/ubuntu-core-gadget-config-defaults/manip_seed.py
@@ -6,25 +6,23 @@ with open(sys.argv[1]) as f:
     seed = yaml.load(f)
 
 i = 0
-snaps = seed['snaps']
+snaps = seed["snaps"]
 while i < len(snaps):
     entry = snaps[i]
-    if entry['name'] == 'pc':
+    if entry["name"] == "pc":
         snaps[i] = {
             "name": "pc",
             "unasserted": True,
             "file": "pc_x1.snap",
-            }
+        }
         break
     i += 1
 
 # test-snapd-with-configure_123.snap -> test-snapd-configure
-snapname = path.basename(sys.argv[2]).split('_')[0]
-snaps.append({
-    "name": snapname,
-    "channel": "edge",
-    "file": sys.argv[2],
-})
+snapname = path.basename(sys.argv[2]).split("_")[0]
+snaps.append(
+    {"name": snapname, "channel": "edge", "file": sys.argv[2],}
+)
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], "w") as f:
     yaml.dump(seed, stream=f, indent=2, default_flow_style=False)

--- a/tests/regression/lp-1815869/hello.py
+++ b/tests/regression/lp-1815869/hello.py
@@ -1,1 +1,3 @@
-print "Hello Python From Beyond"
+# fmt: off
+print 'Hello Python From Beyond'
+# fmt: on

--- a/tests/regression/lp-1815869/hello.py
+++ b/tests/regression/lp-1815869/hello.py
@@ -1,1 +1,1 @@
-print 'Hello Python From Beyond'
+print "Hello Python From Beyond"


### PR DESCRIPTION
This does not have any substantial changes to code like removing variables, etc. and I checked that all of these files are meant to at least be compatible with python3, so black should be fine to format them (black only works with python3 afaik).

(the [previous PR](https://github.com/snapcore/snapd/pull/7960) I had with this was running flake8 actually instead of black, but I hear that black is the new best thing to use for python 3 files)

One last point is that we could add a python black formatter as part of run-checks, but I wasn't sure if we wanted contributors to also need to standup a python environment just to work on go code. Perhaps we do it like spread-shellcheck and have a spread test which checks that all the python code in the codebase is formatted with black?