### PR TITLE
snapstate: refactor things to add the re-refresh task last

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -315,6 +315,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	case "brand-gadget-id":
 		name = "brand-gadget"
 		typ = snap.TypeGadget
+	case "alias-snap-id":
+		name = "snap-id"
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -941,7 +941,12 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 
 	}
 
-	return doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, fromChange)
+	updated, tasksets, err :=  doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, fromChange)
+	if err != nil {
+		return nil, nil, err
+	}
+	tasksets = finalizeUpdate(st, tasksets, len(updates) > 0, updated, userID, flags)
+	return updated, tasksets, nil
 }
 
 func doUpdate(ctx context.Context, st *state.State, names []string, updates []*snap.Info, params func(*snap.Info) (*RevisionOptions, Flags, *SnapState), userID int, globalFlags *Flags, deviceCtx DeviceContext, fromChange string) ([]string, []*state.TaskSet, error) {
@@ -1091,7 +1096,11 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		updated = append(updated, name)
 	}
 
-	if len(updated) > 0 && !globalFlags.NoReRefresh {
+	return updated, tasksets, nil
+}
+
+func finalizeUpdate(st *state.State, tasksets []*state.TaskSet, hasUpdates bool, updated []string, userID int, globalFlags *Flags) []*state.TaskSet {
+	if hasUpdates && !globalFlags.NoReRefresh {
 		// re-refresh will check the lanes to decide what to
 		// _actually_ re-refresh, but it'll be a subset of updated
 		// (and equal to updated if nothing goes wrong)
@@ -1102,8 +1111,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []*s
 		})
 		tasksets = append(tasksets, state.NewTaskSet(rerefresh))
 	}
-
-	return updated, tasksets, nil
+	return tasksets
 }
 
 func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string, refreshAll bool, fromChange string, linkTs func(instanceName string, ts *state.TaskSet)) (*state.TaskSet, error) {
@@ -1480,9 +1488,6 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 	switchCohortKey := snapst.CohortKey != opts.CohortKey
 	toggleIgnoreValidation := snapst.IgnoreValidation != flags.IgnoreValidation
 	if infoErr == store.ErrNoUpdateAvailable && (switchChannel || switchCohortKey || toggleIgnoreValidation) {
-		// NOTE: if we are in here, len(updates) == 0
-		//       (so we're free to add tasks because there's no rerefresh)
-
 		if err := checkChangeConflictIgnoringOneChange(st, name, nil, fromChange); err != nil {
 			return nil, err
 		}
@@ -1530,6 +1535,9 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 		// really nothing to do, return the original no-update-available error
 		return nil, infoErr
 	}
+
+	tts = finalizeUpdate(st, tts, len(updates) > 0, []string{name}, userID, &flags)
+
 	flat := state.NewTaskSet()
 	for _, ts := range tts {
 		// The tasksets we get from "doUpdate" contain important

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -941,7 +941,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, us
 
 	}
 
-	updated, tasksets, err :=  doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, fromChange)
+	updated, tasksets, err := doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, fromChange)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -507,7 +507,10 @@ func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.St
 func verifyLastTasksetIsReRefresh(c *C, tts []*state.TaskSet) {
 	ts := tts[len(tts)-1]
 	c.Assert(ts.Tasks(), HasLen, 1)
-	c.Check(ts.Tasks()[0].Kind(), Equals, "check-rerefresh")
+	reRefresh := ts.Tasks()[0]
+	c.Check(reRefresh.Kind(), Equals, "check-rerefresh")
+	// nothing should wait on it
+	c.Check(reRefresh.NumHaltTasks(), Equals, 0)
 }
 
 func verifyRemoveTasks(c *C, ts *state.TaskSet) {
@@ -7280,7 +7283,10 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 		tasks := ts.Tasks()
 		// make sure the last task from Update is the rerefresh
 		if scenario.update {
-			c.Check(tasks[len(tasks)-1].Kind(), Equals, "check-rerefresh")
+			reRefresh := tasks[len(tasks)-1]
+			c.Check(reRefresh.Kind(), Equals, "check-rerefresh")
+			// nothing should wait on it
+			c.Check(reRefresh.NumHaltTasks(), Equals, 0)
 			tasks = tasks[:len(tasks)-1] // and now forget about it
 		}
 


### PR DESCRIPTION
This is hopefully less fragile to special manipulation of the update tasksets.

