### PR TITLE
tests: remove revision leaking from remodel-kernel

### DIFF
--- a/tests/main/remodel-kernel/task.yaml
+++ b/tests/main/remodel-kernel/task.yaml
@@ -13,6 +13,10 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    # Save the revision of the pc-kernel snap.
+    readlink /snap/pc-kernel/current > original-revision.txt
+
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
     systemctl stop snapd.service snapd.socket
@@ -33,6 +37,18 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    # Wait for the final refresh to complete.
+    snap watch --last=refresh
+
+    # Remove all the revisions of pc-kernel that should not be there.
+    for revno_path in /snap/pc-kernel/*; do
+        revno="$(basename "$revno_path")"
+        if [ "$revno" == current ] || [ "$revno" == "$(cat original-revision.txt)" ]; then
+            continue;
+        fi
+        snap remove pc-kernel --revision="$revno"
+    done
 
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh


### PR DESCRIPTION
This is the last of the three leaking tests. Here we are leaking the
mounted revision of pc-kernel snap that is never removed because we nuke
the state. This patch corrects that and passes without any issues on the
mount leak detector branch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>