### PR TITLE
osutil: add helpers for creating symlinks and renaming in an atomic manner

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -107,6 +107,11 @@ func SetUnsafeIO(b bool) func() {
 	}
 }
 
+func GetUnsafeIO() bool {
+	// a getter so that tests do not attempt to modify that directly
+	return snapdUnsafeIO
+}
+
 func MockOsReadlink(f func(string) (string, error)) func() {
 	realOsReadlink := osReadlink
 	osReadlink = f

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -197,3 +197,5 @@ func MockFindGid(mock func(name string) (uint64, error)) (restore func()) {
 	findGid = mock
 	return func() { findGid = old }
 }
+
+const MaxSymlinkTries = maxSymlinkTries

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/strutil"
@@ -231,44 +232,57 @@ func AtomicWriteChown(filename string, reader io.Reader, perm os.FileMode, flags
 func AtomicRename(oldName, newName string) error {
 	var oldDir, newDir *os.File
 
+	// snapdUnsafeIO controls the ability to ignore expensive disk
+	// synchronization. It is only used inside tests.
 	if !snapdUnsafeIO {
 		oldDirPath := filepath.Dir(oldName)
 		newDirPath := filepath.Dir(newName)
 
-		o, err := os.Open(oldDirPath)
+		oldDir, err := os.Open(oldDirPath)
 		if err != nil {
 			return err
 		}
-		oldDir = o
-		defer o.Close()
+		defer oldDir.Close()
 
-		if oldDir != newDir {
-			n, err := os.Open(newDirPath)
-			if err != nil {
-				return err
-			}
-			newDir = n
-			defer n.Close()
+		newDir, err := os.Open(newDirPath)
+		if err != nil {
+			return err
 		}
+		defer newDir.Close()
+
+		oldInfo, err := oldDir.Stat()
+		if err != nil {
+			return err
+		}
+		newInfo, err := newDir.Stat()
+		if err != nil {
+			return err
+		}
+		if oldStat, ok := oldInfo.Sys().(*syscall.Stat_t); ok {
+			if newStat, ok := newInfo.Sys().(*syscall.Stat_t); ok {
+				// Old and new directories refer to the same location. We can only sync once.
+				if oldStat.Dev == newStat.Dev && oldStat.Ino == newStat.Ino {
+					newDir = nil
+				}
+			}
+		}
+
 	}
 
-	err := os.Rename(oldName, newName)
-	if err != nil {
+	if err := os.Rename(oldName, newName); err != nil {
 		return err
 	}
-
-	if !snapdUnsafeIO {
-		var err1, err2 error
+	var err1, err2 error
+	if oldDir != nil {
 		err1 = oldDir.Sync()
-		if newDir != nil {
-			err2 = newDir.Sync()
-		}
-		if err1 != nil {
-			return err1
-		}
-		return err2
 	}
-	return nil
+	if newDir != nil {
+		err2 = newDir.Sync()
+	}
+	if err1 != nil {
+		return err1
+	}
+	return err2
 }
 
 const maxSymlinkTries = 10

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -235,20 +235,122 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 	c.Check(osutil.FileExists(fn), Equals, false)
 }
 
-// SafeIoAtomicWriteTestSuite runs all AtomicWrite with safe
+type AtomicSymlinkTestSuite struct{}
+
+var _ = Suite(&AtomicSymlinkTestSuite{})
+
+func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
+	mustReadSymlink := func(p, exp string) {
+		target, err := os.Readlink(p)
+		c.Assert(err, IsNil)
+		c.Check(exp, Equals, target)
+	}
+
+	d := c.MkDir()
+	err := osutil.AtomicSymlink("target", filepath.Join(d, "bar"))
+	c.Assert(err, IsNil)
+	mustReadSymlink(filepath.Join(d, "bar"), "target")
+
+	// no nested directory
+	nested := filepath.Join(d, "nested")
+	err = osutil.AtomicSymlink("target", filepath.Join(nested, "bar"))
+	c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: no such file or directory`)
+
+	// create a dir without write permission
+	err = os.MkdirAll(nested, 0644)
+	c.Assert(err, IsNil)
+
+	// no permission to write in dir
+	err = osutil.AtomicSymlink("target", filepath.Join(nested, "bar"))
+	c.Assert(err, ErrorMatches, `symlink target /.*/nested/bar\..*~: permission denied`)
+
+	err = os.Chmod(nested, 0755)
+	c.Assert(err, IsNil)
+
+	err = osutil.AtomicSymlink("target", filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+	mustReadSymlink(filepath.Join(nested, "bar"), "target")
+
+	// symlink gets replaced
+	err = osutil.AtomicSymlink("new-target", filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+	mustReadSymlink(filepath.Join(nested, "bar"), "new-target")
+
+	// don't care about symlink target
+	err = osutil.AtomicSymlink("/this/is/some/funny/path", filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+	mustReadSymlink(filepath.Join(nested, "bar"), "/this/is/some/funny/path")
+
+}
+
+type AtomicRenameTestSuite struct{}
+
+var _ = Suite(&AtomicRenameTestSuite{})
+
+func (ts *AtomicRenameTestSuite) TestAtomicRename(c *C) {
+	d := c.MkDir()
+
+	err := ioutil.WriteFile(filepath.Join(d, "foo"), []byte("foobar"), 0644)
+	c.Assert(err, IsNil)
+
+	err = osutil.AtomicRename(filepath.Join(d, "foo"), filepath.Join(d, "bar"))
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(d, "bar"), testutil.FileEquals, "foobar")
+
+	// no nested directory
+	nested := filepath.Join(d, "nested")
+	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+	if !osutil.GetUnsafeIO() {
+		// with safe IO first op is to open the source and target directories
+		c.Assert(err, ErrorMatches, "open /.*/nested: no such file or directory")
+	} else {
+		c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: no such file or directory")
+	}
+
+	// create a dir without write permission
+	err = os.MkdirAll(nested, 0644)
+	c.Assert(err, IsNil)
+
+	// no permission to write in dir
+	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+	c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: permission denied")
+
+	err = os.Chmod(nested, 0755)
+	c.Assert(err, IsNil)
+
+	// all good now
+	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(nested, "new-bar"), []byte("barbar"), 0644)
+	c.Assert(err, IsNil)
+
+	// target is overwritten
+	err = osutil.AtomicRename(filepath.Join(nested, "new-bar"), filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(nested, "bar"), testutil.FileEquals, "barbar")
+
+	// no source
+	err = osutil.AtomicRename(filepath.Join(d, "does-not-exist"), filepath.Join(nested, "bar"))
+	c.Assert(err, ErrorMatches, "rename /.*/does-not-exist /.*/nested/bar: no such file or directory")
+}
+
+// SafeIoAtomicTestSuite runs all Atomic* tests with safe
 // io enabled
-type SafeIoAtomicWriteTestSuite struct {
+type SafeIoAtomicTestSuite struct {
 	AtomicWriteTestSuite
+	AtomicSymlinkTestSuite
+	AtomicRenameTestSuite
 
 	restoreUnsafeIO func()
 }
 
-var _ = Suite(&SafeIoAtomicWriteTestSuite{})
+var _ = Suite(&SafeIoAtomicTestSuite{})
 
-func (s *SafeIoAtomicWriteTestSuite) SetUpSuite(c *C) {
+func (s *SafeIoAtomicTestSuite) SetUpSuite(c *C) {
 	s.restoreUnsafeIO = osutil.SetUnsafeIO(false)
 }
 
-func (s *SafeIoAtomicWriteTestSuite) TearDownSuite(c *C) {
+func (s *SafeIoAtomicTestSuite) TearDownSuite(c *C) {
 	s.restoreUnsafeIO()
 }


### PR DESCRIPTION
Implement helpers that perform atomic renames (AtomicRename) and create symlinks
in an atomic manner (AtomicSymlink).

Should replace #8043. Ideally, we should use it in #8044.