### PR TITLE
client: move to /v2/users; implement RemoveUser

### DIFF
--- a/client/users.go
+++ b/client/users.go
@@ -47,9 +47,17 @@ type CreateUserOptions struct {
 	ForceManaged bool   `json:"force-managed,omitempty"`
 }
 
+// RemoveUserOptions holds options for removing a local system user.
+//
+// Username indicates which user to remove.
+type RemoveUserOptions struct {
+	Username string `json:"username,omitempty"`
+}
+
 type userAction struct {
 	Action string `json:"action"`
 	*CreateUserOptions
+	*RemoveUserOptions
 }
 
 func (client *Client) doUserAction(act *userAction) ([]*CreateUserResult, error) {
@@ -108,6 +116,15 @@ func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserRe
 		return results, fmt.Errorf("while creating users:%s", buf.Bytes())
 	}
 	return results, nil
+}
+
+// RemoveUser removes a local system user.
+func (client *Client) RemoveUser(options *RemoveUserOptions) error {
+	if options == nil || options.Username == "" {
+		return fmt.Errorf("cannot remove a user without providing a username")
+	}
+	_, err := client.doUserAction(&userAction{Action: "remove", RemoveUserOptions: options})
+	return err
 }
 
 // Users returns the local users.

--- a/client/users.go
+++ b/client/users.go
@@ -48,9 +48,8 @@ type CreateUserOptions struct {
 }
 
 // RemoveUserOptions holds options for removing a local system user.
-//
-// Username indicates which user to remove.
 type RemoveUserOptions struct {
+	// Username indicates which user to remove.
 	Username string `json:"username,omitempty"`
 }
 
@@ -73,7 +72,7 @@ func (client *Client) doUserAction(act *userAction) ([]*CreateUserResult, error)
 
 // CreateUser creates a local system user. See CreateUserOptions for details.
 func (client *Client) CreateUser(options *CreateUserOptions) (*CreateUserResult, error) {
-	if options.Email == "" {
+	if options == nil || options.Email == "" {
 		return nil, fmt.Errorf("cannot create a user without providing an email")
 	}
 
@@ -89,7 +88,7 @@ func (client *Client) CreateUser(options *CreateUserOptions) (*CreateUserResult,
 // Results may be provided even if there are errors.
 func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserResult, error) {
 	for _, opts := range options {
-		if opts.Email == "" && !opts.Known {
+		if opts == nil || opts.Email == "" && !opts.Known {
 			return nil, fmt.Errorf("cannot create user from store details without an email to query for")
 		}
 	}
@@ -106,7 +105,7 @@ func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserRe
 	}
 
 	if len(errs) == 1 {
-		return results, fmt.Errorf("while creating user: %v", errs[0])
+		return results, errs[0]
 	}
 	if len(errs) > 1 {
 		var buf bytes.Buffer

--- a/client/users.go
+++ b/client/users.go
@@ -88,7 +88,7 @@ func (client *Client) CreateUser(options *CreateUserOptions) (*CreateUserResult,
 // Results may be provided even if there are errors.
 func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserResult, error) {
 	for _, opts := range options {
-		if opts == nil || opts.Email == "" && !opts.Known {
+		if opts == nil || (opts.Email == "" && !opts.Known) {
 			return nil, fmt.Errorf("cannot create user from store details without an email to query for")
 		}
 	}

--- a/client/users_test.go
+++ b/client/users_test.go
@@ -33,19 +33,19 @@ func (cs *clientSuite) TestClientCreateUser(c *C) {
 
 	cs.rsp = `{
 		"type": "sync",
-		"result": {
+		"result": [{
                         "username": "karl",
                         "ssh-keys": ["one", "two"]
-		}
+		}]
 	}`
 	rsp, err := cs.cli.CreateUser(&client.CreateUserOptions{Email: "one@email.com", Sudoer: true, Known: true})
 	c.Assert(cs.req.Method, Equals, "POST")
-	c.Assert(cs.req.URL.Path, Equals, "/v2/create-user")
+	c.Assert(cs.req.URL.Path, Equals, "/v2/users")
 	c.Assert(err, IsNil)
 
 	body, err := ioutil.ReadAll(cs.req.Body)
 	c.Assert(err, IsNil)
-	c.Assert(string(body), Equals, `{"email":"one@email.com","sudoer":true,"known":true}`)
+	c.Assert(string(body), Equals, `{"action":"create","email":"one@email.com","sudoer":true,"known":true}`)
 
 	c.Assert(rsp, DeepEquals, &client.CreateUserResult{
 		Username: "karl",
@@ -70,11 +70,11 @@ var createUsersTests = []struct {
 		Known: true,
 	}},
 	bodies: []string{
-		`{"email":"one@example.com","sudoer":true}`,
-		`{"known":true}`,
+		`{"action":"create","email":"one@example.com","sudoer":true}`,
+		`{"action":"create","known":true}`,
 	},
 	responses: []string{
-		`{"type": "sync", "result": {"username": "one", "ssh-keys":["a", "b"]}}`,
+		`{"type": "sync", "result": [{"username": "one", "ssh-keys":["a", "b"]}]}`,
 		`{"type": "sync", "result": [{"username": "two"}, {"username": "three"}]}`,
 	},
 	results: []*client.CreateUserResult{{
@@ -100,7 +100,7 @@ func (cs *clientSuite) TestClientCreateUsers(c *C) {
 		var bodies []string
 		for _, req := range cs.reqs {
 			c.Assert(req.Method, Equals, "POST")
-			c.Assert(req.URL.Path, Equals, "/v2/create-user")
+			c.Assert(req.URL.Path, Equals, "/v2/users")
 			data, err := ioutil.ReadAll(req.Body)
 			c.Assert(err, IsNil)
 			bodies = append(bodies, string(data))

--- a/client/users_test.go
+++ b/client/users_test.go
@@ -46,7 +46,9 @@ func (cs *clientSuite) TestClientRemoveUser(c *C) {
 }
 
 func (cs *clientSuite) TestClientRemoveUserError(c *C) {
-	err := cs.cli.RemoveUser(&client.RemoveUserOptions{})
+	err := cs.cli.RemoveUser(nil)
+	c.Assert(err, ErrorMatches, "cannot remove a user without providing a username")
+	err = cs.cli.RemoveUser(&client.RemoveUserOptions{})
 	c.Assert(err, ErrorMatches, "cannot remove a user without providing a username")
 
 	cs.rsp = `{
@@ -64,7 +66,9 @@ func (cs *clientSuite) TestClientRemoveUserError(c *C) {
 }
 
 func (cs *clientSuite) TestClientCreateUser(c *C) {
-	_, err := cs.cli.CreateUser(&client.CreateUserOptions{})
+	_, err := cs.cli.CreateUser(nil)
+	c.Assert(err, ErrorMatches, "cannot create a user without providing an email")
+	_, err = cs.cli.CreateUser(&client.CreateUserOptions{})
 	c.Assert(err, ErrorMatches, "cannot create a user without providing an email")
 
 	cs.rsp = `{
@@ -96,6 +100,11 @@ var createUsersTests = []struct {
 	results   []*client.CreateUserResult
 	error     string
 }{{
+	// nothing in -> nothing out
+}, {
+	options: []*client.CreateUserOptions{nil},
+	error:   "cannot create user from store details without an email to query for",
+}, {
 	options: []*client.CreateUserOptions{{}},
 	error:   "cannot create user from store details without an email to query for",
 }, {

--- a/client/users_test.go
+++ b/client/users_test.go
@@ -101,6 +101,7 @@ var createUsersTests = []struct {
 	error     string
 }{{
 	// nothing in -> nothing out
+	options: nil,
 }, {
 	options: []*client.CreateUserOptions{nil},
 	error:   "cannot create user from store details without an email to query for",

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -63,10 +63,10 @@ func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 			n++
 		case 1:
 			c.Check(r.Method, Equals, "POST")
-			c.Check(r.URL.Path, Equals, "/v2/create-user")
+			c.Check(r.URL.Path, Equals, "/v2/users")
 			postData, err := ioutil.ReadAll(r.Body)
 			c.Assert(err, IsNil)
-			c.Check(string(postData), Equals, `{"sudoer":true,"known":true}`)
+			c.Check(string(postData), Equals, `{"action":"create","sudoer":true,"known":true}`)
 
 			fmt.Fprintln(w, `{"type": "sync", "result": [{"username": "foo"}]}`)
 			n++
@@ -240,10 +240,10 @@ func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 			n++
 		case 1:
 			c.Check(r.Method, Equals, "POST")
-			c.Check(r.URL.Path, Equals, "/v2/create-user")
+			c.Check(r.URL.Path, Equals, "/v2/users")
 			postData, err := ioutil.ReadAll(r.Body)
 			c.Assert(err, IsNil)
-			c.Check(string(postData), Equals, `{"sudoer":true,"known":true}`)
+			c.Check(string(postData), Equals, `{"action":"create","sudoer":true,"known":true}`)
 
 			fmt.Fprintln(w, `{"type": "sync", "result": [{"username": "foo"}]}`)
 			n++

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -35,13 +35,15 @@ func makeCreateUserChecker(c *check.C, n *int, email string, sudoer, known bool)
 		switch *n {
 		case 0:
 			c.Check(r.Method, check.Equals, "POST")
-			c.Check(r.URL.Path, check.Equals, "/v2/create-user")
+			c.Check(r.URL.Path, check.Equals, "/v2/users")
 			var gotBody map[string]interface{}
 			dec := json.NewDecoder(r.Body)
 			err := dec.Decode(&gotBody)
 			c.Assert(err, check.IsNil)
 
-			wantBody := make(map[string]interface{})
+			wantBody := map[string]interface{}{
+				"action": "create",
+			}
 			if email != "" {
 				wantBody["email"] = "one@email.com"
 			}
@@ -56,7 +58,7 @@ func makeCreateUserChecker(c *check.C, n *int, email string, sudoer, known bool)
 			if email == "" {
 				fmt.Fprintln(w, `{"type": "sync", "result": [{"username": "karl", "ssh-keys": ["a","b"]}]}`)
 			} else {
-				fmt.Fprintln(w, `{"type": "sync", "result": {"username": "karl", "ssh-keys": ["a","b"]}}`)
+				fmt.Fprintln(w, `{"type": "sync", "result": [{"username": "karl", "ssh-keys": ["a","b"]}]}`)
 			}
 		default:
 			c.Fatalf("got too many requests (now on %d)", *n+1)


### PR DESCRIPTION
This PR has two commits, both rather small, so you get to review them together if you want (or separately if you need):

90c2c741 is:

    client: switch things that used /v2/create-user to use /v2/users

    Without changing the API, this switches things that used the old
    create-uer endpoint to use the new users endpoint. I think the
    resulting code is a littie bit cleaner, especially the inner loop of
    (*Client).CreateUsers.
    
    This also impacts cmd/snap's tests, as a few tests there mock the
    daemon responses rather than the client itself.

and then 0ef7ed7d is simply:

    client: implement RemoveUser


I was going to propose them as two separate PRs, but @pedronis suggested I bundle them instead.