### PR TITLE
httputil: use shorter timeout in TestRetryRequestTimeoutHandling

### DIFF
--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -383,7 +383,7 @@ func (s *retrySuite) TestRetryRequestTimeoutHandling(c *C) {
 	defer close(finished)
 
 	cli := httputil.NewHTTPClient(&httputil.ClientOptions{
-		Timeout: 50 * time.Millisecond,
+		Timeout: 25 * time.Millisecond,
 	})
 
 	url := ""


### PR DESCRIPTION
We saw some failures in the PPA and release builds on slower
architectures in the TestRetryRequestTimeoutHandling test. It
looks like 5 retry with 50ms timeout with the test retry
strategy of 1s on slow HW can mean sometimes the retries are not
done within the 1s limit. This commit changes the client timeout
to 25ms and leaves the test retry strategy timeout unchanged.

The full error for reference:
```
FAIL: retry_test.go:359: retrySuite.TestRetryRequestTimeoutHandling

retry_test.go:411:
    // check that we exhausted all retries (as defined by mocked retry strategy)
    c.Assert(permanentlyBrokenSrvCalls.Count(), Equals, 5)
... obtained int = 4
... expected int = 5
```
