### PR TITLE
snap: disable auto-import in uc20 install-mode

### DIFF
--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -322,4 +322,12 @@ func MockSignalNotify(newSignalNotify func(sig ...os.Signal) (chan os.Signal, fu
 	}
 }
 
+func MockProcCmdline(newPath string) (restore func()) {
+	old := procCmdline
+	procCmdline = newPath
+	return func() {
+		procCmdline = old
+	}
+}
+
 type ServiceName = serviceName


### PR DESCRIPTION
Do not try to auto-import block devices in install mode on UC20.
This will work-around the kernel crash LP:#1860231. We also do
not want to enable auto-import in this mode until we have a
use-case.

This works around the kernel crash in LP 1860231.