### PR TITLE
tests: remove execution of ubuntu 19.04 from google backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
         - git fetch --unshallow
         - ./tests/lib/cla_check.py
     - stage: integration
-      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.04, Core 16, Core 18
+      name: Ubuntu 14.04, 16.04, 18.04, 18.10, 19.10, Core 16, Core 18, Core 20
       dist: xenial
       addons:
         apt:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -632,7 +632,7 @@ pkg_dependencies_ubuntu_classic(){
                 packagekit
                 "
             ;;
-        ubuntu-19.04-64|ubuntu-19.10-64)
+        ubuntu-19.10-64)
             echo "
                 evolution-data-server
                 fwupd

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure apt hooks work
 
 # apt hook only available on 18.04+ and aws-cli only for amd64
-systems: [ubuntu-18.04-64, ubuntu-19.04-64, ubuntu-19.10-64]
+systems: [ubuntu-18.04-64, ubuntu-19.10-64]
 
 manual: true
 

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -15,14 +15,9 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems:
-    # Ships xdg-desktop-portal 0.11
-    - ubuntu-18.04-*
-
-    # Ships xdg-desktop-portal 1.2.0
-    - ubuntu-19.04-*
-
-    - ubuntu-19.10-*
+# ubuntu-18.04-*: Ships xdg-desktop-portal 0.11
+# ubuntu-19.10-*: Ships xdg-desktop-portal 1.2.0
+systems: [ubuntu-18.04-*, ubuntu-19.10-*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -9,10 +9,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems:
-  - ubuntu-18.04-*
-  - ubuntu-19.04-*
-  - ubuntu-19.10-*
+systems: [ubuntu-18.04-*, ubuntu-19.10-*]
 
 environment:
     EDITOR_HISTORY: /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -6,9 +6,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems:
-  - ubuntu-18.04-*
-  - ubuntu-19.04-*
+systems: [ubuntu-18.04-*, ubuntu-19.10-*]
 
 environment:
     BROWSER_HISTORY: /tmp/browser-history.txt

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -20,10 +20,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems:
-  - ubuntu-18.04-*
-  - ubuntu-19.04-*
-  - ubuntu-19.10-*
+systems: [ubuntu-18.04-*, ubuntu-19.10-*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -5,7 +5,7 @@ systems: [ ubuntu-1*-*64, ubuntu-2*-*64 ]
 
 environment:
     PLAY_FILE: "/snap/test-snapd-audio-record/current/usr/share/sounds/alsa/Noise.wav"
-    # today, only 19.04 and 19.10 have a mediating pulseaudio
+    # today, only 19.10 has a mediating pulseaudio
     EXFAIL: "ubuntu-1[468]"
 
 prepare: |

--- a/tests/main/seccomp-statx/task.yaml
+++ b/tests/main/seccomp-statx/task.yaml
@@ -8,7 +8,7 @@ details: |
 # This test will only pass on Ubuntu 18.10 and on other systems with seccomp
 # 2.3.3 or newer. Eventually with some tricks we should be able to support all
 # systems but for the purpose of snapd 2.36 this is the best we can do.
-systems: [ubuntu-19.04-*]
+systems: [ubuntu-19.10-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh

--- a/tests/main/snapd-slow-startup/task.yaml
+++ b/tests/main/snapd-slow-startup/task.yaml
@@ -1,6 +1,6 @@
 summary: Test that snapd is not terminated by systemd on a slow startup
 
-systems: [ubuntu-18.04-64,ubuntu-19.04-64]
+systems: [ubuntu-18.04-64, ubuntu-19.10-64]
 
 restore: |
     # extra cleanup in case something in this test went wrong


### PR DESCRIPTION
Tests are not going to be executed on ubuntu 19.04 anymore. 