### PR TITLE
tests: add a command-chain service test

### DIFF
--- a/tests/lib/snaps/command-chain/chain3
+++ b/tests/lib/snaps/command-chain/chain3
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export CHAIN_3_RAN=1
+printf "chain3 "
+exec "$@"

--- a/tests/lib/snaps/command-chain/chain4
+++ b/tests/lib/snaps/command-chain/chain4
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export CHAIN_4_RAN=1
+printf "chain4 "
+exec "$@"

--- a/tests/lib/snaps/command-chain/meta/snap.yaml
+++ b/tests/lib/snaps/command-chain/meta/snap.yaml
@@ -7,6 +7,10 @@ apps:
   hello:
     command: hello
     command-chain: [chain1, chain2]
+  run:
+    command: run
+    command-chain: [chain1, chain2]
+    daemon: simple
 
 hooks:
   configure:

--- a/tests/lib/snaps/command-chain/meta/snap.yaml
+++ b/tests/lib/snaps/command-chain/meta/snap.yaml
@@ -9,7 +9,7 @@ apps:
     command-chain: [chain1, chain2]
   run:
     command: run
-    command-chain: [chain1, chain2]
+    command-chain: [chain3, chain4]
     daemon: simple
 
 hooks:

--- a/tests/lib/snaps/command-chain/run
+++ b/tests/lib/snaps/command-chain/run
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+    echo "running: ${CHAIN_1_RAN:-0} ${CHAIN_2_RAN:-0}"
+    sleep 10
+done

--- a/tests/lib/snaps/command-chain/run
+++ b/tests/lib/snaps/command-chain/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 while true; do
-    echo "running: ${CHAIN_1_RAN:-0} ${CHAIN_2_RAN:-0}"
+    echo "running: ${CHAIN_1_RAN:-0} ${CHAIN_2_RAN:-0} ${CHAIN_3_RAN:-0} ${CHAIN_4_RAN:-0}"
     sleep 10
 done

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -25,7 +25,7 @@ execute: |
     echo "Test that command-chain runs for services"
     # let the logs catch up
     sleep 1
-    snap logs command-chain | MATCH 'chain1 chain2 running: 1 1$'
+    snap logs command-chain | MATCH 'chain3 chain4 running: 0 0 1 1$'
 
     echo "Ensure that the command-chain is run with 'snap run --shell' as well"
     [ "$(snap run --shell command-chain.hello -c 'echo "shell"')" = "chain1 chain2 shell" ]

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -22,6 +22,11 @@ execute: |
     echo "Test that command-chain runs for apps"
     [ "$(command-chain.hello)" = "chain1 chain2 hello" ]
 
+    echo "Test that command-chain runs for services"
+    # let the logs catch up
+    sleep 1
+    snap logs command-chain | MATCH 'chain1 chain2 running: 1 1$'
+
     echo "Ensure that the command-chain is run with 'snap run --shell' as well"
     [ "$(snap run --shell command-chain.hello -c 'echo "shell"')" = "chain1 chain2 shell" ]
     env="$(snap run --shell command-chain.hello -c 'env')"


### PR DESCRIPTION
We didn't have a spread test for a service using command-chain.
This adds that.