### PR TITLE
overlord/auth: add RemoveUserByName

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -178,6 +178,7 @@ func RemoveUserByName(st *state.State, username string) error {
 	return removeUser(st, func(u *UserState) bool { return u.Username == username })
 }
 
+// removeUser removes the first user matching given predicate.
 func removeUser(st *state.State, p func(*UserState) bool) error {
 	var authStateData AuthState
 

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -170,6 +170,15 @@ var ErrInvalidUser = errors.New("invalid user")
 
 // RemoveUser removes a user from the state given its ID
 func RemoveUser(st *state.State, userID int) error {
+	return removeUser(st, func(u *UserState) bool { return u.ID == userID })
+}
+
+// RemoveUserByName removes a user from the state given its username
+func RemoveUserByName(st *state.State, username string) error {
+	return removeUser(st, func(u *UserState) bool { return u.Username == username })
+}
+
+func removeUser(st *state.State, p func(*UserState) bool) error {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
@@ -181,7 +190,7 @@ func RemoveUser(st *state.State, userID int) error {
 	}
 
 	for i := range authStateData.Users {
-		if authStateData.Users[i].ID == userID {
+		if p(&authStateData.Users[i]) {
 			// delete without preserving order
 			n := len(authStateData.Users) - 1
 			authStateData.Users[i] = authStateData.Users[n]

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -374,6 +374,33 @@ func (as *authSuite) TestRemove(c *C) {
 	c.Assert(err, Equals, auth.ErrInvalidUser)
 }
 
+func (as *authSuite) TestRemoveByName(c *C) {
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	as.state.Unlock()
+	c.Check(err, IsNil)
+
+	as.state.Lock()
+	_, err = auth.User(as.state, user.ID)
+	as.state.Unlock()
+	c.Check(err, IsNil)
+
+	as.state.Lock()
+	err = auth.RemoveUserByName(as.state, user.Username)
+	as.state.Unlock()
+	c.Assert(err, IsNil)
+
+	as.state.Lock()
+	_, err = auth.User(as.state, user.ID)
+	as.state.Unlock()
+	c.Check(err, Equals, auth.ErrInvalidUser)
+
+	as.state.Lock()
+	err = auth.RemoveUser(as.state, user.ID)
+	as.state.Unlock()
+	c.Assert(err, Equals, auth.ErrInvalidUser)
+}
+
 func (as *authSuite) TestUsers(c *C) {
 	as.state.Lock()
 	user1, err1 := auth.NewUser(as.state, "user1", "email1@test.com", "macaroon", []string{"discharge"})


### PR DESCRIPTION
This takes auth.RemoveUser and refactors it into a private function
with the predicate getting passed in, so now auth.RemoveUserByName is
a one-liner that uses the same existing and well-tested code.