### PR TITLE
overlord/snapstate: add reproducer for LP#1860324 scenario (2.43)

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1066,8 +1066,10 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 	for name := range reportUpdated {
 		updated = append(updated, name)
 	}
+	if len(updates) > 0 && len(updated) > 0 && !globalFlags.NoReRefresh {
+		// re-refresh only when actual updates that change snap revision
+		// are applied
 
-	if len(updated) > 0 && !globalFlags.NoReRefresh {
 		// re-refresh will check the lanes to decide what to
 		// _actually_ re-refresh, but it'll be a subset of updated
 		// (and equal to updated if nothing goes wrong)


### PR DESCRIPTION
The failure reported in [1] is a panic inside the re-refresh handler. The
problem appears to be caused by a number of things that happened:
- auto aliases are updated
- rerefresh is automatically added
- state has "stable" tracking channel, while the new code uses "latest/stable"

We end up with the following set of tasks (listed in order):
- refresh-aliases
- check-rerefresh <-- panics
- switch-snap-channel

The problem happens on 2.43 branch so far, #8024 for master seems to be ok.

[1]. https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1860324

