### PR TITLE
devicestate: enable encryption based on model grade

### DIFF
--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -116,8 +116,8 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func checkEncryption(model *asserts.Model) (bool, error) {
-	encryptionRequested := model.Grade() == asserts.ModelSecured
 	// TODO:UC20: also check if TPM is available, and return an error if the device must be
-	//            encrypted but but we don't have TPM support
-	return encryptionRequested, nil
+	//            encrypted but we don't have TPM support
+
+	return model.Grade() == asserts.ModelSecured, nil
 }


### PR DESCRIPTION
Models with grade set to "secured" should have their data partition
encrypted if the hardware has such capability. We still must check
for TPM availability and this will be added in a forthcoming PR
along with the rest of TPM sealing support (the key is currently
stored in plaintext).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>