### PR TITLE
cmd/snap-confine: allow snap-confine to link to libpcre2

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -24,7 +24,7 @@
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libncursesw{,-[0-9]*}.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libresolv{,-[0-9]*}.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
-    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
+    /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre{,2}{,-[0-9]*}.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
     /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,


### PR DESCRIPTION
It seems there was a soname bump. I ran into this when doing unrelated
development on a Focal system.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
