### PR TITLE
api: don't return connections referring to non-existing plugs/slots

### DIFF
--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -134,6 +134,18 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 		if err != nil {
 			return nil, err
 		}
+
+		// plug or slot not in the repository, e.g. cref is referring to an
+		// inactive revision of the snap; this can happen when the new revision
+		// doesn't have given plug/slot anymore (but the connection state is
+		// kept in case of revert).
+		// XXX: if we decide to show such connections with special tags, then
+		// this needs to be tweaked together with collectFilter definition and
+		// connectionJSON output.
+		if repo.Plug(cref.PlugRef.Snap, cref.PlugRef.Name) == nil || repo.Slot(cref.SlotRef.Snap, cref.SlotRef.Name) == nil {
+			continue
+		}
+
 		if !filter.plugOrConnectedSlotMatches(&cref.PlugRef, nil) && !filter.slotOrConnectedPlugMatches(&cref.SlotRef, nil) {
 			continue
 		}

--- a/daemon/api_connections_test.go
+++ b/daemon/api_connections_test.go
@@ -303,49 +303,49 @@ func (s *apiSuite) TestConnectionsMissingPlugSlotFilteredOut(c *check.C) {
 			missingPlugOrSlot: map[string]interface{}{
 				"interface": "test",
 			},
-		}, 
-		[]string{"consumer:plug producer:slot"}, 
-		map[string]interface{}{
-			"result": map[string]interface{}{
-				"plugs": []interface{}{
-					map[string]interface{}{
-						"snap":      "consumer",
-						"plug":      "plug",
-						"interface": "test",
-						"attrs":     map[string]interface{}{"key": "value"},
-						"apps":      []interface{}{"app"},
-						"label":     "label",
-						"connections": []interface{}{
-							map[string]interface{}{"snap": "producer", "slot": "slot"},
+		},
+			[]string{"consumer:plug producer:slot"},
+			map[string]interface{}{
+				"result": map[string]interface{}{
+					"plugs": []interface{}{
+						map[string]interface{}{
+							"snap":      "consumer",
+							"plug":      "plug",
+							"interface": "test",
+							"attrs":     map[string]interface{}{"key": "value"},
+							"apps":      []interface{}{"app"},
+							"label":     "label",
+							"connections": []interface{}{
+								map[string]interface{}{"snap": "producer", "slot": "slot"},
+							},
+						},
+					},
+					"slots": []interface{}{
+						map[string]interface{}{
+							"snap":      "producer",
+							"slot":      "slot",
+							"interface": "test",
+							"attrs":     map[string]interface{}{"key": "value"},
+							"apps":      []interface{}{"app"},
+							"label":     "label",
+							"connections": []interface{}{
+								map[string]interface{}{"snap": "consumer", "plug": "plug"},
+							},
+						},
+					},
+					"established": []interface{}{
+						map[string]interface{}{
+							"plug":      map[string]interface{}{"snap": "consumer", "plug": "plug"},
+							"slot":      map[string]interface{}{"snap": "producer", "slot": "slot"},
+							"manual":    true,
+							"interface": "test",
 						},
 					},
 				},
-				"slots": []interface{}{
-					map[string]interface{}{
-						"snap":      "producer",
-						"slot":      "slot",
-						"interface": "test",
-						"attrs":     map[string]interface{}{"key": "value"},
-						"apps":      []interface{}{"app"},
-						"label":     "label",
-						"connections": []interface{}{
-							map[string]interface{}{"snap": "consumer", "plug": "plug"},
-						},
-					},
-				},
-				"established": []interface{}{
-					map[string]interface{}{
-						"plug":      map[string]interface{}{"snap": "consumer", "plug": "plug"},
-						"slot":      map[string]interface{}{"snap": "producer", "slot": "slot"},
-						"manual":    true,
-						"interface": "test",
-					},
-				},
-			},
-			"status":      "OK",
-			"status-code": 200.0,
-			"type":        "sync",
-		})
+				"status":      "OK",
+				"status-code": 200.0,
+				"type":        "sync",
+			})
 	}
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -254,6 +254,9 @@ type ConnectionState struct {
 }
 
 // ConnectionStates return the state of connections stored in the state.
+// Note that this includes inactive connections (i.e. referring to non-
+// existing plug/slots), so this map must be cross-referenced with current
+// snap info if needed.
 // The state must be locked by the caller.
 func ConnectionStates(st *state.State) (connStateByRef map[string]ConnectionState, err error) {
 	states, err := getConns(st)

--- a/tests/main/snap-connections/task.yaml
+++ b/tests/main/snap-connections/task.yaml
@@ -1,5 +1,15 @@
 summary: Check that "snap connections" works as expected
 
+prepare: |
+    snap pack test-snap.v1
+    snap pack test-snap.v2
+
+restore: |
+    rm -f ./*.snap
+    snap remove test-snap || true
+    snap remove network-consumer || true
+    snap remove test-snapd-daemon-notify || true
+
 execute: |
     # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
@@ -71,3 +81,18 @@ execute: |
 
     not snap connections not-found > error.out 2>&1
     MATCH 'error: snap "not-found" not found' < error.out
+
+    echo "Check that connection referring to a missing plug is not reported after a refresh to new revision"
+    snap install --dangerous test-snap_1_all.snap
+    snap connect test-snap:log-observe
+    # sanity check, connection exists
+    snap connections test-snap | MATCH "log-observe +test-snap:log-observe +:log-observe +manual"
+
+    # simulate refresh to a new revision that doesn't have log-observe plug
+    snap install --dangerous test-snap_2_all.snap
+    snap connections test-snap | not MATCH "log-observe"
+
+    echo "But after revert it is reported again"
+    snap revert test-snap
+    snap connections test-snap | MATCH "log-observe +test-snap:log-observe +:log-observe +manual"
+

--- a/tests/main/snap-connections/test-snap.v1/meta/snap.yaml
+++ b/tests/main/snap-connections/test-snap.v1/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snap
+version: 1
+summary: Basic test snap
+
+plugs:
+  log-observe:
+

--- a/tests/main/snap-connections/test-snap.v2/meta/snap.yaml
+++ b/tests/main/snap-connections/test-snap.v2/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snap
+version: 2
+summary: Basic test snap
+
+plugs:
+  home:


### PR DESCRIPTION
Filter out connections obtained from "conns" in the state if respective plug or slot is missing. This can happen after a refresh to a new revision that doesn't have given plug/slot (we keep such connections in state in case of revert).

This fixes LP: #1848516; there was an earlier fix https://github.com/snapcore/snapd/pull/7683 that fixed the problem for auto-connections (only), but the one here is also effective for manual connections.

Fixes: https://bugs.launchpad.net/snapd/+bug/1848516
