### PR TITLE
tests: tweak and enable tests on ubuntu 20.04

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -68,6 +68,8 @@ backends:
                 workers: 8
             - ubuntu-19.10-64:
                 workers: 6
+            - ubuntu-20.04-64:
+                workers: 6
             - ubuntu-core-16-64:
                 image: ubuntu-16.04-64
                 workers: 6
@@ -117,8 +119,6 @@ backends:
             - centos-7-64:
                 workers: 6
                 image: centos-7-64
-            - ubuntu-20.04-64:
-                workers: 6
 
 
     google-sru:

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -5,10 +5,10 @@ summary: Ensure that the calendar-service interface works
 #
 # FIXME: disable opensuse-tumbleweed until
 # https://github.com/snapcore/snapd/pull/7230 is landed
-# ubuntu-19.10: test-snapd-eds is incompatible with eds version shipped with the distro
+# ubuntu-19.10+: test-snapd-eds is incompatible with eds version shipped with the distro
 # arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
 # fedora-31: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -arch-linux-*, -debian-sid-*, -fedora-31-*]
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -opensuse-tumbleweed-*, -ubuntu-19.10-*, -ubuntu-20.04-*, -arch-linux-*, -debian-sid-*, -fedora-31-*]
 
 # fails in the autopkgtest env with:
 # [Wed Aug 15 16:34:12 2018] audit: type=1400

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -3,11 +3,11 @@ summary: Ensure that the contacts-service interface works
 # Only test on classic systems.  Don't test on Ubuntu 14.04, which
 # does not ship a new enough evolution-data-server.
 # amazon: no need to run this on amazon
-# ubuntu-19.10: test-snapd-eds is incompatible with eds shipped with the distro
+# ubuntu-19.10+: test-snapd-eds is incompatible with eds shipped with the distro
 # arch-linux: test-snapd-eds is incompatible with eds version shipped with the distro
 # opensuse-tumbleweed: test-snapd-eds is incompatible with eds version shipped with the distro
 # fedora-31: test-snapd-eds is incompatible with eds version shipped with the distro
-systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -arch-linux-*, -debian-sid-*, -opensuse-tumbleweed-*, -fedora-31-*]
+systems: [-ubuntu-core-*, -ubuntu-14.04-*, -amazon-*, -centos-*, -ubuntu-19.10-*, -ubuntu-20.04-*, -arch-linux-*, -debian-sid-*, -opensuse-tumbleweed-*, -fedora-31-*]
 
 # fails in autopkgtest environment with:
 # [Wed Aug 15 16:08:23 2018] audit: type=1400

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -16,7 +16,7 @@ prepare: |
     # Install a snap declaring a plug on timeserver-control
     install_local test-snapd-timedate-control-consumer
 
-    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-20.04-* ]]; then
         # ensure chrony is not installed as it interferes with
         # the systemd-timesyncd.service
         apt remove -y chrony
@@ -24,7 +24,7 @@ prepare: |
     fi
 
 restore: |
-    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-20.04-* ]]; then
         # bring it back
         apt install -y chrony
         systemctl restart systemd-timesyncd.service

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -18,10 +18,9 @@ execute: |
     rm -r /tmp/static-unit-tests/src/github.com/snapcore/snapd/vendor/*/
     rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
 
-    if [[ "$SPREAD_SYSTEM" == ubuntu-19.10-* ]]; then
-        # the code is formatted according to gofmt 1.10 rules, but those changed
-        # in later releases; skip gofmt checks on systems where go is known to
-        # be newer and produce incompatible formatting
+    # The format of code produced by "gofmt" drifts over time. Perform checks
+    # only on a fixed version to avoid hair-pulling annoyance every six months.
+    if [[ "$SPREAD_SYSTEM" != ubuntu-16.04-* ]]; then
         skip='SKIP_GOFMT=1'
     fi
 


### PR DESCRIPTION
There are a few tests that fail on 19.04 that also needed disabling on 20.04.
There's the usual gofmt problem. Other than that it should just work.
Please check individual commits for details.