### PR TITLE
data/selinux: workaround incorrect fonts cache labeling on RHEL7 (2.43)

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -341,8 +341,11 @@ can_exec(snappy_t, snappy_snap_t)
 # fontconfig cache setup
 miscfiles_manage_fonts_cache(snappy_t)
 files_var_filetrans(snappy_t, fonts_cache_t, dir, "fontconfig")
-# fontconfig cache is in /usr/lib/fontconfig/cache, but its labeling is
-# incorrect, see https://bugzilla.redhat.com/show_bug.cgi?id=1659905
+# fontconfig cache is in /usr/lib/fontconfig/cache, which should be labeled as
+# fonts_cache_t, but it may be incorrectly labeled as lib_t, see
+# https://bugzilla.redhat.com/show_bug.cgi?id=1659905 and a corresponding bug
+# for RHEL7 https://bugzilla.redhat.com/show_bug.cgi?id=1792349 (marked as
+# WONTFIX, so carry the workaround for as long as we support EPEL7)
 libs_manage_lib_dirs(snappy_t)
 libs_manage_lib_files(snappy_t)
 fs_getattr_xattr_fs(snappy_t)
@@ -446,8 +449,16 @@ allow snappy_mount_t bin_t:dir mounton;
 gen_require(`
   type fonts_t, fonts_cache_t;
 ')
+
 allow snappy_mount_t fonts_cache_t:dir mounton;
 allow snappy_mount_t fonts_t:dir mounton;
+# fontconfig cache is in /usr/lib/fontconfig/cache, which should be labeled as
+# fonts_cache_t, but it may be incorrectly labeled as lib_t, see
+# https://bugzilla.redhat.com/show_bug.cgi?id=1659905 and a corresponding bug
+# for RHEL7 https://bugzilla.redhat.com/show_bug.cgi?id=1792349 (marked as
+# WONTFIX, so carry the workaround for as long as we support EPEL7)
+allow snappy_mount_t lib_t:dir mounton;
+
 # mount and unmount on top of snaps
 allow snappy_mount_t snappy_snap_t:dir mounton;
 allow snappy_mount_t snappy_snap_t:file mounton;


### PR DESCRIPTION
The /usr/lib/fontconfig/cache directory should be labeled as
fonts_cache_t (there's even a file type defined for that in the reference
policy), but isn't on some older systems, eg. F29 and RHEL7. We have added a
workaround for fontconfing cache back in F29 days and poked a hole for
snappy_t (snapd context).

We now need a similar whitelist rule for snappy_mount_t (snap-update-ns) to
allow mounting a pre-made cache from the host.

cherry pick of #8026 for 2.43
