### PR TITLE
cmd/snap-boostrap: add mocking for fakeroot

### DIFF
--- a/cmd/snap-bootstrap/partition/mkfs_test.go
+++ b/cmd/snap-bootstrap/partition/mkfs_test.go
@@ -37,6 +37,9 @@ type mkfsSuite struct {
 var _ = Suite(&mkfsSuite{})
 
 func (s *mkfsSuite) SetUpTest(c *C) {
+	// some commads use fakeroot, mock one that just calls the other script
+	cmdFakeroot := testutil.MockCommand(c, "fakeroot", `exec "$@"`)
+	s.AddCleanup(cmdFakeroot.Restore)
 	s.mockMkfsVfat = testutil.MockCommand(c, "mkfs.vfat", "")
 	s.AddCleanup(s.mockMkfsVfat.Restore)
 	s.mockMkfsExt4 = testutil.MockCommand(c, "mkfs.ext4", "")


### PR DESCRIPTION
Some of the mkfs command wrappers in the `gadget` packge use fakeroot. Without
proper mocking, on a system that does not have fakeroot installed, the tests
would fail like so:

```
----------------------------------------------------------------------
FAIL: mkfs_test.go:76: mkfsSuite.TestMakefilesystem

using shellcheck: "/usr/bin/shellcheck"
mkfs_test.go:128:
    c.Assert(err, IsNil)
... value *exec.Error = &exec.Error{Name:"fakeroot", Err:(*errors.errorString)(0xc0000b03f0)} ("exec: \"fakeroot\": executable file not found in $PATH")

----------------------------------------------------------------------
FAIL: mkfs_test.go:60: mkfsSuite.TestMkfsExt4

mkfs_test.go:62:
    c.Assert(err, IsNil)
... value *exec.Error = &exec.Error{Name:"fakeroot", Err:(*errors.errorString)(0xc0000b03f0)} ("exec: \"fakeroot\": executable file not found in $PATH")

OOPS: 19 passed, 2 FAILED
--- FAIL: TestPartition (1.58s)
FAIL
FAIL    github.com/snapcore/snapd/cmd/snap-bootstrap/partition  1.583s
```

Replaces #8009
