### PR TITLE
tests: use test-snapd-upower instead of upower

### DIFF
--- a/tests/main/hook-permissions/task.yaml
+++ b/tests/main/hook-permissions/task.yaml
@@ -11,7 +11,7 @@ prepare: |
     # shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB/systems.sh"
     if is_core_system; then
-        snap install upower
+        snap install test-snapd-upower --edge
     fi
     #shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB"/snaps.sh

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -11,7 +11,13 @@ details: |
     it without error while the plug is connected.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2504
-systems: [-ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*]
+systems:
+    - -ubuntu-*-ppc64el
+    - -fedora-*
+    - -opensuse-*
+    - -arch-*
+    - -amazon-*
+    - -centos-*
 
 prepare: |
     echo "Given a snap declaring a plug on the upower-observe interface is installed"
@@ -21,7 +27,7 @@ prepare: |
     . "$TESTSLIB/systems.sh"
     if is_core_system; then
         echo "And a snap providing a upower-observe slot is installed"
-        snap install upower
+        snap install test-snapd-upower --edge
     fi
 
 execute: |

--- a/tests/main/interfaces-upower-observe/test-snapd-upower/bin/upowerd.sh
+++ b/tests/main/interfaces-upower-observe/test-snapd-upower/bin/upowerd.sh
@@ -16,8 +16,9 @@
 
 DEBUG=false
 
-if [ -e $SNAP_DATA/config ]; then
-	. $SNAP_DATA/config
+if [ -e "$SNAP_DATA/config" ]; then
+	# shellcheck source=/dev/null
+	. "$SNAP_DATA/config"
 fi
 
 UPOWER_OPTS=
@@ -25,12 +26,12 @@ if [ $DEBUG = true ]; then
 	UPOWER_OPTS="-v"
 fi
 
-mkdir -p $SNAP_COMMON/history
+mkdir -p "$SNAP_COMMON/history"
 
-if [ ! -e $SNAP_DATA/UPower.conf ]; then
-	cp $SNAP/etc/UPower/UPower.conf $SNAP_DATA
+if [ ! -e "$SNAP_DATA/UPower.conf" ]; then
+	cp "$SNAP/etc/UPower/UPower.conf" "$SNAP_DATA"
 fi
 
 export UPOWER_CONF_FILE_NAME=$SNAP_DATA/UPower.conf
 
-exec $SNAP/usr/libexec/upowerd $UPOWER_OPTS
+exec "$SNAP/usr/libexec/upowerd" $UPOWER_OPTS

--- a/tests/main/interfaces-upower-observe/test-snapd-upower/bin/upowerd.sh
+++ b/tests/main/interfaces-upower-observe/test-snapd-upower/bin/upowerd.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Copyright (C) 2015-2019 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+DEBUG=false
+
+if [ -e $SNAP_DATA/config ]; then
+	. $SNAP_DATA/config
+fi
+
+UPOWER_OPTS=
+if [ $DEBUG = true ]; then
+	UPOWER_OPTS="-v"
+fi
+
+mkdir -p $SNAP_COMMON/history
+
+if [ ! -e $SNAP_DATA/UPower.conf ]; then
+	cp $SNAP/etc/UPower/UPower.conf $SNAP_DATA
+fi
+
+export UPOWER_CONF_FILE_NAME=$SNAP_DATA/UPower.conf
+
+exec $SNAP/usr/libexec/upowerd $UPOWER_OPTS

--- a/tests/main/interfaces-upower-observe/test-snapd-upower/snapcraft.yaml
+++ b/tests/main/interfaces-upower-observe/test-snapd-upower/snapcraft.yaml
@@ -64,7 +64,14 @@ parts:
       - umockdev
       - xsltproc
       - upower
-
+    stage-packages:
+      - libusb-1.0-0-dev
+      - libgudev-1.0-0
+      - libicu55
+      - libimobiledevice6
+      - libplist3
+      - libusbmuxd4
+      - libxml2
     stage:
       # FIXME: Drop when we have the upower-control interface in place
       # - -etc/dbus-1

--- a/tests/main/interfaces-upower-observe/test-snapd-upower/snapcraft.yaml
+++ b/tests/main/interfaces-upower-observe/test-snapd-upower/snapcraft.yaml
@@ -1,0 +1,81 @@
+name: test-snapd-upower
+base: core
+version: 0.99.4-3
+summary: snapd upower test snap
+description: |
+  Originally adapted from https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git/upower
+confinement: strict
+grade: stable
+
+slots:
+  service:
+    interface: upower-observe
+
+plugs:
+  client:
+    interface: upower-observe
+
+apps:
+  upowerd:
+    daemon: simple
+    adapter: full
+    command: bin/upowerd.sh
+    slots:
+      - service
+    plugs:
+      - hardware-observe
+  upower:
+    command: usr/bin/upower
+    adapter: full
+    plugs:
+      - client
+
+parts:
+  common:
+    plugin: dump
+    source: .
+    stage: [bin]
+  upower:
+    plugin: autotools
+    source: https://git.launchpad.net/ubuntu/+source/upower
+    source-type: git
+    source-branch: applied/ubuntu/xenial
+    configflags:
+      - --prefix=/usr
+      - --sysconfdir=/etc
+      - --with-historydir=/var/snap/upower/common/history
+      - --enable-tests
+    build-packages:
+      - build-essential
+      - autotools-dev
+      - gobject-introspection
+      - gtk-doc-tools
+      - intltool
+      - libgirepository1.0-dev
+      - libglib2.0-dev
+      - libglib2.0-doc
+      - libgudev-1.0-dev
+      - libimobiledevice-dev
+      - libusb-1.0-0-dev
+      - pkg-config
+      - udev
+      - gir1.2-umockdev-1.0
+      - gir1.2-upowerglib-1.0
+      - umockdev
+      - xsltproc
+      - upower
+
+    stage:
+      # FIXME: Drop when we have the upower-control interface in place
+      # - -etc/dbus-1
+      - -usr/share/locale
+      - -usr/share/man
+      - -usr/share/dbus-1
+      - -usr/include
+      - -lib/systemd
+      - -lib/udev
+
+    override-build: |
+      snapcraftctl build
+      # Run all tests shipped by default
+      make check


### PR DESCRIPTION
The upower snap has been unpublished as per https://forum.snapcraft.io/t/upower-snap-deprecation/14772 so we need a replacement for these the hook-permissions and the interfaces-upower-observe tests.

This should unbreak master, as currently the following master spread tests are failing:
- google:ubuntu-core-16-64:tests/main/hook-permissions
- google:ubuntu-core-16-64:tests/main/interfaces-upower-observe
- google:ubuntu-core-18-64:tests/main/hook-permissions
- google:ubuntu-core-18-64:tests/main/interfaces-upower-observe
- google:ubuntu-core-20-64:tests/main/hook-permissions
- google:ubuntu-core-20-64:tests/main/interfaces-upower-observe

I think that the 32-bit variants of the tests also will fail but they perhaps happened to run before the snap was revoked so they passed.

I will add the snapcraft.yaml source here later, just wanted to get spread running ASAP to confirm the tests are unbroken. 