### PR TITLE
daemon: drop support for the DELETE method

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1002,7 +1002,6 @@ func (s *apiSuite) TestRootCmd(c *check.C) {
 	// check it only does GET
 	c.Check(rootCmd.PUT, check.IsNil)
 	c.Check(rootCmd.POST, check.IsNil)
-	c.Check(rootCmd.DELETE, check.IsNil)
 	c.Assert(rootCmd.GET, check.NotNil)
 
 	rec := httptest.NewRecorder()
@@ -1029,7 +1028,6 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	// check it only does GET
 	c.Check(sysInfoCmd.PUT, check.IsNil)
 	c.Check(sysInfoCmd.POST, check.IsNil)
-	c.Check(sysInfoCmd.DELETE, check.IsNil)
 	c.Assert(sysInfoCmd.GET, check.NotNil)
 
 	rec := httptest.NewRecorder()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -89,10 +89,9 @@ type Command struct {
 	Path       string
 	PathPrefix string
 	//
-	GET    ResponseFunc
-	PUT    ResponseFunc
-	POST   ResponseFunc
-	DELETE ResponseFunc
+	GET  ResponseFunc
+	PUT  ResponseFunc
+	POST ResponseFunc
 	// can guest GET?
 	GuestOK bool
 	// can non-admin GET?
@@ -123,7 +122,7 @@ var polkitCheckAuthorization = polkit.CheckAuthorization
 //
 // - if the user is `root` everything is allowed
 // - if a user is logged in (via `snap login`) and the command doesn't have RootOnly, everything is allowed
-// - POST/PUT/DELETE all require `root`, or just `snap login` if not RootOnly
+// - POST/PUT all require `root`, or just `snap login` if not RootOnly
 //
 // Otherwise for GET requests the following parameters are honored:
 // - GuestOK: anyone can access GET
@@ -252,8 +251,6 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rspf = c.PUT
 	case "POST":
 		rspf = c.POST
-	case "DELETE":
-		rspf = c.DELETE
 	}
 
 	if rspf != nil {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -138,9 +138,8 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 	cmd.GET = rf
 	cmd.PUT = rf
 	cmd.POST = rf
-	cmd.DELETE = rf
 
-	for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+	for _, method := range []string{"GET", "POST", "PUT"} {
 		req, err := http.NewRequest(method, "", nil)
 		req.Header.Add("User-Agent", fakeUserAgent)
 		c.Assert(err, check.IsNil)


### PR DESCRIPTION
The daemon supports the DELETE method, but we're not currently using it.
As having unused capabilities is a bad idea, this removes that.

There is no breaking or risky change induced by this branch.
