### PR TITLE
o/auth,daemon: do not remove unknown user

### DIFF
--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -238,6 +238,12 @@ func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
 }
 
 func (s *userSuite) TestPostUserActionRemoveDelUserErr(c *check.C) {
+	st := s.d.overlord.State()
+	st.Lock()
+	_, err := auth.NewUser(st, "some-user", "email@test.com", "macaroon", []string{"discharge"})
+	st.Unlock()
+	c.Check(err, check.IsNil)
+
 	called := 0
 	osutilDelUser = func(username string, opts *osutil.DelUserOptions) error {
 		called++
@@ -274,7 +280,7 @@ func (s *userSuite) TestPostUserActionRemoveStateErr(c *check.C) {
 	rsp := postUsers(usersCmd, req, nil).(*resp)
 	c.Check(rsp.Status, check.Equals, 500)
 	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `internal error: could not unmarshal state entry "auth": .*`)
-	c.Check(called, check.Equals, 1)
+	c.Check(called, check.Equals, 0)
 }
 
 func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
@@ -290,9 +296,8 @@ func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rsp := postUsers(usersCmd, req, nil).(*resp)
-	c.Check(rsp.Status, check.Equals, 200)
-	c.Check(rsp.Result, check.Equals, true)
-	c.Check(called, check.Equals, 1)
+	c.Check(rsp, check.DeepEquals, BadRequest(`user "some-user" is not known`))
+	c.Check(called, check.Equals, 0)
 }
 
 func (s *userSuite) TestPostUserActionRemove(c *check.C) {
@@ -302,8 +307,20 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
-	// everything that happens when the user is not in state still happens
-	s.TestPostUserActionRemoveNoUserInState(c)
+	called := 0
+	osutilDelUser = func(username string, opts *osutil.DelUserOptions) error {
+		called++
+		c.Check(username, check.Equals, "some-user")
+		return nil
+	}
+
+	buf := bytes.NewBufferString(`{"action":"remove","username":"some-user"}`)
+	req, err := http.NewRequest("POST", "/v2/users", buf)
+	c.Assert(err, check.IsNil)
+	rsp := postUsers(usersCmd, req, nil).(*resp)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Check(rsp.Result, check.Equals, true)
+	c.Check(called, check.Equals, 1)
 
 	// and the user is removed from state
 	st.Lock()

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -173,8 +173,8 @@ func RemoveUser(st *state.State, userID int) error {
 	return removeUser(st, func(u *UserState) bool { return u.ID == userID })
 }
 
-// RemoveUserByName removes a user from the state given its username
-func RemoveUserByName(st *state.State, username string) error {
+// RemoveUserByUsername removes a user from the state given its username
+func RemoveUserByUsername(st *state.State, username string) error {
 	return removeUser(st, func(u *UserState) bool { return u.Username == username })
 }
 
@@ -223,8 +223,18 @@ func Users(st *state.State) ([]*UserState, error) {
 	return users, nil
 }
 
-// User returns a user from the state given its ID
+// User returns a user from the state given its ID.
 func User(st *state.State, id int) (*UserState, error) {
+	return findUser(st, func(u *UserState) bool { return u.ID == id })
+}
+
+// UserByUsername returns a user from the state given its username.
+func UserByUsername(st *state.State, username string) (*UserState, error) {
+	return findUser(st, func(u *UserState) bool { return u.Username == username })
+}
+
+// findUser finds the first user matching given predicate.
+func findUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
@@ -235,9 +245,10 @@ func User(st *state.State, id int) (*UserState, error) {
 		return nil, err
 	}
 
-	for _, user := range authStateData.Users {
-		if user.ID == id {
-			return &user, nil
+	for i := range authStateData.Users {
+		u := &authStateData.Users[i]
+		if p(u) {
+			return u, nil
 		}
 	}
 	return nil, ErrInvalidUser

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -291,6 +291,24 @@ func (as *authSuite) TestUser(c *C) {
 	c.Check(user.HasStoreAuth(), Equals, true)
 }
 
+func (as *authSuite) TestUserByUsername(c *C) {
+	as.state.Lock()
+	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	as.state.Unlock()
+	c.Check(err, IsNil)
+
+	as.state.Lock()
+	userFromState, err := auth.UserByUsername(as.state, "username")
+	as.state.Unlock()
+	c.Check(err, IsNil)
+	c.Check(userFromState, DeepEquals, user)
+
+	as.state.Lock()
+	_, err = auth.UserByUsername(as.state, "otherusername")
+	as.state.Unlock()
+	c.Check(err, Equals, auth.ErrInvalidUser)
+}
+
 func (as *authSuite) TestUserHasStoreAuth(c *C) {
 	var user0 *auth.UserState
 	// nil user
@@ -374,7 +392,7 @@ func (as *authSuite) TestRemove(c *C) {
 	c.Assert(err, Equals, auth.ErrInvalidUser)
 }
 
-func (as *authSuite) TestRemoveByName(c *C) {
+func (as *authSuite) TestRemoveByUsername(c *C) {
 	as.state.Lock()
 	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
 	as.state.Unlock()
@@ -386,7 +404,7 @@ func (as *authSuite) TestRemoveByName(c *C) {
 	c.Check(err, IsNil)
 
 	as.state.Lock()
-	err = auth.RemoveUserByName(as.state, user.Username)
+	err = auth.RemoveUserByUsername(as.state, user.Username)
 	as.state.Unlock()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
* do not let remove users not known to snapd

* rename auth.RemoveByName to RemoveByUsername because there is
  a name on system-user assertion which is not the username
  so using name here is confusing

We could add some form of force to do the former?
