### PR TITLE
tests: disable system-usernames test on core20

### DIFF
--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -1,4 +1,15 @@
 summary: ensure seccomp rules for snap_daemon user work correctly
+# This test is failing on core20:
+#
+# 2020-01-25 23:33:09 Error restoring google:ubuntu-core-20-64:tests/main/system-usernames :
+# -----
+# + snap remove --purge test-snapd-daemon-user
+# test-snapd-daemon-user removed
+# + user-tool remove-with-group snap_daemon
+# userdel: user 'snap_daemon' does not exist
+# snap_daemon:x:584788:584788::/nonexistent:/usr/bin/false
+# user exists after removal?
+systems: [-ubuntu-core-20-64]
 
 environment:
     # This is used to abbreviate some of the paths below.


### PR DESCRIPTION
This test is failing and has broken master. I suspect we are missing
writable-paths or something similar but whatever it is, master must not
be broken.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
