### PR TITLE
tests: use snap remove --purge flag in most of the spread tests

### DIFF
--- a/cmd/snap-confine/spread-tests/main/cgroup-used/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/cgroup-used/task.yaml
@@ -28,7 +28,7 @@ execute: |
     snapd-hacker-toolbelt.busybox echo "Hello World" | grep Hello
     if ! grep 'c 1:11 rwm' /sys/fs/cgroup/devices/snap.snapd-hacker-toolbelt.busybox/devices.list ; then exit 1; fi
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -f /etc/udev/rules.d/70-spread-test.rules
     udevadm control --reload-rules
     udevadm settle

--- a/cmd/snap-confine/spread-tests/main/core-is-preferred/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/core-is-preferred/task.yaml
@@ -5,6 +5,6 @@ prepare: |
 execute: |
     snapd-hacker-toolbelt.busybox cat /meta/snap.yaml | grep -q -F 'name: core'
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     # XXX: the core snap cannot be removed, we should use a trick to remove it
     # in some other way but this can wait.

--- a/cmd/snap-confine/spread-tests/main/hostfs-created-on-demand/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/hostfs-created-on-demand/task.yaml
@@ -18,7 +18,7 @@ execute: |
     echo "We can now check that the directory was created on the system"
     test -d /var/lib/snapd/hostfs
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     if [ -d /var/lib/snapd/hostfs.orig ]; then
         mv /var/lib/snapd/hostfs.orig /var/lib/snapd/hostfs
     fi

--- a/cmd/snap-confine/spread-tests/main/media-visible-in-devmode/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/media-visible-in-devmode/task.yaml
@@ -11,5 +11,5 @@ execute: |
     echo "We can see the canary file in /media"
     [ "$(snapd-hacker-toolbelt.busybox cat /media/canary)" = "test" ]
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -f /media/canary

--- a/cmd/snap-confine/spread-tests/main/mount-ns-sharing/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-ns-sharing/task.yaml
@@ -17,4 +17,4 @@ execute: |
         [ "$inner_mnt_ns" = "$(snapd-hacker-toolbelt.busybox readlink /proc/self/ns/mnt)" ]
     done
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-destination/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-destination/task.yaml
@@ -20,7 +20,7 @@ execute: |
     echo "Not only the command failed because snap-confine failed, we see why!"
     dmesg --ctime | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/bin/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" flags="rw, bind"'
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
     dmesg -c

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-source/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-bin-snap-source/task.yaml
@@ -20,7 +20,7 @@ execute: |
     echo "Not only the command failed because snap-confine failed, we see why!"
     dmesg --ctime | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/bin/" flags="rw, bind"'
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
     dmesg -c

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-missing-dst/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-missing-dst/task.yaml
@@ -14,6 +14,6 @@ execute: |
     echo "We can now run busybox.true and expect it to fail"
     ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true ) 
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-missing-src/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-missing-src/task.yaml
@@ -14,6 +14,6 @@ execute: |
     echo "We can now run busybox.true and expect it to fail"
     ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true ) 
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-mount-tmpfs/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-mount-tmpfs/task.yaml
@@ -2,7 +2,7 @@ summary: Check that mount profiles cannot be used to mount tmpfs
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
 execute: |

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-ro-mount/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-ro-mount/task.yaml
@@ -13,6 +13,6 @@ execute: |
     echo "We can now look at the .id file in the destination directory"
     [ "$(/snap/bin/snapd-hacker-toolbelt.busybox cat /snap/snapd-hacker-toolbelt/current/dst/.id)" = "source" ]
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab

--- a/cmd/snap-confine/spread-tests/main/mount-profiles-rw-mount/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-profiles-rw-mount/task.yaml
@@ -19,6 +19,6 @@ execute: |
     # seems that busybox is not any different here.
     /snap/bin/snapd-hacker-toolbelt.busybox mount | grep snapd-hacker-toolbelt
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab

--- a/cmd/snap-confine/spread-tests/main/mount-usr-src/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/mount-usr-src/task.yaml
@@ -14,4 +14,4 @@ execute: |
     echo "We can ensure that /usr/src is mounted"
     /snap/bin/snapd-hacker-toolbelt.busybox cat /proc/self/mounts | grep ' /usr/src '
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt

--- a/cmd/snap-confine/spread-tests/main/test-seccomp-compat/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/test-seccomp-compat/task.yaml
@@ -13,4 +13,4 @@ execute: |
     echo Run the 32 bit binary
     test-seccomp-compat.true32
 restore: |
-    snap remove test-seccomp-compat
+    snap remove --purge test-seccomp-compat

--- a/cmd/snap-confine/spread-tests/main/test-snap-runs/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/test-snap-runs/task.yaml
@@ -12,4 +12,4 @@ execute: |
     if snapd-hacker-toolbelt.busybox touch /var/tmp/evil; then exit 1; fi
     dmesg -c
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt

--- a/cmd/snap-confine/spread-tests/main/user-data-dir-created/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/user-data-dir-created/task.yaml
@@ -19,5 +19,5 @@ execute: |
     echo "And see that the SNAP_USER_DATA directory was created"
     test -d $HOME/snap/snapd-hacker-toolbelt
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf "$HOME/snap/snapd-hacker-toolbelt/"

--- a/cmd/snap-confine/spread-tests/main/user-xdg-runtime-dir-created/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/user-xdg-runtime-dir-created/task.yaml
@@ -17,5 +17,5 @@ execute: |
     echo "And see that the XDG_RUNTIME_DIR directory was created"
     test -d /run/user/`id -u`/snapd-hacker-toolbelt
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     rm -rf "/run/user/`id -u`/snapd-hacker-toolbelt"

--- a/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
+++ b/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
@@ -50,7 +50,7 @@ execute: |
 restore: |
     exit 0
     echo "Remove hello-world"
-    snap remove hello-world
+    snap remove --purge hello-world
     systemctl stop snapd.service snapd.socket
     echo "Unmount the modified core snap"
     # all of this ls madness can go away when we have remote environment

--- a/tests/completion/indirect/task.yaml
+++ b/tests/completion/indirect/task.yaml
@@ -14,7 +14,7 @@ restore: |
   (
       cd ../../lib/snaps/test-snapd-complexion || exit 1
       mv test-snapd-complexion.bash-completer.orig test-snapd-complexion.bash-completer
-      snap remove test-snapd-complexion
+      snap remove --purge test-snapd-complexion
   )
 
 execute: |

--- a/tests/completion/snippets/task.yaml
+++ b/tests/completion/snippets/task.yaml
@@ -12,7 +12,7 @@ restore: |
   (
       cd ../../lib/snaps/test-snapd-complexion || exit 1
       mv test-snapd-complexion.bash-completer.orig test-snapd-complexion.bash-completer
-      snap remove test-snapd-complexion
+      snap remove --purge test-snapd-complexion
   )
 
 execute: |

--- a/tests/core18/remove/task.yaml
+++ b/tests/core18/remove/task.yaml
@@ -2,12 +2,12 @@ summary: Check that removal of essential snaps does not work
 
 execute: |
     echo "Ensure snapd cannot be removed"
-    if snap remove snapd; then
+    if snap remove --purge snapd; then
         echo "The snapd snap should not be removable"
         exit 1
     fi
     echo "Ensure core18 cannot be removed"
-    if snap remove core18; then
+    if snap remove --purge core18; then
         echo "The core18 snap should not removable"
         exit 1
     fi
@@ -15,14 +15,14 @@ execute: |
     echo "Install a snap that requires core as the base"
     snap install test-snapd-sh
     snap list | MATCH '^core '
-    if snap remove core; then
+    if snap remove --purge core; then
         echo "core should not be removalble because test-snapd-tools needs it"
         exit 1
     fi
 
     echo "But core can be removed again once nothing on the system needs it"
-    snap remove test-snapd-sh
-    snap remove core
+    snap remove --purge test-snapd-sh
+    snap remove --purge core
 
     if snap list | MATCH '^core '; then
         echo "core was not removed correctly"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -81,7 +81,7 @@ disable_refreshes() {
     snap refresh --time --abs-time | MATCH "last: 2[0-9]{3}"
 
     echo "Ensure jq is gone"
-    snap remove jq jq-core18 jq-core20
+    snap remove --purge jq jq-core18 jq-core20
 }
 
 setup_systemd_snapd_overrides() {

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -137,7 +137,7 @@ reset_all_snap() {
                             remove_bases="$remove_bases $snap"
                         fi
                     else
-                        snap remove "$snap"
+                        snap remove --purge "$snap"
                     fi
                 fi
                 ;;
@@ -146,7 +146,7 @@ reset_all_snap() {
     # remove all base/os snaps at the end
     if [ -n "$remove_bases" ]; then
         for base in $remove_bases; do
-            snap remove "$base"
+            snap remove --purge "$base"
             if [ -d "$SNAP_MOUNT_DIR/$base" ]; then
                 echo "Error: removing base $base has unexpected leftover dir $SNAP_MOUNT_DIR/$base"
                 ls -al "$SNAP_MOUNT_DIR"

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -52,6 +52,6 @@ execute: |
     alias1|MATCH "ok command 1"
 
     echo "Removing the snap should remove the aliases"
-    snap remove aliases
+    snap remove --purge aliases
     test ! -e "$SNAP_MOUNT_DIR/bin/alias1"
     test ! -e "$SNAP_MOUNT_DIR/bin/alias2"

--- a/tests/main/auto-aliases/task.yaml
+++ b/tests/main/auto-aliases/task.yaml
@@ -18,7 +18,7 @@ execute: |
     snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +-"
 
     echo "Removing the snap should remove the aliases"
-    snap remove test-snapd-auto-aliases
+    snap remove --purge test-snapd-auto-aliases
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown1"
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown2"
     snap aliases | not MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1"

--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -70,7 +70,7 @@ execute: |
     AUTO_REFRESH_ID=$(change_id "Auto-refresh.*test-snapd-public.*" Done)
 
     echo "Try the same with expired creds"
-    snap remove test-snapd-private test-snapd-public
+    snap remove --purge test-snapd-private test-snapd-public
     snap install test-snapd-private test-snapd-public
 
     echo "Clear the snap cache"

--- a/tests/main/bad-interfaces-warn/task.yaml
+++ b/tests/main/bad-interfaces-warn/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   snap pack test-snap
 
 restore: |
-  snap remove test-snap
+  snap remove --purge test-snap
 
 execute: |
   echo "Installing a snap with invalid interfaces issues a warning"

--- a/tests/main/base-migration/task.yaml
+++ b/tests/main/base-migration/task.yaml
@@ -30,7 +30,7 @@ execute: |
   # of the base snap, as seen by the processes of the application snap. This
   # ensures that all processes in a given snap see a consistent view of the
   # filesystem.
-  snap remove test-snapd-core-migration
+  snap remove --purge test-snapd-core-migration
   snap install --dangerous test-snapd-core-migration_1_all.snap
   test-snapd-core-migration.sh -c "exec sleep 1h" &
   pid=$!
@@ -55,6 +55,6 @@ execute: |
 restore: |
 
   if snap list test-snapd-core-migration; then
-    snap remove test-snapd-core-migration
+    snap remove --purge test-snapd-core-migration
   fi
   rm -f test-snapd-core-migration_{1,2}_all.snap

--- a/tests/main/cgroup-devices/task.yaml
+++ b/tests/main/cgroup-devices/task.yaml
@@ -4,4 +4,4 @@ systems: [ -fedora-31-*]
 execute: ./task.sh
 restore: |
     rm -f test-snapd-service_1.0_all.snap
-    snap remove test-snapd-service
+    snap remove --purge test-snapd-service

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -45,7 +45,7 @@ execute: |
     snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap"
     touch /tmp/lala
     "$CLASSIC_SNAP" | MATCH lala
-    snap remove "$CLASSIC_SNAP"
+    snap remove --purge "$CLASSIC_SNAP"
 
     echo "Check that we can install classic confinement snaps from the store"
     snap install --classic "$CLASSIC_SNAP"

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -42,7 +42,7 @@ execute: |
     fi
 
     # Instal again and put the snap into jailmode
-    snap remove test-snapd-hello-classic
+    snap remove --purge test-snapd-hello-classic
     snap install --classic --jailmode test-snapd-hello-classic
 
     $SNAP_MOUNT_DIR/bin/test-snapd-hello-classic | MATCH 'Hello Classic!'

--- a/tests/main/core16-provided-by-core/task.yaml
+++ b/tests/main/core16-provided-by-core/task.yaml
@@ -12,7 +12,7 @@ execute: |
     fi
 
     echo "Ensure there is no core16 installed"
-    snap remove core16
+    snap remove --purge core16
 
     echo "Double check that no earlier test left garbage around"
     if [ -e /snap/core16/current ] || [ -L /snap/core16/current ]; then

--- a/tests/main/core18-configure-hook/task.yaml
+++ b/tests/main/core18-configure-hook/task.yaml
@@ -33,5 +33,5 @@ execute: |
 
 restore: |
     if snap list test-snapd-with-configure-core18; then
-        snap remove test-snapd-with-configure-core18
+        snap remove --purge test-snapd-with-configure-core18
     fi

--- a/tests/main/core18-with-hooks/task.yaml
+++ b/tests/main/core18-with-hooks/task.yaml
@@ -11,4 +11,4 @@ execute: |
     journalctl -u test-snapd-snapctl-core18.service
 
 restore: |
-    snap remove test-snapd-snapctl-core18
+    snap remove --purge test-snapd-snapctl-core18

--- a/tests/main/cwd/task.yaml
+++ b/tests/main/cwd/task.yaml
@@ -10,7 +10,7 @@ prepare: |
     . "$TESTSLIB"/snaps.sh
     install_local test-snapd-sh
 restore: |
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
     rmdir /tmp/test || true
 execute: |
     # The current working directory that exists in the snap mount namespace and

--- a/tests/main/install-cache/task.yaml
+++ b/tests/main/install-cache/task.yaml
@@ -5,6 +5,6 @@ execute: |
     . "$TESTSLIB/journalctl.sh"
 
     snap install test-snapd-sh
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
     snap install test-snapd-sh
     check_journalctl_log 'using cache for .*/test-snapd-sh.*\.snap' -u snapd

--- a/tests/main/install-refresh-private/task.yaml
+++ b/tests/main/install-refresh-private/task.yaml
@@ -32,7 +32,7 @@ execute: |
         snap list|MATCH 'test-snapd-private +2\.0.*private'
 
         echo "After removing it"
-        snap remove test-snapd-private
+        snap remove --purge test-snapd-private
 
         echo "Install it together with a public snap"
         snap install test-snapd-private test-snapd-public

--- a/tests/main/install-refresh-remove-hooks/task.yaml
+++ b/tests/main/install-refresh-remove-hooks/task.yaml
@@ -70,7 +70,7 @@ execute: |
 
     echo "Verify that remove hook is executed"
     snap set "$NAME" exitcode=0
-    snap remove "$NAME"
+    snap remove --purge "$NAME"
     if ! test -f "$REMOVE_HOOK_FILE"; then
         echo "Remove hook was not executed"
         exit 1

--- a/tests/main/install-sideload-epochs/task.yaml
+++ b/tests/main/install-sideload-epochs/task.yaml
@@ -19,9 +19,9 @@ execute: |
     not snap install --dangerous test-snapd-epoch_2_all.snap 2>install.err
     tr -s "\n " "  "  < install.err  | MATCH "$rx"
 
-    snap remove test-snapd-epoch
+    snap remove --purge test-snapd-epoch
     snap install --dangerous test-snapd-epoch_2_all.snap
     not snap install --dangerous test-snapd-epoch_1_all.snap 2>install1.err
     tr -s "\n " "  "  < install1.err  | MATCH "$rx"
 
-    snap remove test-snapd-epoch
+    snap remove --purge test-snapd-epoch

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -20,7 +20,7 @@ execute: |
     snap install --dangerous ./basic_1.0_all.snap | MATCH "$expected"
 
     echo "Sideloaded snap with (deprecated) --force-dangerous option"
-    snap remove basic
+    snap remove --purge basic
     snap install --force-dangerous ./basic_1.0_all.snap | MATCH "$expected"
 
     echo "Sideloaded snap executes commands"

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -17,7 +17,7 @@ execute: |
     for channel in edge beta candidate stable
     do
         snap install --unicode=never "$SNAP_NAME" --channel=$channel | grep -Pzq "$expected"
-        snap remove "$SNAP_NAME"
+        snap remove --purge "$SNAP_NAME"
     done
 
     echo "Install non-devmode snap with devmode option"

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -24,7 +24,7 @@ restore: |
     for f in /var/lib/extrausers/*; do
         sed -i '/^alice:/d' "$f"
     done
-    snap remove "$TSNAP"
+    snap remove --purge "$TSNAP"
 
 execute: |
     snap run "$TSNAP".useradd --extrausers alice

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -29,7 +29,7 @@ prepare: |
 
 restore: |
     HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 su -p -c "pulseaudio --kill" test || true
-    snap remove test-snapd-audio-record
+    snap remove --purge test-snapd-audio-record
     apt-get autoremove --purge -y pulseaudio pulseaudio-utils
     rm -rf /run/user/12345 /home/test/.config/pulse
     if [ -d /home/test/.config.spread ]; then

--- a/tests/main/interfaces-hooks/task.yaml
+++ b/tests/main/interfaces-hooks/task.yaml
@@ -22,8 +22,8 @@ restore: |
     rm -f "$PRODUCER_DATA/disconnect-slot-producer-done"
     rm -f "$CONSUMER_DATA/unprepare-plug-consumer-done"
     rm -f "$PRODUCER_DATA/unprepare-slot-producer-done"
-    snap remove basic-iface-hooks-consumer
-    snap remove basic-iface-hooks-producer
+    snap remove --purge basic-iface-hooks-consumer
+    snap remove --purge basic-iface-hooks-producer
 
 execute: |
     #shellcheck source=tests/lib/snaps.sh
@@ -96,7 +96,7 @@ execute: |
     # disconnect hooks should be executed on snap removal
     snap set basic-iface-hooks-consumer fail=none
     snap connect basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer
-    snap remove basic-iface-hooks-consumer
+    snap remove --purge basic-iface-hooks-consumer
     [ -f "$PRODUCER_DATA/disconnect-slot-producer-done" ]
     snap change --last=remove | MATCH "Run hook disconnect-slot-producer of snap \"basic-iface-hooks-producer"
     snap change --last=remove | MATCH "Run hook disconnect-plug-consumer of snap \"basic-iface-hooks-consumer"

--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -87,4 +87,4 @@ execute: |
 
 restore: |
     # Remove the snaps to avoid timeout in next test
-    snap remove "$CONSUMER_SNAP"
+    snap remove --purge "$CONSUMER_SNAP"

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -85,5 +85,5 @@ restore: |
     if is_core_system; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"
     fi
-    snap remove "$PROVIDER_SNAP"
-    snap remove "$CONSUMER_SNAP"
+    snap remove --purge "$PROVIDER_SNAP"
+    snap remove --purge "$CONSUMER_SNAP"

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -36,7 +36,7 @@ restore: |
     # This snap is removed because it generates thousands of DENIALS in the journal. Most of those
     # are sent after the journalctl cursor for following test is determined producing errors while
     # preparing the test.
-    snap remove network-bind-consumer
+    snap remove --purge network-bind-consumer
 
 execute: |
     echo "The interface is connected by default"

--- a/tests/main/interfaces-network-control-ip-netns/task.yaml
+++ b/tests/main/interfaces-network-control-ip-netns/task.yaml
@@ -37,7 +37,7 @@ execute: |
     test ! -e /run/netns/canary
 
 restore: |
-    snap remove snapd-hacker-toolbelt
+    snap remove --purge snapd-hacker-toolbelt
     # If this doesn't work maybe it is because the test didn't execute correctly
     snapd-hacker-toolbelt.busybox sh -c '/bin/ip netns delete canary' 2>/dev/null || true
     ip netns delete canary 2>/dev/null || true

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -26,4 +26,4 @@ execute: |
     test-snapd-packagekit.pkcon resolve snapd | MATCH "Installed[[:space:]]+snapd"
 
 restore: |
-    snap remove test-snapd-packagekit
+    snap remove --purge test-snapd-packagekit

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -27,7 +27,7 @@ prepare: |
 
 restore: |
     HOME=/home/test XDG_RUNTIME_DIR=/run/user/12345 su -p -c "pulseaudio --kill" test || true
-    snap remove test-snapd-pulseaudio
+    snap remove --purge test-snapd-pulseaudio
     apt-get autoremove --purge -y pulseaudio pulseaudio-utils
     rm -rf /run/user/12345 /home/test/.config/pulse
     if [ -d /home/test/.config.spread ]; then

--- a/tests/main/interfaces-udev/task.yaml
+++ b/tests/main/interfaces-udev/task.yaml
@@ -24,7 +24,7 @@ execute: |
     grep -Pq "$expected" /etc/udev/rules.d/70-snap.modem-manager-consumer.rules
 
     echo "When the snap is removed"
-    snap remove modem-manager-consumer
+    snap remove --purge modem-manager-consumer
 
     echo "Then the udev rules files are removed"
     not test -f /etc/udev/rules.d/70-snap.modem-manager-consumer.rules

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -50,4 +50,4 @@ execute: |
     ps afx | MATCH snapfuse
 
     echo "We can also remove snaps successfully"
-    lxd.lxc exec my-ubuntu -- snap remove test-snapd-sh
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-sh

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -111,7 +111,7 @@ execute: |
     echo "And as root"
     lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c 'echo from-the-inside' | MATCH from-the-inside
     echo "We can also remove snaps successfully"
-    lxd.lxc exec my-ubuntu -- snap remove test-snapd-sh
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-sh
 
     # Ensure that we can run snapd as a snap inside a nested container
 

--- a/tests/main/mount-ns/task.yaml
+++ b/tests/main/mount-ns/task.yaml
@@ -171,10 +171,10 @@ prepare: |
     deterministic-mountinfo-tool                                              -f HOST-AFTER.raw.txt  >HOST-AFTER.deterministic.txt
 
     if snap debug sandbox-features --required confinement-options:classic; then
-        snap remove test-snapd-mountinfo-classic
+        snap remove --purge test-snapd-mountinfo-classic
     fi
-    snap remove test-snapd-mountinfo-core16
-    snap remove test-snapd-mountinfo-core18
+    snap remove --purge test-snapd-mountinfo-core16
+    snap remove --purge test-snapd-mountinfo-core18
 execute: |
     if [ -e please-skip-this-test ]; then
         exit 0

--- a/tests/main/mount-protocol-error/task.yaml
+++ b/tests/main/mount-protocol-error/task.yaml
@@ -24,5 +24,5 @@ execute: |
     for i in $(seq 10); do
        echo "Install $i"
        snap install "${names[@]}"
-       snap remove "${names[@]}"
+       snap remove --purge "${names[@]}"
     done

--- a/tests/main/op-remove-retry/task.yaml
+++ b/tests/main/op-remove-retry/task.yaml
@@ -31,7 +31,7 @@ execute: |
     while [ ! -f $MARKER ]; do sleep 1; done
 
     echo "When we try to remove the snap"
-    snap remove test-snapd-tools &
+    snap remove --purge test-snapd-tools &
 
     echo "Then the remove retry succeeds"
     wait_for_remove_state Done

--- a/tests/main/parallel-install-aliases/task.yaml
+++ b/tests/main/parallel-install-aliases/task.yaml
@@ -70,11 +70,11 @@ execute: |
     test "$(readlink "$SNAP_MOUNT_DIR"/bin/alias1)" = "aliases.cmd1"
 
     echo "Removing the aliases snap should remove its aliases"
-    snap remove aliases
+    snap remove --purge aliases
     test ! -e "$SNAP_MOUNT_DIR/bin/alias1"
 
     echo "Aliases of aliases_foo remain unchanged"
     test "$(readlink "$SNAP_MOUNT_DIR"/bin/alias2)" = "aliases_foo.cmd2"
 
-    snap remove aliases_foo
+    snap remove --purge aliases_foo
     test ! -e "$SNAP_MOUNT_DIR/bin/alias2"

--- a/tests/main/parallel-install-auto-aliases/task.yaml
+++ b/tests/main/parallel-install-auto-aliases/task.yaml
@@ -53,7 +53,7 @@ execute: |
     MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +disabled" < aliases.out
 
     echo "Removing the snap should remove the aliases"
-    snap remove test-snapd-auto-aliases_foo
+    snap remove --purge test-snapd-auto-aliases_foo
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown1"
     test ! -e "$SNAP_MOUNT_DIR/bin/test_snapd_wellknown2"
     snap aliases > aliases.out
@@ -73,7 +73,7 @@ execute: |
     test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown2)" = "test-snapd-auto-aliases.wellknown2"
 
     # clean slate
-    snap remove test-snapd-auto-aliases
+    snap remove --purge test-snapd-auto-aliases
 
     echo "When test-snapd-auto-aliases_foo is installed"
     snap install test-snapd-auto-aliases_foo

--- a/tests/main/parallel-install-common-dirs/task.yaml
+++ b/tests/main/parallel-install-common-dirs/task.yaml
@@ -46,7 +46,7 @@ execute: |
     test -d "/var/snap/test-snapd-sh"
 
     # remove foo instance snap
-    snap remove test-snapd-sh_foo
+    snap remove --purge test-snapd-sh_foo
     # foo instance directories should be gone now
     not test -d "$SNAP_MOUNT_DIR/test-snapd-sh_foo"
     not test -d "/var/snap/test-snapd-sh_foo"
@@ -56,13 +56,13 @@ execute: |
     test -d "/var/snap/test-snapd-sh"
 
     # remove instance-key-less one
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
     # common directories are still around, required by test-snapd-sh_bar
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
     test -d "/var/snap/test-snapd-sh"
 
     # remove bar instance
-    snap remove test-snapd-sh_bar
+    snap remove --purge test-snapd-sh_bar
     not test -d "$SNAP_MOUNT_DIR/test-snapd-sh_bar"
     not test -d "/var/snap/test-snapd-sh_bar"
 
@@ -76,7 +76,7 @@ execute: |
     install_local test-snapd-sh
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
     test -d "/var/snap/test-snapd-sh"
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
     not test -d "$SNAP_MOUNT_DIR/test-snapd-sh"
     not test -d "/var/snap/test-snapd-sh"
 

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -34,11 +34,11 @@ execute: |
     snap list | MATCH '^basic-desktop_longname '
 
     echo "Removing one instance does not remove other instances' data"
-    snap remove basic-desktop_foo
+    snap remove --purge basic-desktop_foo
     test -f /var/lib/snapd/desktop/applications/basic-desktop+longname_echo.desktop
     test -f /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop
 
-    snap remove basic-desktop
+    snap remove --purge basic-desktop
     test -f /var/lib/snapd/desktop/applications/basic-desktop+longname_echo.desktop
 
 restore: |

--- a/tests/main/parallel-install-interfaces/task.yaml
+++ b/tests/main/parallel-install-interfaces/task.yaml
@@ -57,8 +57,8 @@ execute: |
     snap interfaces | MATCH "$CONTENT_CONNECTED_PATTERN"
 
     # Remove the content snaps so that we can reinstall them the other way around
-    snap remove test-snapd-content-plug_foo
-    snap remove test-snapd-content-slot
+    snap remove --purge test-snapd-content-plug_foo
+    snap remove --purge test-snapd-content-slot
 
     echo "The slot side auto-connects when content snap is installed"
     snap install --edge test-snapd-content-plug_foo
@@ -66,6 +66,6 @@ execute: |
     # snap install --edge test-snapd-content-slot
     snap interfaces | MATCH "$CONTENT_CONNECTED_PATTERN"
     echo "The interface is disconnected when content snap provider is removed"
-    snap remove test-snapd-content-slot
+    snap remove --purge test-snapd-content-slot
 
     snap interfaces | MATCH -- '^-\s+test-snapd-content-plug_foo:shared-content-plug$'

--- a/tests/main/parallel-install-local/task.yaml
+++ b/tests/main/parallel-install-local/task.yaml
@@ -42,7 +42,7 @@ execute: |
     snap list | MATCH '^test-snapd-sh_longname '
 
     echo "Removing one instance does not remove other instances' directories"
-    snap remove test-snapd-sh_foo
+    snap remove --purge test-snapd-sh_foo
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh_longname/x1"
     test -d "$SNAP_MOUNT_DIR/test-snapd-sh/x1"
 

--- a/tests/main/parallel-install-remove-after/task.yaml
+++ b/tests/main/parallel-install-remove-after/task.yaml
@@ -64,13 +64,13 @@ execute: |
     fi
 
     # removal of snaps should not fail
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
     if is_classic_system ; then
-        snap remove test-snapd-classic-confinement
+        snap remove --purge test-snapd-classic-confinement
     fi
 
     # neither should the removal of instances
-    snap remove test-snapd-sh_foo
+    snap remove --purge test-snapd-sh_foo
     if is_classic_system ; then
-        snap remove test-snapd-classic-confinement_foo
+        snap remove --purge test-snapd-classic-confinement_foo
     fi

--- a/tests/main/parallel-install-services/task.yaml
+++ b/tests/main/parallel-install-services/task.yaml
@@ -44,7 +44,7 @@ execute: |
     snap list | MATCH '^test-snapd-service_longname '
 
     echo "Removing one instance does not remove services from other instances"
-    snap remove test-snapd-service_foo
+    snap remove --purge test-snapd-service_foo
     not test -f /etc/systemd/system/snap.test-snapd-service_foo.test-snapd-service.service
     test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service
     test -f /etc/systemd/system/snap.test-snapd-service.test-snapd-service.service
@@ -53,11 +53,11 @@ execute: |
     check_services_active test-snapd-service
     check_services_active test-snapd-service_longname
 
-    snap remove test-snapd-service
+    snap remove --purge test-snapd-service
     not test -f /etc/systemd/system/snap.test-snapd-service.test-snapd-service.service
     test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service
     echo "The services of remaining snap are active"
     check_services_active test-snapd-service_longname
 
-    snap remove test-snapd-service_longname
+    snap remove --purge test-snapd-service_longname
     not test -f /etc/systemd/system/snap.test-snapd-service_longname.test-snapd-service.service

--- a/tests/main/parallel-install-snap-icons/task.yaml
+++ b/tests/main/parallel-install-snap-icons/task.yaml
@@ -28,10 +28,10 @@ execute: |
     MATCH '^Icon=snap.test-snapd-icon-theme_foo.foo$' < "$desktopdir/test-snapd-icon-theme+foo_echo.desktop"
 
     echo "Removing once instance does not remove the other instances' icons"
-    snap remove test-snapd-icon-theme_foo
+    snap remove --purge test-snapd-icon-theme_foo
     [ -f "$icondir/snap.test-snapd-icon-theme.foo.svg" ]
     [ -f "$icondir/snap.test-snapd-icon-theme_longname.foo.svg" ]
     [ ! -f "$icondir/snap.test-snapd-icon-theme_foo.foo.svg" ]
 
-    snap remove test-snapd-icon-theme
+    snap remove --purge test-snapd-icon-theme
     [ -f "$icondir/snap.test-snapd-icon-theme_longname.foo.svg" ]

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -15,7 +15,7 @@ environment:
     CONFINEMENT/classic: classic
     CONFINEMENT/strict: strict
 restore: |
-    snap remove test-snapd-refresh
+    snap remove --purge test-snapd-refresh
     rm -f test-snapd-refresh-{1,2}_all.snap
     rm -f test-snapd-refresh.*/meta/snap.yaml
     rmdir /sys/fs/cgroup/pids/snap.test-snapd-refresh.sh || true

--- a/tests/main/refresh-with-epoch-bump/task.yaml
+++ b/tests/main/refresh-with-epoch-bump/task.yaml
@@ -7,7 +7,7 @@ details: |
     before re-refreshing to the expected one.
 
 prepare: |
-    snap remove test-snapd-epoch
+    snap remove --purge test-snapd-epoch
     snap install test-snapd-epoch
 
 debug: |

--- a/tests/main/remodel-base/task.yaml
+++ b/tests/main/remodel-base/task.yaml
@@ -102,7 +102,7 @@ execute: |
         wait_change_done "Refresh model assertion from revision 0 to 2"
         snap debug model|MATCH "revision: 2"
         echo "and we cannot remove the base snap"
-        not snap remove "$NEW_BASE"
+        not snap remove --purge "$NEW_BASE"
         # TODO: test when keeping the old base, test removing the old base
         #       (not possible here as the pc gadget uses core18 as its base)
         echo "And we can remodel again and remove the new base"
@@ -116,7 +116,7 @@ execute: |
         wait_change_done "Refresh model assertion from revision 2 to 3"
         snap debug model|MATCH "revision: 3"
         echo "cleanup"
-        snap remove "$NEW_BASE"
+        snap remove --purge "$NEW_BASE"
         snap refresh --channel="$BASE_CHANNEL" "$OLD_BASE"
         REBOOT
     fi

--- a/tests/main/remodel-gadget/task.yaml
+++ b/tests/main/remodel-gadget/task.yaml
@@ -105,9 +105,9 @@ execute: |
         wait_change_done "Refresh model assertion from revision 0 to 2"
         snap debug model|MATCH "revision: 2"
         echo "and we cannot remove the gadget snap"
-        not snap remove "$NEW_GADGET"
+        not snap remove --purge "$NEW_GADGET"
         echo "but we can remove the old gadget"
-        snap remove "$OLD_GADGET"
+        snap remove --purge "$OLD_GADGET"
         echo "And we can remodel again and remove the new gadget"
         snap remodel "$TESTSLIB"/assertions/developer1-pc-18-revno3.model
         REBOOT
@@ -118,7 +118,7 @@ execute: |
         wait_change_done "Refresh model assertion from revision 2 to 3"
         snap debug model|MATCH "revision: 3"
         echo "cleanup"
-        snap remove "$NEW_GADGET"
+        snap remove --purge "$NEW_GADGET"
         snap refresh --channel="$GADGET_CHANNEL" "$OLD_GADGET"
         REBOOT
     fi

--- a/tests/main/remodel-kernel/task.yaml
+++ b/tests/main/remodel-kernel/task.yaml
@@ -118,11 +118,11 @@ execute: |
         snap debug model|MATCH "revision: 2"
 
         echo "and we cannot remove the kernel snap"
-        not snap remove "$NEW_KERNEL"
+        not snap remove --purge "$NEW_KERNEL"
 
         # TODO: test when keeping the old kernel
         echo "but we can remove the old kernel"
-        snap remove "$OLD_KERNEL"
+        snap remove --purge "$OLD_KERNEL"
 
         echo "And we can remodel again and remove the new kernel"
         snap remodel "$TESTSLIB"/assertions/developer1-pc-revno3.model
@@ -137,7 +137,7 @@ execute: |
         wait_change_done "Refresh model assertion from revision 2 to 3"
         snap debug model|MATCH "revision: 3"
         echo "cleanup"
-        snap remove "$NEW_KERNEL"
+        snap remove --purge "$NEW_KERNEL"
 
         echo "Ensure we are back to the original kernel channel and kernel"
         snap refresh --channel="$KERNEL_CHANNEL" "$OLD_KERNEL"

--- a/tests/main/remodel/task.yaml
+++ b/tests/main/remodel/task.yaml
@@ -95,7 +95,7 @@ execute: |
     snap changes | MATCH "Refresh model assertion from revision 0 to 2"
 
     echo "and we cannot remove the new required snap"
-    not snap remove "$SNAP"
+    not snap remove --purge "$SNAP"
 
     echo "And we can remodel again this time test-snapd-tools is no longer required"
     snap remodel developer1-pc-revno3.model
@@ -104,7 +104,7 @@ execute: |
     echo "and $SNAP is still available"
     snap list "$SNAP"
     echo "and we can clean it up here because it is no longer required"
-    snap remove "$SNAP"
+    snap remove --purge "$SNAP"
 
     echo "and test that the remodel shows up in 'snap changes'"
 

--- a/tests/main/remove-auto-connections/task.yaml
+++ b/tests/main/remove-auto-connections/task.yaml
@@ -25,7 +25,7 @@ execute: |
   inspect_connection | MATCH "true"
 
   echo "Checking that 'home' connection is not reported after removing the test snap"
-  snap remove simplesnap
+  snap remove --purge simplesnap
     if snap connections simplesnap | MATCH "home"; then
       echo "Expected simplesnap:home to be gone after snap got removed"
       exit 1
@@ -46,5 +46,5 @@ execute: |
   inspect_connection | MATCH "false"
 
 restore: |
-  snap remove simplesnap
+  snap remove --purge simplesnap
   rm -f simplesnap_*_all.snap

--- a/tests/main/services-after-before-install/task.yaml
+++ b/tests/main/services-after-before-install/task.yaml
@@ -72,5 +72,5 @@ execute: |
         echo "after-middle service was started after middle became active"
         test "$inactive_leave" -ge "$active_enter"
 
-        snap remove "test-snapd-after-before_$INSTANCE"
+        snap remove --purge "test-snapd-after-before_$INSTANCE"
     done

--- a/tests/main/services-refresh-mode/task.yaml
+++ b/tests/main/services-refresh-mode/task.yaml
@@ -31,6 +31,6 @@ execute: |
     test "$(cat new-endure.pid)" = "$(cat old-endure.pid)"
 
     echo "Once the snap is removed, the service is stopped"
-    snap remove test-snapd-service
+    snap remove --purge test-snapd-service
     # shellcheck disable=SC2119
     get_journalctl_log | MATCH "stop endure"

--- a/tests/main/services-stop-mode-sigkill/task.yaml
+++ b/tests/main/services-stop-mode-sigkill/task.yaml
@@ -7,7 +7,7 @@ backends: [-autopkgtest]
 
 restore: |
     # remove to ensure all services are stopped
-    snap remove test-snapd-service || true
+    snap remove --purge test-snapd-service || true
     pkill sleep || true
 
 debug: |

--- a/tests/main/services-stop-mode/task.yaml
+++ b/tests/main/services-stop-mode/task.yaml
@@ -10,7 +10,7 @@ backends: [-autopkgtest]
 
 restore: |
     # remove to ensure all services are stopped
-    snap remove test-snapd-service || true
+    snap remove --purge test-snapd-service || true
 
 debug: |
     stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all"
@@ -61,7 +61,7 @@ execute: |
     test "$(cat new-main.pid)" != "$(cat old-main.pid)"
 
     echo "Once the snap is removed, all services are stopped"
-    snap remove test-snapd-service
+    snap remove --purge test-snapd-service
     for s in $stop_modes; do
         get_journalctl_log | MATCH "stop ${s}"
     done

--- a/tests/main/services-timer/task.yaml
+++ b/tests/main/services-timer/task.yaml
@@ -39,7 +39,7 @@ execute: |
     fi
 
     echo "When removed, times are not listed by systemd"
-    snap remove test-snapd-timer-service
+    snap remove --purge test-snapd-timer-service
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         for service in regular-timer random-timer range-timer; do
             systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState="

--- a/tests/main/snap-connect/task.yaml
+++ b/tests/main/snap-connect/task.yaml
@@ -57,8 +57,8 @@ execute: |
     snap interfaces | MATCH "$CONTENT_CONNECTED_PATTERN"
 
     # Remove the content snaps so that we can reinstall them the other way around
-    snap remove test-snapd-content-plug
-    snap remove test-snapd-content-slot
+    snap remove --purge test-snapd-content-plug
+    snap remove --purge test-snapd-content-slot
 
     echo "The slot side auto-connects when content snap is installed"
     snap install --edge test-snapd-content-plug

--- a/tests/main/snap-get/task.yaml
+++ b/tests/main/snap-get/task.yaml
@@ -117,7 +117,7 @@ execute: |
     snap get snapctl-hooks root.key2 2>&1 | MATCH 'snap "snapctl-hooks" has no "root.key2" configuration option'
 
     echo "Test that config values are not available once snap is removed"
-    snap remove snapctl-hooks
+    snap remove --purge snapctl-hooks
     if output=$(snap get snapctl-hooks foo); then
         echo "Expected snap get to fail, but got '$output'"
         exit 1

--- a/tests/main/snap-icons/task.yaml
+++ b/tests/main/snap-icons/task.yaml
@@ -17,7 +17,7 @@ execute: |
     MATCH '^Icon=snap.test-snapd-icon-theme.foo$' < "$desktopfile"
 
     echo "Remove the snap"
-    snap remove test-snapd-icon-theme
+    snap remove --purge test-snapd-icon-theme
 
     echo "The icon has been removed"
     [ ! -f "$iconfile" ]

--- a/tests/main/snap-remove-not-mounted/task.yaml
+++ b/tests/main/snap-remove-not-mounted/task.yaml
@@ -13,4 +13,4 @@ execute: |
     umount $SNAP_MOUNT_DIR/test-snapd-tools/x1
 
     # ensure removal still works
-    snap remove test-snapd-tools
+    snap remove --purge test-snapd-tools

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -135,7 +135,7 @@ execute: |
         test-snapd-hello-multi-arch.hello-i386
 
         echo "Ensure secondary arch works in @complain mode too"
-        snap remove test-snapd-hello-multi-arch
+        snap remove --purge test-snapd-hello-multi-arch
         snap install --devmode --edge test-snapd-hello-multi-arch
         test-snapd-hello-multi-arch.hello-i386
     fi

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -33,7 +33,7 @@ prepare: |
 
 restore: |
     if snap list test-snapd-curl; then
-        snap remove test-snapd-curl
+        snap remove --purge test-snapd-curl
     fi
     systemctl stop "user@${TEST_UID}.service"
     rm -rf "${USER_RUNTIME_DIR:?}"/* "${USER_RUNTIME_DIR:?}"/.[!.]*

--- a/tests/main/snapctl-from-snap/task.yaml
+++ b/tests/main/snapctl-from-snap/task.yaml
@@ -93,7 +93,7 @@ execute: |
     check_cookie "$SNAP"
 
     echo "Verify that snap cookie is removed on snap removal"
-    snap remove "$SNAP"
+    snap remove --purge "$SNAP"
     if test -f "$COOKIE_FILE" ; then
         echo "Cookie file $COOKIE_FILE still exists"
         exit 1

--- a/tests/main/snapctl-is-connected/task.yaml
+++ b/tests/main/snapctl-is-connected/task.yaml
@@ -5,7 +5,7 @@ prepare: |
   snap install --dangerous test-snap_1_all.snap
 
 restore: |
-  snap remove test-snap
+  snap remove --purge test-snap
 
 execute: |
   check_empty() {

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -11,7 +11,7 @@ prepare: |
 
 restore: |
     if snap list test-snapd-curl; then
-        snap remove test-snapd-curl
+        snap remove --purge test-snapd-curl
     fi
 
 execute: |

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -23,4 +23,4 @@ execute: |
     snap list | MATCH ^test-snapd-sh
 
 restore: |
-    snap remove test-snapd-sh-core18
+    snap remove --purge test-snapd-sh-core18

--- a/tests/main/snapd-snap-removal/task.yaml
+++ b/tests/main/snapd-snap-removal/task.yaml
@@ -21,19 +21,19 @@ execute: |
     test "$(snap list | grep -v -c ^Name)" = 3
 
     echo "then we cannot remove snapd"
-    not snap remove snapd
+    not snap remove --purge snapd
 
     echo "Now we remove the leaf snap"
     snap remove test-snapd-sh-core18
     test "$(snap list | grep -v -c ^Name)" = 2
 
     echo "we still cannot remove snapd"
-    not snap remove snapd
+    not snap remove --purge snapd
 
     echo "Now we remove core18"
-    snap remove core18
+    snap remove --purge core18
     test "$(snap list | grep -v -c ^Name)" = 1
 
     echo "and now we can remove snapd"
-    snap remove snapd
+    snap remove --purge snapd
     test "$(snap list | grep -v -c ^Name)" = 0

--- a/tests/main/special-home-can-run-classic-snaps/task.yaml
+++ b/tests/main/special-home-can-run-classic-snaps/task.yaml
@@ -26,7 +26,7 @@ prepare: |
             ;;
     esac
 restore: |
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
     # Remove the package we installed above.
     case "$SPECIAL_USER_NAME" in
         jenkins)

--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -10,7 +10,7 @@ prepare: |
     snap install --edge test-snapd-daemon-user
 
 restore: |
-    snap remove test-snapd-daemon-user || true
+    snap remove --purge test-snapd-daemon-user || true
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs
@@ -18,7 +18,7 @@ restore: |
 
 execute: |
     echo "When the snap is removed"
-    snap remove test-snapd-daemon-user
+    snap remove --purge test-snapd-daemon-user
 
     echo "Then the snap_daemon user and group remain"
     getent passwd snap_daemon || exit 1

--- a/tests/main/system-usernames-missing-user/task.yaml
+++ b/tests/main/system-usernames-missing-user/task.yaml
@@ -12,7 +12,7 @@ prepare: |
 restore: |
     # Make sure the snap is removed if the test failed and the snap was
     # installed
-    snap remove test-snapd-daemon-user || true
+    snap remove --purge test-snapd-daemon-user || true
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -18,7 +18,7 @@ prepare: |
 
 restore: |
     # make sure this snap is removed in case it was installed
-    snap remove test-snapd-daemon-user || true
+    snap remove --purge test-snapd-daemon-user || true
 
     # snapd will create this for us, but we'll remove it for consistency in
     # test runs

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -28,7 +28,7 @@ execute: |
     snap list |MATCH core
 
     echo A snap in broken state can be removed
-    snap remove "$SNAP_NAME"
+    snap remove --purge "$SNAP_NAME"
 
     echo And is gone afterwards
     not snap list "$SNAP_NAME"

--- a/tests/main/try-with-hooks/task.yaml
+++ b/tests/main/try-with-hooks/task.yaml
@@ -13,7 +13,7 @@ execute: |
     snap try basic
 
     echo "Remove the snap and snap try again"
-    snap remove basic
+    snap remove --purge basic
 
     snap try basic
 
@@ -29,4 +29,4 @@ execute: |
         exit 1
     fi
 
-    snap remove basic
+    snap remove --purge basic

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -26,7 +26,7 @@ execute: |
     done
 
     echo "When the snap is removed"
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
 
     echo "Then all user data and root data is gone"
     for h in "${homes[@]}"; do

--- a/tests/nightly/install-snaps/task.yaml
+++ b/tests/nightly/install-snaps/task.yaml
@@ -128,7 +128,7 @@ execute: |
     snap list | MATCH "$SNAP"
 
     echo "Check the snap is properly removed"
-    snap remove "$SNAP"
+    snap remove --purge "$SNAP"
 
     if snap list | MATCH "$SNAP"; then
         echo "Snap $SNAP not removed properly"

--- a/tests/regression/lp-1808821/task.yaml
+++ b/tests/regression/lp-1808821/task.yaml
@@ -12,5 +12,5 @@ details: |
     detection code.
 execute: ./task.sh
 restore: |
-    snap remove test-snapd-app
+    snap remove --purge test-snapd-app
     rm -f test-snapd-app_1_all.snap

--- a/tests/regression/lp-1812973/task.yaml
+++ b/tests/regression/lp-1812973/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     snap install --dangerous ./test-snapd-lp-1812973_1_all.snap
 restore: |
     make clean
-    snap remove test-snapd-lp-1812973
+    snap remove --purge test-snapd-lp-1812973
     rm -f ./test-snapd-lp-1812973_1_all.snap
     rm -f ./test-snapd-lp-1812973/usr/bin/lp-1812973
 execute: |

--- a/tests/regression/lp-1813963/task.yaml
+++ b/tests/regression/lp-1813963/task.yaml
@@ -76,8 +76,8 @@ restore: |
     systemctl start snapd.service
     echo "snapd has been started" | systemd-cat
 
-    snap remove test-snapd-sh
-    snap remove test-snapd-simple-service
+    snap remove --purge test-snapd-sh
+    snap remove --purge test-snapd-simple-service
     echo "snaps have been removed" | systemd-cat
 
 execute: |

--- a/tests/regression/lp-1815869/task.yaml
+++ b/tests/regression/lp-1815869/task.yaml
@@ -56,7 +56,7 @@ restore: |
     lxc stop xenial --force || true
     lxc delete --force xenial || true
 
-    snap remove lxd
+    snap remove --purge lxd
     lxd-tool undo-lxd-mount-changes
 
 execute: |

--- a/tests/regression/lp-1825883/task.yaml
+++ b/tests/regression/lp-1825883/task.yaml
@@ -7,8 +7,8 @@ prepare: |
     snap pack test-snapd-content.v1
     snap pack test-snapd-content.v2
 restore: |
-    snap remove test-snapd-app
-    snap remove test-snapd-content
+    snap remove --purge test-snapd-app
+    snap remove --purge test-snapd-content
     rm -f test-snapd-content-app_1_all.snap test-snapd-content-{1,2}_all.snap
 execute: |
     snap install --dangerous test-snapd-app_1_all.snap

--- a/tests/regression/lp-1831010/task.yaml
+++ b/tests/regression/lp-1831010/task.yaml
@@ -7,7 +7,7 @@ details: |
 prepare: |
     snap pack test-snapd-layout
 restore: |
-    snap remove test-snapd-layout
+    snap remove --purge test-snapd-layout
     rm -f test-snapd-layout_1_all.snap
 execute: |
     # Install x1 and run the app to construct the mount namespace

--- a/tests/regression/lp-1844496/task.yaml
+++ b/tests/regression/lp-1844496/task.yaml
@@ -10,6 +10,6 @@ execute: |
     snap install --dangerous test-snapd-layout_1_all.snap
     test "$(test-snapd-layout.sh -c 'cat /usr/lib/x86_64-linux-gnu/wpe-webkit-1.0/canary')" = content
 restore: |
-    snap remove test-snapd-layout
+    snap remove --purge test-snapd-layout
     rm -f test-snapd-layout_1_all.snap
     snap unset core experimental.robust-mount-namespace-updates

--- a/tests/regression/lp-1848567/task.yaml
+++ b/tests/regression/lp-1848567/task.yaml
@@ -32,9 +32,9 @@ execute: |
     test "$(cat memory-kb.txt)" -lt 50000
   fi
 restore: |
-  snap remove test-snapd-app
-  snap remove test-snapd-gnome-3-28-1804
-  snap remove test-snapd-gtk-common-themes
+  snap remove --purge test-snapd-app
+  snap remove --purge test-snapd-gnome-3-28-1804
+  snap remove --purge test-snapd-gtk-common-themes
 
   rm -f test-snapd-app_1_all.snap
   rm -f test-snapd-gnome-3-28-1804_1_all.snap

--- a/tests/regression/lp-1849845/task.yaml
+++ b/tests/regression/lp-1849845/task.yaml
@@ -38,9 +38,9 @@ execute: |
     false
   fi
 restore: |
-  snap remove test-snapd-app
-  snap remove test-snapd-assets-foo
-  snap remove test-snapd-assets-bar
+  snap remove --purge test-snapd-app
+  snap remove --purge test-snapd-assets-foo
+  snap remove --purge test-snapd-assets-bar
 
   rm -f test-snapd-app_1_all.snap
   rm -f test-snapd-assets-foo_1_all.snap

--- a/tests/regression/lp-1852361/task.yaml
+++ b/tests/regression/lp-1852361/task.yaml
@@ -20,6 +20,6 @@ execute: |
     snap install --dangerous test-snapd-layout_1_all.snap
     invariant
 restore: |
-    snap remove test-snapd-layout
+    snap remove --purge test-snapd-layout
     rm -f test-snapd-layout_1_all.snap
     snap unset core experimental.robust-mount-namespace-updates

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -10,7 +10,7 @@ restore: |
     rm -f stderr.log
     rm -f stdout.log
     # requied! in autopkgtest no suite restore is run at all
-    snap remove test-snapd-sh
+    snap remove --purge test-snapd-sh
 
 execute: |
     #shellcheck source=tests/lib/systems.sh

--- a/tests/smoke/sandbox/task.yaml
+++ b/tests/smoke/sandbox/task.yaml
@@ -3,8 +3,8 @@ summary: Sandboxing of the snaps works
 restore: |
     rm -f /home/test/foo
     # requied! in autopkgtest no suite restore is run at all
-    snap remove test-snapd-sandbox
-    snap remove test-snapd-hello-multi-arch
+    snap remove --purge test-snapd-sandbox
+    snap remove --purge test-snapd-hello-multi-arch
 
 execute: |
     if [ "$(snap debug confinement)" != "strict" ]; then


### PR DESCRIPTION
Use `--purge` flag on snap remove in most of the spread tests (and in prepare/restore scripts), to avoid unnecessary snapshots; this should save a little bit of time and I/O. Some tests (those that test remove operation, snapshots, and selinux) are left intact, so remove is tested also without --purge flag where it makes sense.

In general, we should use `--purge` where `remove` op is not the key point of the test, and always in restore sections.


