### PR TITLE
[RFC] interfaces/apparmor: don't emit deny rules in devmode confinement

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1910,7 +1910,7 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 			suppress: true,
 			expected: false,
 		},
-		// devmode, only suppress if suppress == true and uses == false
+		// devmode, never suppress because deny rules aren't devmode friendly
 		{
 			opts:     interfaces.ConfinementOptions{DevMode: true},
 			uses:     false,
@@ -1921,7 +1921,7 @@ func (s *backendSuite) TestPtraceTraceRule(c *C) {
 			opts:     interfaces.ConfinementOptions{DevMode: true},
 			uses:     false,
 			suppress: true,
-			expected: true,
+			expected: false,
 		},
 		{
 			opts:     interfaces.ConfinementOptions{DevMode: true},

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -71,14 +71,20 @@ func MockProfilesPath(t *testutil.BaseTest, profiles string) {
 	})
 }
 
-// MockTemplate replaces apprmor template.
+// MockTemplate replaces apparmor template.
 //
 // NOTE: The real apparmor template is long. For testing it is convenient for
 // replace it with a shorter snippet.
 func MockTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultTemplate
+	origDeny := defaultDenySnippets
 	defaultTemplate = fakeTemplate
-	return func() { defaultTemplate = orig }
+	// TODO: add mock function which also can mock the default deny snippets
+	defaultDenySnippets = ""
+	return func() {
+		defaultTemplate = orig
+		defaultDenySnippets = origDeny
+	}
 }
 
 // MockClassicTemplate replaces the classic apprmor template.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -77,14 +77,6 @@ var defaultTemplate = `
   /etc/python3.[0-9]/**                                r,
   /usr/include/python3.[0-9]*/pyconfig.h               r,
 
-  # explicitly deny noisy denials to read-only filesystems (see LP: #1496895
-  # for details)
-  deny /usr/lib/python3*/{,**/}__pycache__/ w,
-  deny /usr/lib/python3*/{,**/}__pycache__/**.pyc.[0-9]* w,
-  # bind mount used here (see 'parallel installs', above)
-  deny @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/__pycache__/             w,
-  deny @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/__pycache__/*.pyc.[0-9]* w,
-
   # for perl apps/services
   #include <abstractions/perl>
   /usr/bin/perl{,5*} ixr,
@@ -503,11 +495,6 @@ var defaultTemplate = `
   capability sys_chroot,
   /{,usr/}sbin/chroot ixr,
 
-  # Lttng tracing is very noisy and should not be allowed by confined apps. Can
-  # safely deny for the normal case (LP: #1260491). If/when an lttng-trace
-  # interface is needed, we can rework this.
-  deny /{dev,run,var/run}/shm/lttng-ust-* rw,
-
   # Allow read-access on /home/ for navigating to other parts of the
   # filesystem. While this allows enumerating users, this is already allowed
   # via /etc/passwd and getent.
@@ -523,6 +510,21 @@ var defaultTemplate = `
 
 ###SNIPPETS###
 }
+`
+
+var defaultDenySnippets = `
+  # explicitly deny noisy denials to read-only filesystems (see LP: #1496895
+  # for details)
+  deny /usr/lib/python3*/{,**/}__pycache__/ w,
+  deny /usr/lib/python3*/{,**/}__pycache__/**.pyc.[0-9]* w,
+  # bind mount used here (see 'parallel installs', above)
+  deny @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/__pycache__/             w,
+  deny @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/__pycache__/*.pyc.[0-9]* w,
+
+  # Lttng tracing is very noisy and should not be allowed by confined apps. Can
+  # safely deny for the normal case (LP: #1260491). If/when an lttng-trace
+  # interface is needed, we can rework this.
+  deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 `
 
 // Template for privilege drop and chown operations. The specific setuid,

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -50,10 +50,11 @@ type commonInterface struct {
 	baseDeclarationPlugs string
 	baseDeclarationSlots string
 
-	connectedPlugAppArmor  string
-	connectedPlugSecComp   string
-	connectedPlugUDev      []string
-	rejectAutoConnectPairs bool
+	connectedPlugAppArmor     string
+	connectedPlugAppArmorDeny string
+	connectedPlugSecComp      string
+	connectedPlugUDev         []string
+	rejectAutoConnectPairs    bool
 
 	connectedPlugKModModules []string
 	connectedSlotKModModules []string
@@ -94,6 +95,9 @@ func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	}
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)
+	}
+	if iface.connectedPlugAppArmorDeny != "" {
+		spec.AddDenySnippet(iface.connectedPlugAppArmor)
 	}
 	return nil
 }

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -198,7 +198,9 @@ dbus (receive, send)
     interface=org.freedesktop.DBus.Properties
     path=/org/freedesktop/portal/{desktop,documents}{,/**}
     peer=(label=unconfined),
+`
 
+const desktopConnectedPlugAppArmorDeny = `
 # These accesses are noisy and applications can't do anything with the found
 # icon files, so explicitly deny to silence the denials
 deny /var/lib/snapd/desktop/icons/ r,
@@ -233,6 +235,7 @@ func (iface *desktopInterface) fontconfigDirs() []string {
 
 func (iface *desktopInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	spec.AddSnippet(desktopConnectedPlugAppArmor)
+	spec.AddDenySnippet(desktopConnectedPlugAppArmorDeny)
 
 	// Allow mounting document portal
 	emit := spec.AddUpdateNSf

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -76,12 +76,6 @@ mount fstype=fuse.* options=(rw,nosuid,nodev) ** -> /var/snap/{@{SNAP_NAME},@{SN
 mount fstype=fuse.* options=(ro,nosuid,nodev) ** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/common/{,**/},
 mount fstype=fuse.* options=(rw,nosuid,nodev) ** -> /var/snap/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/common/{,**/},
 
-# Explicitly deny reads to /etc/fuse.conf. We do this to ensure that
-# the safe defaults of fuse are used (which are enforced by our mount
-# rules) and not system-specific options from /etc/fuse.conf that
-# may conflict with our mount rules.
-deny /etc/fuse.conf r,
-
 # Allow read access to the fuse filesystem
 /sys/fs/fuse/ r,
 /sys/fs/fuse/** r,
@@ -91,17 +85,26 @@ deny /etc/fuse.conf r,
 #/{,usr/}bin/fusermount ixr,
 `
 
+const fuseSupportConnectedPlugAppArmorDeny = `
+# Explicitly deny reads to /etc/fuse.conf. We do this to ensure that
+# the safe defaults of fuse are used (which are enforced by our mount
+# rules) and not system-specific options from /etc/fuse.conf that
+# may conflict with our mount rules.
+deny /etc/fuse.conf r,
+`
+
 var fuseSupportConnectedPlugUDev = []string{`KERNEL=="fuse"`}
 
 func init() {
 	registerIface(&commonInterface{
-		name:                  "fuse-support",
-		summary:               fuseSupportSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     !(release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04"),
-		baseDeclarationSlots:  fuseSupportBaseDeclarationSlots,
-		connectedPlugAppArmor: fuseSupportConnectedPlugAppArmor,
-		connectedPlugSecComp:  fuseSupportConnectedPlugSecComp,
-		connectedPlugUDev:     fuseSupportConnectedPlugUDev,
+		name:                      "fuse-support",
+		summary:                   fuseSupportSummary,
+		implicitOnCore:            true,
+		implicitOnClassic:         !(release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04"),
+		baseDeclarationSlots:      fuseSupportBaseDeclarationSlots,
+		connectedPlugAppArmor:     fuseSupportConnectedPlugAppArmor,
+		connectedPlugAppArmorDeny: fuseSupportConnectedPlugAppArmorDeny,
+		connectedPlugSecComp:      fuseSupportConnectedPlugSecComp,
+		connectedPlugUDev:         fuseSupportConnectedPlugUDev,
 	})
 }

--- a/interfaces/builtin/gpg_keys.go
+++ b/interfaces/builtin/gpg_keys.go
@@ -38,9 +38,6 @@ const gpgKeysConnectedPlugAppArmor = `
 /usr/share/gnupg/options.skel r,
 
 owner @{HOME}/.gnupg/{,**} r,
-# gpg sometimes updates the trustdb to decide whether or not to update the
-# trustdb. For now, silence the denial since no other policy references this
-deny @{HOME}/.gnupg/trustdb.gpg w,
 
 # 'wk' is required for gpg encrypt and sign unless --no-random-seed-file is
 # used. Ideally we would not allow this access, but denying it causes gpg to
@@ -51,13 +48,20 @@ deny @{HOME}/.gnupg/trustdb.gpg w,
 owner @{HOME}/.gnupg/random_seed wk,
 `
 
+const gpgKeysConnectedPlugAppArmorDeny = `
+# gpg sometimes updates the trustdb to decide whether or not to update the
+# trustdb. For now, silence the denial since no other policy references this
+deny @{HOME}/.gnupg/trustdb.gpg w,
+`
+
 func init() {
 	registerIface(&commonInterface{
-		name:                  "gpg-keys",
-		summary:               gpgKeysSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  gpgKeysBaseDeclarationSlots,
-		connectedPlugAppArmor: gpgKeysConnectedPlugAppArmor,
+		name:                      "gpg-keys",
+		summary:                   gpgKeysSummary,
+		implicitOnCore:            true,
+		implicitOnClassic:         true,
+		baseDeclarationSlots:      gpgKeysBaseDeclarationSlots,
+		connectedPlugAppArmor:     gpgKeysConnectedPlugAppArmor,
+		connectedPlugAppArmorDeny: gpgKeysConnectedPlugAppArmorDeny,
 	})
 }

--- a/interfaces/builtin/gpg_public_keys.go
+++ b/interfaces/builtin/gpg_public_keys.go
@@ -44,6 +44,9 @@ owner @{HOME}/.gnupg/pubring.kbx r,
 owner @{HOME}/.gnupg/trustedkeys.gpg r,
 
 owner @{HOME}/.gnupg/trustdb.gpg r,
+`
+
+const gpgPublicKeysConnectedPlugAppArmorDeny = `
 # gpg sometimes updates the trustdb to decide whether or not to update the
 # trustdb. For now, silence the denial since no other policy references this
 deny @{HOME}/.gnupg/trustdb.gpg w,
@@ -51,11 +54,12 @@ deny @{HOME}/.gnupg/trustdb.gpg w,
 
 func init() {
 	registerIface(&commonInterface{
-		name:                  "gpg-public-keys",
-		summary:               gpgPublicKeysSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  gpgPublicKeysBaseDeclarationSlots,
-		connectedPlugAppArmor: gpgPublicKeysConnectedPlugAppArmor,
+		name:                      "gpg-public-keys",
+		summary:                   gpgPublicKeysSummary,
+		implicitOnCore:            true,
+		implicitOnClassic:         true,
+		baseDeclarationSlots:      gpgPublicKeysBaseDeclarationSlots,
+		connectedPlugAppArmor:     gpgPublicKeysConnectedPlugAppArmor,
+		connectedPlugAppArmorDeny: gpgPublicKeysConnectedPlugAppArmorDeny,
 	})
 }

--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -155,9 +155,6 @@ pivot_root
 @{PROC}/sys/fs/protected_fifos r,
 @{PROC}/sys/fs/protected_regular r,
 
-# mount tries to access this, but it doesn't really need it
-deny /run/mount/utab rw,
-
 # these accesses are needed in order to mount a squashfs file for the rootfs
 # note that these accesses allow reading other snaps and thus grants device control
 /dev/loop-control rw,
@@ -330,6 +327,11 @@ owner /state/server/{,**} rw,
 #include <abstractions/ssl_certs>
 `
 
+const greengrassSupportConnectedPlugAppArmorDeny = `
+# mount tries to access this, but it doesn't really need it
+deny /run/mount/utab rw,
+`
+
 const greengrassSupportConnectedPlugSeccomp = `
 # Description: can manage greengrass 'things' and their sandboxes. This
 # policy is intentionally not restrictive and is here to help guard against
@@ -378,6 +380,8 @@ func (iface *greengrassSupportInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	} else {
 		spec.AddSnippet(greengrassSupportConnectedPlugAppArmor + greengrassSupportConnectedPlugAppArmorCore)
 	}
+	spec.AddDenySnippet(greengrassSupportConnectedPlugAppArmorDeny)
+
 	// greengrass needs to use ptrace
 	spec.SetUsesPtraceTrace()
 

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -265,7 +265,9 @@ dbus (receive, send)
     path=/org/freedesktop
     interface=org.freedesktop.DBus.ObjectManager
     peer=(label=###PLUG_SECURITY_TAGS###),
+`
 
+const networkManagerConnectedSlotAppArmorDeny = `
 # Explicitly deny ptrace to silence noisy denials. These denials happen when NM
 # tries to access /proc/<peer_pid>/stat.  What apparmor prevents is showing
 # internal process addresses that live in that file, but that has no adverse
@@ -512,6 +514,8 @@ func (iface *networkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Speci
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(networkManagerConnectedSlotAppArmor, old, new, -1)
 	spec.AddSnippet(snippet)
+	denySnippet := strings.Replace(networkManagerConnectedSlotAppArmorDeny, old, new, -1)
+	spec.AddDenySnippet(denySnippet)
 	if !release.OnClassic {
 		// See https://bugs.launchpad.net/snapd/+bug/1849291 for details.
 		snippet := strings.Replace(networkManagerConnectedSlotIntrospectionSnippet, old, new, -1)

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -74,13 +74,6 @@ dbus (receive)
 # set-local-rtc commands.
 /usr/bin/timedatectl{,.real} ixr,
 
-# Silence this noisy denial. systemd utilities look at /proc/1/environ to see
-# if running in a container, but they will fallback gracefully. No other
-# interfaces allow this denial, so no problems with silencing it for now. Note
-# that allowing this triggers a 'ptrace trace peer=unconfined' denial, which we
-# want to avoid.
-deny @{PROC}/1/environ r,
-
 # Allow write access to system real-time clock
 # See 'man 4 rtc' for details.
 
@@ -100,6 +93,15 @@ capability sys_time,
 # and 'capability net_admin' here. Applications requiring audit
 # logging should plug 'netlink-audit'.
 /sbin/hwclock ixr,
+`
+
+const timeControlConnectedPlugAppArmorDeny = `
+# Silence this noisy denial. systemd utilities look at /proc/1/environ to see
+# if running in a container, but they will fallback gracefully. No other
+# interfaces allow this denial, so no problems with silencing it for now. Note
+# that allowing this triggers a 'ptrace trace peer=unconfined' denial, which we
+# want to avoid.
+deny @{PROC}/1/environ r,
 `
 
 const timeControlConnectedPlugSecComp = `
@@ -122,13 +124,14 @@ var timeControlConnectedPlugUDev = []string{`SUBSYSTEM=="rtc"`}
 
 func init() {
 	registerIface(&commonInterface{
-		name:                  "time-control",
-		summary:               timeControlSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  timeControlBaseDeclarationSlots,
-		connectedPlugAppArmor: timeControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  timeControlConnectedPlugSecComp,
-		connectedPlugUDev:     timeControlConnectedPlugUDev,
+		name:                      "time-control",
+		summary:                   timeControlSummary,
+		implicitOnCore:            true,
+		implicitOnClassic:         true,
+		baseDeclarationSlots:      timeControlBaseDeclarationSlots,
+		connectedPlugAppArmor:     timeControlConnectedPlugAppArmor,
+		connectedPlugAppArmorDeny: timeControlConnectedPlugAppArmorDeny,
+		connectedPlugSecComp:      timeControlConnectedPlugSecComp,
+		connectedPlugUDev:         timeControlConnectedPlugUDev,
 	})
 }

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -78,7 +78,9 @@ dbus (receive)
 # D-Bus method for controlling network time synchronization via
 # timedatectl's set-ntp command.
 /usr/bin/timedatectl{,.real} ixr,
+`
 
+const timeserverControlConnectedPlugAppArmorDeny = `
 # Silence this noisy denial. systemd utilities look at /proc/1/environ to see
 # if running in a container, but they will fallback gracefully. No other
 # interfaces allow this denial, so no problems with silencing it for now. Note
@@ -89,11 +91,12 @@ deny @{PROC}/1/environ r,
 
 func init() {
 	registerIface(&commonInterface{
-		name:                  "timeserver-control",
-		summary:               timeserverControlSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  timeserverControlBaseDeclarationSlots,
-		connectedPlugAppArmor: timeserverControlConnectedPlugAppArmor,
+		name:                      "timeserver-control",
+		summary:                   timeserverControlSummary,
+		implicitOnCore:            true,
+		implicitOnClassic:         true,
+		baseDeclarationSlots:      timeserverControlBaseDeclarationSlots,
+		connectedPlugAppArmor:     timeserverControlConnectedPlugAppArmor,
+		connectedPlugAppArmorDeny: timeserverControlConnectedPlugAppArmorDeny,
 	})
 }

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -80,7 +80,9 @@ dbus (receive)
 # D-Bus method for setting the timezone via timedatectl's set-timezone
 # command.
 /usr/bin/timedatectl{,.real} ixr,
+`
 
+const timezoneControlConnectedPlugAppArmorDeny = `
 # Silence this noisy denial. systemd utilities look at /proc/1/environ to see
 # if running in a container, but they will fallback gracefully. No other
 # interfaces allow this denial, so no problems with silencing it for now. Note
@@ -91,11 +93,12 @@ deny @{PROC}/1/environ r,
 
 func init() {
 	registerIface(&commonInterface{
-		name:                  "timezone-control",
-		summary:               timezoneControlSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  timezoneControlBaseDeclarationSlots,
-		connectedPlugAppArmor: timezoneControlConnectedPlugAppArmor,
+		name:                      "timezone-control",
+		summary:                   timezoneControlSummary,
+		implicitOnCore:            true,
+		implicitOnClassic:         true,
+		baseDeclarationSlots:      timezoneControlBaseDeclarationSlots,
+		connectedPlugAppArmor:     timezoneControlConnectedPlugAppArmor,
+		connectedPlugAppArmorDeny: timezoneControlConnectedPlugAppArmorDeny,
 	})
 }


### PR DESCRIPTION
This makes it so that we don't put `deny ...` rules in apparmor profiles when the profile is in devmode confinement. I think this is a useful change because it simplifies the process of developing strict mode snaps by installing the snap in devmode and seeing the entire set of denials that happen during strict confinement, whether they are silenced with a deny or not. I don't think this is a degradation of security policy, because we only remove those rules when we are in devmode and a snap could otherwise have just broken out of confinement some other way with these denials missing. Additionally, this makes it easier for folks developing snaps to "practice what we preach" because the preached methodology of "put it in devmode and add interfaces until you can't find interfaces anymore, then go to the forum for help" will work better because now folks would at least have denials to show us rather than needing a more experienced snap developer look at the generated policy for `deny` rules (if they remember that those are even a thing, I have forgotten myself to check for deny rules on a number of occasions and lost some time to it). 

For example, this kind of change would help (or would have helped) with the confinement of the following snaps:

- greengrass
- docker
- kubernetes
- [bandwhich](https://forum.snapcraft.io/t/possibly-missing-apparmor-network-permission/15054/24?u=ijohnson)
- probably others on the forum where it was non-obvious what was triggering denials in the snap

Note that since this is a RFC, I only added the minimum amount of test changes to get tests to pass, I will add more system level tests to ensure this system works well if this approach is not NACK'd. Specifically I think the following tests would be good:
- a test that we don't have any deny rules when in devmode (except with the kubernetes-support interface, see that file in this PR for more details)
- tests that interfaces with deny rules specified have those deny rules show up when run in strict mode, jail mode, partial confinement, etc. 
- tests that interfaces don't have deny rules in their normal snippets
- tests that interfaces only specify deny rules in their deny snippets

Finally, if folks nack this approach, I think a smaller and more targeted thing which would be pretty close to this in terms of being helpful would be just the change to not emit deny ptrace rules when run in devmode. Those seem the most common denials that :
- prevent applications from running properly
- are silenced by deny rules
- only work when a "super-privileged" interface such as docker-support is connected