### PR TITLE
bootloader: add ExtractedRunKernelImageBootloader interface, implement in grub

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -220,11 +220,9 @@ func makeBootable20RunMode(model *asserts.Model, rootdir string, bootWith *Boota
 
 	// get the ubuntu-boot bootloader
 	opts := &bootloader.Options{
-		// TODO:UC20: we use "recovery: true" here because on
-		// the partition the file layout of ubuntu-boot looks
-		// the same as ubuntu-seed.
-		// TODO:UC20: need a better name than recovery
-		Recovery: true,
+		// At this point the run mode bootloader is under the native
+		// layout, no /boot mount.
+		NoSlashBoot: true,
 	}
 	bl, err := bootloader.Find(filepath.Join(runMnt, "ubuntu-boot"), opts)
 	if err != nil {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -46,6 +46,10 @@ type Options struct {
 	// UC16/18 do not have a recovery partition.
 	Recovery bool
 
+	// NoSlashBoot indicates to use the run mode bootloader but
+	// under the native layout and not the /boot mount.
+	NoSlashBoot bool
+
 	// ExtractedRunKernelImage is whether to force kernel asset extraction.
 	ExtractedRunKernelImage bool
 }

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -87,6 +87,15 @@ type RecoveryAwareBootloader interface {
 	SetRecoverySystemEnv(recoverySystemDir string, values map[string]string) error
 }
 
+type ExtractedRunKernelImageBootloader interface {
+	Bootloader
+	EnableKernel(snap.PlaceInfo) error        // makes the symlink
+	EnableTryKernel(snap.PlaceInfo) error     // makes the symlink
+	Kernel() (snap.PlaceInfo, error)          // gives the symlink
+	TryKernel() (snap.PlaceInfo, bool, error) // gives the symlink (if exists)
+	DisableTryKernel() error                  // removes the symlink
+}
+
 func genericInstallBootConfig(gadgetFile, systemFile string) (bool, error) {
 	if !osutil.FileExists(gadgetFile) {
 		return false, nil

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -172,10 +172,8 @@ func ForceError(err error) {
 	forcedError = err
 }
 
-func extractKernelAssetsToBootDir(bootDir string, s snap.PlaceInfo, snapf snap.Container) error {
+func extractKernelAssetsToBootDir(dstDir string, s snap.PlaceInfo, snapf snap.Container, assets []string) error {
 	// now do the kernel specific bits
-	blobName := filepath.Base(s.MountFile())
-	dstDir := filepath.Join(bootDir, blobName)
 	if err := os.MkdirAll(dstDir, 0755); err != nil {
 		return err
 	}
@@ -185,7 +183,7 @@ func extractKernelAssetsToBootDir(bootDir string, s snap.PlaceInfo, snapf snap.C
 	}
 	defer dir.Close()
 
-	for _, src := range []string{"kernel.img", "initrd.img"} {
+	for _, src := range assets {
 		if err := snapf.Unpack(src, dstDir); err != nil {
 			return err
 		}
@@ -193,11 +191,7 @@ func extractKernelAssetsToBootDir(bootDir string, s snap.PlaceInfo, snapf snap.C
 			return err
 		}
 	}
-	if err := snapf.Unpack("dtbs/*", dstDir); err != nil {
-		return err
-	}
-
-	return dir.Sync()
+	return nil
 }
 
 func removeKernelAssetsFromBootDir(bootDir string, s snap.PlaceInfo) error {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -46,7 +46,7 @@ type Options struct {
 	// UC16/18 do not have a recovery partition.
 	Recovery bool
 
-	// ExtractedRunKernelImage is whether to force kernel asset extraction
+	// ExtractedRunKernelImage is whether to force kernel asset extraction.
 	ExtractedRunKernelImage bool
 }
 
@@ -70,7 +70,7 @@ type Bootloader interface {
 	// is found ok is false.
 	InstallBootConfig(gadgetDir string, opts *Options) (ok bool, err error)
 
-	// ExtractKernelAssets extracts kernel assets from the given kernel snap
+	// ExtractKernelAssets extracts kernel assets from the given kernel snap.
 	ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error
 
 	// RemoveKernelAssets removes the assets for the given kernel snap.

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -45,6 +45,9 @@ type Options struct {
 	// Recovery indicates to use the recovery bootloader. Note that
 	// UC16/18 do not have a recovery partition.
 	Recovery bool
+
+	// ExtractedRunKernelImage is whether to force kernel asset extraction
+	ExtractedRunKernelImage bool
 }
 
 // Bootloader provides an interface to interact with the system

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -147,14 +147,14 @@ func (b *MockBootloader) SetRollbackAcrossReboot() error {
 }
 
 // InstallBootConfig installs the boot config in the gadget directory to the
-// mock bootloader's root directory
+// mock bootloader's root directory.
 func (b *MockBootloader) InstallBootConfig(gadgetDir string, opts *bootloader.Options) (bool, error) {
 	b.InstallBootConfigCalled = append(b.InstallBootConfigCalled, gadgetDir)
 	return b.InstallBootConfigResult, b.InstallBootConfigErr
 }
 
 // SetRecoverySystemEnv sets the recovery system environment bootloader
-// variables; part of RecoveryAwareBootloader
+// variables; part of RecoveryAwareBootloader.
 func (b *MockBootloader) SetRecoverySystemEnv(recoverySystemDir string, blVars map[string]string) error {
 	if recoverySystemDir == "" {
 		panic("MockBootloader.SetRecoverySystemEnv called without recoverySystemDir")
@@ -167,7 +167,7 @@ func (b *MockBootloader) SetRecoverySystemEnv(recoverySystemDir string, blVars m
 // SetRunKernelImageEnabledKernel sets the current kernel "symlink" as returned
 // by Kernel(); returns' a restore function to set it back to what it was
 // before.
-func (b *MockBootloader) SetRunKernelImageEnabledKernel(kernel snap.PlaceInfo) func() {
+func (b *MockBootloader) SetRunKernelImageEnabledKernel(kernel snap.PlaceInfo) (restore func()) {
 	old := b.runKernelImageEnabledKernel
 	b.runKernelImageEnabledKernel = kernel
 	return func() {
@@ -179,7 +179,7 @@ func (b *MockBootloader) SetRunKernelImageEnabledKernel(kernel snap.PlaceInfo) f
 // returned by TryKernel(). If set to nil, TryKernel()'s second return value
 // will be false; returns' a restore function to set it back to what it was
 // before.
-func (b *MockBootloader) SetRunKernelImageEnabledTryKernel(kernel snap.PlaceInfo) func() {
+func (b *MockBootloader) SetRunKernelImageEnabledTryKernel(kernel snap.PlaceInfo) (restore func()) {
 	old := b.runKernelImageEnabledTryKernel
 	b.runKernelImageEnabledTryKernel = kernel
 	return func() {
@@ -187,10 +187,10 @@ func (b *MockBootloader) SetRunKernelImageEnabledTryKernel(kernel snap.PlaceInfo
 	}
 }
 
-// SetRunKernelImageErrorFunction allows setting an error to be returned for the
+// SetRunKernelImageFunctionError allows setting an error to be returned for the
 // specified function; it returns a restore function to set it back to what it
-// was before
-func (b *MockBootloader) SetRunKernelImageErrorFunction(f string, err error) func() {
+// was before.
+func (b *MockBootloader) SetRunKernelImageFunctionError(f string, err error) (restore func()) {
 	// check the function
 	switch f {
 	case "EnableKernel", "EnableTryKernel", "Kernel", "TryKernel", "DisableTryKernel":
@@ -204,9 +204,9 @@ func (b *MockBootloader) SetRunKernelImageErrorFunction(f string, err error) fun
 	}
 }
 
-// GetRunKernelImageFunctionSnapCalls returns what snap calls were specified
-// during execution, in order as well as the number of calls for methods that
-// don't take args
+// GetRunKernelImageFunctionSnapCalls returns which snaps were specified during
+// execution, in order of calls, as well as the number of calls for methods that
+// don't take a snap to set.
 func (b *MockBootloader) GetRunKernelImageFunctionSnapCalls(f string) ([]snap.PlaceInfo, int) {
 	switch f {
 	case "EnableKernel":
@@ -222,21 +222,21 @@ func (b *MockBootloader) GetRunKernelImageFunctionSnapCalls(f string) ([]snap.Pl
 	}
 }
 
-// EnableKernel enables the kernel; part of ExtractedRunKernelImageBootloader
+// EnableKernel enables the kernel; part of ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) EnableKernel(s snap.PlaceInfo) error {
 	b.runKernelImageEnableKernelCalls = append(b.runKernelImageEnableKernelCalls, s)
 	return b.runKernelImageMockedErrs["EnableKernel"]
 }
 
 // EnableTryKernel enables a try-kernel; part of
-// ExtractedRunKernelImageBootloader
+// ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) EnableTryKernel(s snap.PlaceInfo) error {
 	b.runKernelImageEnableTryKernelCalls = append(b.runKernelImageEnableTryKernelCalls, s)
 	return b.runKernelImageMockedErrs["EnableTryKernel"]
 }
 
 // Kernel returns the current kernel set in the bootloader; part of
-// ExtractedRunKernelImageBootloader
+// ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) Kernel() (snap.PlaceInfo, error) {
 	b.runKernelImageMockedNumCalls["Kernel"]++
 	err := b.runKernelImageMockedErrs["Kernel"]
@@ -247,7 +247,7 @@ func (b *MockBootloader) Kernel() (snap.PlaceInfo, error) {
 }
 
 // TryKernel returns the current kernel set in the bootloader; part of
-// ExtractedRunKernelImageBootloader
+// ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) TryKernel() (snap.PlaceInfo, bool, error) {
 	b.runKernelImageMockedNumCalls["TryKernel"]++
 	err := b.runKernelImageMockedErrs["TryKernel"]
@@ -261,7 +261,7 @@ func (b *MockBootloader) TryKernel() (snap.PlaceInfo, bool, error) {
 }
 
 // DisableTryKernel removes the current try-kernel "symlink" set in the
-// bootloader; part of ExtractedRunKernelImageBootloader
+// bootloader; part of ExtractedRunKernelImageBootloader.
 func (b *MockBootloader) DisableTryKernel() error {
 	b.runKernelImageMockedNumCalls["DisableTryKernel"]++
 	return b.runKernelImageMockedErrs["DisableTryKernel"]

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -46,6 +46,16 @@ type MockBootloader struct {
 
 	RecoverySystemDir      string
 	RecoverySystemBootVars map[string]string
+
+	runKernelImageEnableKernelCalls     []snap.PlaceInfo
+	runKernelImageEnableTryKernelCalls  []snap.PlaceInfo
+	runKernelImageDisableKernelCalls    []snap.PlaceInfo
+	runKernelImageDisableTryKernelCalls []snap.PlaceInfo
+	runKernelImageEnabledKernel         snap.PlaceInfo
+	runKernelImageEnabledTryKernel      snap.PlaceInfo
+
+	runKernelImageMockedErrs     map[string]error
+	runKernelImageMockedNumCalls map[string]int
 }
 
 // ensure MockBootloader implements the Bootloader interface
@@ -57,6 +67,9 @@ func Mock(name, bootdir string) *MockBootloader {
 		bootdir: bootdir,
 
 		BootVars: make(map[string]string),
+
+		runKernelImageMockedErrs:     make(map[string]error),
+		runKernelImageMockedNumCalls: make(map[string]int),
 	}
 }
 
@@ -133,11 +146,15 @@ func (b *MockBootloader) SetRollbackAcrossReboot() error {
 	return nil
 }
 
+// InstallBootConfig installs the boot config in the gadget directory to the
+// mock bootloader's root directory
 func (b *MockBootloader) InstallBootConfig(gadgetDir string, opts *bootloader.Options) (bool, error) {
 	b.InstallBootConfigCalled = append(b.InstallBootConfigCalled, gadgetDir)
 	return b.InstallBootConfigResult, b.InstallBootConfigErr
 }
 
+// SetRecoverySystemEnv sets the recovery system environment bootloader
+// variables; part of RecoveryAwareBootloader
 func (b *MockBootloader) SetRecoverySystemEnv(recoverySystemDir string, blVars map[string]string) error {
 	if recoverySystemDir == "" {
 		panic("MockBootloader.SetRecoverySystemEnv called without recoverySystemDir")
@@ -145,4 +162,107 @@ func (b *MockBootloader) SetRecoverySystemEnv(recoverySystemDir string, blVars m
 	b.RecoverySystemDir = recoverySystemDir
 	b.RecoverySystemBootVars = blVars
 	return nil
+}
+
+// SetRunKernelImageEnabledKernel sets the current kernel "symlink" as returned
+// by Kernel(); returns' a restore function to set it back to what it was
+// before.
+func (b *MockBootloader) SetRunKernelImageEnabledKernel(kernel snap.PlaceInfo) func() {
+	old := b.runKernelImageEnabledKernel
+	b.runKernelImageEnabledKernel = kernel
+	return func() {
+		b.runKernelImageEnabledKernel = old
+	}
+}
+
+// SetRunKernelImageEnabledTryKernel sets the current try-kernel "symlink" as
+// returned by TryKernel(). If set to nil, TryKernel()'s second return value
+// will be false; returns' a restore function to set it back to what it was
+// before.
+func (b *MockBootloader) SetRunKernelImageEnabledTryKernel(kernel snap.PlaceInfo) func() {
+	old := b.runKernelImageEnabledTryKernel
+	b.runKernelImageEnabledTryKernel = kernel
+	return func() {
+		b.runKernelImageEnabledTryKernel = old
+	}
+}
+
+// SetRunKernelImageErrorFunction allows setting an error to be returned for the
+// specified function; it returns a restore function to set it back to what it
+// was before
+func (b *MockBootloader) SetRunKernelImageErrorFunction(f string, err error) func() {
+	// check the function
+	switch f {
+	case "EnableKernel", "EnableTryKernel", "Kernel", "TryKernel", "DisableTryKernel":
+		old := b.runKernelImageMockedErrs[f]
+		b.runKernelImageMockedErrs[f] = err
+		return func() {
+			b.runKernelImageMockedErrs[f] = old
+		}
+	default:
+		panic(fmt.Sprintf("unknown ExtractedRunKernelImageBootloader method %q to mock error for", f))
+	}
+}
+
+// GetRunKernelImageFunctionSnapCalls returns what snap calls were specified
+// during execution, in order as well as the number of calls for methods that
+// don't take args
+func (b *MockBootloader) GetRunKernelImageFunctionSnapCalls(f string) ([]snap.PlaceInfo, int) {
+	switch f {
+	case "EnableKernel":
+		l := b.runKernelImageEnableKernelCalls
+		return l, len(l)
+	case "EnableTryKernel":
+		l := b.runKernelImageEnableTryKernelCalls
+		return l, len(l)
+	case "Kernel", "TryKernel", "DisableTryKernel":
+		return nil, b.runKernelImageMockedNumCalls[f]
+	default:
+		panic(fmt.Sprintf("unknown ExtractedRunKernelImageBootloader method %q to return snap args for", f))
+	}
+}
+
+// EnableKernel enables the kernel; part of ExtractedRunKernelImageBootloader
+func (b *MockBootloader) EnableKernel(s snap.PlaceInfo) error {
+	b.runKernelImageEnableKernelCalls = append(b.runKernelImageEnableKernelCalls, s)
+	return b.runKernelImageMockedErrs["EnableKernel"]
+}
+
+// EnableTryKernel enables a try-kernel; part of
+// ExtractedRunKernelImageBootloader
+func (b *MockBootloader) EnableTryKernel(s snap.PlaceInfo) error {
+	b.runKernelImageEnableTryKernelCalls = append(b.runKernelImageEnableTryKernelCalls, s)
+	return b.runKernelImageMockedErrs["EnableTryKernel"]
+}
+
+// Kernel returns the current kernel set in the bootloader; part of
+// ExtractedRunKernelImageBootloader
+func (b *MockBootloader) Kernel() (snap.PlaceInfo, error) {
+	b.runKernelImageMockedNumCalls["Kernel"]++
+	err := b.runKernelImageMockedErrs["Kernel"]
+	if err != nil {
+		return nil, err
+	}
+	return b.runKernelImageEnabledKernel, nil
+}
+
+// TryKernel returns the current kernel set in the bootloader; part of
+// ExtractedRunKernelImageBootloader
+func (b *MockBootloader) TryKernel() (snap.PlaceInfo, bool, error) {
+	b.runKernelImageMockedNumCalls["TryKernel"]++
+	err := b.runKernelImageMockedErrs["TryKernel"]
+	if err != nil {
+		return nil, false, err
+	}
+	if b.runKernelImageEnabledTryKernel == nil {
+		return nil, false, nil
+	}
+	return b.runKernelImageEnabledTryKernel, true, nil
+}
+
+// DisableTryKernel removes the current try-kernel "symlink" set in the
+// bootloader; part of ExtractedRunKernelImageBootloader
+func (b *MockBootloader) DisableTryKernel() error {
+	b.runKernelImageMockedNumCalls["DisableTryKernel"]++
+	return b.runKernelImageMockedErrs["DisableTryKernel"]
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -40,6 +40,8 @@ type grub struct {
 	rootdir string
 
 	basedir string
+
+	uefiRunKernelExtraction bool
 }
 
 // newGrub create a new Grub bootloader object
@@ -52,6 +54,9 @@ func newGrub(rootdir string, opts *Options) RecoveryAwareBootloader {
 	}
 	if !osutil.FileExists(g.ConfigFile()) {
 		return nil
+	}
+	if opts != nil {
+		g.uefiRunKernelExtraction = opts.ExtractedRunKernelImage
 	}
 
 	return g

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -209,10 +209,9 @@ func (g *grub) makeKernelEfiSymlink(s snap.PlaceInfo, name string) error {
 // was incorrectly created.
 func (g *grub) unlinkKernelEfiSymlink(name string) error {
 	symlink := filepath.Join(g.dir(), name)
-	// check that the symlink exists
-	if _, err := os.Lstat(symlink); err == nil {
-		// symlink exists, remove it unconditionally
-		return os.Remove(symlink)
+	err := os.Remove(symlink)
+	if err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -219,6 +219,9 @@ func (g *grub) readKernelSymlink(name string) (snap.PlaceInfo, error) {
 
 // actual ExtractedRunKernelImageBootloader methods
 
+// EnableKernel will install a kernel.efi symlink on the bootloader pointing
+// to the referenced kernel snap. EnableKernel() will fail if the referenced
+// kernel snap does not exist.
 func (g *grub) EnableKernel(s snap.PlaceInfo) error {
 	// add symlink from ubuntuBootPartition/kernel.efi to
 	// <ubuntu-boot>/EFI/ubuntu/<snap-name>.snap/kernel.efi
@@ -227,6 +230,9 @@ func (g *grub) EnableKernel(s snap.PlaceInfo) error {
 	return g.makeKernelEfiSymlink(s, "kernel.efi")
 }
 
+// EnableTryKernel will install a try-kernel.efi symlink on the bootloader
+// pointing towards the referenced kernel snap. EnableTryKernel() will fail if
+// the referenced kernel snap does not exist.
 func (g *grub) EnableTryKernel(s snap.PlaceInfo) error {
 	// add symlink from ubuntuBootPartition/kernel.efi to
 	// <ubuntu-boot>/EFI/ubuntu/<snap-name>.snap/kernel.efi
@@ -235,16 +241,24 @@ func (g *grub) EnableTryKernel(s snap.PlaceInfo) error {
 	return g.makeKernelEfiSymlink(s, "try-kernel.efi")
 }
 
+// DisableTryKernel will remove the try-kernel.efi symlink if it exists. Note
+// that when performing an update, you should probably first use EnableKernel(),
+// then DisableTryKernel() for maximum safety.
 func (g *grub) DisableTryKernel() error {
 	return g.unlinkKernelEfiSymlink("try-kernel.efi")
 }
 
+// Kernel will return the kernel snap currently installed on the bootloader at
+// the kernel.efi symlink.
 func (g *grub) Kernel() (snap.PlaceInfo, error) {
 	return g.readKernelSymlink("kernel.efi")
 }
 
+// TryKernel will return the kernel snap currently being tried if it exists and
+// false if there is not currently a try-kernel.efi symlink. Note if the symlink
+// exists but does not point to an existing file an error will be returned.
 func (g *grub) TryKernel() (snap.PlaceInfo, bool, error) {
-	// try to read the symlink from ubuntuBootPartition/try-kernel.efi
+	// try to read the symlink from <rootdir>/try-kernel.efi
 	if osutil.FileExists(filepath.Join(g.rootdir, "try-kernel.efi")) {
 		p, err := g.readKernelSymlink("try-kernel.efi")
 		// if we failed to read the symlink, then the try kernel isn't usable,

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -48,7 +48,7 @@ type grub struct {
 // newGrub create a new Grub bootloader object
 func newGrub(rootdir string, opts *Options) RecoveryAwareBootloader {
 	g := &grub{rootdir: rootdir}
-	if opts != nil && opts.Recovery {
+	if opts != nil && (opts.Recovery || opts.NoSlashBoot) {
 		g.basedir = "EFI/ubuntu"
 	} else {
 		g.basedir = "boot/grub"

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -214,9 +214,7 @@ func (g *grub) unlinkKernelEfiSymlink(name string) error {
 		// symlink exists, remove it unconditionally
 		return os.Remove(symlink)
 	}
-
-	// return more helpful error if the symlink doesn't exist
-	return fmt.Errorf("cannot disable kernel, symlink %s missing", symlink)
+	return nil
 }
 
 func (g *grub) readKernelSymlink(name string) (snap.PlaceInfo, error) {
@@ -232,16 +230,15 @@ func (g *grub) readKernelSymlink(name string) (snap.PlaceInfo, error) {
 
 	targetKernelEfi, err := os.Readlink(link)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't read %s symlink: %v", link, err)
+		return nil, fmt.Errorf("cannot read %s symlink: %v", link, err)
 	}
 
 	kernelSnapFileName := filepath.Base(filepath.Dir(targetKernelEfi))
 	sn, err := snap.ParsePlaceInfoFromSnapFileName(kernelSnapFileName)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"bad kernel snap file path at %q (from symlink %q), unable to parse into snap file name: %v",
+			"cannot parse kernel snap file name from symlink target %q: %v",
 			kernelSnapFileName,
-			link,
 			err,
 		)
 	}
@@ -250,9 +247,9 @@ func (g *grub) readKernelSymlink(name string) (snap.PlaceInfo, error) {
 
 // actual ExtractedRunKernelImageBootloader methods
 
-// EnableKernel will install a kernel.efi symlink on the bootloader pointing
-// to the referenced kernel snap. EnableKernel() will fail if the referenced
-// kernel snap does not exist.
+// EnableKernel will install a kernel.efi symlink in the bootloader partition,
+// pointing to the referenced kernel snap. EnableKernel() will fail if the
+// referenced kernel snap does not exist.
 func (g *grub) EnableKernel(s snap.PlaceInfo) error {
 	// add symlink from ubuntuBootPartition/kernel.efi to
 	// <ubuntu-boot>/EFI/ubuntu/<snap-name>.snap/kernel.efi
@@ -261,9 +258,9 @@ func (g *grub) EnableKernel(s snap.PlaceInfo) error {
 	return g.makeKernelEfiSymlink(s, "kernel.efi")
 }
 
-// EnableTryKernel will install a try-kernel.efi symlink on the bootloader
-// pointing towards the referenced kernel snap. EnableTryKernel() will fail if
-// the referenced kernel snap does not exist.
+// EnableTryKernel will install a try-kernel.efi symlink in the bootloader
+// partition, pointing towards the referenced kernel snap. EnableTryKernel()
+// will fail if the referenced kernel snap does not exist.
 func (g *grub) EnableTryKernel(s snap.PlaceInfo) error {
 	// add symlink from ubuntuBootPartition/kernel.efi to
 	// <ubuntu-boot>/EFI/ubuntu/<snap-name>.snap/kernel.efi
@@ -279,8 +276,8 @@ func (g *grub) DisableTryKernel() error {
 	return g.unlinkKernelEfiSymlink("try-kernel.efi")
 }
 
-// Kernel will return the kernel snap currently installed on the bootloader at
-// the kernel.efi symlink.
+// Kernel will return the kernel snap currently installed in the bootloader
+// partition, pointed to by the kernel.efi symlink.
 func (g *grub) Kernel() (snap.PlaceInfo, error) {
 	return g.readKernelSymlink("kernel.efi")
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -315,8 +315,8 @@ func (s *grubTestSuite) makeKernelAssetSnapAndSymlink(c *C, snapFileName, symlin
 
 	// make a kernel.efi symlink to the kernel.efi above
 	err := os.Symlink(
-		filepath.Join("EFI/ubuntu/", snapFileName, "kernel.efi"),
-		filepath.Join(s.rootdir, symlinkName),
+		filepath.Join(snapFileName, "kernel.efi"),
+		filepath.Join(s.grubRecoveryDir(), symlinkName),
 	)
 	c.Assert(err, IsNil)
 
@@ -352,14 +352,14 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageTryKernelMethod(c *C) {
 	// appropriately
 	kernelSnapExtractedAssetsDir := filepath.Join(s.grubRecoveryDir(), "bad_snap_rev_name")
 	badKernelSnapPath := filepath.Join(kernelSnapExtractedAssetsDir, "kernel.efi")
-	tryKernelSymlink := filepath.Join(s.rootdir, "try-kernel.efi")
+	tryKernelSymlink := filepath.Join(s.grubRecoveryDir(), "try-kernel.efi")
 	err = os.MkdirAll(kernelSnapExtractedAssetsDir, 0755)
 	c.Assert(err, IsNil)
 
 	err = ioutil.WriteFile(badKernelSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	err = os.Symlink("EFI/ubuntu/bad_snap_rev_name/kernel.efi", tryKernelSymlink)
+	err = os.Symlink("bad_snap_rev_name/kernel.efi", tryKernelSymlink)
 	c.Assert(err, IsNil)
 
 	_, exists, err = eg.TryKernel()
@@ -398,7 +398,7 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableKernelMethod(c *C) 
 	nonExistSnap, err := snap.ParsePlaceInfoFromSnapFileName("pc-kernel_12.snap")
 	c.Assert(err, IsNil)
 	err = eg.EnableKernel(nonExistSnap)
-	c.Assert(err, ErrorMatches, "cannot enable kernel.efi at EFI/ubuntu/pc-kernel_12.snap/kernel.efi: file does not exist")
+	c.Assert(err, ErrorMatches, "cannot enable kernel.efi at pc-kernel_12.snap/kernel.efi: file does not exist")
 
 	kernel := s.makeKernelAssetSnap(c, "pc-kernel_1.snap")
 
@@ -407,10 +407,10 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableKernelMethod(c *C) 
 	c.Assert(err, IsNil)
 
 	// ensure that the symlink was put where we expect it
-	asset, err := os.Readlink(filepath.Join(s.rootdir, "kernel.efi"))
+	asset, err := os.Readlink(filepath.Join(s.grubRecoveryDir(), "kernel.efi"))
 	c.Assert(err, IsNil)
 
-	c.Assert(asset, DeepEquals, filepath.Join("EFI/ubuntu", "pc-kernel_1.snap", "kernel.efi"))
+	c.Assert(asset, DeepEquals, filepath.Join("pc-kernel_1.snap", "kernel.efi"))
 }
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableTryKernelMethod(c *C) {
@@ -426,10 +426,10 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableTryKernelMethod(c *
 	c.Assert(err, IsNil)
 
 	// ensure that the symlink was put where we expect it
-	asset, err := os.Readlink(filepath.Join(s.rootdir, "try-kernel.efi"))
+	asset, err := os.Readlink(filepath.Join(s.grubRecoveryDir(), "try-kernel.efi"))
 	c.Assert(err, IsNil)
 
-	c.Assert(asset, DeepEquals, filepath.Join("EFI/ubuntu", "pc-kernel_1.snap", "kernel.efi"))
+	c.Assert(asset, DeepEquals, filepath.Join("pc-kernel_1.snap", "kernel.efi"))
 }
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageDisableTryKernelMethod(c *C) {

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -367,7 +367,7 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageTryKernel(c *C) {
 	c.Assert(err, IsNil)
 
 	_, exists, err = eg.TryKernel()
-	c.Assert(err, ErrorMatches, "bad kernel snap file path at \"bad_snap_rev_name\".*")
+	c.Assert(err, ErrorMatches, "cannot parse kernel snap file name from symlink target \"bad_snap_rev_name\": .*")
 	c.Assert(exists, Equals, false)
 
 	// remove the bad symlink
@@ -442,10 +442,10 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageDisableTryKernel(c *C) {
 	eg, ok := g.(bootloader.ExtractedRunKernelImageBootloader)
 	c.Assert(ok, Equals, true)
 
-	// trying to disable when the try-kernel.efi symlink is missing produces an
-	// error
+	// trying to disable when the try-kernel.efi symlink is missing does not
+	// raise any errors
 	err := eg.DisableTryKernel()
-	c.Assert(err, ErrorMatches, "cannot disable kernel, symlink .* missing")
+	c.Assert(err, IsNil)
 
 	// make the symlink and check that the symlink is missing afterwards
 	s.makeKernelAssetSnapAndSymlink(c, "pc-kernel_1.snap", "try-kernel.efi")

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -109,7 +109,9 @@ func (u *uboot) GetBootVars(names ...string) (map[string]string, error) {
 }
 
 func (u *uboot) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
-	return extractKernelAssetsToBootDir(u.dir(), s, snapf)
+	dstDir := filepath.Join(u.dir(), filepath.Base(s.MountFile()))
+	assets := []string{"kernel.img", "initrd.img", "dtbs/*"}
+	return extractKernelAssetsToBootDir(dstDir, s, snapf, assets)
 }
 
 func (u *uboot) RemoveKernelAssets(s snap.PlaceInfo) error {


### PR DESCRIPTION
This is the second followup to supersede #7947.

This adds a new Bootloader interface implementation, ExtractedRunKernelImageBootloader, which isn't currently used anywhere here, but will be used in `bootState20` in the next PR here and also in `makeBootable20RunMode` (also in the next PR). 

I thought it would be easier to review if I broke out the interface changes and the grub implementation of this interface before opening the full thing, though I still intend to open the next PR and provide pointers here to show how certain parts are used. 