### PR TITLE
osutil: add Renameat2()

### DIFF
--- a/osutil/sys_linux.go
+++ b/osutil/sys_linux.go
@@ -62,3 +62,31 @@ func Readlinkat(dirfd int, path string, buf []byte) (n int, err error) {
 	}
 	return n, nil
 }
+
+// Renameat2 is a direct pass-through to the renameat2() system call.
+func Renameat2(oldfd int, old string, newfd int, new string, flags int) (err error) {
+	oldPathPtr, err := syscall.BytePtrFromString(old)
+	if err != nil {
+		return err
+	}
+
+	newPathPtr, err := syscall.BytePtrFromString(new)
+	if err != nil {
+		return err
+	}
+
+	_, _, errno := syscall.Syscall6(
+		SYS_RENAMEAT2,
+		uintptr(oldfd),
+		uintptr(unsafe.Pointer(oldPathPtr)),
+		uintptr(newfd),
+		uintptr(unsafe.Pointer(newPathPtr)),
+		uintptr(flags),
+		0,
+	)
+	if errno != 0 {
+		return errno
+	}
+
+	return nil
+}

--- a/osutil/zsys_linux_386.go
+++ b/osutil/zsys_linux_386.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+const (
+	SYS_RENAMEAT2   = 316
+	RENAME_EXCHANGE = 0x2
+)

--- a/osutil/zsys_linux_amd64.go
+++ b/osutil/zsys_linux_amd64.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+const (
+	SYS_RENAMEAT2   = 316
+	RENAME_EXCHANGE = 0x2
+)

--- a/osutil/zsys_linux_arm.go
+++ b/osutil/zsys_linux_arm.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+const (
+	SYS_RENAMEAT2   = 382
+	RENAME_EXCHANGE = 0x2
+)

--- a/osutil/zsys_linux_arm64.go
+++ b/osutil/zsys_linux_arm64.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+const (
+	SYS_RENAMEAT2   = 353
+	RENAME_EXCHANGE = 0x2
+)

--- a/osutil/zsys_linux_s390x.go
+++ b/osutil/zsys_linux_s390x.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+const (
+	SYS_RENAMEAT2   = 316
+	RENAME_EXCHANGE = 0x2
+)


### PR DESCRIPTION
This function is needed to atomically move a symlink in the grub bootloader, but could have other uses as we need to do more critical file operations at other times.

This is now a pre-req for https://github.com/snapcore/snapd/pull/8001