### PR TITLE
debian: check embedded keys for snap-{bootstrap,preseed} too

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -204,9 +204,11 @@ override_dh_auto_test:
 # a tested default (production) build should have no test keys
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# check that only the main trusted account-keys are included
-	[ $$(strings _build/bin/snapd|grep -c -E "public-key-sha3-384: [a-zA-Z0-9_-]{64}") -eq 2 ]
-	strings _build/bin/snapd|grep -c "^public-key-sha3-384: -CvQKAwRQ5h3Ffn10FILJoEZUXOv6km9FwA80-Rcj-f-6jadQ89VRswHNiEB9Lxk$$"
-	strings _build/bin/snapd|grep -c "^public-key-sha3-384: d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa$$"
+	for b in _build/bin/snapd _build/bin/snap-bootstrap _build/bin/snap-preseed; do \
+	  [ $$(strings $$b |grep -c -E "public-key-sha3-384: [a-zA-Z0-9_-]{64}") -eq 2 ] && \
+	  strings $$b |grep -c "^public-key-sha3-384: -CvQKAwRQ5h3Ffn10FILJoEZUXOv6km9FwA80-Rcj-f-6jadQ89VRswHNiEB9Lxk$$" && \
+	  strings $$b |grep -c "^public-key-sha3-384: d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa$$"; \
+	done;
 	# same for snap-repair
 	[ $$(strings _build/bin/snap-repair|grep -c -E "public-key-sha3-384: [a-zA-Z0-9_-]{64}") -eq 3 ]
 	# common with snapd


### PR DESCRIPTION
This commit adds a check to ensure that the embedded keys for
snap-{bootstrap,preseed} are correct.
