### PR TITLE
gadget: skip update when raw structure content is unchanged

### DIFF
--- a/gadget/update.go
+++ b/gadget/update.go
@@ -266,7 +266,9 @@ func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume, policy
 }
 
 type Updater interface {
-	// Update applies the update or errors out on failures
+	// Update applies the update or errors out on failures. When no actual
+	// update was applied because the new content is identical a special
+	// ErrNoUpdate is returned.
 	Update() error
 	// Backup prepares a backup copy of data that will be modified by
 	// Update()
@@ -294,12 +296,21 @@ func applyUpdates(new GadgetData, updates []updatePair, rollbackDir string) erro
 
 	var updateErr error
 	var updateLastAttempted int
+	var skipped int
 	for i, one := range updaters {
 		updateLastAttempted = i
 		if err := one.Update(); err != nil {
+			if err == ErrNoUpdate {
+				skipped++
+				continue
+			}
 			updateErr = fmt.Errorf("cannot update volume structure %v: %v", updates[i].to, err)
 			break
 		}
+	}
+	if skipped == len(updaters) {
+		// all updates were a noop
+		return ErrNoUpdate
 	}
 
 	if updateErr == nil {


### PR DESCRIPTION
Even though the structure edition is bumped, the actual content of raw structure
may be unchanged. This can only be determined once we run the `Backup()` phase
of the update sequence. Should such scenario be identified, return an error
indicating that there is no update. The callers up the stack are already
prepared to handle such scenarios and trigger no reboot.

The mechanism is introduced for 'raw' (or non-filesystem) structures first,
since their analysis is much simpler.
