### PR TITLE
snap: make `snap version` output host without extra whitespace

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -69,7 +69,11 @@ func printVersions(cli *client.Client) error {
 		fmt.Fprintf(w, "kernel\t%s\n", sv.KernelVersion)
 	}
 	if sv.Architecture != "" {
-		fmt.Fprintf(w, "host\t%s %s\n", sv.Architecture, sv.Virtualization)
+		if sv.Virtualization != "" {
+			fmt.Fprintf(w, "host\t%s/%s\n", sv.Architecture, sv.Virtualization)
+		} else {
+			fmt.Fprintf(w, "host\t%s\n", sv.Architecture)
+		}
 	}
 
 	w.Flush()

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\nhost    ia64 \n")
+	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\nhost    ia64\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -54,7 +54,7 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nhost    powerpc qemu\n")
+	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nhost    powerpc/qemu\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 


### PR DESCRIPTION
The current `snap version` output for the "host" added in 2.43
can look like this:
```
$ snap version
...
host amd64 kvm
```
This leads to a parse error in charms that use the snap layer
because the charm expects at most a single whitespace.

This PR implements a possible fix by using a different deliminer:
```
$ snap version
...
host amd64/kvm
```
Alternatively we could simply revert showing the host or use any
different char like: `amd64,kvm` or `amd64(kvm)`. Ideas welcome. 
