### PR TITLE
store, overlord/snapstate, etc: SnapAction now returns a []…Result

### DIFF
--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -76,14 +76,14 @@ func streamOneSnap(c *Command, action snapDownloadAction, user *auth.UserState) 
 		CohortKey:    action.CohortKey,
 		Channel:      action.Channel,
 	}}
-	snaps, err := getStore(c).SnapAction(context.TODO(), nil, actions, user, nil)
+	sars, err := getStore(c).SnapAction(context.TODO(), nil, actions, user, nil)
 	if err != nil {
 		return errToResponse(err, []string{action.SnapName}, InternalError, "cannot download snap: %v")
 	}
-	if len(snaps) != 1 {
-		return InternalError("internal error: unexpected number %v of results for a single download", len(snaps))
+	if len(sars) != 1 {
+		return InternalError("internal error: unexpected number %v of results for a single download", len(sars))
 	}
-	info := snaps[0]
+	info := sars[0].Info
 
 	downloadInfo := info.DownloadInfo
 	r, err := getStore(c).DownloadStream(context.TODO(), action.SnapName, &downloadInfo, user)

--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -113,7 +113,7 @@ var storeSnaps = map[string]*snap.Info{
 	},
 }
 
-func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	if len(actions) != 1 {
 		panic(fmt.Sprintf("unexpected amount of actions: %v", len(actions)))
 	}
@@ -131,7 +131,7 @@ func (s *snapDownloadSuite) SnapAction(ctx context.Context, currentSnaps []*stor
 	if !action.Revision.Unset() && action.Revision != info.Revision {
 		panic(fmt.Sprintf("unexpected revision %q for %s snap", action.Revision, action.InstanceName))
 	}
-	return []*snap.Info{info}, nil
+	return []store.SnapActionResult{{Info: info}}, nil
 }
 
 func (s *snapDownloadSuite) DownloadStream(ctx context.Context, name string, downloadInfo *snap.DownloadInfo, user *auth.UserState) (io.ReadCloser, error) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -150,7 +150,7 @@ func (s *apiBaseSuite) Find(ctx context.Context, search *store.Search, user *aut
 	return s.rsnaps, s.err
 }
 
-func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	s.pokeStateLock()
 
 	if ctx == nil {
@@ -160,7 +160,11 @@ func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.Cur
 	s.actions = actions
 	s.user = user
 
-	return s.rsnaps, s.err
+	sars := make([]store.SnapActionResult, len(s.rsnaps))
+	for i, rsnap := range s.rsnaps {
+		sars[i] = store.SnapActionResult{Info: rsnap}
+	}
+	return sars, s.err
 }
 
 func (s *apiBaseSuite) SuggestedCurrency() string {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -52,7 +52,7 @@ import (
 
 // A Store can find metadata on snaps, download snaps and fetch assertions.
 type Store interface {
-	SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error)
+	SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, error)
 	Download(ctx context.Context, name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, dlOpts *store.DownloadOptions) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
@@ -292,12 +292,12 @@ func (tsto *ToolingStore) DownloadSnap(name string, opts DownloadOptions) (targe
 		Channel:      opts.Channel,
 	}}
 
-	snaps, err := sto.SnapAction(context.TODO(), nil, actions, tsto.user, nil)
+	sars, err := sto.SnapAction(context.TODO(), nil, actions, tsto.user, nil)
 	if err != nil {
 		// err will be 'cannot download snap "foo": <reasons>'
 		return "", nil, err
 	}
-	snap := snaps[0]
+	snap := sars[0].Info
 
 	if opts.TargetPathFunc == nil {
 		baseName := opts.Basename

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -126,7 +126,7 @@ func (s *imageSuite) TearDownTest(c *C) {
 }
 
 // interface for the store
-func (s *imageSuite) SnapAction(_ context.Context, _ []*store.CurrentSnap, actions []*store.SnapAction, _ *auth.UserState, _ *store.RefreshOptions) ([]*snap.Info, error) {
+func (s *imageSuite) SnapAction(_ context.Context, _ []*store.CurrentSnap, actions []*store.SnapAction, _ *auth.UserState, _ *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	if len(actions) != 1 {
 		return nil, fmt.Errorf("expected 1 action, got %d", len(actions))
 	}
@@ -144,7 +144,7 @@ func (s *imageSuite) SnapAction(_ context.Context, _ []*store.CurrentSnap, actio
 	if info := s.AssertedSnapInfo(actions[0].InstanceName); info != nil {
 		info1 := *info
 		info1.Channel = actions[0].Channel
-		return []*snap.Info{&info1}, nil
+		return []store.SnapActionResult{{Info: &info1}}, nil
 	}
 	return nil, fmt.Errorf("no %q in the fake store", actions[0].InstanceName)
 }

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -48,41 +48,43 @@ type fakeStore struct {
 	storetest.Store
 }
 
-func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	if actions[0].Action == "install" {
-		installs := make([]*snap.Info, 0, len(actions))
+		installs := make([]store.SnapActionResult, 0, len(actions))
 		for _, a := range actions {
 			snapName, instanceKey := snap.SplitInstanceName(a.InstanceName)
 			if instanceKey != "" {
 				panic(fmt.Sprintf("unexpected instance name %q in snap install action", a.InstanceName))
 			}
 
-			installs = append(installs, &snap.Info{
+			installs = append(installs, store.SnapActionResult{Info: &snap.Info{
 				SideInfo: snap.SideInfo{
 					RealName: snapName,
 					Revision: snap.R(2),
 				},
 				Architectures: []string{"all"},
-			})
+			}})
 		}
 
 		return installs, nil
 	}
 
-	return []*snap.Info{{
+	snaps := []store.SnapActionResult{{Info: &snap.Info{
 		SideInfo: snap.SideInfo{
 			RealName: "test-snap",
 			Revision: snap.R(2),
 			SnapID:   "test-snap-id",
 		},
 		Architectures: []string{"all"},
-	}, {SideInfo: snap.SideInfo{
-		RealName: "other-snap",
-		Revision: snap.R(2),
-		SnapID:   "other-snap-id",
-	},
+	}}, {Info: &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "other-snap",
+			Revision: snap.R(2),
+			SnapID:   "other-snap-id",
+		},
 		Architectures: []string{"all"},
-	}}, nil
+	}}}
+	return snaps, nil
 }
 
 type servicectlSuite struct {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -50,7 +50,7 @@ type autoRefreshStore struct {
 	err error
 }
 
-func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	if !opts.IsAutoRefresh {
 		panic("AutoRefresh snap action did not set IsAutoRefresh flag")
 	}

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -41,7 +41,7 @@ type StoreService interface {
 	SnapInfo(ctx context.Context, spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(ctx context.Context, search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 
-	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error)
+	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error)
 
 	Sections(ctx context.Context, user *auth.UserState) ([]string, error)
 	WriteCatalogs(ctx context.Context, names io.Writer, adder store.SnapAdder) error

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -382,7 +382,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	return nil, store.ErrNoUpdateAvailable
 }
 
-func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	if ctx == nil {
 		panic("context required")
 	}
@@ -433,7 +433,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 
 	refreshErrors := make(map[string]error)
 	installErrors := make(map[string]error)
-	var res []*snap.Info
+	var res []store.SnapActionResult
 	for _, a := range sorted {
 		if a.Action != "install" && a.Action != "refresh" {
 			panic("not supported")
@@ -466,7 +466,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				info.Channel = ""
 			}
 			info.InstanceKey = instanceKey
-			res = append(res, info)
+			res = append(res, store.SnapActionResult{Info: info})
 			continue
 		}
 
@@ -518,7 +518,7 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 			info.Channel = ""
 		}
 		info.InstanceKey = instanceKey
-		res = append(res, info)
+		res = append(res, store.SnapActionResult{Info: info})
 	}
 
 	if len(refreshErrors)+len(installErrors) > 0 || len(res) == 0 {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -40,7 +40,7 @@ type recordingStore struct {
 	ops []string
 }
 
-func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	if ctx == nil || !auth.IsEnsureContext(ctx) {
 		panic("Ensure marked context required")
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -814,7 +814,8 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 	}
 
 	tasksets := make([]*state.TaskSet, 0, len(installs))
-	for _, info := range installs {
+	for _, sar := range installs {
+		info := sar.Info
 		var snapst SnapState
 		var flags Flags
 

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -53,7 +53,7 @@ func (Store) Find(context.Context, *store.Search, *auth.UserState) ([]*snap.Info
 	panic("Store.Find not expected")
 }
 
-func (Store) SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error) {
+func (Store) SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, error) {
 	panic("Store.SnapAction not expected")
 }
 


### PR DESCRIPTION
SnapAction will in some situations return a "redirect channel" which
snapstate et al should use to know that something interesting has
happened.

Rather than add this field to *snap.Info, it seemed to me to make more
sense to make SnapAction return it separately.

Rather than make SnapAction return []*snap.Info, []string, error, I
introduce SnapActionResult which contains a *snap.Info for now, and
can easily grow to have a string.

There already exists a snapActionResult used for marhsalling to the
store; hopefully the use is just the right intersection of different
enough and similar enough for it not to cause problems.
