### PR TITLE
snap-bootstrap: create encrypted partition

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -54,7 +54,11 @@ func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err e
 	return "", fmt.Errorf("cannot find role %s in gadget", role)
 }
 
-func Run(gadgetRoot, device string, options *Options) error {
+func Run(gadgetRoot, device string, options Options) error {
+	if options.Encrypt && options.KeyFile == "" {
+		return fmt.Errorf("key file must be specified when encrypting")
+	}
+
 	if gadgetRoot == "" {
 		return fmt.Errorf("cannot use empty gadget root directory")
 	}

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -136,6 +136,8 @@ func Run(gadgetRoot, device string, options *Options) error {
 }
 
 func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *partition.DeviceLayout) error {
+	// XXX: the compatibility tests don't recognize encrypted partitions, so we
+	//      won't be able to add more partitions if we already have LUKS devices.
 	eq := func(ds partition.DeviceStructure, gs gadget.LaidOutStructure) bool {
 		dv := ds.VolumeStructure
 		gv := gs.VolumeStructure

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -26,10 +26,17 @@ import (
 	"github.com/snapcore/snapd/gadget"
 )
 
+const (
+	ubuntuDataLabel = "ubuntu-data"
+)
+
 type Options struct {
 	// Also mount the filesystems after creation
 	Mount bool
-	// will contain encryption later
+	// Encrypt the data partition
+	Encrypt bool
+	// KeyFile is the location where the encryption key is written to
+	KeyFile string
 }
 
 func deviceFromRole(lv *gadget.LaidOutVolume, role string) (device string, err error) {
@@ -83,7 +90,25 @@ func Run(gadgetRoot, device string, options *Options) error {
 		return fmt.Errorf("cannot create the partitions: %v", err)
 	}
 
+	// generate key externally so multiple encrypted partitions can use the same key
+	var key partition.EncryptionKey
+	if options.Encrypt {
+		key, err = partition.NewEncryptionKey()
+		if err != nil {
+			return fmt.Errorf("cannot create encryption key: %v", err)
+		}
+	}
+
 	for _, part := range created {
+		if options.Encrypt && part.Role == gadget.SystemData {
+			dataPart, err := partition.NewEncryptedDevice(&part, key, ubuntuDataLabel)
+			if err != nil {
+				return err
+			}
+			// update the encrypted device node
+			part.Node = dataPart.Node
+		}
+
 		if err := partition.MakeFilesystem(part); err != nil {
 			return err
 		}
@@ -96,6 +121,14 @@ func Run(gadgetRoot, device string, options *Options) error {
 			if err := partition.MountFilesystem(part, dirs.RunMnt); err != nil {
 				return err
 			}
+		}
+	}
+
+	// store the encryption key as the last part of the process to reduce the
+	// possiblity of exiting with an error after the TPM provisioning
+	if options.Encrypt {
+		if err := key.Store(options.KeyFile); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -84,6 +84,9 @@ func Run(gadgetRoot, device string, options Options) error {
 		return fmt.Errorf("cannot read %v partitions: %v", device, err)
 	}
 
+	// TODO:UC20: if there are partitions on disk that were added during
+	//            a failed install attempt, remove them before proceeding.
+
 	// check if the current partition table is compatible with the gadget
 	if err := ensureLayoutCompatibility(lv, diskLayout); err != nil {
 		return fmt.Errorf("gadget and %v partition table not compatible: %v", device, err)
@@ -140,8 +143,6 @@ func Run(gadgetRoot, device string, options Options) error {
 }
 
 func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *partition.DeviceLayout) error {
-	// XXX: the compatibility tests don't recognize encrypted partitions, so we
-	//      won't be able to add more partitions if we already have LUKS devices.
 	eq := func(ds partition.DeviceStructure, gs gadget.LaidOutStructure) bool {
 		dv := ds.VolumeStructure
 		gv := gs.VolumeStructure

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
@@ -56,7 +56,7 @@ func (s *bootstrapSuite) SetUpTest(c *C) {
 }
 
 func (s *bootstrapSuite) TestBootstrapRunError(c *C) {
-	err := bootstrap.Run("", "", nil)
+	err := bootstrap.Run("", "", bootstrap.Options{})
 	c.Assert(err, ErrorMatches, "cannot use empty gadget root directory")
 }
 

--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -20,8 +20,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 )
 
@@ -41,7 +39,7 @@ func init() {
 type cmdCreatePartitions struct {
 	Mount   bool   `short:"m" long:"mount" description:"Also mount filesystems after creation"`
 	Encrypt bool   `long:"encrypt" description:"Encrypt the data partition"`
-	KeyFile string `long:"key-file" value-name:"name" description:"Where the key file will be stored"`
+	KeyFile string `long:"key-file" value-name:"filename" description:"Where the key file will be stored"`
 
 	Positional struct {
 		GadgetRoot string `positional-arg-name:"<gadget-root>"`
@@ -50,11 +48,7 @@ type cmdCreatePartitions struct {
 }
 
 func (c *cmdCreatePartitions) Execute(args []string) error {
-	if c.Encrypt && c.KeyFile == "" {
-		return fmt.Errorf("if encrypting, the output key file must be specified")
-	}
-
-	options := &bootstrap.Options{
+	options := bootstrap.Options{
 		Mount:   c.Mount,
 		Encrypt: c.Encrypt,
 		KeyFile: c.KeyFile,

--- a/cmd/snap-bootstrap/cmd_create_partitions.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/bootstrap"
 )
 
@@ -37,7 +39,9 @@ func init() {
 }
 
 type cmdCreatePartitions struct {
-	Mount bool `short:"m" long:"mount" description:"Also mount filesystems after creation" optional:"yes"`
+	Mount   bool   `short:"m" long:"mount" description:"Also mount filesystems after creation"`
+	Encrypt bool   `long:"encrypt" description:"Encrypt the data partition"`
+	KeyFile string `long:"key-file" value-name:"name" description:"Where the key file will be stored"`
 
 	Positional struct {
 		GadgetRoot string `positional-arg-name:"<gadget-root>"`
@@ -46,8 +50,14 @@ type cmdCreatePartitions struct {
 }
 
 func (c *cmdCreatePartitions) Execute(args []string) error {
+	if c.Encrypt && c.KeyFile == "" {
+		return fmt.Errorf("if encrypting, the output key file must be specified")
+	}
+
 	options := &bootstrap.Options{
-		Mount: c.Mount,
+		Mount:   c.Mount,
+		Encrypt: c.Encrypt,
+		KeyFile: c.KeyFile,
 	}
 
 	return bootstrapRun(c.Positional.GadgetRoot, c.Positional.Device, options)

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2020 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -54,6 +54,24 @@ func (s *cmdSuite) TestCreatePartitionsMount(c *C) {
 	defer restore()
 
 	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "--mount", "gadget-dir", "device"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Assert(n, Equals, 1)
+}
+
+func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
+	n := 0
+	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts *bootstrap.Options) error {
+		c.Check(gadgetRoot, Equals, "gadget-dir")
+		c.Check(device, Equals, "device")
+		c.Check(opts.Encrypt, Equals, true)
+		c.Check(opts.KeyFile, Equals, "keyfile")
+		n++
+		return nil
+	})
+	defer restore()
+
+	rest, err := main.Parser.ParseArgs([]string{"create-partitions", "--encrypt", "--key-file", "keyfile", "gadget-dir", "device"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Assert(n, Equals, 1)

--- a/cmd/snap-bootstrap/cmd_create_partitions_test.go
+++ b/cmd/snap-bootstrap/cmd_create_partitions_test.go
@@ -28,7 +28,7 @@ import (
 
 func (s *cmdSuite) TestCreatePartitionsHappy(c *C) {
 	n := 0
-	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts *bootstrap.Options) error {
+	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts bootstrap.Options) error {
 		c.Check(gadgetRoot, Equals, "gadget-dir")
 		c.Check(device, Equals, "device")
 		n++
@@ -44,7 +44,7 @@ func (s *cmdSuite) TestCreatePartitionsHappy(c *C) {
 
 func (s *cmdSuite) TestCreatePartitionsMount(c *C) {
 	n := 0
-	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts *bootstrap.Options) error {
+	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts bootstrap.Options) error {
 		c.Check(gadgetRoot, Equals, "gadget-dir")
 		c.Check(device, Equals, "device")
 		c.Check(opts.Mount, Equals, true)
@@ -61,7 +61,7 @@ func (s *cmdSuite) TestCreatePartitionsMount(c *C) {
 
 func (s *cmdSuite) TestCreatePartitionsWithEncryption(c *C) {
 	n := 0
-	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts *bootstrap.Options) error {
+	restore := main.MockBootstrapRun(func(gadgetRoot, device string, opts bootstrap.Options) error {
 		c.Check(gadgetRoot, Equals, "gadget-dir")
 		c.Check(device, Equals, "device")
 		c.Check(opts.Encrypt, Equals, true)

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -29,7 +29,7 @@ var (
 	Parser = parser
 )
 
-func MockBootstrapRun(f func(string, string, *bootstrap.Options) error) (restore func()) {
+func MockBootstrapRun(f func(string, string, bootstrap.Options) error) (restore func()) {
 	oldBootstrapRun := bootstrapRun
 	bootstrapRun = f
 	return func() {

--- a/cmd/snap-bootstrap/partition/deploy_test.go
+++ b/cmd/snap-bootstrap/partition/deploy_test.go
@@ -131,14 +131,7 @@ func (s *deploySuite) TestMountFilesystem(c *C) {
 	err := partition.MountFilesystem(mockDeviceStructureBiosBoot, dirs.RunMnt)
 	c.Assert(err, ErrorMatches, "cannot mount a partition with no filesystem")
 
-	// try to mount a filesystem with no label
-	err = partition.MountFilesystem(mockDeviceStructureSystemSeed, dirs.RunMnt)
-	c.Assert(err, ErrorMatches, "cannot mount a filesystem with no label")
-
-	// now set a label...
-	mockDeviceStructureSystemSeed.Label = "ubuntu-seed"
-	defer func() { mockDeviceStructureSystemSeed.Label = "" }()
-
+	// mount a filesystem...
 	err = partition.MountFilesystem(mockDeviceStructureSystemSeed, dirs.RunMnt)
 	c.Assert(err, IsNil)
 
@@ -148,4 +141,12 @@ func (s *deploySuite) TestMountFilesystem(c *C) {
 	c.Check(s.mockMountCalls, DeepEquals, []struct{ source, target, fstype string }{
 		{"/dev/node2", node2MountPoint, "vfat"},
 	})
+
+	// now try to mount a filesystem with no label
+	mockDeviceStructureSystemSeed.Label = ""
+	defer func() { mockDeviceStructureSystemSeed.Label = "ubuntu-seed" }()
+
+	err = partition.MountFilesystem(mockDeviceStructureSystemSeed, dirs.RunMnt)
+	c.Assert(err, ErrorMatches, "cannot mount a filesystem with no label")
+
 }

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -92,6 +92,8 @@ func (dev *EncryptedDevice) Close() error {
 }
 
 func cryptsetupFormat(key EncryptionKey, node string) error {
+	// We use a high entropy keyfile so we can keep the KDF iteration count to
+	// a minimum, longer processing will not increase security.
 	cmd := exec.Command("cryptsetup", "-q", "luksFormat", "--type", "luks2", "--key-file", "-", "--pbkdf", "argon2i", "--iter-time", "1", node)
 	cmd.Stdin = bytes.NewReader(key[:])
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -1,0 +1,117 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package partition
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+var (
+	tempFile = ioutil.TempFile
+)
+
+// Our key is 32 bytes long
+const (
+	keySize = 32
+)
+
+type EncryptionKey [keySize]byte
+
+func NewEncryptionKey() (EncryptionKey, error) {
+	var key EncryptionKey
+	_, err := rand.Read(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
+}
+
+// Store writes the LUKS key in the location specified by filename.
+func (key EncryptionKey) Store(filename string) error {
+	// XXX: must provision the TPM, generate and store the lockout authorization,
+	// and seal the key. Currently we're just storing the unprocessed data.
+	if err := ioutil.WriteFile(filename, key[:], 0600); err != nil {
+		return fmt.Errorf("cannot store key file: %v", err)
+	}
+
+	return nil
+}
+
+// EncryptedDevice represents a LUKS-backed encrypted block device.
+type EncryptedDevice struct {
+	parent *DeviceStructure
+	name   string
+	Node   string
+}
+
+// NewEncryptedDevice creates an encrypted device in the existing partition using the
+// specified key.
+func NewEncryptedDevice(part *DeviceStructure, key EncryptionKey, name string) (*EncryptedDevice, error) {
+	dev := &EncryptedDevice{
+		parent: part,
+		name:   name,
+		// A new block device is used to access the encrypted data. Note that
+		// you can't open an encrypted device under different names and a name
+		// can't be used in more than one device at the same time.
+		Node: fmt.Sprintf("/dev/mapper/%s", name),
+	}
+
+	if err := cryptsetupFormat(key, part.Node); err != nil {
+		return nil, fmt.Errorf("cannot format encrypted device: %v", err)
+	}
+
+	if err := cryptsetupOpen(key, part.Node, name); err != nil {
+		return nil, fmt.Errorf("cannot open encrypted device on %s: %s", part.Node, err)
+	}
+
+	return dev, nil
+}
+
+func (dev *EncryptedDevice) Close() error {
+	return cryptsetupClose(dev.name)
+}
+
+func cryptsetupFormat(key EncryptionKey, node string) error {
+	cmd := exec.Command("cryptsetup", "-q", "luksFormat", "--type", "luks2", "--key-file", "-", "--pbkdf", "argon2i", "--iter-time", "1", node)
+	cmd.Stdin = bytes.NewReader(key[:])
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}
+
+func cryptsetupOpen(key EncryptionKey, node, name string) error {
+	cmd := exec.Command("cryptsetup", "open", "--key-file", "-", node, name)
+	cmd.Stdin = bytes.NewReader(key[:])
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}
+
+func cryptsetupClose(name string) error {
+	if output, err := exec.Command("cryptsetup", "close", name).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -49,8 +49,8 @@ func NewEncryptionKey() (EncryptionKey, error) {
 
 // Store writes the LUKS key in the location specified by filename.
 func (key EncryptionKey) Store(filename string) error {
-	// XXX: must provision the TPM, generate and store the lockout authorization,
-	// and seal the key. Currently we're just storing the unprocessed data.
+	// TODO:UC20: provision the TPM, generate and store the lockout authorization,
+	//            and seal the key. Currently we're just storing the unprocessed data.
 	if err := ioutil.WriteFile(filename, key[:], 0600); err != nil {
 		return fmt.Errorf("cannot store key file: %v", err)
 	}

--- a/cmd/snap-bootstrap/partition/encrypt.go
+++ b/cmd/snap-bootstrap/partition/encrypt.go
@@ -93,8 +93,9 @@ func (dev *EncryptedDevice) Close() error {
 }
 
 func cryptsetupFormat(key EncryptionKey, node string) error {
-	// We use a high entropy keyfile so we can keep the KDF iteration count to
-	// a minimum, longer processing will not increase security.
+	// We use a keyfile with the same entropy as the derived key so we can
+	// keep the KDF iteration count to a minimum. Longer processing will not
+	// increase security in this case.
 	args := []string{
 		// batch processing, no password verification
 		"-q",

--- a/cmd/snap-bootstrap/partition/encrypt_test.go
+++ b/cmd/snap-bootstrap/partition/encrypt_test.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package partition_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type encryptSuite struct {
+	testutil.BaseTest
+
+	mockCryptsetup *testutil.MockCmd
+	tempDir        string
+}
+
+var _ = Suite(&encryptSuite{})
+
+var mockDeviceStructure = partition.DeviceStructure{
+	LaidOutStructure: gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Name: "Test structure",
+			Size: 0x100000,
+		},
+		StartOffset: 0,
+		Index:       1,
+	},
+	Node: "/dev/node1",
+}
+
+func (s *encryptSuite) SetUpTest(c *C) {
+	s.tempDir = c.MkDir()
+}
+
+func (s *encryptSuite) TestEncryptHappy(c *C) {
+	s.mockCryptsetup = testutil.MockCommand(c, "cryptsetup", "")
+	s.AddCleanup(s.mockCryptsetup.Restore)
+
+	// XXX: create empty key to prevent blocking on lack of system entropy
+	key := partition.EncryptionKey{}
+	dev, err := partition.NewEncryptedDevice(&mockDeviceStructure, key, "some-label")
+	c.Assert(err, IsNil)
+	c.Assert(dev.Node, Equals, "/dev/mapper/some-label")
+
+	tempFile := filepath.Join(s.tempDir, "tempfile")
+	c.Assert(s.mockCryptsetup.Calls(), DeepEquals, [][]string{
+		{"cryptsetup", "-q", "luksFormat", "--type", "luks2", "--key-file", "-", "--pbkdf", "argon2i", "--iter-time", "1", "/dev/node1"},
+		{"cryptsetup", "open", "--key-file", "-", "/dev/node1", "some-label"},
+	})
+
+	// test temporary file removal
+	c.Assert(tempFile, Not(testutil.FilePresent))
+
+	err = dev.Close()
+	c.Assert(err, IsNil)
+}
+
+func (s *encryptSuite) TestEncryptFormatError(c *C) {
+	s.mockCryptsetup = testutil.MockCommand(c, "cryptsetup", `[ "$2" == "luksFormat" ] && exit 127 || exit 0`)
+	s.AddCleanup(s.mockCryptsetup.Restore)
+
+	key := partition.EncryptionKey{}
+	_, err := partition.NewEncryptedDevice(&mockDeviceStructure, key, "some-label")
+	c.Assert(err, ErrorMatches, "cannot format encrypted device:.*")
+}
+
+func (s *encryptSuite) TestEncryptOpenError(c *C) {
+	s.mockCryptsetup = testutil.MockCommand(c, "cryptsetup", `[ "$1" == "open" ] && exit 127 || exit 0`)
+	s.AddCleanup(s.mockCryptsetup.Restore)
+
+	key := partition.EncryptionKey{}
+	_, err := partition.NewEncryptedDevice(&mockDeviceStructure, key, "some-label")
+	c.Assert(err, ErrorMatches, "cannot open encrypted device on /dev/node1:.*")
+}

--- a/cmd/snap-bootstrap/partition/encrypt_test.go
+++ b/cmd/snap-bootstrap/partition/encrypt_test.go
@@ -19,8 +19,6 @@
 package partition_test
 
 import (
-	"path/filepath"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
@@ -63,14 +61,10 @@ func (s *encryptSuite) TestEncryptHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(dev.Node, Equals, "/dev/mapper/some-label")
 
-	tempFile := filepath.Join(s.tempDir, "tempfile")
 	c.Assert(s.mockCryptsetup.Calls(), DeepEquals, [][]string{
 		{"cryptsetup", "-q", "luksFormat", "--type", "luks2", "--key-file", "-", "--pbkdf", "argon2i", "--iter-time", "1", "/dev/node1"},
 		{"cryptsetup", "open", "--key-file", "-", "/dev/node1", "some-label"},
 	})
-
-	// test temporary file removal
-	c.Assert(tempFile, Not(testutil.FilePresent))
 
 	err = dev.Close()
 	c.Assert(err, IsNil)

--- a/cmd/snap-bootstrap/partition/partition_test.go
+++ b/cmd/snap-bootstrap/partition/partition_test.go
@@ -62,6 +62,7 @@ var mockDeviceStructureSystemSeed = partition.DeviceStructure{
 			Size:       1258291200,
 			Type:       "EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
 			Role:       "system-seed",
+			Label:      "ubuntu-seed",
 			Filesystem: "vfat",
 			Content: []gadget.VolumeContent{
 				{

--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	ubuntuBootLabel = "ubuntu-boot"
+	ubuntuSeedLabel = "ubuntu-seed"
 	ubuntuDataLabel = "ubuntu-data"
 
 	sectorSize gadget.Size = 512
@@ -263,6 +264,8 @@ func buildPartitionList(ptable *sfdiskPartitionTable, pv *gadget.LaidOutVolume) 
 		switch s.Role {
 		case gadget.SystemBoot:
 			s.Label = ubuntuBootLabel
+		case gadget.SystemSeed:
+			s.Label = ubuntuSeedLabel
 		case gadget.SystemData:
 			s.Label = ubuntuDataLabel
 		}

--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -260,6 +260,9 @@ func buildPartitionList(ptable *sfdiskPartitionTable, pv *gadget.LaidOutVolume) 
 		fmt.Fprintf(buf, "%s : start=%12d, size=%12d, type=%s, name=%q\n", node, p.StartOffset/sectorSize,
 			s.Size/sectorSize, partitionType(ptable.Label, p.Type), s.Name)
 
+		// TODO:UC20: also add an attribute to mark partitions created at install
+		//            time so they can be removed case the installation fails.
+
 		// Set expected labels based on role
 		switch s.Role {
 		case gadget.SystemBoot:

--- a/tests/main/uc20-snap-recovery-encrypt/task.yaml
+++ b/tests/main/uc20-snap-recovery-encrypt/task.yaml
@@ -1,0 +1,120 @@
+summary: Integration tests for the snap-bootstrap binary
+
+# one system is enough, its a very specialized test for now
+systems: [ubuntu-19.10-64]
+
+debug: |
+    cat /proc/partitions
+
+restore: |
+    if [ -f loop.txt ]; then
+        losetup -d "$(cat loop.txt)"
+    fi
+
+prepare: |
+    echo "Create a fake block device image"
+    truncate --size=2GB fake.img
+
+    echo "Setup the image as a block device"
+    # without -P this test will not work, then /dev/loop1p? will be missing
+    losetup -fP fake.img
+    losetup -a |grep fake.img|cut -f1 -d: > loop.txt
+    LOOP="$(cat loop.txt)"
+
+    echo "Create an empty partition header"
+    echo "label: gpt" | sfdisk "$LOOP"
+
+    # XXX: update to the UC20 gadget when it's available
+    echo "Get the UC16 gadget"
+    snap download pc
+    unsquashfs -d gadget-dir pc_*.snap
+
+execute: |
+    LOOP="$(cat loop.txt)"
+    echo "Run the snap-bootstrap tool"
+    /usr/lib/snapd/snap-bootstrap create-partitions ./gadget-dir "$LOOP"
+
+    echo "And check that the partitions are created"
+    sfdisk -l "$LOOP" | MATCH '1M\s+BIOS boot'
+    sfdisk -l "$LOOP" | MATCH '50M\s+EFI System'
+    # we used "lsblk --fs" here but it was unreliable
+    mkdir -p ./mnt
+    mount "${LOOP}p2" ./mnt
+    df -T "${LOOP}p2" | MATCH vfat
+    umount ./mnt
+    file -s "${LOOP}p2" | MATCH 'label: "system-boot"'
+
+    echo "Check that the non-fs content was deployed"
+    dd if="${LOOP}p1" of=bios-boot.img
+    # the bios-boot.img is 1Mb
+    test "$(stat --printf="%s" ./bios-boot.img)" = 1048576
+    # we truncate it to the size of pc-core.img
+    truncate --size="$(stat --printf="%s" ./gadget-dir/pc-core.img)" bios-boot.img
+    # and verify that its the same
+    cmp bios-boot.img ./gadget-dir/pc-core.img
+
+    echo "Check that the filesystem was not auto-mounted"
+    mount
+    mount | not MATCH /run/mnt/system-boot
+
+    echo "Check that the filesystem content was deployed"
+    mkdir -p ./mnt
+    mount "${LOOP}p2" ./mnt
+    ls ./mnt/EFI/boot/grubx64.efi
+    ls ./mnt/EFI/boot/bootx64.efi
+    ls ./mnt/EFI/ubuntu/grub.cfg
+    umount ./mnt
+
+    # debug message to see if the udev database is correctly updated
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
+
+    echo "now add a partition"
+    cat >> gadget-dir/meta/gadget.yaml <<EOF
+          - name: Other ext4
+            type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+            filesystem: ext4
+            filesystem-label: other-ext4
+            size: 110M
+          - name: Boot partition
+            type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+            role: system-boot
+            filesystem: ext4
+            size: 120M
+          - name: Data partition
+            type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+            role: system-data
+            filesystem: ext4
+            size: 130M
+    EOF
+    /usr/lib/snapd/snap-bootstrap create-partitions --encrypt --key-file=keyfile --mount ./gadget-dir "$LOOP"
+    sfdisk -l "$LOOP" | MATCH '110M\s* Linux filesystem'
+    sfdisk -l "$LOOP" | MATCH '120M\s* Linux filesystem'
+    sfdisk -l "$LOOP" | MATCH '130M\s* Linux filesystem'
+
+    echo "check that the filesystems are created and mounted"
+    mount
+
+    mount | MATCH /run/mnt/other-ext4
+    df -T "${LOOP}p3" | MATCH ext4
+    file -s "${LOOP}p3" | MATCH 'volume name "other-ext4"'
+    umount /run/mnt/other-ext4
+
+    mount | MATCH /run/mnt/ubuntu-boot
+    df -T "${LOOP}p4" | MATCH ext4
+    file -s "${LOOP}p4" | MATCH 'volume name "ubuntu-boot"'
+    umount /run/mnt/ubuntu-boot
+
+    cryptsetup isLuks "${LOOP}p5"
+
+    mount | MATCH /run/mnt/ubuntu-data
+    df -T /dev/mapper/ubuntu-data | MATCH ext4
+    POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
+    umount /run/mnt/ubuntu-data
+
+    echo "ensure that we can open the encrypted device using the key"
+    cryptsetup close /dev/mapper/ubuntu-data
+    cryptsetup open --key-file keyfile "${LOOP}p5" test-udata
+    mount /dev/mapper/test-udata ./mnt
+    umount ./mnt
+    cryptsetup close /dev/mapper/test-udata
+

--- a/tests/main/uc20-snap-recovery-encrypt/task.yaml
+++ b/tests/main/uc20-snap-recovery-encrypt/task.yaml
@@ -13,7 +13,7 @@ restore: |
 
 prepare: |
     echo "Create a fake block device image"
-    truncate --size=2GB fake.img
+    truncate --size=6GB fake.img
 
     echo "Setup the image as a block device"
     # without -P this test will not work, then /dev/loop1p? will be missing
@@ -24,25 +24,43 @@ prepare: |
     echo "Create an empty partition header"
     echo "label: gpt" | sfdisk "$LOOP"
 
-    # XXX: update to the UC20 gadget when it's available
-    echo "Get the UC16 gadget"
-    snap download pc
+    echo "Get the UC20 gadget"
+    snap download --channel=20/edge pc
     unsquashfs -d gadget-dir pc_*.snap
 
 execute: |
     LOOP="$(cat loop.txt)"
     echo "Run the snap-bootstrap tool"
-    /usr/lib/snapd/snap-bootstrap create-partitions ./gadget-dir "$LOOP"
+    /usr/lib/snapd/snap-bootstrap create-partitions --encrypt --key-file keyfile ./gadget-dir "$LOOP"
 
-    echo "And check that the partitions are created"
+    echo "Check that the key file was created"
+    test "$(stat --printf="%s" ./keyfile)" = 32
+
+    echo "Check that the partitions are created"
     sfdisk -l "$LOOP" | MATCH '1M\s+BIOS boot'
-    sfdisk -l "$LOOP" | MATCH '50M\s+EFI System'
+    sfdisk -l "$LOOP" | MATCH '1\.2G\s+EFI System'
+
+    not cryptsetup isLuks "${LOOP}p1"
+    not cryptsetup isLuks "${LOOP}p2"
+    not cryptsetup isLuks "${LOOP}p3"
+    cryptsetup isLuks "${LOOP}p4"
+
     # we used "lsblk --fs" here but it was unreliable
     mkdir -p ./mnt
     mount "${LOOP}p2" ./mnt
     df -T "${LOOP}p2" | MATCH vfat
     umount ./mnt
-    file -s "${LOOP}p2" | MATCH 'label: "system-boot"'
+    file -s "${LOOP}p2" | MATCH 'label: "ubuntu-seed"'
+
+    mount "${LOOP}p3" ./mnt
+    df -T "${LOOP}p3" | MATCH ext4
+    umount ./mnt
+    file -s "${LOOP}p3" | MATCH 'volume name "ubuntu-boot"'
+
+    mount /dev/mapper/ubuntu-data ./mnt
+    df -T /dev/mapper/ubuntu-data | MATCH ext4
+    umount ./mnt
+    POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
 
     echo "Check that the non-fs content was deployed"
     dd if="${LOOP}p1" of=bios-boot.img
@@ -53,10 +71,6 @@ execute: |
     # and verify that its the same
     cmp bios-boot.img ./gadget-dir/pc-core.img
 
-    echo "Check that the filesystem was not auto-mounted"
-    mount
-    mount | not MATCH /run/mnt/system-boot
-
     echo "Check that the filesystem content was deployed"
     mkdir -p ./mnt
     mount "${LOOP}p2" ./mnt
@@ -65,56 +79,21 @@ execute: |
     ls ./mnt/EFI/ubuntu/grub.cfg
     umount ./mnt
 
-    # debug message to see if the udev database is correctly updated
-    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
-
-    echo "now add a partition"
-    cat >> gadget-dir/meta/gadget.yaml <<EOF
-          - name: Other ext4
-            type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-            filesystem: ext4
-            filesystem-label: other-ext4
-            size: 110M
-          - name: Boot partition
-            type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-            role: system-boot
-            filesystem: ext4
-            size: 120M
-          - name: Data partition
-            type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-            role: system-data
-            filesystem: ext4
-            size: 130M
-    EOF
-    /usr/lib/snapd/snap-bootstrap create-partitions --encrypt --key-file=keyfile --mount ./gadget-dir "$LOOP"
-    sfdisk -l "$LOOP" | MATCH '110M\s* Linux filesystem'
-    sfdisk -l "$LOOP" | MATCH '120M\s* Linux filesystem'
-    sfdisk -l "$LOOP" | MATCH '130M\s* Linux filesystem'
-
-    echo "check that the filesystems are created and mounted"
-    mount
-
-    mount | MATCH /run/mnt/other-ext4
-    df -T "${LOOP}p3" | MATCH ext4
-    file -s "${LOOP}p3" | MATCH 'volume name "other-ext4"'
-    umount /run/mnt/other-ext4
-
-    mount | MATCH /run/mnt/ubuntu-boot
-    df -T "${LOOP}p4" | MATCH ext4
-    file -s "${LOOP}p4" | MATCH 'volume name "ubuntu-boot"'
-    umount /run/mnt/ubuntu-boot
-
-    cryptsetup isLuks "${LOOP}p5"
-
-    mount | MATCH /run/mnt/ubuntu-data
-    df -T /dev/mapper/ubuntu-data | MATCH ext4
-    POSIXLY_CORRECT=1 file -s /dev/mapper/ubuntu-data | MATCH 'volume name "ubuntu-data"'
-    umount /run/mnt/ubuntu-data
+    mount "${LOOP}p3" ./mnt
+    ls ./mnt/EFI/boot/grubx64.efi
+    ls ./mnt/EFI/boot/bootx64.efi
+    ls ./mnt/EFI/ubuntu/grub.cfg
+    umount ./mnt
 
     echo "ensure that we can open the encrypted device using the key"
     cryptsetup close /dev/mapper/ubuntu-data
-    cryptsetup open --key-file keyfile "${LOOP}p5" test-udata
+    cryptsetup open --key-file keyfile "${LOOP}p4" test-udata
     mount /dev/mapper/test-udata ./mnt
     umount ./mnt
     cryptsetup close /dev/mapper/test-udata
 
+    # debug message to see if the udev database is correctly updated
+    udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
+
+    # XXX: can't add more partitions after an encrypted partition is created
+    # (gadget compatibility tests fail)

--- a/tests/main/uc20-snap-recovery-encrypt/task.yaml
+++ b/tests/main/uc20-snap-recovery-encrypt/task.yaml
@@ -7,6 +7,13 @@ debug: |
     cat /proc/partitions
 
 restore: |
+    if [[ -d ./mnt ]]; then
+        umount ./mnt || true
+    fi
+
+    cryptsetup close /dev/mapper/ubuntu-data || true
+    cryptsetup close /dev/mapper/test-udata || true
+
     if [ -f loop.txt ]; then
         losetup -d "$(cat loop.txt)"
     fi


### PR DESCRIPTION
Encrypt the data partition and store the encryption key. The key is
currently stored in unencrypted form, sealing it will be implemented
in a forthcoming patch.

This is a rework of PR #7723.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>