### PR TITLE
daemon, store: better expose single action errors

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -7438,7 +7438,7 @@ func (s *apiSuite) TestErrToResponse(c *check.C) {
 	}}
 	saOe := &store.SnapActionError{Other: []error{e}}
 	// this one can't happen (but fun to test):
-	saXe := &store.SnapActionError{Refresh: map[string]error{"foo": s1e}}
+	saXe := &store.SnapActionError{Refresh: map[string]error{"foo": sa1e}}
 
 	makeErrorRsp := func(kind errorKind, err error, value interface{}) Response {
 		return SyncResponse(&resp{

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -591,6 +591,14 @@ func errToResponse(err error, snaps []string, fallback func(format string, v ...
 			} else {
 				handled = false
 			}
+		case *store.SnapActionError:
+			// we only handle a few specific cases
+			_, _, e := err.SingleOpError()
+			if e != nil {
+				// 👉😎👉
+				return errToResponse(e, snaps, fallback, format)
+			}
+			handled = false
 		default:
 			handled = false
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -6324,6 +6324,11 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 	}}
 	c.Check(e.Error(), Equals, `cannot refresh snap "foo": sad refresh`)
 
+	op, name, err := e.SingleOpError()
+	c.Check(op, Equals, "refresh")
+	c.Check(name, Equals, "foo")
+	c.Check(err, ErrorMatches, "sad refresh")
+
 	e = &store.SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
 		"bar": fmt.Errorf("sad refresh 2"),
@@ -6333,10 +6338,20 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 	c.Check(errMsg, testutil.Contains, "\nsad refresh 1: \"foo\"")
 	c.Check(errMsg, testutil.Contains, "\nsad refresh 2: \"bar\"")
 
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
+
 	e = &store.SnapActionError{Install: map[string]error{
 		"foo": fmt.Errorf("sad install"),
 	}}
 	c.Check(e.Error(), Equals, `cannot install snap "foo": sad install`)
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "install")
+	c.Check(name, Equals, "foo")
+	c.Check(err, ErrorMatches, "sad install")
 
 	e = &store.SnapActionError{Install: map[string]error{
 		"foo": fmt.Errorf("sad install 1"),
@@ -6347,10 +6362,20 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 	c.Check(errMsg, testutil.Contains, "\nsad install 1: \"foo\"")
 	c.Check(errMsg, testutil.Contains, "\nsad install 2: \"bar\"")
 
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
+
 	e = &store.SnapActionError{Download: map[string]error{
 		"foo": fmt.Errorf("sad download"),
 	}}
 	c.Check(e.Error(), Equals, `cannot download snap "foo": sad download`)
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "download")
+	c.Check(name, Equals, "foo")
+	c.Check(err, ErrorMatches, "sad download")
 
 	e = &store.SnapActionError{Download: map[string]error{
 		"foo": fmt.Errorf("sad download 1"),
@@ -6360,6 +6385,11 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 	c.Check(strings.HasPrefix(errMsg, "cannot download:\n"), Equals, true)
 	c.Check(errMsg, testutil.Contains, "\nsad download 1: \"foo\"")
 	c.Check(errMsg, testutil.Contains, "\nsad download 2: \"bar\"")
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
 
 	e = &store.SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
@@ -6371,6 +6401,11 @@ func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
 sad refresh 1: "foo"
 sad install 2: "bar"`)
 
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
+
 	e = &store.SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
 	},
@@ -6381,6 +6416,11 @@ sad install 2: "bar"`)
 sad refresh 1: "foo"
 sad download 2: "bar"`)
 
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
+
 	e = &store.SnapActionError{Install: map[string]error{
 		"foo": fmt.Errorf("sad install 1"),
 	},
@@ -6390,6 +6430,11 @@ sad download 2: "bar"`)
 	c.Check(e.Error(), Equals, `cannot install or download:
 sad install 1: "foo"
 sad download 2: "bar"`)
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
 
 	e = &store.SnapActionError{Refresh: map[string]error{
 		"foo": fmt.Errorf("sad refresh 1"),
@@ -6405,11 +6450,21 @@ sad refresh 1: "foo"
 sad install 2: "bar"
 sad download 3: "baz"`)
 
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
+
 	e = &store.SnapActionError{
 		NoResults: true,
 		Other:     []error{fmt.Errorf("other error")},
 	}
 	c.Check(e.Error(), Equals, `cannot refresh, install, or download: other error`)
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
 
 	e = &store.SnapActionError{
 		Other: []error{fmt.Errorf("other error 1"), fmt.Errorf("other error 2")},
@@ -6417,6 +6472,11 @@ sad download 3: "baz"`)
 	c.Check(e.Error(), Equals, `cannot refresh, install, or download:
 other error 1
 other error 2`)
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
 
 	e = &store.SnapActionError{
 		Install: map[string]error{
@@ -6429,10 +6489,20 @@ sad install: "bar"
 other error 1
 other error 2`)
 
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
+
 	e = &store.SnapActionError{
 		NoResults: true,
 	}
 	c.Check(e.Error(), Equals, "no install/refresh information results from the store")
+
+	op, name, err = e.SingleOpError()
+	c.Check(op, Equals, "")
+	c.Check(name, Equals, "")
+	c.Check(err, IsNil)
 }
 
 func (s *storeTestSuite) TestSnapActionRefreshesBothAuths(c *C) {


### PR DESCRIPTION
When a snap action (that is, a POST to the store's refresh endpoint)
results in a single error for a single operation on a single snap, the
current code raises it as an InternalError.

This means a download of an unknown snap becomes an internal error; a
download of a snap from the wrong channel becomes an internal error,
etc.  This relatively minor issue becomes user-visible wackiness with
the switch to download being via snapd (and using the mentioned
endpoint).

This change fixes that, such that _if_ it's a single operation on a
single snap returning a single error, then the error raised is the
internal one.

More work could be done to coalesce things such that if it's the same
error for multiple snaps it's handled differently; this would simplify
the "no refreshes found" logging and reporting, I suspect (but haven't
checked).
