### PR TITLE
[RFC] daemon, store: support download resume from /v2/download

### DIFF
--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -39,6 +39,7 @@ var snapDownloadCmd = &Command{
 // SnapDownloadAction is used to request a snap download
 type snapDownloadAction struct {
 	SnapName string `json:"snap-name,omitempty"`
+	Resume   int64  `json:"resume,omitempty"`
 	snapRevisionOptions
 }
 
@@ -86,7 +87,8 @@ func streamOneSnap(c *Command, action snapDownloadAction, user *auth.UserState) 
 	info := sars[0].Info
 
 	downloadInfo := info.DownloadInfo
-	r, err := getStore(c).DownloadStream(context.TODO(), action.SnapName, &downloadInfo, user)
+	dlOpts := &store.DownloadOptions{Resume: action.Resume}
+	r, err := getStore(c).DownloadStream(context.TODO(), action.SnapName, &downloadInfo, user, dlOpts)
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -47,7 +47,7 @@ type StoreService interface {
 	WriteCatalogs(ctx context.Context, names io.Writer, adder store.SnapAdder) error
 
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, *store.DownloadOptions) error
-	DownloadStream(context.Context, string, *snap.DownloadInfo, *auth.UserState) (io.ReadCloser, error)
+	DownloadStream(context.Context, string, *snap.DownloadInfo, *auth.UserState, *store.DownloadOptions) (io.ReadCloser, error)
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -113,7 +113,7 @@ func MockDownload(f func(ctx context.Context, name, sha3_384, downloadURL string
 	}
 }
 
-func MockDoDownloadReq(f func(ctx context.Context, storeURL *url.URL, cdnHeader string, s *Store, user *auth.UserState) (*http.Response, error)) (restore func()) {
+func MockDoDownloadReq(f func(ctx context.Context, storeURL *url.URL, cdnHeader string, opts *DownloadOptions, s *Store, user *auth.UserState) (*http.Response, error)) (restore func()) {
 	orig := doDownloadReq
 	doDownloadReq = f
 	return func() {

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -61,7 +61,7 @@ func (Store) Download(context.Context, string, string, *snap.DownloadInfo, progr
 	panic("Store.Download not expected")
 }
 
-func (Store) DownloadStream(ctx context.Context, name string, downloadInfo *snap.DownloadInfo, user *auth.UserState) (io.ReadCloser, error) {
+func (Store) DownloadStream(ctx context.Context, name string, downloadInfo *snap.DownloadInfo, user *auth.UserState, dlOpts *store.DownloadOptions) (io.ReadCloser, error) {
 	panic("Store.DownloadStream not expected")
 }
 


### PR DESCRIPTION
This commit adds support for resuming downloads from the
/v2/download endpoint.

Marking RFC as I'm not sure if store.DownloadOptions is the right way to pass this option. If we are we can simplify `func download()` and remove resume there and pass that via dlOpts.

Also there is this problem that the client needs to know the filename to resume but it will only learn the filename from snapd - so maybe this is not that useful :/