### PR TITLE
tests: detect LXD launching i386 containers

### DIFF
--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -25,8 +25,15 @@ execute: |
 
     # The snapd package we build as part of the tests will only run on the
     # distro we build on. So we need to launch the right ubuntu version.
-    . /etc/os-release
-    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
+    (
+        . /etc/os-release
+        lxd.lxc launch --quiet "ubuntu:${VERSION_ID:-}" my-ubuntu
+    )
+    if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
+        echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
+        snap info lxd
+        exit 1
+    fi
 
     echo "Remove fuse to trigger the fuse sanity check"
     lxd.lxc exec my-ubuntu -- apt autoremove -y fuse

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -31,8 +31,15 @@ execute: |
 
     # The snapd package we build as part of the tests will only run on the
     # distro we build on. So we need to launch the right ubuntu version.
-    . /etc/os-release
-    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
+    (
+        . /etc/os-release
+        lxd.lxc launch --quiet "ubuntu:${VERSION_ID:-}" my-ubuntu
+    )
+    if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
+        echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
+        snap info lxd
+        exit 1
+    fi
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -69,13 +69,26 @@ execute: |
     # prep two containers, the my-ubuntu normal container and the 
     # my-nesting-ubuntu nesting container
 
-    . /etc/os-release
-    # TODO:2004: remove version check once the image for ubuntu 20.04 is published
-    if [ "$VERSION_ID" == 20.04 ]; then
-        VERSION_ID=19.10
+    (
+        . /etc/os-release
+        # TODO:2004: remove version check once the image for ubuntu 20.04 is published
+        if [ "$VERSION_ID" == 20.04 ]; then
+            # shellcheck disable=SC2031
+            VERSION_ID=19.10
+        fi
+        lxd.lxc launch --quiet "ubuntu:${VERSION_ID:-}" my-ubuntu
+        lxd.lxc launch --quiet "ubuntu:${VERSION_ID:-}" my-nesting-ubuntu -c security.nesting=true
+    )
+    if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
+        echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
+        snap info lxd
+        exit 1
     fi
-    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-ubuntu
-    lxd.lxc launch --quiet "ubuntu:${VERSION_ID}" my-nesting-ubuntu -c security.nesting=true
+    if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-nesting-ubuntu | grep "Architecture: i686"; then
+        echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
+        snap info lxd
+        exit 1
+    fi
 
     for cont_name in my-ubuntu my-nesting-ubuntu; do
         echo "Ensure we can run things inside"
@@ -126,7 +139,16 @@ execute: |
     lxd.lxc exec my-nesting-ubuntu -- snap set lxd waitready.timeout=240
     lxd.lxc exec my-nesting-ubuntu -- lxd waitready
     lxd.lxc exec my-nesting-ubuntu -- lxd init --auto
-    lxd.lxc exec my-nesting-ubuntu -- lxd.lxc launch "ubuntu:${VERSION_ID}" my-inner-ubuntu
+
+    (
+        . /etc/os-release
+        # TODO:2004: remove version check once the image for ubuntu 20.04 is published
+        if [ "$VERSION_ID" == 20.04 ]; then
+            # shellcheck disable=SC2031
+            VERSION_ID=19.10
+        fi
+        lxd.lxc exec my-nesting-ubuntu -- lxd.lxc launch "ubuntu:${VERSION_ID:-}" my-inner-ubuntu
+    )
     lxd.lxc exec my-nesting-ubuntu -- lxd.lxc exec my-inner-ubuntu -- echo "from-the-INSIDE-inside" | MATCH from-the-INSIDE-inside
 
     echo "Install lxd-demo server to exercise the lxd interface"

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -47,6 +47,11 @@ execute: |
     fi
 
     lxd.lxc launch --quiet "ubuntu:18.04" my-ubuntu
+    if [ "$(uname -m)" = x86_64 ] && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
+        echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"
+        snap info lxd
+        exit 1
+    fi
 
     echo "Ensure we can run things inside"
     lxd.lxc exec my-ubuntu echo hello | MATCH hello


### PR DESCRIPTION
Since late Friday lxd has been sometimes launching i386 containers on
amd64 hosts. This patch adds explicit detection of this situation.

This contains a detector for regression of https://github.com/lxc/lxd/pull/6773

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
