### PR TITLE
 devicestate: encryption regardless of grade

### DIFF
--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -322,4 +322,12 @@ func MockSignalNotify(newSignalNotify func(sig ...os.Signal) (chan os.Signal, fu
 	}
 }
 
+func MockProcCmdline(newPath string) (restore func()) {
+	old := procCmdline
+	procCmdline = newPath
+	return func() {
+		procCmdline = old
+	}
+}
+
 type ServiceName = serviceName

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -311,11 +311,11 @@ func (s *deviceMgrInstallModeSuite) TestInstallSignedWithTPM(c *C) {
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSignedBypassEncryption(c *C) {
-	s.doRunChangeTestWithEncryption(c, "signed", false, true, false, "")
+	s.doRunChangeTestWithEncryption(c, "signed", false, true, false, "(?s).*cannot bypass encryption in a secured or signed device.*")
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSignedWithTPMBypassEncryption(c *C) {
-	s.doRunChangeTestWithEncryption(c, "signed", true, true, false, "")
+	s.doRunChangeTestWithEncryption(c, "signed", true, true, false, "(?s).*cannot bypass encryption in a secured or signed device.*")
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecured(c *C) {
@@ -327,9 +327,9 @@ func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPM(c *C) {
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecuredBypassEncryption(c *C) {
-	s.doRunChangeTestWithEncryption(c, "secured", false, true, false, "(?s).*cannot bypass encryption in a secured device.*")
+	s.doRunChangeTestWithEncryption(c, "secured", false, true, false, "(?s).*cannot bypass encryption in a secured or signed device.*")
 }
 
 func (s *deviceMgrInstallModeSuite) TestInstallSecuredWithTPMBypassEncryption(c *C) {
-	s.doRunChangeTestWithEncryption(c, "secured", true, true, false, "(?s).*cannot bypass encryption in a secured device.*")
+	s.doRunChangeTestWithEncryption(c, "secured", true, true, false, "(?s).*cannot bypass encryption in a secured or signed device.*")
 }

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -210,7 +210,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		c.Assert(mockSnapBootstrapCmd.Calls(), DeepEquals, [][]string{
 			{
 				"snap-bootstrap", "create-partitions", "--mount", "--encrypt",
-				"--keyfile", filepath.Join(dirs.RunMnt, "ubuntu-boot/keyfile"),
+				"--key-file", filepath.Join(dirs.RunMnt, "ubuntu-boot/keyfile"),
 				filepath.Join(dirs.SnapMountDir, "/pc/1"),
 			},
 		})

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -199,3 +199,11 @@ func MockBootMakeBootable(f func(model *asserts.Model, rootdir string, bootWith 
 		bootMakeBootable = old
 	}
 }
+
+func MockCheckTPMAvailability(f func() error) (restore func()) {
+	old := checkTPMAvailability
+	checkTPMAvailability = f
+	return func() {
+		checkTPMAvailability = old
+	}
+}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -72,7 +72,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 			// enable data encryption
 			"--encrypt",
 			// location to store the sealed keyfile
-			"--keyfile", filepath.Join(dirs.RunMnt, "ubuntu-boot", "keyfile"),
+			"--key-file", filepath.Join(dirs.RunMnt, "ubuntu-boot", "keyfile"),
 		)
 	}
 	args = append(args, gadgetDir)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -119,5 +119,10 @@ func checkEncryption(model *asserts.Model) (bool, error) {
 	// TODO:UC20: also check if TPM is available, and return an error if the device must be
 	//            encrypted but we don't have TPM support
 
+	// Force encryption regardless of grade for developer testing
+	if osutil.FileExists(filepath.Join(dirs.RunMnt, "ubuntu-seed", ".force-encryption")) {
+		return true, nil
+	}
+
 	return model.Grade() == asserts.ModelSecured, nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -116,8 +116,8 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func checkEncryption(model *asserts.Model) (bool, error) {
-	encryptionRequested := model.Grade() == asserts.ModelSecured
 	// TODO:UC20: also check if TPM is available, and return an error if the device must be
-	//            encrypted but but we don't have TPM support
-	return encryptionRequested, nil
+	//            encrypted but we don't have TPM support
+
+	return model.Grade() == asserts.ModelSecured, nil
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -122,11 +122,12 @@ var checkTPMAvailability = func() error {
 
 func checkEncryption(model *asserts.Model) (res bool, err error) {
 	secured := model.Grade() == asserts.ModelSecured
+	signed := model.Grade() == asserts.ModelSigned
 
 	// check if we should disable encryption non-secured devices
 	if osutil.FileExists(filepath.Join(dirs.RunMnt, "ubuntu-seed", ".force-unencrypted")) {
-		if secured {
-			err = fmt.Errorf("cannot bypass encryption in a secured device")
+		if secured || signed {
+			err = fmt.Errorf("cannot bypass encryption in a secured or signed device")
 		}
 		return false, err
 	}


### PR DESCRIPTION
This is #7999 with an extra patch  716952c   to workaround the kernel crash #1860231.