### PR TITLE
daemon: refactor create-user to a user action & hide behind a flag

### DIFF
--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -52,6 +52,7 @@ var (
 		POST: logoutUser,
 	}
 
+	// backwards compat; to-be-deprecated
 	createUserCmd = &Command{
 		Path:     "/v2/create-user",
 		POST:     postCreateUser,
@@ -61,6 +62,7 @@ var (
 	usersCmd = &Command{
 		Path:     "/v2/users",
 		GET:      getUsers,
+		POST:     postUsers,
 		RootOnly: true,
 	}
 )
@@ -208,14 +210,54 @@ func logoutUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	return SyncResponse(nil, nil)
 }
 
+// this might need to become a function, if having user admin becomes a config option
+var hasUserAdmin = !release.OnClassic
+
+const noUserAdmin = "system user administration via snapd is not allowed on this system"
+
+func postUsers(c *Command, r *http.Request, user *auth.UserState) Response {
+	if !hasUserAdmin {
+		return MethodNotAllowed(noUserAdmin, r.Method)
+	}
+
+	var postData postUserData
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&postData); err != nil {
+		return BadRequest("cannot decode user action data from request body: %v", err)
+	}
+	if decoder.More() {
+		return BadRequest("spurious content after user action")
+	}
+	switch postData.Action {
+	case "create":
+		return createUser(c, postData.postUserCreateData)
+	case "remove":
+		return removeUser(c, postData.Username)
+	case "":
+		return BadRequest("missing user action")
+	}
+	return BadRequest("unsupported user action %q", postData.Action)
+}
+
+func removeUser(c *Command, username string) Response {
+	return NotImplemented("not implemented")
+}
+
 func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response {
+	if !hasUserAdmin {
+		return Forbidden(noUserAdmin)
+	}
 	var createData postUserCreateData
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&createData); err != nil {
 		return BadRequest("cannot decode create-user data from request body: %v", err)
 	}
+	return createUser(c, createData)
+}
 
+func createUser(c *Command, createData postUserCreateData) Response {
 	// verify request
 	st := c.d.overlord.State()
 	st.Lock()
@@ -394,6 +436,12 @@ func getUserDetailsFromAssertion(st *state.State, modelAs *asserts.Model, email 
 		ForcePasswordChange: su.ForcePasswordChange(),
 	}
 	return su.Username(), opts, nil
+}
+
+type postUserData struct {
+	Action   string `json:"action"`
+	Username string `json:"username"`
+	postUserCreateData
 }
 
 type postUserCreateData struct {

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -233,14 +233,14 @@ func postUsers(c *Command, r *http.Request, user *auth.UserState) Response {
 	case "create":
 		return createUser(c, postData.postUserCreateData)
 	case "remove":
-		return removeUser(c, postData.Username)
+		return removeUser(c, postData.Username, postData.postUserDeleteData)
 	case "":
 		return BadRequest("missing user action")
 	}
 	return BadRequest("unsupported user action %q", postData.Action)
 }
 
-func removeUser(c *Command, username string) Response {
+func removeUser(c *Command, username string, opts postUserDeleteData) Response {
 	return NotImplemented("not implemented")
 }
 
@@ -442,6 +442,7 @@ type postUserData struct {
 	Action   string `json:"action"`
 	Username string `json:"username"`
 	postUserCreateData
+	postUserDeleteData
 }
 
 type postUserCreateData struct {
@@ -450,6 +451,8 @@ type postUserCreateData struct {
 	Known        bool   `json:"known"`
 	ForceManaged bool   `json:"force-managed"`
 }
+
+type postUserDeleteData struct{}
 
 var userLookup = user.Lookup
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -168,9 +168,7 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 func (s *userSuite) TestNoUserAdminCreateUser(c *check.C) { s.testNoUserAdmin(c, "/v2/create-user") }
 func (s *userSuite) TestNoUserAdminPostUser(c *check.C)   { s.testNoUserAdmin(c, "/v2/users") }
 func (s *userSuite) testNoUserAdmin(c *check.C, endpoint string) {
-	oldHas := hasUserAdmin
 	hasUserAdmin = false
-	defer func() { hasUserAdmin = oldHas }()
 
 	buf := bytes.NewBufferString("{}")
 	req, err := http.NewRequest("POST", endpoint, buf)

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -217,12 +217,12 @@ func (s *userSuite) TestPostUserNoAction(c *check.C) {
 }
 
 func (s *userSuite) TestPostUserBadAction(c *check.C) {
-	buf := bytes.NewBufferString(`{"action":"potatos"}`)
+	buf := bytes.NewBufferString(`{"action":"patatas"}`)
 	req, err := http.NewRequest("POST", "/v2/users", buf)
 	c.Assert(err, check.IsNil)
 
 	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp, check.DeepEquals, BadRequest(`unsupported user action "potatos"`))
+	c.Check(rsp, check.DeepEquals, BadRequest(`unsupported user action "patatas"`))
 }
 
 func (s *userSuite) TestPostUserActionRemoveNotImplemented(c *check.C) {


### PR DESCRIPTION
This adds POST method support to /v2/users, with an action of "create"
that does the same thing as /v2/create-user (with the latter to be
deprecated later), and an action of "remove" that is to be done in an
upcoming PR.

It also makes all system user admin actions depend on a flag. This
flag is release.OnClassic for now, but could trivially be made to
check a config value if needed.