### PR TITLE
packaging/opensuse: build-depend on fakeroot

### DIFF
--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -124,6 +124,7 @@ BuildRequires:  gcc-32bit
 BuildRequires:  libapparmor-devel
 BuildRequires:  apparmor-rpm-macros
 %endif
+BuildRequires:  fakeroot
 
 PreReq:         permissions
 


### PR DESCRIPTION
It seems that fakeroot is now required by partition tests?

    [  146s]
    [  146s] ----------------------------------------------------------------------
    [  146s] FAIL: mkfs_test.go:72: mkfsSuite.TestMakefilesystems
    [  146s]
    [  146s] using shellcheck: "/usr/bin/shellcheck"
    [  146s] mkfs_test.go:121:
    [  146s]     c.Assert(err, IsNil)
    [  146s] ... value *exec.Error = &exec.Error{Name:"fakeroot", Err:(*errors.errorString)(0xc00005c490)} ("exec: \"fakeroot\": executable file not found in $PATH")
    [  146s]
    [  146s]
    [  146s] ----------------------------------------------------------------------
    [  146s] FAIL: mkfs_test.go:57: mkfsSuite.TestMkfsExt4
    [  146s]
    [  146s] mkfs_test.go:59:
    [  146s]     c.Assert(err, IsNil)
    [  146s] ... value *exec.Error = &exec.Error{Name:"fakeroot", Err:(*errors.errorString)(0xc00005c490)} ("exec: \"fakeroot\": executable file not found in $PATH")
    [  146s]
    [  146s] OOPS: 18 passed, 2 FAILED
    [  146s] --- FAIL: TestPartition (1.52s)
    [  146s] FAIL
    [  146s] FAIL	github.com/snapcore/snapd/cmd/snap-bootstrap/partition	1.521s

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
