### PR TITLE
grub: support atomically renaming kernel symlinks

### DIFF
--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -180,27 +180,28 @@ func (g *grub) RemoveKernelAssets(s snap.PlaceInfo) error {
 func (g *grub) makeKernelEfiSymlink(s snap.PlaceInfo, name string) error {
 	// use a relative symlink destination so that it resolves properly, if grub
 	// is located at /run/mnt/ubuntu-boot or /boot/grub, etc.
-	extractedKernel := filepath.Join(
+	target := filepath.Join(
 		filepath.Base(s.MountFile()),
 		"kernel.efi",
 	)
 
+	// the location of the destination symlink as an absolute filepath
+	source := filepath.Join(g.dir(), name)
+
 	// check that the kernel snap has been extracted already so we don't
 	// inadvertently create a dangling symlink
 	// expand the relative symlink from g.dir()
-	if !osutil.FileExists(filepath.Join(g.dir(), extractedKernel)) {
+	if !osutil.FileExists(filepath.Join(g.dir(), target)) {
 		return fmt.Errorf(
 			"cannot enable %s at %s: %v",
 			name,
-			extractedKernel,
+			target,
 			os.ErrNotExist,
 		)
 	}
 
-	return os.Symlink(
-		extractedKernel,
-		filepath.Join(g.dir(), name),
-	)
+	// the symlink doesn't exist so just create it
+	return osutil.AtomicSymlink(target, source)
 }
 
 // unlinkKernelEfiSymlink will remove the specified symlink if it exists. Note

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -413,8 +413,18 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableKernel(c *C) {
 	// ensure that the symlink was put where we expect it
 	asset, err := os.Readlink(filepath.Join(s.grubDir(), "kernel.efi"))
 	c.Assert(err, IsNil)
-
 	c.Assert(asset, DeepEquals, filepath.Join("pc-kernel_1.snap", "kernel.efi"))
+
+	// create a new kernel snap and ensure that we can safely enable that one
+	// too
+	kernel2 := s.makeKernelAssetSnap(c, "pc-kernel_2.snap")
+	err = eg.EnableKernel(kernel2)
+	c.Assert(err, IsNil)
+
+	// ensure that the symlink was put where we expect it
+	asset, err = os.Readlink(filepath.Join(s.grubDir(), "kernel.efi"))
+	c.Assert(err, IsNil)
+	c.Assert(asset, DeepEquals, filepath.Join("pc-kernel_2.snap", "kernel.efi"))
 }
 
 func (s *grubTestSuite) TestGrubExtractedRunKernelImageEnableTryKernel(c *C) {


### PR DESCRIPTION
Previously, makeKernelEfiSymlink would fail if the symlink already existed. This situation happens when we have a kernel snap refresh, where the kernel.efi symlink already exists and we want to move it after a successful refresh. We can fix this by using the AtomicSymlink helper, which atomically creates the symlink, even if the symlink already exists.

Also add a unit test for this situation.

Based on top of https://github.com/snapcore/snapd/pull/8045, the relevant commit here to review is https://github.com/snapcore/snapd/pull/8044/commits/6169f769049e1fcde6054a414e37e9813351722b