### PR TITLE
osutil: implement deluser

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -35,6 +35,7 @@ import (
 var (
 	StreamsEqualChunked  = streamsEqualChunked
 	FilesAreEqualChunked = filesAreEqualChunked
+	SudoersFile          = sudoersFile
 )
 
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {


### PR DESCRIPTION
This change introduces `osutil.DelUser`, a companion to
`osutil.AddUser`.
