### PR TITLE
boot: add bootloader options to coreKernel

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -99,8 +99,8 @@ func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
 
 // bootloaderOptionsForDeviceKernel returns a set of bootloader options that
 // enable correct kernel extraction and removal for given device
-func bootloaderOptionsForDeviceKernel(dev Device) bootloader.Options {
-	return bootloader.Options{
+func bootloaderOptionsForDeviceKernel(dev Device) *bootloader.Options {
+	return &bootloader.Options{
 		// unified extractable kernel if in uc20 mode
 		ExtractedRunKernelImage: dev.HasModeenv(),
 	}

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -96,12 +97,21 @@ func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
 	return trivial{}
 }
 
+// bootloaderOptionsForDeviceKernel returns a set of bootloader options that
+// enable correct kernel extraction and removal for given device
+func bootloaderOptionsForDeviceKernel(dev Device) bootloader.Options {
+	return bootloader.Options{
+		// unified extractable kernel if in uc20 mode
+		ExtractedRunKernelImage: dev.HasModeenv(),
+	}
+}
+
 // Kernel checks that the given arguments refer to a kernel snap
 // that participates in the boot process, and returns the associated
 // BootKernel, or a trivial implementation otherwise.
 func Kernel(s snap.PlaceInfo, t snap.Type, dev Device) BootKernel {
 	if t == snap.TypeKernel && applicable(s, t, dev) {
-		return &coreKernel{s: s, dev: dev}
+		return &coreKernel{s: s, bopts: bootloaderOptionsForDeviceKernel(dev)}
 	}
 	return trivial{}
 }

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -101,7 +101,7 @@ func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
 // BootKernel, or a trivial implementation otherwise.
 func Kernel(s snap.PlaceInfo, t snap.Type, dev Device) BootKernel {
 	if t == snap.TypeKernel && applicable(s, t, dev) {
-		return &coreKernel{s: s}
+		return &coreKernel{s: s, dev: dev}
 	}
 	return trivial{}
 }

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -303,7 +303,6 @@ func (s *bootSetSuite) TestParticipantBaseWithModel(c *C) {
 func (s *bootSetSuite) TestKernelWithModel(c *C) {
 	info := &snap.Info{}
 	info.RealName = "kernel"
-	expected := boot.NewCoreKernel(info)
 
 	type tableT struct {
 		model string
@@ -319,7 +318,7 @@ func (s *bootSetSuite) TestKernelWithModel(c *C) {
 		}, {
 			model: "kernel",
 			nop:   false,
-			krn:   expected,
+			krn:   boot.NewCoreKernel(info, boottest.MockDevice("kernel")),
 		}, {
 			model: "",
 			nop:   true,

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -32,7 +32,7 @@ func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev Device) *coreBoot
 }
 
 func NewCoreKernel(s snap.PlaceInfo, d Device) *coreKernel {
-	return &coreKernel{s, d}
+	return &coreKernel{s, bootloaderOptionsForDeviceKernel(d)}
 }
 
 type Trivial = trivial

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -31,8 +31,8 @@ func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev Device) *coreBoot
 	return &coreBootParticipant{s: s, bs: bs}
 }
 
-func NewCoreKernel(s snap.PlaceInfo) *coreKernel {
-	return &coreKernel{s}
+func NewCoreKernel(s snap.PlaceInfo, d Device) *coreKernel {
+	return &coreKernel{s, d}
 }
 
 type Trivial = trivial

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -53,8 +53,8 @@ func (bp *coreBootParticipant) SetNextBoot() (rebootRequired bool, err error) {
 }
 
 type coreKernel struct {
-	s   snap.PlaceInfo
-	dev Device
+	s     snap.PlaceInfo
+	bopts bootloader.Options
 }
 
 // ensure coreKernel is a Kernel
@@ -64,12 +64,7 @@ func (*coreKernel) IsTrivial() bool { return false }
 
 func (k *coreKernel) RemoveKernelAssets() error {
 	// XXX: shouldn't we check the snap type?
-	opts := &bootloader.Options{}
-	if k.dev.HasModeenv() {
-		// we are in uc20 mode, so find an extractable kernel
-		opts.ExtractedRunKernelImage = true
-	}
-	bootloader, err := bootloader.Find("", opts)
+	bootloader, err := bootloader.Find("", &k.bopts)
 	if err != nil {
 		return fmt.Errorf("cannot remove kernel assets: %s", err)
 	}
@@ -79,12 +74,7 @@ func (k *coreKernel) RemoveKernelAssets() error {
 }
 
 func (k *coreKernel) ExtractKernelAssets(snapf snap.Container) error {
-	opts := &bootloader.Options{}
-	if k.dev.HasModeenv() {
-		// we are in uc20 mode, so find an extractable kernel
-		opts.ExtractedRunKernelImage = true
-	}
-	bootloader, err := bootloader.Find("", opts)
+	bootloader, err := bootloader.Find("", &k.bopts)
 	if err != nil {
 		return fmt.Errorf("cannot extract kernel assets: %s", err)
 	}

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -54,7 +54,7 @@ func (bp *coreBootParticipant) SetNextBoot() (rebootRequired bool, err error) {
 
 type coreKernel struct {
 	s     snap.PlaceInfo
-	bopts bootloader.Options
+	bopts *bootloader.Options
 }
 
 // ensure coreKernel is a Kernel
@@ -64,7 +64,7 @@ func (*coreKernel) IsTrivial() bool { return false }
 
 func (k *coreKernel) RemoveKernelAssets() error {
 	// XXX: shouldn't we check the snap type?
-	bootloader, err := bootloader.Find("", &k.bopts)
+	bootloader, err := bootloader.Find("", k.bopts)
 	if err != nil {
 		return fmt.Errorf("cannot remove kernel assets: %s", err)
 	}
@@ -74,7 +74,7 @@ func (k *coreKernel) RemoveKernelAssets() error {
 }
 
 func (k *coreKernel) ExtractKernelAssets(snapf snap.Container) error {
-	bootloader, err := bootloader.Find("", &k.bopts)
+	bootloader, err := bootloader.Find("", k.bopts)
 	if err != nil {
 		return fmt.Errorf("cannot extract kernel assets: %s", err)
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -63,13 +63,13 @@ func (s *coreBootSetSuite) SetUpTest(c *C) {
 
 func (s *coreBootSetSuite) TestExtractKernelAssetsError(c *C) {
 	bootloader.ForceError(errors.New("brkn"))
-	err := boot.NewCoreKernel(&snap.Info{}).ExtractKernelAssets(nil)
+	err := boot.NewCoreKernel(&snap.Info{}, boottest.MockDevice("")).ExtractKernelAssets(nil)
 	c.Check(err, ErrorMatches, `cannot extract kernel assets: brkn`)
 }
 
 func (s *coreBootSetSuite) TestRemoveKernelAssetsError(c *C) {
 	bootloader.ForceError(errors.New("brkn"))
-	err := boot.NewCoreKernel(&snap.Info{}).RemoveKernelAssets()
+	err := boot.NewCoreKernel(&snap.Info{}, boottest.MockDevice("")).RemoveKernelAssets()
 	c.Check(err, ErrorMatches, `cannot remove kernel assets: brkn`)
 }
 
@@ -265,7 +265,7 @@ func (s *ubootBootSetSuite) TestExtractKernelAssetsAndRemoveOnUboot(c *C) {
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
 	c.Assert(err, IsNil)
 
-	bp := boot.NewCoreKernel(info)
+	bp := boot.NewCoreKernel(info, boottest.MockDevice(""))
 	err = bp.ExtractKernelAssets(snapf)
 	c.Assert(err, IsNil)
 
@@ -347,7 +347,7 @@ func (s *grubBootSetSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
 	c.Assert(err, IsNil)
 
-	bp := boot.NewCoreKernel(info)
+	bp := boot.NewCoreKernel(info, boottest.MockDevice(""))
 	err = bp.ExtractKernelAssets(snapf)
 	c.Assert(err, IsNil)
 
@@ -378,7 +378,7 @@ func (s *grubBootSetSuite) TestExtractKernelForceWorks(c *C) {
 	info, err := snap.ReadInfoFromSnapFile(snapf, si)
 	c.Assert(err, IsNil)
 
-	bp := boot.NewCoreKernel(info)
+	bp := boot.NewCoreKernel(info, boottest.MockDevice(""))
 	err = bp.ExtractKernelAssets(snapf)
 	c.Assert(err, IsNil)
 

--- a/tests/core20/basic/task.yaml
+++ b/tests/core20/basic/task.yaml
@@ -24,3 +24,7 @@ execute: |
 
     echo "Ensure passwd/group is available for snaps"
     test-snapd-sh-core18.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test
+
+    # TODO:UC20: also check for /boot/grub/kernel.efi symlink once it's there
+    echo "Check that we have an extracted kernel"
+    test -e /boot/grub/pc-kernel*/kernel.efi


### PR DESCRIPTION
This allows us to ask the device if we are on UC20 essentially, and figure out
what options we should use when searching for a bootloader to extract/remove
kernel assets from.

This is a small subset of PR#8001 that is useful on it's own.