### PR TITLE
daemon: make users result more consistent

### DIFF
--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -280,7 +280,7 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 
 	// this is /v2/create-user, meaning we want the
 	// backwards-compatible wackiness
-	createData.compat = true
+	createData.singleUserResultCompat = true
 
 	return createUser(c, createData)
 }
@@ -353,7 +353,7 @@ func createUser(c *Command, createData postUserCreateData) Response {
 		SSHKeys:  opts.SSHKeys,
 	}
 
-	if createData.compat {
+	if createData.singleUserResultCompat {
 		// return a single userResponseData in this case
 		return SyncResponse(&result, nil)
 	} else {
@@ -486,9 +486,9 @@ type postUserCreateData struct {
 	Known        bool   `json:"known"`
 	ForceManaged bool   `json:"force-managed"`
 
-	// not from JSON: this indicates whether to preserve backwards
-	// compatibility, which results in more clunky return values
-	compat bool
+	// indicates whether to preserve backwards compatibility,
+	// which results in more clunky return values; not from JSON.
+	singleUserResultCompat bool
 }
 
 type postUserDeleteData struct{}

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -499,8 +499,10 @@ type postUserCreateData struct {
 	Known        bool   `json:"known"`
 	ForceManaged bool   `json:"force-managed"`
 
-	// indicates whether to preserve backwards compatibility,
-	// which results in more clunky return values; not from JSON.
+	// singleUserResultCompat indicates whether to preserve
+	// backwards compatibility, which results in more clunky
+	// return values (userResponseData OR [userResponseData] vs now
+	// uniform [userResponseData]); internal, not from JSON.
 	singleUserResultCompat bool
 }
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -130,23 +130,26 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 	}
 
 	var rsp *resp
+	var expected interface{}
+	expectedItem := userResponseData{
+		Username: expectedUsername,
+		SSHKeys:  []string{"ssh1", "ssh2"},
+	}
+
 	if oldWay {
 		buf := bytes.NewBufferString(fmt.Sprintf(`{"email": "%s"}`, s.userInfoExpectedEmail))
 		req, err := http.NewRequest("POST", "/v2/create-user", buf)
 		c.Assert(err, check.IsNil)
 
 		rsp = postCreateUser(createUserCmd, req, nil).(*resp)
+		expected = &expectedItem
 	} else {
 		buf := bytes.NewBufferString(fmt.Sprintf(`{"action":"create","email": "%s"}`, s.userInfoExpectedEmail))
 		req, err := http.NewRequest("POST", "/v2/users", buf)
 		c.Assert(err, check.IsNil)
 
 		rsp = postUsers(usersCmd, req, nil).(*resp)
-	}
-
-	expected := &userResponseData{
-		Username: expectedUsername,
-		SSHKeys:  []string{"ssh1", "ssh2"},
+		expected = []userResponseData{expectedItem}
 	}
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
@@ -291,7 +294,7 @@ func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 
 	rsp := postUsers(usersCmd, req, nil).(*resp)
 	c.Check(rsp.Status, check.Equals, 200)
-	c.Check(rsp.Result, check.Equals, true)
+	c.Check(rsp.Result, check.IsNil)
 	c.Check(called, check.Equals, 1)
 }
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -65,8 +65,14 @@ func (s *userSuite) SetUpTest(c *check.C) {
 	hasUserAdmin = true
 
 	// make sure we don't call these by accident
-	osutilAddUser = nil
-	osutilDelUser = nil
+	osutilAddUser = func(name string, opts *osutil.AddUserOptions) error {
+		c.Fatalf("unexpected add user %q call", name)
+		return fmt.Errorf("unexpected add user %q call", name)
+	}
+	osutilDelUser = func(name string, opts *osutil.DelUserOptions) error {
+		c.Fatalf("unexpected del user %q call", name)
+		return fmt.Errorf("unexpected del user %q call", name)
+	}
 }
 
 func (s *userSuite) TearDownTest(c *check.C) {


### PR DESCRIPTION
without this change /v2/users' Result would sometimes be a list of
users, sometimes a single user, and sometimes a bool.

This change makes it always be a list. Should simplify the client
quite a bit.
