### PR TITLE
tests: add ubuntu 20.04 to the tests execution and remove tumbleweed from unstable

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -66,8 +66,6 @@ backends:
                 workers: 8
             - ubuntu-18.04-64:
                 workers: 8
-            - ubuntu-19.04-64:
-                workers: 6
             - ubuntu-19.10-64:
                 workers: 6
             - ubuntu-core-16-64:
@@ -101,6 +99,8 @@ backends:
                 manual: true
             - opensuse-15.1-64:
                 workers: 6
+            - opensuse-tumbleweed-64:
+                workers: 6
             - arch-linux-64:
                 workers: 6
 
@@ -117,9 +117,9 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
-            # zypper either segfaults or hangs installing snapd build dependencies
-            - opensuse-tumbleweed-64:
+            - ubuntu-20.04-64:
                 workers: 6
+
 
     google-sru:
         type: google

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -639,6 +639,13 @@ pkg_dependencies_ubuntu_classic(){
                 packagekit
                 "
             ;;
+        ubuntu-20.04-64)
+            echo "
+                evolution-data-server
+                gccgo-9
+                packagekit
+                "
+            ;;
         ubuntu-*)
             echo "
                 squashfs-tools

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure apt hooks work
 
 # apt hook only available on 18.04+ and aws-cli only for amd64
-systems: [ubuntu-18.04-64, ubuntu-19.10-64]
+systems: [ubuntu-18.04-64, ubuntu-19.10-64, ubuntu-20.04-64]
 
 manual: true
 

--- a/tests/main/desktop-portal-filechooser/task.yaml
+++ b/tests/main/desktop-portal-filechooser/task.yaml
@@ -17,7 +17,7 @@ description: |
 # Expand as needed.
 # ubuntu-18.04-*: Ships xdg-desktop-portal 0.11
 # ubuntu-19.10-*: Ships xdg-desktop-portal 1.2.0
-systems: [ubuntu-18.04-*, ubuntu-19.10-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/desktop-portal-open-file/task.yaml
+++ b/tests/main/desktop-portal-open-file/task.yaml
@@ -9,7 +9,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-19.10-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 environment:
     EDITOR_HISTORY: /tmp/editor-history.txt

--- a/tests/main/desktop-portal-open-uri/task.yaml
+++ b/tests/main/desktop-portal-open-uri/task.yaml
@@ -6,7 +6,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-19.10-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 environment:
     BROWSER_HISTORY: /tmp/browser-history.txt

--- a/tests/main/desktop-portal-screenshot/task.yaml
+++ b/tests/main/desktop-portal-screenshot/task.yaml
@@ -20,7 +20,7 @@ description: |
 
 # Only enable the test on systems we know portals to function on.
 # Expand as needed.
-systems: [ubuntu-18.04-*, ubuntu-19.10-*]
+systems: [ubuntu-18.04-*, ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
     #shellcheck source=tests/lib/desktop-portal.sh

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -70,6 +70,10 @@ execute: |
     # my-nesting-ubuntu nesting container
 
     . /etc/os-release
+    # TODO:2004: remove version check once the image for ubuntu 20.04 is published
+    if [ "$VERSION_ID" == 20.04 ]; then
+        VERSION_ID=19.10
+    fi
     lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
     lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-nesting-ubuntu -c security.nesting=true
 

--- a/tests/main/seccomp-statx/task.yaml
+++ b/tests/main/seccomp-statx/task.yaml
@@ -8,7 +8,7 @@ details: |
 # This test will only pass on Ubuntu 18.10 and on other systems with seccomp
 # 2.3.3 or newer. Eventually with some tricks we should be able to support all
 # systems but for the purpose of snapd 2.36 this is the best we can do.
-systems: [ubuntu-19.10-*]
+systems: [ubuntu-19.10-*, ubuntu-20.04-*]
 
 prepare: |
     #shellcheck source=tests/lib/snaps.sh


### PR DESCRIPTION
After last update of tumbleweed image this should not fail anymore.

Add ubuntu 20.04 to unstable execution, then we can iterate and fix the tests which are failing currently