### PR TITLE
render: add the render package and basic widgets

### DIFF
--- a/render/export_test.go
+++ b/render/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package render
+
+var ComposeStripes = composeStripes

--- a/render/heuristic/heuristic.go
+++ b/render/heuristic/heuristic.go
@@ -1,0 +1,87 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package heuristic
+
+import (
+	"unicode"
+)
+
+// RuneWidth returns the width of a given rune.
+//
+// Non-graphic runes have width of zero. Most graphical runes have the width of
+// one.  Some graphics runes have width of two.  Those include hiragana,
+// katakana, han/kanji and hangul.
+func RuneWidth(r rune) int {
+	if !unicode.IsGraphic(r) {
+		return 0
+	}
+	if !unicode.In(r, unicode.Hiragana, unicode.Katakana, unicode.Hangul, unicode.Han) {
+		return 1
+	}
+	return 2
+}
+
+// TerminalRenderSize returns the size of given text as rendered on a terminal.
+//
+// This is a heuristic because terminal emulators have bugs and features that
+// make it impossible to determine the size perfectly. The return value should
+// be correct in all practical cases, though, and is perfectly sufficient for
+// computing alignment and positioning.
+//
+// The heuristic is based on the following observation:
+// - graphic have certain width (see RuneWidth)
+// - some control characters are handled (\n, \r, \t, \v and \b)
+func TerminalRenderSize(text string) (width, height int) {
+	width = 0
+	height = 1
+	n := 0
+	for _, r := range text {
+		switch {
+		case unicode.IsGraphic(r):
+			n += RuneWidth(r)
+		case unicode.IsControl(r):
+			switch r {
+			case '\n':
+				if n > width {
+					width = n
+				}
+				height++
+				n = 0
+			case '\r':
+				if n > width {
+					width = n
+				}
+				n = 0
+			case '\t':
+				n += 8
+			case '\v':
+				height++
+			case '\b':
+				if n > 0 {
+					n--
+				}
+			}
+		}
+	}
+	if n > width {
+		width = n
+	}
+	return width, height
+}

--- a/render/heuristic/heuristic_test.go
+++ b/render/heuristic/heuristic_test.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package heuristic_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render/heuristic"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type heuristicSuite struct{}
+
+var _ = Suite(&heuristicSuite{})
+
+func (s *heuristicSuite) TestRuneWidth(c *C) {
+	c.Check(heuristic.RuneWidth('a'), Equals, 1)
+	c.Check(heuristic.RuneWidth('ф'), Equals, 1)
+	c.Check(heuristic.RuneWidth('ひ'), Equals, 2)
+	c.Check(heuristic.RuneWidth('カ'), Equals, 2)
+	c.Check(heuristic.RuneWidth('漢'), Equals, 2)
+	c.Check(heuristic.RuneWidth('한'), Equals, 2)
+	c.Check(heuristic.RuneWidth('ע'), Equals, 1)
+	c.Check(heuristic.RuneWidth('λ'), Equals, 1)
+	c.Check(heuristic.RuneWidth('\n'), Equals, 0)
+}
+
+func (s *heuristicSuite) TestTerminalRenderSize(c *C) {
+	for _, t := range []struct {
+		s    string
+		w, h int
+	}{
+		{s: "", w: 0, h: 1},
+		{s: "alphabet", w: 8, h: 1},
+		{s: "алфавит", w: 7, h: 1},
+		{s: "ひらがな", w: 8, h: 1},
+		{s: "カタカナ", w: 8, h: 1},
+		{s: "漢字", w: 4, h: 1},
+		{s: "한글", w: 4, h: 1},
+		{s: "עברית", w: 5, h: 1},
+		{s: "Ελληνική", w: 8, h: 1},
+		{s: "\n", w: 0, h: 2},
+		{s: "\t", w: 8, h: 1},
+		{s: "\v", w: 0, h: 2},
+		{s: "hi\r", w: 2, h: 1},
+		{s: "hi\rt", w: 2, h: 1},
+		{s: "hi\rthere", w: 5, h: 1},
+		{s: "hi\b", w: 1, h: 1},
+		{s: "1 2 3", w: 5, h: 1},
+	} {
+		comment := Commentf("s: %q", t.s)
+		w, h := heuristic.TerminalRenderSize(t.s)
+		c.Check(w, Equals, t.w, comment)
+		c.Check(h, Equals, t.h, comment)
+	}
+}

--- a/render/render.go
+++ b/render/render.go
@@ -1,0 +1,196 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package render
+
+import (
+	"os"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/snapcore/snapd/render/heuristic"
+)
+
+// Point contains the X and Y coordinates.
+//
+// The coordinate system is such that (0, 0) is the top-left corner of the
+// screen/terminal. X axis grows towards the right while the Y axis grows
+// towards the bottom.
+type Point struct {
+	X int
+	Y int
+}
+
+// Size contains the width and height.
+type Size struct {
+	Width  int
+	Height int
+}
+
+// Stripe represents a horizontal stripe to be rendered.
+type Stripe struct {
+	X, Y     int
+	ScanLine string
+}
+
+// RenderWidth returns the number of cells the stripe takes after rendering.
+func (s *Stripe) RenderWidth() int {
+	w, _ := heuristic.TerminalRenderSize(s.ScanLine)
+	return w
+}
+
+// Widget is anything that can be displayed.
+//
+// Widgets can be rendered into a number of stripes, perfect for writing to a
+// terminal.  Internally one widget can contain other widgets. The way they are
+// all positioned given a fixed amount of horizontal space (vertical space is
+// assumed to be unconstrained) can be determined by Pack. After that the
+// precise location of each widget can be queried by Size and Position.
+type Widget interface {
+	// Pack computes the size and position of the widget given the available
+	// width and its current position. Pack may alter the size of the widget
+	// and can resize and move any constituent widgets.
+	Pack(widthAvailable int)
+
+	// Render slices the widget into a number of stripes that are easier to
+	// print to a stream or display on a terminal.
+	Render() []Stripe
+
+	// Position returns the coordinate of the top-left corner of the widget.
+	Position() Point
+	// Move re-positions the widget without changing its size.
+	Move(to Point)
+	// Size returns the width and height of the widget.
+	Size() Size
+	// Resize reshapes the widget without changing the location of the top-left corner.
+	Resize(to Size)
+}
+
+// inPaintOrder allows sorting stripes by their (Y, X) coordinates.
+type inPaintOrder []Stripe
+
+func (stripes inPaintOrder) Len() int {
+	return len(stripes)
+}
+
+func (stripes inPaintOrder) Less(i, j int) bool {
+	if stripes[i].Y == stripes[j].Y {
+		return stripes[i].X < stripes[j].X
+	}
+	return stripes[i].Y < stripes[j].Y
+}
+
+func (stripes inPaintOrder) Swap(i, j int) {
+	stripes[i], stripes[j] = stripes[j], stripes[i]
+}
+
+// composeStripes composites a number of stripes and prints them to a stream.
+func composeStripes(f *os.File, stripes []Stripe) {
+	// Sort the stripes in paint order. This allows for single pass printing to
+	// the given stream.
+	sort.Sort(inPaintOrder(stripes))
+
+	// Find the size of the canvas we are rendering. Maximum Y is easy, it's
+	// the Y of the last stripe. Maximum X is more costly since we don't know
+	// how many stripes are on the last line.
+	var maxX, maxY int
+	if n := len(stripes); n > 0 {
+		maxY = stripes[n-1].Y
+	}
+	for _, stripe := range stripes {
+		if x := stripe.X + stripe.RenderWidth(); x > maxX {
+			maxX = x
+		}
+	}
+
+	// Using a one-line buffer render each each line, consuming stripes in
+	// order. This bounds the complexity of the render algorithm to O(N) +
+	// O(Nlog(N)).
+	lineBuffer := make([][]rune, maxX)
+	for i := range lineBuffer {
+		lineBuffer[i] = make([]rune, 1)
+	}
+	sIdx := 0 // index to the current stripe we are considering.
+	sEnd := len(stripes)
+	for y := 0; y <= maxY; y += 1 {
+		// Reset the line buffer.
+		for i := 0; i < maxX; i++ {
+			if len(lineBuffer[i]) == 0 {
+				lineBuffer[i] = append(lineBuffer[i], ' ')
+			} else {
+				lineBuffer[i][0] = ' '
+			}
+		}
+		// Advance to the first stripe for the line we want to render.
+		for ; sIdx < sEnd; sIdx++ {
+			if stripes[sIdx].Y >= y {
+				break
+			}
+		}
+		// Composite all stripes for current Y index.
+		for ; sIdx < sEnd; sIdx++ {
+			if stripes[sIdx].Y != y {
+				break
+			}
+			x := stripes[sIdx].X
+			for _, r := range stripes[sIdx].ScanLine {
+				switch heuristic.RuneWidth(r) {
+				case 0:
+					lineBuffer[x] = lineBuffer[x][:0]
+				case 1:
+					if len(lineBuffer[x]) == 0 {
+						lineBuffer[x] = append(lineBuffer[x], r)
+					} else {
+						lineBuffer[x][0] = r
+					}
+					x++
+				case 2:
+					if len(lineBuffer[x]) == 0 {
+						lineBuffer[x] = append(lineBuffer[x], r)
+					} else {
+						lineBuffer[x][0] = r
+					}
+					lineBuffer[x+1] = lineBuffer[x+1][:0]
+					x += 2
+				}
+			}
+		}
+
+		// Strip trailing white-space to avoid printing a big rectangle.
+		var right int
+		for right = maxX - 1; right >= 0; right-- {
+			if rb := lineBuffer[right]; len(rb) > 0 && rb[0] != ' ' {
+				break
+			}
+		}
+		utf8Buffer := make([]byte, 16)
+		for i := 0; i <= right; i++ {
+			if runes := lineBuffer[i]; len(runes) > 0 {
+				n := utf8.EncodeRune(utf8Buffer, runes[0])
+				f.Write(utf8Buffer[:n])
+			}
+		}
+		f.Write([]byte{'\n'})
+	}
+}
+
+func Display(f *os.File, w Widget) {
+	w.Pack(80) // XXX: can we guess that from stream?
+	composeStripes(f, w.Render())
+}

--- a/render/render.go
+++ b/render/render.go
@@ -72,7 +72,9 @@ type Widget interface {
 	// print to a stream or display on a terminal.
 	Render() []Stripe
 
-	// Position returns the coordinate of the top-left corner of the widget.
+	// Position returns the coordinate of the top-left corner of the widget
+	// relative to the parent, if any. Relative positioning allows a widget to
+	// be re-positioned without affecting its children.
 	Position() Point
 	// Move re-positions the widget without changing its size.
 	Move(to Point)

--- a/render/render.go
+++ b/render/render.go
@@ -207,9 +207,10 @@ func composeStripes(f *os.File, stripes []Stripe) {
 					}
 					x += 2
 				}
-			}
-			if x > localMaxX {
-				localMaxX = x
+				// As long as we're not printing spaces, keep track of localMaxX
+				if r != ' ' && x > localMaxX {
+					localMaxX = x
+				}
 			}
 		}
 

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package render_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type renderSuite struct {
+	stdout *os.File
+}
+
+func (s *renderSuite) StdoutText() string {
+	s.stdout.Seek(0, 0)
+	blob, err := ioutil.ReadAll(s.stdout)
+	if err != nil {
+		panic(err)
+	}
+	return string(blob)
+}
+
+var _ = Suite(&renderSuite{})
+
+func (s *renderSuite) SetUpTest(c *C) {
+	f, err := ioutil.TempFile("", "stdout-*.txt")
+	c.Assert(err, IsNil)
+	s.stdout = f
+}
+
+func (s *renderSuite) TearDownTest(c *C) {
+	if s.stdout != nil {
+		defer s.stdout.Close()
+		os.Remove(s.stdout.Name())
+	}
+}
+
+func (s *renderSuite) TestComposeStripes(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 10, Y: 2, ScanLine: "Render   "},
+		{X: 10, Y: 3, ScanLine: "This  "},
+		{X: 8, Y: 2, ScanLine: "-"},
+		{X: 8, Y: 2, ScanLine: "*"}, // overlap
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"\n"+
+		"\n"+
+		"        * Render\n"+
+		"          This\n"+
+		"")
+}
+
+func (s *renderSuite) TestComposeHiragana(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{{ScanLine: "ひ"}})
+	c.Check(s.StdoutText(), Equals, "ひ\n")
+}
+
+func (s *renderSuite) TestComposeOverwriteDoubleWidth(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "0123456789"},
+		{X: 0, Y: 1, ScanLine: "abcdefghij"},
+		// Overwrite 'b' and 'c' above with hiragana 'HI' syllable.
+		{X: 1, Y: 1, ScanLine: "ひ"},
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"0123456789\n"+
+		"aひdefghij\n"+
+		"")
+}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -79,15 +79,80 @@ func (s *renderSuite) TestComposeHiragana(c *C) {
 	c.Check(s.StdoutText(), Equals, "ひ\n")
 }
 
-func (s *renderSuite) TestComposeOverwriteDoubleWidth(c *C) {
+// Overwrite 'a' and 'b' with hiragana 'HI' syllable.
+func (s *renderSuite) TestComposeOverwriteTwoCellslignedEven(c *C) {
 	render.ComposeStripes(s.stdout, []render.Stripe{
 		{X: 0, Y: 0, ScanLine: "0123456789"},
 		{X: 0, Y: 1, ScanLine: "abcdefghij"},
-		// Overwrite 'b' and 'c' above with hiragana 'HI' syllable.
+		{X: 0, Y: 1, ScanLine: "ひ"},
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"0123456789\n"+
+		"ひcdefghij\n"+
+		"")
+}
+
+// Overwrite 'b' and 'c' with hiragana 'HI' syllable.
+func (s *renderSuite) TestComposeOverwriteTwoCellsAlignedOdd(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "0123456789"},
+		{X: 0, Y: 1, ScanLine: "abcdefghij"},
 		{X: 1, Y: 1, ScanLine: "ひ"},
 	})
 	c.Check(s.StdoutText(), Equals, ""+
 		"0123456789\n"+
 		"aひdefghij\n"+
+		"")
+}
+
+// Overwrite the first half of hiragana 'HI' syllable with 'i'.
+func (s *renderSuite) TestComposeOverwriteFirstHalfAlignedEven(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "0123456789"},
+		{X: 0, Y: 1, ScanLine: "あいうえお"},
+		{X: 2, Y: 1, ScanLine: "i"},
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"0123456789\n"+
+		"あi うえお\n"+
+		"")
+}
+
+// Overwrite the first half of hiragana 'I' syllable with 'i'.
+func (s *renderSuite) TestComposeOverwriteFirstHalfMisalignedOdd(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "0123456789"},
+		{X: 0, Y: 1, ScanLine: "aあいうえb"},
+		{X: 3, Y: 1, ScanLine: "i"},
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"0123456789\n"+
+		"aあi うえb\n"+
+		"")
+}
+
+// Overwrite the second half of hiragana 'I' syllable with 'i'.
+func (s *renderSuite) TestComposeOverwriteSecondHalfMisalignedEven(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "0123456789"},
+		{X: 0, Y: 1, ScanLine: "aあいうえb"},
+		{X: 4, Y: 1, ScanLine: "i"},
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"0123456789\n"+
+		"aあ iうえb\n"+
+		"")
+}
+
+// Overwrite the second half of hiragana 'I' syllable with 'i'.
+func (s *renderSuite) TestComposeOverwriteSecondHalfAlignedOdd(c *C) {
+	render.ComposeStripes(s.stdout, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "0123456789"},
+		{X: 0, Y: 1, ScanLine: "あいうえお"},
+		{X: 3, Y: 1, ScanLine: "i"},
+	})
+	c.Check(s.StdoutText(), Equals, ""+
+		"0123456789\n"+
+		"あ iうえお\n"+
 		"")
 }

--- a/render/widgets/hbox.go
+++ b/render/widgets/hbox.go
@@ -43,15 +43,13 @@ type HBox struct {
 // Spacing is inserted between consecutive items. For typical text applications
 // spacing should be set to one to have one column of space between elements.
 func (hbox *HBox) Pack(widthAvailable int) {
-	x := hbox.rect.topLeft.X
-	y := hbox.rect.topLeft.Y
 	widthSoFar := 0
 	maxHeight := 0
 	for i, item := range hbox.Items {
 		if i > 0 {
 			widthSoFar += hbox.Spacing
 		}
-		item.Move(render.Point{X: x + widthSoFar, Y: y})
+		item.Move(render.Point{X: widthSoFar, Y: 0})
 		item.Pack(widthAvailable - widthSoFar)
 		widthSoFar += item.Size().Width
 		if h := item.Size().Height; h > maxHeight {
@@ -68,6 +66,10 @@ func (hbox *HBox) Render() []render.Stripe {
 	var stripes []render.Stripe
 	for _, item := range hbox.Items {
 		stripes = append(stripes, item.Render()...)
+	}
+	for i := range stripes {
+		stripes[i].X += hbox.rect.topLeft.X
+		stripes[i].Y += hbox.rect.topLeft.Y
 	}
 	return stripes
 }

--- a/render/widgets/hbox.go
+++ b/render/widgets/hbox.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets
+
+import (
+	"github.com/snapcore/snapd/render"
+)
+
+// HBox is a container that packs items horizontally.
+//
+// After packing all the elements have the same Y coordinate and have
+// consecutive X coordinates according to the size of their predecessor and the
+// spacing between them.
+type HBox struct {
+	rect
+	Items   []render.Widget
+	Spacing int
+}
+
+// Pack arranges all the items horizontally.
+//
+// The height of the box is the height of tallest item. The width is the sum of
+// widths of all the items, with spacing in between. Each item is given the
+// remaining width to pack itself.
+//
+// Spacing is inserted between consecutive items. For typical text applications
+// spacing should be set to one to have one column of space between elements.
+func (hbox *HBox) Pack(widthAvailable int) {
+	x := hbox.rect.topLeft.X
+	y := hbox.rect.topLeft.Y
+	widthSoFar := 0
+	maxHeight := 0
+	for i, item := range hbox.Items {
+		if i > 0 {
+			widthSoFar += hbox.Spacing
+		}
+		item.Move(render.Point{X: x + widthSoFar, Y: y})
+		item.Pack(widthAvailable - widthSoFar)
+		widthSoFar += item.Size().Width
+		if h := item.Size().Height; h > maxHeight {
+			maxHeight = h
+		}
+	}
+	for _, item := range hbox.Items {
+		item.Resize(render.Size{Width: item.Size().Width, Height: maxHeight})
+	}
+	hbox.Resize(render.Size{Width: widthSoFar, Height: maxHeight})
+}
+
+func (hbox *HBox) Render() []render.Stripe {
+	var stripes []render.Stripe
+	for _, item := range hbox.Items {
+		stripes = append(stripes, item.Render()...)
+	}
+	return stripes
+}

--- a/render/widgets/hbox_test.go
+++ b/render/widgets/hbox_test.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render"
+	"github.com/snapcore/snapd/render/widgets"
+)
+
+type hboxSuite struct{}
+
+var _ = Suite(&hboxSuite{})
+
+// HBox that is empty takes no space.
+func (s *hboxSuite) TestPackingEmpty(c *C) {
+	hbox := widgets.HBox{}
+	hbox.Pack(80)
+	c.Check(hbox.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(hbox.Size(), Equals, render.Size{Width: 0, Height: 0})
+}
+
+// HBox with some labels inside is packed as consecutive columns.
+func (s *hboxSuite) TestPackingTypical(c *C) {
+	hbox := widgets.HBox{
+		Items: []render.Widget{
+			&widgets.Pre{Text: "123"},
+			&widgets.Pre{Text: "ab"},
+		},
+		Spacing: 1,
+	}
+	// Move to (10, 10) to see how position of the box is reflected in the items.
+	hbox.Move(render.Point{X: 10, Y: 10})
+	hbox.Pack(80)
+	c.Check(hbox.Position(), Equals, render.Point{X: 10, Y: 10})
+	c.Check(hbox.Items[0].Size(), Equals, render.Size{Width: 3, Height: 1})
+	c.Check(hbox.Items[1].Size(), Equals, render.Size{Width: 2, Height: 1})
+	c.Check(hbox.Items[0].Position(), Equals, render.Point{X: 10, Y: 10})
+	c.Check(hbox.Items[1].Position(), Equals, render.Point{X: 14, Y: 10})
+	c.Check(hbox.Size(), Equals, render.Size{Width: 3 + 2 + /* spacing */ 1, Height: 1})
+}
+
+// Packing a hbox sets the height of all items to that of the tallest one.
+func (s *hboxSuite) TestPackingCommonHeight(c *C) {
+	hbox := widgets.HBox{
+		Items: []render.Widget{
+			&widgets.Pre{Text: "hello"},
+			&widgets.Pre{Text: "\n-\n"},
+			&widgets.Pre{Text: "horizontal"},
+		},
+		Spacing: 1,
+	}
+	hbox.Pack(80)
+	c.Check(hbox.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(hbox.Items[0].Size(), Equals, render.Size{Width: 5, Height: 3})
+	c.Check(hbox.Items[1].Size(), Equals, render.Size{Width: 1, Height: 3})
+	c.Check(hbox.Items[2].Size(), Equals, render.Size{Width: 10, Height: 3})
+	c.Check(hbox.Items[0].Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(hbox.Items[1].Position(), Equals, render.Point{X: 6, Y: 0})
+	c.Check(hbox.Items[2].Position(), Equals, render.Point{X: 8, Y: 0})
+	c.Check(hbox.Size(), Equals, render.Size{Width: 5 + 1 + 10 + /* spacing */ 2, Height: 3})
+}
+
+func (s *hboxSuite) TestRendering(c *C) {
+	hbox := widgets.HBox{
+		Items: []render.Widget{
+			&widgets.Pre{Text: "123"},
+			&widgets.Pre{Text: "ab"},
+		},
+		Spacing: 1,
+	}
+	hbox.Pack(80)
+	c.Check(hbox.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "123"},
+		{X: 4, Y: 0, ScanLine: "ab"},
+	})
+}

--- a/render/widgets/hbox_test.go
+++ b/render/widgets/hbox_test.go
@@ -51,10 +51,11 @@ func (s *hboxSuite) TestPackingTypical(c *C) {
 	hbox.Move(render.Point{X: 10, Y: 10})
 	hbox.Pack(80)
 	c.Check(hbox.Position(), Equals, render.Point{X: 10, Y: 10})
+	// Nested widgets use relative positioning and are unaffected by the position of the box.
 	c.Check(hbox.Items[0].Size(), Equals, render.Size{Width: 3, Height: 1})
 	c.Check(hbox.Items[1].Size(), Equals, render.Size{Width: 2, Height: 1})
-	c.Check(hbox.Items[0].Position(), Equals, render.Point{X: 10, Y: 10})
-	c.Check(hbox.Items[1].Position(), Equals, render.Point{X: 14, Y: 10})
+	c.Check(hbox.Items[0].Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(hbox.Items[1].Position(), Equals, render.Point{X: 4, Y: 0})
 	c.Check(hbox.Size(), Equals, render.Size{Width: 3 + 2 + /* spacing */ 1, Height: 1})
 }
 

--- a/render/widgets/pad.go
+++ b/render/widgets/pad.go
@@ -38,7 +38,7 @@ func (pad *Padding) Pack(widthAvailable int) {
 	extraHeight := pad.Top + pad.Bottom
 	size := render.Size{Width: extraWidth, Height: extraHeight}
 	if pad.Body != nil {
-		pad.Body.Move(render.Point{X: pad.rect.topLeft.X + pad.Left, Y: pad.rect.topLeft.Y + pad.Top})
+		pad.Body.Move(render.Point{X: pad.Left, Y: pad.Top})
 		pad.Body.Pack(widthAvailable - extraWidth)
 		bodySize := pad.Body.Size()
 		size.Width += bodySize.Width
@@ -59,8 +59,13 @@ func (pad *Padding) Resize(size render.Size) {
 }
 
 func (pad *Padding) Render() []render.Stripe {
+	var stripes []render.Stripe
 	if pad.Body != nil {
-		return pad.Body.Render()
+		stripes = append(stripes, pad.Body.Render()...)
 	}
-	return nil
+	for i := range stripes {
+		stripes[i].X += pad.rect.topLeft.X
+		stripes[i].Y += pad.rect.topLeft.Y
+	}
+	return stripes
 }

--- a/render/widgets/pad.go
+++ b/render/widgets/pad.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets
+
+import (
+	"github.com/snapcore/snapd/render"
+)
+
+// Padding applies padding to a nested widget.
+type Padding struct {
+	rect
+
+	// The amount of padding to apply
+	Top, Left, Bottom, Right int
+	// The widget to render in the center
+	Body render.Widget
+}
+
+func (pad *Padding) Pack(widthAvailable int) {
+	extraWidth := pad.Left + pad.Right
+	extraHeight := pad.Top + pad.Bottom
+	size := render.Size{Width: extraWidth, Height: extraHeight}
+	if pad.Body != nil {
+		pad.Body.Move(render.Point{X: pad.rect.topLeft.X + pad.Left, Y: pad.rect.topLeft.Y + pad.Top})
+		pad.Body.Pack(widthAvailable - extraWidth)
+		bodySize := pad.Body.Size()
+		size.Width += bodySize.Width
+		size.Height += bodySize.Height
+	}
+	// Clip the pre if it doesn't fit.
+	if size.Width > widthAvailable {
+		size.Width = widthAvailable
+	}
+	pad.rect.Resize(size)
+}
+
+func (pad *Padding) Resize(size render.Size) {
+	pad.rect.Resize(size)
+	if pad.Body != nil {
+		pad.Body.Resize(render.Size{Width: size.Width - pad.Left - pad.Right, Height: size.Height - pad.Top - pad.Bottom})
+	}
+}
+
+func (pad *Padding) Render() []render.Stripe {
+	if pad.Body != nil {
+		return pad.Body.Render()
+	}
+	return nil
+}

--- a/render/widgets/pad_test.go
+++ b/render/widgets/pad_test.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render"
+	"github.com/snapcore/snapd/render/widgets"
+)
+
+type padSuite struct{}
+
+var _ = Suite(&padSuite{})
+
+// Resizing and moving
+func (s *padSuite) TestResizingAndMoving(c *C) {
+	pad := widgets.Padding{}
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 0, Height: 0})
+
+	pad.Move(render.Point{X: 10, Y: 5})
+	c.Check(pad.Position(), Equals, render.Point{X: 10, Y: 5})
+
+	pad.Resize(render.Size{Width: 3, Height: 7})
+	c.Check(pad.Size(), Equals, render.Size{Width: 3, Height: 7})
+}
+
+// Packing a pre gives it the size combined of padding and the widget inside.
+func (s *padSuite) TestPacking(c *C) {
+	pad := widgets.Padding{}
+	pad.Pack(80)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 0, Height: 0})
+
+	pad.Top = 1
+	pad.Pack(80)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 0, Height: 1})
+
+	pad.Left = 1
+	pad.Pack(80)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 1, Height: 1})
+
+	pad.Bottom = 1
+	pad.Pack(80)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 1, Height: 2})
+
+	pad.Right = 1
+	pad.Pack(80)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 2, Height: 2})
+
+	pad.Body = &widgets.Pre{Text: "a"}
+	pad.Pack(80)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 3, Height: 3})
+	c.Check(pad.Body.Position(), Equals, render.Point{X: 1, Y: 1})
+	c.Check(pad.Body.Size(), Equals, render.Size{Width: 1, Height: 1})
+}
+
+// Pres don't re-flow text and are clipped once out of space.
+func (s *padSuite) TestPackingInsufficientSpace(c *C) {
+	pad := widgets.Padding{Left: 5, Right: 5}
+	pad.Pack(7)
+	c.Check(pad.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pad.Size(), Equals, render.Size{Width: 7, Height: 0})
+}
+
+func (s *padSuite) TestRendering(c *C) {
+	pad := widgets.Padding{Top: 1, Left: 1, Right: 1, Bottom: 1}
+	pad.Pack(80)
+	c.Check(pad.Render(), HasLen, 0)
+
+	pad.Body = &widgets.Pre{Text: "a"}
+	pad.Pack(80)
+	c.Check(pad.Render(), DeepEquals, []render.Stripe{
+		{X: 1, Y: 1, ScanLine: "a"},
+	})
+}
+
+func (s *padSuite) TestClipping(c *C) {
+	pad := widgets.Padding{Top: 1, Left: 1, Right: 1, Bottom: 1}
+	pad.Body = &widgets.Pre{Text: "0000\n1111\n2222\n3333"}
+	pad.Pack(80)
+	pad.Resize(render.Size{Width: 3, Height: 3})
+	c.Check(pad.Render(), DeepEquals, []render.Stripe{
+		{X: 1, Y: 1, ScanLine: "0"},
+	})
+}

--- a/render/widgets/pre.go
+++ b/render/widgets/pre.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets
+
+import (
+	"strings"
+
+	"github.com/snapcore/snapd/render"
+	"github.com/snapcore/snapd/render/heuristic"
+)
+
+// Pre is a widget that displays pre-formatted text.
+//
+// The text is never re-flowed but can be aligned both horizontally and
+// vertically within the available space that the widget occupies.
+type Pre struct {
+	rect
+
+	Text   string
+	VAlign Alignment
+	HAlign Alignment
+}
+
+func (pre *Pre) Pack(widthAvailable int) {
+	w, h := heuristic.TerminalRenderSize(pre.Text)
+	// Clip the pre if it doesn't fit.
+	if w > widthAvailable {
+		w = widthAvailable
+	}
+	pre.Resize(render.Size{Width: w, Height: h})
+}
+
+// Render produces a strip for each visible line in the pre.
+func (pre *Pre) Render() []render.Stripe {
+	// XXX: Render should handle more control characters, presumably by using
+	// heuristic to tokenize text into actionable elements, to reuse the single
+	// definition of all the heuristic.
+	lines := strings.Split(pre.Text, "\n")
+	stripes := make([]render.Stripe, 0, len(lines))
+	for i, line := range lines {
+		if i >= pre.rect.size.Height {
+			break
+		}
+		w := 0
+		h := 1
+		for i, r := range line {
+			if inc := heuristic.RuneWidth(r); w+inc <= pre.rect.size.Width {
+				w += inc
+			} else {
+				line = line[:i]
+				break
+			}
+		}
+		var x, y int
+		switch pre.HAlign {
+		case Beginning:
+			x = 0
+		case Center:
+			x = (pre.rect.size.Width - w) / 2
+		case End:
+			x = pre.rect.size.Width - w
+		}
+		switch pre.VAlign {
+		case Beginning:
+			y = i
+		case Center:
+			y = (pre.rect.size.Height - (h + i)) / 2
+		case End:
+			y = pre.rect.size.Height - (h + i)
+		}
+		stripes = append(stripes, render.Stripe{
+			X:        pre.rect.topLeft.X + x,
+			Y:        pre.rect.topLeft.Y + y,
+			ScanLine: line,
+		})
+	}
+	return stripes
+}

--- a/render/widgets/pre_test.go
+++ b/render/widgets/pre_test.go
@@ -1,0 +1,143 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render"
+	"github.com/snapcore/snapd/render/widgets"
+)
+
+type preSuite struct{}
+
+var _ = Suite(&preSuite{})
+
+// Resizing and moving
+func (s *preSuite) TestResizingAndMoving(c *C) {
+	pre := widgets.Pre{}
+	c.Check(pre.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pre.Size(), Equals, render.Size{Width: 0, Height: 0})
+
+	pre.Move(render.Point{X: 10, Y: 5})
+	c.Check(pre.Position(), Equals, render.Point{X: 10, Y: 5})
+
+	pre.Resize(render.Size{Width: 3, Height: 7})
+	c.Check(pre.Size(), Equals, render.Size{Width: 3, Height: 7})
+}
+
+// Packing a pre gives it the size of the text inside.
+func (s *preSuite) TestPacking(c *C) {
+	pre := widgets.Pre{Text: "123\n123456\n1234567"}
+	pre.Pack(80)
+	c.Check(pre.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pre.Size(), Equals, render.Size{Width: 7, Height: 3})
+}
+
+// Pres don't re-flow text and are clipped once out of space.
+func (s *preSuite) TestPackingInsufficientSpace(c *C) {
+	pre := widgets.Pre{Text: "Hello World"}
+	pre.Pack(7)
+	c.Check(pre.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(pre.Size(), Equals, render.Size{Width: 7, Height: 1})
+}
+
+func (s *preSuite) TestTextRendering(c *C) {
+	pre := widgets.Pre{}
+	pre.Pack(80)
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: ""},
+	})
+
+	pre = widgets.Pre{Text: "pre"}
+	pre.Pack(80)
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "pre"},
+	})
+
+	pre = widgets.Pre{Text: "some text\nand more\n\n"}
+	pre.Pack(80)
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "some text"},
+		{X: 0, Y: 1, ScanLine: "and more"},
+		{X: 0, Y: 2, ScanLine: ""},
+		{X: 0, Y: 3, ScanLine: ""},
+	})
+
+	pre = widgets.Pre{Text: "\n\nspeak yoda\nwe can"}
+	pre.Pack(80)
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: ""},
+		{X: 0, Y: 1, ScanLine: ""},
+		{X: 0, Y: 2, ScanLine: "speak yoda"},
+		{X: 0, Y: 3, ScanLine: "we can"},
+	})
+}
+
+func (s *preSuite) TestHorizontalAlignment(c *C) {
+	pre := widgets.Pre{Text: "a"}
+	pre.Resize(render.Size{Width: 10, Height: 10})
+
+	pre.HAlign = widgets.Beginning
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "a"},
+	})
+
+	pre.HAlign = widgets.Center
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 4, Y: 0, ScanLine: "a"},
+	})
+
+	pre.HAlign = widgets.End
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 9, Y: 0, ScanLine: "a"},
+	})
+}
+
+func (s *preSuite) TestVerticalAlignment(c *C) {
+	pre := widgets.Pre{Text: "a"}
+	pre.Resize(render.Size{Width: 10, Height: 10})
+
+	pre.VAlign = widgets.Beginning
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "a"},
+	})
+
+	pre.VAlign = widgets.Center
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 4, ScanLine: "a"},
+	})
+
+	pre.VAlign = widgets.End
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 9, ScanLine: "a"},
+	})
+}
+
+func (s *preSuite) TestClipping(c *C) {
+	pre := widgets.Pre{Text: "0000\n1111\n2222\n3333"}
+	pre.Pack(80)
+	pre.Resize(render.Size{Width: 3, Height: 3})
+	c.Check(pre.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "000"},
+		{X: 0, Y: 1, ScanLine: "111"},
+		{X: 0, Y: 2, ScanLine: "222"},
+	})
+}

--- a/render/widgets/structural.go
+++ b/render/widgets/structural.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/render"
+)
+
+// H1 returns a widget for a header one.
+func H1(text string) render.Widget {
+	return &Padding{Top: 2, Bottom: 1, Body: &Pre{Text: fmt.Sprintf("# %s", text)}}
+}
+
+// H2 returns a widget for a header two.
+func H2(text string) render.Widget {
+	return &Padding{Top: 1, Body: &Pre{Text: fmt.Sprintf("## %s", text)}}
+}
+
+// T returns a widget for pre-formatted text.
+func T(text string) render.Widget {
+	return &Pre{Text: text}
+}
+
+// Seq returns a widget for displaying widgets on consecutive lines.
+func Seq(items ...render.Widget) render.Widget {
+	return &VBox{Items: items}
+}
+
+// Map returns a widget for displaying a key-value map of other widgets.
+func Map(things map[string]render.Widget) render.Widget {
+	keys := make([]string, 0, len(things))
+	for key := range things {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	hbox := &VBox{
+		Items: make([]render.Widget, len(things)),
+	}
+	for i, key := range keys {
+		hbox.Items[i] = &HBox{
+			Items:   []render.Widget{T(key), &Padding{Right: 1, Body: T(":")}, things[key]},
+			Spacing: 0,
+		}
+	}
+	return &Padding{Left: 3, Body: hbox}
+}
+
+// List returns a widget for displaying itemized list of other widgets.
+func List(marker string, things ...render.Widget) render.Widget {
+	hbox := &VBox{
+		Items: make([]render.Widget, len(things)),
+	}
+	for i, item := range things {
+		hbox.Items[i] = &HBox{
+			Items: []render.Widget{&Padding{Left: 1, Right: 1, Body: T(marker)}, item},
+		}
+	}
+	return hbox
+}

--- a/render/widgets/structural_test.go
+++ b/render/widgets/structural_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets_test
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render"
+	"github.com/snapcore/snapd/render/widgets"
+)
+
+type demoSuite struct {
+	stdout *os.File
+}
+
+func (s *demoSuite) StdoutText() string {
+	s.stdout.Seek(0, 0)
+	blob, err := ioutil.ReadAll(s.stdout)
+	if err != nil {
+		panic(err)
+	}
+	return string(blob)
+}
+
+var _ = Suite(&demoSuite{})
+
+func (s *demoSuite) SetUpTest(c *C) {
+	f, err := ioutil.TempFile("", "stdout-*.txt")
+	c.Assert(err, IsNil)
+	s.stdout = f
+}
+
+func (s *demoSuite) TearDownTest(c *C) {
+	if s.stdout != nil {
+		defer s.stdout.Close()
+		os.Remove(s.stdout.Name())
+	}
+}
+
+func (s *demoSuite) TestRenderDemo(c *C) {
+	render.Display(s.stdout, widgets.Seq(
+		widgets.H1("Welcome to this rendering demo!"),
+		widgets.T("This demo shows how various elements work together."),
+		widgets.H2("This is an itemized list"),
+		widgets.List("-", widgets.T("This is a list item\n"+"It spans multiple lines"),
+			widgets.Seq(
+				widgets.T("This is another item"),
+				widgets.List("*", widgets.T("This is a nested list")))),
+		widgets.H2("This is a key-value map"),
+		widgets.Map(map[string]render.Widget{
+			"Αα": widgets.T("The first letter of the Greek alphabet"),
+			"Ωω": widgets.T("The last letter of the Greek alphabet"),
+			// The wrong formatting created by gofmt is caused by gofmt's
+			// unawareness of double-width characters. Oh the irony ;)
+			"ひ": widgets.T("The HI syllable in Hiragana"),
+		}),
+		widgets.T("(keys in the map are always sorted)"),
+	))
+	c.Check(s.StdoutText(), Equals, ""+
+		"\n"+
+		"\n"+
+		"# Welcome to this rendering demo!\n"+
+		"\n"+
+		"This demo shows how various elements work together.\n"+
+		"\n"+
+		"## This is an itemized list\n"+
+		" - This is a list item\n"+
+		"   It spans multiple lines\n"+
+		" - This is another item\n"+
+		"    * This is a nested list\n"+
+		"\n"+
+		"## This is a key-value map\n"+
+		"   Αα: The first letter of the Greek alphabet\n"+
+		"   Ωω: The last letter of the Greek alphabet\n"+
+		"   ひ: The HI syllable in Hiragana\n"+
+		"(keys in the map are always sorted)\n")
+}

--- a/render/widgets/vbox.go
+++ b/render/widgets/vbox.go
@@ -43,15 +43,13 @@ type VBox struct {
 // Spacing is inserted between consecutive items. For typical text applications
 // spacing should be set to zero to have line-by-line output.
 func (vbox *VBox) Pack(widthAvailable int) {
-	x := vbox.rect.topLeft.X
-	y := vbox.rect.topLeft.Y
 	maxWidth := 0
 	heightSoFar := 0
 	for i, item := range vbox.Items {
 		if i > 0 {
 			heightSoFar += vbox.Spacing
 		}
-		item.Move(render.Point{X: x, Y: y + heightSoFar})
+		item.Move(render.Point{X: 0, Y: heightSoFar})
 		item.Pack(widthAvailable)
 		if w := item.Size().Width; w > maxWidth {
 			maxWidth = w
@@ -68,6 +66,10 @@ func (vbox *VBox) Render() []render.Stripe {
 	var stripes []render.Stripe
 	for _, item := range vbox.Items {
 		stripes = append(stripes, item.Render()...)
+	}
+	for i := range stripes {
+		stripes[i].X += vbox.rect.topLeft.X
+		stripes[i].Y += vbox.rect.topLeft.Y
 	}
 	return stripes
 }

--- a/render/widgets/vbox.go
+++ b/render/widgets/vbox.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets
+
+import (
+	"github.com/snapcore/snapd/render"
+)
+
+// VBox is a container that packs items vertically.
+//
+// After packing all the elements have the same X coordinate and have
+// consecutive Y coordinates according to the size of their predecessor and the
+// spacing between them.
+type VBox struct {
+	rect
+	Items   []render.Widget
+	Spacing int
+}
+
+// Pack arranges all the items vertically.
+//
+// The width of the box is the width of widest item. The height is the sum of
+// heights of all the items, with spacing in between. Each item is given the
+// entire width available to pack itself.
+//
+// Spacing is inserted between consecutive items. For typical text applications
+// spacing should be set to zero to have line-by-line output.
+func (vbox *VBox) Pack(widthAvailable int) {
+	x := vbox.rect.topLeft.X
+	y := vbox.rect.topLeft.Y
+	maxWidth := 0
+	heightSoFar := 0
+	for i, item := range vbox.Items {
+		if i > 0 {
+			heightSoFar += vbox.Spacing
+		}
+		item.Move(render.Point{X: x, Y: y + heightSoFar})
+		item.Pack(widthAvailable)
+		if w := item.Size().Width; w > maxWidth {
+			maxWidth = w
+		}
+		heightSoFar += item.Size().Height
+	}
+	for _, item := range vbox.Items {
+		item.Resize(render.Size{Width: maxWidth, Height: item.Size().Height})
+	}
+	vbox.Resize(render.Size{Width: maxWidth, Height: heightSoFar})
+}
+
+func (vbox *VBox) Render() []render.Stripe {
+	var stripes []render.Stripe
+	for _, item := range vbox.Items {
+		stripes = append(stripes, item.Render()...)
+	}
+	return stripes
+}

--- a/render/widgets/vbox_test.go
+++ b/render/widgets/vbox_test.go
@@ -49,11 +49,12 @@ func (s *vboxSuite) TestPackingTypical(c *C) {
 	// Move to (10, 10) to see how position of the box is reflected in the items.
 	vbox.Move(render.Point{X: 10, Y: 10})
 	vbox.Pack(80)
+	// Nested widgets use relative positioning and are unaffected by the position of the box.
 	c.Check(vbox.Position(), Equals, render.Point{X: 10, Y: 10})
 	c.Check(vbox.Items[0].Size(), Equals, render.Size{Width: 3, Height: 1})
 	c.Check(vbox.Items[1].Size(), Equals, render.Size{Width: 3, Height: 1})
-	c.Check(vbox.Items[0].Position(), Equals, render.Point{X: 10, Y: 10})
-	c.Check(vbox.Items[1].Position(), Equals, render.Point{X: 10, Y: 11})
+	c.Check(vbox.Items[0].Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(vbox.Items[1].Position(), Equals, render.Point{X: 0, Y: 1})
 	c.Check(vbox.Size(), Equals, render.Size{Width: 3, Height: 2})
 }
 

--- a/render/widgets/vbox_test.go
+++ b/render/widgets/vbox_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/render"
+	"github.com/snapcore/snapd/render/widgets"
+)
+
+type vboxSuite struct{}
+
+var _ = Suite(&vboxSuite{})
+
+// VBox that is empty takes no space.
+func (s *vboxSuite) TestPackingEmpty(c *C) {
+	vbox := widgets.VBox{}
+	vbox.Pack(80)
+	c.Check(vbox.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(vbox.Size(), Equals, render.Size{Width: 0, Height: 0})
+}
+
+// VBox with some labels inside is packed as consecutive lines.
+func (s *vboxSuite) TestPackingTypical(c *C) {
+	vbox := widgets.VBox{
+		Items: []render.Widget{
+			&widgets.Pre{Text: "123"},
+			&widgets.Pre{Text: "ab"},
+		},
+	}
+	// Move to (10, 10) to see how position of the box is reflected in the items.
+	vbox.Move(render.Point{X: 10, Y: 10})
+	vbox.Pack(80)
+	c.Check(vbox.Position(), Equals, render.Point{X: 10, Y: 10})
+	c.Check(vbox.Items[0].Size(), Equals, render.Size{Width: 3, Height: 1})
+	c.Check(vbox.Items[1].Size(), Equals, render.Size{Width: 3, Height: 1})
+	c.Check(vbox.Items[0].Position(), Equals, render.Point{X: 10, Y: 10})
+	c.Check(vbox.Items[1].Position(), Equals, render.Point{X: 10, Y: 11})
+	c.Check(vbox.Size(), Equals, render.Size{Width: 3, Height: 2})
+}
+
+// Packing a vbox sets the width of all items to that of the widest one.
+func (s *vboxSuite) TestPackingCommonWidth(c *C) {
+	vbox := widgets.VBox{
+		Items: []render.Widget{
+			&widgets.Pre{Text: "hello"},
+			&widgets.Pre{Text: "-"},
+			&widgets.Pre{Text: "vertical"},
+		},
+	}
+	vbox.Pack(80)
+	c.Check(vbox.Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(vbox.Items[0].Size(), Equals, render.Size{Width: 8, Height: 1})
+	c.Check(vbox.Items[1].Size(), Equals, render.Size{Width: 8, Height: 1})
+	c.Check(vbox.Items[2].Size(), Equals, render.Size{Width: 8, Height: 1})
+	c.Check(vbox.Items[0].Position(), Equals, render.Point{X: 0, Y: 0})
+	c.Check(vbox.Items[1].Position(), Equals, render.Point{X: 0, Y: 1})
+	c.Check(vbox.Items[2].Position(), Equals, render.Point{X: 0, Y: 2})
+	c.Check(vbox.Size(), Equals, render.Size{Width: 8, Height: 3})
+}
+
+func (s *vboxSuite) TestRendering(c *C) {
+	vbox := widgets.VBox{
+		Items: []render.Widget{
+			&widgets.Pre{Text: "123"},
+			&widgets.Pre{Text: "ab"},
+		},
+	}
+	vbox.Pack(80)
+	c.Check(vbox.Render(), DeepEquals, []render.Stripe{
+		{X: 0, Y: 0, ScanLine: "123"},
+		{X: 0, Y: 1, ScanLine: "ab"},
+	})
+}

--- a/render/widgets/widgets.go
+++ b/render/widgets/widgets.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets
+
+import (
+	"github.com/snapcore/snapd/render"
+)
+
+// Alignment determines to position content within a rectangle.
+type Alignment int
+
+const (
+	// Beginning positions the content at the beginning of the available space.
+	Beginning Alignment = iota
+	// Center positions the content in the center of the available space.
+	Center
+	// End positions the content at the end of the available space.
+	End
+)
+
+type rect struct {
+	topLeft render.Point
+	size    render.Size
+}
+
+func (r *rect) Position() render.Point {
+	return r.topLeft
+}
+
+func (r *rect) Move(to render.Point) {
+	r.topLeft = to
+}
+
+func (r *rect) Size() render.Size {
+	return r.size
+}
+
+func (r *rect) Resize(to render.Size) {
+	r.size = to
+}

--- a/render/widgets/widgets_test.go
+++ b/render/widgets/widgets_test.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package widgets_test
+
+import (
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
The render package allows compositing textual widgets and display them
in a terminal effortlessly. Unlike hand-crafted wrap-and-print-spaces
code it is easier to handle complex structures correctly.

Rendering is based on stripes. The widget tree is de-composed into
horizontal stripes, or rectangles of height of one, and rendered into a
single-line temporary buffer using the painter's algorithm. There's some
provisions for supporting double-width characters, allowing to mix i18n
text with arbitrary English text correctly.

The widgets sub-package contains the following widgets:
 Pre - pre-formatted text, text label that is similar to Printf
 Padding - container that applies padding to another widget
 HBox and VBox - containers that pack widgets horizontally and
 vertically.

The heuristics sub-package contains code that guesses what a terminal
would do with a given string, mainly to determine the width and height
of the encompassing rectangle.

For simplicity, all of this is wrapped into simple functions that craft
structural presentation: Sequences, Headers, Text, Lists and Maps.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
