### PR TITLE
snap: remove "host" output from `snap version`

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -68,9 +68,6 @@ func printVersions(cli *client.Client) error {
 	if sv.KernelVersion != "" {
 		fmt.Fprintf(w, "kernel\t%s\n", sv.KernelVersion)
 	}
-	if sv.Architecture != "" {
-		fmt.Fprintf(w, "host\t%s %s\n", sv.Architecture, sv.Virtualization)
-	}
 
 	w.Flush()
 

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -39,7 +39,7 @@ func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\nhost    ia64 \n")
+	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -54,7 +54,7 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nhost    powerpc qemu\n")
+	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 


### PR DESCRIPTION
The newly added output of `host $cpu $virtualization` broke existing
software that relied on the fact that `snap version` has a single
whitespace delimiter.

The "host" output was added to help people give us good
information for bugreport. I.e. the "snap version" output should
be part of each bugreport. But conceptually "host" is not a good
fit for the version output so this commit remove it again.

In the future we will provide a "snap debug" command that will
output the relevant version information plus the architecture
and the virtualization environment.
