### PR TITLE
tests: skip interfaces-network-manager on arm devices

### DIFF
--- a/tests/main/interfaces-network-manager/task.yaml
+++ b/tests/main/interfaces-network-manager/task.yaml
@@ -12,7 +12,9 @@ details: |
 # boards because the (wifi) network is already managed by netplan
 # there and when n-m gets installed/removed it will hang when
 # trying to deconfigure the wifi network which is already owned.
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-18-64, ubuntu-core-18-32, ubuntu-core-20-64, ubuntu-core-20-32]
+# TODO:UC20: Enable test once Network Manager snap properly works
+# on core20 system
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-18-64, ubuntu-core-18-32]
 
 prepare: |
     echo "Give a network-manager snap is installed"

--- a/tests/main/interfaces-network-manager/task.yaml
+++ b/tests/main/interfaces-network-manager/task.yaml
@@ -12,7 +12,7 @@ details: |
 # boards because the (wifi) network is already managed by netplan
 # there and when n-m gets installed/removed it will hang when
 # trying to deconfigure the wifi network which is already owned.
-systems: [ubuntu-core-1*-64, ubuntu-core-1*-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-18-64, ubuntu-core-18-32, ubuntu-core-20-64, ubuntu-core-20-32]
 
 prepare: |
     echo "Give a network-manager snap is installed"


### PR DESCRIPTION
The test interfaces-network-manager is being executed on arm devices,
and as it is specified in the test comments.

This is the comment in the test:

run only against the amd64 VM, we cannot run this on arm/arm64
boards because the (wifi) network is already managed by netplan
there and when n-m gets installed/removed it will hang when
trying to deconfigure the wifi network which is already owned.

This is the test I did to see why the test is being executed:

sergio@cachiomachine:~/workspace/snapcore/snapd$ spread -list
external:ubuntu-core-16-arm-32: | grep network-manager
external:ubuntu-core-16-arm-32:tests/main/interfaces-network-manager
