### PR TITLE
run-checks, travis: allow skipping spread jobs by adding a label

### DIFF
--- a/check-pr-skip-spread.py
+++ b/check-pr-skip-spread.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python3
+
+import argparse
+import urllib.request
+import logging
+
+from html.parser import HTMLParser
+
+# PR label indicating that spread job should be skipped
+LABEL_SKIP_SPREAD_JOB = "Skip spread"
+
+
+class GithubLabelsParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.in_labels = False
+        self.deep = 0
+        self.labels = []
+
+    def handle_starttag(self, tag, attributes):
+        logging.debug(attributes)
+
+        if not self.in_labels:
+            attr_class = [attr[1] for attr in attributes if attr[0] == "class"]
+            if len(attr_class) == 0:
+                return
+            # labels are in separate div defined like:
+            # <div class=".. labels .." .. >
+            elems = attr_class[0].split(" ")
+            if "labels" in elems:
+                self.in_labels = True
+                self.deep = 1
+                logging.debug("labels start")
+        else:
+            # nesting counter
+            self.deep += 1
+
+            # inside labels
+            # label entry has
+            # <a class=".." data-name="<label name>" />
+            attr_data_name = [attr[1] for attr in attributes if attr[0] == "data-name"]
+            if len(attr_data_name) == 0:
+                return
+            data_name = attr_data_name[0]
+            logging.debug("found label: %s", data_name)
+            self.labels.append(data_name)
+
+    def handle_endtag(self, tag):
+        if self.in_labels:
+            self.deep -= 1
+            if self.deep < 1:
+                logging.debug("labels end")
+                self.in_labels = False
+
+    def handle_data(self, data):
+        if self.in_labels:
+            logging.debug("data: %s", data)
+
+
+def grab_pr_labels(pr_number: int):
+    # ideally we would use the github API - however we can't because:
+    # a) its rate limiting and travis IPs hit the API a lot so we regularly
+    #    get errors
+    # b) using a API token is tricky because travis will not allow the secure
+    #    vars for forks
+    # so instead we just scrape the html title which is unlikely to change
+    # radically
+    parser = GithubLabelsParser()
+    with urllib.request.urlopen(
+        "https://github.com/snapcore/snapd/pull/{}".format(pr_number)
+    ) as f:
+        parser.feed(f.read().decode("utf-8"))
+    return parser.labels
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "pr_number", metavar="PR number", help="the github PR number to check"
+    )
+    parser.add_argument(
+        "-d", "--debug", help="enable debug logging", action="store_true"
+    )
+    args = parser.parse_args()
+
+    lvl = logging.INFO
+    if args.debug:
+        lvl = logging.DEBUG
+    logging.basicConfig(level=lvl)
+
+    labels = grab_pr_labels(args.pr_number)
+    print("labels:", labels)
+
+    if LABEL_SKIP_SPREAD_JOB not in labels:
+        raise SystemExit(1)
+
+    print("requested to skip the spread job")
+
+
+if __name__ == "__main__":
+    main()

--- a/check-pr-title.py
+++ b/check-pr-title.py
@@ -1,11 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
-import base64
-import json
-import os
 import re
-import sys
 import urllib.request
 
 from html.parser import HTMLParser
@@ -75,7 +71,7 @@ def main():
         print("module: short description")
         print("E.g.:")
         print("daemon: fix frobinator bug")
-        sys.exit(1)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/run-checks
+++ b/run-checks
@@ -307,6 +307,14 @@ if [ "$UNIT" = 1 ]; then
 fi
 
 if [ -n "$SPREAD" ]; then
+    if [ -n "${TRAVIS_PULL_REQUEST:-}" ] && [ "${TRAVIS_PULL_REQUEST:-}" != "false" ]; then
+        echo "Checking whether PR author requested to skip spread"
+        if ./check-pr-skip-spread.py "$TRAVIS_PULL_REQUEST"; then
+            echo "Skipping spread job on request"
+            exit 0
+        fi
+    fi
+
     TMP_SPREAD="$(mktemp -d)"
     addtrap "rm -rf \"$TMP_SPREAD\""
 


### PR DESCRIPTION
Allow spread jobs to be skipped by adding `Skip spread` label to the PR.

The check is executed at the time the Travis job runs. This is still a bit wasteful because we'd be blocked waiting for travis node to launch a job which then quits.
