### PR TITLE
tests: remove revision leaking from ubuntu-core-refresh

### DIFF
--- a/tests/main/ubuntu-core-refresh/task.yaml
+++ b/tests/main/ubuntu-core-refresh/task.yaml
@@ -9,6 +9,20 @@ details: |
 # TODO:UC20: enable for UC20
 systems: [ubuntu-core-1*]
 
+
+restore: |
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB"/systems.sh
+    TARGET_SNAP_NAME=core
+    if is_core18_system; then
+        TARGET_SNAP_NAME=core18
+    fi
+
+    if not snap remove "$TARGET_SNAP_NAME" --revision=x2; then
+        snap changes
+        exit 1
+    fi
+
 execute: |
     #shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB"/journalctl.sh
@@ -51,9 +65,8 @@ execute: |
 
         REBOOT
     elif [ "$SPREAD_REBOOT" = 1 ]; then
-        while ! snap changes | MATCH "Done.*Install \"${TARGET_SNAP_NAME}\" snap from file.*"; do
-            sleep 1
-        done
+        # Wait for the install to complete.
+        snap watch --last=install
 
         # Check the current revision has changed
         currRev="$(readlink /snap/${TARGET_SNAP_NAME}/current)"
@@ -78,6 +91,8 @@ execute: |
 
         REBOOT
     elif [  "$SPREAD_REBOOT" = 2 ]; then
+        # Wait for the revert to complete.
+        snap watch --last=revert-snap
         # Check the current revision is the same than the original
         currRev="$(readlink /snap/${TARGET_SNAP_NAME}/current)"
         [ "$(cat initialRev)" ==  "$currRev" ]


### PR DESCRIPTION
This is the second of the three, well-known tests, that leak a snap
revision, which upsets the mount leak detector, which also upsets the
mount-ns test.

This case is simple, since core devices do not remove unused revisions
across tests, we just have to do it manually.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
