### PR TITLE
tests: fix revisions leaking from snapd-refresh test

### DIFF
--- a/tests/core18/snapd-refresh/task.yaml
+++ b/tests/core18/snapd-refresh/task.yaml
@@ -1,5 +1,16 @@
 summary: Test refreshing snapd and running new units
 
+restore: |
+    # Remove all inactive revisions of snapd.
+    current=$(readlink /snap/snapd/current)
+    for revno_path in /snap/snapd/*; do
+        revno=$(basename "$revno_path")
+        if [ "$revno" == current ] || [ "$revno" == "$current" ]; then
+            continue
+        fi
+        snap remove snapd --revision="$revno"
+    done
+
 execute: |
     echo "Testing refresh/revert of snapd"
     current=$(readlink /snap/snapd/current)


### PR DESCRIPTION
This test leaves behind inactive revisions of the snapd snap that were
not removed and were detected by the mount leak detector.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
