### PR TITLE
cmd/snap-discard-ns: fix pattern for .info files

### DIFF
--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
     sc_must_snprintf(usr_fstab_pattern, sizeof usr_fstab_pattern, "snap\\.%s\\.*\\.user-fstab", snap_instance_name);
     sc_must_snprintf(sys_mnt_pattern, sizeof sys_mnt_pattern, "%s\\.mnt", snap_instance_name);
     sc_must_snprintf(usr_mnt_pattern, sizeof usr_mnt_pattern, "%s\\.*\\.mnt", snap_instance_name);
-    sc_must_snprintf(sys_info_pattern, sizeof sys_info_pattern, "%s\\.*\\.info", snap_instance_name);
+    sc_must_snprintf(sys_info_pattern, sizeof sys_info_pattern, "snap\\.%s\\.info", snap_instance_name);
 
     DIR* ns_dir = fdopendir(ns_dir_fd);
     if (ns_dir == NULL) {

--- a/tests/main/snap-discard-ns/task.yaml
+++ b/tests/main/snap-discard-ns/task.yaml
@@ -42,7 +42,7 @@ execute: |
     $LIBEXECDIR/snapd/snap-discard-ns test-snapd-tools
     test ! -e /run/snapd/ns/test-snapd-tools.mnt
     test ! -e /run/snapd/ns/test-snapd-tools.1000.mnt
-    test ! -e /run/snapd/ns/test-snapd-tools.info
+    test ! -e /run/snapd/ns/snap.test-snapd-tools.info
 
     echo "We can fake a current mount profile and see that it is removed too"
     test-snapd-tools.success


### PR DESCRIPTION
The pattern used to identify and remove mount namespace information
files was wrong. This patch fixes it and corrects the spread test that
checked for the absence of the wrong file.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
Fixes: https://bugs.launchpad.net/snapd/+bug/1859629