### PR TITLE
tests: fix gadget-update-pc test leaking snaps

### DIFF
--- a/tests/main/gadget-update-pc/task.yaml
+++ b/tests/main/gadget-update-pc/task.yaml
@@ -25,6 +25,14 @@ prepare: |
         exit 1
     fi
 
+    # Set the retain count to 4 to ensure we keep the current gadget snap
+    # intact and can roll back to it. This is easier to get right than to
+    # manually fiddle with re-installing it.
+    snap set core refresh.retain=4
+    # Save the current revision of the pc snap. At this moment the pc snap is
+    # the real snap from the store and the revision will drift over time.
+    readlink /snap/pc/current > original-revision.txt
+
     snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
 
     #shellcheck source=tests/lib/store.sh
@@ -93,15 +101,14 @@ restore: |
     . "$TESTSLIB"/store.sh
     teardown_fake_store "$BLOB_DIR"
 
-    # restore the original gadget snap
-    snap install gadget.snap
-
-    # restoring the snapshot of / does not clean up /var/snap/pc/<rev>
-    # directories that were created during the test, given that the state is
-    # restored these directories will not be accounted for
-    for i in $(seq 0 2); do
-        rm -rf "/var/snap/pc/$((START_REVISION+i))"
+    # Restore the state of the gadget snap.
+    snap revert pc --revision="$(cat original-revision.txt)"
+    rm -f original-revision.txt
+    for rev in $(seq "$START_REVISION" "$((START_REVISION + 2))") ; do
+        snap remove --revision="$rev" pc
     done
+    # Undo changes to refresh.retain settings.
+    snap unset core refresh.retain
 
 execute: |
     # external backends do not enable test keys


### PR DESCRIPTION
This test was long on the list of well-known tests that leak stuff. In
particular, this test is leaking revisions of the pc gadget, that remain
mounted even after their snaps are deleted from disk.

The fix, in hindsight, is rather simple and should have been obvious
earlier. The entire problem is that attempting to re-install the
original snap and get the perfect outcome is hard (for example, loopback
devices may change). Instead of doing that, just _retain_ the original
snap, keep the other snaps while we are testing, and revert to the
original revision afterwards.

This passes as clean on the long-lived, in progress mount leak detector
branch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
