### PR TITLE
boot: add HasModeenv to Device

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -64,7 +64,7 @@ var _ BootParticipant = trivial{}
 // ensure trivial is a Kernel
 var _ BootKernel = trivial{}
 
-// Device carries information about the devie model and mode that is
+// Device carries information about the device model and mode that is
 // relevant to boot. Note snapstate.DeviceContext implements this, and that's
 // the expected use case.
 type Device interface {
@@ -73,6 +73,8 @@ type Device interface {
 
 	Kernel() string
 	Base() string
+
+	HasModeenv() bool
 }
 
 // Participant figures out what the BootParticipant is for the given
@@ -149,6 +151,7 @@ type bootState interface {
 	// the type's boot snap. actually committing the update
 	// is done via the returned bootStateUpdate's commit.
 	setNext(s snap.PlaceInfo) (rebootRequired bool, u bootStateUpdate, err error)
+
 	// markSuccessful lazily implements marking the boot
 	// successful for the type's boot snap. The actual committing
 	// of the update is done via bootStateUpdate's commit, that

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -245,7 +245,7 @@ func (s *bootSetSuite) TestParticipantBaseWithModel(c *C) {
 
 	type tableT struct {
 		with  *snap.Info
-		model boottest.MockDevice
+		model string
 		nop   bool
 	}
 
@@ -291,10 +291,11 @@ func (s *bootSetSuite) TestParticipantBaseWithModel(c *C) {
 	}
 
 	for i, t := range table {
-		bp := boot.Participant(t.with, t.with.GetType(), t.model)
+		dev := boottest.MockDevice(t.model)
+		bp := boot.Participant(t.with, t.with.GetType(), dev)
 		c.Check(bp.IsTrivial(), Equals, t.nop, Commentf("%d", i))
 		if !t.nop {
-			c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(t.with, t.with.GetType(), t.model))
+			c.Check(bp, DeepEquals, boot.NewCoreBootParticipant(t.with, t.with.GetType(), dev))
 		}
 	}
 }
@@ -305,7 +306,7 @@ func (s *bootSetSuite) TestKernelWithModel(c *C) {
 	expected := boot.NewCoreKernel(info)
 
 	type tableT struct {
-		model boottest.MockDevice
+		model string
 		nop   bool
 		krn   boot.BootKernel
 	}
@@ -331,7 +332,8 @@ func (s *bootSetSuite) TestKernelWithModel(c *C) {
 	}
 
 	for _, t := range table {
-		krn := boot.Kernel(info, snap.TypeKernel, t.model)
+		dev := boottest.MockDevice(t.model)
+		krn := boot.Kernel(info, snap.TypeKernel, dev)
 		c.Check(krn.IsTrivial(), Equals, t.nop)
 		c.Check(krn, DeepEquals, t.krn)
 	}

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -386,3 +386,24 @@ func (s *bootSetSuite) TestMarkBootSuccessfulKKernelUpdate(c *C) {
 		"snap_kernel": "k2",
 	})
 }
+func (s *bootSetSuite) TestMarkBootSuccessfulBaseUpdate(c *C) {
+	coreDev := boottest.MockDevice("some-snap")
+
+	s.bootloader.BootVars["snap_mode"] = "trying"
+	s.bootloader.BootVars["snap_core"] = "os1"
+	s.bootloader.BootVars["snap_kernel"] = "k1"
+	s.bootloader.BootVars["snap_try_core"] = "os2"
+	s.bootloader.BootVars["snap_try_kernel"] = ""
+	err := boot.MarkBootSuccessful(coreDev)
+	c.Assert(err, IsNil)
+	c.Assert(s.bootloader.BootVars, DeepEquals, map[string]string{
+		// cleared
+		"snap_mode":     "",
+		"snap_try_core": "",
+		// unchanged
+		"snap_kernel":     "k1",
+		"snap_try_kernel": "",
+		// updated
+		"snap_core": "os2",
+	})
+}

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -38,7 +38,7 @@ func MockDevice(s string) boot.Device {
 	return &mockDevice{str: s}
 }
 
-// MockUC20Device implements boot.Device and returns true for HasModeenv
+// MockUC20Device implements boot.Device and returns true for HasModeenv.
 func MockUC20Device(s string) boot.Device {
 	return &mockDevice{str: s, uc20: true}
 }
@@ -59,7 +59,7 @@ func (d *mockDevice) Base() string   { return d.snapAndMode()[0] }
 func (d *mockDevice) Classic() bool  { return d.snapAndMode()[0] == "" }
 func (d *mockDevice) RunMode() bool  { return d.snapAndMode()[1] == "run" }
 
-// HasModeenv is true when created with uc20 string
+// HasModeenv is true when created with uc20 string.
 func (d *mockDevice) HasModeenv() bool {
 	return d.uc20
 }

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -21,16 +21,30 @@ package boottest
 
 import (
 	"strings"
+
+	"github.com/snapcore/snapd/boot"
 )
+
+type mockDevice struct {
+	str  string
+	uc20 bool
+}
 
 // MockDevice implements boot.Device. It wraps a string like
 // <boot-snap-name>[@<mode>], no <boot-snap-name> means classic, no
 // <mode> defaults to "run". It returns <boot-snap-name> for both
 // Base and Kernel, for more control mock a DeviceContext.
-type MockDevice string
+func MockDevice(s string) boot.Device {
+	return &mockDevice{str: s}
+}
 
-func (d MockDevice) snapAndMode() []string {
-	parts := strings.SplitN(string(d), "@", 2)
+// MockUC20Device implements boot.Device and returns true for HasModeenv
+func MockUC20Device(s string) boot.Device {
+	return &mockDevice{str: s, uc20: true}
+}
+
+func (d *mockDevice) snapAndMode() []string {
+	parts := strings.SplitN(string(d.str), "@", 2)
 	if len(parts) == 1 {
 		return append(parts, "run")
 	}
@@ -40,7 +54,12 @@ func (d MockDevice) snapAndMode() []string {
 	return parts
 }
 
-func (d MockDevice) Kernel() string { return d.snapAndMode()[0] }
-func (d MockDevice) Base() string   { return d.snapAndMode()[0] }
-func (d MockDevice) Classic() bool  { return d.snapAndMode()[0] == "" }
-func (d MockDevice) RunMode() bool  { return d.snapAndMode()[1] == "run" }
+func (d *mockDevice) Kernel() string { return d.snapAndMode()[0] }
+func (d *mockDevice) Base() string   { return d.snapAndMode()[0] }
+func (d *mockDevice) Classic() bool  { return d.snapAndMode()[0] == "" }
+func (d *mockDevice) RunMode() bool  { return d.snapAndMode()[1] == "run" }
+
+// HasModeenv is true when created with uc20 string
+func (d *mockDevice) HasModeenv() bool {
+	return d.uc20
+}

--- a/boot/boottest/modeenv.go
+++ b/boot/boottest/modeenv.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boottest
+
+import (
+	"os"
+
+	"github.com/snapcore/snapd/boot"
+)
+
+// ForceModeenv forces ReadModeenv to always return a specific Modeenv for a
+// given root dir, returning a restore function to reset to the old behavior.
+// If rootdir is empty, then all invocations return the specified modeenv
+func ForceModeenv(rootdir string, m *boot.Modeenv) func() {
+	old := boot.ReadModeenv
+	boot.ReadModeenv = func(callerrootdir string) (*boot.Modeenv, error) {
+		if rootdir == "" || callerrootdir == rootdir {
+			return m, nil
+		}
+
+		// all other cases return doesn't exist
+		return nil, os.ErrNotExist
+	}
+
+	return func() {
+		boot.ReadModeenv = old
+	}
+}

--- a/boot/boottest/modeenv.go
+++ b/boot/boottest/modeenv.go
@@ -28,9 +28,8 @@ import (
 // ForceModeenv forces ReadModeenv to always return a specific Modeenv for a
 // given root dir, returning a restore function to reset to the old behavior.
 // If rootdir is empty, then all invocations return the specified modeenv
-func ForceModeenv(rootdir string, m *boot.Modeenv) func() {
-	old := boot.ReadModeenv
-	boot.ReadModeenv = func(callerrootdir string) (*boot.Modeenv, error) {
+func ForceModeenv(rootdir string, m *boot.Modeenv) (restore func()) {
+	mock := func(callerrootdir string) (*boot.Modeenv, error) {
 		if rootdir == "" || callerrootdir == rootdir {
 			return m, nil
 		}
@@ -39,7 +38,5 @@ func ForceModeenv(rootdir string, m *boot.Modeenv) func() {
 		return nil, os.ErrNotExist
 	}
 
-	return func() {
-		boot.ReadModeenv = old
-	}
+	return boot.MockReadModeenv(mock)
 }

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -44,11 +44,25 @@ type Modeenv struct {
 	read bool
 }
 
-var ReadModeenv = readModeenv
+var readModeenv = readModeenvImpl
 
-// readModeenv will attempt to read the file specified by
-// "rootdir/dirs.SnapModeenvFile" as a Modeenv
-func readModeenv(rootdir string) (*Modeenv, error) {
+// ReadModeenvImpl attempts to read the file specified by
+// "rootdir/dirs.SnapModeenvFile" as a Modeenv.
+func ReadModeenv(rootdir string) (*Modeenv, error) {
+	return readModeenv(rootdir)
+}
+
+// MockReadModeenv replaces the current implementation of ReadModeenv with a
+// mocked one. For use in tests.
+func MockReadModeenv(f func(rootdir string) (*Modeenv, error)) (restore func()) {
+	old := readModeenv
+	readModeenv = f
+	return func() {
+		readModeenv = old
+	}
+}
+
+func readModeenvImpl(rootdir string) (*Modeenv, error) {
 	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
 	cfg := goconfigparser.New()
 	cfg.AllowNoSectionHeader = true

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -46,7 +46,7 @@ type Modeenv struct {
 
 var readModeenv = readModeenvImpl
 
-// ReadModeenvImpl attempts to read the file specified by
+// ReadModeenv attempts to read the file specified by
 // "rootdir/dirs.SnapModeenvFile" as a Modeenv.
 func ReadModeenv(rootdir string) (*Modeenv, error) {
 	return readModeenv(rootdir)

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -62,8 +62,15 @@ func MockReadModeenv(f func(rootdir string) (*Modeenv, error)) (restore func()) 
 	}
 }
 
+func modeenvFile(rootdir string) string {
+	if rootdir == "" {
+		rootdir = dirs.GlobalRootDir
+	}
+	return dirs.SnapModeenvFileUnder(rootdir)
+}
+
 func readModeenvImpl(rootdir string) (*Modeenv, error) {
-	modeenvPath := dirs.SnapModeenvFileUnder(rootdir)
+	modeenvPath := modeenvFile(rootdir)
 	cfg := goconfigparser.New()
 	cfg.AllowNoSectionHeader = true
 	if err := cfg.ReadFile(modeenvPath); err != nil {
@@ -89,7 +96,7 @@ func (m *Modeenv) Unset() bool {
 
 // Write outputs the modeenv to the file at <rootdir>/var/lib/snapd/modeenv.
 func (m *Modeenv) Write(rootdir string) error {
-	modeenvPath := dirs.SnapModeenvFileUnder(rootdir)
+	modeenvPath := modeenvFile(rootdir)
 
 	if err := os.MkdirAll(filepath.Dir(modeenvPath), 0755); err != nil {
 		return err

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -44,7 +44,11 @@ type Modeenv struct {
 	read bool
 }
 
-func ReadModeenv(rootdir string) (*Modeenv, error) {
+var ReadModeenv = readModeenv
+
+// readModeenv will attempt to read the file specified by
+// "rootdir/dirs.SnapModeenvFile" as a Modeenv
+func readModeenv(rootdir string) (*Modeenv, error) {
 	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
 	cfg := goconfigparser.New()
 	cfg.AllowNoSectionHeader = true
@@ -69,6 +73,8 @@ func (m *Modeenv) Unset() bool {
 	return !m.read
 }
 
+// Write outputs the modeenv to the file specified by
+// "rootdir/dirs.SnapModeenvFile".
 func (m *Modeenv) Write(rootdir string) error {
 	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
 

--- a/boot/modeenv.go
+++ b/boot/modeenv.go
@@ -46,8 +46,8 @@ type Modeenv struct {
 
 var readModeenv = readModeenvImpl
 
-// ReadModeenv attempts to read the file specified by
-// "rootdir/dirs.SnapModeenvFile" as a Modeenv.
+// ReadModeenv attempts to read the modeenv file at
+// <rootdir>/var/iib/snapd/modeenv.
 func ReadModeenv(rootdir string) (*Modeenv, error) {
 	return readModeenv(rootdir)
 }
@@ -63,7 +63,7 @@ func MockReadModeenv(f func(rootdir string) (*Modeenv, error)) (restore func()) 
 }
 
 func readModeenvImpl(rootdir string) (*Modeenv, error) {
-	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
+	modeenvPath := dirs.SnapModeenvFileUnder(rootdir)
 	cfg := goconfigparser.New()
 	cfg.AllowNoSectionHeader = true
 	if err := cfg.ReadFile(modeenvPath); err != nil {
@@ -87,10 +87,9 @@ func (m *Modeenv) Unset() bool {
 	return !m.read
 }
 
-// Write outputs the modeenv to the file specified by
-// "rootdir/dirs.SnapModeenvFile".
+// Write outputs the modeenv to the file at <rootdir>/var/lib/snapd/modeenv.
 func (m *Modeenv) Write(rootdir string) error {
-	modeenvPath := filepath.Join(rootdir, dirs.SnapModeenvFile)
+	modeenvPath := dirs.SnapModeenvFileUnder(rootdir)
 
 	if err := os.MkdirAll(filepath.Dir(modeenvPath), 0755); err != nil {
 		return err

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -226,6 +226,11 @@ func SnapStateFileUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "state.json")
 }
 
+// SnapModeenvFileUnder returns the path to the modeenv file under rootdir.
+func SnapModeenvFileUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "modeenv")
+}
+
 // SetRootDir allows settings a new global root directory, this is useful
 // for e.g. chroot operations
 func SetRootDir(rootdir string) {
@@ -282,7 +287,7 @@ func SetRootDir(rootdir string) {
 	SnapSeedDir = SnapSeedDirUnder(rootdir)
 	SnapDeviceDir = filepath.Join(rootdir, snappyDir, "device")
 
-	SnapModeenvFile = filepath.Join(rootdir, snappyDir, "modeenv")
+	SnapModeenvFile = SnapModeenvFileUnder(rootdir)
 
 	SnapRepairDir = filepath.Join(rootdir, snappyDir, "repair")
 	SnapRepairStateFile = filepath.Join(SnapRepairDir, "repair.json")

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -95,6 +95,12 @@ func (dc groundDeviceContext) RunMode() bool {
 	return dc.operatingMode == "run"
 }
 
+// HasModeenv is true if the grade is set
+// TODO:UC20: will classic devices with uc20 models have a modeenv? I think so?
+func (dc groundDeviceContext) HasModeenv() bool {
+	return dc.model.Grade() != asserts.ModelGradeUnset
+}
+
 // sanity
 var _ snapstate.DeviceContext = &groundDeviceContext{}
 

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -901,6 +901,8 @@ func (s *deviceMgrRemodelSuite) TestDeviceCtxNoTask(c *C) {
 	c.Check(deviceCtx.Kernel(), Equals, "kernel")
 	c.Check(deviceCtx.Base(), Equals, "")
 	c.Check(deviceCtx.RunMode(), Equals, true)
+	// not a uc20 model, so no modeenv
+	c.Check(deviceCtx.HasModeenv(), Equals, false)
 }
 
 func (s *deviceMgrRemodelSuite) TestDeviceCtxGroundContext(c *C) {

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -211,4 +211,9 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20Happy(c *C) {
 	err = state.Get("seed-time", &seedTime)
 	c.Assert(err, IsNil)
 	c.Check(seedTime.IsZero(), Equals, false)
+
+	// check that the default device ctx has a Modeenv
+	dev, err := devicestate.DeviceCtx(s.overlord.State(), nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(dev.HasModeenv(), Equals, true)
 }

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -66,6 +66,10 @@ func (dc *TrivialDeviceContext) Base() string {
 	return dc.DeviceModel.Base()
 }
 
+func (dc *TrivialDeviceContext) HasModeenv() bool {
+	return dc.Model().Grade() != asserts.ModelGradeUnset
+}
+
 func (dc *TrivialDeviceContext) RunMode() bool {
 	return dc.OperatingMode() == "run"
 }


### PR DESCRIPTION
This is the first of 3 PR's meant to supersede #7947. 

Here, we add a `HasModeenv()` method which in most implementations just checks that the model is not `ModelGradeUnset`. In the MockDevice implementation, I had to refactor a bit because it is useful to mock a simple device like this but still easily control whether HasModeenv returns true. That isn't used much in this PR though I will comment with a link to my other PR when that's open with an example there of how it's used for context.

Also some miscellaneous, but related changes: 
- Add a unit test around updating just the base snap
- Add a testing function to force a Modeenv to be read whenever ReadModeenv is called, this way ended up being cleaner than my other idea which was to mock that actual file for every test that needs it, as this is just in memory and easily undone. 
- Fix some typos / doc-comments
- Add some simple checks in standard places where we should have a Modeenv and where we shouldn't have a Modeenv.