### PR TITLE
travis, tests, run-checks: skip nakedret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ matrix:
         - ./get-deps.sh
       script:
         - set -e
-        # skip nakedret errors until
-        # https://github.com/alexkohler/nakedret/issues/11 is resolved
-        - SKIP_NAKEDRET=1 ./run-checks --static
+        - ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick
       go: "1.10.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ matrix:
         - ./get-deps.sh
       script:
         - set -e
-        - ./run-checks --static
+        # skip nakedret errors until
+        # https://github.com/alexkohler/nakedret/issues/11 is resolved
+        - SKIP_NAKEDRET=1 ./run-checks --static
         - ./run-checks --short-unit
     - stage: quick
       go: "1.10.x"

--- a/run-checks
+++ b/run-checks
@@ -235,7 +235,11 @@ if [ "$STATIC" = 1 ]; then
     got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)
     if [ -n "$got" ]; then
         echo "$got"
-        exit 1
+        if [ -z "${SKIP_NAKEDRET:-}" ]; then
+            exit 1
+        else
+            echo "Ignoring nakedret errors as requested"
+        fi
     fi
 
     echo Checking all interfaces have minimal spread test

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -6,6 +6,11 @@ systems: [-debian-sid-*]
 # Start before anything else as it takes a long time.
 priority: 1000
 
+environment:
+    # skip nakedret errors until
+    # https://github.com/alexkohler/nakedret/issues/11 is resolved
+    SKIP_NAKEDRET: 1
+
 restore: |
     rm -rf /tmp/static-unit-tests
 
@@ -23,6 +28,10 @@ execute: |
         # in later releases; skip gofmt checks on systems where go is known to
         # be newer and produce incompatible formatting
         skip='SKIP_GOFMT=1'
+    fi
+
+    if [[ -n "${SKIP_NAKEDRET:-}" ]]; then
+        skip="${skip:-} SKIP_NAKEDRET=1"
     fi
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -6,11 +6,6 @@ systems: [-debian-sid-*]
 # Start before anything else as it takes a long time.
 priority: 1000
 
-environment:
-    # skip nakedret errors until
-    # https://github.com/alexkohler/nakedret/issues/11 is resolved
-    SKIP_NAKEDRET: 1
-
 restore: |
     rm -rf /tmp/static-unit-tests
 

--- a/testutil/containschecker.go
+++ b/testutil/containschecker.go
@@ -86,7 +86,7 @@ func (c *containsChecker) Check(params []interface{}, names []string) (result bo
 	var container interface{} = params[0]
 	var elem interface{} = params[1]
 	if commonEquals(container, elem, &result, &error) {
-		return
+		return result, error
 	}
 	// Do the actual test using ==
 	switch containerV := reflect.ValueOf(container); containerV.Kind() {
@@ -116,7 +116,7 @@ type deepContainsChecker struct {
 }
 
 // DeepContains is a Checker that looks for a elem in a container using
-// DeepEqual.  The elem can be any object. The container can be an array, slice
+// DeepEqual. The elem can be any object. The container can be an array, slice
 // or string.
 var DeepContains check.Checker = &deepContainsChecker{
 	&check.CheckerInfo{Name: "DeepContains", Params: []string{"container", "elem"}},
@@ -126,7 +126,7 @@ func (c *deepContainsChecker) Check(params []interface{}, names []string) (resul
 	var container interface{} = params[0]
 	var elem interface{} = params[1]
 	if commonEquals(container, elem, &result, &error) {
-		return
+		return result, error
 	}
 	// Do the actual test using reflect.DeepEqual
 	switch containerV := reflect.ValueOf(container); containerV.Kind() {


### PR DESCRIPTION
Nakedret uptream broke and reports false positives for nested function literals
[1]. A PR with a fix is open already, but until it lands, we need to skip
nakedret errors.

While at it, fix the valid issues raised by nakedret.

1. https://github.com/alexkohler/nakedret/issues/11

