### PR TITLE
cmd/snap-confine,tests: support x.y.z nvidia version

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -348,7 +348,7 @@ typedef struct {
 	// Driver version format is MAJOR.MINOR[.MICRO] but we only care about the
 	// major version and the full version string. The micro component has been
 	// seen with relevant leading zeros (e.g. "440.48.02").
-	char raw[sizeof("1234.5678.90AB")];
+	char raw[sizeof("1234.5678.90AB\n")];
 } sc_nv_version;
 
 static void sc_probe_nvidia_driver(sc_nv_version * version)

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -121,8 +121,6 @@ static const char *nvidia_globs[] = {
 static const size_t nvidia_globs_len =
     sizeof nvidia_globs / sizeof *nvidia_globs;
 
-#define LIBNVIDIA_GLCORE_SO_PATTERN "libnvidia-glcore.so.%d.%d"
-
 #endif				// defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 
 // Populate libgl_dir with a symlink farm to files matching glob_list.
@@ -345,55 +343,62 @@ static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir)
 
 #ifdef NVIDIA_MULTIARCH
 
-struct sc_nvidia_driver {
-	int major_version;
-	int minor_version;
-};
+typedef struct {
+	int major;
+	// Driver version format is MAJOR.MINOR[.MICRO] but we only care about the
+	// major version and the full version string. The micro component has been
+	// seen with relevant leading zeros (e.g. "440.48.02").
+	char raw[sizeof("1234.5678.90AB")];
+} sc_nv_version;
 
-static void sc_probe_nvidia_driver(struct sc_nvidia_driver *driver)
+static void sc_probe_nvidia_driver(sc_nv_version * version)
 {
+	memset(version, 0, sizeof *version);
+
 	FILE *file SC_CLEANUP(sc_cleanup_file) = NULL;
 	debug("opening file describing nvidia driver version");
 	file = fopen(SC_NVIDIA_DRIVER_VERSION_FILE, "rt");
 	if (file == NULL) {
 		if (errno == ENOENT) {
 			debug("nvidia driver version file doesn't exist");
-			driver->major_version = 0;
-			driver->minor_version = 0;
 			return;
 		}
 		die("cannot open file describing nvidia driver version");
 	}
-	// Driver version format is MAJOR.MINOR where both MAJOR and MINOR are
-	// integers. We can use sscanf to parse this data.
-	if (fscanf
-	    (file, "%d.%d", &driver->major_version,
-	     &driver->minor_version) != 2) {
-		die("cannot parse nvidia driver version string");
+	int nread = fread(version->raw, 1, sizeof version->raw - 1, file);
+	if (nread < 0) {
+		die("cannot read nvidia driver version string");
 	}
-	debug("parsed nvidia driver version: %d.%d", driver->major_version,
-	      driver->minor_version);
+	if (nread == sizeof version->raw - 1 && !feof(file)) {
+		die("cannot fit entire nvidia driver version string");
+	}
+	version->raw[nread] = '\0';
+	if (nread > 0 && version->raw[nread - 1] == '\n') {
+		version->raw[nread - 1] = '\0';
+	}
+	if (sscanf(version->raw, "%d.", &version->major) < 0) {
+		die("cannot parse major version from nvidia driver version string");
+	}
 }
 
 static void sc_mkdir_and_mount_and_bind(const char *rootfs_dir,
 					const char *src_dir,
 					const char *tgt_dir)
 {
-	struct sc_nvidia_driver driver;
+	sc_nv_version version;
 
 	// Probe sysfs to get the version of the driver that is currently inserted.
-	sc_probe_nvidia_driver(&driver);
+	sc_probe_nvidia_driver(&version);
 
 	// If there's driver in the kernel then don't mount userspace.
-	if (driver.major_version == 0) {
+	if (version.major == 0) {
 		return;
 	}
 	// Construct the paths for the driver userspace libraries
 	// and for the gl directory.
 	char src[PATH_MAX] = { 0 };
 	char dst[PATH_MAX] = { 0 };
-	sc_must_snprintf(src, sizeof src, "%s-%d", src_dir,
-			 driver.major_version);
+	sc_must_snprintf(src, sizeof src, "%s-%d", src_dir, version.major);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", rootfs_dir, tgt_dir);
 
 	// If there is no userspace driver available then don't try to mount it.
@@ -423,21 +428,24 @@ static int sc_mount_nvidia_is_driver_in_dir(const char *dir)
 {
 	char driver_path[512] = { 0 };
 
-	struct sc_nvidia_driver driver;
+	sc_nv_version version;
 
 	// Probe sysfs to get the version of the driver that is currently inserted.
-	sc_probe_nvidia_driver(&driver);
+	sc_probe_nvidia_driver(&version);
 
 	// If there's no driver then we should not bother ourselves with finding the
 	// matching library
-	if (driver.major_version == 0) {
+	if (version.major == 0) {
 		return 0;
 	}
-	// Probe if a well known library is found in directory dir
-	sc_must_snprintf(driver_path, sizeof driver_path,
-			 "%s/" LIBNVIDIA_GLCORE_SO_PATTERN, dir,
-			 driver.major_version, driver.minor_version);
 
+	// Probe if a well known library is found in directory dir. We must use the
+	// raw version because it may contain more than just major.minor. In
+	// practice the micro version may have leading zeros that are relevant.
+	sc_must_snprintf(driver_path, sizeof driver_path,
+			 "%s/libnvidia-glcore.so.%s", dir, version.raw);
+
+	debug("looking for nvidia canary file %s", driver_path);
 	if (access(driver_path, F_OK) == 0) {
 		debug("nvidia library detected at path %s", driver_path);
 		return 1;

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -348,7 +348,7 @@ typedef struct {
 	// Driver version format is MAJOR.MINOR[.MICRO] but we only care about the
 	// major version and the full version string. The micro component has been
 	// seen with relevant leading zeros (e.g. "440.48.02").
-	char raw[sizeof("1234.5678.90AB\n")];
+	char raw[128]; // The size was picked as "big enough" for version strings.
 } sc_nv_version;
 
 static void sc_probe_nvidia_driver(sc_nv_version * version)

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -376,7 +376,7 @@ static void sc_probe_nvidia_driver(sc_nv_version * version)
 	if (nread > 0 && version->raw[nread - 1] == '\n') {
 		version->raw[nread - 1] = '\0';
 	}
-	if (sscanf(version->raw, "%d.", &version->major) < 0) {
+	if (sscanf(version->raw, "%d.", &version->major) != 1) {
 		die("cannot parse major version from nvidia driver version string");
 	}
 }

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -2,11 +2,15 @@ summary: Ensure that basic opengl works with faked nvidia
 
 systems: [ubuntu-14.04-*, ubuntu-16.04-*, ubuntu-18.04-*]
 
+environment:
+    NV_VERSION/stable: "123.456"
+    NV_VERSION/experimental: "123.456.02" # because reality
+
 prepare: |
     # mock nvidia driver
     mount -t tmpfs tmp /sys/module
     mkdir -p /sys/module/nvidia
-    echo "123.456" > /sys/module/nvidia/version
+    echo "$NV_VERSION" > /sys/module/nvidia/version
 
     # mock nvidia icd file
     test ! -d /usr/share/vulkan
@@ -27,38 +31,38 @@ prepare: |
         mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX.so.0.0.1
         echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX_nvidia.so.0.0.1
-        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so.123.456
-        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls/libnvidia-tls.so.123.456
-        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so.123.456
-        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau/libvdpau_nvidia.so.123.456
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so."$NV_VERSION"
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls/libnvidia-tls.so."$NV_VERSION"
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so."$NV_VERSION"
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau/libvdpau_nvidia.so."$NV_VERSION"
         if [[ "$(uname -m)" == x86_64 ]]; then
             mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls
             mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX.so.0.0.1
             echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX_nvidia.so.0.0.1
-            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so.123.456
-            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls/libnvidia-tls.so.123.456
-            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so.123.456
-            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau/libvdpau_nvidia.so.123.456
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so."$NV_VERSION"
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls/libnvidia-tls.so."$NV_VERSION"
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so."$NV_VERSION"
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau/libvdpau_nvidia.so."$NV_VERSION"
         fi
     fi
     mkdir -p /usr/lib/nvidia-123/tls
     mkdir -p /usr/lib/nvidia-123/vdpau
     echo "canary-legacy" >> /usr/lib/nvidia-123/libGLX.so.0.0.1
     echo "canary-legacy" >> /usr/lib/nvidia-123/libGLX_nvidia.so.0.0.1
-    echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-glcore.so.123.456
-    echo "canary-legacy" >> /usr/lib/nvidia-123/tls/libnvidia-tls.so.123.456
-    echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-tls.so.123.456
-    echo "canary-legacy" >> /usr/lib/nvidia-123/vdpau/libvdpau_nvidia.so.123.456
+    echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-glcore.so."$NV_VERSION"
+    echo "canary-legacy" >> /usr/lib/nvidia-123/tls/libnvidia-tls.so."$NV_VERSION"
+    echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-tls.so."$NV_VERSION"
+    echo "canary-legacy" >> /usr/lib/nvidia-123/vdpau/libvdpau_nvidia.so."$NV_VERSION"
     if [[ "$(uname -m)" == x86_64 ]]; then
         mkdir -p /usr/lib32/nvidia-123/tls
         mkdir -p /usr/lib32/nvidia-123/vdpau
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libGLX.so.0.0.1
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libGLX_nvidia.so.0.0.1
-        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libnvidia-glcore.so.123.456
-        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/tls/libnvidia-tls.so.123.456
-        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libnvidia-tls.so.123.456
-        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/vdpau/libvdpau_nvidia.so.123.456
+        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libnvidia-glcore.so."$NV_VERSION"
+        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/tls/libnvidia-tls.so."$NV_VERSION"
+        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/libnvidia-tls.so."$NV_VERSION"
+        echo "canary-32-legacy" >> /usr/lib32/nvidia-123/vdpau/libvdpau_nvidia.so."$NV_VERSION"
     fi
 
 restore: |
@@ -73,15 +77,15 @@ restore: |
         rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/vdpau
         rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX.so.0.0.1
         rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX_nvidia.so.0.0.1
-        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so.123.456
-        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so.123.456
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so."$NV_VERSION"
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so."$NV_VERSION"
         if [[ "$(uname -m)" == x86_64 ]]; then
             rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls
             rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/vdpau
             rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX.so.0.0.1
             rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX_nvidia.so.0.0.1
-            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so.123.456
-            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so.123.456
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so."$NV_VERSION"
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so."$NV_VERSION"
         fi
     fi
     rm -rf /usr/lib/nvidia-123
@@ -103,7 +107,7 @@ execute: |
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
         expected="canary-triplet"
     fi
-    files="libGLX.so.0.0.1 libGLX_nvidia.so.0.0.1 libnvidia-glcore.so.123.456 tls/libnvidia-tls.so.123.456 libnvidia-tls.so.123.456 vdpau/libvdpau_nvidia.so.123.456"
+    files="libGLX.so.0.0.1 libGLX_nvidia.so.0.0.1 libnvidia-glcore.so.$NV_VERSION tls/libnvidia-tls.so.$NV_VERSION libnvidia-tls.so.$NV_VERSION vdpau/libvdpau_nvidia.so.$NV_VERSION"
     for f in $files; do
        snap run test-snapd-policy-app-consumer.opengl -c "cat /var/lib/snapd/lib/gl/$f" | MATCH "$expected"
     done


### PR DESCRIPTION
Nvidia driver version used to be just x.y but now we see x.y.z in the
wild. What's worse is that the micro version component has relevant
leading zeros.

To handle this the version structrue is extended to hold the major
version, that we need separately for another reason, as well as the raw,
full version.

The patch includes a spread test variant that emulates the new version
scheme. I also bundled a small typedef and a memset instead of per-field
assignment.

Tested on NVidia 2080s on Ubuntu 20.04 development build using stock
drivers (x.y) as well as the beta drivers from graphics-drivers ppa.

Forum: https://forum.snapcraft.io/t/13342
Forum: https://forum.snapcraft.io/t/12392

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
