### PR TITLE
store, o/snapstate: send default-tracks header, use RedirectChannel

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -466,7 +467,11 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 				info.Channel = ""
 			}
 			info.InstanceKey = instanceKey
-			res = append(res, store.SnapActionResult{Info: info})
+			sar := store.SnapActionResult{Info: info}
+			if strings.HasSuffix(snapName, "-with-default-track") && strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
+				sar.RedirectChannel = "2.0/" + a.Channel
+			}
+			res = append(res, sar)
 			continue
 		}
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -501,7 +501,7 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func installInfoUnlocked(st *state.State, snapsup *SnapSetup, deviceCtx DeviceContext) (*snap.Info, error) {
+func installInfoUnlocked(st *state.State, snapsup *SnapSetup, deviceCtx DeviceContext) (store.SnapActionResult, error) {
 	st.Lock()
 	defer st.Unlock()
 	opts := &RevisionOptions{Channel: snapsup.Channel, CohortKey: snapsup.CohortKey, Revision: snapsup.Revision()}
@@ -571,7 +571,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		RateLimit:     rate,
 	}
 	if snapsup.DownloadInfo == nil {
-		var storeInfo *snap.Info
+		var storeInfo store.SnapActionResult
 		// COMPATIBILITY - this task was created from an older version
 		// of snapd that did not store the DownloadInfo in the state
 		// yet. Therefore do not worry about DeviceContext.

--- a/store/store.go
+++ b/store/store.go
@@ -2198,6 +2198,8 @@ func genInstanceKey(curSnap *CurrentSnap, salt string) (string, error) {
 	return fmt.Sprintf("%s:%s", curSnap.SnapID, enc), nil
 }
 
+// SnapActionResult encapsulates the non-error result of a single
+// action of the SnapAction call.
 type SnapActionResult struct {
 	*snap.Info
 	RedirectChannel string

--- a/store/store.go
+++ b/store/store.go
@@ -929,6 +929,7 @@ func (s *Store) newRequest(ctx context.Context, reqOptions *requestOptions, user
 	req.Header.Set(hdrSnapDeviceArchitecture[reqOptions.APILevel], s.architecture)
 	req.Header.Set(hdrSnapDeviceSeries[reqOptions.APILevel], s.series)
 	req.Header.Set(hdrSnapClassic[reqOptions.APILevel], strconv.FormatBool(release.OnClassic))
+	req.Header.Set("Snap-Device-Capabilities", "default-tracks")
 	if cua := ClientUserAgent(ctx); cua != "" {
 		req.Header.Set("Snap-Client-User-Agent", cua)
 	}
@@ -2101,6 +2102,7 @@ type snapActionResult struct {
 	Name             string    `json:"name,omitempty"`
 	Snap             storeSnap `json:"snap"`
 	EffectiveChannel string    `json:"effective-channel,omitempty"`
+	RedirectChannel  string    `json:"redirect-channel,omitempty"`
 	Error            struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
@@ -2198,6 +2200,7 @@ func genInstanceKey(curSnap *CurrentSnap, salt string) (string, error) {
 
 type SnapActionResult struct {
 	*snap.Info
+	RedirectChannel string
 }
 
 func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, actions []*SnapAction, user *auth.UserState, opts *RefreshOptions) ([]SnapActionResult, error) {
@@ -2427,7 +2430,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		_, instanceKey := snap.SplitInstanceName(instanceName)
 		snapInfo.InstanceKey = instanceKey
 
-		sars = append(sars, SnapActionResult{snapInfo})
+		sars = append(sars, SnapActionResult{Info: snapInfo, RedirectChannel: res.RedirectChannel})
 	}
 
 	for _, errObj := range results.ErrorList {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -5540,18 +5540,24 @@ func (s *storeTestSuite) TestSnapActionOptions(c *C) {
 }
 
 func (s *storeTestSuite) TestSnapActionInstall(c *C) {
-	s.testSnapActionGet("install", "", c)
+	s.testSnapActionGet("install", "", "", c)
 }
 func (s *storeTestSuite) TestSnapActionInstallWithCohort(c *C) {
-	s.testSnapActionGet("install", "what", c)
+	s.testSnapActionGet("install", "what", "", c)
 }
 func (s *storeTestSuite) TestSnapActionDownload(c *C) {
-	s.testSnapActionGet("download", "", c)
+	s.testSnapActionGet("download", "", "", c)
 }
 func (s *storeTestSuite) TestSnapActionDownloadWithCohort(c *C) {
-	s.testSnapActionGet("download", "here", c)
+	s.testSnapActionGet("download", "here", "", c)
 }
-func (s *storeTestSuite) testSnapActionGet(action, cohort string, c *C) {
+func (s *storeTestSuite) TestSnapActionInstallRedirect(c *C) {
+	s.testSnapActionGet("install", "", "2.0/candidate", c)
+}
+func (s *storeTestSuite) TestSnapActionDownloadRedirect(c *C) {
+	s.testSnapActionGet("download", "", "2.0/candidate", c)
+}
+func (s *storeTestSuite) testSnapActionGet(action, cohort, redirectChannel string, c *C) {
 	// action here is one of install or download
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -5602,6 +5608,7 @@ func (s *storeTestSuite) testSnapActionGet(action, cohort string, c *C) {
      "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
      "name": "hello-world",
      "effective-channel": "candidate",
+     "redirect-channel": "%s",
      "snap": {
        "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
        "name": "hello-world",
@@ -5614,7 +5621,7 @@ func (s *storeTestSuite) testSnapActionGet(action, cohort string, c *C) {
        }
      }
   }]
-}`, action)
+}`, action, redirectChannel)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -5646,6 +5653,7 @@ func (s *storeTestSuite) testSnapActionGet(action, cohort string, c *C) {
 	c.Assert(results[0].Deltas, HasLen, 0)
 	// effective-channel
 	c.Assert(results[0].Channel, Equals, "candidate")
+	c.Assert(results[0].RedirectChannel, Equals, redirectChannel)
 }
 
 func (s *storeTestSuite) TestSnapActionInstallAmend(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1625,6 +1625,7 @@ func (s *storeTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 		c.Check(r.Header.Get("X-Foo-Header"), Equals, `Bar`)
 		c.Check(r.Header.Get("Content-Type"), Equals, `application/bson`)
 		c.Check(r.Header.Get("Accept"), Equals, `application/hal+bson`)
+		c.Check(r.Header.Get("Snap-Device-Capabilities"), Equals, "default-tracks")
 		io.WriteString(w, "response-data")
 	}))
 	c.Assert(mockServer, NotNil)

--- a/tests/main/default-tracks/task.yaml
+++ b/tests/main/default-tracks/task.yaml
@@ -1,8 +1,8 @@
 summary: Check that default tracks work
 
 environment:
-    A_SNAP: fooxboo1
-    A_TRACK: 2.0
+    A_SNAP: test-snapd-default-track
+    A_TRACK: default
 
 prepare: |
     snap install http jq
@@ -18,6 +18,20 @@ execute: |
     # TODO: check error output when trying to install from [default]/stable
 
     # now install a snap that has a default track
+    # (and you got candidate from the default track)
     snap install --candidate "$A_SNAP" | MATCH "$A_TRACK/candidate"
 
     test "$( snap run  jq -r ".data.snaps.\"$A_SNAP\".channel" < /var/lib/snapd/state.json )" = "$A_TRACK/candidate"
+
+    snap remove --purge "$A_SNAP" http jq
+
+    # now try a multi-install
+    snap install "$A_SNAP" "jq"
+    # you get stable from the default track
+    test "$( snap run  jq -r ".data.snaps.\"$A_SNAP\".channel" < /var/lib/snapd/state.json )" = "$A_TRACK/stable"
+
+    # now another
+    snap set core experimental.parallel-instances=true
+    snap install "${A_SNAP}_a" "${A_SNAP}_b"
+    test "$( snap run  jq -r ".data.snaps.\"${A_SNAP}_a\".channel" < /var/lib/snapd/state.json )" = "$A_TRACK/stable"
+    test "$( snap run  jq -r ".data.snaps.\"${A_SNAP}_b\".channel" < /var/lib/snapd/state.json )" = "$A_TRACK/stable"

--- a/tests/main/default-tracks/task.yaml
+++ b/tests/main/default-tracks/task.yaml
@@ -4,10 +4,13 @@ environment:
     A_SNAP: fooxboo1
     A_TRACK: 2.0
 
+prepare: |
+    snap install http jq
+
 execute: |
     # first, sanity check that the snap has a default track
-    curl -s -H Snap-Device-Series:16 "https://api.snapcraft.io/v2/snaps/info/$A_SNAP" > info
-    test "$( jq -r '."default-track"' < info )" == "$A_TRACK"
+    snap run http GET "https://api.snapcraft.io/v2/snaps/info/$A_SNAP" Snap-Device-Series:16 > info
+    test "$( snap run  jq -r '."default-track"' < info )" == "$A_TRACK"
 
     # TODO: check the output of 'snap info' for the default-track-having snap
     # once that works as expected (order of tracks is wrong right now)
@@ -17,4 +20,4 @@ execute: |
     # now install a snap that has a default track
     snap install --candidate "$A_SNAP" | MATCH "$A_TRACK/candidate"
 
-    test "$( jq -r ".data.snaps.\"$A_SNAP\".channel" /var/lib/snapd/state.json )" = "$A_TRACK/candidate"
+    test "$( snap run  jq -r ".data.snaps.\"$A_SNAP\".channel" < /var/lib/snapd/state.json )" = "$A_TRACK/candidate"

--- a/tests/main/default-tracks/task.yaml
+++ b/tests/main/default-tracks/task.yaml
@@ -1,0 +1,20 @@
+summary: Check that default tracks work
+
+environment:
+    A_SNAP: fooxboo1
+    A_TRACK: 2.0
+
+execute: |
+    # first, sanity check that the snap has a default track
+    curl -s -H Snap-Device-Series:16 "https://api.snapcraft.io/v2/snaps/info/$A_SNAP" > info
+    test "$( jq -r '."default-track"' < info )" == "$A_TRACK"
+
+    # TODO: check the output of 'snap info' for the default-track-having snap
+    # once that works as expected (order of tracks is wrong right now)
+
+    # TODO: check error output when trying to install from [default]/stable
+
+    # now install a snap that has a default track
+    snap install --candidate "$A_SNAP" | MATCH "$A_TRACK/candidate"
+
+    test "$( jq -r ".data.snaps.\"$A_SNAP\".channel" /var/lib/snapd/state.json )" = "$A_TRACK/candidate"


### PR DESCRIPTION
This implements default tracks on install.