### PR TITLE
interfaces/builtin: Allow NotificationReplied signal on org.freedesktop.Notifications

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -105,7 +105,7 @@ dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member={ActionInvoked,NotificationClosed}
+    member={ActionInvoked,NotificationClosed,NotificationReplied}
     peer=(label=unconfined),
 
 # DesktopAppInfo Launched

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -444,7 +444,7 @@ dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member={ActionInvoked,NotificationClosed}
+    member={ActionInvoked,NotificationClosed,NotificationReplied}
     peer=(label=unconfined),
 
 dbus (send)


### PR DESCRIPTION
This signal is emitted by KDE Plasma 5.18+ for when an inline reply is sent by the user.

Forum: https://forum.snapcraft.io/t/kde-plasma-quick-reply-support/15229
