### PR TITLE
cmd/snap-bootstrap: check device size before boostrapping and produce a meaningful error

### DIFF
--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -20,7 +20,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
 	"github.com/snapcore/snapd/dirs"
@@ -143,28 +142,6 @@ func Run(gadgetRoot, device string, options Options) error {
 	return nil
 }
 
-// bytesIEC is a heleper type that implements the Stringer() interface and
-// formats the size using multiples from IEC units (i.e. kibibytes, mibibytes).
-// Printed values are truncated to 2 decimal points.
-type bytesIEC gadget.Size
-
-func (b bytesIEC) String() string {
-	var maxFloat float64 = 999.5
-	var r float64 = float64(b)
-	var prefix rune
-	for _, prefix = range "KMGTPEZY" {
-		r /= 1024
-		if r < maxFloat {
-			break
-		}
-	}
-	precision := 0
-	if math.Floor(r) != r {
-		precision = 2
-	}
-	return fmt.Sprintf("%.*f%ciB", precision, r, prefix)
-}
-
 func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *partition.DeviceLayout) error {
 	eq := func(ds partition.DeviceStructure, gs gadget.LaidOutStructure) bool {
 		dv := ds.VolumeStructure
@@ -182,7 +159,7 @@ func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *p
 
 	if gadgetLayout.Size > diskLayout.Size {
 		return fmt.Errorf("device %v (%s) is too small to fit the requested layout (%s)", diskLayout.Device,
-			bytesIEC(diskLayout.Size), bytesIEC(gadgetLayout.Size))
+			diskLayout.Size.IECString(), gadgetLayout.Size.IECString())
 	}
 
 	// Check if top level properties match

--- a/cmd/snap-bootstrap/bootstrap/bootstrap.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/snapcore/snapd/cmd/snap-bootstrap/partition"
 	"github.com/snapcore/snapd/dirs"
@@ -142,6 +143,28 @@ func Run(gadgetRoot, device string, options Options) error {
 	return nil
 }
 
+// bytesIEC is a heleper type that implements the Stringer() interface and
+// formats the size using multiples from IEC units (i.e. kibibytes, mibibytes).
+// Printed values are truncated to 2 decimal points.
+type bytesIEC gadget.Size
+
+func (b bytesIEC) String() string {
+	var maxFloat float64 = 999.5
+	var r float64 = float64(b)
+	var prefix rune
+	for _, prefix = range "KMGTPEZY" {
+		r /= 1024
+		if r < maxFloat {
+			break
+		}
+	}
+	precision := 0
+	if math.Floor(r) != r {
+		precision = 2
+	}
+	return fmt.Sprintf("%.*f%ciB", precision, r, prefix)
+}
+
 func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *partition.DeviceLayout) error {
 	eq := func(ds partition.DeviceStructure, gs gadget.LaidOutStructure) bool {
 		dv := ds.VolumeStructure
@@ -155,6 +178,11 @@ func ensureLayoutCompatibility(gadgetLayout *gadget.LaidOutVolume, diskLayout *p
 			}
 		}
 		return false
+	}
+
+	if gadgetLayout.Size > diskLayout.Size {
+		return fmt.Errorf("device %v (%s) is too small to fit the requested layout (%s)", diskLayout.Device,
+			bytesIEC(diskLayout.Size), bytesIEC(gadgetLayout.Size))
 	}
 
 	// Check if top level properties match

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
@@ -148,7 +148,7 @@ func (s *bootstrapSuite) TestLayoutCompatibility(c *C) {
 	// sanity check
 	c.Check(gadgetLayoutWithExtras.Size > smallDeviceLayout.Size, Equals, true)
 	err = bootstrap.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &smallDeviceLayout)
-	c.Assert(err, ErrorMatches, `device /dev/node \(100MiB\) is too small to fit the requested layout \(1\.17GiB\)`)
+	c.Assert(err, ErrorMatches, `device /dev/node \(100 MiB\) is too small to fit the requested layout \(1\.17 GiB\)`)
 }
 
 func (s *bootstrapSuite) TestSchemaCompatibility(c *C) {

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
@@ -109,7 +109,7 @@ var mockDeviceLayout = partition.DeviceLayout{
 	ID:         "anything",
 	Device:     "/dev/node",
 	Schema:     "gpt",
-	Size:       0x500000,
+	Size:       2 * gadget.SizeGiB,
 	SectorSize: 512,
 }
 
@@ -141,6 +141,14 @@ func (s *bootstrapSuite) TestLayoutCompatibility(c *C) {
 	// extra structure (should fail)
 	err = bootstrap.EnsureLayoutCompatibility(gadgetLayout, &deviceLayoutWithExtras)
 	c.Assert(err, ErrorMatches, `cannot find disk partition /dev/node3.* in gadget`)
+
+	// layout is not compatible if the device is too small
+	smallDeviceLayout := mockDeviceLayout
+	smallDeviceLayout.Size = 100 * gadget.SizeMiB
+	// sanity check
+	c.Check(gadgetLayoutWithExtras.Size > smallDeviceLayout.Size, Equals, true)
+	err = bootstrap.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &smallDeviceLayout)
+	c.Assert(err, ErrorMatches, `device /dev/node \(100MiB\) is too small to fit the requested layout \(1\.17GiB\)`)
 }
 
 func (s *bootstrapSuite) TestSchemaCompatibility(c *C) {
@@ -286,4 +294,19 @@ func (s *bootstrapSuite) TestDeviceFromRoleErrorNoRole(c *C) {
 
 	_, err := bootstrap.DeviceFromRole(lv, gadget.SystemSeed)
 	c.Assert(err, ErrorMatches, "cannot find role system-seed in gadget")
+}
+
+func (s *bootstrapSuite) TestFormatSize(c *C) {
+	for _, tc := range []struct {
+		size gadget.Size
+		exp  string
+	}{
+		{123 * gadget.SizeKiB, "123KiB"},
+		{512 * gadget.SizeKiB, "512KiB"},
+		{578 * gadget.SizeMiB, "578MiB"},
+		{1*gadget.SizeGiB + 123*gadget.SizeMiB, "1.12GiB"},
+		{1024 * gadget.SizeGiB, "1TiB"},
+	} {
+		c.Check(bootstrap.BytesIEC(tc.size).String(), Equals, tc.exp)
+	}
 }

--- a/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
+++ b/cmd/snap-bootstrap/bootstrap/bootstrap_test.go
@@ -295,18 +295,3 @@ func (s *bootstrapSuite) TestDeviceFromRoleErrorNoRole(c *C) {
 	_, err := bootstrap.DeviceFromRole(lv, gadget.SystemSeed)
 	c.Assert(err, ErrorMatches, "cannot find role system-seed in gadget")
 }
-
-func (s *bootstrapSuite) TestFormatSize(c *C) {
-	for _, tc := range []struct {
-		size gadget.Size
-		exp  string
-	}{
-		{123 * gadget.SizeKiB, "123KiB"},
-		{512 * gadget.SizeKiB, "512KiB"},
-		{578 * gadget.SizeMiB, "578MiB"},
-		{1*gadget.SizeGiB + 123*gadget.SizeMiB, "1.12GiB"},
-		{1024 * gadget.SizeGiB, "1TiB"},
-	} {
-		c.Check(bootstrap.BytesIEC(tc.size).String(), Equals, tc.exp)
-	}
-}

--- a/cmd/snap-bootstrap/bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/bootstrap/export_test.go
@@ -22,5 +22,3 @@ var (
 	EnsureLayoutCompatibility = ensureLayoutCompatibility
 	DeviceFromRole            = deviceFromRole
 )
-
-type BytesIEC = bytesIEC

--- a/cmd/snap-bootstrap/bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/bootstrap/export_test.go
@@ -22,3 +22,5 @@ var (
 	EnsureLayoutCompatibility = ensureLayoutCompatibility
 	DeviceFromRole            = deviceFromRole
 )
+
+type BytesIEC = bytesIEC

--- a/cmd/snap-bootstrap/partition/sfdisk.go
+++ b/cmd/snap-bootstrap/partition/sfdisk.go
@@ -63,11 +63,13 @@ type sfdiskPartition struct {
 }
 
 type DeviceLayout struct {
-	Structure      []DeviceStructure
-	ID             string
-	Device         string
-	Schema         string
-	Size           gadget.Size
+	Structure []DeviceStructure
+	ID        string
+	Device    string
+	Schema    string
+	// size in bytes
+	Size gadget.Size
+	// sector size in bytes
 	SectorSize     gadget.Size
 	partitionTable *sfdiskPartitionTable
 }
@@ -211,7 +213,7 @@ func deviceLayoutFromDump(dump *sfdiskDeviceDump) (*DeviceLayout, error) {
 		ID:             ptable.ID,
 		Device:         ptable.Device,
 		Schema:         ptable.Label,
-		Size:           gadget.Size(ptable.LastLBA),
+		Size:           gadget.Size(ptable.LastLBA) * sectorSize,
 		SectorSize:     sectorSize,
 		partitionTable: &ptable,
 	}

--- a/cmd/snap-bootstrap/partition/sfdisk_test.go
+++ b/cmd/snap-bootstrap/partition/sfdisk_test.go
@@ -134,6 +134,8 @@ exit 0`)
 	c.Assert(err, IsNil)
 	c.Assert(dl.ID, Equals, "9151F25B-CDF0-48F1-9EDE-68CBD616E2CA")
 	c.Assert(dl.Device, Equals, "/dev/node")
+	c.Assert(dl.SectorSize, Equals, gadget.Size(512))
+	c.Assert(dl.Size, Equals, gadget.Size(8388574*512))
 	c.Assert(len(dl.Structure), Equals, 2)
 
 	c.Assert(dl.Structure, DeepEquals, []partition.DeviceStructure{

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -871,20 +871,21 @@ func (s *Size) String() string {
 // mebibytes), that is as multiples of 1024. Printed values are truncated to 2
 // decimal points.
 func (s *Size) IECString() string {
-	var maxFloat float64 = 999.5
-	var r float64 = float64(*s)
-	var prefix rune
-	for _, prefix = range "KMGTPEZY" {
-		r /= 1024
+	maxFloat := float64(1023.5)
+	r := float64(*s)
+	unit := "B"
+	for _, rangeUnit := range []string{"KiB", "MiB", "GiB", "TiB", "PiB"} {
 		if r < maxFloat {
 			break
 		}
+		r /= 1024
+		unit = rangeUnit
 	}
 	precision := 0
 	if math.Floor(r) != r {
 		precision = 2
 	}
-	return fmt.Sprintf("%.*f%ciB", precision, r, prefix)
+	return fmt.Sprintf("%.*f %s", precision, r, unit)
 }
 
 // RelativeOffset describes an offset where structure data is written at.

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -864,6 +865,26 @@ func (s *Size) String() string {
 		return "unspecified"
 	}
 	return fmt.Sprintf("%d", *s)
+}
+
+// IECString formats the size using multiples from IEC units (i.e. kibibytes,
+// mebibytes), that is as multiples of 1024. Printed values are truncated to 2
+// decimal points.
+func (s *Size) IECString() string {
+	var maxFloat float64 = 999.5
+	var r float64 = float64(*s)
+	var prefix rune
+	for _, prefix = range "KMGTPEZY" {
+		r /= 1024
+		if r < maxFloat {
+			break
+		}
+	}
+	precision := 0
+	if math.Floor(r) != r {
+		precision = 2
+	}
+	return fmt.Sprintf("%.*f%ciB", precision, r, prefix)
 }
 
 // RelativeOffset describes an offset where structure data is written at.

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1957,11 +1957,16 @@ func (s *gadgetSizeTestSuite) TestIECString(c *C) {
 		size gadget.Size
 		exp  string
 	}{
-		{123 * gadget.SizeKiB, "123KiB"},
-		{512 * gadget.SizeKiB, "512KiB"},
-		{578 * gadget.SizeMiB, "578MiB"},
-		{1*gadget.SizeGiB + 123*gadget.SizeMiB, "1.12GiB"},
-		{1024 * gadget.SizeGiB, "1TiB"},
+		{512, "512 B"},
+		{1000, "1000 B"},
+		{1030, "1.01 KiB"},
+		{gadget.SizeKiB + 512, "1.50 KiB"},
+		{123 * gadget.SizeKiB, "123 KiB"},
+		{512 * gadget.SizeKiB, "512 KiB"},
+		{578 * gadget.SizeMiB, "578 MiB"},
+		{1*gadget.SizeGiB + 123*gadget.SizeMiB, "1.12 GiB"},
+		{1024 * gadget.SizeGiB, "1 TiB"},
+		{2 * 1024 * 1024 * 1024 * gadget.SizeGiB, "2048 PiB"},
 	} {
 		c.Check(tc.size.IECString(), Equals, tc.exp)
 	}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1947,3 +1947,22 @@ volumes:
 	err = gadget.IsCompatible(gi, giNew)
 	c.Check(err, IsNil)
 }
+
+type gadgetSizeTestSuite struct{}
+
+var _ = Suite(&gadgetSizeTestSuite{})
+
+func (s *gadgetSizeTestSuite) TestIECString(c *C) {
+	for _, tc := range []struct {
+		size gadget.Size
+		exp  string
+	}{
+		{123 * gadget.SizeKiB, "123KiB"},
+		{512 * gadget.SizeKiB, "512KiB"},
+		{578 * gadget.SizeMiB, "578MiB"},
+		{1*gadget.SizeGiB + 123*gadget.SizeMiB, "1.12GiB"},
+		{1024 * gadget.SizeGiB, "1TiB"},
+	} {
+		c.Check(tc.size.IECString(), Equals, tc.exp)
+	}
+}


### PR DESCRIPTION
When debugging problems with UC20 yesterday, the boostrap process failed due to the disk device being too small. However, the error returned in the process was completely non-obvious, since snap boostrap already called sfdisk to partition the device and a raw error output was returned. Try to make it more explicit and user friendly.
