### PR TITLE
snap: add `snap pack --compression=<comp>` options

### DIFF
--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -273,7 +273,7 @@ func (s *infoSuite) TestMaybePrintBuildDate(c *check.C) {
 	c.Assert(ioutil.WriteFile(arbfile, nil, 0600), check.IsNil)
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	diskSnap := squashfs.New(filename)
-	c.Assert(diskSnap.Build(dir, "app"), check.IsNil)
+	c.Assert(diskSnap.Build(dir, nil), check.IsNil)
 	buildDate := diskSnap.BuildDate().Format(time.Kitchen)
 
 	// no disk snap -> no build date
@@ -305,7 +305,7 @@ func (s *infoSuite) TestMaybePrintSum(c *check.C) {
 	dir := c.MkDir()
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	diskSnap := squashfs.New(filename)
-	c.Assert(diskSnap.Build(dir, "app"), check.IsNil)
+	c.Assert(diskSnap.Build(dir, nil), check.IsNil)
 	iw := snap.NewInfoWriter(&buf)
 	snap.SetVerbose(iw, true)
 

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -36,6 +36,7 @@ import (
 type packCmd struct {
 	CheckSkeleton bool   `long:"check-skeleton"`
 	Filename      string `long:"filename"`
+	Compression   string `long:"compression" hidden:"yes"`
 	Positional    struct {
 		SnapDir   string `positional-arg-name:"<snap-dir>"`
 		TargetDir string `positional-arg-name:"<target-dir>"`
@@ -72,6 +73,8 @@ func init() {
 			"check-skeleton": i18n.G("Validate snap-dir metadata only"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"filename": i18n.G("Output to this filename"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"compression": i18n.G("Compresson to use"),
 		}, nil)
 	cmd.extra = func(cmd *flags.Command) {
 		// TRANSLATORS: this describes the default filename for a snap, e.g. core_16-2.35.2_amd64.snap
@@ -103,7 +106,11 @@ func (x *packCmd) Execute([]string) error {
 		return err
 	}
 
-	snapPath, err := pack.Snap(x.Positional.SnapDir, x.Positional.TargetDir, x.Filename)
+	snapPath, err := pack.Snap(x.Positional.SnapDir, &pack.Options{
+		TargetDir:   x.Positional.TargetDir,
+		SnapName:    x.Filename,
+		Compression: x.Compression,
+	})
 	if err != nil {
 		// TRANSLATORS: the %q is the snap-dir (the first positional
 		// argument to the command); the %v is an error

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -74,7 +74,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"filename": i18n.G("Output to this filename"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"compression": i18n.G("Compresson to use"),
+			"compression": i18n.G("Compression to use"),
 		}, nil)
 	cmd.extra = func(cmd *flags.Command) {
 		// TRANSLATORS: this describes the default filename for a snap, e.g. core_16-2.35.2_amd64.snap

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -74,7 +74,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"filename": i18n.G("Output to this filename"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"compression": i18n.G("Compression to use"),
+			"compression": i18n.G("Compression to use (e.g. xz)"),
 		}, nil)
 	cmd.extra = func(cmd *flags.Command) {
 		// TRANSLATORS: this describes the default filename for a snap, e.g. core_16-2.35.2_amd64.snap

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -242,7 +242,7 @@ func (s *validateSuite) TestValidateFromYamlSnapSnapInvalid(c *C) {
 	// need to build the snap "manually" pack.Snap() will do validation
 	snapFilePath := filepath.Join(c.MkDir(), "some-snap-invalid-yaml_1.snap")
 	d := squashfs.New(snapFilePath)
-	err = d.Build(snapBuildDir, "app")
+	err = d.Build(snapBuildDir, nil)
 	c.Assert(err, IsNil)
 
 	// put the broken snap in place

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -372,7 +372,7 @@ func makeTestSnap(c *C, snapYaml string) string {
 
 	dest := filepath.Join(tmp, "foo.snap")
 	snap := squashfs.New(dest)
-	err = snap.Build(snapSource, m.Type)
+	err = snap.Build(snapSource, &squashfs.BuildOpts{SnapType: m.Type})
 	c.Assert(err, IsNil)
 
 	return dest

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -186,10 +186,12 @@ type Options struct {
 	TargetDir string
 	// SnapName is the name of the snap file, or empty to use the default name
 	// which is <snapname>_<version>_<architecture>.snap
-	SnapName
+	SnapName string
 	// Compression method to use
 	Compression string
 }
+
+var Defaults *Options = nil
 
 // Snap the given sourceDirectory and return the generated
 // snap file

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -181,7 +181,14 @@ func excludesFile() (filename string, err error) {
 }
 
 type Options struct {
-	TargetDir, SnapName, Compression string
+	// TargetDir is the direction where the snap file will be placed, or empty
+	// to use the current directory
+	TargetDir string
+	// SnapName is the name of the snap file, or empty to use the default name
+	// which is <snapname>_<version>_<architecture>.snap
+	SnapName
+	// Compression method to use
+	Compression string
 }
 
 // Snap the given sourceDirectory and return the generated

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -115,7 +115,7 @@ printf "hello world"
 func (s *packSuite) TestPackNoManifestFails(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	c.Assert(os.Remove(filepath.Join(sourceDir, "meta", "snap.yaml")), IsNil)
-	_, err := pack.Snap(sourceDir, nil)
+	_, err := pack.Snap(sourceDir, pack.Defaults)
 	c.Assert(err, ErrorMatches, `.*/meta/snap\.yaml: no such file or directory`)
 }
 
@@ -127,7 +127,7 @@ apps:
   command: bin/hello-world
 `)
 	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
-	_, err := pack.Snap(sourceDir, nil)
+	_, err := pack.Snap(sourceDir, pack.Defaults)
 	c.Assert(err, Equals, snap.ErrMissingPaths)
 }
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -115,7 +115,7 @@ printf "hello world"
 func (s *packSuite) TestPackNoManifestFails(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	c.Assert(os.Remove(filepath.Join(sourceDir, "meta", "snap.yaml")), IsNil)
-	_, err := pack.Snap(sourceDir, "", "")
+	_, err := pack.Snap(sourceDir, nil)
 	c.Assert(err, ErrorMatches, `.*/meta/snap\.yaml: no such file or directory`)
 }
 
@@ -127,7 +127,7 @@ apps:
   command: bin/hello-world
 `)
 	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
-	_, err := pack.Snap(sourceDir, "", "")
+	_, err := pack.Snap(sourceDir, nil)
 	c.Assert(err, Equals, snap.ErrMissingPaths)
 }
 
@@ -157,7 +157,7 @@ func (s *packSuite) TestPackExcludesBackups(c *C) {
 	target := c.MkDir()
 	// add a backup file
 	c.Assert(ioutil.WriteFile(filepath.Join(sourceDir, "foo~"), []byte("hi"), 0755), IsNil)
-	snapfile, err := pack.Snap(sourceDir, c.MkDir(), "")
+	snapfile, err := pack.Snap(sourceDir, &pack.Options{TargetDir: c.MkDir()})
 	c.Assert(err, IsNil)
 	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 
@@ -175,7 +175,7 @@ func (s *packSuite) TestPackExcludesTopLevelDEBIAN(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "DEBIAN", "foo"), 0755), IsNil)
 	// and a non-toplevel DEBIAN
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "bar", "DEBIAN", "baz"), 0755), IsNil)
-	snapfile, err := pack.Snap(sourceDir, c.MkDir(), "")
+	snapfile, err := pack.Snap(sourceDir, &pack.Options{TargetDir: c.MkDir()})
 	c.Assert(err, IsNil)
 	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 	cmd := exec.Command("diff", "-qr", sourceDir, target)
@@ -193,7 +193,7 @@ func (s *packSuite) TestPackExcludesWholeDirs(c *C) {
 	// add a file inside a skipped dir
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, ".bzr"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(sourceDir, ".bzr", "foo"), []byte("hi"), 0755), IsNil)
-	snapfile, err := pack.Snap(sourceDir, c.MkDir(), "")
+	snapfile, err := pack.Snap(sourceDir, &pack.Options{TargetDir: c.MkDir()})
 	c.Assert(err, IsNil)
 	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 	out, _ := exec.Command("find", sourceDir).Output()
@@ -244,7 +244,10 @@ integration:
 
 	for i, t := range table {
 		comm := Commentf("%d", i)
-		resultSnap, err := pack.Snap(sourceDir, t.outputDir, t.filename)
+		resultSnap, err := pack.Snap(sourceDir, &pack.Options{
+			TargetDir: t.outputDir,
+			SnapName:  t.filename,
+		})
 		c.Assert(err, IsNil, comm)
 
 		// check that there is result
@@ -299,19 +302,54 @@ volumes:
 	absSnapFile := filepath.Join(c.MkDir(), "foo.snap")
 
 	// gadget validation fails during layout
-	_, err = pack.Snap(sourceDir, outputDir, absSnapFile)
+	_, err = pack.Snap(sourceDir, &pack.Options{
+		TargetDir: outputDir,
+		SnapName:  absSnapFile,
+	})
 	c.Assert(err, ErrorMatches, `invalid layout of volume "bad": cannot lay out structure #1 \("bare-struct"\): content "bare.img": stat .*/bare.img: no such file or directory`)
 
 	err = ioutil.WriteFile(filepath.Join(sourceDir, "bare.img"), []byte("foo"), 0644)
 	c.Assert(err, IsNil)
 
 	// gadget validation fails during content presence checks
-	_, err = pack.Snap(sourceDir, outputDir, absSnapFile)
+	_, err = pack.Snap(sourceDir, &pack.Options{
+		TargetDir: outputDir,
+		SnapName:  absSnapFile,
+	})
 	c.Assert(err, ErrorMatches, `invalid volume "bad": structure #0 \("fs-struct"\), content source:foo/: source path does not exist`)
 
 	err = os.Mkdir(filepath.Join(sourceDir, "foo"), 0644)
 	c.Assert(err, IsNil)
 	// all good now
-	_, err = pack.Snap(sourceDir, outputDir, absSnapFile)
+	_, err = pack.Snap(sourceDir, &pack.Options{
+		TargetDir: outputDir,
+		SnapName:  absSnapFile,
+	})
 	c.Assert(err, IsNil)
+}
+
+func (s *packSuite) TestPackWithCompressionHappy(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
+
+	for _, comp := range []string{"", "xz"} {
+		snapfile, err := pack.Snap(sourceDir, &pack.Options{
+			TargetDir:   c.MkDir(),
+			Compression: comp,
+		})
+		c.Assert(err, IsNil)
+		c.Assert(snapfile, testutil.FilePresent)
+	}
+}
+
+func (s *packSuite) TestPackWithCompressionUnhappy(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
+
+	for _, comp := range []string{"gzip", "lzo", "zstd", "silly"} {
+		snapfile, err := pack.Snap(sourceDir, &pack.Options{
+			TargetDir:   c.MkDir(),
+			Compression: comp,
+		})
+		c.Assert(err, ErrorMatches, fmt.Sprintf("cannot use compression %q", comp))
+		c.Assert(snapfile, Equals, "")
+	}
 }

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -215,7 +215,7 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 
 	err = osutil.ChDir(snapSource, func() error {
 		var err error
-		snapFilePath, err = pack.Snap(snapSource, "", "")
+		snapFilePath, err = pack.Snap(snapSource, nil)
 		return err
 	})
 	if err != nil {

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -415,6 +415,9 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 	// default to xz
 	compression := opts.Compression
 	if compression == "" {
+		// TODO: support other compression options, xz is very
+		// slow for certain apps, see
+		// https://forum.snapcraft.io/t/squashfs-performance-effect-on-snap-startup-time/13920
 		compression = "xz"
 	}
 	cmd, err := cmdutilCommandFromSystemSnap("/usr/bin/mksquashfs")

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -393,8 +393,17 @@ func verifyContentAccessibleForBuild(sourceDir string) error {
 	return errPaths.asErr()
 }
 
+type BuildOpts struct {
+	SnapType     string
+	Compression  string
+	ExcludeFiles []string
+}
+
 // Build builds the snap.
-func (s *Snap) Build(sourceDir, snapType string, excludeFiles ...string) error {
+func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
+	if opts == nil {
+		opts = &BuildOpts{}
+	}
 	if err := verifyContentAccessibleForBuild(sourceDir); err != nil {
 		return err
 	}
@@ -403,6 +412,11 @@ func (s *Snap) Build(sourceDir, snapType string, excludeFiles ...string) error {
 	if err != nil {
 		return err
 	}
+	// default to xz
+	compression := opts.Compression
+	if compression == "" {
+		compression = "xz"
+	}
 	cmd, err := cmdutilCommandFromSystemSnap("/usr/bin/mksquashfs")
 	if err != nil {
 		cmd = exec.Command("mksquashfs")
@@ -410,16 +424,17 @@ func (s *Snap) Build(sourceDir, snapType string, excludeFiles ...string) error {
 	cmd.Args = append(cmd.Args,
 		".", fullSnapPath,
 		"-noappend",
-		"-comp", "xz",
+		"-comp", compression,
 		"-no-fragments",
 		"-no-progress",
 	)
-	if len(excludeFiles) > 0 {
+	if len(opts.ExcludeFiles) > 0 {
 		cmd.Args = append(cmd.Args, "-wildcards")
-		for _, excludeFile := range excludeFiles {
+		for _, excludeFile := range opts.ExcludeFiles {
 			cmd.Args = append(cmd.Args, "-ef", excludeFile)
 		}
 	}
+	snapType := opts.SnapType
 	if snapType != "os" && snapType != "core" && snapType != "base" {
 		cmd.Args = append(cmd.Args, "-all-root", "-no-xattrs")
 	}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -98,7 +98,7 @@ func makeSnapInDir(c *C, dir, manifest, data string) *squashfs.Snap {
 	tmp := makeSnapContents(c, manifest, data)
 	// build it
 	snap := squashfs.New(filepath.Join(dir, "foo.snap"))
-	err := snap.Build(tmp, snapType)
+	err := snap.Build(tmp, &squashfs.BuildOpts{SnapType: snapType})
 	c.Assert(err, IsNil)
 
 	return snap
@@ -381,7 +381,7 @@ func (s *SquashfsTestSuite) TestBuild(c *C) {
 	c.Assert(err, IsNil)
 
 	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err = snap.Build(buildDir, "app")
+	err = snap.Build(buildDir, &squashfs.BuildOpts{SnapType: "app"})
 	c.Assert(err, IsNil)
 
 	// unsquashfs writes a funny header like:
@@ -422,7 +422,10 @@ data.bin
 	c.Assert(err, IsNil)
 
 	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err = snap.Build(buildDir, "app", excludesFilename)
+	err = snap.Build(buildDir, &squashfs.BuildOpts{
+		SnapType:     "app",
+		ExcludeFiles: []string{excludesFilename},
+	})
 	c.Assert(err, IsNil)
 
 	outputWithHeader, err := exec.Command("unsquashfs", "-n", "-l", snap.Path()).Output()
@@ -447,7 +450,10 @@ func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcard
 
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
 	snap := squashfs.New(snapPath)
-	err := snap.Build(c.MkDir(), "core", "exclude1", "exclude2", "exclude3")
+	err := snap.Build(c.MkDir(), &squashfs.BuildOpts{
+		SnapType:     "core",
+		ExcludeFiles: []string{"exclude1", "exclude2", "exclude3"},
+	})
 	c.Assert(err, IsNil)
 	calls := mksq.Calls()
 	c.Assert(calls, HasLen, 1)
@@ -472,7 +478,7 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 	buildDir := c.MkDir()
 
 	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err := snap.Build(buildDir, "app")
+	err := snap.Build(buildDir, nil)
 	c.Assert(err, IsNil)
 	c.Check(usedFromCore, Equals, true)
 	c.Check(mksq.Calls(), HasLen, 0)
@@ -491,7 +497,7 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(
 	buildDir := c.MkDir()
 
 	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err := snap.Build(buildDir, "app")
+	err := snap.Build(buildDir, nil)
 	c.Assert(err, IsNil)
 	c.Check(triedFromCore, Equals, true)
 	c.Check(mksq.Calls(), HasLen, 1)
@@ -510,7 +516,7 @@ func (s *SquashfsTestSuite) TestBuildFailsIfNoMksquashfs(c *C) {
 	buildDir := c.MkDir()
 
 	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
-	err := snap.Build(buildDir, "app")
+	err := snap.Build(buildDir, nil)
 	c.Assert(err, ErrorMatches, "mksquashfs call failed:.*")
 	c.Check(triedFromCore, Equals, true)
 	c.Check(mksq.Calls(), HasLen, 1)
@@ -547,7 +553,7 @@ func (s *SquashfsTestSuite) TestBuildVariesArgsByType(c *C) {
 		mksq.ForgetCalls()
 		comm := Commentf("type: %s", t.snapType)
 
-		c.Check(snap.Build(buildDir, t.snapType), IsNil, comm)
+		c.Check(snap.Build(buildDir, &squashfs.BuildOpts{SnapType: t.snapType}), IsNil, comm)
 		c.Assert(mksq.Calls(), HasLen, 1, comm)
 		c.Assert(mksq.Calls()[0], HasLen, len(t.args)+1)
 		c.Check(mksq.Calls()[0][0], Equals, "mksquashfs", comm)
@@ -565,7 +571,7 @@ exit 1
 	data := "mock kernel snap"
 	dir := makeSnapContents(c, "", data)
 	snap := squashfs.New("foo.snap")
-	c.Check(snap.Build(dir, "kernel"), ErrorMatches, `mksquashfs call failed: Yeah, nah.`)
+	c.Check(snap.Build(dir, &squashfs.BuildOpts{SnapType: "kernel"}), ErrorMatches, `mksquashfs call failed: Yeah, nah.`)
 }
 
 func (s *SquashfsTestSuite) TestUnsquashfsStderrWriter(c *C) {
@@ -628,7 +634,7 @@ func (s *SquashfsTestSuite) TestBuildDate(c *C) {
 	// make a snap using this directory
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	snap := squashfs.New(filename)
-	c.Assert(snap.Build(d, "app"), IsNil)
+	c.Assert(snap.Build(d, nil), IsNil)
 	// and see it's BuildDate is _now_, not _then_.
 	c.Check(squashfs.BuildDate(filename), Equals, snap.BuildDate())
 	c.Check(math.Abs(now.Sub(snap.BuildDate()).Seconds()) <= 61, Equals, true, Commentf("Unexpected build date %s", snap.BuildDate()))
@@ -660,7 +666,7 @@ func (s *SquashfsTestSuite) TestBuildChecksReadDifferentFiles(c *C) {
 
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	snap := squashfs.New(filename)
-	err = snap.Build(d, "app")
+	err = snap.Build(d, nil)
 	c.Assert(err, ErrorMatches, `(?s)cannot access the following locations in the snap source directory:
 - ro-(file|dir) \(owner [0-9]+:[0-9]+ mode 000\)
 - ro-(file|dir) \(owner [0-9]+:[0-9]+ mode 000\)
@@ -685,7 +691,7 @@ func (s *SquashfsTestSuite) TestBuildChecksReadErrorLimit(c *C) {
 	}
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	snap := squashfs.New(filename)
-	err := snap.Build(d, "app")
+	err := snap.Build(d, nil)
 	c.Assert(err, ErrorMatches, `(?s)cannot access the following locations in the snap source directory:
 (- [0-9]+ \(owner [0-9]+:[0-9]+ mode 000.*\).){10}- too many errors, listing first 10 entries
 `)
@@ -694,6 +700,40 @@ func (s *SquashfsTestSuite) TestBuildChecksReadErrorLimit(c *C) {
 func (s *SquashfsTestSuite) TestBuildBadSource(c *C) {
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	snap := squashfs.New(filename)
-	err := snap.Build("does-not-exist", "app")
+	err := snap.Build("does-not-exist", nil)
 	c.Assert(err, ErrorMatches, ".*does-not-exist/: no such file or directory")
+}
+
+func (s *SquashfsTestSuite) TestBuildWithCompressionHappy(c *C) {
+	buildDir := c.MkDir()
+	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
+
+	defaultComp := "xz"
+	for _, comp := range []string{"", "xz", "gzip", "lzo"} {
+		snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+		err = snap.Build(buildDir, &squashfs.BuildOpts{
+			Compression: comp,
+		})
+		c.Assert(err, IsNil)
+
+		// check compression
+		outputWithHeader, err := exec.Command("unsquashfs", "-n", "-s", snap.Path()).CombinedOutput()
+		c.Assert(err, IsNil)
+		// ensure default is xz
+		if comp == "" {
+			comp = defaultComp
+		}
+		c.Assert(string(outputWithHeader), Matches, fmt.Sprintf(`(?ms).*Compression %s$`, comp))
+	}
+}
+
+func (s *SquashfsTestSuite) TestBuildWithCompressionUnhappy(c *C) {
+	buildDir := c.MkDir()
+	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
+
+	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
+	err = snap.Build(buildDir, &squashfs.BuildOpts{
+		Compression: "silly",
+	})
+	c.Assert(err, ErrorMatches, "(?m)^mksquashfs call failed: ")
 }

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -707,6 +707,7 @@ func (s *SquashfsTestSuite) TestBuildBadSource(c *C) {
 func (s *SquashfsTestSuite) TestBuildWithCompressionHappy(c *C) {
 	buildDir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
+	c.Assert(err, IsNil)
 
 	defaultComp := "xz"
 	for _, comp := range []string{"", "xz", "gzip", "lzo"} {
@@ -730,6 +731,7 @@ func (s *SquashfsTestSuite) TestBuildWithCompressionHappy(c *C) {
 func (s *SquashfsTestSuite) TestBuildWithCompressionUnhappy(c *C) {
 	buildDir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
+	c.Assert(err, IsNil)
 
 	snap := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
 	err = snap.Build(buildDir, &squashfs.BuildOpts{


### PR DESCRIPTION
This adds support for switching the compression of a snap. It
also refactors a bit to make adding this sligthly easier. For
now only the "xz" compression is allowed. Once we evaluated
the faster options this will change.